### PR TITLE
emit reviewer progress events via a helper script

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -23,6 +23,14 @@ Invoke once. This skill drives its own loop via `ScheduleWakeup`; do NOT wrap it
 - `--new` or "fresh run" -> force independent new run with carryover.
 - Do NOT ask user to confirm no-arg scope; no arg intentionally means whole repo.
 
+## Bundled Scripts
+
+Bundled scripts live in `scripts/`, resolved relative to the directory holding this `SKILL.md` (not
+the current working directory) — installed as `${CLAUDE_PLUGIN_ROOT}/skills/campaign/scripts/`, or in
+the repo at `plugins/gauntlet/skills/campaign/scripts/`. Pass their absolute paths to subtasks. The
+review gauntlet's `scripts/emit-progress.py` emits canonical reviewer progress events (see
+`references/stage-2-review-gate.md`).
+
 ## Load Discipline
 
 Read references on demand. Do NOT load every reference up front.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -157,8 +157,11 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    point, not a guarantee of complete coverage. If an important dimension is missing or a unit is \
    wrong, append a plan_amendment_request event to the progress JSONL naming the gap; do NOT silently \
    limit your review to the listed units, and do NOT rewrite the plan yourself. Running the emit tool \
-   is the ONLY way to record progress: you MUST NOT write the progress file directly — never \
-   hand-write JSON, echo, printf, or redirect into it. Run \
+   is the ONLY way to record unit-progress (started/done) events: you MUST NOT write those unit-progress \
+   events into the progress file directly — never hand-write JSON, echo, printf, or redirect them into \
+   it. That emit-only rule covers ONLY started/done unit-progress; the emit tool does not emit \
+   plan_amendment_request, so append that event directly to the progress JSONL (it is exempt from the \
+   emit-only rule). Run \
    'python3 <SCRIPT> --file $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl --unit <plan unit id> \
    --status started' when a planned unit begins, and the same command with \
    '--status done --evidence \"<concrete citation: a file:line, a backticked span, or a filename>\"' \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -118,7 +118,7 @@ the tool and is shown only to document its shape:
 
 ```
 {"type":"progress","unit":"u01","status":"started"}
-{"type":"progress","unit":"u01","status":"done","evidence":"checked canonicalization paths and edge-case tests"}
+{"type":"progress","unit":"u01","status":"done","evidence":"validate_idc.go:42 `canonicalizeValue`; edge case tested at validate_idc_test.go:88"}
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
 ```
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -98,13 +98,13 @@ always `progress`; the only allowed `status` values are `started` and `done`. Th
 `status="started"`) and NO `evidence`; a `done` event has `type`, `unit`, `status` (with
 `status="done"`) AND a required `evidence` field carrying a concrete citation (a `file:line`, a
 backticked span, or a filename). Do NOT rename to `unit_done`/`unit_id`/`id`/`no_findings` or invent
-other event types for unit progress. Additional keys (e.g. `ts`) are tolerated, but each event's
-required keys above must be present and named exactly. The `plan_amendment_request` event keeps its
-existing shape:
+other event types for unit progress. Unit-progress events carry ONLY the exact required keys above
+(no extra keys such as `ts`); each event's required keys must be present and named exactly. The
+`plan_amendment_request` event keeps its existing shape:
 
 ```
-{"type":"progress","unit":"u01","status":"started","ts":"2026-07-06T00:00:00Z"}
-{"type":"progress","unit":"u01","status":"done","ts":"2026-07-06T00:04:00Z","evidence":"checked canonicalization paths and edge-case tests"}
+{"type":"progress","unit":"u01","status":"started"}
+{"type":"progress","unit":"u01","status":"done","evidence":"checked canonicalization paths and edge-case tests"}
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
 ```
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -92,12 +92,15 @@ Rules:
   orchestrator folds that request on the next wake and either updates the plan + restarts the review
   pass, or ignores it with a note; the reviewer completes the existing units meanwhile.
 
