### PR TITLE
bump gauntlet to 0.1.2

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"


### PR DESCRIPTION
- #22 changed campaign skill content; version is the plugin cache key, so installed copies stay stale until it moves