### PR TITLE
redirect codex exec stdin from /dev/null

### DIFF
--- a/plugins/gauntlet/skills/codex-exec/SKILL.md
+++ b/plugins/gauntlet/skills/codex-exec/SKILL.md
@@ -23,7 +23,7 @@ Delegate a task to `codex exec` for non-interactive execution.
 2. `mkdir -p .gauntlet/tmp` (git-ignored; add `.gauntlet/` to `.gitignore` if missing), then run:
 
 ```
-codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -o .gauntlet/tmp/codex-output.txt "<prompt>"
+codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -o .gauntlet/tmp/codex-output.txt "<prompt>" < /dev/null
 ```
 
 Flags:
@@ -31,6 +31,7 @@ Flags:
 - `-c "sandbox_workspace_write.network_access=true"` → allow network access from within the workspace-write sandbox
 - `-o .gauntlet/tmp/codex-output.txt` → capture final agent message
 - `-C <dir>` → set working directory if different from current
+- `< /dev/null` → redirect stdin from `/dev/null`. `codex exec` reads stdin and, when a prompt is also passed as an argument, appends it as a `<stdin>` block; in a script/background context stdin stays open with no EOF, so codex **blocks forever waiting for input**. Redirecting from `/dev/null` gives immediate EOF. Omit ONLY when deliberately piping input into the prompt.
 
 3. Read `.gauntlet/tmp/codex-output.txt` for results.
 4. Present results to user concisely.
@@ -40,5 +41,6 @@ Flags:
 - NEVER pass destructive instructions (delete, force-push, reset) to codex exec.
 - NEVER use `--dangerously-bypass-approvals-and-sandbox`.
 - Always use `--sandbox workspace-write -c "sandbox_workspace_write.network_access=true"` for sandboxed execution.
+- ALWAYS redirect stdin from `/dev/null` (`< /dev/null`) unless deliberately piping input — otherwise `codex exec` blocks reading stdin in non-interactive/background use (it appends piped stdin to the prompt as a `<stdin>` block and waits for EOF that never comes).
 - Store output in `.gauntlet/tmp/` — NEVER `/tmp/`. Never `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable.
 - If codex exec fails or times out, fall back to handling the task directly.


### PR DESCRIPTION
- `codex exec` with a prompt arg also reads stdin and appends it as a `<stdin>` block; in a non-interactive/background context stdin never EOFs, so it hangs forever
- Codify `< /dev/null` in the codex-exec skill: example command, flag note, and a rule