### PR TITLE
add ledger accessor script for state.md

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -40,7 +40,7 @@ the current working directory) — installed as `${CLAUDE_PLUGIN_ROOT}/skills/ca
 the repo at `plugins/gauntlet/skills/campaign/scripts/`. Pass their absolute paths to subtasks. The
 review gauntlet's `scripts/emit-progress.py` (already present there) emits canonical reviewer progress
 events (see `references/stage-2-review-gate.md`). `scripts/ledger.py` is the schema-owning accessor for
-`state.md` — read/write the ledger header and per-PR rows **by field name** through it, never by column
+`state.jsonl` — read/write the ledger header and per-PR rows **by field name** through it, never by column
 position (see `references/files-and-ledger.md`); pass its absolute path to subtasks the same way.
 
 ## Load Discipline
@@ -97,7 +97,7 @@ Read stage refs only when that stage/action is due:
 1. **Resolve run + lease;** adopt only absent/stale lease, stand down if fresh different owner.
 2. **Adopt `#PR` args + reconcile run-labelled PRs.** For each explicit `#PR`, adopt it per
    `references/pr-adoption.md` (refresh existing row on re-adoption, never duplicate); then reconcile
-   every PR carrying this run's `gauntlet-run-<run-id>` label from a batched snapshot. Treat `state.md`
+   every PR carrying this run's `gauntlet-run-<run-id>` label from a batched snapshot. Treat `state.jsonl`
    as cache.
 3. **Fold completed review / CI / fix tasks** against the SHA each ran on.
 4. **Triage tier per PR, then launch due gate work up to caps.** Re-derive each PR's tier from its

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -39,7 +39,9 @@ Bundled scripts live in `scripts/`, resolved relative to the directory holding t
 the current working directory) — installed as `${CLAUDE_PLUGIN_ROOT}/skills/campaign/scripts/`, or in
 the repo at `plugins/gauntlet/skills/campaign/scripts/`. Pass their absolute paths to subtasks. The
 review gauntlet's `scripts/emit-progress.py` (already present there) emits canonical reviewer progress
-events (see `references/stage-2-review-gate.md`).
+events (see `references/stage-2-review-gate.md`). `scripts/ledger.py` is the schema-owning accessor for
+`state.md` — read/write the ledger header and per-PR rows **by field name** through it, never by column
+position (see `references/files-and-ledger.md`); pass its absolute path to subtasks the same way.
 
 ## Load Discipline
 

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -90,7 +90,7 @@ Read stage refs only when that stage/action is due:
 - **Progress ledger:** reviewer progress means planned unit `done` or accepted amendment, not vague
   output.
 - **No green by watch exit:** derive CI from re-polled `gh pr checks` snapshot.
-- **Public API changes require user confirmation** unless ledger `api_changes: allowed`.
+- **Public API changes require user confirmation** unless the ledger's `api_changes` field is `allowed`.
 
 ## Wake Skeleton
 

--- a/plugins/gauntlet/skills/campaign/references/carryover.md
+++ b/plugins/gauntlet/skills/campaign/references/carryover.md
@@ -64,11 +64,11 @@ snapshot path.
 1. **Preflight the `#PR` set FIRST — read-only, before any run state.** Read every PR's metadata
    (`gh pr view`), run the refusal checks (foreign-owned, cross-repo/fork per `pr-adoption.md`), and
    verify all share a common `baseRefName`. This touches **no** run-id, `<rundir>`, lease, or
-   `state.md`. If any PR is refused or the bases disagree, **prompt and create nothing** — a rejected
+   `state.jsonl`. If any PR is refused or the bases disagree, **prompt and create nothing** — a rejected
    set must never leave an orphan run behind.
 2. **Only once preflight passes: mint the run-id + token, atomically create the clean `<rundir>`, and
    record the run.** A bare `mkdir` (no `-p`) of `.gauntlet/tmp/<new-run-id>/` starts empty and fails
-   loudly on the rare id clash (retry with a fresh id). Write the lease and the `state.md` header —
+   loudly on the rare id clash (retry with a fresh id). Write the lease and the `state.jsonl` header —
    with `base_branch` filled from the agreed `baseRefName` (known from preflight) — then adopt each PR
    (ledger row + labels + worktree + CI watch); a death mid-adoption still leaves a discoverable run.
    Any already-live run keeps its own dir, lease, and heartbeat; a fresh run never closes, merges, or

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -1,6 +1,6 @@
 ## Rules
 
-- Runs are isolated by `run_id`: a run touches ONLY its own `<rundir>`, its `state.md`, and the PRs
+- Runs are isolated by `run_id`: a run touches ONLY its own `<rundir>`, its `state.jsonl`, and the PRs
   carrying its `gauntlet-run-<run-id>` label. Adopted PRs keep their OWN head branch, so ownership is
   scoped by that LABEL only (never a branch prefix). NEVER reconcile, review, fix, merge, relabel, or
   clean up another run's work — scope every git/gh scan by that label.
@@ -103,7 +103,7 @@
   conflict-resolving rebase / bot or manual PR-branch commit) makes prior verdicts stale. Base
   advancement with no conflict and unchanged PR diff does NOT invalidate verdicts; carry `reviews_ok`
   forward, update `head_sha`, and require fresh CI.
