### PR TITLE
detect a review pass that never started

### DIFF
--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -163,8 +163,10 @@ flowchart TD
   can't return a verdict because of a system problem — quota or rate limits, auth, a timeout — it
   retries once and then falls back to its own subagents, so a transient outage slows a run down but
   doesn't stall it. A reviewer that never gets going at all — hung on input, a bad path, a sandbox
-  denial — is caught the same way: every review pass has to report progress within about five minutes
-  of being dispatched, and one that reports nothing is killed and relaunched rather than left hanging.
+  denial — is caught the same way: every review pass has to write *something* to its progress file
+  within about five minutes of being dispatched, and one that writes nothing at all is killed and
+  relaunched rather than left hanging. The bar there is just "is it alive", so anything the reviewer
+  writes clears it; a review that is merely slow is judged by a separate, longer timer.
 - It works through GitHub PRs via the `gh` CLI, so the repo needs a GitHub remote.
 - Before it spends a review on a PR, it first clears anything that would waste one: it addresses any
   GitHub Copilot review comments, fixes failing CI, and rebases a PR that has fallen into conflict

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -162,7 +162,9 @@ flowchart TD
   codex") or record it as your preferred reviewer (memory or `CLAUDE.md`). If an external reviewer
   can't return a verdict because of a system problem — quota or rate limits, auth, a timeout — it
   retries once and then falls back to its own subagents, so a transient outage slows a run down but
-  doesn't stall it.
+  doesn't stall it. A reviewer that never gets going at all — hung on input, a bad path, a sandbox
+  denial — is caught the same way: every review pass has to report progress within about five minutes
+  of being dispatched, and one that reports nothing is killed and relaunched rather than left hanging.
 - It works through GitHub PRs via the `gh` CLI, so the repo needs a GitHub remote.
 - Before it spends a review on a PR, it first clears anything that would waste one: it addresses any
   GitHub Copilot review comments, fixes failing CI, and rebases a PR that has fallen into conflict

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -80,7 +80,10 @@
   (a `started`/`done` `progress` event *or* a `plan_amendment_request`) — none within ~5 min of dispatch
   → the pass never started → kill + relaunch into attempt-scoped artifacts per the Stage 2a launch
   check. **Meaningful progress** is the stronger bar (`done`/accepted amendment) — stale for ~15 min →
-  suspicious review → retry/fallback per Stage 2a.
+  suspicious review → retry/fallback per Stage 2a. Both bars judge a **live** process. A pass whose
+  task is **dead** with no verdict (killed session) ignores launch evidence entirely and dispatches on
+  `launch_attempt` alone: `1` → relaunch once; `2` → fresh-subagent fallback. Never leave a dead pass
+  on neither branch.
 - Reviewers do not own the plan but must not treat it as presumptively complete: critically evaluate
   its coverage first, and raise any omitted dimension or materially wrong unit via a
   `plan_amendment_request` event rather than silently reviewing only the listed units. Never rewrite

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -71,10 +71,13 @@
   stochastic reviewer to catch a missed defect — the two are NOT statistically independent (the same
   diff, task, and protocol correlate them; same-reviewer passes also share model/prompt), so the gate
   is a miss-catcher, not a proof of correctness.
-- Before each review, write an orchestrator-owned `review-<pr>-<n>.plan.jsonl`; reviewers append
-  `review-<pr>-<n>.progress.jsonl` events against planned units. Meaningful progress = planned unit
-  `done` or accepted plan amendment, not vague "still working" output. Stale meaningful progress →
-  suspicious review → retry/fallback per Stage 2a.
+- Before each review, write an orchestrator-owned `review-<pr>-<n>.plan.jsonl` (per-pass — a relaunch
+  reuses it); reviewers append progress events against planned units to the **active launch attempt's**
+  progress file (`review-<pr>-<n>.progress.jsonl` for attempt 1, `review-<pr>-<n>.a<k>.progress.jsonl`
+  for a relaunch — only the attempt named in the active `pass_identity` is read or counted). Meaningful
+  progress = planned unit `done` or accepted plan amendment, not vague "still working" output. No
+  progress event at all within ~5 min of dispatch → the pass never started → kill + relaunch per the
+  Stage 2a launch check. Stale meaningful progress → suspicious review → retry/fallback per Stage 2a.
 - Reviewers do not own the plan but must not treat it as presumptively complete: critically evaluate
   its coverage first, and raise any omitted dimension or materially wrong unit via a
   `plan_amendment_request` event rather than silently reviewing only the listed units. Never rewrite

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -75,9 +75,12 @@
   reuses it); reviewers append progress events against planned units to the **active launch attempt's**
   progress file (`review-<pr>-<n>.progress.jsonl` for attempt 1, `review-<pr>-<n>.a<k>.progress.jsonl`
   for a relaunch — only the attempt named in the active `pass_identity` is read or counted). Meaningful
