### PR TITLE
bump gauntlet to 0.1.1

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"


### PR DESCRIPTION
- version is the plugin cache key; 0.1.0 shipped #13–#20 without a bump, so installed copies are stale (still carry the removed codex-exec skill, lack the codex stdin guard)
- bumping invalidates the cache so a reinstall picks up the current skill