-Progress JSONL schema. Unit-progress events use the REQUIRED exact keys and values below — key names
-`type`, `unit`, `status`, `evidence` verbatim; `type` is always `progress`; the only allowed `status`
-values are `started` and `done`; a `done` event MUST carry `evidence` (a concrete `file:line`, a
+Progress JSONL schema. Unit-progress events use the REQUIRED exact key names verbatim; `type` is
+always `progress`; the only allowed `status` values are `started` and `done`. The required keys are
+**per event type**: a `started` event has EXACTLY the keys `type`, `unit`, `status` (with
+`status="started"`) and NO `evidence`; a `done` event has `type`, `unit`, `status` (with
+`status="done"`) AND a required `evidence` field carrying a concrete citation (a `file:line`, a
 backticked span, or a filename). Do NOT rename to `unit_done`/`unit_id`/`id`/`no_findings` or invent
-other event types for unit progress. Additional keys (e.g. `ts`) are tolerated but the four required
-keys must be present and named exactly. The `plan_amendment_request` event keeps its existing shape:
+other event types for unit progress. Additional keys (e.g. `ts`) are tolerated, but each event's
+required keys above must be present and named exactly. The `plan_amendment_request` event keeps its
+existing shape:
 
 ```
 {"type":"progress","unit":"u01","status":"started","ts":"2026-07-06T00:00:00Z"}
@@ -127,10 +130,12 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    event {\"type\":\"progress\",\"unit\":\"<plan unit id>\",\"status\":\"started\"} when the unit \
    begins, and a done event \
    {\"type\":\"progress\",\"unit\":\"<plan unit id>\",\"status\":\"done\",\"evidence\":\"<concrete \
-   citation: a file:line, a backticked span, or a filename>\"} when it finishes. Use the exact keys \
-   type, unit, status, evidence; the only allowed status values are started and done; do NOT rename to \
-   unit_done/unit_id/id/no_findings or add other event types for unit progress. progress counts only \
-   when it references a planned unit and includes concrete evidence. \
+   citation: a file:line, a backticked span, or a filename>\"} when it finishes. The started event has \
+   EXACTLY the keys type, unit, status (status=started) and NO evidence; the done event has type, \
+   unit, status (status=done) AND a required evidence field; the only allowed status values are \
+   started and done; do NOT rename to unit_done/unit_id/id/no_findings or add other event types for \
+   unit progress. progress counts only when it references a planned unit and its done event includes \
+   concrete evidence. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -92,7 +92,12 @@ Rules:
   orchestrator folds that request on the next wake and either updates the plan + restarts the review
   pass, or ignores it with a note; the reviewer completes the existing units meanwhile.
 
-Progress JSONL schema:
+Progress JSONL schema. Unit-progress events use the REQUIRED exact keys and values below — key names
+`type`, `unit`, `status`, `evidence` verbatim; `type` is always `progress`; the only allowed `status`
+values are `started` and `done`; a `done` event MUST carry `evidence` (a concrete `file:line`, a
+backticked span, or a filename). Do NOT rename to `unit_done`/`unit_id`/`id`/`no_findings` or invent
+other event types for unit progress. Additional keys (e.g. `ts`) are tolerated but the four required
+keys must be present and named exactly. The `plan_amendment_request` event keeps its existing shape:
 
 ```
 {"type":"progress","unit":"u01","status":"started","ts":"2026-07-06T00:00:00Z"}
@@ -117,8 +122,15 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    point, not a guarantee of complete coverage. If an important dimension is missing or a unit is \
    wrong, append a plan_amendment_request event to the progress JSONL naming the gap; do NOT silently \
    limit your review to the listed units, and do NOT rewrite the plan yourself. Then append progress \
-   JSONL to $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl as each planned unit starts and finishes; \
-   progress counts only when it references a planned unit and includes concrete evidence. \
+   JSONL to $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl, emitting per planned unit EXACTLY two \
+   single-line JSON events with EXACTLY these keys and values, using the key names verbatim: a start \
+   event {\"type\":\"progress\",\"unit\":\"<plan unit id>\",\"status\":\"started\"} when the unit \
+   begins, and a done event \
+   {\"type\":\"progress\",\"unit\":\"<plan unit id>\",\"status\":\"done\",\"evidence\":\"<concrete \
+   citation: a file:line, a backticked span, or a filename>\"} when it finishes. Use the exact keys \
+   type, unit, status, evidence; the only allowed status values are started and done; do NOT rename to \
+   unit_done/unit_id/id/no_findings or add other event types for unit progress. progress counts only \
+   when it references a planned unit and includes concrete evidence. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -100,7 +100,14 @@ always `progress`; the only allowed `status` values are `started` and `done`. Th
 backticked span, or a filename). Do NOT rename to `unit_done`/`unit_id`/`id`/`no_findings` or invent
 other event types for unit progress. Unit-progress events carry ONLY the exact required keys above
 (no extra keys such as `ts`); each event's required keys must be present and named exactly. The
-`plan_amendment_request` event keeps its existing shape:
+`plan_amendment_request` event keeps its existing shape.
+
+**Calling `emit-progress.py` is the ONLY sanctioned way to record a progress event.** The reviewer
+MUST NOT ever write the progress file directly — no hand-written JSON, no `echo`/`printf`/redirection
+into it, no editor append. Every event reaches the file through the tool and no other path.
+
+The block below is the canonical event shape the tool emits — shown for reference and as the parser's
+contract, NOT a template for you to write by hand:
 
 ```
 {"type":"progress","unit":"u01","status":"started"}
@@ -108,11 +115,14 @@ other event types for unit progress. Unit-progress events carry ONLY the exact r
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
 ```
 
-Reviewers do NOT hand-write these events. The orchestrator resolves the bundled emitter's absolute
-path as `<skill-dir>/scripts/emit-progress.py` (skill dir = the directory holding the campaign
-`SKILL.md`) and passes it into the review prompt, exactly as it already passes the progress file's
+Reviewers do NOT hand-write these events — ever; the emit tool is the only way they are produced. The
+orchestrator resolves the bundled emitter's absolute path as `<skill-dir>/scripts/emit-progress.py`
+(skill dir = the directory holding the campaign `SKILL.md`) and, before dispatch, substitutes it for
+the `<SCRIPT>` placeholder in the review prompt — in the SAME way it substitutes `<rundir>`, `<pr>`,
+`<n>`, `<base>`, and `<branch>` — so the reviewer receives a concrete runnable path and never a literal
+`<SCRIPT>`. It passes that path into the prompt exactly as it already passes the progress file's
 absolute path; it also ensures the `<rundir>` is a reviewer-writable root (via `--add-dir`) so the
-reviewer can append. The reviewer calls that script to emit each event, which writes the canonical
+reviewer can append. The reviewer MUST call that script to emit each event, which writes the canonical
 shape by construction; a non-zero exit means the inputs were rejected and must be fixed and re-run.
 
 Meaningful progress = a `done` event for a planned unit, or an accepted plan amendment. `started`
@@ -123,6 +133,11 @@ mark the review suspicious; if it remains stale on the next wake, treat it as a 
 retry once, then use the fresh-subagent fallback. Ignore any late verdict from a stale/superseded
 attempt unless its attempt id still matches the active review pass.
 
+**Orchestrator:** before dispatching this command, substitute EVERY placeholder with its resolved
+value — `<rundir>`, `<pr>`, `<n>`, `<base>`, `<branch>`, and `<SCRIPT>` (the resolved absolute path
+`<skill-dir>/scripts/emit-progress.py`). The reviewer must receive a concrete runnable path, never a
+literal `<SCRIPT>`.
+
 ```
 codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -C $PROJECT/.worktrees/<branch> \
   -o <rundir>/review-<pr>-<n>.txt \
@@ -131,8 +146,9 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    cover the review dimensions this change actually needs — the plan is the orchestrator's starting \
    point, not a guarantee of complete coverage. If an important dimension is missing or a unit is \
    wrong, append a plan_amendment_request event to the progress JSONL naming the gap; do NOT silently \
-   limit your review to the listed units, and do NOT rewrite the plan yourself. To record unit \
-   progress, do NOT hand-write JSON. Run \
+   limit your review to the listed units, and do NOT rewrite the plan yourself. Running the emit tool \
+   is the ONLY way to record progress: you MUST NOT write the progress file directly — never \
+   hand-write JSON, echo, printf, or redirect into it. Run \
    'python3 <SCRIPT> --file $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl --unit <plan unit id> \
    --status started' when a planned unit begins, and the same command with \
    '--status done --evidence \"<concrete citation: a file:line, a backticked span, or a filename>\"' \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -102,12 +102,19 @@ other event types for unit progress. Unit-progress events carry ONLY the exact r
 (no extra keys such as `ts`); each event's required keys must be present and named exactly. The
 `plan_amendment_request` event keeps its existing shape.
 
-**Calling `emit-progress.py` is the ONLY sanctioned way to record a progress event.** The reviewer
-MUST NOT ever write the progress file directly — no hand-written JSON, no `echo`/`printf`/redirection
-into it, no editor append. Every event reaches the file through the tool and no other path.
+**Calling `emit-progress.py` is the ONLY sanctioned way to record a unit-progress event
+(`started`/`done`).** The reviewer MUST NOT ever write those unit-progress events into the progress
+file directly — no hand-written JSON, no `echo`/`printf`/redirection into it, no editor append. Every
+unit-progress event reaches the file through the tool and no other path. This emit-only rule applies
+ONLY to the `started`/`done` unit-progress events: the tool does not produce any other event type.
+`plan_amendment_request` events are NOT emitted by the tool — the reviewer raises them through the
+amendment mechanism above — and `pass_identity` is written by the orchestrator; both are EXEMPT from
+the tool-only rule.
 
-The block below is the canonical event shape the tool emits — shown for reference and as the parser's
-contract, NOT a template for you to write by hand:
+The block below shows the canonical event shapes the parser accepts. The two unit-progress lines
+(`started`/`done`) are exactly what the tool emits — shown for reference and as the parser's contract,
+NOT a template for you to write by hand. The third line (`plan_amendment_request`) is NOT produced by
+the tool and is shown only to document its shape:
 
 ```
 {"type":"progress","unit":"u01","status":"started"}
@@ -115,7 +122,9 @@ contract, NOT a template for you to write by hand:
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
 ```
 
-Reviewers do NOT hand-write these events — ever; the emit tool is the only way they are produced. The
+Reviewers do NOT hand-write the unit-progress events (`started`/`done`) — ever; the emit tool is the
+only way those are produced. (The `plan_amendment_request` line is the exception: the tool does not
+emit it, so it is not subject to the emit-only rule.) The
 orchestrator resolves the bundled emitter's absolute path as `<skill-dir>/scripts/emit-progress.py`
 (skill dir = the directory holding the campaign `SKILL.md`) and, before dispatch, substitutes it for
 the `<SCRIPT>` placeholder in the review prompt — in the SAME way it substitutes `<rundir>`, `<pr>`,
@@ -140,6 +149,7 @@ literal `<SCRIPT>`.
 
 ```
 codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -C $PROJECT/.worktrees/<branch> \
+  --add-dir $PROJECT/<rundir> \
   -o <rundir>/review-<pr>-<n>.txt \
   "Review the changes on this branch vs <base> (the whole git diff <base>...HEAD). \
    First read $PROJECT/<rundir>/review-<pr>-<n>.plan.jsonl, then critically assess whether its units \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -108,6 +108,13 @@ other event types for unit progress. Unit-progress events carry ONLY the exact r
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
 ```
 
+Reviewers do NOT hand-write these events. The orchestrator resolves the bundled emitter's absolute
+path as `<skill-dir>/scripts/emit-progress.py` (skill dir = the directory holding the campaign
+`SKILL.md`) and passes it into the review prompt, exactly as it already passes the progress file's
+absolute path; it also ensures the `<rundir>` is a reviewer-writable root (via `--add-dir`) so the
+reviewer can append. The reviewer calls that script to emit each event, which writes the canonical
+shape by construction; a non-zero exit means the inputs were rejected and must be fixed and re-run.
+
 Meaningful progress = a `done` event for a planned unit, or an accepted plan amendment. `started`
 events and vague "still working" lines prove only process liveness and MUST NOT reset the meaningful
 progress timer. The reviewer MUST append progress events immediately as units complete, not batch them
@@ -124,18 +131,14 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    cover the review dimensions this change actually needs — the plan is the orchestrator's starting \
    point, not a guarantee of complete coverage. If an important dimension is missing or a unit is \
    wrong, append a plan_amendment_request event to the progress JSONL naming the gap; do NOT silently \
-   limit your review to the listed units, and do NOT rewrite the plan yourself. Then append progress \
-   JSONL to $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl, emitting per planned unit EXACTLY two \
-   single-line JSON events with EXACTLY these keys and values, using the key names verbatim: a start \
-   event {\"type\":\"progress\",\"unit\":\"<plan unit id>\",\"status\":\"started\"} when the unit \
-   begins, and a done event \
-   {\"type\":\"progress\",\"unit\":\"<plan unit id>\",\"status\":\"done\",\"evidence\":\"<concrete \
-   citation: a file:line, a backticked span, or a filename>\"} when it finishes. The started event has \
-   EXACTLY the keys type, unit, status (status=started) and NO evidence; the done event has type, \
-   unit, status (status=done) AND a required evidence field; the only allowed status values are \
-   started and done; do NOT rename to unit_done/unit_id/id/no_findings or add other event types for \
-   unit progress. progress counts only when it references a planned unit and its done event includes \
-   concrete evidence. \
+   limit your review to the listed units, and do NOT rewrite the plan yourself. To record unit \
+   progress, do NOT hand-write JSON. Run \
+   'python3 <SCRIPT> --file $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl --unit <plan unit id> \
+   --status started' when a planned unit begins, and the same command with \
+   '--status done --evidence \"<concrete citation: a file:line, a backticked span, or a filename>\"' \
+   when it finishes. The tool appends the canonical progress event; a non-zero exit means your inputs \
+   were rejected — fix them and re-run. progress counts only when it references a planned unit and its \
+   done event includes concrete evidence. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+STATUS_STARTED = "started"
+STATUS_DONE = "done"
+ALLOWED_STATUSES = (STATUS_STARTED, STATUS_DONE)
+
+
+def fail(msg: str) -> NoReturn:
+    print(f"emit-progress: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Append one canonical reviewer progress event to a progress.jsonl file."
+    )
+    parser.add_argument("--file", required=True, help="path to the progress.jsonl to append to")
+    parser.add_argument("--unit", required=True, help="plan unit id this event is about")
+    parser.add_argument("--status", required=True, choices=ALLOWED_STATUSES, help="started or done")
+    parser.add_argument("--evidence", help="concrete citation; required for --status done")
+    return parser.parse_args(argv)
+
+
+def build_event(unit: str, status: str, evidence: "str | None") -> dict:
+    unit = unit.strip()
+    if not unit:
+        fail("--unit must be non-empty")
+
+    if status == STATUS_STARTED:
+        if evidence is not None:
+            fail("--evidence must NOT be provided when --status is started")
+        return {"type": "progress", "unit": unit, "status": STATUS_STARTED}
+
+    # status == STATUS_DONE
+    if evidence is None or not evidence.strip():
+        fail("--evidence is required and must be non-empty when --status is done")
+    return {
+        "type": "progress",
+        "unit": unit,
+        "status": STATUS_DONE,
+        "evidence": evidence,
+    }
+
+
+def append_event(path: Path, event: dict) -> str:
+    line = json.dumps(event, separators=(",", ":")) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as outfile:
+        outfile.write(line)
+    return line
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    event = build_event(args.unit, args.status, args.evidence)
+    line = append_event(Path(args.file), event)
+    sys.stdout.write(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
- Add scripts/emit-progress.py: reviewer calls it to append canonical progress events (correct by construction)
- Keep the tightened canonical schema doc; replace the hand-write-JSON prompt instruction with a tool call
- Eliminates the recurring progress-JSONL schema drift (unit_done/unit_id/missing-status/extra-ts)