-  progress = planned unit `done` or accepted plan amendment, not vague "still working" output. No
-  progress event at all within ~5 min of dispatch → the pass never started → kill + relaunch per the
-  Stage 2a launch check. Stale meaningful progress → suspicious review → retry/fallback per Stage 2a.
+  progress = planned unit `done` or accepted plan amendment, not vague "still working" output. Two
+  distinct bars, never collapsed: **launch evidence** = ANY reviewer-written line after `pass_identity`
+  (a `started`/`done` `progress` event *or* a `plan_amendment_request`) — none within ~5 min of dispatch
+  → the pass never started → kill + relaunch into attempt-scoped artifacts per the Stage 2a launch
+  check. **Meaningful progress** is the stronger bar (`done`/accepted amendment) — stale for ~15 min →
+  suspicious review → retry/fallback per Stage 2a.
 - Reviewers do not own the plan but must not treat it as presumptively complete: critically evaluate
   its coverage first, and raise any omitted dimension or materially wrong unit via a
   `plan_amendment_request` event rather than silently reviewing only the listed units. Never rewrite

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -10,9 +10,10 @@ files from colliding — see "Run identity and concurrency".
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
 | `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input (Loop control) |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
-| `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` |
-| `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` |
-| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` |
+| `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1) |
+| `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
+| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1) |
+| `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
 | `ci-<pr>.txt` | Latest `gh pr checks` snapshot for a PR (re-polled after the watch, not the watch stream) |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -42,7 +42,10 @@ file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh r
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is
 GitHub via `gh`, plus local worktrees** (`gh pr list/view` for PRs and merged/open state, each PR's
 `headRefOid` from `gh` — keyed by PR number — for the live head SHA, `gh pr checks` for live CI, and
-the `review-<pr>-<n>.txt` files for which verdicts exist on which SHA). `git rev-parse HEAD` is used
+the **active launch attempt's** review output files for which verdicts exist on which SHA —
+`review-<pr>-<n>.txt` for attempt 1, `review-<pr>-<n>.a<k>.txt` after a relaunch, counting only the
+attempt named in that pass's `pass_identity`, so a relaunch's verdict is never missed and a dead
+attempt's is never counted). `git rev-parse HEAD` is used
 ONLY to validate/read an existing worktree when one is checked out — never as the primary source of a
 PR's live head (an adopted PR may have no local branch/worktree at all). Every wake re-derives what's
 due from those, then refreshes this file. So a stale or half-written ledger is self-healing — never

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -117,8 +117,10 @@ blocks; each completion is its own wake.
      task (one at a time per PR — the second, when the tier requires two, only after the first is
      SATISFIED; Stage 2a). If a precondition is dirty, clear it first (address Copilot items / fix CI /
      rebase) instead of spending a review;
-   - a review pass is in flight but the **active attempt's** progress file holds **no reviewer event**
-     past its **~5-min launch deadline** (measured from that file's `pass_identity.dispatched_at`) →
+   - a review pass is in flight but the **active attempt's** progress file holds **no launch evidence**
+     — no reviewer-written line of ANY kind after `pass_identity` (a `progress` `started`/`done` event
+     *or* a `plan_amendment_request` all count) — past its **~5-min launch deadline** (measured from
+     that file's `pass_identity.dispatched_at`) →
      it **never started** (Stage 2a launch check — a reviewer hung on stdin, a bad path, a sandbox
      denial). Kill the task, re-check the command for the known launch faults (above all `< /dev/null`
      on `codex exec`), and re-dispatch the pass once into **attempt-scoped artifacts**
@@ -159,9 +161,9 @@ blocks; each completion is its own wake.
      task that **hangs** (e.g. a reviewer stuck on input) and never completes, or a **killed/orphaned
      session** whose in-flight tasks died with it, so a later self-wake reconciles and resumes/adopts
      the run (see "Resume after a killed session"). **Size the delay to the nearest stall it guards:**
-     **~5 min** while any dispatched review pass is still awaiting its first progress event — its Stage
-     2a launch deadline is then the soonest thing that can fire, and a hung launch must not sit
-     undetected for a full heartbeat — otherwise **~15 min**, matching the Stage 2a meaningful-progress
+     **~5 min** while any dispatched review pass is still awaiting its first line of **launch evidence**
+     — its Stage 2a launch deadline is then the soonest thing that can fire, and a hung launch must not
+     sit undetected for a full heartbeat — otherwise **~15 min**, matching the Stage 2a meaningful-progress
      threshold: with no launch deadline pending, nothing can declare a review stalled before then, so a
      shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
      wake). ALWAYS schedule a heartbeat whenever non-terminal work remains — skipping it means a hung

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -115,6 +115,13 @@ blocks; each completion is its own wake.
      task (one at a time per PR — the second, when the tier requires two, only after the first is
      SATISFIED; Stage 2a). If a precondition is dirty, clear it first (address Copilot items / fix CI /
      rebase) instead of spending a review;
+   - a review pass is in flight but its `review-<pr>-<n>.progress.jsonl` holds **no reviewer event**
+     past its **~5-min launch deadline** (measured from that file's `pass_identity.dispatched_at`) →
+     it **never started** (Stage 2a launch check — a reviewer hung on stdin, a bad path, a sandbox
+     denial). Kill the task, re-check the command for the known launch faults (above all `< /dev/null`
+     on `codex exec`), and re-dispatch the pass once (fresh `pass_identity`, `launch_attempt: 2`); a
+     dead `launch_attempt: 2` → fresh-subagent fallback. A failed launch yields no verdict: it never
+     touches `reviews_ok` and never bumps the row's `attempts`;
    - CI red and no CI-fix subagent is already in flight for that PR/SHA → dispatch a scoped fix
      subagent (Stage 2b); different PRs may fix CI concurrently within the cap.
    - CI snapshot reads `pending` for a PR whose watch task has already exited → **relaunch the watch
@@ -147,10 +154,13 @@ blocks; each completion is its own wake.
      first, so the heartbeat forces a wake in the cases **no completion ever arrives** — a background
      task that **hangs** (e.g. a reviewer stuck on input) and never completes, or a **killed/orphaned
      session** whose in-flight tasks died with it, so a later self-wake reconciles and resumes/adopts
-     the run (see "Resume after a killed session"). Size the delay to the stall it guards, **~15 min**,
-     matching the Stage 2a meaningful-progress threshold: nothing can declare a review stalled before
-     then, so a shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context
-     cost per wake). ALWAYS schedule it whenever non-terminal work remains — skipping it means a hung
+     the run (see "Resume after a killed session"). **Size the delay to the nearest stall it guards:**
+     **~5 min** while any dispatched review pass is still awaiting its first progress event — its Stage
+     2a launch deadline is then the soonest thing that can fire, and a hung launch must not sit
+     undetected for a full heartbeat — otherwise **~15 min**, matching the Stage 2a meaningful-progress
+     threshold: with no launch deadline pending, nothing can declare a review stalled before then, so a
+     shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
+     wake). ALWAYS schedule a heartbeat whenever non-terminal work remains — skipping it means a hung
      or orphaned run wakes no one. Return.
    - All this run's PRs `merged` or `aborted` → **distill the run into the carryover ledger** (write
      this run's block to its own file `.gauntlet/history/<run-id>.md` — merged PRs, aborted

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -27,11 +27,12 @@ blocks; each completion is its own wake.
    - **This run has live work → resume.** **Reconcile against ground truth** (do NOT redo *completed*
      work — a CI task whose output file is missing may be re-launched, since in-flight tasks die with
      their session. A **review** whose output file is missing is NOT simply re-launched: resolve its
-     **active launch attempt** first (Stage 2a) — read the highest-numbered attempt's `pass_identity`,
-     and relaunch only if that attempt is `launch_attempt: 1`; an attempt already at `2` with no launch
-     evidence has spent its relaunch and takes the **fresh-subagent fallback**. A missing output file
-     alone must never re-arm the relaunch budget, or a run that keeps dying would relaunch the same
-     hanging reviewer forever across sessions):
+     **active launch attempt** first (Stage 2a) — read the highest-numbered attempt's `pass_identity`
+     and dispatch on `launch_attempt` **alone**: `1` → relaunch once (as attempt `2`); `2` → the
+     relaunch is spent, so take the **fresh-subagent fallback**. **Launch evidence is irrelevant on
+     this path** — the task is already dead, so whether it managed to write a `started` line before
+     dying says nothing about whether it will ever produce a verdict. A missing output file must never
+     re-arm the relaunch budget, and a dead attempt `2` must never be left un-dispatched):
      for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
      the ledger — write every ledger update through `scripts/ledger.py … set/header set` **by field
      name** (`files-and-ledger.md`), never by hand-editing rows by column position. Do the PR scan as
@@ -195,12 +196,20 @@ in-flight tasks do.
 **Resume after a killed session — including by a different agent instance:** in-flight background
 tasks die with the session, but nothing authoritative is lost. A new invocation reconciles against
 git/gh and continues — completed work is never redone (existing PRs, landed verdict files); a CI task
-whose output file is missing re-launches, and a **review** whose output file is missing goes through
+whose output file is missing re-launches, and a **review** with no verdict and no live task goes through
 **Stage 2a active-attempt resolution** rather than a blind re-launch: read the highest-numbered launch
-attempt's `pass_identity`, relaunch only from `launch_attempt: 1`, and take the fresh-subagent fallback
-when attempt `2` has no launch evidence. **The relaunch budget lives on disk, not in the session**, so
-it survives the death of the agent that spent it — otherwise each new instance would rediscover a
-missing output file, relaunch the same hung reviewer, die, and repeat forever. It binds to the run via
+attempt's `pass_identity` and dispatch on `launch_attempt` alone — `1` → relaunch once as attempt `2`;
+`2` → fresh-subagent fallback. **The relaunch budget lives on disk, not in the session**, so it survives
+the death of the agent that spent it — otherwise each new instance would rediscover a missing output
+file, relaunch the same hung reviewer, die, and repeat forever.
+
+**Every dead pass must land on exactly one of those two branches.** Do NOT gate the resume path on
+launch evidence: a dead attempt `2` that *did* write a `started` line before its session died would
+then satisfy neither "relaunch" (budget spent) nor "fall back" (evidence present) — no rule would fire
+and the PR would stall forever, which is the very failure this feature exists to prevent. Launch
+evidence answers "is this **live** process working?" and is meaningful **only** for the in-flight
+~5-min launch check; once the task is gone, the only question is how much relaunch budget remains. It
+binds to the run via
 `--run <id>` (what every self-wake carries, so a fresh instance adopting an orphaned run's heartbeat
 just works) or, for a bare re-invocation, by discovering live runs and adopting the sole **orphaned**
 one (asking among several). Adoption is gated on the **run lease**: an agent takes over only a run

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -25,8 +25,13 @@ blocks; each completion is its own wake.
    Three cases:
 
    - **This run has live work → resume.** **Reconcile against ground truth** (do NOT redo *completed*
-     work — a review/CI task whose output file is missing may be re-launched, since in-flight tasks die
-     with their session):
+     work — a CI task whose output file is missing may be re-launched, since in-flight tasks die with
+     their session. A **review** whose output file is missing is NOT simply re-launched: resolve its
+     **active launch attempt** first (Stage 2a) — read the highest-numbered attempt's `pass_identity`,
+     and relaunch only if that attempt is `launch_attempt: 1`; an attempt already at `2` with no launch
+     evidence has spent its relaunch and takes the **fresh-subagent fallback**. A missing output file
+     alone must never re-arm the relaunch budget, or a run that keeps dying would relaunch the same
+     hanging reviewer forever across sessions):
      for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
      the ledger — write every ledger update through `scripts/ledger.py … set/header set` **by field
      name** (`files-and-ledger.md`), never by hand-editing rows by column position. Do the PR scan as
@@ -189,8 +194,13 @@ in-flight tasks do.
 
 **Resume after a killed session — including by a different agent instance:** in-flight background
 tasks die with the session, but nothing authoritative is lost. A new invocation reconciles against
-git/gh and continues — completed work is never redone (existing PRs, landed verdict files); only a
-review/CI task whose output file is missing re-launches. It binds to the run via
+git/gh and continues — completed work is never redone (existing PRs, landed verdict files); a CI task
+whose output file is missing re-launches, and a **review** whose output file is missing goes through
+**Stage 2a active-attempt resolution** rather than a blind re-launch: read the highest-numbered launch
+attempt's `pass_identity`, relaunch only from `launch_attempt: 1`, and take the fresh-subagent fallback
+when attempt `2` has no launch evidence. **The relaunch budget lives on disk, not in the session**, so
+it survives the death of the agent that spent it — otherwise each new instance would rediscover a
+missing output file, relaunch the same hung reviewer, die, and repeat forever. It binds to the run via
 `--run <id>` (what every self-wake carries, so a fresh instance adopting an orphaned run's heartbeat
 just works) or, for a bare re-invocation, by discovering live runs and adopting the sole **orphaned**
 one (asking among several). Adoption is gated on the **run lease**: an agent takes over only a run

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -85,8 +85,10 @@ blocks; each completion is its own wake.
    `gauntlet-accepted` if its current HEAD holds `required(tier)` SATISFIED verdicts, else
    `gauntlet-reviewing`; add the status label if it has none. **Never touch another run's PRs.**
 2. **Fold in completions.** For any background task that finished (CI watch → `ci-<pr>.txt`; review →
-   `review-<pr>-<n>.txt`, with `review-<pr>-<n>.progress.jsonl` as its liveness evidence; CI/review
-   fix), record the result against the SHA it ran on and act per Stage 2.
+   the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
+   writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and
+   only the attempt named in the current `pass_identity` is read or counted (Stage 2a); CI/review fix),
+   record the result against the SHA it ran on and act per Stage 2.
 3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,
    not just the PR/job that woke you. Launch every due action that fits a free slot before returning.
    Launch only what is actually due *and not already in flight* (check ground truth first, never the
@@ -115,13 +117,15 @@ blocks; each completion is its own wake.
      task (one at a time per PR — the second, when the tier requires two, only after the first is
      SATISFIED; Stage 2a). If a precondition is dirty, clear it first (address Copilot items / fix CI /
      rebase) instead of spending a review;
-   - a review pass is in flight but its `review-<pr>-<n>.progress.jsonl` holds **no reviewer event**
+   - a review pass is in flight but the **active attempt's** progress file holds **no reviewer event**
      past its **~5-min launch deadline** (measured from that file's `pass_identity.dispatched_at`) →
      it **never started** (Stage 2a launch check — a reviewer hung on stdin, a bad path, a sandbox
      denial). Kill the task, re-check the command for the known launch faults (above all `< /dev/null`
-     on `codex exec`), and re-dispatch the pass once (fresh `pass_identity`, `launch_attempt: 2`); a
-     dead `launch_attempt: 2` → fresh-subagent fallback. A failed launch yields no verdict: it never
-     touches `reviews_ok` and never bumps the row's `attempts`;
+     on `codex exec`), and re-dispatch the pass once into **attempt-scoped artifacts**
+     (`review-<pr>-<n>.a2.*`, fresh `pass_identity` with `launch_attempt: 2` — never the dead attempt's
+     files, which a surviving process could still write to); a dead `launch_attempt: 2` →
+     fresh-subagent fallback. A failed launch yields no verdict: it never touches `reviews_ok` and
+     never bumps the row's `attempts`;
    - CI red and no CI-fix subagent is already in flight for that PR/SHA → dispatch a scoped fix
      subagent (Stage 2b); different PRs may fix CI concurrently within the cap.
    - CI snapshot reads `pending` for a PR whose watch task has already exited → **relaunch the watch

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -29,8 +29,10 @@ complete, valid reviewer.
 ### Running the default reviewer — Claude subagents
 
 The reviewer's only job is the **Stage 2a per-PR review pass**: spawn a **fresh** subagent to review
-the whole `origin/<base>...HEAD` diff with an adversarial pass, using the same `review-<pr>-<n>.plan.jsonl` /
-`review-<pr>-<n>.progress.jsonl` protocol — planned units, then the unstructured adversarial sweep —
+the whole `origin/<base>...HEAD` diff with an adversarial pass, using the same plan / progress protocol
+— the per-pass `review-<pr>-<n>.plan.jsonl` and the **active launch attempt's** progress file
+(`review-<pr>-<n>.progress.jsonl`, or `review-<pr>-<n>.a<k>.progress.jsonl` after a relaunch;
+`stage-2-review-gate.md`) — planned units, then the unstructured adversarial sweep —
 and, on SATISFIED, the same `RESIDUAL-RISK: <area> — <why>` line immediately above exactly one final
 `VERDICT: SATISFIED` / `VERDICT: NOT SATISFIED` line. Each pass is a fresh, context-isolated subagent,
 so the review gate holds: for a two-pass tier, launch review 2 only after review 1 is SATISFIED, one

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -39,9 +39,16 @@ at a time per PR (see Stage 2a-triage for the per-tier pass count).
 ### Running an external reviewer (e.g. Codex CLI)
 
 When the selected reviewer is an external command like `codex exec`, invoke it as the stage refs show
-(`codex exec --sandbox workspace-write …`, output to the run's file). NEVER pass destructive
+(`codex exec --sandbox workspace-write … < /dev/null`, output to the run's file — the full command is
+in `stage-2-review-gate.md`; build it from there, never from this abbreviation). NEVER pass destructive
 instructions (delete, force-push, reset) to an external reviewer command, and NEVER use
 `--dangerously-bypass-approvals-and-sandbox`.
+
+**ALWAYS redirect stdin from `/dev/null` (`< /dev/null`) on every `codex exec` dispatch.** `codex exec`
+reads stdin and appends it as a `<stdin>` block when a prompt is also passed as an argument; in a
+background / non-interactive context stdin never reaches EOF, so codex **blocks forever waiting for
+input** and the pass emits nothing at all. `< /dev/null` gives it an immediate EOF. (Omit it only when
+deliberately piping the prompt in on stdin.)
 
 An external reviewer can fail in a way that yields **no usable verdict**: quota/rate-limit
 exhaustion, auth failures, timeouts, or other system errors. Distinguish this from a real review — a
@@ -53,3 +60,9 @@ default Claude subagents** (the per-PR procedure above) rather than stalling, lo
 gate — then note in the final report which passes ran on the subagent fallback. The gate is unchanged:
 a subagent pass is a fresh, context-isolated re-roll that counts toward the review gate exactly like an
 external pass.
+
+A reviewer that **never starts** is a distinct failure — it produces not even a partial result — and
+has its own guard: the Stage 2a **launch check** kills any pass that has emitted no progress event
+within ~5 min of dispatch, re-dispatches it once, and falls back to a fresh subagent if the relaunch is
+also dead on arrival. A dropped `< /dev/null` is the most common cause, so re-check the command before
+relaunching: an identical relaunch hangs identically.

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -64,7 +64,9 @@ a subagent pass is a fresh, context-isolated re-roll that counts toward the revi
 external pass.
 
 A reviewer that **never starts** is a distinct failure — it produces not even a partial result — and
-has its own guard: the Stage 2a **launch check** kills any pass that has emitted no progress event
-within ~5 min of dispatch, re-dispatches it once, and falls back to a fresh subagent if the relaunch is
-also dead on arrival. A dropped `< /dev/null` is the most common cause, so re-check the command before
-relaunching: an identical relaunch hangs identically.
+has its own guard: the Stage 2a **launch check** kills any pass that has written **no launch evidence**
+within ~5 min of dispatch (launch evidence = any reviewer-written line after `pass_identity`, including
+a `plan_amendment_request`, not just a `progress` event), re-dispatches it once into attempt-scoped
+artifacts, and falls back to a fresh subagent if the relaunch is also dead on arrival. A dropped
+`< /dev/null` is the most common cause, so re-check the command before relaunching: an identical
+relaunch hangs identically.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -213,11 +213,19 @@ a bad binary/`-C` path, or a sandbox/auth denial that never reaches the model. S
 rule is sized for a reviewer working slowly, not one that never woke up. Gate every review pass on a
 **first-event deadline**:
 
-- **Deadline = ~5 min from the pass's `pass_identity.dispatched_at`.** By then the progress file MUST
-  hold at least one reviewer-written `progress` event. A `started` event **counts** — this check asks
-  only "did the process boot and can it write?", so it is deliberately weaker than meaningful progress
-  (which ignores `started`).
-- **Zero reviewer events past the deadline → the pass never started.** Do NOT wait out the 15-min
+- **Launch evidence = ANY reviewer-written line appended after the orchestrator's `pass_identity`.**
+  A `progress` event (`started` **or** `done`) counts, and so does a `plan_amendment_request` — the
+  protocol lets a reviewer open by flagging a plan gap, and such a reviewer is demonstrably alive. The
+  question this check asks is only **"did the process boot and can it write?"**, so **every** line the
+  reviewer authors answers it. Requiring specifically a `progress` event would kill a live reviewer
+  whose first act was a legitimate amendment request.
+- **Deadline = ~5 min from the pass's `pass_identity.dispatched_at`.** By then the active attempt's
+  progress file MUST hold at least one line of launch evidence.
+- **Launch evidence and meaningful progress are two different bars, deliberately.** Launch evidence is
+  the weaker one (any reviewer-written line, ~5 min, "is it alive?"); meaningful progress is the
+  stronger one (a planned unit `done` or an accepted amendment, ~15 min, "is it getting anywhere?").
+  A `started` event is launch evidence but is **not** meaningful progress. Never collapse the two.
+- **Zero launch evidence past the deadline → the pass never started.** Do NOT wait out the 15-min
   stale path. Kill the task and re-dispatch the pass **once**, into **fresh, attempt-scoped artifacts**
   (`review-<pr>-<n>.a2.*`, per the table above — never the dead attempt's files): write a new
   `pass_identity` carrying `launch_attempt: 2` and a new `dispatched_at` as that file's first line, then

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -250,9 +250,22 @@ The reviewer runs the following review contract (shown as the external-reviewer 
 default Claude-subagent path gives a fresh subagent the same instructions and output file):
 
 **Orchestrator:** before dispatching this command, substitute EVERY placeholder with its resolved
-value — `<rundir>`, `<pr>`, `<n>`, `<base>`, `<worktree>`, and `<SCRIPT>` (the resolved absolute path
-`<skill-dir>/scripts/emit-progress.py`). The reviewer must receive a concrete runnable path, never a
-literal `<SCRIPT>`.
+value — `<rundir>`, `<pr>`, `<n>`, `<base>`, `<worktree>`, `<SCRIPT>` (the resolved absolute path
+`<skill-dir>/scripts/emit-progress.py`), and the two **attempt-scoped artifact** placeholders. The
+reviewer must receive concrete runnable paths, never a literal `<SCRIPT>`/`<review-output>`/`<progress-file>`.
+
+`<review-output>` and `<progress-file>` resolve to the **active launch attempt's** files (per the
+attempt-artifact table above) — NOT to fixed names:
+
+| Launch attempt | `<review-output>` | `<progress-file>` |
+|---|---|---|
+| `1` | `review-<pr>-<n>.txt` | `review-<pr>-<n>.progress.jsonl` |
+| `k ≥ 2` (relaunch) | `review-<pr>-<n>.a<k>.txt` | `review-<pr>-<n>.a<k>.progress.jsonl` |
+
+Substituting attempt-1 names into a **relaunch** is a silent self-defeat: the relaunched reviewer would
+write its progress into the *dead* attempt's file, leaving the active `.a<k>.progress.jsonl` holding
+only `pass_identity` — so the launch check would read the live relaunch as dead and fall back. The
+placeholders exist so the dispatch command and the attempt-isolation rule can never drift apart.
 
 **Note:** the review runs in `<worktree>` — the PR row's ledger `worktree` column value, the single
 source of truth for this PR's checkout path (created at adoption/pre-review per `pr-adoption.md`; the
@@ -277,7 +290,7 @@ review launches. All review diffs then use `origin/<base>...HEAD`.
 ```
 codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=true" -C <worktree> \
   --add-dir $PROJECT/<rundir> \
-  -o $PROJECT/<rundir>/review-<pr>-<n>.txt \
+  -o $PROJECT/<rundir>/<review-output> \
   "Review the changes on this branch vs origin/<base> (the whole git diff origin/<base>...HEAD). \
    First read $PROJECT/<rundir>/review-<pr>-<n>.plan.jsonl, then critically assess whether its units \
    cover the review dimensions this change actually needs — the plan is the orchestrator's starting \
@@ -289,7 +302,7 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    it. That emit-only rule covers ONLY started/done unit-progress; the emit tool does not emit \
    plan_amendment_request, so append that event directly to the progress JSONL (it is exempt from the \
    emit-only rule). Run \
-   'python3 <SCRIPT> --file $PROJECT/<rundir>/review-<pr>-<n>.progress.jsonl --unit <plan unit id> \
+   'python3 <SCRIPT> --file $PROJECT/<rundir>/<progress-file> --unit <plan unit id> \
    --status started' when a planned unit begins, and the same command with \
    '--status done --evidence \"<concrete citation: a file:line, a backticked span, or a filename>\"' \
    when it finishes. The tool appends the canonical progress event; a non-zero exit means your inputs \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -166,13 +166,33 @@ the tool and is shown only to document its shape. The fourth (`pass_identity`) i
 ```
 
 **`pass_identity` is the pass's attempt id and its dispatch clock.** The orchestrator writes it as the
-**first line** of `review-<pr>-<n>.progress.jsonl` **before** launching the reviewer process, so the
-progress file exists from dispatch onward. Three rules depend on it: a late verdict is ignored unless
-its attempt id (`pr` + `pass` + `head_sha`) still matches the active pass; `dispatched_at` is the clock
-the launch check below measures against; and `launch_attempt` (`1`, then `2` on a relaunch) is how a
-*later wake* — possibly a fresh agent — knows whether this pass has already been relaunched once. A
-progress file holding **only** this line is therefore evidence that the reviewer has produced nothing —
-not evidence of a missing file.
+**first line** of the launch attempt's progress file **before** launching the reviewer process, so that
+file exists from dispatch onward. Three rules depend on it: a late verdict is ignored unless its attempt
+id still matches the active pass; `dispatched_at` is the clock the launch check below measures against;
+and `launch_attempt` (`1`, then `2` on a relaunch) is how a *later wake* — possibly a fresh agent —
+knows whether this pass has already been relaunched once. A progress file holding **only** this line is
+therefore evidence that the reviewer has produced nothing — not evidence of a missing file.
+
+**The attempt id is `pr` + `pass` + `head_sha` + `launch_attempt` — all four.** A relaunch keeps the
+first three, so without `launch_attempt` the two launch attempts of one pass are indistinguishable and
+a killed-but-not-dead attempt could be mistaken for the live one.
+
+**Each launch attempt owns its own artifacts — a relaunch NEVER reuses the dead attempt's files.**
+A process that survived its kill still writes to the paths it was given, so reusing them would let a
+zombie attempt 1 append `started`/`done` into attempt 2's progress file (falsely satisfying attempt 2's
+launch check) or land a stale verdict in the shared output file. Path isolation, not the kill, is what
+makes that impossible:
+
+| Launch attempt | Progress file | Output (verdict) file |
+|---|---|---|
+| `1` | `review-<pr>-<n>.progress.jsonl` | `review-<pr>-<n>.txt` |
+| `k ≥ 2` | `review-<pr>-<n>.a<k>.progress.jsonl` | `review-<pr>-<n>.a<k>.txt` |
+
+The plan (`review-<pr>-<n>.plan.jsonl`) is per-pass, not per-attempt — a relaunch reuses it unchanged.
+The orchestrator substitutes the **active attempt's** paths into the review prompt (`-o` and the emit
+tool's `--file`), and **reads only those paths**: progress events and a verdict are counted **only**
+from the artifacts of the attempt named in the active `pass_identity`. A dead attempt's files are inert
+— left on disk for forensics, never read, never counted.
 
 Reviewers do NOT hand-write the unit-progress events (`started`/`done`) — ever; the emit tool is the
 only way those are produced. (The `plan_amendment_request` line is the exception: the tool does not
@@ -198,12 +218,15 @@ rule is sized for a reviewer working slowly, not one that never woke up. Gate ev
   only "did the process boot and can it write?", so it is deliberately weaker than meaningful progress
   (which ignores `started`).
 - **Zero reviewer events past the deadline → the pass never started.** Do NOT wait out the 15-min
-  stale path. Kill the task and re-dispatch the pass **once**: rewrite the progress file with a fresh
-  `pass_identity` carrying `launch_attempt: 2` and a new `dispatched_at`, then launch again. If the
-  relaunch (`launch_attempt: 2`) also produces nothing by its own deadline → treat it as a reviewer
-  system failure and take the fresh-subagent fallback (same path as a verdict-less external reviewer,
-  above). Reading the retry count off the file, not off memory, is what makes this survive a killed
-  session: a fresh agent adopting the run sees `launch_attempt: 2` and falls back instead of
+  stale path. Kill the task and re-dispatch the pass **once**, into **fresh, attempt-scoped artifacts**
+  (`review-<pr>-<n>.a2.*`, per the table above — never the dead attempt's files): write a new
+  `pass_identity` carrying `launch_attempt: 2` and a new `dispatched_at` as that file's first line, then
+  launch with the `a2` paths substituted into the prompt. From that moment the `a2` artifacts are the
+  only ones read, so anything the killed attempt 1 still writes is inert. If the relaunch also produces
+  nothing by its own deadline → treat it as a reviewer system failure and take the fresh-subagent
+  fallback (same path as a verdict-less external reviewer, above). Reading the retry count off the file,
+  not off memory, is what makes this survive a killed session: a fresh agent adopting the run finds the
+  highest-numbered attempt's `pass_identity`, sees `launch_attempt: 2`, and falls back instead of
   relaunching forever.
 - Before re-dispatching, **re-check the command** for the known launch faults — most of all the
   `< /dev/null` stdin redirect on every `codex exec` (see below). A relaunch of the same hanging

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -155,13 +155,24 @@ the tool-only rule.
 The block below shows the canonical event shapes the parser accepts. The two unit-progress lines
 (`started`/`done`) are exactly what the tool emits — shown for reference and as the parser's contract,
 NOT a template for you to write by hand. The third line (`plan_amendment_request`) is NOT produced by
-the tool and is shown only to document its shape:
+the tool and is shown only to document its shape. The fourth (`pass_identity`) is written by the
+**orchestrator** at dispatch, never by the reviewer:
 
 ```
 {"type":"progress","unit":"u01","status":"started"}
 {"type":"progress","unit":"u01","status":"done","evidence":"validate_idc.go:42 `canonicalizeValue`; edge case tested at validate_idc_test.go:88"}
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
+{"type":"pass_identity","pr":"41","pass":"1","head_sha":"a3f29c1b","launch_attempt":"1","dispatched_at":"2026-07-06T00:00:00Z"}
 ```
+
+**`pass_identity` is the pass's attempt id and its dispatch clock.** The orchestrator writes it as the
+**first line** of `review-<pr>-<n>.progress.jsonl` **before** launching the reviewer process, so the
+progress file exists from dispatch onward. Three rules depend on it: a late verdict is ignored unless
+its attempt id (`pr` + `pass` + `head_sha`) still matches the active pass; `dispatched_at` is the clock
+the launch check below measures against; and `launch_attempt` (`1`, then `2` on a relaunch) is how a
+*later wake* — possibly a fresh agent — knows whether this pass has already been relaunched once. A
+progress file holding **only** this line is therefore evidence that the reviewer has produced nothing —
+not evidence of a missing file.
 
 Reviewers do NOT hand-write the unit-progress events (`started`/`done`) — ever; the emit tool is the
 only way those are produced. (The `plan_amendment_request` line is the exception: the tool does not
@@ -174,6 +185,34 @@ the `<SCRIPT>` placeholder in the review prompt — in the SAME way it substitut
 absolute path; it also ensures the `<rundir>` is a reviewer-writable root (via `--add-dir`) so the
 reviewer can append. The reviewer MUST call that script to emit each event, which writes the canonical
 shape by construction; a non-zero exit means the inputs were rejected and must be fixed and re-run.
+
+**Launch check — prove the reviewer actually started.** A dispatch can fail in a way that produces
+**no events at all**: an external reviewer blocked reading stdin (`codex exec` without `< /dev/null`),
+a bad binary/`-C` path, or a sandbox/auth denial that never reaches the model. Such a process is
+*alive* but has never begun, so the meaningful-progress rule below does not catch it quickly — that
+rule is sized for a reviewer working slowly, not one that never woke up. Gate every review pass on a
+**first-event deadline**:
+
+- **Deadline = ~5 min from the pass's `pass_identity.dispatched_at`.** By then the progress file MUST
+  hold at least one reviewer-written `progress` event. A `started` event **counts** — this check asks
+  only "did the process boot and can it write?", so it is deliberately weaker than meaningful progress
+  (which ignores `started`).
+- **Zero reviewer events past the deadline → the pass never started.** Do NOT wait out the 15-min
+  stale path. Kill the task and re-dispatch the pass **once**: rewrite the progress file with a fresh
+  `pass_identity` carrying `launch_attempt: 2` and a new `dispatched_at`, then launch again. If the
+  relaunch (`launch_attempt: 2`) also produces nothing by its own deadline → treat it as a reviewer
+  system failure and take the fresh-subagent fallback (same path as a verdict-less external reviewer,
+  above). Reading the retry count off the file, not off memory, is what makes this survive a killed
+  session: a fresh agent adopting the run sees `launch_attempt: 2` and falls back instead of
+  relaunching forever.
+- Before re-dispatching, **re-check the command** for the known launch faults — most of all the
+  `< /dev/null` stdin redirect on every `codex exec` (see below). A relaunch of the same hanging
+  command hangs identically.
+- **A failed launch is a dispatch fault, not a review outcome.** It yields no verdict — it never
+  counts SATISFIED or NOT SATISFIED, never touches `reviews_ok`, and never escalates the tier. It is
+  also **not** a PR-task attempt: do **NOT** bump the ledger's `attempts` for it. That column drives
+  the PR-level retry-once bailout, and charging a reviewer's failure to launch against it could abort
+  a perfectly good PR for a fault that was never in its diff.
 
 Meaningful progress = a `done` event for a planned unit, or an accepted plan amendment. `started`
 events and vague "still working" lines prove only process liveness and MUST NOT reset the meaningful

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -236,6 +236,15 @@ rule is sized for a reviewer working slowly, not one that never woke up. Gate ev
   not off memory, is what makes this survive a killed session: a fresh agent adopting the run finds the
   highest-numbered attempt's `pass_identity`, sees `launch_attempt: 2`, and falls back instead of
   relaunching forever.
+- **This deadline test applies ONLY to a pass whose process is still alive.** It asks "this thing is
+  running — has it started?", and launch evidence is the answer. A pass whose task is **gone** (the
+  session died with it) is a different question entirely, and launch evidence is **irrelevant** to it:
+  a dead process will never produce a verdict no matter what it wrote before dying. Recovery there
+  dispatches on `launch_attempt` **alone** — `1` → relaunch once as attempt `2`; `2` → the budget is
+  spent, take the fresh-subagent fallback (Loop control step 1 / "Resume after a killed session").
+  **Every dead pass lands on exactly one of those two branches**; gating that path on launch evidence
+  too would strand a dead attempt `2` that had written a `started` line — neither relaunchable nor
+  fallback-eligible — and the PR would hang forever.
 - Before re-dispatching, **re-check the command** for the known launch faults — most of all the
   `< /dev/null` stdin redirect on every `codex exec` (see below). A relaunch of the same hanging
   command hangs identically.


### PR DESCRIPTION
- Stage 2a launch check: a review pass with no progress event ~5 min after dispatch never started (reviewer hung on stdin, bad path, sandbox denial) — kill, relaunch once, then fresh-subagent fallback
- define `pass_identity` (previously referenced but never specified): attempt id + `dispatched_at` clock + `launch_attempt`, so the relaunch-once budget survives a killed session
- heartbeat sizes to ~5 min while a pass awaits its first event, else ~15 min
- `reviewer.md` abbreviated `codex exec` form now carries `< /dev/null` — the stdin hang the check guards against