### PR TITLE
add gauntlet plugin, marketplace, and CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "lestrrat-ai",
+  "description": "Claude Code plugins by lestrrat.",
+  "owner": {
+    "name": "lestrrat"
+  },
+  "plugins": [
+    {
+      "name": "gauntlet",
+      "source": "./plugins/gauntlet",
+      "description": "Adversarial review-to-merge pipeline for Claude Code.",
+      "license": "MIT",
+      "keywords": ["code-review", "adversarial-review", "pull-request", "ci", "codex"]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     name: Validate plugins
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       # Pinned so a new Claude Code release can't turn CI red without a commit.
       # Bump deliberately; new versions may add validation rules.
@@ -38,7 +38,7 @@ jobs:
     name: Lint scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Shellcheck
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugins:
+    name: Validate plugins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Pinned so a new Claude Code release can't turn CI red without a commit.
+      # Bump deliberately; new versions may add validation rules.
+      - name: Install Claude Code
+        run: npm install -g '@anthropic-ai/claude-code@2.1.206'
+
+      # `claude plugin validate` is offline and needs no credentials, so this
+      # step works unchanged on pull requests from forks.
+      - name: Validate marketplace, plugins, and skills
+        run: ./scripts/validate-plugins.sh
+
+  scripts:
+    name: Lint scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Shellcheck
+        run: |
+          mapfile -t files < <(find . -name '*.sh' -not -path './.git/*')
+          printf 'checking %s\n' "${files[@]}"
+          shellcheck "${files[@]}"
+
+      - name: Python syntax
+        run: |
+          mapfile -t files < <(find . -name '*.py' -not -path './.git/*')
+          printf 'checking %s\n' "${files[@]}"
+          python3 -m py_compile "${files[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tmp/
+.gauntlet/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# claude-code-plugins
+
+Claude Code plugins by [lestrrat](https://github.com/lestrrat-ai), published as a plugin marketplace.
+
+## Install
+
+Add the marketplace once:
+
+```
+/plugin marketplace add lestrrat-ai/claude-code-plugins
+```
+
+Then install whichever plugins you want:
+
+```
+/plugin install gauntlet@lestrrat-ai
+```
+
+## Plugins
+
+| Plugin | What it is |
+|--------|------------|
+| [`gauntlet`](plugins/gauntlet/README.md) | Adversarial code review that follows through to a merge — reviews, files fixes as PRs, defends them through repeated review rounds and green CI, and merges. |
+
+## License
+
+MIT

--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "gauntlet",
+  "version": "0.1.0",
+  "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
+  "author": {
+    "name": "lestrrat"
+  },
+  "homepage": "https://github.com/lestrrat-ai/claude-code-plugins",
+  "repository": "https://github.com/lestrrat-ai/claude-code-plugins",
+  "license": "MIT",
+  "keywords": ["code-review", "adversarial-review", "pull-request", "ci", "codex"]
+}

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -1,0 +1,43 @@
+# gauntlet
+
+Adversarial code review that follows through to a merge.
+
+The centerpiece is `/gauntlet:campaign`: point it at your code and it runs an adversarial review, files
+each real finding as its own pull request, defends that PR through repeated context-isolated review
+rounds until it passes a strict bar with green CI, and merges. Run it once — it schedules its own
+follow-ups and keeps working unattended.
+
+If you only want to know what's wrong, `/gauntlet:review` reports findings and changes nothing.
+
+## Install
+
+```
+/plugin marketplace add lestrrat-ai/claude-code-plugins
+/plugin install gauntlet@lestrrat-ai
+```
+
+## Skills
+
+| Skill | What it does |
+|-------|--------------|
+| `/gauntlet:campaign` | The review-to-merge pipeline. Writes code and merges it. See [its README](skills/campaign/README.md). |
+| `/gauntlet:review` | A standalone two-pass hostile review: pass 1 surfaces everything, pass 2 neutrally confirms or refutes each finding. Reports only. |
+| `/gauntlet:copilot-address-reviews` | Verify and address GitHub Copilot's PR review comments, one at a time. |
+| `/gauntlet:codex-exec` | Delegate a lightweight task to Codex CLI via `codex exec`. |
+
+## Requirements
+
+- A GitHub remote — the pipeline works through PRs via the `gh` CLI.
+- [Codex CLI](https://github.com/openai/codex) for the adversarial reviewer. If Codex can't return a
+  verdict because of a system problem (quota, auth, timeout), the pipeline retries once and then does
+  the equivalent review with its own subagents, so an outage slows a run rather than stalling it.
+
+## Scratch files
+
+Both skills keep working state under `.gauntlet/` at the repo root, which is git-ignored. Run scratch
+lives in `.gauntlet/tmp/` and is safe to delete; `.gauntlet/history/` holds durable carryover between
+campaign runs, so don't remove `.gauntlet/` wholesale.
+
+## License
+
+MIT

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -1,0 +1,142 @@
+# Campaign
+
+Point it at your code and it runs a tough, end-to-end review cycle for you: an adversarial review
+finds problems, each real one gets fixed in its own pull request, every PR is re-reviewed until it
+passes a strict quality bar **and** CI is green, and then it merges — all on its own, hands-off.
+
+Think of it as an automated senior reviewer that doesn't just leave comments, but follows through:
+files the fixes, defends them through repeated review rounds, waits for CI, and ships.
+
+## What it's good for
+
+- Hardening a codebase or a feature area before a release.
+- Turning "someone should really review this" into actual merged fixes.
+- Running a thorough pass unattended while you do something else.
+
+## How to use it
+
+```
+/gauntlet:campaign                 # campaign over the whole repo
+/gauntlet:campaign auth & sessions # campaign over just that area or topic
+/gauntlet:campaign --new           # force a brand-new run, even over an old one
+```
+
+Run it **once** — that's it. It schedules its own follow-ups and keeps working until everything is
+resolved; you don't need to keep it open or re-run it.
+
+If you do come back and run it again later, it does the sensible thing. Run it plain (no area) and it
+resumes a run that's still in progress; if the last run already finished it asks whether to start a
+fresh one rather than restarting silently or insisting everything's already fixed. Give it an area
+(or `--new`) and it starts a new run instead — which is also how you deliberately run two at once over
+different parts of the code. A fresh run isn't a blind redo — it remembers what earlier runs learned (which findings it
+gave up on, which it set aside as your call, and which it judged not worth fixing) so it can pick up
+the unfinished threads and not re-litigate the same non-issues. Add `--new` (or just say "start a
+fresh run") to force a new run immediately without being asked.
+
+## What to expect
+
+It opens a pull request for each problem worth fixing and merges them itself once they pass two
+separate, context-isolated reviews of the same PR content and CI is green. (Two fresh reviews rather than
+one because a single stochastic review can miss a defect — not because two runs are statistically
+independent; reading the same diff under the same review task makes their verdicts correlated.) There's no approval step along the way, so
+starting it is your sign-off — and a whole-repo run can spin up several PRs and keep going for a
+while before it's done.
+
+The loop is PR-first: it implements, commits, pushes, opens or updates the PR, then watches CI and
+reviews that PR's current HEAD. Review and CI fixes get another commit and push on the same PR; it
+doesn't keep work local until everything has passed.
+
+It also doesn't wait around. On a big scope the review sweep runs in slices, and fixes start flowing
+as soon as the first findings are confirmed — while the rest of the sweep is still going. Everything
+long-running happens in the background, so at any moment it's doing all the work that's ready to do.
+
+You can follow along on GitHub: each PR is labeled `gauntlet-reviewing` while it's working through
+the loop, and that flips to `gauntlet-accepted` once it has passed both reviews (the skill creates
+the labels if your repo doesn't have them).
+
+By default it checks with you before changing anything in your public API — exported signatures,
+formats, CLI flags, defaults, or any behavior callers depend on — so it never merges a breaking
+change behind your back. Tell it up front that breakage is fine and it'll stop asking.
+
+It tidies up as it goes, deleting merged branches and their worktrees. If a fix just can't clear the
+bar, it retries once, then sets that one aside with a note on why and moves on rather than stalling
+everything else. When it's finished you get a short rundown: what merged, what it gave up on, and
+anything it left for you to weigh in on.
+
+## Flow
+
+```mermaid
+flowchart TD
+    A(["invoke /gauntlet:campaign"]) --> A1{"live work, finished run, or --new?"}
+    A1 -- live work --> A2[resume: reconcile + continue loop] --> M
+    A1 -- finished run --> A3{start a new run?}
+    A3 -- no --> A4([prior final report])
+    A3 -- yes --> B
+    A1 -->|"nothing yet / --new"| B
+    B{area or topic given?}
+    B -- yes --> C[codex reviews that area]
+    B -- no --> D[codex whole-repo sweep, in slices]
+    C --> E["neutral verification pass<br/>(streamed: each slice verifies as it lands)"]
+    D --> E
+    E --> F{more than 10 findings?}
+    F -- yes --> G[parallel verifier shards] --> H[dedup each survivor against the run's set on arrival]
+    F -- no --> I[single verifier]
+    H --> J
+    I --> J[survivors = CONFIRMED or ADJUSTED]
+    J --> K[Stage 1: fan out - one PR per finding,<br/>starting while the sweep continues]
+    K --> L0[per finding: worktree off base branch, implement the fix]
+    L0 --> AB{changes public API surface or behavior?}
+    AB -- no --> L[commit, push, open PR, launch CI watch]
+    AB -- yes --> AC{api_changes flag?}
+    AC -- allowed --> L
+    AC -- ask --> AD[park finding awaiting-api, confirm with user]
+    AD --> AE{approved?}
+    AE -- yes --> L
+    AE -- no --> AF[skip - report at end]
+    L --> M[[event loop: gate each PR]]
+
+    M --> N{2 SATISFIED on current SHA?}
+    N -- no --> O[run one codex review on HEAD SHA<br/>second only after the first passes]
+    O --> P{SATISFIED?}
+    P -- no --> Q[scoped fix subagent: commit + push, new SHA]
+    P -- yes --> M
+    N -- yes --> R{CI status on current SHA?}
+    R -- red --> S[scoped CI-fix subagent: commit + push, new SHA]
+    R -- pending --> M
+    Q --> T[reset gates - verdicts and CI are SHA-pinned]
+    S --> T
+    T --> M
+    R -- green --> U[merge: serialized, auto, squash, delete-branch]
+    U --> U2[sync local base branch to remote ff-only]
+    U2 --> V[cleanup worktree + local branch, mark merged]
+    V --> W{all PRs merged or aborted?}
+    W -- no --> M
+    W -- yes --> X[write carryover ledger + final report] --> X2([done])
+
+    M -. 1h cap exceeded .-> Y{first attempt?}
+    Y -. yes .-> Z[retry once in fresh worktree]
+    Z -.-> M
+    Y -. no .-> AA[abort + write log, continue others]
+    AA -.-> W
+```
+
+## Good to know
+
+- You can run more than one at a time in the same repo — say one over `auth` and another over
+  `storage`. Each is its own isolated run with its own pull requests and bookkeeping, so they never
+  step on each other. And if a run gets interrupted, another agent can pick it up right where it left
+  off: it can tell a run that's still being actively driven from one that's been abandoned, so it only
+  ever resumes an orphaned run and never doubles up on one already in progress.
+- It uses Codex as the reviewer, so Codex CLI should be available. If Codex can't return a verdict
+  because of a system problem — quota or rate limits, auth, a timeout — it retries once and then does
+  the equivalent review with its own subagents, so a transient Codex outage slows a run down but
+  doesn't stall it.
+- It works through GitHub PRs via the `gh` CLI, so the repo needs a GitHub remote.
+- Before it spends a review on a PR, it first clears anything that would waste one: it addresses any
+  GitHub Copilot review comments, fixes failing CI, and rebases a PR that has fallen into conflict
+  with the base branch — then reviews the clean result.
+- It keeps a small `.gauntlet/history/` at the repo root (git-ignored, one file per run) to remember what past
+  runs learned. That's the memory a fresh run carries over. Each fresh run also tidies that file,
+  dropping entries that no longer apply to the current code — and when it isn't sure an entry is
+  safe to drop, it asks you first rather than guessing.
+- Full mechanics live in [`SKILL.md`](./SKILL.md) and [`references/`](./references/).

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: campaign
+description: >-
+  Writes code and merges it. A self-looping adversarial-review-to-merge campaign: an adversarial reviewer sweeps a given area/topic (else the whole repo), findings are neutrally verified, each survivor becomes its own PR, and a per-PR review gauntlet (two fresh, context-isolated SATISFIED verdicts on the same PR content, reviewed one at a time over the whole diff) plus event-driven CI monitoring gate the merge. Multiple isolated runs (each keyed by a run-id, with a lease so only one agent drives each) can run concurrently in one repo. Drives its own loop via ScheduleWakeup — invoke once, no /loop wrapper. For a report with no changes, use gauntlet:review instead. Args: [--run id] [area or topic]
+---
+
+# Campaign
+
+Self-looping, reactive adversarial-review-to-merge pipeline.
+
+Codex is adversarial reviewer. Claude Code is orchestrator + implementer. Fixes fan out in
+parallel, but gates, CI watching, and merges stay centralized.
+
+Invoke once. This skill drives its own loop via `ScheduleWakeup`; do NOT wrap it in `/loop`.
+
+## Args
+
+`/gauntlet:campaign [--run <id>] [--new] [area or topic]`
+
+- Argument -> Codex reviews that area/topic.
+- No argument -> whole-repo adversarial sweep, or resume sole orphaned run.
+- `--run <id>` -> resume specific run; self-wakes also carry internal `--token`.
+- `--new` or "fresh run" -> force independent new run with carryover.
+- Do NOT ask user to confirm no-arg scope; no arg intentionally means whole repo.
+
+## Load Discipline
+
+Read references on demand. Do NOT load every reference up front.
+
+Always read before touching run state:
+
+- `references/run-identity-and-lease.md`
+- `references/files-and-ledger.md`
+
+Read `references/loop-control.md` at each wake before dispatch.
+
+Read stage refs only when that stage/action is due:
+
+| Situation | Read |
+|-----------|------|
+| Public API change, run-owned operation scope | `references/scope-and-constraints.md` |
+| Fresh run, carryover, pruning old findings | `references/carryover.md` |
+| Codex quota/auth/timeout/system error | `references/codex-fallback.md` |
+| Stage 0 sweep / neutral verification | `references/stage-0-review-and-verify.md` |
+| Implementing survivor fixes / opening PRs | `references/stage-1-fanout.md` |
+| PR review gauntlet / progress ledger | `references/stage-2-review-gate.md` |
+| Repeated sibling findings / shared root cause | `references/root-cause-pass.md` |
+| CI watch, check polling, CI fix | `references/stage-2-ci.md` |
+| Merge candidate / base refresh / cleanup | `references/stage-3-merge.md` |
+| Stuck task, abort, final report | `references/bailout-and-final-report.md` |
+| Rule lookup / uncertainty | `references/critical-rules.md` |
+
+## Core Invariants
+
+- **PR-first:** implement -> commit -> push -> open/update PR -> watch CI + review PR HEAD.
+- **Work-conserving:** every wake reconciles, folds completions, launches all due work up to caps,
+  drains still-ready PRs serially, then reschedules only when no useful action remains launchable.
+- **Driver never blocks:** sweeps, verifications, reviews, and CI watches run as background tasks —
+  completions are wakes. Stage 0 pipelines into fan-out (survivors fix while later shards sweep).
+  A pending-CI PR always has a live watch; a review doomed by a pending content change is stopped,
+  not awaited.
+- **Run isolation:** touch only this run's `<rundir>`, ledger, labels, branches, PRs, and worktrees.
+- **One active driver:** lease controls ownership; never double-drive one run.
+- **Base branch is data:** read `base_branch` from ledger every wake; never assume `main`.
+- **Two-review gate:** two fresh, context-isolated `SATISFIED` verdicts on same live PR content + green CI.
+- **Sequential same-PR reviews:** launch review 2 only after review 1 is `SATISFIED`.
+- **Progress ledger:** reviewer progress means planned unit `done` or accepted amendment, not vague
+  output.
+- **No green by watch exit:** derive CI from re-polled `gh pr checks` snapshot.
+- **Public API changes require user confirmation** unless ledger `api_changes: allowed`.
+
+## Wake Skeleton
+
+1. Resolve run + lease; adopt only absent/stale lease, stand down if fresh different owner.
+2. Reconcile state from git + GitHub; treat `state.md` as cache.
+3. Fold completed sweep/verification/review/CI/fix tasks.
+4. Launch all due work up to caps — sweep shards, verification chunks, fix fan-out, reviews, CI
+   watches/fixes, base refresh; stop in-flight reviews doomed by a content change.
+5. Merge ready PRs one at a time until no candidate remains immediately ready after base refresh.
+6. Update carryover/final state if terminal; otherwise refresh lease and schedule next wake.
+
+## Critical Rules
+
+- NEVER ask scope confirmation for no-arg invocation.
+- NEVER review unpublished local work.
+- NEVER spend review over open Copilot items, red checks, or conflicts.
+- NEVER pass destructive instructions to `codex exec`.
+- NEVER use `--dangerously-bypass-approvals-and-sandbox`; use `--sandbox workspace-write`.
+- NEVER force-push/reset/delete outside explicit stage procedure and run scope.
+- NEVER touch another run's PR/branch/worktree.
+- NEVER merge over red/pending CI or stale review verdicts.
+- NEVER add "Test plan" section to PR bodies.
+- NEVER commit run/scratch files (the whole `.gauntlet/**` tree) — they are
+  driver bookkeeping, not repo content. Stage only the specific source files a fix touches, by explicit
+  path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing).
+- NEVER `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable — the rest is carryover history.

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -1,0 +1,45 @@
+## Bailout
+
+- **1-hour cap per task** — one hour of wall-clock since `started` without merging. The cap catches a
+  *stuck* task, not a slow external system, and the ledger records no separately-metered work time — so
+  key it off recorded row state, not a running subtraction of durations nothing stores: **do not fire
+  the cap on a wake where the row is blocked on an external wait** — `status == awaiting-api` (parked
+  for user approval), or `ci == pending` for the current `head_sha` (CI still running). Only a wake
+  where `started` is over an hour old *and* the row is agent-controlled (not in either wait) trips it.
+  When it trips, abort cleanly and **retry once** from a fresh worktree (`attempts` += 1, reset
+  `started`). **Supersede the prior attempt's PR** — close it noting the supersession — so a stale
+  open PR doesn't linger; the retry opens its own.
+- On the **second** stuck/failure, abort permanently: stop work on that finding, **close its open PR
+  and remove its gate labels**, write `<rundir>/abort-<id>.md` with the full history (reviews, CI
+  failures, diffs, what blocked it), set status `aborted`, and **continue the other findings**. Only
+  ever touch this run's own PRs. **Terminal detection requires the closure**: loop control gates the
+  finished-run branch on "no open `fix-<run-id>-*` PR", and a PR-first pipeline almost always left one
+  open — an aborted row is terminal and lacks two SATISFIED verdicts, so reconcile will never merge or
+  keep driving it, but a dangling open PR would block terminal exit and heartbeat forever.
+- **Converging-but-expensively → escalate to the root-cause pass.** The bailouts above catch a *stuck*
+  task; this catches one that's *progressing by whack-a-mole*. A targeted per-finding fix is right for
+  the **first** `NOT SATISFIED` on a PR, or for genuinely independent findings. But on the **second**
+  `NOT SATISFIED` on the same PR, **stop targeted patching and run the §2a-deep root-cause pass** — map
+  the whole space with a dedicated read-only mapper and fix at one chokepoint. This is a hard backstop:
+  even if the archetype wasn't obvious on finding 1, the 2nd sibling finding forces the pass no later.
+
+Other stop conditions — escalate rather than loop: a worktree won't build, codex keeps returning the
+same unactionable verdict, or CI fails identically after a fix attempt.
+
+---
+
+## Final report
+
+When the loop exits, summarize:
+
+- **Merged** — finding id, PR number, one-line fix.
+- **Residual risk** — for each merged PR, both accepting SATISFIED passes' `RESIDUAL-RISK` lines (the
+  least-certain area each named), and a flag when the two name the same area. This is non-actionable,
+  non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
+- **Aborted** — finding id, why, pointer to `abort-<id>.md`.
+- **Skipped** — REFUTED findings, UNCERTAIN ones the user should triage, and any API-changing fix the
+  user was asked about and declined (with the change each would have needed).
+- Any worktrees left for inspection.
+
+The same outcomes are written to this run's durable carryover file
+(`.gauntlet/history/<run-id>.md`) on exit (Loop control step 5), so the next fresh run inherits them.

--- a/plugins/gauntlet/skills/campaign/references/carryover.md
+++ b/plugins/gauntlet/skills/campaign/references/carryover.md
@@ -1,0 +1,103 @@
+## Fresh runs and carryover
+
+A **fresh run** is a new Stage 0/1 cycle started when a prior run already happened — triggered either
+by the user answering "yes" to the finished-run prompt (Loop control step 1) or by an explicit
+`--new`. It is *not* a resume: it does a brand-new codex sweep. What makes it more than a blind
+re-run is **carryover** — it inherits what earlier runs already learned.
+
+### The carryover ledger — `.gauntlet/history/`
+
+A durable, git-ignored store (a sibling of `.gauntlet/tmp/`, NOT under it — scratch gets wiped, this
+must not). To stay
+concurrency-safe it is **one file per run**, `.gauntlet/history/<run-id>.md` — never a single
+shared file two runs could clobber. Each finished run writes **its own** file exactly once; a fresh
+run reads **every file in the directory** (concatenated) so knowledge compounds across runs. A per-run
+file records:
+
+- **merged** — finding slug + one-line fix, per PR that shipped.
+- **aborted** — finding slug + why it couldn't clear the bar (pointer to its `abort-<id>.md` if still
+  present).
+- **declined-api** — findings parked under `ask` that the user declined, with the change they'd have
+  needed.
+- **refuted** — findings the verification pass rejected as non-issues, with a one-line reason.
+- **uncertain** — findings left for the user to triage.
+
+If `.gauntlet/history/` doesn't exist, create it (and add `.gauntlet/` to the repo's
+`.gitignore` if it's not already ignored). When the directory is empty, a fresh run is just a normal
+first run.
+
+**Why per-run files.** Because each run only ever writes and prunes its **own** file, appends never
+contend and there is no shared-file rewrite to race — the append/prune hazard of a single `history.md`
+is gone. (A legacy single `history.md`, if present from before this split, is still read for carryover;
+leave it in place as read-only history.)
+
+### Pruning the ledger
+
+The ledger grows append-only during runs, so **prune it regularly** — at the start of every fresh
+run (right before feeding carryover into Stage 0), and any time the user asks. The goal is to drop
+entries that **no longer apply to the current code**, so stale context can't mislead the new sweep.
+Check each entry against current `<base>`:
+
+- **refuted / aborted / uncertain** whose cited `file:line` no longer exists, or whose code has
+  materially changed since — the finding as recorded can't still hold. A changed refuted/aborted site
+  should be *re-judged fresh* by the new sweep, not carried as a settled verdict, so drop the stale
+  entry.
+- **declined-api** whose referenced surface no longer exists, or that has since shipped — moot.
+- **merged** entries are historical record and cheap; keep them unless the user wants them condensed.
+
+**Confirm before deleting when unsure — this is the load-bearing rule.** Delete outright *only*
+entries that are unambiguously moot: the exact cited site is gone and there's nothing to re-judge.
+For anything you're not certain about — the site moved but the concern might still stand, an aborted
+finding you can't confirm was resolved, a declined-api you're unsure shipped — **do NOT delete it.
+List those candidates with why each looks stale and ask the user** which to remove. Never silently
+drop an entry you're uncertain about; a wrongly-pruned `refuted` re-opens a settled non-issue, and a
+wrongly-pruned `aborted` loses a real unfinished thread.
+
+**The question must not stall the run.** Keep every uncertain entry in place, feed carryover as-is,
+and launch Stage 0 immediately — surface the candidate list to the user in the same message and fold
+the answer in when it lands as its own wake (prune then; kept-by-default entries are only advisory
+verifier context, so starting without the answer costs nothing). Same principle as "never hold the
+run hostage on a user prompt" (Run lease).
+
+Note what was pruned (and what the user kept) so the decision is auditable on the next run.
+
+A run is distilled into the ledger **exactly once**, on its **normal exit** (all its PRs terminal) —
+Loop control step 5 writes that run's own `.gauntlet/history/<run-id>.md`. The finished-run
+"ask the user → yes" path reuses *that* file; it does not re-distill. (`--new` no longer pre-empts
+other runs — each run is isolated and always distills itself on its own exit — so there is no
+mid-flight snapshot path.)
+
+### Starting a fresh run
+
+1. **Mint the new run-id + agent token; atomically create its clean `<rundir>`.** Per-run dirs make a
+   fresh run isolated by construction — a bare `mkdir` (no `-p`) of `.gauntlet/tmp/<new-run-id>/`
+   starts empty and fails loudly on the rare id clash, so retry with a fresh id; there is nothing to
+   archive and no prior scratch to wipe. Write the
+   lease and a minimal `state.md` header immediately (so the run is discoverable before Stage 0
+   finishes). Any already-live run keeps its own dir, lease, and heartbeat; a fresh run never closes,
+   merges, or stops driving another run's PRs (abandoning a specific run is a separate explicit ask).
+2. **Read every file in `.gauntlet/history/`, then prune** (drop entries no longer applicable
+   to current `<base>`; uncertain deletions are asked about **without blocking** — keep the entries
+   and launch Stage 0 while the question is pending, see "Pruning the ledger"). Pruning only ever
+   edits **finished** runs' own files (no live writer), so there's nothing to race. Feed the pruned
+   carryover into Stage 0 (below).
+3. Proceed through Stage 0 → Stage 1 → the loop as normal, on the clean `<rundir>`.
+
+### How carryover shapes Stage 0
+
+- **Re-surface unresolved items.** Seed the verification pass with the prior **aborted**,
+  **declined-api**, and **uncertain** findings as priority candidates: if the new codex sweep
+  re-finds them (or they're still live in the code), they survive into the ledger ahead of net-new
+  findings rather than being silently forgotten. A declined-api finding stays parked under `ask`
+  unless the user has since OK'd it.
+- **Suppress known false-positives.** Give the neutral verifier the prior **refuted** set so it
+  doesn't re-litigate the same non-issues — a finding matching a prior refutation is dropped unless
+  the code at that site has since changed (in which case re-judge it fresh).
+- **Dedup already-merged fixes.** Give the verifier the prior **merged** set so it doesn't re-propose
+  work already shipped. (Usually moot — the merged fix changed the code — but it catches a sweep that
+  re-flags the same site from a different angle.)
+
+Carryover is advisory context for the verifier, never an auto-accept or auto-reject: every finding
+still goes through normal CONFIRMED/ADJUSTED/REFUTED/UNCERTAIN judgement.
+
+---

--- a/plugins/gauntlet/skills/campaign/references/codex-fallback.md
+++ b/plugins/gauntlet/skills/campaign/references/codex-fallback.md
@@ -1,0 +1,24 @@
+## Codex fallback — quota / system errors
+
+`codex exec` is the default reviewer, but it can fail in a way that yields **no usable verdict**:
+quota/rate-limit exhaustion, auth failures, timeouts, or other system errors. Distinguish this from a
+real review — a codex run that returns an actual finding list or a `VERDICT: …` line is a *result*,
+act on it. A *failure* is the absence of a verdict.
+
+When codex can't deliver a verdict, retry once. If it still can't, **do the equivalent work with your
+own subagents** rather than stalling, looping on codex, or skipping the gate — then note in the final
+report that the pass ran on the Claude-subagent fallback.
+
+- **Stage 0 (adversarial review)** → run the adversarial sweep with your own subagents: follow the
+  `gauntlet:review` skill over the same scope (tier/shard it for a large surface, as Stage 0
+  already describes), writing findings to that shard's `findings-raw-<shard>.md` in the same shape
+  codex would have. The streamed verification (Stage 0 step 2) is unchanged.
+- **Stage 2a (per-PR review)** → spawn a **fresh** subagent to review the whole `<base>...HEAD` diff
+  with an equally adversarial pass, using the same `review-<pr>-<n>.plan.jsonl` /
+  `review-<pr>-<n>.progress.jsonl` protocol — planned units, then the unstructured adversarial sweep —
+  and — on SATISFIED — the same
+  `RESIDUAL-RISK: <area> — <why>` line immediately above exactly one final `VERDICT: SATISFIED` /
+  `VERDICT: NOT SATISFIED` line. Each fallback pass is still a fresh, context-isolated re-roll in its
+  own subagent/context, so the two-SATISFIED-verdict gate holds exactly as it does with codex.
+
+This is a fallback for *system* failure, not a preference — use codex whenever it can actually run.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -1,0 +1,120 @@
+## Rules
+
+- Runs are isolated by `run_id`: a run touches ONLY its own `<rundir>`, its `state.md`, and PRs/branches
+  carrying its `gauntlet-run-<run-id>` label / `fix-<run-id>-` prefix. NEVER reconcile, review, fix,
+  merge, relabel, or clean up another run's work — scope every git/gh scan by that label or prefix.
+- One active driver per run, enforced by `<rundir>/lease.json` under an atomic `mkdir <rundir>/claim.lock`:
+  take/adopt a run only inside the claim lock, and adopt ONLY when its lease is absent or stale
+  (`now - updated` > ~30 min); refresh the lease every wake AND around long foreground ops; on a
+  self-wake whose lease is fresh but bears a different token, **stand down** — never double-drive a ledger.
+- Every self-wake carries `--run <run-id> --token <agent-token>` (ScheduleWakeup + background
+  completions); the token re-proves lease ownership so a summarized wake never mistakes its own run for
+  another's. Re-read `run_id` from the ledger each wake, never from memory.
+- Resume is intent-scoped: a fresh instance resumes via `--run <id>` or an **arg-less** bare invocation
+  (adopts the sole orphaned run). A **scoped** bare invocation and `--new` start an independent new run
+  and never pre-empt other live runs.
+- Carryover is **one file per run** under `.gauntlet/history/<run-id>.md`: a run writes and
+  prunes only its own file, so appends never contend and there's no shared-file rewrite to race.
+- Run-owned git/GitHub operations are authorized by invocation: `add`, `commit`, `push`, PR
+  create/update, labels/checks/comments, and merge. Ask only for public API changes, active-run
+  takeover, uncertain carryover pruning, or out-of-scope/destructive work.
+- NEVER commit the run's own bookkeeping — the whole `.gauntlet/**` tree: the `<rundir>` under
+  `.gauntlet/tmp/**` (ledger, plans, progress, review/CI outputs, lease) and the carryover tree
+  `.gauntlet/history/**`. A fix commit stages ONLY the specific source files it changes, by explicit
+  path — never `git add -A` / `git add .`, which would sweep in run state. The tree must be
+  git-ignored; add `.gauntlet/` to `.gitignore` if missing.
+- NEVER `rm -rf .gauntlet/` — that destroys the durable carryover history. Only `.gauntlet/tmp/**` is
+  disposable.
+- NEVER pass destructive instructions (delete, force-push, reset) to `codex exec`.
+- NEVER use `--dangerously-bypass-approvals-and-sandbox`; always `--sandbox workspace-write`.
+- One finding = one tightly-scoped PR. Do not bundle unrelated fixes.
+- PR-first loop is mandatory: implement → commit → push → create/update PR → watch CI + review PR
+  HEAD. NEVER do local gauntlet reviews first and wait to push/open a PR until the end.
+- Fan-out is a **rolling cap (~8 in flight), never a barrier wave**: backfill each freed slot with the
+  next `pending` finding immediately. Never let a draining group of findings stall the backlog —
+  Loop-control step 3 owns this refill for both initial fan-out and resume.
+- Work-conserving dispatch is mandatory: every wake scans all findings/PRs and launches every due
+  action that fits a free slot before returning. Waiting is allowed only when no useful action is
+  launchable anywhere in the run.
+- Stage 0 is **pipelined, never a blocking phase**: sweep shards and verification chunks run as
+  background tasks; each verification chunk's confirmed findings are deduped incrementally against
+  the run-wide survivor set and fanned out immediately. NEVER barrier on the full sweep or full
+  verification before starting fixes, and NEVER run a sweep as a blocking foreground call.
+- A pending-CI PR must ALWAYS have a live watch: if the CI snapshot reads pending and the watch task
+  has exited (including after any rebase/push), relaunch the watch in the same wake — never wait for
+  the heartbeat.
+- Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
+  copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
+  slot. Refill the slot with the next due review.
+- Reconcile from ONE batched `gh pr list --label gauntlet-run-<run-id> --json …` snapshot per wake
+  (`<rundir>/prs.json`); per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth
+  stays the re-polled `gh pr checks` snapshot.
+- Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, launch Stage 0
+  immediately, ask the user asynchronously, and fold the answer in as its own wake.
+- Public API surface/behavior changes need user confirmation by default (see Constraints). The
+  `api_changes` flag lives in the ledger header and is re-read every wake — never trust memory, never
+  auto-merge an unapproved API break.
+- Before queueing a review pass on a PR, clear its preconditions on the current tip: address any
+  GitHub Copilot review items (`/gauntlet:copilot-address-reviews <pr>`), fix any CI failures (one at a time,
+  prefer a scoped subagent), and rebase away any conflict with `<base>`. PR-content changes reset
+  verdicts. Clean base-only rebase with unchanged PR diff keeps `reviews_ok` and sets `ci = pending`.
+  Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
+- Reviews are fresh, context-isolated re-rolls: separate `codex exec` each pass, no shared context.
+  Two passes re-roll a stochastic reviewer to catch a missed defect — they are NOT statistically
+  independent (the same diff, task, and protocol correlate them; the normal codex path also shares
+  model/prompt), so the gate is a miss-catcher, not a proof of correctness.
+- Before each review, write an orchestrator-owned `review-<pr>-<n>.plan.jsonl`; reviewers append
+  `review-<pr>-<n>.progress.jsonl` events against planned units. Meaningful progress = planned unit
+  `done` or accepted plan amendment, not vague "still working" output. Stale meaningful progress →
+  suspicious review → retry/fallback per Stage 2a.
+- Reviewers do not own the plan but must not treat it as presumptively complete: critically evaluate
+  its coverage first, and raise any omitted dimension or materially wrong unit via a
+  `plan_amendment_request` event rather than silently reviewing only the listed units. Never rewrite
+  the plan or self-grant units (Stage 2a).
+- After finishing every planned unit, a pass runs a brief UNSTRUCTURED ADVERSARIAL SWEEP for defects
+  outside the plan's decomposition (cross-unit interactions, unstated assumptions, edge cases,
+  unenumerated categories). It complements — never replaces — the plan, reports only concrete
+  `file:line` defects at the normal finding bar (a real one → NOT SATISFIED), and treats "nothing
+  found" as a fine result; no speculative "might be fragile" notes (Stage 2a).
+- A SATISFIED verdict carries one `RESIDUAL-RISK: <area> — <why>` line (the least-certain part of the
+  diff). It is calibration metadata, never a finding: it never withholds the gate, never enters the fix
+  loop, and is never fed into the corroborating review. Do not manufacture a concern to fill it; a real
+  defect found while identifying it is a normal finding → NOT SATISFIED (Stage 2a).
+- One decision at N sites is the most common root cause. Trigger the §2a-deep root-cause pass on the
+  **first** "missing/wrong at site X" finding (its shape, not a round count), map the whole space with
+  a dedicated **read-only mapper** subagent — never one that also fixes, which under-maps toward what
+  it can reach — and fix at a **single chokepoint**. Hard backstop: a 2nd `NOT SATISFIED` on one PR
+  forces the pass (Bailout).
+- The two reviews on a PR run **sequentially, never queued together**: launch the first, wait for its
+  verdict, and launch the second **only if the first came back SATISFIED**. A NOT-SATISFIED first
+  review means a fix lands and the SHA changes, so a concurrently-queued second review would be burned
+  on a commit that's about to be replaced — wasted tokens. (Reviews for *different* PRs still run
+  concurrently; only the two for the same PR serialize. See Stage 2a.)
+- Verdicts are pinned to reviewed PR content: any PR-content change (review fix / CI fix /
+  conflict-resolving rebase / bot or manual PR-branch commit) makes prior verdicts stale. Base
+  advancement with no conflict and unchanged PR diff does NOT invalidate verdicts; carry `reviews_ok`
+  forward, update `head_sha`, and require fresh CI.
+- Resume vs. fresh run is decided by **liveness**, not by `state.md` existing: live work → resume
+  (no Stage 0/1); a finished prior run → ask the user before a fresh run; `--new` → fresh run with
+  carryover (Loop control step 1). A finished run must never silently exit "all fixed" or silently
+  restart.
+- A fresh run carries over prior knowledge from `.gauntlet/history/` (refuted to suppress,
+  unresolved to re-surface, merged to dedup) but still judges every finding fresh — carryover is
+  advisory, never auto-accept/reject.
+- Prune `.gauntlet/history/` at every fresh run: drop only entries unambiguously moot against
+  current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
+  prune an entry you're unsure about.
+- If `codex exec` can't deliver a verdict (quota/rate-limit, auth, timeout, or other system error —
+  *not* a real finding list / `VERDICT:` line), retry once, then do the equivalent work with your own
+  subagents: the Stage 0 adversarial sweep, or a fresh, context-isolated subagent pass in Stage 2a. The
+  gate is unchanged — note any fallback pass in the report. See "Codex fallback".
+- CI status comes from a re-polled `gh pr checks` snapshot with **zero fail AND zero pending lines** —
+  never from the `--watch` exit code (it can exit 0 on pending/unregistered checks). No green, no merge.
+- The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
+  be `main`** — it defaults to the branch checked out at invocation. PRs open with `--base <base>`,
+  worktrees branch off `<base>`, and reviews diff `<base>...HEAD`. Re-read it each wake (see "Base
+  branch").
+- After every merge, fast-forward local `<base>` to `origin/<base>` (Stage 3 step 4) so subsequent
+  fan-out worktrees and `<base>...HEAD` diffs branch off the just-merged tip, not a stale base. If the
+  fast-forward fails, bail out — never force it.
+- No "Test plan" section in PR bodies.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -1,0 +1,81 @@
+## File locations
+
+Everything under the run's own dir `<rundir>` = `.gauntlet/tmp/<run-id>/` (create at the start
+of a fresh run; on resume, reuse the run's existing dir). Per-run dirs are what keep concurrent runs'
+files from colliding — see "Run identity and concurrency".
+
+| File (under `<rundir>`) | Contents |
+|------|----------|
+| `findings-raw-<shard>.md` | Codex's raw adversarial findings, one file per sweep shard (single-shard runs have one) |
+| `verdicts-<chunk>.md` | Neutral verification verdicts per chunk (which findings survive) |
+| `state.md` | Live per-finding ledger — a **cache/hint**, not the source of truth (see below) |
+| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input (Loop control) |
+| `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
+| `review-<pr>-<n>.txt` | Codex's PR review output, round `n` |
+| `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` |
+| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` |
+| `ci-<pr>.txt` | Latest `gh pr checks` snapshot for a PR (re-polled after the watch, not the watch stream) |
+| `abort-<id>.md` | Detailed log for an aborted finding-task |
+
+Store ALL codex and `gh` output under `<rundir>` first, then Read/Grep it. NEVER `/tmp/`.
+
+All of this is driver bookkeeping, **never repo content — do NOT commit it**: the whole `.gauntlet/`
+tree stays git-ignored, and a fix commit stages only the specific source files it changes (explicit
+paths, never `git add -A`/`.`).
+
+**Durable cross-run knowledge lives outside `.gauntlet/tmp/`.** The plugin owns one directory at the
+repo root, `.gauntlet/` (git-ignored; add `.gauntlet/` to `.gitignore` if missing), split by lifetime:
+
+| Path | Lifetime |
+|------|----------|
+| `.gauntlet/tmp/<run-id>/` | Ephemeral. Safe to wipe once a run reaches a terminal state. |
+| `.gauntlet/history/<run-id>.md` | Durable. The carryover ledger — the one thing a *new* run needs to remember from old ones. |
+
+**Only `.gauntlet/tmp/` is disposable — never `rm -rf .gauntlet/` itself.** That would take the
+carryover history with it. Scratch cleanup targets `.gauntlet/tmp/**` and nothing above it.
+
+The history tree keeps **one file per run** (`<run-id>.md`) so concurrent runs never clobber a shared
+file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh runs and carryover".
+
+### The ledger — `state.md`
+
+One row per surviving finding. It is a **cache**, not the authoritative state — **ground truth is
+git + GitHub** (`gh pr list/view` for PRs and merged/open state, `git rev-parse HEAD` per branch for
+the live SHA, `gh pr checks` for live CI, and the `review-<pr>-<n>.txt` files for which verdicts
+exist on which SHA). Every wake re-derives what's due from those, then refreshes this file. So a
+stale or half-written ledger is self-healing — never act on it without reconciling against git/gh
+first.
+
+The file opens with a short run-config header (`run_id`, `base_branch`, `api_changes`, `phase` —
+re-read every wake, see Constraints and "Run identity and concurrency"), then one row per finding:
+
+```
+run_id: g260704-0915-a3f29c1b  # this run's identity — namespaces its dir/branches/label/wakes (set once)
+base_branch: main       # the branch PRs target & diffs measure against (set once; see "Base branch")
+api_changes: ask        # ask | allowed (run-wide; set once from the invocation)
+phase: fanout           # reviewing (Stage 0) → fanout (Stage 1+); written at run start before Stage 0
+
+id | slug | branch | worktree | pr | head_sha | reviews_ok | ci | attempts | started | api_approval | status
+```
+
+- `head_sha` — the branch tip (`git rev-parse HEAD`) that `reviews_ok` and `ci` describe. `ci` is
+  pinned to this exact SHA. `reviews_ok` is pinned to this SHA **unless** the only change is a clean
+  base-only rebase/merge with the PR diff unchanged; then carry `reviews_ok` forward to the new
+  `head_sha` and set `ci = pending`.
+- `reviews_ok` — number of fresh, context-isolated SATISFIED verdicts recorded against this PR's
+  current content (need 2).
+- `ci` — `green` / `red` / `pending` / `none` for `head_sha`.
+- `attempts` — task attempts so far (for the retry-once bailout).
+- `started` — wall-clock start of the current attempt (for the 1-hour cap).
+- `api_approval` — durable record of the user's decision on this finding's API-changing fix: `-`
+  (not an API change, or not yet decided) | `approved@<iso>` | `declined@<iso>`. Written the moment
+  the user answers, so a later wake — or a fresh agent that adopted the run — reads it and never
+  re-asks about a finding already decided. It records the decision (an input); `status` stays the
+  live position, so the two never contradict: `approved` pairs with the finding back in normal
+  fanout, `declined` with a terminal `aborted`. A one-off approval lands here only; it never flips
+  the run-wide `api_changes` header.
+- `status` — `pending` → `in_review` → `mergeable` → `merged`, or `aborted`; plus `awaiting-api`
+  while parked for the user to approve an API-changing fix. That park resolves via `api_approval`:
+  `approved` returns the finding to the normal flow, `declined` makes it `aborted` (terminal).
+
+---

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -1,0 +1,141 @@
+## Loop control
+
+The skill is **event-driven**. Wakes come from three sources, all handled identically: the first
+invocation, a `ScheduleWakeup` firing (heartbeat fallback), and a **background task completing** — a
+sweep shard, a verification chunk, a CI watch, *or* a review. All long work runs as background tasks,
+so the driver never blocks; each completion is its own wake.
+
+**Every wake — reconcile, dispatch, reschedule:**
+
+1. **Resolve the run + lease, then init / resume / start fresh.** First bind **which run this wake is
+   for** and confirm you may drive it, per "Run identity and concurrency": a `--run <id>` self-wake
+   presents its `--token` and, under the run's claim lock, continues if the token matches the lease,
+   adopts if the lease is absent/stale, or **stands down** if a fresh lease bears a different token; a
+   **scoped** bare invocation starts a NEW run, while an **arg-less** bare invocation discovers runs
+   and adopts the sole **orphaned** one (asks among several, refuses to hijack an actively-driven one).
+   This claim-locked lease check is what guarantees **no two agents drive one ledger**.
+
+   Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.md`
+   exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label / `fix-<run-id>-`
+   branch prefix so another run's PRs are never mistaken for your own. Live work (this run) = any open
+   PR carrying this run's label / on a `fix-<run-id>-` branch, **OR** any non-terminal row in this run's
+   `state.md` (`pending` / `in_review` / `mergeable` / `awaiting-api`), **OR** a non-terminal `state.md`
+   still in `phase: reviewing` — the Stage 0 pipeline is sweeping/verifying and may have zero rows yet
+   (a resume re-launches any shard/verification whose output file is missing, since in-flight tasks die
+   with their session). Three cases:
+
+   - **This run has live work → resume.** **Reconcile against ground truth** (do NOT redo *completed*
+     Stage 0/1 work — re-launch only Stage 0 tasks whose output files are missing):
+     for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
+     the ledger. Do the PR scan as **one batched snapshot per wake** —
+     `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
+     — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
+     isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
+     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, and `api_changes` from the ledger header — they
+     govern namespacing, the merge/diff target, and API-change handling, and must be consulted fresh
+     each wake, never from memory (a wake may be a fresh agent instance that just adopted the run;
+     Constraints, Base branch). Refresh the lease. This is the path every `--run` self-wake takes.
+   - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
+     Mint a run-id + agent token, atomically create `<rundir>`, write the lease **and a minimal
+     `state.md` header** (`run_id`/`base_branch`/`api_changes`, `phase: reviewing`) *before* Stage 0 —
+     so a death mid-sweep leaves a discoverable, adoptable run rather than an invisible one — then
+     launch Stage 0's sweep shard(s) as background tasks and fall through to dispatch/reschedule.
+     Stage 1 fan-out starts as survivors confirm, not after Stage 0 completes (Stage 0 is pipelined).
+   - **This run's `state.md` is fully terminal — every row `merged`/`aborted`, no open `fix-<run-id>-*`
+     PR → the run is finished.** Do **not** silently exit "all fixed" (the old bug) and do **not**
+     silently restart. **Ask the user** whether to start a new run — e.g. "gauntlet run
+     <run-id> finished (N merged, M aborted). Start a new run?" On yes, start a fresh run **with
+     carryover** (see "Fresh runs and carryover"). On no, emit that run's final report and stop. This
+     prompt is the *only* wake that asks the user about scope.
+
+   **The `--new` fresh-run signal short-circuits the above:** `--new` (or "fresh run" / "start over")
+   mints a NEW run-id + token and starts a fresh run with carryover immediately, regardless of any
+   run's liveness — no prompt, and **other live runs are left untouched** (they keep running under
+   their own drivers). Its scope is the arg, if any.
+
+   **Reconcile labels too** (idempotent, retroactive, **scoped to this run**). Ensure the labels exist
+   (`gh label create … --force`, as in Stage 1 — including this run's `gauntlet-run-<run-id>`), then
+   for every PR **of this run** (its label, or on a `fix-<run-id>-` branch): ensure it carries
+   `gauntlet-run-<run-id>`, and set its status label to match its **live** gate state —
+   `gauntlet-accepted` if its current HEAD holds two SATISFIED verdicts, else `gauntlet-reviewing`;
+   add the status label if it has none. **Never touch another run's PRs.**
+2. **Fold in completions.** For any background task that finished (sweep shard →
+   `findings-raw-<shard>.md` and verification chunk → `verdicts-<chunk>.md`, acted on per Stage 0;
+   CI watch → `ci-<pr>.txt`; review → `review-<pr>-<n>.txt`, with `review-<pr>-<n>.progress.jsonl` as
+   its liveness evidence), record the result against the SHA it ran on and act per Stage 0/2.
+3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,
+   not just the PR/job that woke you. Launch every due action that fits a free slot before returning.
+   Launch only what is actually due *and not already in flight* (check ground truth first, never the
+   ledger alone). This owns **both** the initial fan-out and all downstream work — there is no
+   separate batched fan-out phase:
+   - any Stage 0 sweep shard not yet launched → launch it as a background codex task; any folded
+     shard whose verification isn't dispatched → launch its verification chunks (Stage 0). Survivors
+     confirmed and deduped this wake become `pending` rows and fan out **this same wake** — Stage 0
+     and Stage 1+ overlap by design.
+   - any `pending` finding with no PR yet, while fewer than ~8 fix subagents are in flight → launch
+     its fix subagent (Stage 1). This **backfills continuously**: as each fix subagent finishes and a
+     slot frees, pull the next `pending` finding in — never wait for a whole group to drain before
+     starting more.
+   - current tip has < 2 SATISFIED verdicts, its **review preconditions are clear** (no unaddressed
+     Copilot review items, CI not red, no merge conflict with `<base>` — see Stage 2a preconditions),
+     and no review running for that SHA → launch **one** review pass as a **background** task (one at
+     a time per PR — the second only after the first is SATISFIED; Stage 2a). If a precondition is
+     dirty, clear it first (address Copilot items / fix CI / rebase) instead of spending a review;
+   - CI red and no CI-fix subagent is already in flight for that PR/SHA → dispatch a scoped fix
+     subagent (Stage 2b); different PRs may fix CI concurrently within the cap.
+   - CI snapshot reads `pending` for a PR whose watch task has already exited → **relaunch the watch
+     in this same wake**. A pending PR must never sit unwatched until the heartbeat; the heartbeat is
+     a fallback, not the mechanism.
+   - about to dispatch content-changing work on a PR (review fix, CI fix, copilot-address,
+     conflict-resolving rebase) while a review is in flight on that PR → **stop that review task
+     first** (its verdict can only describe a SHA the fix is about to replace); the freed slot goes
+     to the next due review.
+   - mergeable → queue for serialized merge drain.
+   Treat ~8 as a **rolling concurrency cap**, not a wave size: keep up to ~8 fix subagents and ~8
+   review processes in flight, refilling each free slot immediately; queue the rest. **Launch, do not
+   wait — never barrier on a group of findings before dispatching the next.**
+   Allowed idle state is narrow and explicit: no sweep shard or verification chunk is dispatchable,
+   no pending finding can launch, no PR can start a review, no CI/precondition fix is due, no exited
+   watch needs relaunching, no PR is mergeable, and every remaining wait is external (background
+   sweep/verification/review/CI), user/API approval, or a genuinely full cap.
+4. **Merge** queued PRs as a serialized drain: re-confirm one candidate against the live SHA, merge
+   it, sync `<base>`, reconcile remaining candidates, and repeat while another PR is immediately
+   mergeable (Stage 3).
+5. **Reschedule or exit.**
+   - Any sweep shard or verification chunk still running, or any non-terminal finding/PR remains →
+     refresh this run's lease, then set a `ScheduleWakeup` heartbeat
+     (`prompt: "/gauntlet:campaign --run <run-id> --token <agent-token> <args>"` — `--run` rebinds the
+     wake to this run and `--token` re-proves ownership of its lease; delay ~3–4 min, cache-warm) as a
+     fallback; background completions will usually wake you sooner. Return.
+   - All this run's PRs `merged` or `aborted` → **distill the run into the carryover ledger** (write
+     this run's block to its own file `.gauntlet/history/<run-id>.md` — merged fixes, aborted
+     findings + why, declined-API findings, and the REFUTED/UNCERTAIN sets; per-run files never
+     contend, see "Fresh runs and carryover"), **release the run** (delete this run's
+     `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, and delete
+     `<rundir>/lease.json`; the shared status labels stay), emit the final report, and **do not
+     reschedule**. This run's loop ends. **Leave
+     `<rundir>` in place** (do NOT delete it here) — its terminal `state.md` is what lets a later bare
+     invocation detect *this* *finished* run and take the "ask the user" branch in step 1 instead of a
+     silent exit. (A stale heartbeat firing after exit harmlessly re-hits the finished-run branch via
+     its `--run <run-id>`; with the lease released it reads as an un-driven finished run.)
+
+**Idempotency is the load-bearing property.** Because every wake re-derives from git/gh and launches
+only work not already in flight, a relaunch after a killed session — or two completions landing close
+together — cannot corrupt state or act on a stale verdict (PR-content pinning rejects stale verdicts
+at the gate). The worst case is a wasted duplicate review, which is harmless: it's just another fresh,
+context-isolated re-roll anyway. The agent is also single-threaded per turn, so wake *decisions* never truly race — only
+in-flight tasks do.
+
+**Resume after a killed session — including by a different agent instance:** in-flight background
+tasks die with the session, but nothing authoritative is lost. A new invocation reconciles against
+git/gh and continues — completed work is never redone (existing PRs/branches, landed
+`findings-raw-<shard>.md` / `verdicts-<chunk>.md`); only Stage 0 tasks whose output files are missing
+re-launch. It binds to the run via
+`--run <id>` (what every self-wake carries, so a fresh instance adopting an orphaned run's heartbeat
+just works) or, for a bare re-invocation, by discovering live runs and adopting the sole **orphaned**
+one (asking among several). Adoption is gated on the **run lease**: an agent takes over only a run
+whose lease is absent or stale, so it can always tell whether another agent is still driving that
+ledger and never double-drives an actively-held run (see "Run identity and concurrency" and Loop
+control step 1). This is how a later agent picks up exactly where a previous instance left off.
+
+---

--- a/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
@@ -1,0 +1,53 @@
+### 2a-deep. Root-cause pass — one decision made at N sites
+
+**The archetype — recognize it on sight.** The most common root cause behind a run of review findings
+is **one decision duplicated at N independent sites**: the same error-classification across every
+loader + caller, the same notation/resolution across every code path, the same attribute-value
+handling per read-site. Each site is a sibling in a finite space the code must cover **identically**.
+The fix is almost never per-site — it is a **single chokepoint every site routes through**, and the
+enumeration's whole job is to find **all N sites, including the ones no reviewer has hit yet**. Treat
+each review finding as a *symptom of the shared decision*, not a new problem.
+
+**Trigger on the finding's SHAPE, not on a round count.** Fire this the moment the **first** finding
+takes the form "this check / resolution / classification is missing (or wrong) at site X" — i.e. a
+decision applied independently at more than one site. Do **NOT** wait for the reviewer to surface
+sites 2..N over successive rounds — that is the reviewer mapping *your* space for you, one expensive
+review at a time. One such finding is enough to suspect the archetype and map the whole space now. (A
+string of `NOT SATISFIED` findings that are siblings in one structured space — same function/concept,
+different instance — is the same signal arriving late; treat it identically, and see the Bailout
+escalation rung, which forces this pass no later than the 2nd `NOT SATISFIED` on a PR.)
+
+**Enumeration is a SEPARATE read-only pass — NEVER folded into a fix.**
+
+1. **Name the space and its axes.** What is the finite set every site must cover identically, and what
+   are its axes? (The set of cases/inputs/states a function must handle; a `{variant} × {code-path}`
+   grid; both directions of a round-trip or other symmetric relation; every call site of one operation
+   that must behave the same.) The axes are domain-specific — derive them from the finding, don't
+   assume a fixed shape.
+2. **Dispatch a dedicated MAPPER subagent whose SOLE deliverable is the map** — read-only, in a
+   *fresh* worktree at the PR tip (NOT the fix worktree). It enumerates every cell, marks each
+   `HANDLED` / `GAP` / `N-A` with a one-line why, and returns **the complete cell table + a
+   one-sentence root-cause statement** — each gap with `file:line` + a minimal repro confirmed by a
+   throwaway test (deleted before it reports). Emit the table literally.
+
+   **NEVER ask one subagent to both enumerate and fix.** A fixer under-maps toward what it can reach:
+   it finds the sites next to its diff and misses the caller two layers up or the code path it has no
+   handle on. A mapper carries no fix pressure, so it maps the space exhaustively — which is the point.
+   Enumeration and fix are two subagents, in that order, always.
+3. **One batch-fix round** for all confirmed gaps. Route every site through **ONE shared
+   chokepoint/helper** so the cells can't diverge again. Add a test per cell.
+4. **Resume the gauntlet** (two fresh, context-isolated SATISFIED) on the batched result.
+
+Caveats:
+
+- A cell's verdict can be **wrong** — the analysis is a hypothesis (e.g. "handled by X" when X doesn't
+  actually cover it). The adversarial gauntlet still arbitrates; the deep pass *accelerates*
+  convergence, it does NOT replace the gate. Re-feed any reviewer-found gap into the enumeration.
+- Completeness = no false-positive AND no false-negative across the space. The pass surfaces both: an
+  over-strict path that rejects valid cells is as much a gap as a missing one.
+- A whole AXIS can be missed. When a later finding reveals a dimension the enumeration didn't have,
+  RE-RUN it on the expanded space rather than patching the single new cell.
+
+Pairs with the **Codex fallback** subagents, and — when the user authorizes the spend for a large PR
+— a **parallel adversarial reviewer** running the same enumeration independently for breadth while
+codex runs the gate; reviewer diversity catches different cells.

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -1,0 +1,124 @@
+## Base branch
+
+The run targets a **base branch** — the branch every PR merges into and every fix diff is measured
+against. It is **not assumed to be `main`**: it defaults to the branch checked out at invocation
+(`git rev-parse --abbrev-ref HEAD`; fall back to the repo's default branch if HEAD is detached), which
+may be a release or integration branch. Resolve it **once** at the start of a run and record it in the
+ledger header as `base_branch`; re-read it from the ledger every wake, never from memory (a run is
+long and the checked-out branch can drift).
+
+Throughout this doc, `<base>` means that branch and `origin/<base>` its remote-tracking branch.
+Concretely: fix worktrees branch off `<base>`, PRs open with `--base <base>`, every review diffs
+`<base>...HEAD`, carryover entries are re-judged against current `<base>`, and after each merge local
+`<base>` is fast-forwarded to `origin/<base>`. Where examples below show `main`, read it as `<base>` —
+`main` is only the common default.
+
+## Run identity and concurrency
+
+Multiple gauntlet runs can execute concurrently in one repo, and a new agent instance can pick
+up a run a prior instance left mid-flight — but **never two agents driving the same ledger at once**
+(that is the bug this guards against). Two mechanisms: a **run ID** that namespaces everything a run
+owns, and a **run lease** that marks whether an agent is actively driving that run right now.
+
+### Run ID — namespacing
+
+Minted once at the start of a fresh run — compact, filesystem- and label-safe. Create the run dir
+**atomically** (`mkdir` fails if it already exists) so a run-id collision can't silently share a dir;
+retry with a fresh id on the rare clash:
+
+```
+run_id="g$(date +%y%m%d-%H%M)-$(openssl rand -hex 4)"   # e.g. g260704-0915-a3f29c1b (32 bits entropy)
+mkdir -p "$PROJECT/.gauntlet/tmp"                    # parent only; -p is safe here
+mkdir "$PROJECT/.gauntlet/tmp/$run_id" || run_id=…   # NO -p: must fail on collision
+```
+
+The run dir's `mkdir` carries **no `-p`** on purpose — it must fail if the id is already taken. Create
+the `.gauntlet/tmp` parent in its own `-p` call, never by `-p`-ing the run dir itself.
+
+Record it in the ledger header (`run_id:`) and re-read it every wake (like `base_branch`); never trust
+in-context memory for it — a wake may be a fresh agent instance. It flows into:
+
+| Owned by the run | Namespaced form |
+|------------------|-----------------|
+| tmp working dir  | `<rundir>` = `.gauntlet/tmp/<run-id>/` (all findings/verdicts/state/review/ci/abort/lease files) |
+| ledger header    | `run_id: <run-id>` |
+| fix branch       | `fix-<run-id>-<finding-id>-<slug>` (finding-id keeps same-slug findings from colliding) |
+| worktree         | `$PROJECT/.worktrees/fix-<run-id>-<finding-id>-<slug>` |
+| PR owner label   | `gauntlet-run-<run-id>` (every PR the run opens carries it; authoritative "mine" marker) |
+| self-wake prompt | `/gauntlet:campaign --run <run-id> --token <agent-token> <args>` (carries the id **and** the driver token so a summarized wake re-proves ownership without guessing) |
+
+**Isolation invariant — a run touches ONLY its own work.** It reads/writes only its `<rundir>`, only
+its `state.md`, only PRs carrying its `gauntlet-run-<run-id>` label (equivalently on a `fix-<run-id>-`
+branch), and only those worktrees/branches. It MUST NOT reconcile, relabel, review, fix, merge, or
+clean up another run's PRs/branches — **every git/gh scan is filtered to this run's label or branch
+prefix.** The status labels `gauntlet-reviewing` / `gauntlet-accepted` describe gate state and are
+shared across runs; ownership is the per-run label, never a status label.
+
+**Shared across runs:** the carryover ledger tree `.gauntlet/history/` (kept race-free by one
+file per run — see "Fresh runs and carryover"), the two status labels, and the Copilot precondition's
+scratch file `.gauntlet/tmp/copilot-review-items.json` (written by `/gauntlet:copilot-address-reviews`) — treat that
+last one as ephemeral to a single fetch→address cycle and re-fetch rather than trusting a stale
+snapshot another run may have overwritten.
+
+### Run lease — one active driver at a time
+
+Namespacing keeps two *runs* apart; the **lease** keeps two *agents* from driving the **same** run.
+Each run has `<rundir>/lease.json`:
+
+```
+{ "agent": "<token>", "updated": <unix-ts> }   # token = the agent holding the run; ts = last heartbeat
+```
+
+- **Mint** an agent token (`openssl rand -hex 4`) when you first take a run — at fresh-run start or on
+  adoption — keep it in context, **and put it in your self-wake prompt** (`--token <tok>`) so a
+  summarized/amnesiac wake recovers it from the prompt instead of guessing. **You own the run iff the
+  token you present (prompt `--token`, else in-context) equals the lease's `agent`.**
+- **Claim atomically.** Taking or adopting a run is a check-and-set that MUST be serialized against
+  other agents: acquire an atomic lock first — `mkdir <rundir>/claim.lock` (fails if held) — then read
+  the lease, decide, write your token + fresh `updated`, and `rmdir` the lock. Two agents racing to
+  adopt can't both win because only one `mkdir` succeeds. (A crashed claim leaves a stale
+  `claim.lock`; treat one whose mtime is older than a few minutes as abandoned and clear it.)
+- **Heartbeat.** Rewrite the lease with `updated = $(date +%s)` every wake once you're the confirmed
+  owner, **and** immediately before and after any long *foreground* step, should one be unavoidable,
+  so a busy turn still looks alive. All long work — sweep shards, verification chunks, reviews, CI —
+  is backgrounded, so turns stay short and the per-wake refresh normally suffices. A lease is
+  **stale** only once `now - updated` exceeds **~30 min** — comfortably longer than any single
+  foreground operation, so liveness flags a *dead* driver, not a busy one.
+- **Never hold the run hostage on a user prompt.** Do NOT block the loop waiting on a user answer —
+  that freezes the heartbeat and could let the run be declared stale mid-drive. Park the finding
+  `awaiting-api`, surface the question, keep driving the other findings, reschedule, and fold the
+  answer in when it lands as its own wake (Constraints).
+- **Adopt only an orphaned run.** Safe to take over only when the lease is **absent or stale** (under
+  the claim lock). After writing your token, re-read: if it isn't yours, you lost the race — stand down.
+- **Stand down if superseded.** On a self-wake, present your `--token`: if the lease is **fresh** and
+  its `agent` is a **different** token, you were superseded (a takeover while you were hung) — do NOT
+  drive; report and stop. Never overwrite a fresh lease you don't own. (Carrying the token in the
+  prompt removes any amnesia ambiguity — a self-wake always knows its own token.)
+- **Release** on normal exit: delete `lease.json` (with the owner label) so the finished run shows no
+  active driver.
+
+### Resolving a wake (Loop control step 1 applies this)
+
+1. **`--run <id>` given** (every self-wake; also a manual targeted resume). Load `<rundir>/state.md`.
+   Under the claim lock, compare the token you present to the lease: **matches** (self-wake with
+   `--token`) → refresh lease, reconcile, continue; **lease absent/stale** → adopt (write token, fresh
+   ts, read-back); **lease fresh but a different token** → for a self-wake, stand down (superseded);
+   for a **manual** `--run` with no matching token, another agent appears active, so **confirm takeover
+   with the user** before adopting.
+2. **Bare invocation** → the arg decides intent:
+   - **A scope arg is given** (`/gauntlet:campaign <area>`, no `--run`) → **start a NEW run** on that
+     scope. A scope is an explicit "sweep this now", so it never silently adopts an existing run — this
+     is how you launch a second concurrent run (`auth` alongside `storage`). To resume a specific run
+     instead, pass `--run <id>`.
+   - **No arg at all** (`/gauntlet:campaign`) → resume-oriented: **discover runs** and bucket by lease —
+     distinct `gauntlet-run-*` labels on open `fix-*` PRs ∪ run-ids with a `<rundir>/` (its `state.md`
+     or `lease.json`; a run mid-Stage-0 has a dir before any PR), each **actively-driven** (fresh
+     lease), **orphaned** (non-terminal, lease absent/stale), or **finished** (terminal, no open PR):
+     - exactly one **orphaned** → adopt and resume it ("pick up where the previous instance left off");
+     - several orphaned → list them (id, scope, #open PRs) and **ask which to resume, or start new**;
+     - only **actively-driven** → each has a live driver; do NOT hijack — offer to start a **new** run;
+     - only **finished** → the finished-run prompt (Loop control step 1), per run;
+     - none at all → first run: mint a run-id, Stage 0 → Stage 1.
+3. **`--new`** (or "fresh run" / "start over") → always mint a NEW run-id + token and start fresh with
+   carryover; it creates an independent run and does **not** pre-empt other runs (they keep their own
+   drivers). Scope is the arg, if any.

--- a/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
+++ b/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
@@ -1,0 +1,43 @@
+## Run-owned operation scope
+
+Invoking this skill authorizes the git/GitHub operations it performs on branches/PRs it creates:
+`add`, `commit`, `push`, PR create/update, labels/checks/comments, and merge.
+
+Do NOT ask again before run-owned operations when the state machine reaches them.
+
+Scope does NOT cover unrelated branches/PRs, destructive git operations, force-push/reset, or
+cross-run work. Worktree removal still goes through merged-branch verification in Stage 3.
+
+## Constraints
+
+**Public API changes require user confirmation — on by default.** A fix may not modify the project's
+public API *surface or its observable behavior* without the user's say-so:
+
+- *Surface* — exported functions, types, and methods and their signatures; public constants/enums;
+  serialized formats and wire/HTTP contracts; CLI flags; config keys.
+- *Behavior* — the observable contract of the above (return/error semantics, defaults, output shape)
+  even when the signature is unchanged.
+
+Internal-only changes that leave both identical need no confirmation.
+
+Handling depends on the run's `api_changes` flag, stored in the ledger header:
+
+- **`ask` (default)** — when a fix would cross the line, do NOT make the change. Park that finding
+  (status `awaiting-api`, `api_approval: -`), show the user the proposed change and what it would
+  break, and ask whether to proceed. Keep working the other findings meanwhile. On approval, apply it
+  and set `api_approval: approved@<iso>` (the finding resumes normal fanout); if the user declines,
+  set `api_approval: declined@<iso>`, set the finding aside as skipped (status `aborted`), and report
+  it. Both decisions are durable: before re-asking on a later wake, check `api_approval` — a finding
+  already approved or declined is settled, never re-ask it.
+- **`allowed`** — proceed without asking. Set this *only* when the user, at invocation, explicitly
+  said API breakage is acceptable (e.g. "allow API changes" / "ignore breakage").
+
+**Store the flag in the ledger and re-consult it every wake.** Derive `api_changes: ask|allowed` once
+from the invocation and record it in the ledger header. A run is long, so NEVER trust in-context
+memory for this — re-read the flag from the ledger before any API-affecting change, so the behavior
+can't drift mid-run. A blanket "yes, stop asking" from the user flips the header to `allowed`; a
+one-off "yes" approves only that finding (recorded durably in its `api_approval`) and leaves the
+flag at `ask`.
+
+Backstop: when you scan a PR you built, flag any public-API change in its diff. Under `ask`, an
+unapproved API change must not merge — revert it or get approval first (grounds for `NOT SATISFIED`).

--- a/plugins/gauntlet/skills/campaign/references/stage-0-review-and-verify.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-0-review-and-verify.md
@@ -1,0 +1,72 @@
+## Stage 0 — Review and verify (pipelined, non-blocking)
+
+Stage 0 is a **pipeline of background tasks**, not a serial phase the driver waits out. Sweep shards,
+verification chunks, and fan-out overlap: each completion is a wake, and a confirmed survivor starts
+its fix while later shards are still sweeping. The dispatcher (Loop control step 3) owns every launch
+below — never barrier on the full sweep or full verification before starting downstream work.
+
+1. **Launch the codex adversarial sweep as background task(s).** Scope = the arg if given, else the
+   whole repo.
+
+   ```
+   # run in background — the driver never blocks on a sweep
+   codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -o <rundir>/findings-raw-<shard>.md \
+     "Perform an adversarial code review of <SHARD SCOPE>. For each finding give: a stable ID, \
+      severity, file:line, the defect, a concrete reproduction trigger, the impact, and a \
+      concrete fix. Be hostile — surface everything that could be wrong. Do not edit code."
+   ```
+
+   - **Small/scoped surface** → a single shard.
+   - **Whole-repo or large surface** → split into shards by area, mirroring the tiering strategy in
+     the `gauntlet:review` skill, and launch them concurrently within the dispatcher cap. Shards
+     also keep each codex call short relative to the ~30-min lease-stale window (see "Run lease");
+     the driver heartbeats on every wake between completions.
+
+   Backgrounding, not sharding, is what keeps the driver free: even a single-shard sweep runs in
+   background while the driver heartbeats, dispatches anything else due, reschedules, and folds the
+   shard's findings when its completion wakes it.
+
+   If a shard can't produce findings (quota/rate-limit, auth, timeout, hang, or other system error —
+   see "Codex fallback"), retry that shard once, then run it with your own subagents into the same
+   `findings-raw-<shard>.md` and continue.
+
+   **On a fresh run, load carryover first** (all of `.gauntlet/history/`, pruned of stale
+   entries per "Pruning the ledger" — pruning never blocks the sweep launch) and pass the prior
+   unresolved items (aborted / declined-api / uncertain) to the reviewer as known areas of interest,
+   so a re-find is recognized rather than treated as net-new. See "Fresh runs and carryover".
+
+2. **Verify per shard, as findings land.** The moment a shard's `findings-raw-<shard>.md` is folded
+   in, dispatch its neutral verification — do NOT wait for other shards. Audit each finding with the
+   `gauntlet:review` Phase 2 scheme — `CONFIRMED` / `ADJUSTED` / `REFUTED` / `UNCERTAIN`, biased
+   toward refuting — into `<rundir>/verdicts-<chunk>.md`. Scale by the shard's finding count:
+   - **≤ 10 findings** → one fresh `Explore` subagent audits the shard's whole set.
+   - **> 10 findings** → chunks of 5–8, one `Explore` subagent per chunk in parallel, each auditing
+     only its assigned IDs.
+
+   Only **CONFIRMED** and **ADJUSTED** survive as work items. Drop REFUTED; list UNCERTAIN in the
+   final report for the user to triage. On a fresh run, hand every verifier the carryover sets
+   (refuted to suppress, merged to dedup, unresolved to prioritize) per "Fresh runs and carryover".
+
+3. **Incremental reconcile — dedup on arrival, no barrier.** Chunked verifiers are blind across
+   chunks and shards, so the orchestrator keeps a run-wide **survivor set**. As each verification
+   chunk lands, check its confirmed findings against that set AND against findings already fanned
+   out: collapse same-underlying-bug duplicates into the existing work item; a causally-linked
+   finding shares the existing PR or is sequenced behind it — never a parallel PR colliding on the
+   same code. Checking each arrival against the accumulated set gives the same pairwise coverage as
+   a batch dedup, so nothing is gained by waiting for all chunks. This is set-level dedup, NOT
+   re-verification — the chunk already judged each finding.
+
+4. **Append survivors and fan out immediately.** Each deduped survivor becomes a `pending` row in
+   `state.md` (the run-config header — `run_id`, `base_branch`, `api_changes` — was written at run
+   start; Loop control step 1 / "Starting a fresh run"), eligible for a Stage 1 fix slot **on the
+   same wake**. Flip `phase` from `reviewing` to `fanout` when the first row lands; sweep shards and
+   verification chunks may still be running during fanout — `phase` is advisory, liveness comes from
+   rows + PRs (Loop control).
+
+If ALL shards and verification chunks complete with zero survivors, **release the run before
+stopping** — write its (empty) carryover file `.gauntlet/history/<run-id>.md`, delete
+`<rundir>/lease.json` and the `gauntlet-run-<run-id>` label *if it exists* (Stage 1 hasn't run yet on
+a zero-survivor exit, so the owner label is usually not created — skip it then), mark `state.md`
+terminal — then report and stop (no loop). Do not leave the lease dangling.
+
+---

--- a/plugins/gauntlet/skills/campaign/references/stage-1-fanout.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-1-fanout.md
@@ -1,0 +1,46 @@
+## Stage 1 — Fan out (one PR per finding)
+
+**Ensure the labels exist** first — the two shared status labels plus this run's owner label
+(idempotent — `--force` creates or updates, safe on every resume):
+
+```
+gh label create gauntlet-reviewing --color FBCA04 --description "gauntlet: under review" --force
+gh label create gauntlet-accepted  --color 0E8A16 --description "gauntlet: passed two reviews" --force
+gh label create gauntlet-run-<run-id> --color 5319E7 --description "gauntlet: run <run-id>" --force
+```
+
+Spawn one subagent per surviving finding, up to a **rolling cap of ~8 in flight** — NOT in barrier
+waves. Launch the first ~8 immediately, then refill: the moment any fix subagent finishes (and its PR
+enters the gates), pull the next `pending` finding into the freed slot. Never wait for a group of ~8
+to fully drain before starting more — a small remainder of one group must not stall the rest of the
+backlog. From the first wake onward this refilling is owned by Loop-control step 3 (the same dispatch
+that launches reviews/CI fixes/merges), so initial fan-out and resume use one identical slot-driven
+path; this Stage 1 description is just what each fix subagent does. Each subagent:
+
+1. `git worktree add $PROJECT/.worktrees/<branch> -b <branch> <base>`, `<branch>` =
+   `fix-<run-id>-<finding-id>-<short-slug>` (the `<run-id>` prefix scopes the branch to this run so
+   concurrent runs never collide; the `<finding-id>` keeps two findings with the same slug apart;
+   branch off `<base>`, not whatever HEAD happens to be).
+2. Implement the fix for **that finding only**, diff tight and scoped. If it would modify the public
+   API surface or behavior, follow **Constraints**: under `ask`, park the finding (`awaiting-api`)
+   and confirm with the user before changing anything; under `allowed`, proceed.
+3. Commit, push, open the PR off `<base>` **before any gauntlet review or CI gate**, tagged with this
+   run's owner label **and**
+   `gauntlet-reviewing`:
+   `gh pr create --base <base> --label gauntlet-run-<run-id> --label gauntlet-reviewing --title ... --body ...`
+   (no "Test plan" section).
+4. Return: finding id, branch, worktree path, PR number, one-line fix summary.
+
+For each PR: record it in `state.md` (status `in_review`, `started` = now, `attempts` += 1) and
+launch its background CI watch. The `--watch` only **blocks** until the run settles; immediately
+after, **re-poll a fresh snapshot** into the file — that snapshot, not the watch, is what you read:
+
+```
+# run in background. ';' (not '&&') so the re-poll ALWAYS runs, even when --watch exits non-zero on failure
+gh pr checks <pr> --watch ; gh pr checks <pr> > <rundir>/ci-<pr>.txt
+```
+
+The fix subagents only produce the fix + PR. They do NOT run reviews, watch CI, or merge — those
+are yours.
+
+---

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -1,0 +1,26 @@
+### 2b. CI (event-driven)
+
+Each PR has a background task that waits on `gh pr checks --watch`, then **re-polls** `gh pr checks
+<pr>` into `ci-<pr>.txt`. The watch only blocks; the re-polled snapshot is the source of truth. When
+the task completes, a wake reads the file and decides `ci` **from the file's contents — never from
+the watch exit code**:
+
+- **green** → ONLY if the snapshot shows **zero failing lines AND zero pending lines** and the
+  expected checks are actually present. `gh pr checks --watch` can exit 0 while checks are still
+  pending or have not yet registered, so a clean exit is not evidence of green.
+- **pending** → any line still pending, or the expected checks haven't appeared yet → not green;
+  leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
+  pending PR must never sit unwatched waiting for the heartbeat.
+- **red** → any failing line → **stop any review pass in flight on that PR first** (Loop control
+  step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then
+  diagnose from the check logs and dispatch a scoped CI-fix subagent into that worktree. Its fix
+  commits + pushes → code changed → **reset `reviews_ok` to 0**, relaunch the watch immediately,
+  re-enter 2a.
+
+Every CI failure must be handled; never merge over a red or pending check, and never infer green from
+the watch's exit code alone — always confirm against the re-polled snapshot.
+
+CI fixes serialize only within one PR/SHA. Different PRs with red CI may run scoped CI-fix subagents
+concurrently within the dispatcher cap.
+
+---

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -1,0 +1,195 @@
+## Stage 2 — Gates (orchestrator-owned, reactive)
+
+### 2a. The review gauntlet
+
+**Preconditions — clear Copilot items, CI, and conflicts before reviewing.** A codex review pass is
+expensive and is invalidated by any PR-content change, so never spend one on a PR whose current tip
+still has review-blocking issues. Before launching a pass, check three things and clear any that are
+dirty. Each fix changes PR content, so `reviews_ok` resets to 0 and the review re-starts on the clean
+tip:
+
+- **GitHub Copilot review items.** If the PR has any unresolved Copilot review comments, address them
+  with `/gauntlet:copilot-address-reviews <pr>` before reviewing (that skill verifies each item against source
+  before changing code, works them one at a time, and resolves the threads). Detect them from a
+  stored `gh` snapshot — the copilot skill's `fetch-review-items.sh` normalizes unresolved
+  Copilot-authored comments into `.gauntlet/tmp/copilot-review-items.json` — never scrape HTML. That path is
+  **shared across runs**, so treat it as ephemeral: fetch immediately before acting and **verify the
+  JSON is for THIS PR** (re-fetch if a concurrent run overwrote it), and don't interleave two runs'
+  copilot-address cycles. No items → no-op.
+- **CI failures.** If `ci` is red for the current tip, do NOT review — fix CI first (Stage 2b).
+  Handle failures **one at a time per PR/SHA**, and **prefer a scoped subagent** per failure; different
+  PRs may fix CI concurrently within the cap.
+- **Merge conflicts with `<base>`.** If GitHub flags the PR conflicting/behind
+  (`gh pr view <pr> --json mergeable,mergeStateStatus` → `CONFLICTING` / `DIRTY` / `BEHIND`), rebase
+  it onto `<base>` before reviewing. Clean rebase with the PR diff unchanged keeps `reviews_ok` but
+  sets `ci = pending`; conflict-resolving rebase changes PR content, so it resets the gate (Stage 3
+  step 5).
+
+Only launch a review pass once all three are clear for the current tip.
+
+Run reviews **one at a time per PR** — never two at once for the same SHA. When a PR's tip
+(`head_sha`) has fewer than two SATISFIED verdicts and no review already running for it, the wake's
+dispatch step launches **one** review pass: a **fresh** `codex exec` over the whole `<base>...HEAD`
+diff, no shared context, run as a **background** task (its completion is a wake; the loop folds the
+verdict in at step 2). The second, corroborating review is launched only **after** the first comes
+back SATISFIED — so a still-broken commit never burns the second review before the first has said
+"fix it". (Reviews for *different* PRs still run concurrently, up to the ~8 cap; it's only the two
+reviews for the same PR that serialize.) Each pass is a separate process with no shared context, so
+the second verdict is a fresh, context-isolated execution rather than a continuation influenced by the
+first.
+
+**Kill doomed passes — don't let them finish.** If a precondition goes dirty while a review is in
+flight on a PR — CI turns red, Copilot items land, a conflict appears — or any content-changing fix
+is about to be dispatched for it, **stop the in-flight review task before dispatching the fix**: its
+verdict can only describe a SHA that is about to be replaced, so letting it run wastes both the
+tokens and the review slot. The freed slot immediately refills with the next due review (Loop
+control step 3).
+
+If a pass's `codex exec` can't return a verdict (quota/rate-limit, auth, timeout, or other system
+error — see "Codex fallback"), retry it once, then run that pass as a **fresh subagent** reviewing the
+whole `<base>...HEAD` diff under the same output contract — a `RESIDUAL-RISK` line on SATISFIED
+immediately above exactly one final `VERDICT:` line. A subagent fallback pass counts
+toward the two-SATISFIED-verdict gate exactly like a codex pass — it's another fresh, context-isolated
+re-roll in its own context.
+
+**Review work-plan ledger — orchestrator-owned, target-generic.** Before launching each review pass,
+write `<rundir>/review-<pr>-<n>.plan.jsonl`. The orchestrator owns the plan; the reviewer reports
+progress against it but does NOT redefine it. The reviewer is nonetheless expected to critically
+evaluate the plan for completeness before executing it, and to flag any omitted dimension via the
+amendment mechanism below rather than silently accepting the supplied decomposition as exhaustive.
+Derive units from the review target, not from fixed global stages:
+
+- **Code PR default** → changed files/modules, public API/behavior boundaries, cross-file invariants,
+  tests/coverage relevant to changed behavior, migration/docs/golden updates when touched.
+- **Docs/articles/non-code** → artifact/section units, claim-support/evidence checks, structure/flow,
+  tone/audience, repetition, terminology/cross-document consistency, citations/sources if present.
+- **Mixed target** → include both code-shaped and artifact-shaped units.
+
+Plan JSONL schema:
+
+```
+{"type":"unit","id":"u01","kind":"file","target":"xsd/validate_idc.go","checks":["value canonicalization","union member selection"]}
+{"type":"unit","id":"u02","kind":"cross-cutting","target":"IDC key equality","checks":["primitive tags","list boundaries","keyref parity"]}
+```
+
+Rules:
+
+- Keep units auditable and finite. Prefer 5–15 units; split huge units, merge tiny mechanical ones.
+- The plan describes PR content, so **reuse it across passes on unchanged content**: for pass 2 on
+  the same SHA (or clean base-only rebase, diff unchanged), copy pass 1's plan to
+  `review-<pr>-2.plan.jsonl` instead of re-deriving. Re-derive only when PR content changed.
+- Each unit MUST name concrete `target` + concrete `checks`.
+- For code, include at least one cross-cutting unit when behavior spans files or packages.
+- For non-code, include at least one cross-artifact/whole-piece unit when multiple artifacts/sections
+  exist.
+- **The reviewer must not treat the plan as presumptively complete.** Before working the units, judge
+  whether they cover the dimensions this target actually needs; deterministic coverage is a design
+  goal, but the orchestrator's decomposition can still miss something. When a materially important
+  review dimension is omitted (or a unit is wrong), the reviewer MUST append a `plan_amendment_request`
+  event naming the gap rather than silently reviewing only the listed units — an unraised omission is a
+  reviewer failure. Requesting an amendment is the *only* sanctioned response: the reviewer never
+  rewrites the plan or self-grants units, and unapproved amendments do NOT count as plan units. The
+  orchestrator folds that request on the next wake and either updates the plan + restarts the review
+  pass, or ignores it with a note; the reviewer completes the existing units meanwhile.
+
+Progress JSONL schema:
+
+```
+{"type":"progress","unit":"u01","status":"started","ts":"2026-07-06T00:00:00Z"}
+{"type":"progress","unit":"u01","status":"done","ts":"2026-07-06T00:04:00Z","evidence":"checked canonicalization paths and edge-case tests"}
+{"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
+```
+
+Meaningful progress = a `done` event for a planned unit, or an accepted plan amendment. `started`
+events and vague "still working" lines prove only process liveness and MUST NOT reset the meaningful
+progress timer. The reviewer MUST append progress events immediately as units complete, not batch them
+at final output. If no meaningful progress lands for ~15 min while the review process is still alive,
+mark the review suspicious; if it remains stale on the next wake, treat it as a codex system failure:
+retry once, then use the fresh-subagent fallback. Ignore any late verdict from a stale/superseded
+attempt unless its attempt id still matches the active review pass.
+
+```
+codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -C $PROJECT/.worktrees/<branch> \
+  -o <rundir>/review-<pr>-<n>.txt \
+  "Review the changes on this branch vs <base> (the whole git diff <base>...HEAD). \
+   First read $PROJECT/<rundir>/review-<pr>-<n>.plan.jsonl, then critically assess whether its units \
+   cover the review dimensions this change actually needs — the plan is the orchestrator's starting \
+   point, not a guarantee of complete coverage. If an important dimension is missing or a unit is \
+   wrong, append a plan_amendment_request event to the progress JSONL naming the gap; do NOT silently \
+   limit your review to the listed units, and do NOT rewrite the plan yourself. Then append progress \
+   JSONL to $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl as each planned unit starts and finishes; \
+   progress counts only when it references a planned unit and includes concrete evidence. \
+   After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
+   defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
+   cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \
+   it. Report only concrete file:line defects that would actually fail, at the same bar as any finding; \
+   finding nothing is a fine and common result — do NOT lower the bar or list speculative 'might be \
+   fragile' concerns. \
+   List any issues with file:line and a concrete fix. If — and only if — your verdict is SATISFIED, \
+   output one line immediately above the verdict, in the form RESIDUAL-RISK: <area or file> — <why \
+   this was the hardest part to verify fully>, naming the part of the diff you checked with the LEAST \
+   certainty relative to the rest. It is a calibration signal, NOT a finding, and does not weaken your \
+   SATISFIED — do not manufacture a concern to fill it; if identifying it surfaces a real defect, list \
+   it with file:line and return NOT SATISFIED instead. End with exactly one line: \
+   'VERDICT: SATISFIED' or 'VERDICT: NOT SATISFIED'."   # run in background
+```
+
+As each verdict lands, tally it for the SHA it ran on:
+
+- **NOT SATISFIED** → dispatch a scoped fix subagent into that worktree with the issue list; it
+  commits + pushes → HEAD advances → the SHA's tally is void. A later wake starts a fresh review on
+  the new tip. (Because reviews are sequential, no second review was spent on this broken commit.)
+- **SATISFIED** → record it. If it's the **first** for this SHA, the next wake launches the second
+  (corroborating) review on the same SHA. If it's the **second** SATISFIED on the same SHA, the
+  review gate is met for this HEAD — swap the PR's label:
+  `gh pr edit <pr> --remove-label gauntlet-reviewing --add-label gauntlet-accepted`.
+
+Every pass reviews the whole `<base>...HEAD` diff (not just the last fix-delta), so accumulated fixes
+are always judged as one piece.
+
+**Unstructured adversarial sweep.** After a pass finishes every planned unit, it runs one brief
+free-form sweep for defects the plan's decomposition would never surface — cross-unit interactions,
+unstated assumptions, edge cases, and whole categories no unit enumerated. It **complements** the
+structured plan and never replaces it: the units still run in full first. The sweep reports through the
+normal finding channel — only concrete `file:line` defects that would actually fail, held to the same
+bar as any other finding, so a real one drives `NOT SATISFIED`. It is NOT a brainstorm: "nothing found"
+is the expected, honest common outcome, and speculative "might be fragile" notes are not findings and
+do not block SATISFIED. (This is distinct from a `plan_amendment_request`, which fixes the plan
+structurally; the sweep finds a defect now, regardless of the plan.)
+
+**Residual-risk signal (SATISFIED only).** A SATISFIED verdict carries one
+`RESIDUAL-RISK: <area> — <why>` line naming the part of the diff the pass verified with the least
+certainty, relative to the rest. It is calibration metadata, never a finding and never a verdict
+input: a SATISFIED with a residual-risk line is a **full** SATISFIED, and the line NEVER withholds the
+gate, NEVER enters the fix loop, and is NEVER fed into the corroborating review (which stays
+context-isolated). It reflects the gauntlet's purpose — lower the odds a defect survives stochastic
+variation, not claim certainty — by making residual uncertainty explicit instead of hidden behind a
+binary verdict. Record it with the verdict and carry **each accepting pass's** line into the final
+report, grouped by PR (a PR accepts on two SATISFIED passes, so two lines). Its only aggregate use:
+when **both** accepting passes on the same content name the same area, note that convergence in the
+report, and the orchestrator MAY add a plan unit covering it the next time the PR content changes and a
+fresh review round starts — but it never blocks the current gate.
+
+**Gate is two fresh, context-isolated SATISFIED verdicts on the same PR content.** The two passes are
+not statistically or epistemically independent observations — they judge the same diff under the same
+review task and protocol (and, on the normal both-codex path, the same model and prompt), so their
+verdicts are correlated and this is not a probabilistic proof of correctness. What the second pass
+buys is a re-roll of a stochastic reviewer: a fresh execution, with none of the first pass's context
+to anchor it, that can catch a defect the first pass happened to miss. Record the reviewed SHA
+(`git rev-parse HEAD`) with each pass. A verdict counts while its SHA equals the live tip. It also
+continues to count after `<base>` advances if the PR is still non-conflicting and the PR diff/content
+is unchanged (e.g. clean base-only rebase); carry `reviews_ok` forward to the new `head_sha` and set
+`ci = pending`. The moment PR content changes — review fix, CI fix, conflict-resolving rebase, a
+formatter/bot commit on the PR branch, or manual push — earlier verdicts are stale and `reviews_ok`
+drops to 0. Pinning to SHA plus the clean-base-only exception makes the gate verifiable from git while
+not burning reviews merely because another PR merged cleanly. A `NOT SATISFIED` invalidates that
+content's tally even before a fix lands. The two satisfied verdicts and green CI must all describe the
+same live PR content; CI must still be green for the current HEAD SHA.
+
+**Status labels mirror the review gate.** A PR carries `gauntlet-reviewing` until its current HEAD
+holds two SATISFIED verdicts for the same live PR content, then `gauntlet-accepted`. Because any
+PR-content change resets the gate, if an accepted PR's content later changes — a CI fix,
+conflict-resolving rebase, formatter/bot commit, etc. — swap the label back
+(`--remove-label gauntlet-accepted --add-label gauntlet-reviewing`). A clean base-only rebase with
+unchanged PR diff keeps the review label state but sets `ci = pending`. Reconcile labels against the
+live gate state each wake so they never lie.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -1,0 +1,65 @@
+## Stage 3 — Merge (serialized, auto)
+
+A PR is mergeable when the **current** `git rev-parse HEAD` equals `head_sha` AND `reviews_ok == 2`
+AND `ci == green` — i.e. two SATISFIED verdicts and green CI all recorded against the live tip.
+
+1. **Serialize merge operations, not wakes.** A wake may merge multiple PRs, but only one at a time.
+   Before each merge, re-confirm both gates still hold for the current HEAD (a late push may have
+   reset them), **and re-fetch `origin/<base>` and re-check
+   `gh pr view <pr> --json mergeable,mergeStateStatus`** — a concurrent run sharing this base may
+   have advanced it since the PR was last reviewed. If it now reads `BEHIND`/`DIRTY`/`CONFLICTING`,
+   refresh the PR per step 6 instead of merging it.
+2. Push guard: `gh pr view <branch> --json state --jq .state` must be `OPEN`.
+3. Merge: `gh pr merge <pr> --squash --delete-branch` (use the repo's prevailing merge method if not
+   squash).
+4. **Sync the local base branch with the remote.** The merge landed on `origin/<base>`, but local
+   `<base>` is now behind — and Stage 1 worktrees branch off it (`git worktree add … -b <branch>
+   <base>`). Fast-forward it so every subsequent fan-out, rebase, and `<base>...HEAD` diff is measured
+   against the just-merged tip, not a stale one (`<base>` = the run's base branch, not assumed `main`).
+   Local `<base>` is **shared** with any concurrent run on the same base; the fast-forward is
+   idempotent, so if another run already advanced it, a no-op "already up to date" is fine — just never
+   force it.
+
+   **Run the fast-forward from wherever `<base>` is actually checked out** — don't assume it's the
+   root checkout. A branch can be checked out in at most one working tree, so first locate that tree
+   (`git worktree list` shows the branch per path; the root package counts as one), then fast-forward
+   there. If `<base>` is checked out **nowhere**, update the ref directly instead — a plain `fetch`
+   into the local branch (this form is refused while the branch is checked out, which is why it's the
+   no-working-tree case):
+
+   ```
+   git -C $PROJECT fetch origin <base>
+   # case A — <base> is checked out in some working tree <dir> (root or a worktree):
+   git -C <dir> merge --ff-only origin/<base>
+   # case B — <base> is checked out in no working tree:
+   git -C $PROJECT fetch origin <base>:<base>
+   ```
+
+   Fast-forward only — never a merge commit or reset. If the fast-forward fails (local `<base>` somehow
+   diverged), do NOT force it: that's a bailout condition (stop and surface it), since branching new
+   fixes off a wrong base would corrupt every downstream diff.
+5. **Clean up on successful merge.** Once the merge is confirmed (`gh pr view <branch> --json state
+   --jq .state` → `MERGED`), tear down that PR's local footprint:
+   - `--delete-branch` above already removed the **remote** branch.
+   - Verify the merge with the `git-detect-merged` skill, then use `git-cleanup-merged` to remove the
+     **worktree** (`.worktrees/<branch>`) and delete the **local branch**.
+   - Set status `merged` and stop its background tasks.
+
+   This runs only after the merge is verified, and only ever touches **this run's own**
+   `fix-<run-id>-*` worktrees/branches (per the Authorization note and the isolation invariant) — never
+   another run's. Leave the worktree in place if the merge cannot be confirmed — treat that as a
+   bailout condition, not a cleanup.
+6. After each merge+sync+cleanup, reconcile other open PRs. **Base advancement alone does NOT
+   invalidate gauntlet reviews.** Rebase only if GitHub flags the PR behind/conflicting:
+   - Clean rebase (no conflicts) → verify the PR's own diff/content is unchanged → keep `reviews_ok`,
+     update `head_sha` to the new tip, set `ci = pending`, **and relaunch its CI watch in the same
+     wake** — the rebased PR must not sit unwatched until the heartbeat; CI must return green before
+     merging.
+   - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0**, relaunch
+     the CI watch, re-enter Stage 2.
+   - Still open, mergeable, not behind/dirty/conflicting, same live `head_sha`, `reviews_ok == 2`,
+     and `ci == green` → still immediately mergeable; return to step 1 in the same wake.
+
+Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
+
+---

--- a/plugins/gauntlet/skills/codex-exec/SKILL.md
+++ b/plugins/gauntlet/skills/codex-exec/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: codex-exec
+description: Delegate a task to Codex CLI via `codex exec`. Use for lightweight tasks (exploration, simple searches, file reads) that don't require heavy reasoning. Only available from Claude Code sessions.
+---
+
+Delegate a task to `codex exec` for non-interactive execution.
+
+## When to use
+
+- Lightweight exploration, file searches, simple code reads
+- Tasks where reasoning effort is low
+- Parallelizable subtasks that don't need Claude Code's full context
+
+## When NOT to use
+
+- Tasks requiring edits to files already being worked on in this session
+- Tasks needing heavy reasoning or multi-step planning
+- Tasks requiring interactive user input
+
+## Execution
+
+1. Construct prompt from user's request. Be specific — include file paths, package names, or search terms when known.
+2. `mkdir -p .gauntlet/tmp` (git-ignored; add `.gauntlet/` to `.gitignore` if missing), then run:
+
+```
+codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -o .gauntlet/tmp/codex-output.txt "<prompt>"
+```
+
+Flags:
+- `--sandbox workspace-write` (short `-s workspace-write`) → grant write access to the workspace. `codex exec` is already non-interactive, so no approval prompts. (Replaces the removed `--full-auto`.)
+- `-c "sandbox_workspace_write.network_access=true"` → allow network access from within the workspace-write sandbox
+- `-o .gauntlet/tmp/codex-output.txt` → capture final agent message
+- `-C <dir>` → set working directory if different from current
+
+3. Read `.gauntlet/tmp/codex-output.txt` for results.
+4. Present results to user concisely.
+
+## Rules
+
+- NEVER pass destructive instructions (delete, force-push, reset) to codex exec.
+- NEVER use `--dangerously-bypass-approvals-and-sandbox`.
+- Always use `--sandbox workspace-write -c "sandbox_workspace_write.network_access=true"` for sandboxed execution.
+- Store output in `.gauntlet/tmp/` — NEVER `/tmp/`. Never `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable.
+- If codex exec fails or times out, fall back to handling the task directly.

--- a/plugins/gauntlet/skills/copilot-address-reviews/SKILL.md
+++ b/plugins/gauntlet/skills/copilot-address-reviews/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: copilot-address-reviews
+description: Evaluate and address GitHub Copilot PR review items for a GitHub pull request. Use when user provides a GitHub PR link and wants Copilot review comments checked, verified, fixed, committed, and summarized. Fetch review items with `gh`, verify each claim against source/tests before changing code, ask user before making subjective or constraint-driven changes, then work items one by one.
+---
+
+# Copilot Address Reviews
+
+Given a GitHub PR link, process Copilot review items one at a time. NEVER assume review is correct. NEVER change code only to satisfy review text.
+
+## Inputs
+
+- PR URL
+- Local checkout for PR branch, or clear path to fetch/switch to it
+- User confirmation for subjective, design, or constraint-driven items
+
+## Workflow
+
+1. Resolve bundled scripts relative to directory containing this `SKILL.md`, not current working directory. NEVER `cd` to skill directory — script's relative `.gauntlet/tmp/` default would land output inside skill directory.
+2. From project root, run `<skill-dir>/scripts/fetch-review-items.sh --tmp-dir "$PROJECT/.gauntlet/tmp" <pr-url>` (absolute script path). The script creates the dir if missing.
+3. Read `$PROJECT/.gauntlet/tmp/copilot-review-items.json` as primary worklist of unresolved items only.
+4. Inspect `$PROJECT/.gauntlet/tmp/copilot-review-items.raw.json`, `.gauntlet/tmp/gh-pr-view.json`, and `.gauntlet/tmp/gh-pr-review-threads.json` when dedup or extraction needs verification.
+5. Select next unhandled unresolved item from worklist. NEVER work resolved items.
+6. For current item, choose exactly one outcome before moving on:
+   - valid → fix
+   - invalid → no code change
+   - subjective/constraint-driven/ambiguous → ask user
+   - deferred/won't fix → ask user, then no code change
+   - already fixed on branch → no code change
+7. After each valid item:
+   - make smallest code change that addresses verified issue
+   - run focused tests first
+   - add/update tests when they materially prove claim or prevent regression
+   - run broader relevant tests when change touches shared behavior
+   - commit only files for that item
+   - after commit, resolve corresponding GitHub review thread/comment if it is still unresolved
+8. After each invalid, deferred, won't-fix, or already-fixed item:
+   - record why no code change is needed
+   - if current source/tests do not already make decision obvious, add concise code comment near relevant logic so future reviewers can see reasoning or constraint
+   - if outcome is deferred or won't fix and user confirmed that outcome, resolve corresponding GitHub review thread/comment if it is still unresolved
+   - do not make speculative edits
+9. Mark current item handled, then look up whether more unhandled items remain.
+10. If more items remain, return to step 5. Continue until worklist is empty.
+11. After all items, report every item, decision, evidence, and commit hash when applicable.
+
+## Scripts
+
+Resolve bundled resources relative to this `SKILL.md`. Script directory = `scripts/` next to this file.
+
+- Installed skill layout: skill directory contains `SKILL.md` + `scripts/` as siblings. When installed
+  as part of the `gauntlet` plugin it lives under `${CLAUDE_PLUGIN_ROOT}/skills/copilot-address-reviews/`.
+- Repository layout: skill directory = `plugins/gauntlet/skills/copilot-address-reviews/`.
+- Run scripts by absolute path from project root. ALWAYS pass `--tmp-dir "$PROJECT/.gauntlet/tmp"` so output lands in project `.gauntlet/tmp/`, never skill directory.
+- NEVER assume current working directory already is skill directory.
+
+### `scripts/fetch-review-items.sh`
+
+- Entry point for PR review item discovery.
+- Use `gh` CLI only. NEVER scrape HTML.
+- Save raw GitHub output to `.gauntlet/tmp/` first.
+- Fetch PR metadata + all pages of review threads/comments.
+- Normalize unresolved Copilot-authored review comments into `.gauntlet/tmp/copilot-review-items.raw.json`.
+- Invoke `scripts/dedup_review_items.py` to write `.gauntlet/tmp/copilot-review-items.json`.
+- If GitHub response shape is incomplete for current PR, extend GraphQL query or inspect raw JSON before changing code.
+
+### `scripts/dedup_review_items.py`
+
+- Python scope is dedup only.
+- Input: normalized raw item JSON array.
+- Output: deduped JSON object with representative items + grouped ids.
+- NEVER expand Python script into code validation, test selection, or fix synthesis.
+
+## Fetch Review Items
+
+- Start with `scripts/fetch-review-items.sh <pr-url>`.
+- Treat `.gauntlet/tmp/copilot-review-items.json` as candidate worklist of unresolved items, not truth.
+- Inspect Copilot review submissions as well as inline discussion comments. Do not assume a `#pullrequestreview-...` URL is represented directly in normalized output.
+- If user points to review submission URL or review id, map it to attached inline review comments and confirm those comments are present in worklist before proceeding.
+- Filter results to authors that represent GitHub Copilot review bots. Do not assume exact login string is stable if raw output shows another Copilot variant.
+- Exclude resolved items from scope. Ignore them unless raw GitHub output suggests resolution state is wrong.
+- Capture for each item:
+  - review/comment id
+  - file path + line/range
+  - exact claim/request
+  - thread state if available
+- Read raw GitHub output when:
+  - review submission URL needs to be mapped to inline comments
+  - dedup merged items unexpectedly
+  - line/path metadata looks wrong
+  - thread state affects whether item still needs work
+
+## Validate Before Editing
+
+Verify claim with source and tests before changing code.
+
+### Code Analysis
+
+- Read surrounding implementation, callers, tests, and PR diff context.
+- Check whether review conflicts with intentional invariants, API contracts, compatibility rules, performance limits, or repository conventions.
+- Prefer smallest proof that establishes whether review is valid.
+
+### Test Strategy
+
+- Use R/G testing for general development: make failing case visible first, then change code until test passes.
+- If existing tests already cover claim, run them first.
+- If claim is behavioral and uncovered, add focused test that fails before fix and passes after fix.
+- If claim is not directly testable, explain why and use code-level reasoning instead.
+- NEVER add a test that merely encodes Copilot preference when behavior is intentionally unspecified.
+
+## Ask User Instead Of Deciding
+
+Ask user before changing code when item is primarily about:
+
+- naming, style, or readability with no correctness issue
+- API shape, public behavior, or compatibility policy
+- performance vs. simplicity tradeoff
+- logging/error wording
+- architectural direction or ownership boundaries
+- possible arbitrary local constraint that cannot be verified from code/tests
+
+When asking user, include:
+
+- review item summary
+- current behavior
+- why item appears subjective or constraint-driven
+- recommended options
+
+## Fix Rules
+
+- Keep fix scoped to verified issue.
+- Avoid opportunistic cleanup unless required for fix or approved by user.
+- If multiple Copilot items map to same defect, ask user before combining them into one commit.
+- If current branch already addresses item, record it as already fixed and move on.
+
+## Review Interaction
+
+- NEVER post GitHub comments, review replies, review submissions, or issue comments on user's behalf.
+- Resolve relevant GitHub review thread/comment only after committed fix exists.
+- Resolve relevant GitHub review thread/comment after user-confirmed deferred/won't-fix decision exists.
+- NEVER resolve review thread/comment before commit for that item exists.
+- NEVER resolve deferred/won't-fix thread/comment before user decision for that item exists.
+- Resolve thread/comment without posting reply text.
+- Report decisions to user in local output instead.
+- If a GitHub comment would help, ask user first. Draft text only when user asks for it.
+
+## Commit Rules
+
+- One focused commit per addressed item.
+- Stage only files relevant to current item.
+- Write commit message around behavioral change, not around Copilot.
+- Follow repository/user git rules before `git add` / `git commit`.
+- Do not create no-op commit for rejected, subjective, deferred, won't-fix, or already-fixed items.
+
+## Final Report
+
+Report items in review order or grouped by file. For each item include:
+
+- item identifier or file/line
+- Copilot claim summary
+- decision: fixed / rejected / deferred / won't fix / already fixed
+- evidence: code reading, tests run, or user instruction
+- commit hash for fixed items

--- a/plugins/gauntlet/skills/copilot-address-reviews/scripts/dedup_review_items.py
+++ b/plugins/gauntlet/skills/copilot-address-reviews/scripts/dedup_review_items.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+
+STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "be",
+    "copilot",
+    "for",
+    "github",
+    "has",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "please",
+    "review",
+    "should",
+    "that",
+    "the",
+    "this",
+    "to",
+    "use",
+    "you",
+    "your",
+}
+
+
+def usage() -> int:
+    print("usage: dedup_review_items.py <raw-items.json> <deduped-items.json>", file=sys.stderr)
+    return 1
+
+
+def fail(msg: str) -> NoReturn:
+    print(msg, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _coerce_optional_str(value: object) -> "str | None":
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return str(value)
+    return None
+
+
+def coerce_item(raw: object) -> dict:
+    if not isinstance(raw, dict):
+        fail("each raw review item must be a JSON object")
+    item = dict(raw)
+
+    comment_id = item.get("comment_id")
+    item["comment_id"] = "" if comment_id is None else str(comment_id)
+
+    item["thread_id"] = _coerce_optional_str(item.get("thread_id"))
+    item["author_login"] = _coerce_optional_str(item.get("author_login"))
+
+    body = item.get("body")
+    item["body"] = "" if body is None else str(body)
+
+    return item
+
+
+def load_items(path: Path) -> list[dict]:
+    try:
+        with path.open() as infile:
+            data = json.load(infile)
+    except FileNotFoundError:
+        fail(f"raw review items file not found: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"raw review items file is not valid JSON: {path} ({exc})")
+    if not isinstance(data, list):
+        fail("raw review items must be a JSON array")
+    return [coerce_item(x) for x in data]
+
+
+def normalize_text(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"`[^`]*`", " ", text)
+    text = re.sub(r"https?://\S+", " ", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def fingerprint(text: str) -> tuple[str, ...]:
+    tokens = []
+    for token in normalize_text(text).split():
+        if token in STOP_WORDS:
+            continue
+        if len(token) <= 2:
+            continue
+        tokens.append(token)
+    if not tokens:
+        return tuple()
+    return tuple(sorted(set(tokens[:24])))
+
+
+def line_anchor(item: dict) -> int:
+    for key in ("line", "start_line", "original_line", "original_start_line"):
+        value = item.get(key)
+        if isinstance(value, int):
+            return value
+    return -1
+
+
+def similarity(left: dict, right: dict) -> float:
+    left_text = normalize_text(left.get("body", ""))
+    right_text = normalize_text(right.get("body", ""))
+    if not left_text or not right_text:
+        return 0.0
+    return difflib.SequenceMatcher(a=left_text, b=right_text).ratio()
+
+
+def same_group(group: dict, item: dict) -> bool:
+    representative = group["representative"]
+    if representative.get("path") != item.get("path"):
+        return False
+
+    left_anchor = line_anchor(representative)
+    right_anchor = line_anchor(item)
+    if left_anchor != -1 and right_anchor != -1 and abs(left_anchor - right_anchor) > 2:
+        return False
+
+    left_fp = group["fingerprint"]
+    right_fp = fingerprint(item.get("body", ""))
+    overlap = len(set(left_fp) & set(right_fp))
+    similarity_score = similarity(representative, item)
+
+    if similarity_score >= 0.88:
+        return True
+    if left_fp and right_fp and left_fp == right_fp:
+        return True
+    if overlap >= 4:
+        return True
+
+    left_text = normalize_text(representative.get("body", ""))
+    right_text = normalize_text(item.get("body", ""))
+    if left_text and right_text and (left_text in right_text or right_text in left_text):
+        return True
+
+    return False
+
+
+def dedup_items(items: list[dict]) -> dict:
+    groups: list[dict] = []
+    sorted_items = sorted(items, key=lambda item: (item.get("path") or "", line_anchor(item), item.get("comment_id") or ""))
+
+    for item in sorted_items:
+        matched = None
+        for group in groups:
+            if same_group(group, item):
+                matched = group
+                break
+
+        if matched is None:
+            matched = {
+                "representative": item,
+                "fingerprint": fingerprint(item.get("body", "")),
+                "items": [],
+            }
+            groups.append(matched)
+
+        matched["items"].append(item)
+
+    deduped = []
+    for group in groups:
+        representative = dict(group["representative"])
+        representative["dedup_key"] = "|".join(
+            [
+                representative.get("path") or "",
+                str(line_anchor(representative)),
+                " ".join(group["fingerprint"]),
+            ]
+        )
+        representative["duplicate_count"] = len(group["items"]) - 1
+        representative["grouped_comment_ids"] = [item.get("comment_id") for item in group["items"]]
+        representative["grouped_thread_ids"] = sorted(
+            {item.get("thread_id") for item in group["items"] if item.get("thread_id")}
+        )
+        representative["grouped_author_logins"] = sorted(
+            {item.get("author_login") for item in group["items"] if item.get("author_login")}
+        )
+        deduped.append(representative)
+
+    return {
+        "raw_item_count": len(items),
+        "deduped_item_count": len(deduped),
+        "items": deduped,
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        return usage()
+
+    input_path = Path(argv[1])
+    output_path = Path(argv[2])
+
+    items = load_items(input_path)
+    result = dedup_items(items)
+
+    with output_path.open("w") as outfile:
+        json.dump(result, outfile, indent=2, sort_keys=True)
+        outfile.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/plugins/gauntlet/skills/copilot-address-reviews/scripts/fetch-review-items.sh
+++ b/plugins/gauntlet/skills/copilot-address-reviews/scripts/fetch-review-items.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: fetch-review-items.sh [options] <pr-url>
+
+Fetch GitHub Copilot PR review items, normalize them to JSON, then deduplicate
+them via dedup_review_items.py.
+
+Options:
+  --tmp-dir PATH              Directory for raw gh output. Default: .gauntlet/tmp
+  --pr-view-json PATH         Use existing gh pr view JSON instead of fetching
+  --review-threads-json PATH  Use existing GraphQL review thread JSON instead of fetching
+  --raw-output PATH           Normalized pre-dedup JSON. Default: <tmp-dir>/copilot-review-items.raw.json
+  --dedup-output PATH         Deduped JSON. Default: <tmp-dir>/copilot-review-items.json
+  --copilot-pattern REGEX     Regex for Copilot author logins
+  --help                      Show this message
+EOF
+}
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+# Arity guard: call BEFORE reading $2 for a value-taking option.
+# remaining_argc is $# at the point of the case branch (includes the flag itself),
+# so a present value means remaining_argc >= 2.
+require_value() {
+  local flag="$1"
+  local remaining_argc="$2"
+  if [[ "$remaining_argc" -lt 2 ]]; then
+    die "option $flag requires a value"
+  fi
+}
+
+# Existence + well-formedness guard for a JSON input file.
+read_json_file() {
+  local path="$1"
+  local label="$2"
+  if [[ ! -f "$path" ]]; then
+    die "$label: file not found: $path"
+  fi
+  if ! jq empty "$path" >/dev/null 2>&1; then
+    die "$label: not valid JSON: $path"
+  fi
+}
+
+# Chokepoint for EVERY page of EVERY paginated GraphQL fetch. Fails closed on a
+# short or malformed page so a truncated result can never be reported as complete
+# and a null/empty cursor can never spin the pagination loop forever.
+#
+#   validate_page <json_file> <connection_path> <label>
+#
+# <connection_path> is the jq path to the GraphQL *connection object*, e.g.
+#   Axis A: .data.repository.pullRequest.reviewThreads
+#   Axis B: .data.node.comments
+#
+# Asserts, in order, calling die() on the first failure:
+#   1. top-level .errors is absent/empty
+#   2. <connection_path> is non-null            (covers null pullRequest AND null node)
+#   3. <connection_path>.nodes is an array
+#   4. <connection_path>.pageInfo.hasNextPage is present AND a boolean (never defaulted)
+#   5. when hasNextPage == true, <connection_path>.pageInfo.endCursor is a non-empty string
+# Because presence and shape are guaranteed here, callers MUST NOT re-add // false /
+# // "" fallbacks on hasNextPage/endCursor — a fallback would silently re-open the hole.
+validate_page() {
+  local path="$1"
+  local connection_path="$2"
+  local label="$3"
+
+  # One type-safe pass: reject a non-object top-level value up front (a raw
+  # `has(...)`/`getpath(...)` on an array/scalar would abort jq), then surface
+  # GraphQL errors, then assert the connection shape. The `if ! result=$(...)`
+  # form captures jq's exit status explicitly so a parse error on a non-JSON
+  # page routes to the SAME labeled die below instead of tripping `set -e` with
+  # a raw jq trace.
+  local result
+  if ! result=$(jq -r --arg cp "$connection_path" '
+    def conn: getpath($cp | ltrimstr(".") | split("."));
+    if (type != "object") then
+      "GraphQL page is not a JSON object (got \(type))"
+    elif (has("errors") and (.errors | length > 0)) then
+      "GraphQL API returned errors: \([.errors[].message] | join("; "))"
+    elif (conn == null) then
+      "connection object is null (\($cp))"
+    elif ((conn.nodes | type) != "array") then
+      "\($cp).nodes is missing or not an array"
+    elif ((conn.pageInfo | type) != "object") then
+      "\($cp).pageInfo is missing or not an object"
+    elif ((conn.pageInfo | has("hasNextPage")) | not) then
+      "\($cp).pageInfo.hasNextPage is missing"
+    elif ((conn.pageInfo.hasNextPage | type) != "boolean") then
+      "\($cp).pageInfo.hasNextPage is not a boolean"
+    elif (conn.pageInfo.hasNextPage == true
+          and ((conn.pageInfo.endCursor | type) != "string" or conn.pageInfo.endCursor == "")) then
+      "\($cp).pageInfo.hasNextPage is true but endCursor is null/empty"
+    else
+      "ok"
+    end
+  ' "$path" 2>/dev/null); then
+    die "$label: unreadable GraphQL page (invalid JSON or not a JSON object): $path"
+  fi
+
+  if [[ "$result" != "ok" ]]; then
+    die "$label: $result"
+  fi
+}
+
+# Validate the nested comments connection carried by every review-thread node of an
+# Axis A page. The Axis B seed reads .comments.pageInfo off these nodes, so a missing
+# or false-defaulted nested pageInfo here would silently drop overflow comments or
+# spin the Axis B loop. Enforce the same shape as validate_page, per node.
+validate_nested_comment_connections() {
+  local path="$1"
+  local label="$2"
+  # Same treatment as validate_page: a jq-level `$c | type != "object"` guard runs
+  # BEFORE any `$c.nodes` access, so a node whose .comments is an array/scalar yields
+  # a labeled, thread-naming message instead of aborting jq on a string-index error.
+  # The `if ! result=$(...)` form then captures jq's exit status explicitly, so any
+  # residual jq failure routes to the SAME labeled die below rather than tripping
+  # `set -e` with a raw (stderr-suppressed) trace.
+  local result
+  if ! result=$(jq -r '
+    [ .data.repository.pullRequest.reviewThreads.nodes[]
+      | .id as $tid
+      | .comments as $c
+      | if ($c == null) then
+          "thread \($tid): comments connection is null"
+        elif (($c | type) != "object") then
+          "thread \($tid): comments connection is not an object (got \($c | type))"
+        elif (($c.nodes | type) != "array") then
+          "thread \($tid): comments.nodes is missing or not an array"
+        elif (($c.pageInfo | type) != "object") then
+          "thread \($tid): comments.pageInfo is missing or not an object"
+        elif (($c.pageInfo | has("hasNextPage")) | not) then
+          "thread \($tid): comments.pageInfo.hasNextPage is missing"
+        elif (($c.pageInfo.hasNextPage | type) != "boolean") then
+          "thread \($tid): comments.pageInfo.hasNextPage is not a boolean"
+        elif ($c.pageInfo.hasNextPage == true
+              and (($c.pageInfo.endCursor | type) != "string" or $c.pageInfo.endCursor == "")) then
+          "thread \($tid): comments.pageInfo.hasNextPage is true but endCursor is null/empty"
+        else
+          empty
+        end
+    ] | .[0] // "ok"
+  ' "$path" 2>/dev/null); then
+    die "$label: unreadable GraphQL page (invalid JSON or not a JSON object): $path"
+  fi
+
+  if [[ "$result" != "ok" ]]; then
+    die "$label: $result"
+  fi
+}
+
+# Fail closed on an Axis A (review threads) page: validate the reviewThreads
+# connection, then every thread's nested comments connection. Keeps its name and
+# behavior for existing callers; internally routes through the validate_page chokepoint.
+validate_graphql_response() {
+  local path="$1"
+  local label="$2"
+  validate_page "$path" ".data.repository.pullRequest.reviewThreads" "$label"
+  validate_nested_comment_connections "$path" "$label"
+}
+
+# Pre-flight the user-supplied Copilot author regex before jq test() aborts on it.
+validate_regex() {
+  local pattern="$1"
+  if ! jq -n --arg p "$pattern" '"" | test($p; "i")' >/dev/null 2>&1; then
+    die "invalid --copilot-pattern: not a valid regex: $pattern"
+  fi
+}
+
+merge_review_thread_page() {
+  local aggregate_json="$1"
+  local page_json="$2"
+  local merged_json="${aggregate_json}.tmp"
+
+  jq -s '
+    .[0] as $aggregate
+    | .[1] as $page
+    | {
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                # Carry the (already validate_page-checked) latest page pageInfo so the
+                # merged aggregate stays a well-formed connection object. After the loop
+                # exits, this is the final page pageInfo (hasNextPage == false), which
+                # lets the same validate_page chokepoint re-validate the aggregate.
+                pageInfo: (
+                  $page.data.repository.pullRequest.reviewThreads.pageInfo
+                  // $aggregate.data.repository.pullRequest.reviewThreads.pageInfo
+                ),
+                nodes: (
+                  ($aggregate.data.repository.pullRequest.reviewThreads.nodes // [])
+                  + ($page.data.repository.pullRequest.reviewThreads.nodes // [])
+                )
+              }
+            }
+          }
+        }
+      }
+  ' "$aggregate_json" "$page_json" >"$merged_json"
+
+  mv "$merged_json" "$aggregate_json"
+}
+
+merge_thread_comment_page() {
+  local aggregate_json="$1"
+  local page_json="$2"
+  local thread_id="$3"
+  local merged_json="${aggregate_json}.tmp"
+
+  jq \
+    --arg thread_id "$thread_id" \
+    --slurpfile page "$page_json" \
+    '
+      (.data.repository.pullRequest.reviewThreads.nodes) |= map(
+        if .id == $thread_id then
+          .comments.nodes += ($page[0].data.node.comments.nodes // [])
+          | .comments.pageInfo = ($page[0].data.node.comments.pageInfo // .comments.pageInfo)
+        else
+          .
+        end
+      )
+    ' "$aggregate_json" >"$merged_json"
+
+  mv "$merged_json" "$aggregate_json"
+}
+
+fetch_all_review_threads() {
+  local output_json="$1"
+  local cursor=""
+  local has_next="true"
+  local page_number=1
+
+  jq -n '
+    {
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: []
+            }
+          }
+        }
+      }
+    }
+  ' >"$output_json"
+
+  while [[ "$has_next" == "true" ]]; do
+    local page_json="$TMP_DIR/gh-pr-review-threads-page-$page_number.json"
+
+    # shellcheck disable=SC2016  # $owner/$name are GraphQL variables; the shell must not expand them
+    gh api graphql \
+      -F owner="$REPO_OWNER" \
+      -F name="$REPO_NAME" \
+      -F number="$PR_NUMBER" \
+      -F after="$cursor" \
+      -f query='
+        query($owner: String!, $name: String!, $number: Int!, $after: String) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $after) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  path
+                  line
+                  startLine
+                  originalLine
+                  originalStartLine
+                  diffSide
+                  startDiffSide
+                  comments(first: 100) {
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                    nodes {
+                      id
+                      databaseId
+                      url
+                      body
+                      createdAt
+                      authorAssociation
+                      author {
+                        login
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ' >"$page_json"
+
+    validate_graphql_response "$page_json" "review threads page $page_number"
+    merge_review_thread_page "$output_json" "$page_json"
+
+    # No // false / // "" fallbacks: validate_graphql_response has already asserted
+    # hasNextPage is a boolean and, when true, endCursor is a non-empty string.
+    has_next=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' "$page_json")
+    cursor=$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' "$page_json")
+    page_number=$((page_number + 1))
+  done
+}
+
+fetch_all_thread_comments() {
+  local aggregate_json="$1"
+  local comment_thread_ids
+
+  comment_thread_ids=$(jq -r '
+    .data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.comments.pageInfo.hasNextPage == true)
+    | .id
+  ' "$aggregate_json")
+
+  if [[ -z "$comment_thread_ids" ]]; then
+    return
+  fi
+
+  while IFS= read -r thread_id; do
+    [[ -n "$thread_id" ]] || continue
+
+    local cursor
+    local has_next
+    local page_number=2
+
+    # No // "" / // false fallbacks: the aggregate was built from Axis A pages that
+    # validate_nested_comment_connections already asserted carry a boolean
+    # hasNextPage and, when true, a non-empty endCursor for every thread.
+    cursor=$(jq -r '
+      .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.id == $thread_id)
+      | .comments.pageInfo.endCursor
+    ' --arg thread_id "$thread_id" "$aggregate_json")
+    has_next=$(jq -r '
+      .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.id == $thread_id)
+      | .comments.pageInfo.hasNextPage
+    ' --arg thread_id "$thread_id" "$aggregate_json")
+
+    while [[ "$has_next" == "true" ]]; do
+      local page_json="$TMP_DIR/gh-thread-comments-${thread_id//[^A-Za-z0-9._-]/_}-page-$page_number.json"
+
+      # shellcheck disable=SC2016  # $threadId/$after are GraphQL variables; the shell must not expand them
+      gh api graphql \
+        -F threadId="$thread_id" \
+        -F after="$cursor" \
+        -f query='
+          query($threadId: ID!, $after: String) {
+            node(id: $threadId) {
+              ... on PullRequestReviewThread {
+                id
+                comments(first: 100, after: $after) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                  nodes {
+                    id
+                    databaseId
+                    url
+                    body
+                    createdAt
+                    authorAssociation
+                    author {
+                      login
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ' >"$page_json"
+
+      validate_page "$page_json" ".data.node.comments" \
+        "thread comments (thread $thread_id, page $page_number)"
+      merge_thread_comment_page "$aggregate_json" "$page_json" "$thread_id"
+
+      # No // false / // "" fallbacks: validate_page has already asserted hasNextPage
+      # is a boolean and, when true, endCursor is a non-empty string.
+      has_next=$(jq -r '.data.node.comments.pageInfo.hasNextPage' "$page_json")
+      cursor=$(jq -r '.data.node.comments.pageInfo.endCursor' "$page_json")
+      page_number=$((page_number + 1))
+    done
+  done <<<"$comment_thread_ids"
+}
+
+extract_repo_parts() {
+  local pr_url="$1"
+  local trimmed="$pr_url"
+
+  trimmed="${trimmed#https://github.com/}"
+  trimmed="${trimmed#http://github.com/}"
+  trimmed="${trimmed#github.com/}"
+
+  IFS='/' read -r REPO_OWNER REPO_NAME PULL_SEGMENT PR_NUMBER _ <<<"$trimmed"
+  if [[ -z "${REPO_OWNER:-}" || -z "${REPO_NAME:-}" || "${PULL_SEGMENT:-}" != "pull" || -z "${PR_NUMBER:-}" ]]; then
+    die "unable to parse GitHub PR URL: $pr_url"
+  fi
+  if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    die "invalid PR number in URL: expected an integer, got '$PR_NUMBER' ($pr_url)"
+  fi
+}
+
+TMP_DIR=".gauntlet/tmp"
+PR_VIEW_JSON=""
+REVIEW_THREADS_JSON=""
+RAW_OUTPUT=""
+DEDUP_OUTPUT=""
+# Anchored so the alternation matches the WHOLE login, not a substring: an
+# unanchored pattern accepts an impostor like `not-a-copilot-user`. The optional
+# `[bot]` suffix covers the review author `copilot-pull-request-reviewer[bot]`;
+# the comment author is the bare `Copilot` (case-folded by test(...; "i") below).
+COPILOT_PATTERN='^(copilot|github-copilot|copilot-pull-request-reviewer)(\[bot\])?$'
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tmp-dir)
+      require_value "$1" "$#"
+      TMP_DIR="$2"
+      shift 2
+      ;;
+    --pr-view-json)
+      require_value "$1" "$#"
+      PR_VIEW_JSON="$2"
+      shift 2
+      ;;
+    --review-threads-json)
+      require_value "$1" "$#"
+      REVIEW_THREADS_JSON="$2"
+      shift 2
+      ;;
+    --raw-output)
+      require_value "$1" "$#"
+      RAW_OUTPUT="$2"
+      shift 2
+      ;;
+    --dedup-output)
+      require_value "$1" "$#"
+      DEDUP_OUTPUT="$2"
+      shift 2
+      ;;
+    --copilot-pattern)
+      require_value "$1" "$#"
+      COPILOT_PATTERN="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+PR_URL="$1"
+mkdir -p "$TMP_DIR"
+
+if [[ -z "$RAW_OUTPUT" ]]; then
+  RAW_OUTPUT="$TMP_DIR/copilot-review-items.raw.json"
+fi
+
+if [[ -z "$DEDUP_OUTPUT" ]]; then
+  DEDUP_OUTPUT="$TMP_DIR/copilot-review-items.json"
+fi
+
+# shellcheck disable=SC1007  # `CDPATH= cd` is a deliberate empty-assignment prefix, not a typo'd assignment
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+
+require_cmd jq
+require_cmd python3
+
+validate_regex "$COPILOT_PATTERN"
+
+if [[ -z "$PR_VIEW_JSON" || -z "$REVIEW_THREADS_JSON" ]]; then
+  require_cmd gh
+fi
+
+if [[ -z "$PR_VIEW_JSON" ]]; then
+  PR_VIEW_JSON="$TMP_DIR/gh-pr-view.json"
+  gh pr view "$PR_URL" --json number,title,url,headRefName,baseRefName,files >"$PR_VIEW_JSON"
+fi
+
+read_json_file "$PR_VIEW_JSON" "--pr-view-json"
+
+CANONICAL_PR_URL=$(jq -r '.url' "$PR_VIEW_JSON")
+extract_repo_parts "$CANONICAL_PR_URL"
+
+if [[ -z "$REVIEW_THREADS_JSON" ]]; then
+  REVIEW_THREADS_JSON="$TMP_DIR/gh-pr-review-threads.json"
+  fetch_all_review_threads "$REVIEW_THREADS_JSON"
+  fetch_all_thread_comments "$REVIEW_THREADS_JSON"
+fi
+
+read_json_file "$REVIEW_THREADS_JSON" "--review-threads-json"
+validate_graphql_response "$REVIEW_THREADS_JSON" "--review-threads-json"
+
+jq -n \
+  --slurpfile pr "$PR_VIEW_JSON" \
+  --slurpfile threads "$REVIEW_THREADS_JSON" \
+  --arg copilot_pattern "$COPILOT_PATTERN" \
+  '
+    ($pr[0]) as $prv
+    | ($threads[0].data.repository.pullRequest.reviewThreads.nodes) as $thread_nodes
+    | [
+        $thread_nodes[]
+        | select(.isResolved | not)
+        | . as $thread
+        | ($thread.comments.nodes // [])[]
+        | select((.author.login // "") | test($copilot_pattern; "i"))
+        | {
+            pr: {
+              url: $prv.url,
+              number: $prv.number,
+              title: $prv.title,
+              head_ref: $prv.headRefName,
+              base_ref: $prv.baseRefName
+            },
+            thread_id: $thread.id,
+            comment_id: (.databaseId // .id),
+            comment_graphql_id: .id,
+            author_login: (.author.login // null),
+            author_association: (.authorAssociation // null),
+            created_at: (.createdAt // null),
+            path: ($thread.path // null),
+            line: ($thread.line // null),
+            start_line: ($thread.startLine // null),
+            original_line: ($thread.originalLine // null),
+            original_start_line: ($thread.originalStartLine // null),
+            diff_side: ($thread.diffSide // null),
+            start_diff_side: ($thread.startDiffSide // null),
+            is_resolved: $thread.isResolved,
+            is_outdated: ($thread.isOutdated // false),
+            body: (.body // ""),
+            url: (.url // null)
+          }
+      ]
+  ' >"$RAW_OUTPUT"
+
+# Catch a stale/wrong --copilot-pattern before it fails open. If unresolved review
+# threads carried comments but NONE matched, a wrong allowlist yields zero items —
+# indistinguishable from a genuinely clean PR (SKILL-001). Warn loudly on stderr,
+# naming the author logins that were actually seen and the pattern used, so a changed
+# Copilot login is visible instead of silent. This is NOT treated as an error: a PR
+# with only human comments legitimately matches nothing, so exit stays 0. A truly
+# empty PR (no unresolved comments at all) stays silent — nothing to warn about.
+MATCHED_COUNT=$(jq 'length' "$RAW_OUTPUT")
+UNRESOLVED_COMMENT_COUNT=$(jq '
+  [ .data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved | not)
+    | (.comments.nodes // [])[]
+  ] | length
+' "$REVIEW_THREADS_JSON")
+
+if [[ "$MATCHED_COUNT" -eq 0 && "$UNRESOLVED_COMMENT_COUNT" -gt 0 ]]; then
+  AUTHORS_SEEN=$(jq -r '
+    [ .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.isResolved | not)
+      | (.comments.nodes // [])[]
+      | .author.login // "(null)"
+    ] | unique | join(", ")
+  ' "$REVIEW_THREADS_JSON")
+  printf "WARNING: 0 of %s review comments matched --copilot-pattern '%s'\n" \
+    "$UNRESOLVED_COMMENT_COUNT" "$COPILOT_PATTERN" >&2
+  printf 'WARNING: authors seen: %s\n' "$AUTHORS_SEEN" >&2
+  printf "WARNING: if Copilot's login has changed, pass --copilot-pattern to override\n" >&2
+fi
+
+python3 "$SCRIPT_DIR/dedup_review_items.py" "$RAW_OUTPUT" "$DEDUP_OUTPUT"
+
+echo "raw_items=$RAW_OUTPUT"
+echo "deduped_items=$DEDUP_OUTPUT"

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: review
+description: Reports findings; makes no changes. A two-pass adversarial code review focused on security, API consistency/symmetry, and user experience. Pass 1 is hostile (assume the worst, surface everything). Pass 2 is a neutral audit that confirms, adjusts, or refutes each finding. Use when the user asks for a hostile, skeptical, or hard review — not a friendly pass. To also fix and merge the findings, use gauntlet:campaign instead.
+---
+
+# Review
+
+Two phases, in order. The hostile pass finds; the neutral pass filters. Skipping phase 2 means delivering noise.
+
+## Phase 1 — Hostile Pass
+
+Treat the code as a suspect, not a colleague. Goal: surface everything that *could* be wrong.
+
+## Mindset
+
+- Assume every input is malicious, every caller is confused, every assumption is wrong.
+- "It works on happy path" is not evidence. Adversary picks the path.
+- Author's intent does NOT excuse behavior. Only the code's actual behavior matters.
+- No diplomatic softening. State the defect, the impact, the trigger.
+
+## Scope
+
+Resolve target before reviewing:
+
+- PR / branch → `git diff <base>...HEAD` (and read full files for changed regions, not just hunks)
+- Package / dir → enumerate files, read each
+- Single file → read whole file
+
+Always read enough surrounding context to understand callers and invariants. Hunks alone hide bugs.
+
+## Sizing — pick a strategy
+
+Measure surface BEFORE reading code:
+
+- PR/branch: `git diff --stat <base>...HEAD` (changed-file count, lines added+removed)
+- Dir/package: enumerate files with Glob (count = file count), then `wc -l <files>` for LOC.
+
+Before starting, `mkdir -p .gauntlet/tmp` (git-ignored; add `.gauntlet/` to `.gitignore` if missing) and delete stale `.gauntlet/tmp/review-*` files from previous runs. Never `rm -rf .gauntlet/` — a campaign's carryover history lives under `.gauntlet/history/`. Intermediate file paths are fixed — concurrent reviews in the same checkout collide; run one at a time.
+
+Pick by the larger of file count or LOC:
+
+| Surface | Strategy |
+|---------|----------|
+| ≤ 5 files AND ≤ 1000 LOC | **Single-pass**: review all three lenses yourself |
+| 6–30 files OR 1000–5000 LOC | **Parallel by lens**: spawn 3 subagents (security, api, ux), each covers the full target |
+| 30–200 files, single package or small cluster | **Parallel by lens × area**: subdivide each lens across bounded areas (one subagent per lens × area) |
+| > 200 files, whole-repo audit, or sprawling multi-package | **Triage-then-depth** (see "Whole-codebase mode" below) |
+
+A whole-codebase adversarial review IS in scope. Do not narrow the target, sample a "representative subset", or push back on size. Pick the strategy and dispatch. Coverage gaps go in the "Unreviewed" section, not in a refusal.
+
+In parallel mode, you are a **dispatcher**, not a reviewer. Spawn subagents in a single parallel Agent-tool block, wait for all to finish, then merge their outputs. Do NOT also review the code yourself — that produces duplicate findings and burns the main context. Your only Phase 1 reading is whatever sizing requires.
+
+**Bounded parallelism**: dispatch at most ~8 subagents per Agent-tool block. For larger fan-outs, run waves of 8, merging output between waves. This keeps each subagent's findings reviewable and avoids overwhelming the runtime.
+
+## Whole-codebase mode
+
+Triggered by the > 200 files / whole-repo row. The codebase is too big to deep-audit every file with equal rigor in one pass; coverage is by tier, not uniform.
+
+### Step 1 — Map risk surfaces
+
+Spawn ONE `Explore` subagent to enumerate the codebase and rank files into tiers:
+
+- **T1 (hot)**: untrusted-input entry points (HTTP/RPC handlers, message consumers, file parsers), auth + session code, crypto, deserialization, anything touching secrets/credentials, `unsafe` blocks, FFI/CGO, raw SQL, shell exec, template rendering, IPC.
+- **T2 (warm)**: business logic the T1 surfaces call into, persistence layer, internal RPC, background jobs, anything mutating shared state.
+- **T3 (cold)**: pure utilities, type defs, generated code, tests, docs, vendored deps.
+
+Output: `.gauntlet/tmp/review-tiers.md` with files grouped by tier, plus a short rationale per tier. Subagent prompt should explicitly say "do NOT review code — only classify by risk surface".
+
+### Step 2 — Depth-audit T1
+
+Run the full **parallel-by-lens × area** flow on T1 files only. All three lenses, full rigor, no severity floor.
+
+### Step 3 — Breadth-scan T2
+
+Spawn one subagent per lens with a tightened prompt:
+
+```
+This is a BREADTH SCAN, not a deep audit. Cover the assigned files for
+the top defect classes of your lens only — do not exhaustively enumerate.
+
+Lens: <LENS>
+Severity floor: MEDIUM (drop LOW findings; raise borderline cases instead
+of recording nits).
+
+Top defect classes to look for:
+  security → injection, missing auth, secret leaks, broken crypto
+  api     → broken symmetric pairs, inconsistent error/return shapes,
+            mixed naming for the same concept
+  ux      → footguns, silently-wrong defaults, missing required-init traps
+
+Otherwise follow Phase 1 rules from the SKILL.
+```
+
+### Step 4 — Spot-check T3
+
+ONE subagent does a rapid pass for CRITICAL-only findings across T3: hardcoded secrets, obvious injection, world-writable artifacts, panics on user input, committed `.env`-style files. Anything below CRITICAL is dropped.
+
+### Step 5 — Merge and Phase 2
+
+Merge all tier outputs into the standard `.gauntlet/tmp/review-findings.md`, tagging each finding with its tier (`[T1]`, `[T2]`, `[T3]`). Run **sharded Phase 2** as defined below. Sort chunks so T1 findings get audited first — that's where confirmation matters most.
+
+The final report's "Unreviewed" section must explicitly state what tiering chose to scan-only or skip, so the user can escalate any tier on a follow-up run.
+
+## Parallel Phase 1 — dispatcher protocol
+
+For each lens, spawn one subagent (`subagent_type: Explore` — read-only is sufficient for Phase 1). Issue ALL subagent calls in a **single parallel Agent-tool block**.
+
+`<SKILL-PATH>` below is this file's own absolute path — `${CLAUDE_PLUGIN_ROOT}/skills/review/SKILL.md` when installed as part of the `gauntlet` plugin. Resolve it to a concrete absolute path before you substitute it into the prompt: the subagent inherits no plugin-root variable and cannot expand it.
+
+Subagent prompt template:
+
+```
+You are running Phase 1 of an adversarial code review. Lens: <LENS>.
+
+Read <SKILL-PATH> and apply
+ONLY the "<LENS>" subsection of "Lenses". Do not review the other lenses.
+
+Repository root: <absolute path>
+Review target: <git ref / files / dir as given by user>
+Files in scope: <explicit list, or the command that produces it>
+Area assignment (sharded mode only): <subset of files this subagent owns>
+
+Read each in-scope file fully. Read enough surrounding code (callers,
+init, validators, middleware, type defs) to make accurate claims about
+reachability and invariants.
+
+Output: write findings to .gauntlet/tmp/review-findings-<lens>[-<area>].md
+using the format, severity scale, and ID prefixes (SEC-/API-/UX-) defined
+in the SKILL. Number sequentially within your lens (and area, if sharded).
+
+End with an "Unreviewed" section listing what you did NOT examine and why.
+
+Do NOT edit code. Do NOT verify findings — that is Phase 2's job. Bias
+toward overclaiming.
+```
+
+After all subagents return, the dispatcher:
+
+1. Concatenates lens files into `.gauntlet/tmp/review-findings.md`.
+2. Dedupes: same `file:line` + same root cause → keep the more specific finding, drop the duplicate. Different defects at the same line stay separate.
+3. Renumbers if necessary so IDs remain unique within each lens.
+4. Merges all "Unreviewed" lists.
+
+If a subagent returns a thin or empty report for a lens that obviously has surface (e.g., security lens on a package with HTTP handlers), re-dispatch it with a sharper file list — do not paper over with your own findings.
+
+## Lenses
+
+Apply each lens explicitly. Do NOT collapse them — each finds different defects.
+
+### 1. Security
+
+Check, in order:
+
+- **Input trust**: Any value from user / network / file / env treated as safe? Injection (SQL, shell, template, header, log, path traversal, SSRF, XXE, deserialization).
+- **Auth**: Authentication present where required? Authorization checked AFTER authentication? IDOR (object refs without ownership check)? Privilege escalation paths?
+- **Secrets**: Hardcoded keys, tokens, passwords? Secrets logged, returned in errors, or sent to telemetry? `.env` / config files committed?
+- **Crypto**: Custom crypto? Weak algos (MD5, SHA1 for security, DES, ECB)? Hardcoded IVs / nonces? `math/rand` where `crypto/rand` required? Cert verification disabled?
+- **Concurrency**: TOCTOU between check and use? Shared mutable state without sync? Map writes without lock? Goroutine leaks?
+- **Resource limits**: Unbounded loops, allocations, recursion, request body reads, regex on user input (ReDoS)? Missing timeouts on network/IO?
+- **Error info leakage**: Stack traces / internal paths / DB errors returned to clients?
+- **Dependencies**: New deps — known CVEs? Maintained? Pinned? Typosquat risk?
+
+### 2. API Consistency + Symmetry
+
+Check across the package / module, not just the changed function:
+
+- **Naming**: Same concept named the same way everywhere? `Get`/`Fetch`/`Load` mixed for same operation? Plural vs. singular for collections?
+- **Parameter order**: `ctx` first? Receiver/subject before modifier? Same order across sibling funcs?
+- **Symmetric pairs**: `Open`/`Close`, `Lock`/`Unlock`, `Begin`/`Commit`+`Rollback`, `Subscribe`/`Unsubscribe`, `Add`/`Remove`, `Create`/`Delete`, `Encode`/`Decode`, `Marshal`/`Unmarshal` — both halves present? Identical signatures where applicable?
+- **Return types**: Error position consistent (last)? `(T, bool)` vs. `(T, error)` mixed for similar lookups? Nil vs. zero-value vs. error conventions consistent?
+- **Optionality**: Options pattern used the same way? Required vs. optional split consistent? Defaults documented and applied uniformly?
+- **Idempotency**: Operations that should be idempotent actually are? Retries safe?
+- **Error types**: Sentinel errors vs. typed errors vs. wrapped — pattern consistent? Caller can distinguish cases it needs to?
+- **Visibility**: Exported surface minimal? Internals leaked through return types (e.g., returning concrete `*Foo` when interface suffices, or vice versa)?
+
+### 3. User Experience
+
+"User" = downstream caller, integrator, operator, end user — whichever applies. Check each that applies:
+
+- **Footguns**: Easy to misuse correctly? Zero value usable or trap? Required init step that compiles fine if skipped?
+- **Errors**: Message tells caller what went wrong AND what to do? Or just "invalid input"? Wrapped errors preserve cause? Caller can programmatically handle (typed/sentinel) AND human can read (message)?
+- **Surprises**: Function name implies one thing, does another? Side effects undocumented? Mutates input? Blocks unexpectedly? Allocates unexpectedly?
+- **Defaults**: Default behavior safe? Or does silent fallback hide bugs?
+- **Discoverability**: Required option / required call order obvious from signature? Or only from reading source?
+- **Docs vs. behavior**: Doc comment matches actual behavior? Examples compile and run? Edge cases (nil, empty, zero, negative) documented?
+- **Observability**: Failures debuggable from logs/metrics alone, or does user need a debugger?
+- **Migration**: Breaking change? Deprecation path? Old + new coexist?
+
+## Phase 1 Output (intermediate, NOT the final report)
+
+Write findings to `.gauntlet/tmp/review-findings.md`. One section per lens. Within each section, one finding per bullet:
+
+```
+[ID] [SEVERITY] <file>:<line> — <one-line defect>
+  Trigger: <how to reproduce / when this fires>
+  Impact: <what breaks, who notices>
+  Fix: <concrete change, not "consider X">
+```
+
+`ID` = `SEC-1`, `API-1`, `UX-1`, ... — stable IDs so phase 2 can reference them.
+
+Severity: `CRITICAL` (exploitable / data loss / silent corruption), `HIGH` (likely bug or hostile-input crash), `MEDIUM` (inconsistency, footgun, poor error), `LOW` (nit with rationale).
+
+Also list **unreviewed areas** explicitly. "I didn't look at X" is a finding, not a gap to hide.
+
+## Phase 1 Rules
+
+- NEVER soften findings. "Might be worth considering" is banned. State the defect.
+- NEVER report a finding without a concrete reproduction trigger or code citation.
+- NEVER invent issues to fill a lens. Empty lens → say "no findings" and move on.
+- ALWAYS cite `file:line`. No floating claims.
+- Do NOT edit code. Review only.
+
+## Phase 2 — Neutral Audit
+
+Verify every finding from phase 1. Default: spawn a subagent so the audit runs in a fresh context with no commitment to the hostile framing.
+
+### Preferred — Subagent (fresh context)
+
+Use the Agent tool with `subagent_type: Explore` (read-only is sufficient; use `general-purpose` only if the audit needs to run scripts).
+
+**Single audit** (≤ 10 findings): one subagent verifies all findings.
+
+**Sharded audit** (> 10 findings): split findings into chunks of 5–8 by ID. Keep related findings together where possible (e.g., findings citing the same file or chain of callers in one chunk — co-located findings share read context). Spawn one audit subagent per chunk in a **single parallel Agent-tool block**, each restricted to its assigned IDs. Each writes to `.gauntlet/tmp/review-verdicts-<chunk>.md`. Dispatcher concatenates into `.gauntlet/tmp/review-verdicts.md`.
+
+Subagent prompt template:
+
+```
+You are auditing a code review for accuracy. You are NOT the original
+reviewer. Your job is to either confirm or refute each finding by reading
+the cited code and its surrounding context.
+
+Findings file: .gauntlet/tmp/review-findings.md
+Assigned IDs (audit ONLY these; ignore others): <e.g., SEC-1, SEC-2, API-3>
+Repository root: <absolute path>
+Review target: <branch/PR/dir as given by user>
+
+For each assigned finding, read the cited file:line AND enough surrounding
+code (callers, validators, auth middleware, init code) to judge whether
+the trigger is actually reachable in this codebase.
+
+Ground external-API claims. When a finding's reasoning depends on how a
+stdlib / framework / third-party function behaves (e.g. "tls.Conn.SetDeadline
+doesn't propagate to the underlying conn", "json.Decoder accepts trailing
+data", "context.Background().Deadline() panics"), DO NOT accept that
+claim at face value from Phase 1. Open the dependency source or
+authoritative doc and verify the actual behavior. Cite the source you
+read (e.g. `$GOROOT/src/crypto/tls/conn.go:<line>`, official doc URL,
+package's own godoc) in the verdict. A claim about external behavior you
+cannot ground is grounds for UNCERTAIN, not CONFIRMED. The hostile pass
+overclaims about external semantics as often as about local ones —
+verifying these is Phase 2's job.
+
+For each finding, emit one verdict:
+
+- CONFIRMED — defect real, trigger reachable, severity correct.
+- ADJUSTED — defect real but severity wrong / fix wrong / trigger
+  narrower than claimed. State the correction.
+- REFUTED — finding is wrong. State which guarantee / validator /
+  invariant invalidates it, with file:line.
+- UNCERTAIN — cannot determine from code alone. State what info is
+  needed.
+
+Verdict honesty:
+
+- "CONFIRMED with caveat" is not a verdict. If you can articulate the
+  caveat, the verdict is either ADJUSTED (defect narrower / less severe
+  than claimed) or REFUTED (caveat invalidates the claim). Forcing
+  yourself to pick one of the four labels exposes hedges as the audit
+  dodging its job.
+- "Pre-refactor parity" / "behavior matches prior code" is NOT a verdict
+  modifier on its own. Resolve it: either the prior code was correct
+  (→ REFUTED for the new code, since both are correct) or the prior
+  code was also buggy (→ CONFIRMED as a pre-existing defect, with
+  trigger and impact stated independently of when it was introduced).
+  "Same as before, so confirmed but not a regression" is hedging.
+- "Sloppy but not exploitable", "design issue exists in both versions",
+  "technically a leak but unreachable in practice" — same pattern. Pick
+  REFUTED, ADJUSTED, or CONFIRMED with a specific trigger.
+
+Bias toward REFUTED and ADJUSTED. The hostile pass overclaims by design.
+Confirming a finding requires evidence it is reachable, not absence of
+evidence it isn't.
+
+Output: write verdicts to .gauntlet/tmp/review-verdicts[-<chunk>].md,
+one block per finding ID. Do not rewrite the findings — only judge them.
+```
+
+When subagents return, read findings + verdicts and merge.
+
+### Fallback — Same-context audit
+
+If subagent unavailable or user declines, do the audit yourself, but explicitly switch stance:
+
+1. Re-read each cited location with intent to *disprove* the finding.
+2. For each finding, search for: input validators upstream, auth checks, type-system guarantees, framework defaults, tests that already cover the case.
+3. For findings whose reasoning turns on the behavior of stdlib / framework / third-party APIs, read the dependency source (or authoritative doc) — do not accept the Phase 1 claim about external behavior on trust. Cite what you read.
+4. Apply the same CONFIRMED / ADJUSTED / REFUTED / UNCERTAIN verdicts. Reject "CONFIRMED with caveat" and "pre-refactor parity" as verdicts — resolve to one of the four labels with the reasoning explicit.
+5. If you cannot find evidence to refute, that is NOT a confirmation — mark UNCERTAIN.
+
+Same-context bias is real. Default to harsher self-criticism than feels natural.
+
+## Dispatcher spot-check before final report
+
+Phase 2 subagents can miss things too. Before merging verdicts into the final report, spot-check every CONFIRMED and ADJUSTED verdict for the two failure modes most likely to produce false confirmations:
+
+1. **Unverified external-API claim.** Does the verdict's reasoning rest on a claim about how a stdlib / framework / third-party function behaves? If so, did the audit cite the source it read to ground that claim? If not, the audit may have accepted Phase 1's claim on trust. Demote to UNCERTAIN and either re-dispatch the audit with an explicit "read the dependency source" instruction, or verify the claim yourself before promoting it.
+2. **Hedged confirmation.** Phrases like "CONFIRMED with caveat", "matches prior code", "this is sloppy but not exploitable", "the defect exists but" — every one is a sign the auditor couldn't fully commit. Re-read the verdict; if the hedge resolves to "the code is actually fine," demote to REFUTED with the reason. If it resolves to "the code is buggy in a way the audit struggled to articulate," dig in until you can articulate it.
+
+A 30-second pass over the 8–10 confirmed findings is cheaper than shipping a final report that misleads the user about which fixes matter. Past failure: a Phase 2 audit confirmed a TLS handshake-deadline finding by repeating Phase 1's (incorrect) claim that `*tls.Conn.SetDeadline` doesn't delegate to the underlying conn. The grounding step — reading `crypto/tls/conn.go` — would have refuted both in one minute.
+
+## Reflexive self-check before recommending fixes
+
+The dispatcher spot-check above catches hedges in audit verdicts. But the dispatcher's own final report — especially the "Top N fixes" recommendation and any prose summarizing confirmed findings — is a NEW piece of writing that can introduce its own hedges and ungrounded claims. **Apply the same rules to your own writing.** A spot-check that doesn't apply to the spot-checker has a blind spot exactly where it matters most.
+
+Before producing the final report, walk every item in your "Top N" recommendation through these checks:
+
+1. **Hedge ban on your own prose.** Re-read each top-N entry with the question: "if the user implements this exactly, will it fix a real defect, or am I recommending a defensive cleanup whose justification reduces to 'a future caller might'?" If the latter, drop or downgrade. Watch especially for: "validation asymmetry between X and Y" (resolve to: which is correct?), "the in-tree codepath is safe today but..." (then it's REFUTED), "low-level primitive vs high-level wrapper" (if the wrapper is the user-facing API, the primitive is internal — REFUTED on convention grounds), "consistency improvement" (cleanups are not the same as fixes — separate them).
+2. **External-API claims in the report must cite source.** Every "X function panics on Y" / "stdlib doesn't validate Z" / "Go arithmetic overflows here" — back it with a `$GOROOT/...` file:line or authoritative doc URL inline in the report. If you can't cite it in 30 seconds, demote to UNCERTAIN or omit. Do this BEFORE writing the recommendation, not after the user pushes back.
+3. **Math claims in particular.** Overflow / truncation / underflow claims require an arithmetic sanity check. For Go: `uint32 * time.Second` cannot overflow `int64` (max value `4.29e9 * 1e9 = 4.29e18` ≪ `9.22e18`). Don't recommend a fix for an overflow that can't happen.
+4. **Prefer narrow fixes over new API surface, especially on stable libraries.** Before recommending a new option, a new typed budget, a new error class, a new extension point — ask in order:
+   - Is there an existing knob whose **default** is wrong? Tighten it.
+   - Is there an existing knob whose **semantics** are wrong (e.g., per-iteration when it should be cumulative)? Fix the semantics.
+   - Is the bug a missing **direct** validation (RFC-specified field size, minimum length)? Add it at the parse site, no option needed.
+   - Does the caller already have a **first-class lever** for this (e.g., `context.WithTimeout` for CPU bounds, rate-limit at the edge, request-size cap at the proxy)? Document it; do not duplicate it in the library.
+
+   Only after all four fail does a new option earn its place. Each new option on a stable library is a permanent tax on every reader of the API, and "5 knobs to defend against 1 attack class" almost always means the defect is narrower than the proposal. Watch for: "WithMax* / WithBudget* / WithLimit*" appearing more than once in the same top-N (smell of overengineering), "we need this for defense-in-depth" (collapses to #4), and "systematic" framings that fan out into N options when 1 default tweak would do.
+
+This step takes ~60 seconds for an 8-item top-N. Skipping it means recommending fixes the user will reasonably reject after they read the code — wasting their time and your credibility.
+
+Past failures:
+- A whole-codebase review produced a Top-3 fixes list where the spot-check had already caught 9 hedge-confirmations in the audit output, but two of the three top-N items still relied on the same patterns (one with an unverified `time.Duration` overflow claim — `uint32 * time.Second` was assumed to overflow `int64` but cannot — and one with a "future external caller might forget" footgun). Both were dropped when the user re-applied the rules. The fix-rate of the recommended top-3 was 33% — and the user noticed before code was changed. Apply checks 1–3 before, not after.
+- A different review correctly identified a defect class with several related instances (per-iteration limits that compound across an outer loop the attacker controls). The recommended fix was a "unified work budget" exposed as ~5 new typed options, one per instance. The user pushed back: every caller now has to learn N options and pick numbers they have no basis for, while a deadline/cancellation primitive the runtime already provides bounds the underlying resource; meanwhile the actual defects were narrower (one existing limit had per-iteration semantics where cumulative was needed; one default was set far higher than realistic usage; one missing validation was specified by the relevant standard and just wasn't implemented). The right fix was small and in-place. The wrong fix was an option fan-out that would have looked impressive in a changelog and degraded the API forever. Check 4 above exists because of this failure.
+
+## Final Report
+
+Merge phase 1 findings with phase 2 verdicts. Group by verdict, not by lens:
+
+```
+## Confirmed (N)
+[SEC-1] [HIGH] path/file.go:42 — <defect>
+  Trigger: ...
+  Impact: ...
+  Fix: ...
+  Audit: confirmed — <one-line why audit agreed>
+
+## Adjusted (N)
+[API-2] [was MEDIUM, now LOW] path/file.go:88 — <defect>
+  ...
+  Audit: <what changed and why>
+
+## Refuted (N)
+[UX-3] path/file.go:120 — <original claim>
+  Audit: refuted — <validator/guarantee that invalidates it, file:line>
+
+## Uncertain (N)
+[SEC-5] path/file.go:200 — <defect>
+  Audit: cannot verify — <what info would resolve it>
+```
+
+End with:
+
+- **Summary**: counts per verdict + per severity (confirmed + adjusted only).
+- **Top 3**: highest-leverage confirmed fixes if author has limited time.
+- **Unreviewed**: areas neither pass examined.
+
+## Global Rules
+
+- Phase 2 is mandatory. A single-pass hostile review is NOT this skill.
+- Refuted findings stay in the report. The user benefits from seeing what was considered and ruled out.
+- Do NOT edit code. Review only. User decides what to fix.

--- a/scripts/validate-plugins.sh
+++ b/scripts/validate-plugins.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Validate the marketplace manifest, every plugin it lists, and skill layout.
+#
+# Runs fully offline: `claude plugin validate` needs no credentials, so this is
+# safe on forked pull requests.
+#
+# Usage: scripts/validate-plugins.sh
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd -- "$root"
+
+status=0
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  status=1
+}
+
+for tool in claude jq; do
+  command -v "$tool" >/dev/null || {
+    printf 'error: required tool not found: %s\n' "$tool" >&2
+    exit 127
+  }
+done
+
+manifest=.claude-plugin/marketplace.json
+[[ -f $manifest ]] || {
+  printf 'error: missing %s\n' "$manifest" >&2
+  exit 1
+}
+
+echo "==> marketplace manifest"
+claude plugin validate . --strict || status=1
+
+echo
+echo "==> plugin sources"
+while IFS=$'\t' read -r name source kind; do
+  # Remote sources (github/git objects) resolve at install time, not here.
+  if [[ $kind != string ]]; then
+    printf 'skip: %s has a %s source; nothing to check locally\n' "$name" "$kind"
+    continue
+  fi
+
+  # A bare path such as "gauntlet" is a hard schema error; catch it with a
+  # readable message rather than the validator's "Invalid input".
+  [[ $source == ./* ]] ||
+    fail "$name: source must be a ./-prefixed relative path, got '$source'"
+
+  # `claude plugin validate` passes silently when a source points nowhere, so a
+  # typo'd path would otherwise ship green. Assert existence ourselves.
+  [[ -d $source ]] || {
+    fail "$name: source directory '$source' does not exist"
+    continue
+  }
+  [[ -f $source/.claude-plugin/plugin.json ]] || {
+    fail "$name: '$source' has no .claude-plugin/plugin.json"
+    continue
+  }
+
+  declared=$(jq -r '.name // ""' "$source/.claude-plugin/plugin.json")
+  [[ $declared == "$name" ]] ||
+    fail "$name: plugin.json declares name '$declared'; marketplace entry says '$name'"
+
+  echo "--> $name ($source)"
+  claude plugin validate "$source" --strict || status=1
+done < <(jq -r '.plugins[] | [.name, (.source | tostring), (.source | type)] | @tsv' "$manifest")
+
+echo
+echo "==> skill directories"
+while IFS= read -r skill; do
+  dir=${skill%/SKILL.md}
+  dir=${dir##*/}
+
+  # Read only the first frontmatter block.
+  declared=$(awk '
+    /^---[[:space:]]*$/ { blocks++; next }
+    blocks == 1 && /^name:[[:space:]]/ {
+      sub(/^name:[[:space:]]*/, ""); print; exit
+    }
+    blocks >= 2 { exit }
+  ' "$skill")
+
+  # The directory name is what makes a skill invocable as /<plugin>:<dir>.
+  # Frontmatter `name` is a display label, so a mismatch silently misleads.
+  if [[ -n $declared && $declared != "$dir" ]]; then
+    fail "$skill: frontmatter name '$declared' does not match directory '$dir'"
+  fi
+
+  grep -Eq '^description:[[:space:]]*\S' "$skill" ||
+    fail "$skill: frontmatter is missing a non-empty 'description'"
+done < <(find plugins -path '*/skills/*/SKILL.md' -type f | sort)
+
+echo
+if ((status == 0)); then
+  echo "all checks passed"
+else
+  echo "validation failed" >&2
+fi
+exit "$status"


### PR DESCRIPTION
- gauntlet plugin: `campaign` (review-to-merge pipeline), `review` (report-only), `copilot-address-reviews`, `codex-exec`
- fix `marketplace.json`: `source` must be `./`-prefixed; `metadata.pluginRoot` is not resolved and silently skipped plugin validation
- skill scratch moves from `.tmp/` to `.gauntlet/tmp/`; `.gauntlet/history/` stays durable
- CI validates marketplace/plugin manifests and skill layout under `--strict`, plus shellcheck and py_compile