### PR TITLE
document adopting existing PRs into a run

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -22,6 +22,7 @@ Invoke once. This skill drives its own loop via `ScheduleWakeup`; do NOT wrap it
 - `--run <id>` -> resume specific run; self-wakes also carry internal `--token`.
 - `--new` or "fresh run" -> force independent new run with carryover.
 - Do NOT ask user to confirm no-arg scope; no arg intentionally means whole repo.
+- To fold an **existing repo PR** (one the campaign did not open) into a run and drive it through the same gate + merge, see `references/adopting-external-prs.md`.
 
 ## Load Discipline
 
@@ -49,6 +50,7 @@ Read stage refs only when that stage/action is due:
 | Merge candidate / base refresh / cleanup | `references/stage-3-merge.md` |
 | Stuck task, abort, final report | `references/bailout-and-final-report.md` |
 | Rule lookup / uncertainty | `references/critical-rules.md` |
+| Folding an existing (non-campaign) PR into the run | `references/adopting-external-prs.md` |
 
 ## Core Invariants
 

--- a/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
+++ b/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
@@ -7,7 +7,15 @@ gauntlet without reopening it.
 
 To adopt PR `<pr>` into run `<run-id>`:
 
-1. **Own it.** Add the run's owner label and the reviewing status label:
+1. **Own it — but check for an existing owner first.** Before adding any label, inspect the PR's
+   current labels: `gh pr view <pr> --json labels --jq '.labels[].name'`. If it already carries a
+   `gauntlet-run-<other>` owner label for a *different* run, do NOT adopt it blindly — two runs would
+   otherwise both treat the PR as theirs. In that case either refuse the adoption, or transfer
+   ownership only after confirming the other run is inactive (its lease is absent or stale) AND first
+   removing the old owner label
+   (`gh api -X DELETE repos/<owner>/<repo>/issues/<pr>/labels/gauntlet-run-<other>`), so that exactly
+   one run owns the PR. Only once no other `gauntlet-run-*` owner label remains, add this run's owner
+   label and the reviewing status label:
    `gh api -X POST repos/<owner>/<repo>/issues/<pr>/labels -f 'labels[]=gauntlet-run-<run-id>' -f 'labels[]=gauntlet-reviewing'`
    (use the REST API if `gh pr edit --add-label` fails). The owner label is what makes the PR "this
    run's" for every scoped git/gh scan — an adopted PR keeps its original branch name, so the label,
