### PR TITLE
document the review-to-campaign handoff in campaign docs

### DIFF
--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -5,7 +5,7 @@ Part of the [gauntlet](../../README.md) plugin.
 Point it at existing pull requests and it drives each one to merge: it re-reviews the PR against a
 strict quality bar, waits for CI to go green, and merges — all on its own, hands-off. It doesn't go
 hunting for problems and it doesn't write fixes from scratch; it **gates PRs that already exist**
-(yours, or ones [`/gauntlet:review`](../review/SKILL.md) opened for you) and merges each only once it
+(yours, or ones [`/gauntlet:review`](../review/README.md) opened for you) and merges each only once it
 clears the bar.
 
 Think of it as an automated senior reviewer that follows through: it defends each PR through repeated
@@ -53,7 +53,7 @@ re-litigate the same ground.
 
 ## Where the PRs come from: the review handoff
 
-Campaign gates PRs; it doesn't find the problems. [`/gauntlet:review`](../review/SKILL.md) is the
+Campaign gates PRs; it doesn't find the problems. [`/gauntlet:review`](../review/README.md) is the
 other half. Review runs its two-pass adversarial pass and, by default, only reports — it makes no
 source/tracked-file or GitHub changes (it may write ephemeral `.gauntlet/tmp` review scratch). But at
 the end of a confirmed-findings report it offers an opt-in step: open one pull request per

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -14,7 +14,9 @@ is set (explicit invocation, or a preference in memory/`CLAUDE.md`/carryover). A
 different agent/model than the orchestrator (e.g. Codex CLI) is recommended for stronger reviewer
 diversity but never required — see `references/reviewer.md`. Reviews and CI watches run as background
 tasks; gates and merges stay centralized. Campaign gates **existing** PRs; it never writes fixes from
-scratch — to find issues first, use `gauntlet:review`.
+scratch — to find issues first, use `gauntlet:review`, which after its report offers to open one PR per
+confirmed fix and hand them straight here (`/gauntlet:campaign #PRs`). That opt-in handoff is a common
+way PRs enter a campaign; you can also open them yourself.
 
 Invoke once. This skill drives its own loop via `ScheduleWakeup`; do NOT wrap it in `/loop`.
 


### PR DESCRIPTION
- Note in campaign SKILL.md that gauntlet:review, after its report, offers to open one PR per confirmed fix and hand them to a campaign (the review-first entry path)
- Point the campaign README's gauntlet:review cross-links at the review README (now that it exists) instead of its SKILL.md
- Docs only