-- Resume vs. fresh run is decided by **liveness**, not by `state.md` existing: live work → resume;
+- Resume vs. fresh run is decided by **liveness**, not by `state.jsonl` existing: live work → resume;
   a finished prior run → ask the user before a fresh run; `--new` → fresh run with
   carryover (Loop control step 1). A finished run must never silently exit "all done" or silently
   restart.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -156,7 +156,10 @@ ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matchi
 ```
 
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
-errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. A
-non-zero exit with a clear stderr message means the input was rejected — fix it and re-run.
+errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also
+validates the store on every read and refuses a corrupt ledger — a malformed JSON line, a record that
+is not a JSON object or has a missing/unknown `type`, or a duplicate `pr` row — reporting the offending
+line number rather than silently dropping records. A non-zero exit with a clear stderr message means the
+input was rejected — fix it and re-run.
 
 ---

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -123,4 +123,34 @@ Header field notes (the header fields above; per-row fields follow):
   while parked for the user to approve an API-changing fix. That park resolves via `api_approval`:
   `approved` returns the PR to the normal flow, `declined` makes it `aborted` (terminal).
 
+### Editing the ledger — use `scripts/ledger.py`
+
+`scripts/ledger.py` is the **sanctioned way** to read and write `state.md` (both the header block and
+the per-PR rows) **by FIELD NAME**. The script owns the schema (the header fields and the row column
+order above) in ONE place, so agents and subtasks **must not hand-edit rows by column position** —
+adding a column shifts every positional offset and silently corrupts hand-edited rows. Address fields
+by name and the script keeps the layout correct.
+
+This mirrors how `stage-2-review-gate.md` treats `emit-progress.py`: the file stays **plaintext and
+human-readable** (`cat`/grep-able), the accessor just owns the schema and writes the canonical layout.
+`state.md` is still a cache reconciled against ground truth every wake (above) — the accessor changes
+*how* rows are written, not what the ledger means.
+
+Resolve its absolute path as `<skill-dir>/scripts/ledger.py` (skill dir = the directory holding the
+campaign `SKILL.md`) and pass that path to subtasks, exactly as with `emit-progress.py`. Subcommands
+(`<state.md>` = this run's `<rundir>/state.md`):
+
+```
+ledger.py --file <state.md> header get <field>                 # read a run-config header field
+ledger.py --file <state.md> header set <field> <value>         # set a run-config header field
+ledger.py --file <state.md> add-row --pr N [--<field> <val> …] # register a row (refuses a duplicate pr; unset fields default)
+ledger.py --file <state.md> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
+ledger.py --file <state.md> get --pr N [--field <f>]           # print the row as JSON, or one field
+ledger.py --file <state.md> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
+```
+
+It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
+errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. A
+non-zero exit with a clear stderr message means the input was rejected — fix it and re-run.
+
 ---

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -158,8 +158,10 @@ ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matchi
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
 errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also
 validates the store on every read and refuses a corrupt ledger — a malformed JSON line, a record that
-is not a JSON object or has a missing/unknown `type`, or a duplicate `pr` row — reporting the offending
-line number rather than silently dropping records. A non-zero exit with a clear stderr message means the
-input was rejected — fix it and re-run.
+is not a JSON object or has a missing/unknown `type`, a duplicate `pr` row, or a header that is missing,
+not first, or repeated — reporting the offending line number rather than silently dropping records. On
+read it also normalizes every field value to a string (so an on-disk numeric/boolean `pr` matches the
+string key) and recomputes each row's derived `id` from its `pr`, never trusting the `id` on disk. A
+non-zero exit with a clear stderr message means the input was rejected — fix it and re-run.
 
 ---

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -6,7 +6,7 @@ files from colliding — see "Run identity and concurrency".
 
 | File (under `<rundir>`) | Contents |
 |------|----------|
-| `state.md` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
+| `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
 | `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input (Loop control) |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
@@ -36,7 +36,7 @@ carryover history with it. Scratch cleanup targets `.gauntlet/tmp/**` and nothin
 The history tree keeps **one file per run** (`<run-id>.md`) so concurrent runs never clobber a shared
 file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh runs and carryover".
 
-### The ledger — `state.md`
+### The ledger — `state.jsonl`
 
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is
 GitHub via `gh`, plus local worktrees** (`gh pr list/view` for PRs and merged/open state, each PR's
@@ -47,19 +47,25 @@ PR's live head (an adopted PR may have no local branch/worktree at all). Every w
 due from those, then refreshes this file. So a stale or half-written ledger is self-healing — never
 act on it without reconciling against gh (and any existing worktree) first.
 
-The file opens with a short run-config header (`run_id`, `base_branch`, `api_changes`, `reviewer`,
-`branch_ownership` — re-read every wake, see Constraints and "Run identity and concurrency"), then one
-row per adopted PR:
+The store is **JSONL** — one JSON object per line, `cat`/`grep`/`jq`-able. The first line is the
+run-config header record (`{"type": "header", …}` — `run_id`, `base_branch`, `api_changes`, `reviewer`,
+`branch_ownership`, re-read every wake, see Constraints and "Run identity and concurrency"); each
+following line is one adopted PR's row record (`{"type": "row", …}`). Every record is **self-describing**
+— fields are keyed by NAME, never by column position:
 
 ```
-run_id: g260704-0915-a3f29c1b  # this run's identity — namespaces its dir/label/wakes (set once)
-base_branch: main       # the adopted PRs' baseRefName — the branch they merge into & diffs measure against (set once; see "Base branch")
-api_changes: ask        # ask | allowed (run-wide; set once from the invocation)
-reviewer: default       # default (Claude subagents) | codex | <other> — the selected reviewer (set once; see "The reviewer")
-branch_ownership: declined  # declined | granted — may campaign delete the adopted PR's REMOTE head branch on merge (local worktree/branch cleanup is ALWAYS per-PR worktree_owned/branch_owned; set once; see "PR adoption")
-
-id | slug | branch | worktree | worktree_owned | branch_owned | pr | head_sha | reviews_ok | ci | tier | attempts | started | api_approval | status
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "default", "branch_ownership": "declined"}
+{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
+{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
+
+Header-record fields: `run_id` (this run's identity — namespaces its dir/label/wakes; set once),
+`base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
+once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
+`reviewer` (`default` (Claude subagents) | `codex` | `<other>` — the selected reviewer; set once, see
+"The reviewer"), `branch_ownership` (`declined` | `granted` — may campaign delete the adopted PR's
+REMOTE head branch on merge; local worktree/branch cleanup is ALWAYS per-PR worktree_owned/branch_owned;
+set once, see "PR adoption").
 
 Header field notes (the header fields above; per-row fields follow):
 
@@ -125,28 +131,28 @@ Header field notes (the header fields above; per-row fields follow):
 
 ### Editing the ledger — use `scripts/ledger.py`
 
-`scripts/ledger.py` is the **sanctioned way** to read and write `state.md` (both the header block and
-the per-PR rows) **by FIELD NAME**. The script owns the schema (the header fields and the row column
-order above) in ONE place, so agents and subtasks **must not hand-edit rows by column position** —
-adding a column shifts every positional offset and silently corrupts hand-edited rows. Address fields
-by name and the script keeps the layout correct.
+`scripts/ledger.py` is the **sanctioned way** to read and write `state.jsonl` (both the header record
+and the per-PR row records) **by FIELD NAME**. The script owns the schema (the header fields and the
+row fields above) in ONE place, so agents and subtasks **must not hand-edit the JSONL**. Address fields
+by name and the script keeps the store canonical.
 
 This mirrors how `stage-2-review-gate.md` treats `emit-progress.py`: the file stays **plaintext and
-human-readable** (`cat`/grep-able), the accessor just owns the schema and writes the canonical layout.
-`state.md` is still a cache reconciled against ground truth every wake (above) — the accessor changes
-*how* rows are written, not what the ledger means.
+human-readable** JSONL (`cat`/`grep`/`jq`-able), the accessor just owns the schema and writes the
+canonical layout — the store is now JSONL owned by the script. `state.jsonl` is still a cache reconciled
+against ground truth every wake (above) — the accessor changes *how* records are written, not what the
+ledger means.
 
 Resolve its absolute path as `<skill-dir>/scripts/ledger.py` (skill dir = the directory holding the
 campaign `SKILL.md`) and pass that path to subtasks, exactly as with `emit-progress.py`. Subcommands
-(`<state.md>` = this run's `<rundir>/state.md`):
+(`<state.jsonl>` = this run's `<rundir>/state.jsonl`):
 
 ```
-ledger.py --file <state.md> header get <field>                 # read a run-config header field
-ledger.py --file <state.md> header set <field> <value>         # set a run-config header field
-ledger.py --file <state.md> add-row --pr N [--<field> <val> …] # register a row (refuses a duplicate pr; unset fields default)
-ledger.py --file <state.md> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
-ledger.py --file <state.md> get --pr N [--field <f>]           # print the row as JSON, or one field
-ledger.py --file <state.md> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
+ledger.py --file <state.jsonl> header get <field>                 # read a run-config header field
+ledger.py --file <state.jsonl> header set <field> <value>         # set a run-config header field
+ledger.py --file <state.jsonl> add-row --pr N [--<field> <val> …] # register a row (refuses a duplicate pr; unset fields default)
+ledger.py --file <state.jsonl> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
+ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
+ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
 ```
 
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -17,11 +17,11 @@ blocks; each completion is its own wake.
    the idle prompt (run `gauntlet:review`, or pass PR numbers).
    This claim-locked lease check is what guarantees **no two agents drive one ledger**.
 
-   Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.md`
+   Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.jsonl`
    exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label so another run's
    PRs are never mistaken for your own (adopted PRs keep their OWN head branch, so ownership is the
    LABEL only — never a branch prefix). Live work (this run) = any open PR carrying this run's label,
-   **OR** any non-terminal row in this run's `state.md` (`in_review` / `mergeable` / `awaiting-api`).
+   **OR** any non-terminal row in this run's `state.jsonl` (`in_review` / `mergeable` / `awaiting-api`).
    Three cases:
 
    - **This run has live work → resume.** **Reconcile against ground truth** (do NOT redo *completed*
@@ -46,7 +46,7 @@ blocks; each completion is its own wake.
    - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no
      `#PR` args (a bare or non-`#PR` invocation that found no live run to resume — likewise `--new`
-     with no `#PR` args), **create nothing** — no run-id, no `<rundir>`, no lease, no `state.md` — and
+     with no `#PR` args), **create nothing** — no run-id, no `<rundir>`, no lease, no `state.jsonl` — and
      **PROMPT** the user: "No PRs under a campaign. Run gauntlet:review to find issues, or pass PR
      numbers to gate." Creating `<rundir>`/lease/header before a PR is confirmed would leave an empty
      orphan run that later no-arg invocations rediscover as bogus state.
@@ -54,20 +54,20 @@ blocks; each completion is its own wake.
      When there **are** `#PR` args, **preflight the whole set FIRST — read-only, before creating any
      run state**: read every PR's metadata (`gh pr view`), run the refusal checks (foreign-owned,
      cross-repo/fork per `pr-adoption.md`), and verify all share a common `baseRefName`. This touches
-     **no** run-id, `<rundir>`, lease, `state.md`, label, worktree, or CI watch. **If the bases
+     **no** run-id, `<rundir>`, lease, `state.jsonl`, label, worktree, or CI watch. **If the bases
      disagree or any PR is refused, prompt and create nothing** — so a rejected set never leaves an
      empty orphan run behind. **Only once the full set passes preflight**: mint a run-id + agent token,
-     atomically create `<rundir>`, and write the lease **and `state.md` header** — now with
+     atomically create `<rundir>`, and write the lease **and `state.jsonl` header** — now with
      `base_branch` filled from the agreed `baseRefName` (known from preflight). Then **adopt** each PR
      (ledger row + labels + worktree + CI watch per `pr-adoption.md`); a death mid-adoption still leaves
      a discoverable, adoptable run. Then fall through to dispatch/reschedule.
-   - **This run's `state.md` is fully terminal — every row `merged`/`aborted`, no open PR carrying this
+   - **This run's `state.jsonl` is fully terminal — every row `merged`/`aborted`, no open PR carrying this
      run's label → the run is finished.** Do **not** silently exit "all fixed" (the old bug) and do **not**
      silently restart. **Ask the user** whether to gate more PRs — e.g. "gauntlet run
      <run-id> finished (N merged, M aborted). Gate more PRs? Pass PR numbers (or run gauntlet:review
      first)." A new run needs a `#PR` set, so collect PR numbers (equivalently direct the user to
      `/gauntlet:campaign --new #PR...`); on a PR set, start a fresh run **with carryover** (see "Fresh
-     runs and carryover") — **no run-id/lease/`state.md` is created until that set passes preflight**.
+     runs and carryover") — **no run-id/lease/`state.jsonl` is created until that set passes preflight**.
      With no PR numbers (or "no"), emit that run's final report and stop. This prompt is the *only* wake
      that asks the user about scope.
 
@@ -160,7 +160,7 @@ blocks; each completion is its own wake.
      `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, and delete
      `<rundir>/lease.json`; the shared status labels stay), emit the final report, and **do not
      reschedule**. This run's loop ends. **Leave
-     `<rundir>` in place** (do NOT delete it here) — its terminal `state.md` is what lets a later bare
+     `<rundir>` in place** (do NOT delete it here) — its terminal `state.jsonl` is what lets a later bare
      invocation detect *this* *finished* run and take the "ask the user" branch in step 1 instead of a
      silent exit. (A stale heartbeat firing after exit harmlessly re-hits the finished-run branch via
      its `--run <run-id>`; with the lease released it reads as an un-driven finished run.)

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -28,7 +28,9 @@ blocks; each completion is its own wake.
      work — a review/CI task whose output file is missing may be re-launched, since in-flight tasks die
      with their session):
      for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
-     the ledger. Do the PR scan as **one batched snapshot per wake** —
+     the ledger — write every ledger update through `scripts/ledger.py … set/header set` **by field
+     name** (`files-and-ledger.md`), never by hand-editing rows by column position. Do the PR scan as
+     **one batched snapshot per wake** —
      `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
      isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
@@ -93,7 +95,8 @@ blocks; each completion is its own wake.
    - any newly-adopted PR whose ledger row lacks a `tier`, or any PR whose `head_sha` changed since it
      was last triaged → **re-triage its tier** (deterministic file-class classification of the changed
      files at that `head_sha`; agent-docs = code; default STANDARD on uncertainty — see the tiers
-     spec). The tier is pinned to `head_sha` and sets `required(tier)` = **1 if TRIVIAL else 2**.
+     spec) and write it back with `ledger.py … set --pr <N> --tier <tier>`. The tier is pinned to
+     `head_sha` and sets `required(tier)` = **1 if TRIVIAL else 2**.
    - current tip has `reviews_ok < required(tier)`, its **review preconditions are clear** (no
      unaddressed Copilot review items, CI not red, no merge conflict with `<base>` — see Stage 2a
      preconditions), and no review running for that SHA → **first ensure the PR-head worktree exists**

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -94,8 +94,8 @@ For each `#PR` to adopt:
 
 3. **Register the ledger row — refresh, never duplicate.** Write the row through
    `scripts/ledger.py` (the schema-owning accessor — `references/files-and-ledger.md`), addressing
-   every field **by name**; never hand-edit `state.md` rows by column position. Look the PR up first
-   (`ledger.py --file <state.md> get --pr <N>`): if a row already exists (re-adoption / resume),
+   every field **by name**; never hand-edit `state.jsonl` rows by column position. Look the PR up first
+   (`ledger.py --file <state.jsonl> get --pr <N>`): if a row already exists (re-adoption / resume),
    **refresh it in place** with `ledger.py … set --pr <N> --<field> <val> …` — never append a second
    row for the same PR (`add-row` refuses a duplicate `pr`). Otherwise create it with
    `ledger.py … add-row --pr <N> --<field> <val> …`. Write the **full** row:
@@ -173,7 +173,7 @@ For each `#PR` to adopt:
      worktree_owned=yes                                 # campaign created the worktree — safe to remove at cleanup
    fi
    # record via the accessor, by field name (never by column position):
-   #   ledger.py --file <state.md> set --pr <N> --worktree "$worktree" \
+   #   ledger.py --file <state.jsonl> set --pr <N> --worktree "$worktree" \
    #     --worktree_owned "$worktree_owned" --branch_owned "$branch_owned"
    # (worktree ownership and branch ownership are tracked separately)
    ```

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -92,9 +92,13 @@ For each `#PR` to adopt:
    re-open from a branch in this repo) so campaign can adopt it. Only a same-repo PR
    (`isCrossRepository=false`) adopts normally.
 
-3. **Register the ledger row — refresh, never duplicate.** Look the PR up in `state.md` by `pr`/`id`
-   first. If a row already exists (re-adoption / resume), **refresh it in place** — never append a
-   second row for the same PR. Otherwise append a new row. Write the **full** row:
+3. **Register the ledger row — refresh, never duplicate.** Write the row through
+   `scripts/ledger.py` (the schema-owning accessor — `references/files-and-ledger.md`), addressing
+   every field **by name**; never hand-edit `state.md` rows by column position. Look the PR up first
+   (`ledger.py --file <state.md> get --pr <N>`): if a row already exists (re-adoption / resume),
+   **refresh it in place** with `ledger.py … set --pr <N> --<field> <val> …` — never append a second
+   row for the same PR (`add-row` refuses a duplicate `pr`). Otherwise create it with
+   `ledger.py … add-row --pr <N> --<field> <val> …`. Write the **full** row:
 
    - `id` = `pr<N>`; `slug` = slugified PR title; `branch` = the PR's **own** `headRefName` (adopted PRs
      keep their branch — do NOT mint a `fix-<run-id>-...` branch); `worktree` = `-`,
@@ -168,8 +172,10 @@ For each `#PR` to adopt:
      worktree=$PROJECT/.worktrees/<headRefName>         # created default path: .worktrees/<headRefName>
      worktree_owned=yes                                 # campaign created the worktree — safe to remove at cleanup
    fi
-   # record $worktree in the row's `worktree` column, $worktree_owned in `worktree_owned`,
-   # and $branch_owned in `branch_owned` (worktree ownership and branch ownership are tracked separately)
+   # record via the accessor, by field name (never by column position):
+   #   ledger.py --file <state.md> set --pr <N> --worktree "$worktree" \
+   #     --worktree_owned "$worktree_owned" --branch_owned "$branch_owned"
+   # (worktree ownership and branch ownership are tracked separately)
    ```
 
    (Do **not** substitute `git fetch origin pull/<pr>/head:<headRefName>` here — that form writes the
@@ -178,10 +184,11 @@ For each `#PR` to adopt:
 
    Record the **actual** resolved `$worktree` — `$PROJECT/.worktrees/<headRefName>` is only the
    **created default** used on the `git worktree add` path; a reused checkout sits at some **other**
-   path — in the row's `worktree`, record `$worktree_owned` (`yes` = campaign created the worktree,
-   `no` = reused a pre-existing checkout) in the row's `worktree_owned`, and record `$branch_owned`
-   (`yes` = campaign created the local branch via `-b`, `no` = reused a pre-existing local branch or
-   checkout) in the row's `branch_owned`. **That `worktree` path is the source
+   path — in the row's `worktree` (via `ledger.py … set --pr <N> --worktree …`), record
+   `$worktree_owned` (`yes` = campaign created the worktree, `no` = reused a pre-existing checkout) in
+   the row's `worktree_owned`, and record `$branch_owned` (`yes` = campaign created the local branch
+   via `-b`, `no` = reused a pre-existing local branch or checkout) in the row's `branch_owned` — all
+   by field name through the accessor. **That `worktree` path is the source
    of truth the review and CI steps read/diff against**, and `worktree_owned`/`branch_owned` tell
    Stage 3 cleanup what it may remove: it removes the worktree only when `worktree_owned = yes` and
    deletes the local branch only when `branch_owned = yes` — a reused worktree or a pre-existing local

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -35,7 +35,8 @@ Use the same explicit > preference > default precedence as the reviewer (`refere
 Do **NOT** block the loop on a live prompt for this — never hold the run hostage on a user prompt. The
 grant comes from an explicit instruction in the invocation or from stored settings, not a mandatory
 question; absent one, the safe default holds.
-Record the resolved value in the header (`branch_ownership: declined | granted`); it is re-read every
+Record the resolved value in the `branch_ownership` header field (`ledger.py --file <state.jsonl>
+header set branch_ownership <declined|granted>`); it is re-read every
 wake and never re-derived mid-run.
 
 `worktree_owned`/`branch_owned` are tracked **per-PR** (below) and govern **local** cleanup in **both**

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -36,13 +36,14 @@ mkdir "$PROJECT/.gauntlet/tmp/$run_id" || run_id=…   # NO -p: must fail on col
 The run dir's `mkdir` carries **no `-p`** on purpose — it must fail if the id is already taken. Create
 the `.gauntlet/tmp` parent in its own `-p` call, never by `-p`-ing the run dir itself.
 
-Record it in the ledger header (`run_id:`) and re-read it every wake (like `base_branch`); never trust
+Record it in the ledger header field `run_id` (`ledger.py --file <state.jsonl> header set run_id
+<run-id>`) and re-read it every wake (`ledger.py … header get run_id`, like `base_branch`); never trust
 in-context memory for it — a wake may be a fresh agent instance. It flows into:
 
 | Owned by the run | Namespaced form |
 |------------------|-----------------|
 | tmp working dir  | `<rundir>` = `.gauntlet/tmp/<run-id>/` (all state/pr/review/ci/abort/lease files) |
-| ledger header    | `run_id: <run-id>` |
+| ledger header    | the `run_id` header field (set/read via `ledger.py … header set/get run_id`) |
 | PR owner label   | `gauntlet-run-<run-id>` — the **authoritative "mine" marker**. Every adopted PR is tagged with it; it, not any branch name, is what makes a PR this run's. |
 | branch           | the **adopted PR's own `headRefName`** — campaign reuses the PR's existing branch and does NOT mint a `fix-<run-id>-...` branch, so ownership can't be read off the branch name (that's the label's job). |
 | worktree         | the ledger-recorded `worktree` path — the created default `$PROJECT/.worktrees/<headRefName>` when campaign runs `git worktree add`, or a reused existing checkout when the branch was already checked out elsewhere — resolved from the PR's head branch during adoption / before its first review, and reused for review/CI fixes. Only a campaign-created worktree (`worktree_owned = yes`) is ever removed; a reused checkout (the root/main checkout or a user worktree) and a reused local branch are **always** left in place — in **both** `declined` and `granted` modes, regardless of `branch_ownership`, which governs only the remote head branch (see "PR adoption" / Stage 3). |

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -49,7 +49,7 @@ in-context memory for it — a wake may be a fresh agent instance. It flows into
 | self-wake prompt | `/gauntlet:campaign --run <run-id> --token <agent-token>` — **only** these two flags (carries the id **and** the driver token so a summarized wake re-proves ownership without guessing). It **never** carries `--new` or the original `#PR` adoption args: those are **start-time-only** (they *create/adopt*), whereas `--run` **resumes** an existing run — replaying `--new` on a self-wake would mint a fresh run every heartbeat. |
 
 **Isolation invariant — a run touches ONLY its own work.** It reads/writes only its `<rundir>`, only
-its `state.md`, and only PRs carrying its `gauntlet-run-<run-id>` label (adopted PRs keep their own
+its `state.jsonl`, and only PRs carrying its `gauntlet-run-<run-id>` label (adopted PRs keep their own
 branch names, so the **label alone** — not any branch prefix — scopes ownership), and only those
 PRs' branches/worktrees. It MUST NOT reconcile, relabel, review, fix, merge, or clean up another run's
 PRs/branches — **every git/gh scan is filtered to this run's owner label.** The status labels
@@ -102,7 +102,7 @@ Each run has `<rundir>/lease.json`:
 
 ### Resolving a wake (Loop control step 1 applies this)
 
-1. **`--run <id>` given** (every self-wake; also a manual targeted resume). Load `<rundir>/state.md`.
+1. **`--run <id>` given** (every self-wake; also a manual targeted resume). Load `<rundir>/state.jsonl`.
    Under the claim lock, compare the token you present to the lease: **matches** (self-wake with
    `--token`) → refresh lease, reconcile, continue; **lease absent/stale** → adopt (write token, fresh
    ts, read-back); **lease fresh but a different token** → for a self-wake, stand down (superseded);
@@ -117,7 +117,7 @@ Each run has `<rundir>/lease.json`:
    - **No arg at all** (`/gauntlet:campaign`) → resume-oriented: **discover runs** and bucket by lease —
      the distinct `gauntlet-run-*` ids present on open PRs — list PRs **with their labels** and extract
      the ids, since no id is known yet to query by (`gh pr list --state open --json number,labels`, then
-     pick labels matching `gauntlet-run-*`) ∪ run-ids with a `<rundir>/` (its `state.md` or
+     pick labels matching `gauntlet-run-*`) ∪ run-ids with a `<rundir>/` (its `state.jsonl` or
      `lease.json`), each **actively-driven** (fresh lease),
      **orphaned** (non-terminal, lease absent/stale), or **finished** (terminal, no open PR):
      - exactly one **orphaned** → adopt and resume it ("pick up where the previous instance left off"),

--- a/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
+++ b/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
@@ -36,8 +36,9 @@ Handling depends on the run's `api_changes` flag, stored in the ledger header:
 - **`allowed`** — proceed without asking. Set this *only* when the user, at invocation, explicitly
   said API breakage is acceptable (e.g. "allow API changes" / "ignore breakage").
 
-**Store the flag in the ledger and re-consult it every wake.** Derive `api_changes: ask|allowed` once
-from the invocation and record it in the ledger header. A run is long, so NEVER trust in-context
+**Store the flag in the ledger and re-consult it every wake.** Derive the `api_changes` header field
+(`ask` | `allowed`) once from the invocation and record it via `ledger.py --file <state.jsonl> header
+set api_changes <ask|allowed>`. A run is long, so NEVER trust in-context
 memory for this — re-read the flag from the ledger before any API-affecting change, so the behavior
 can't drift mid-run. A blanket "yes, stop asking" from the user flips the header to `allowed`; a
 one-off "yes" approves only that PR (recorded durably in its `api_approval`) and leaves the

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -3,7 +3,9 @@
 Each PR has a background task that waits on `gh pr checks --watch`, then **re-polls** `gh pr checks
 <pr>` into `ci-<pr>.txt`. The watch only blocks; the re-polled snapshot is the source of truth. When
 the task completes, a wake reads the file and decides `ci` **from the file's contents — never from
-the watch exit code**:
+the watch exit code** — and writes the `ci`/`reviews_ok` result through `scripts/ledger.py … set --pr
+<N> --ci <state> [--reviews_ok 0]` **by field name** (`files-and-ledger.md`), never by hand-editing the
+row by column position:
 
 - **green** → ONLY if the snapshot shows **zero failing lines AND zero pending lines** and the
   expected checks are actually present. `gh pr checks --watch` can exit 0 while checks are still

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -5,8 +5,9 @@
 Before the review gauntlet, triage each PR to a **risk tier**. Triage is **deterministic** and
 **size-agnostic** — there are **NO line-count or file-count thresholds**; only *what kind* of file the
 PR touches and whether the change is systemic. Re-derive the tier **every wake** from the PR's current
-`head_sha` and pin it there; record it in the ledger `tier` column. Default to **STANDARD** whenever
-you are unsure. `reviews_ok` target = `required(tier)`: **1 if `tier==TRIVIAL`, else 2**.
+`head_sha` and pin it there; record it in the ledger `tier` column via `scripts/ledger.py … set --pr
+<N> --tier <tier>` (by field name — the schema-owning accessor, `files-and-ledger.md`; never hand-edit
+the row by column position). Default to **STANDARD** whenever you are unsure. `reviews_ok` target = `required(tier)`: **1 if `tier==TRIVIAL`, else 2**.
 
 **File classes (classify every changed file; default CODE when unsure).**
 
@@ -253,7 +254,8 @@ As each verdict lands, tally it for the SHA it ran on:
   `worktree` column value) with the issue list; it
   commits + pushes → HEAD advances → the SHA's tally is void. A later wake starts a fresh review on
   the new tip. (Because reviews are sequential, no second review was spent on this broken commit.)
-- **SATISFIED** → record it. The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
+- **SATISFIED** → record it (bump `reviews_ok` via `ledger.py … set --pr <N> --reviews_ok <count>`, by
+  field name). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a
   `required==2` PR — the next wake launches the next (corroborating) review on the same SHA. When the
   tally **reaches** `required(tier)` on the same SHA, the review gate is met for this HEAD — swap the

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -91,13 +91,17 @@ via `gh`, never a local `git rev-parse HEAD`.)
 
    So the **only** difference between `granted` and `declined` is step 3's remote `--delete-branch`;
    local ref safety (`worktree_owned`/`branch_owned`, never touching the root/main checkout or any
-   reused ref) is identical and absolute in both. Once cleanup is done set status `merged` and stop the
-   PR's background tasks.
+   reused ref) is identical and absolute in both. Once cleanup is done set status `merged` (via
+   `scripts/ledger.py … set --pr <N> --status merged`, by field name — the schema-owning accessor,
+   `files-and-ledger.md`; never hand-edit the row by column position) and stop the PR's background
+   tasks.
 
    This runs only after the merge is verified, and only ever touches PRs this run **owns** — those
    carrying its `gauntlet-run-<run-id>` label — never another run's. Leave the worktree in place if the
    merge cannot be confirmed — treat that as a bailout condition, not a cleanup.
-6. After each merge+sync+cleanup, reconcile other open PRs. **Base advancement alone does NOT
+6. After each merge+sync+cleanup, reconcile other open PRs (write any `reviews_ok`/`head_sha`/`ci`
+   change below through `scripts/ledger.py … set --pr <N> --<field> <val>` by field name, never by
+   hand-editing the row by column position). **Base advancement alone does NOT
    invalidate gauntlet reviews.** Rebase only if GitHub flags the PR behind/conflicting:
    - Clean rebase (no conflicts) → verify the PR's own diff/content is unchanged → keep `reviews_ok`,
      update `head_sha` to the new tip, set `ci = pending`, **and relaunch its CI watch in the same

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -60,20 +60,31 @@ def load(path: Path) -> "tuple[dict, list[dict]]":
     rows: list[dict] = []
     if not path.exists():
         return header, rows
-    for line in path.read_text().splitlines():
+    seen_pr: set[str] = set()
+    for n, line in enumerate(path.read_text().splitlines(), start=1):
         if not line.strip():
             continue
-        rec = json.loads(line)
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError as e:
+            fail(f"malformed JSON on line {n}: {e}")
+        if not isinstance(rec, dict):
+            fail(f"line {n}: record is not a JSON object")
         kind = rec.get("type")
+        if kind not in ("header", "row"):
+            fail(f"line {n}: missing or unknown record type {kind!r}")
         if kind == "header":
             for f in HEADER_FIELDS:
                 header[f] = rec.get(f, HEADER_DEFAULTS[f])
-        elif kind == "row":
+        else:  # kind == "row"
             row = dict(ROW_DEFAULTS)
             for f in ROW_FIELDS:
                 row[f] = rec.get(f, ROW_DEFAULTS[f])
+            pr = row["pr"]
+            if pr in seen_pr:
+                fail(f"line {n}: duplicate row for pr {pr}")
+            seen_pr.add(pr)
             rows.append(row)
-        # unknown `type` values are ignored defensively
     return header, rows
 
 
@@ -113,9 +124,15 @@ def cmd_header(path: Path, args) -> int:
 
 
 def _named_field_values(args) -> dict:
-    """Collect the --<row-field> options that were actually supplied."""
+    """Collect the --<row-field> options that were actually supplied.
+
+    `pr` is the row key (passed via --pr) and `id` is always derived from it,
+    so neither is a settable update field; both are excluded here.
+    """
     values = {}
     for name in ROW_FIELDS:
+        if name in ("pr", "id"):
+            continue
         val = getattr(args, name, None)
         if val is not None:
             values[name] = val
@@ -128,10 +145,9 @@ def cmd_add_row(path: Path, args) -> int:
     if find_row(rows, pr) is not None:
         fail(f"a row for pr {pr} already exists; use `set` to update it")
     row = dict(ROW_DEFAULTS)
-    row["pr"] = pr
-    row["id"] = f"pr{pr}"
-    row.update(_named_field_values(args))
-    row["pr"] = pr  # --pr is the key, not overridable by a stray --pr option
+    row.update(_named_field_values(args))  # pr/id excluded, so both stay derived
+    row["pr"] = pr  # --pr is the row key
+    row["id"] = f"pr{pr}"  # id is always derived from pr, never caller-set
     rows.append(row)
     dump(path, header, rows)
     print(json.dumps(row))
@@ -194,8 +210,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     def add_row_field_opts(p) -> None:
         for name in ROW_FIELDS:
-            if name == "pr":
-                continue  # pr is the row key, passed via --pr
+            if name in ("pr", "id"):
+                continue  # pr is the row key (via --pr); id is always derived
             # Canonical flag is dash-form (--reviews-ok); accept the underscore
             # alias too. dest stays the underscore field name so getattr(args,
             # name) in cmd_set/cmd_add_row keeps working.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -53,14 +53,19 @@ def load(path: Path) -> "tuple[dict, list[dict]]":
     """Return (header, rows). A missing file yields defaults + no rows.
 
     The store is JSONL: one JSON object per line, routed by its `type` key. The
-    `header` record populates the header dict; each `row` record appends a row.
-    Missing fields fill from the defaults; unknown `type` values are ignored.
+    header record MUST be the first non-blank line and appear exactly once; each
+    following `row` record appends a row. Missing fields fill from the defaults.
+    Every ingested field value is coerced to `str` (mirroring how `dump()` writes
+    via `str()`), so on-disk JSON numbers/bools compare as the string keys the rest
+    of the accessor uses; a row's `id` is always recomputed from its normalized
+    `pr` (never trusted from the file). An unknown `type` is rejected, not dropped.
     """
     header = dict(HEADER_DEFAULTS)
     rows: list[dict] = []
     if not path.exists():
         return header, rows
     seen_pr: set[str] = set()
+    saw_first = False
     for n, line in enumerate(path.read_text().splitlines(), start=1):
         if not line.strip():
             continue
@@ -73,14 +78,26 @@ def load(path: Path) -> "tuple[dict, list[dict]]":
         kind = rec.get("type")
         if kind not in ("header", "row"):
             fail(f"line {n}: missing or unknown record type {kind!r}")
+        # Header must be the first non-blank record and appear exactly once.
+        if not saw_first:
+            if kind != "header":
+                fail(f"line {n}: first record must be the header")
+            saw_first = True
+        elif kind == "header":
+            fail(f"line {n}: unexpected second/out-of-order header record")
         if kind == "header":
+            # coerce every value to str, matching dump()'s write side
             for f in HEADER_FIELDS:
-                header[f] = rec.get(f, HEADER_DEFAULTS[f])
+                header[f] = str(rec.get(f, HEADER_DEFAULTS[f]))
         else:  # kind == "row"
             row = dict(ROW_DEFAULTS)
+            # coerce every value to str first, so 11 and "11" are one key
             for f in ROW_FIELDS:
-                row[f] = rec.get(f, ROW_DEFAULTS[f])
+                row[f] = str(rec.get(f, ROW_DEFAULTS[f]))
             pr = row["pr"]
+            # id is derived, never trusted from the file: recompute from pr
+            row["id"] = f"pr{pr}"
+            # duplicate detection runs on the normalized (string) pr key
             if pr in seen_pr:
                 fail(f"line {n}: duplicate row for pr {pr}")
             seen_pr.add(pr)

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -208,7 +208,13 @@ def build_parser() -> argparse.ArgumentParser:
         for name in ROW_FIELDS:
             if name == "pr":
                 continue  # pr is the row key, passed via --pr
-            p.add_argument(f"--{name}", help=f"row field '{name}'")
+            # Canonical flag is dash-form (--reviews-ok); accept the underscore
+            # alias too. dest stays the underscore field name so getattr(args,
+            # name) in cmd_set/cmd_add_row keeps working.
+            opts = [f"--{name.replace('_', '-')}"]
+            if "_" in name:
+                opts.append(f"--{name}")
+            p.add_argument(*opts, dest=name, help=f"row field '{name}'")
 
     a = sub.add_parser("add-row", help="append a new row for --pr")
     a.add_argument("--pr", required=True, help="PR number (row key)")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Schema-owning accessor for the campaign ledger (state.md).
+
+The store stays a plaintext, cat/grep-able file: a small `key: value` run-config
+header block, a blank line, one pipe-table header line naming the columns, then
+one `val | val | ...` row per adopted PR. This script owns the schema ONCE (the
+field lists below) so callers read/write by FIELD NAME and never by column
+position — adding a column here can't silently shift every offset in the skill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+DESCRIPTION = "Schema-owning accessor for the campaign ledger (state.md)."
+from pathlib import Path
+from typing import NoReturn
+
+# --- schema (owned here, once) ------------------------------------------------
+
+HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "branch_ownership")
+HEADER_DEFAULTS = {
+    "run_id": "-",
+    "base_branch": "-",
+    "api_changes": "ask",
+    "reviewer": "default",
+    "branch_ownership": "declined",
+}
+
+ROW_FIELDS = (
+    "id", "slug", "branch", "worktree", "worktree_owned", "branch_owned", "pr",
+    "head_sha", "reviews_ok", "ci", "tier", "attempts", "started",
+    "api_approval", "status",
+)
+ROW_DEFAULTS = {
+    "id": "-", "slug": "-", "branch": "-", "worktree": "-", "worktree_owned": "-",
+    "branch_owned": "-", "pr": "-", "head_sha": "-", "reviews_ok": "0", "ci": "pending",
+    "tier": "-", "attempts": "0", "started": "-", "api_approval": "-", "status": "pending",
+}
+
+
+def fail(msg: str) -> NoReturn:
+    print(f"ledger: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+# --- parse / serialize --------------------------------------------------------
+
+def load(path: Path) -> "tuple[dict, list[dict]]":
+    """Return (header, rows). A missing file yields defaults + no rows."""
+    header = dict(HEADER_DEFAULTS)
+    rows: list[dict] = []
+    if not path.exists():
+        return header, rows
+    lines = path.read_text().splitlines()
+    i = 0
+    # header block: leading `key: value` lines (inline `# comments` tolerated)
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            break
+        # a run-config line is `key: value`; the table-header line has no colon.
+        # (an inline `# a | b` comment must NOT be mistaken for the table.)
+        if line.lstrip().startswith("#") or ":" not in line:
+            break
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.split("#", 1)[0].strip()
+        if key in HEADER_FIELDS:
+            header[key] = value
+        i += 1
+    # table: find the column-header line, then read rows under it
+    while i < len(lines) and "|" not in lines[i]:
+        i += 1
+    if i < len(lines):
+        i += 1  # skip the column-header line itself
+    for line in lines[i:]:
+        if not line.strip():
+            continue
+        cells = [c.strip() for c in line.split("|")]
+        row = dict(ROW_DEFAULTS)
+        for name, cell in zip(ROW_FIELDS, cells):
+            row[name] = cell
+        rows.append(row)
+    return header, rows
+
+
+def dump(path: Path, header: dict, rows: list[dict]) -> None:
+    out = [f"{f}: {header.get(f, HEADER_DEFAULTS[f])}" for f in HEADER_FIELDS]
+    out.append("")
+    out.append(" | ".join(ROW_FIELDS))
+    for row in rows:
+        out.append(" | ".join(str(row.get(f, ROW_DEFAULTS[f])) for f in ROW_FIELDS))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(out) + "\n")
+
+
+def find_row(rows: list[dict], pr: str) -> "dict | None":
+    for row in rows:
+        if row.get("pr") == pr:
+            return row
+    return None
+
+
+def check_field(name: str, valid: "tuple[str, ...]") -> None:
+    if name not in valid:
+        fail(f"unknown field '{name}'; valid: {', '.join(valid)}")
+
+
+# --- subcommands --------------------------------------------------------------
+
+def cmd_header(path: Path, args) -> int:
+    header, rows = load(path)
+    check_field(args.field, HEADER_FIELDS)
+    if args.action == "get":
+        print(header.get(args.field, HEADER_DEFAULTS[args.field]))
+        return 0
+    if args.value is None:
+        fail("header set requires a value")
+    header[args.field] = args.value
+    dump(path, header, rows)
+    return 0
+
+
+def _named_field_values(args) -> dict:
+    """Collect the --<row-field> options that were actually supplied."""
+    values = {}
+    for name in ROW_FIELDS:
+        val = getattr(args, name, None)
+        if val is not None:
+            values[name] = val
+    return values
+
+
+def cmd_add_row(path: Path, args) -> int:
+    header, rows = load(path)
+    pr = str(args.pr)
+    if find_row(rows, pr) is not None:
+        fail(f"a row for pr {pr} already exists; use `set` to update it")
+    row = dict(ROW_DEFAULTS)
+    row["pr"] = pr
+    row["id"] = f"pr{pr}"
+    row.update(_named_field_values(args))
+    row["pr"] = pr  # --pr is the key, not overridable by a stray --pr option
+    rows.append(row)
+    dump(path, header, rows)
+    print(json.dumps(row))
+    return 0
+
+
+def cmd_set(path: Path, args) -> int:
+    header, rows = load(path)
+    pr = str(args.pr)
+    row = find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}; use `add-row` to create it")
+    updates = _named_field_values(args)
+    if not updates:
+        fail("set requires at least one --<field> <value>")
+    row.update(updates)  # by NAME — never by column position
+    dump(path, header, rows)
+    print(json.dumps(row))
+    return 0
+
+
+def cmd_get(path: Path, args) -> int:
+    _, rows = load(path)
+    row = find_row(rows, str(args.pr))
+    if row is None:
+        fail(f"no row for pr {args.pr}")
+    if args.field:
+        check_field(args.field, ROW_FIELDS)
+        print(row[args.field])
+    else:
+        print(json.dumps(row))
+    return 0
+
+
+def cmd_list(path: Path, args) -> int:
+    _, rows = load(path)
+    if args.where:
+        if "=" not in args.where:
+            fail("--where must be <field>=<value>")
+        field, _, value = args.where.partition("=")
+        check_field(field, ROW_FIELDS)
+        rows = [r for r in rows if r.get(field) == value]
+    for row in rows:
+        print(row["pr"])
+    return 0
+
+
+# --- cli ----------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("--file", required=True, help="path to the ledger (state.md)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    h = sub.add_parser("header", help="get/set a run-config header field")
+    h.add_argument("action", choices=("get", "set"))
+    h.add_argument("field")
+    h.add_argument("value", nargs="?")
+
+    def add_row_field_opts(p) -> None:
+        for name in ROW_FIELDS:
+            if name == "pr":
+                continue  # pr is the row key, passed via --pr
+            p.add_argument(f"--{name}", help=f"row field '{name}'")
+
+    a = sub.add_parser("add-row", help="append a new row for --pr")
+    a.add_argument("--pr", required=True, help="PR number (row key)")
+    add_row_field_opts(a)
+
+    s = sub.add_parser("set", help="update named fields on the row for --pr")
+    s.add_argument("--pr", required=True, help="PR number (row key)")
+    add_row_field_opts(s)
+
+    g = sub.add_parser("get", help="print the row for --pr as JSON, or one field")
+    g.add_argument("--pr", required=True, help="PR number (row key)")
+    g.add_argument("--field", help="print only this field")
+
+    ls = sub.add_parser("list", help="print matching rows' pr numbers")
+    ls.add_argument("--where", help="filter as <field>=<value>")
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    path = Path(args.file)
+    handlers = {
+        "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set,
+        "get": cmd_get, "list": cmd_list,
+    }
+    return handlers[args.cmd](path, args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -197,7 +197,7 @@ def cmd_get(path: Path, args) -> int:
     row = find_row(rows, str(args.pr))
     if row is None:
         fail(f"no row for pr {args.pr}")
-    if args.field:
+    if args.field is not None:  # an empty --field is an invalid field, not "omitted"
         check_field(args.field, ROW_FIELDS)
         print(row[args.field])
     else:
@@ -208,7 +208,7 @@ def cmd_get(path: Path, args) -> int:
 
 def cmd_list(path: Path, args) -> int:
     _, rows = load(path)
-    if args.where:
+    if args.where is not None:  # an empty --where is malformed, not "omitted"
         if "=" not in args.where:
             fail("--where must be <field>=<value>")
         field, _, value = args.where.partition("=")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -137,6 +137,8 @@ def cmd_header(path: Path, args) -> int:
     header, rows = load(path)
     check_field(args.field, HEADER_FIELDS)
     if args.action == "get":
+        if args.value is not None:  # `header get <field>` takes no value; reject a stray extra arg
+            fail("header get takes no value")
         print(header.get(args.field, HEADER_DEFAULTS[args.field]))
         return 0
     if args.value is None:

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Schema-owning accessor for the campaign ledger (state.md).
+"""Schema-owning accessor for the campaign ledger (state.jsonl).
 
-The store stays a plaintext, cat/grep-able file: a small `key: value` run-config
-header block, a blank line, one pipe-table header line naming the columns, then
-one `val | val | ...` row per adopted PR. This script owns the schema ONCE (the
-field lists below) so callers read/write by FIELD NAME and never by column
-position — adding a column here can't silently shift every offset in the skill.
+The store is a plaintext, cat/grep/jq-able JSONL file: one JSON object per line.
+Line 1 is the run-config header record (`{"type": "header", ...}`); each following
+line is one adopted PR's row record (`{"type": "row", ...}`). This script owns the
+schema ONCE (the field lists below) so callers read/write by FIELD NAME and never
+by column position — adding a field here can't silently shift every offset in the
+skill.
 """
 
 from __future__ import annotations
@@ -14,7 +15,7 @@ import argparse
 import json
 import sys
 
-DESCRIPTION = "Schema-owning accessor for the campaign ledger (state.md)."
+DESCRIPTION = "Schema-owning accessor for the campaign ledger (state.jsonl)."
 from pathlib import Path
 from typing import NoReturn
 
@@ -49,51 +50,37 @@ def fail(msg: str) -> NoReturn:
 # --- parse / serialize --------------------------------------------------------
 
 def load(path: Path) -> "tuple[dict, list[dict]]":
-    """Return (header, rows). A missing file yields defaults + no rows."""
+    """Return (header, rows). A missing file yields defaults + no rows.
+
+    The store is JSONL: one JSON object per line, routed by its `type` key. The
+    `header` record populates the header dict; each `row` record appends a row.
+    Missing fields fill from the defaults; unknown `type` values are ignored.
+    """
     header = dict(HEADER_DEFAULTS)
     rows: list[dict] = []
     if not path.exists():
         return header, rows
-    lines = path.read_text().splitlines()
-    i = 0
-    # header block: leading `key: value` lines (inline `# comments` tolerated)
-    while i < len(lines):
-        line = lines[i]
-        if not line.strip():
-            i += 1
-            break
-        # a run-config line is `key: value`; the table-header line has no colon.
-        # (an inline `# a | b` comment must NOT be mistaken for the table.)
-        if line.lstrip().startswith("#") or ":" not in line:
-            break
-        key, _, value = line.partition(":")
-        key = key.strip()
-        value = value.split("#", 1)[0].strip()
-        if key in HEADER_FIELDS:
-            header[key] = value
-        i += 1
-    # table: find the column-header line, then read rows under it
-    while i < len(lines) and "|" not in lines[i]:
-        i += 1
-    if i < len(lines):
-        i += 1  # skip the column-header line itself
-    for line in lines[i:]:
+    for line in path.read_text().splitlines():
         if not line.strip():
             continue
-        cells = [c.strip() for c in line.split("|")]
-        row = dict(ROW_DEFAULTS)
-        for name, cell in zip(ROW_FIELDS, cells):
-            row[name] = cell
-        rows.append(row)
+        rec = json.loads(line)
+        kind = rec.get("type")
+        if kind == "header":
+            for f in HEADER_FIELDS:
+                header[f] = rec.get(f, HEADER_DEFAULTS[f])
+        elif kind == "row":
+            row = dict(ROW_DEFAULTS)
+            for f in ROW_FIELDS:
+                row[f] = rec.get(f, ROW_DEFAULTS[f])
+            rows.append(row)
+        # unknown `type` values are ignored defensively
     return header, rows
 
 
 def dump(path: Path, header: dict, rows: list[dict]) -> None:
-    out = [f"{f}: {header.get(f, HEADER_DEFAULTS[f])}" for f in HEADER_FIELDS]
-    out.append("")
-    out.append(" | ".join(ROW_FIELDS))
+    out = [json.dumps({"type": "header", **{f: header.get(f, HEADER_DEFAULTS[f]) for f in HEADER_FIELDS}})]
     for row in rows:
-        out.append(" | ".join(str(row.get(f, ROW_DEFAULTS[f])) for f in ROW_FIELDS))
+        out.append(json.dumps({"type": "row", **{f: str(row.get(f, ROW_DEFAULTS[f])) for f in ROW_FIELDS}}))
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(out) + "\n")
 
@@ -175,7 +162,8 @@ def cmd_get(path: Path, args) -> int:
         check_field(args.field, ROW_FIELDS)
         print(row[args.field])
     else:
-        print(json.dumps(row))
+        # project onto ROW_FIELDS so the injected `type` key never leaks out
+        print(json.dumps({f: row[f] for f in ROW_FIELDS}))
     return 0
 
 
@@ -196,7 +184,7 @@ def cmd_list(path: Path, args) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
-    parser.add_argument("--file", required=True, help="path to the ledger (state.md)")
+    parser.add_argument("--file", required=True, help="path to the ledger (state.jsonl)")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     h = sub.add_parser("header", help="get/set a run-config header field")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -102,6 +102,12 @@ def load(path: Path) -> "tuple[dict, list[dict]]":
                 fail(f"line {n}: duplicate row for pr {pr}")
             seen_pr.add(pr)
             rows.append(row)
+    # A present file must carry a header record. A genuinely MISSING file is a
+    # fresh start (returned defaults above); a present-but-headerless file (empty,
+    # all-blank, or truncated) is corrupt — reject it rather than silently reset to
+    # defaults, which would drop the run config and every row without complaint.
+    if not saw_first:
+        fail("line 1: missing header record")
     return header, rows
 
 


### PR DESCRIPTION
Give `gauntlet:campaign` a schema-owning accessor for its per-PR ledger, so the skill stops reading/writing state by column position.

- Add `scripts/ledger.py`: owns the ledger schema once (header + row fields) and exposes `header get/set`, `add-row`, `set`, `get`, `list` — callers read/write by field NAME, so adding a field can't silently shift every offset.
- Store the ledger as **JSONL** (`state.jsonl`), one JSON object per line: line 1 is the `type:header` run-config record, each following line a `type:row` PR record. Self-describing and `cat`/`grep`/`jq`-able; replaces the old positional pipe-delimited `state.md` table.
- Route the skill's ledger reads/writes through the accessor and update the reference docs to describe the JSONL store and the sanctioned subcommands (the `emit-progress.py` pattern, applied to state I/O).