@@ -18,10 +26,15 @@ To adopt PR `<pr>` into run `<run-id>`:
    branch at its head, so the worktree must check out that branch — never create it off `<base>`, which
    would give you the base branch instead of the PR's changes. Then append a complete `state.md` row
    with every column in order — `id | slug | branch | worktree | pr | head_sha | reviews_ok | ci |
-   attempts | started | api_approval | status` — e.g. the PR's existing `branch` and its `worktree`,
-   `pr`, current `head_sha`, `reviews_ok=0`, live `ci`, `attempts=1`, `started=<timestamp>`,
-   `api_approval=-`, and `status: in_review`. It is NOT a Stage 0 finding, so it has no
-   `findings-raw`/verdict entry — it enters the pipeline at Stage 2.
+   attempts | started | api_approval | status`. Because an adopted PR has no Stage 0 finding, derive
+   `id` and `slug` deterministically so two agents adopting the same PR pick identical values: set
+   `id = pr-<pr-number>` (e.g. `pr-6`), and set `slug` to the PR's head branch name (fall back to its
+   title) sanitized to a short kebab-case token — lowercase, non-alphanumerics collapsed to single
+   hyphens, trimmed of leading/trailing hyphens, truncated to ~40 chars (e.g. head branch
+   `Feat/New Auth` → `feat-new-auth`). Fill the rest from the PR: the PR's existing `branch` and its
+   `worktree`, `pr`, current `head_sha`, `reviews_ok=0`, live `ci`, `attempts=1`,
+   `started=<timestamp>`, `api_approval=-`, and `status: in_review`. It is NOT a Stage 0 finding, so it
+   has no `findings-raw`/verdict entry — it enters the pipeline at Stage 2.
 3. **Gate and merge as usual.** From here the normal loop applies with no special-casing: clear the
    Stage 2a preconditions (Copilot / CI / conflicts), run the two-review gauntlet over `<base>...HEAD`,
    and merge on two admissible SATISFIED verdicts + green CI (Stage 2, Stage 3).

--- a/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
+++ b/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
@@ -7,15 +7,14 @@ gauntlet without reopening it.
 
 To adopt PR `<pr>` into run `<run-id>`:
 
-1. **Own it — but check for an existing owner first.** Before adding any label, inspect the PR's
-   current labels: `gh pr view <pr> --json labels --jq '.labels[].name'`. If it already carries a
-   `gauntlet-run-<other>` owner label for a *different* run, do NOT adopt it blindly — two runs would
-   otherwise both treat the PR as theirs. In that case either refuse the adoption, or transfer
-   ownership only after confirming the other run is inactive (its lease is absent or stale) AND first
-   removing the old owner label
-   (`gh api -X DELETE repos/<owner>/<repo>/issues/<pr>/labels/gauntlet-run-<other>`), so that exactly
-   one run owns the PR. Only once no other `gauntlet-run-*` owner label remains, add this run's owner
-   label and the reviewing status label:
+1. **Own it — but refuse a PR already owned by another run.** Before adding any label, inspect the
+   PR's current labels: `gh pr view <pr> --json labels --jq '.labels[].name'`. If it already carries a
+   `gauntlet-run-<other>` owner label for a *different* run, do NOT adopt it — refuse the adoption and
+   tell the user to let that other run finish, or to release the PR (drop its `gauntlet-run-<other>`
+   label) first. Never remove or transfer another run's owner label yourself: that would orphan the
+   other run's ledger row. Only a PR with no existing `gauntlet-run-*` owner label, or one already
+   owned by THIS run, may be adopted. Once you have confirmed no other run owns it, add this run's
+   owner label and the reviewing status label:
    `gh api -X POST repos/<owner>/<repo>/issues/<pr>/labels -f 'labels[]=gauntlet-run-<run-id>' -f 'labels[]=gauntlet-reviewing'`
    (use the REST API if `gh pr edit --add-label` fails). The owner label is what makes the PR "this
    run's" for every scoped git/gh scan — an adopted PR keeps its original branch name, so the label,

--- a/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
+++ b/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
@@ -12,9 +12,15 @@ To adopt PR `<pr>` into run `<run-id>`:
    (use the REST API if `gh pr edit --add-label` fails). The owner label is what makes the PR "this
    run's" for every scoped git/gh scan — an adopted PR keeps its original branch name, so the label,
    not a `fix-<run-id>-` prefix, is what ties it to the run.
-2. **Add a ledger row.** Append a `state.md` row: `id`, a slug, the PR's existing `branch` and a
-   `worktree` for it (create one off `<base>` if none exists), `pr`, current `head_sha`,
-   `reviews_ok=0`, live `ci`, and `status: in_review`. It is NOT a Stage 0 finding, so it has no
+2. **Add a ledger row.** First get the PR's head branch onto disk and into a worktree that checks out
+   THAT branch (not `<base>`): `git fetch origin <pr-branch>` then
+   `git worktree add $PROJECT/.worktrees/<pr-branch> <pr-branch>`. An adopted PR already has its own
+   branch at its head, so the worktree must check out that branch — never create it off `<base>`, which
+   would give you the base branch instead of the PR's changes. Then append a complete `state.md` row
+   with every column in order — `id | slug | branch | worktree | pr | head_sha | reviews_ok | ci |
+   attempts | started | api_approval | status` — e.g. the PR's existing `branch` and its `worktree`,
+   `pr`, current `head_sha`, `reviews_ok=0`, live `ci`, `attempts=1`, `started=<timestamp>`,
+   `api_approval=-`, and `status: in_review`. It is NOT a Stage 0 finding, so it has no
    `findings-raw`/verdict entry — it enters the pipeline at Stage 2.
 3. **Gate and merge as usual.** From here the normal loop applies with no special-casing: clear the
    Stage 2a preconditions (Copilot / CI / conflicts), run the two-review gauntlet over `<base>...HEAD`,
@@ -26,5 +32,7 @@ Constraints:
   campaign whose base matches.
 - Merging an adopted PR is still a merge, so the run-wide `api_changes` gate applies — an API-changing
   adopted PR needs user confirmation unless `api_changes: allowed`.
-- Cleanup at merge treats the adopted PR like any other (squash-merge, delete the remote branch,
-  remove its worktree/local branch) — but only ever this run's own labelled PR.
+- Cleanup at merge: squash-merge and delete the remote branch as usual, but the Stage 3 worktree/local
+  branch cleanup only sweeps `fix-<run-id>-*` names, so an adopted PR's differently-named branch is
+  SKIPPED by that rule. You must clean up its worktree and local branch explicitly, by the exact
+  `branch`/`worktree` names recorded in the ledger row — and only ever for this run's own labelled PR.

--- a/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
+++ b/plugins/gauntlet/skills/campaign/references/adopting-external-prs.md
@@ -1,0 +1,30 @@
+## Adopting an existing PR
+
+A campaign normally opens its own `fix-<run-id>-*` PRs from Stage 0 findings. But an **existing repo
+PR** — one a human or another tool already opened — can be **folded into a run** and driven through
+the same Stage 2 review gate and Stage 3 merge. Use this to put a hand-authored PR through the review
+gauntlet without reopening it.
+
+To adopt PR `<pr>` into run `<run-id>`:
+
+1. **Own it.** Add the run's owner label and the reviewing status label:
+   `gh api -X POST repos/<owner>/<repo>/issues/<pr>/labels -f 'labels[]=gauntlet-run-<run-id>' -f 'labels[]=gauntlet-reviewing'`
+   (use the REST API if `gh pr edit --add-label` fails). The owner label is what makes the PR "this
+   run's" for every scoped git/gh scan — an adopted PR keeps its original branch name, so the label,
+   not a `fix-<run-id>-` prefix, is what ties it to the run.
+2. **Add a ledger row.** Append a `state.md` row: `id`, a slug, the PR's existing `branch` and a
+   `worktree` for it (create one off `<base>` if none exists), `pr`, current `head_sha`,
+   `reviews_ok=0`, live `ci`, and `status: in_review`. It is NOT a Stage 0 finding, so it has no
+   `findings-raw`/verdict entry — it enters the pipeline at Stage 2.
+3. **Gate and merge as usual.** From here the normal loop applies with no special-casing: clear the
+   Stage 2a preconditions (Copilot / CI / conflicts), run the two-review gauntlet over `<base>...HEAD`,
+   and merge on two admissible SATISFIED verdicts + green CI (Stage 2, Stage 3).
+
+Constraints:
+
+- The PR must target this run's `base_branch`; if it targets a different branch, retarget it or run a
+  campaign whose base matches.
+- Merging an adopted PR is still a merge, so the run-wide `api_changes` gate applies — an API-changing
+  adopted PR needs user confirmation unless `api_changes: allowed`.
+- Cleanup at merge treats the adopted PR like any other (squash-merge, delete the remote branch,
+  remove its worktree/local branch) — but only ever this run's own labelled PR.


### PR DESCRIPTION
- Document folding an existing (non-campaign) PR into a running campaign
- New reference adopting-external-prs.md: own via run label, add ledger row, then gate + merge as usual
- SKILL.md: load-table row + Args pointer