### PR TITLE
relabel a PR when its gate resets

### DIFF
--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -90,6 +90,12 @@ the loop, and that flips to `gauntlet-accepted` once it has passed the review(s)
 one for a TRIVIAL docs-only PR, two for anything touching code or agent-facing files (the skill
 creates the labels if your repo doesn't have them).
 
+The label flips **back** just as readily. Anything that changes a PR's content after it was accepted —
+a CI fix, a rebase that had to resolve conflicts, a stray push to the branch — invalidates the reviews
+it had passed, so the PR returns to `gauntlet-reviewing` and must earn its verdicts again on the new
+content. The label always describes the code that is on the PR *right now*, so `gauntlet-accepted`
+never means "this passed at some point" — it means "this, as it currently stands, passed."
+
 By default it checks with you before changing anything in your public API — exported signatures,
 formats, CLI flags, defaults, or any behavior callers depend on — so it never merges a breaking
 change behind your back. Tell it up front that breakage is fine and it'll stop asking.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -66,6 +66,17 @@
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
   on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive
   change always requires two). Re-derive the tier from `head_sha` each wake.
+- **NEVER leave `gauntlet-accepted` on a PR whose live content no longer holds `required(tier)`
+  SATISFIED verdicts.** The label is a projection of `reviews_ok`, and it is the only run state a human
+  sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a gauntlet it did not. So the
+  **gate and the label move together, in the same step**: every action that drops `reviews_ok` to 0 (a
+  `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a conflict-resolving rebase, any other
+  content change on the head branch) MUST also run `gh pr edit <pr> --remove-label gauntlet-accepted
+  --add-label gauntlet-reviewing`. Never defer the swap to the next wake — that leaves the label lying
+  until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
+  unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` (it only sets
+  `ci = pending`). Per-wake label reconcile is the self-healing backstop, never the mechanism
+  (`stage-2-review-gate.md`, "Status labels mirror the review gate").
 - Reviews are fresh, context-isolated re-rolls: a separate reviewer invocation each pass (Claude
   subagent by default, or the user's preferred reviewer), no shared context. A second pass re-rolls a
   stochastic reviewer to catch a missed defect — the two are NOT statistically independent (the same

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -90,6 +90,12 @@ blocks; each completion is its own wake.
    it carries `gauntlet-run-<run-id>`, and set its status label to match its **live** gate state —
    `gauntlet-accepted` if its current HEAD holds `required(tier)` SATISFIED verdicts, else
    `gauntlet-reviewing`; add the status label if it has none. **Never touch another run's PRs.**
+
+   This reconcile is a **backstop, not the mechanism**. The relabel is owed at the moment the gate
+   resets, in the same step that writes `reviews_ok = 0` (`stage-2-review-gate.md`, "Status labels
+   mirror the review gate"); this pass only *self-heals* a swap that was somehow missed. A PR that
+   reaches this point still wearing a stale `gauntlet-accepted` means some reset site skipped its
+   relabel — fix the label here, and treat it as a bug in that site, not as normal operation.
 2. **Fold in completions.** For any background task that finished (CI watch → `ci-<pr>.txt`; review →
    the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
    writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -35,7 +35,18 @@ blocks; each completion is its own wake.
      re-arm the relaunch budget, and a dead attempt `2` must never be left un-dispatched):
      for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
      the ledger — write every ledger update through `scripts/ledger.py … set/header set` **by field
-     name** (`files-and-ledger.md`), never by hand-editing rows by column position. Do the PR scan as
+     name** (`files-and-ledger.md`), never by hand-editing rows by column position.
+
+     **This refresh is itself a gate-reset site — relabel here, in this step.** When it detects that a
+     PR's live `head_sha` has moved with the PR diff changed (a formatter/bot commit, a manual push,
+     any content change this run did not dispatch), it resets `reviews_ok` to 0 — and MUST, in the same
+     step, run `gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing` on a PR
+     carrying `gauntlet-accepted` (`stage-2-review-gate.md`, "Status labels mirror the review gate").
+     Do NOT leave this to the label-reconcile pass below: that pass is the **backstop**, and a reset
+     site that defers to it is the exact bug this rule forbids. (A clean base-only advance with the PR
+     diff unchanged does not reset the gate, so it keeps `gauntlet-accepted`.)
+
+     Do the PR scan as
      **one batched snapshot per wake** —
      `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -98,15 +98,32 @@ blocks; each completion is its own wake.
    **Reconcile labels too** (idempotent, retroactive, **scoped to this run**). Ensure the labels exist
    (`gh label create … --force`, including this run's `gauntlet-run-<run-id>`), then for every PR **of
    this run** (its `gauntlet-run-<run-id>` label — the only ownership marker for adopted PRs): ensure
-   it carries `gauntlet-run-<run-id>`, and set its status label to match its **live** gate state —
-   `gauntlet-accepted` if its current HEAD holds `required(tier)` SATISFIED verdicts, else
-   `gauntlet-reviewing`; add the status label if it has none. **Never touch another run's PRs.**
+   it carries `gauntlet-run-<run-id>`, and **overwrite** its status label to match its **live** gate
+   state. **Never touch another run's PRs.**
+
+   **Always apply one status label AND remove the other — never merely add.** The two status labels are
+   mutually exclusive, so a purely additive reconcile cannot repair the one state it most needs to: a
+   PR wearing **both** labels (what a missed swap at a reset site actually produces) would keep the
+   contradictory label forever, because adding a label it already carries changes nothing. Write it
+   unconditionally, in one call per PR, so the outcome does not depend on which labels are already there:
+
+   ```
+   # current HEAD holds required(tier) SATISFIED verdicts:
+   gh pr edit <pr> --add-label gauntlet-accepted  --remove-label gauntlet-reviewing
+   # otherwise:
+   gh pr edit <pr> --add-label gauntlet-reviewing --remove-label gauntlet-accepted
+   ```
+
+   Both forms are idempotent (`--add-label` of a label already present and `--remove-label` of one that
+   is absent are both no-ops), so this converges from **any** starting state — neither label, one label,
+   the wrong label, or both.
 
    This reconcile is a **backstop, not the mechanism**. The relabel is owed at the moment the gate
    resets, in the same step that writes `reviews_ok = 0` (`stage-2-review-gate.md`, "Status labels
    mirror the review gate"); this pass only *self-heals* a swap that was somehow missed. A PR that
-   reaches this point still wearing a stale `gauntlet-accepted` means some reset site skipped its
-   relabel — fix the label here, and treat it as a bug in that site, not as normal operation.
+   reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
+   site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
+   operation.
 2. **Fold in completions.** For any background task that finished (CI watch → `ci-<pr>.txt`; review →
    the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
    writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -99,16 +99,33 @@ For each `#PR` to adopt:
      durable API-decision contract, `files-and-ledger.md` / `scope-and-constraints.md`, and could re-ask
      or revive an already-declined/aborted PR). Only re-read `head_sha`/`ci` from ground truth; reset
      `reviews_ok` to `0` and re-triage `tier` **only if** reconciliation detects a PR-content change
-     since the recorded `head_sha` (per the gate's SHA-pinning rules).
+     since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
+     site: in the same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
+     (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing` —
+     `stage-2-review-gate.md`, "Status labels mirror the review gate"). Step 4's `--add-label
+     gauntlet-reviewing` alone is NOT sufficient: it would leave the stale `gauntlet-accepted` in
+     place, so the PR would carry **both** status labels and still publicly claim it passed.
 
    The ownership marker for an adopted PR is the **label**, not the branch name (its branch won't match
    the `fix-<run-id>-` prefix) — so labelling in step 4 is what makes the PR ours.
 
-4. **Label it ours + under review.** Add this run's owner label and the shared reviewing status label:
+4. **Label it ours + under review.** Add this run's owner label and the shared reviewing status label.
+   **Status labels are mutually exclusive** — a PR carries exactly one — so always remove the other in
+   the same call rather than only adding:
 
    ```
-   gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-reviewing
+   gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-reviewing --remove-label gauntlet-accepted
    ```
+
+   `--remove-label` on a label the PR doesn't carry is a harmless no-op, so this one form is safe for a
+   fresh adoption **and** for a re-adoption of a previously-accepted PR whose content has since changed.
+   A bare `--add-label gauntlet-reviewing` would leave a stale `gauntlet-accepted` alongside it, and a
+   PR wearing both status labels still publicly claims it passed its gauntlet.
+
+   (Re-adopting a PR whose content has **not** changed keeps `reviews_ok`, so it keeps
+   `gauntlet-accepted` — the gate did not reset. Set the status label to whatever the *live* gate says:
+   `gauntlet-accepted` when the current HEAD already holds `required(tier)` verdicts, else
+   `gauntlet-reviewing`.)
 
 5. **Create the PR-head worktree before the first review pass — off the PR's OWN head, never `<base>`.**
    The review itself needs a real checkout: the review command runs `codex exec -C <worktree>` (the

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -109,23 +109,29 @@ For each `#PR` to adopt:
    The ownership marker for an adopted PR is the **label**, not the branch name (its branch won't match
    the `fix-<run-id>-` prefix) — so labelling in step 4 is what makes the PR ours.
 
-4. **Label it ours + under review.** Add this run's owner label and the shared reviewing status label.
-   **Status labels are mutually exclusive** — a PR carries exactly one — so always remove the other in
-   the same call rather than only adding:
+4. **Label it ours, and set the status label from the LIVE gate.** Add this run's owner label, then
+   apply the status label that matches the PR's gate state **as it stands after step 3** — never a
+   hardcoded `gauntlet-reviewing`.
+
+   **The status labels are mutually exclusive** — a PR carries exactly one — so whichever you apply,
+   remove the other in the same call. Which one you apply is decided by the live gate, not by the fact
+   that you are adopting:
 
    ```
+   # Gate NOT met at the current HEAD — a fresh adoption (reviews_ok = 0), or a re-adoption whose
+   # content changed (step 3 just reset reviews_ok). The common case:
    gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-reviewing --remove-label gauntlet-accepted
+
+   # Gate ALREADY met at the current HEAD — re-adoption of a PR whose content did NOT change, so step 3
+   # preserved reviews_ok >= required(tier). Its acceptance is still valid; do not revoke it:
+   gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-accepted --remove-label gauntlet-reviewing
    ```
 
-   `--remove-label` on a label the PR doesn't carry is a harmless no-op, so this one form is safe for a
-   fresh adoption **and** for a re-adoption of a previously-accepted PR whose content has since changed.
-   A bare `--add-label gauntlet-reviewing` would leave a stale `gauntlet-accepted` alongside it, and a
-   PR wearing both status labels still publicly claims it passed its gauntlet.
-
-   (Re-adopting a PR whose content has **not** changed keeps `reviews_ok`, so it keeps
-   `gauntlet-accepted` — the gate did not reset. Set the status label to whatever the *live* gate says:
-   `gauntlet-accepted` when the current HEAD already holds `required(tier)` verdicts, else
-   `gauntlet-reviewing`.)
+   Applying the first form unconditionally would **strip a valid `gauntlet-accepted`** from a PR whose
+   verdicts step 3 just preserved, sending an already-passed PR back under review — the mirror-image bug
+   of leaving a stale `gauntlet-accepted` in place. The label tracks the gate in **both** directions.
+   (`--remove-label` on a label the PR does not carry is a harmless no-op, so neither form needs a
+   pre-check for the label's presence — only for the gate's state.)
 
 5. **Create the PR-head worktree before the first review pass — off the PR's OWN head, never `<base>`.**
    The review itself needs a real checkout: the review command runs `codex exec -C <worktree>` (the

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -20,7 +20,11 @@ row by column position:
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout). Its fix
   commits + pushes to the PR's **own head branch**
-  → code changed → **reset `reviews_ok` to 0**, relaunch the watch immediately, re-enter 2a.
+  → code changed → **reset `reviews_ok` to 0 AND, in that same step, restore `gauntlet-reviewing` if
+  the PR carries `gauntlet-accepted`** (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label
+  gauntlet-reviewing`) — the gate and its label move together, never one without the other
+  (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the watch
+  immediately and re-enter 2a.
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -447,7 +447,7 @@ that drop `reviews_ok` to 0):
 | CI-fix commit pushed | `stage-2-ci.md` |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
 | Conflict-resolving rebase | `stage-3-merge.md` |
-| Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (and step 4's label call, which must `--remove-label gauntlet-accepted`, never merely add) |
+| Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |
 | Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the wake that *detects* it resets the gate, so it relabels there |
 
 **Every row names a place where `reviews_ok` is written to 0 — never "the reconcile pass".** The

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -440,14 +440,21 @@ reconcile it is simply wrong; if the session dies in that window it stays wrong 
 **Every trigger that resets the gate must relabel** (this is the exhaustive list — the same events
 that drop `reviews_ok` to 0):
 
-| Trigger | Where |
+| Trigger | Where the reset happens — and therefore where the relabel is owed |
 |---|---|
 | `NOT SATISFIED` verdict lands | this file, verdict tally |
 | Review-fix commit pushed | this file, verdict tally |
 | CI-fix commit pushed | `stage-2-ci.md` |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
 | Conflict-resolving rebase | `stage-3-merge.md` |
-| Any other PR-content change on the head branch — formatter/bot commit, manual push | reconcile, Loop control |
+| Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (and step 4's label call, which must `--remove-label gauntlet-accepted`, never merely add) |
+| Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the wake that *detects* it resets the gate, so it relabels there |
+
+**Every row names a place where `reviews_ok` is written to 0 — never "the reconcile pass".** The
+label-reconcile in Loop control is the backstop that *heals* a missed swap; naming it as the mechanism
+for any trigger would defeat this rule. If you add a new site that resets the gate, it goes in this
+table with the relabel attached, and the search that proves this table complete is for **writes of
+`reviews_ok`**, not for any particular phrasing.
 
 **Exception — a clean base-only rebase** (PR diff unchanged) carries `reviews_ok` forward and therefore
 **keeps** `gauntlet-accepted`; it only sets `ci = pending`. The gate did not reset, so the label does

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -40,8 +40,9 @@ the row by column position). Default to **STANDARD** whenever you are unsure. `r
 **Preconditions — clear Copilot items, CI, and conflicts before reviewing.** A review pass is
 expensive and is invalidated by any PR-content change, so never spend one on a PR whose current tip
 still has review-blocking issues. Before launching a pass, check three things and clear any that are
-dirty. Each fix changes PR content, so `reviews_ok` resets to 0 and the review re-starts on the clean
-tip:
+dirty. Each fix changes PR content, so `reviews_ok` resets to 0 **and the status label is restored to
+`gauntlet-reviewing` in that same step** if the PR was `gauntlet-accepted` ("Status labels mirror the
+review gate"), and the review re-starts on the clean tip:
 
 - **GitHub Copilot review items.** If the PR has any unresolved Copilot review comments, address them
   with `/gauntlet:copilot-address-reviews <pr>` before reviewing (that skill verifies each item against source
@@ -349,10 +350,15 @@ NEVER use `--dangerously-bypass-approvals-and-sandbox` — always `--sandbox wor
 
 As each verdict lands, tally it for the SHA it ran on:
 
-- **NOT SATISFIED** → dispatch a scoped fix subagent into `<worktree>` (the PR row's ledger
-  `worktree` column value) with the issue list; it
-  commits + pushes → HEAD advances → the SHA's tally is void. A later wake starts a fresh review on
-  the new tip. (Because reviews are sequential, no second review was spent on this broken commit.)
+- **NOT SATISFIED** → the SHA's tally is void: set `reviews_ok = 0` **and, in the same step, restore
+  `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** (`gh pr edit <pr> --remove-label
+  gauntlet-accepted --add-label gauntlet-reviewing` — "Status labels mirror the review gate"). This
+  applies the moment the verdict lands, *before* any fix is written: a PR whose latest verdict says
+  NOT SATISFIED must never still read `gauntlet-accepted` on GitHub. Then dispatch a scoped fix
+  subagent into `<worktree>` (the PR row's ledger `worktree` column value) with the issue list; it
+  commits + pushes → HEAD advances (a second gate reset — relabel again if the first was somehow
+  skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
+  second review was spent on this broken commit.)
 - **SATISFIED** → record it (bump `reviews_ok` via `ledger.py … set --pr <N> --reviews_ok <count>`, by
   field name). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a
@@ -411,10 +417,42 @@ not burning reviews merely because another PR merged cleanly. A `NOT SATISFIED` 
 content's tally even before a fix lands. The `required(tier)` SATISFIED verdicts and green CI must all
 describe the same live PR content; CI must still be green for the current HEAD SHA.
 
-**Status labels mirror the review gate.** A PR carries `gauntlet-reviewing` until its current HEAD
-holds `required(tier)` SATISFIED verdicts for the same live PR content, then `gauntlet-accepted`. Because any
-PR-content change resets the gate, if an accepted PR's content later changes — a CI fix,
-conflict-resolving rebase, formatter/bot commit, etc. — swap the label back
-(`--remove-label gauntlet-accepted --add-label gauntlet-reviewing`). A clean base-only rebase with
-unchanged PR diff keeps the review label state but sets `ci = pending`. Reconcile labels against the
-live gate state each wake so they never lie.
+### Status labels mirror the review gate — relabel is part of the reset, not a later chore
+
+A PR carries `gauntlet-reviewing` until its current HEAD holds `required(tier)` SATISFIED verdicts for
+the same live PR content, then `gauntlet-accepted`. The label is a **projection of `reviews_ok`**, so it
+is only ever as true as the moment it was last written.
+
+**THE RULE — the gate and the label move together, in the same step.** Any action that takes
+`reviews_ok` to `0` (or otherwise voids the tally) MUST, in that same step, restore
+`gauntlet-reviewing` on a PR that currently carries `gauntlet-accepted`:
+
+```
+gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing
+```
+
+Never write the ledger reset and defer the label to "the next wake". A `gauntlet-accepted` label on a
+PR whose live content no longer holds `required(tier)` verdicts is a **false public claim that the PR
+passed its gauntlet** — the label is what a human reads on GitHub, and it is the one part of this
+run's state that is visible to people who will never see the ledger. Between the reset and the next
+reconcile it is simply wrong; if the session dies in that window it stays wrong indefinitely.
+
+**Every trigger that resets the gate must relabel** (this is the exhaustive list — the same events
+that drop `reviews_ok` to 0):
+
+| Trigger | Where |
+|---|---|
+| `NOT SATISFIED` verdict lands | this file, verdict tally |
+| Review-fix commit pushed | this file, verdict tally |
+| CI-fix commit pushed | `stage-2-ci.md` |
+| Copilot-item fix pushed | Stage 2a preconditions, above |
+| Conflict-resolving rebase | `stage-3-merge.md` |
+| Any other PR-content change on the head branch — formatter/bot commit, manual push | reconcile, Loop control |
+
+**Exception — a clean base-only rebase** (PR diff unchanged) carries `reviews_ok` forward and therefore
+**keeps** `gauntlet-accepted`; it only sets `ci = pending`. The gate did not reset, so the label does
+not move. Gate and label stay in lockstep in both directions.
+
+**Reconcile is the backstop, not the mechanism.** Loop control re-derives every label from the live
+gate each wake so a missed swap self-heals, exactly as the CI-watch heartbeat backstops a missed watch.
+Relying on it as the primary path is the bug this rule exists to prevent.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -94,11 +94,15 @@ via `gh`, never a local `git rev-parse HEAD`.)
    hand-editing the row by column position). **Base advancement alone does NOT
    invalidate gauntlet reviews.** Rebase only if GitHub flags the PR behind/conflicting:
    - Clean rebase (no conflicts) → verify the PR's own diff/content is unchanged → keep `reviews_ok`,
-     update `head_sha` to the new tip, set `ci = pending`, **and relaunch its CI watch in the same
-     wake** — the rebased PR must not sit unwatched until the heartbeat; CI must return green before
-     merging.
-   - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0**, relaunch
-     the CI watch, re-enter Stage 2.
+     **keep its status label as-is** (the gate did not reset, so an accepted PR stays
+     `gauntlet-accepted`), update `head_sha` to the new tip, set `ci = pending`, **and relaunch its CI
+     watch in the same wake** — the rebased PR must not sit unwatched until the heartbeat; CI must
+     return green before merging.
+   - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0 AND, in that
+     same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** (`gh pr edit <pr>
+     --remove-label gauntlet-accepted --add-label gauntlet-reviewing`) — the gate and its label move
+     together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the CI
+     watch and re-enter Stage 2.
    - Still open, mergeable, not behind/dirty/conflicting, same live `head_sha`,
      `reviews_ok >= required(tier)`, and `ci == green` → still immediately mergeable; return to step 1
      in the same wake.


### PR DESCRIPTION
- `gauntlet-accepted` is a projection of `reviews_ok`, but no reset site relabelled — only the next wake's reconcile did, so the label lied until then, and indefinitely if the session died first
- gate and label now move in the same step at every site that drops `reviews_ok` to 0: NOT SATISFIED verdict, review/CI/copilot fix, conflict-resolving rebase
- clean base-only rebase keeps `reviews_ok`, so it correctly keeps `gauntlet-accepted`
- per-wake reconcile is restated as a self-healing backstop, not the mechanism