### PR TITLE
set an explicit model on every subagent dispatch

### DIFF
--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -177,120 +177,38 @@ flowchart TD
 - Before it spends a review on a PR, it first clears anything that would waste one: it addresses any
   GitHub Copilot review comments, fixes failing CI, and rebases a PR that has fallen into conflict
   with the base branch — then reviews the clean result.
-- Some CI failures — formatting ones — can be fixed by running the **formatter itself**, with no model
-  involved at all. **Campaign ships with no tool enabled and it vouches for none.** Out of the box every CI
-  failure, formatting included, goes to a full-strength fix subagent. If you want the shortcut, **you** turn a
-  tool on, and that is a decision you are making about a tool you trust — not one campaign made for you.
+- Not every CI failure needs a full-strength model. A **formatting or lint failure** — the kind a standard
+  formatter fixes — goes to a deliberately **cheap** fix subagent (Sonnet; Haiku when the failure is
+  trivially mechanical). Its job is narrow and it is *in the loop*, not bypassed: work out what failed, run
+  the formatter, **read the diff that formatter produced**, and check it — that the diff contains only the
+  change it was supposed to produce, that no file it didn't mean to touch was touched, that no test, check,
+  or config was weakened, and that the exact check that failed now passes. Only then does it commit. If any
+  of that doesn't hold — the check is still red, the diff contains something it can't explain, the real fix
+  turns out to be a change to your program's logic — it **stops and hands the failure to a full-strength fix
+  subagent**. Escalating is the expected outcome, not a failure.
 
-  Here is the honest version, because the alternative is a safety claim nobody can back. What campaign
-  guarantees is **how** a tool is run, never **what** the tool does:
+  Two rules it always gets, word for word. It may **never make CI pass by weakening the check**: no deleted
+  or loosened assertions, no `skip`/`xfail`, no disabled lint rules, no raised timeouts. It fixes the cause —
+  and if the check itself is genuinely wrong, it says so out loud and escalates rather than quietly
+  rewriting it. And it may **never reach for a catch-all `--fix`** (`golangci-lint run --fix`, `ruff --fix`,
+  `eslint --fix`) or a tool documented to rewrite your code — `goimports` *adds* imports, and an added import
+  runs that package's `init()`; `prettier` rewrites the contents of tagged template literals; `gofumpt`
+  applies extra rewrite rules on top of layout. A formatter that only reformats, nothing more. It also never
+  runs a binary out of the pull request's own tree (that's untrusted content), and never points a tool at a
+  bare glob or a whole directory — it names the files it is fixing.
 
-  - it owns the exact command line (`gofmt -w --`, `gci write --`, `ruff format --`) and never appends a flag;
-  - it resolves the binary to a trusted absolute path outside your repo;
-  - it checks every filename it passes (details below);
-  - and any commit the tool makes **resets the review gate**, so the result is reviewed like any other change.
+  **The honest version of the trade:** a cheap model reading a tool's diff is a good miss-catcher, not a
+  proof. It can miss a semantic change. What backs it up is that the failing check has to pass, that the
+  subagent has to escalate anything it cannot verify, and that **every commit campaign makes still resets the
+  review gate** — the pull request is re-reviewed from scratch, by the full gauntlet, on the new commit. That
+  gate is a miss-catcher too, and campaign will not pretend otherwise: it will never tell you the cheap path
+  is safe because "CI will catch it". This is a small, bounded risk, taken deliberately, for a loop that is
+  cheaper *and* more capable than either running a full-strength model on every stray formatting failure or
+  running the tool blind with nothing looking at what it did.
 
-  What it does **not** guarantee is that the tool preserves the meaning of your program. Take `gofmt`: its
-  documentation (https://pkg.go.dev/cmd/gofmt) describes formatting behaviour and flags — it never actually
-  *states* a semantic-equivalence guarantee. "A pretty-printer that parses and re-prints your code can't
-  change what it means" is a reasonable inference, and it is **an inference, not a documented promise**. The
-  same is true of `gci` (its docs describe import ordering and grouping; they never say it neither adds nor
-  removes an import) and of `ruff format` (its formatter docs don't state the AST-equivalence guarantee you'd
-  be relying on — and your own Ruff config can turn on `format.docstring-code-format`, which rewrites code
-  inside docstrings). Enabling one of these means you have read that and accepted the risk.
-
-  There is one thing campaign **does** refuse, and the asymmetry is deliberate: **it refuses what is
-  documented to be unsafe; it does not bless what is merely undocumented.** `goimports` *adds* missing imports
-  and *removes* unreferenced ones — an added import runs that package's `init()`, and a guessed import can be
-  the wrong package. `prettier` rewrites the contents of tagged template literals. `gofumpt` applies extra
-  rewrite rules on top of gofmt's layout. Code rewriters (`modernize`, codemods) and every catch-all
-  `--fix`/`--write` linter flag change your program by design. Those are **documented facts**, so campaign
-  denies them outright — you cannot switch them on. Where the docs are simply silent, the call is yours.
-
-  **How to decide:** read the tool's own documentation, decide whether you accept the inference above, and
-  only then enable it. Whatever you enable, campaign still gates every commit the tool makes.
-
-  **Name the tools when you invoke campaign** ("use gofmt"), or **record a preference in memory** and campaign
-  will pick it up on later runs. There is no file to configure. Whatever it resolves to is fixed once, at the
-  start of the run, and written into the run's ledger `formatters` field — `-` when nothing is enabled (the
-  default), otherwise the tool ids you named — so a later wake, or a fresh agent that picks the run up, uses
-  the same list rather than quietly changing its mind.
-
-  There is deliberately **no config file for this, and campaign will not read one from your repo** — not a
-  file at the repo root, not `CLAUDE.md`, not anything else in the tree. Files in your repo are things a pull
-  request can edit, and this list is what decides whether a change gets committed to that same pull request
-  *without a review pass*. If it lived in the repo, a pull request could widen the rules that govern its own
-  review. Keeping it out of the repo makes that impossible by construction, rather than something campaign
-  has to defend against.
-
-  Naming a tool is all you get to do. You do **not** supply a command, flags, or an argv — campaign owns the
-  exact command line for each tool it knows.
-  Flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a
-  rewrite engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if
-  you also get to pick *how* it runs, so campaign doesn't let you pick.
-
-  Campaign also picks the **binary**, not just the command line. The tool runs inside the pull request's own
-  worktree, and that pull request is untrusted content, so campaign resolves the executable to an absolute
-  path outside your repo before running it — a pull request that ships a file called `gofmt` never gets
-  executed. If the real tool can't be found outside the repo, campaign refuses the shortcut and uses a model
-  instead.
-
-  And it is careful about the **filenames** it hands the tool, because those come out of the pull request
-  too. A pull request can add a file called `-cpuprofile=prof.go`; it is a perfectly good match for `**/*.go`,
-  and `gofmt -w '-cpuprofile=prof.go' a.go` doesn't format it — it reads it as a *flag* and writes a CPU
-  profile. So campaign always passes `--` before the file list, always passes absolute paths rather than bare
-  names, and drops any candidate file whose name starts with `-` (it logs it and carries on with the rest).
-  Campaign owns the *shape* of the command; the filenames in it are pull-request data, and get treated as
-  data.
-
-  Spelling a path safely is not the same as knowing where it *leads*. A pull request can also add `link.go` —
-  a **symlink** whose target sits outside the worktree entirely. The name looks fine, but `gofmt -w -- link.go`
-  follows it and rewrites the file it points at. So campaign checks what each candidate resolves to, not just
-  how it is written: it drops symlinks, drops anything that isn't a plain regular file, and drops anything
-  whose fully-resolved real path lands outside the worktree. Each drop is logged; the rest of the run
-  continues.
-
-  And below even that: a path check bounds where campaign *looks*, not what it *writes*. A **hardlink** is a
-  perfectly ordinary regular file, it is not a symlink, and its real path really is inside the worktree — but
-  it shares an *inode* with a file outside the tree, and `gofmt -w` rewrites the existing inode, so formatting
-  it changes the outside file too. It passes every check above. So campaign adds a sixth: it drops any
-  candidate whose **link count is greater than one**. A source file in a normal checkout has exactly one link;
-  anything with more is either a hardlink escape or something there is no reason to format. Logged, dropped,
-  run continues.
-
-  One layer further down, the same lesson generalises: **a name is not a location.** A pull request can add a
-  symlinked *directory* — `safe/gh` pointing at `.github`. The candidate `safe/gh/actions/main.go` isn't a
-  symlink itself, its real path is inside the worktree, it's a regular file with one link, and its name is
-  clean: it passes all six checks. But campaign's exclusion filter (below) lists `.github/**`, and
-  `safe/gh/...` doesn't *look* like `.github/...` — so a **CI check definition** would be handed to the tool,
-  with no model and no review. The fix is the general one: **every check that reasons about a path reasons
-  about the path it resolves to.** The exclusion filter is matched against the resolved path as well as the
-  written one — either one matching is a refusal — and, as a seventh check and an explicit tripwire, campaign
-  drops any candidate with a **symlink anywhere in its directory path**.
-
-  If the refusals empty the file set, campaign runs **nothing** for that tool and sends the failure to a
-  model. It never invokes the tool with no files: `gofmt` with no file operands reads standard input, which
-  is not the run anyone asked for.
-
-  Every known tool has a default glob (`gofmt`/`gci` → `**/*.go`, `ruff format` → `**/*.py`), so you normally
-  name nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,
-  never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion
-  filter afterwards, every time, and nothing widens it: tests, check definitions, CI workflows, and tool
-  config (`**/*_test.go`, `.github/**`, `.golangci.yml`, `pyproject.toml`, …) are removed no matter what
-  your glob says — and matched against what each candidate **resolves to**, not just how it is spelled.
-  (A glob that *directly* names a protected path is refused outright.)
-
-  That filter is a pattern list, and a pattern list is **not complete** — it can't be. A repo-specific check
-  written as ordinary source, say a Go checker at `tools/ci/check.go`, matches `**/*.go`, matches none of
-  those patterns, and does get formatted by a tool you enabled. So be exact about what the filter is: it keeps
-  the tool's diff small and off the files a reviewer expects untouched — **defence in depth, and admittedly
-  incomplete**. It is not a reason to trust a tool, and campaign never presents it as one.
-
-  Teaching campaign a genuinely new tool is a change to the skill — reviewed and gated like any other code
-  change. And to be clear about what all this buys: the tool list comes from *you*, so the denylist and the
-  narrow shape of the list are a **guard against footguns**, not a security boundary against yourself. The
-  real boundary is that the tool runs on untrusted pull-request content, which is why campaign resolves the
-  binary outside your repo and owns the exclusion filter itself.
+  Everything else — a failing test, a compile error, anything needing judgment — goes to a full-strength fix
+  subagent, as does every escalation from the cheap one. Review passes are never cheapened: a review pass
+  *is* the gate.
 - It keeps a small `.gauntlet/history/` at the repo root (git-ignored, one file per run) to remember what past
   runs learned. That's the memory a fresh run carries over. Each fresh run also tidies that file,
   dropping entries that no longer apply to the current code — and when it isn't sure an entry is

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -177,33 +177,44 @@ flowchart TD
 - Before it spends a review on a PR, it first clears anything that would waste one: it addresses any
   GitHub Copilot review comments, fixes failing CI, and rebases a PR that has fallen into conflict
   with the base branch — then reviews the clean result.
-- Some CI failures — pure formatting ones — it fixes by running the **formatter itself**, with no model
-  involved at all. A tool only qualifies if its own documentation guarantees the output is *semantically
-  equivalent* to the input (an AST-preserving pretty-printer, not a text munger); anything else, including
-  every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent.
+- Some CI failures — formatting ones — can be fixed by running the **formatter itself**, with no model
+  involved at all. **Campaign ships with no tool enabled and it vouches for none.** Out of the box every CI
+  failure, formatting included, goes to a full-strength fix subagent. If you want the shortcut, **you** turn a
+  tool on, and that is a decision you are making about a tool you trust — not one campaign made for you.
 
-  The table holds exactly **one tool: `gofmt`**. That is small on purpose — it is what survived a rule that
-  demands a *documented* guarantee, quoted from the source. Everything else, **including all Python, JS and
-  other-language formatting**, goes to the session model, which is the safe default and is what happened
-  before this shortcut existed. It is not a limitation to work around: it is the rule working.
+  Here is the honest version, because the alternative is a safety claim nobody can back. What campaign
+  guarantees is **how** a tool is run, never **what** the tool does:
 
-  Tools you might expect and won't find: **`ruff format`**, because the formatter docs we cite don't actually
-  state the AST-equivalence guarantee we'd be relying on; **`gci`**, because its docs describe import
-  ordering and grouping but never say it neither adds nor removes an import; **`goimports`**, because it
-  *adds* missing imports and *removes* unreferenced ones — adding an import runs that package's `init()`, and
-  a guessed import can be the wrong package; and **`gofumpt`**, because it applies extra rewrite rules on top
-  of gofmt's layout and documents them as a rule list, not as semantics-preserving. All four are formatters
-  in the colloquial sense and none meets the bar, which is the point: the bar is a *source that states the
-  guarantee*, not the tool's reputation or the vibe of its diff. Adding a tool is a change to the skill
-  itself, and it needs that source quoted in the table.
+  - it owns the exact command line (`gofmt -w --`, `gci write --`, `ruff format --`) and never appends a flag;
+  - it resolves the binary to a trusted absolute path outside your repo;
+  - it checks every filename it passes (details below);
+  - and any commit the tool makes **resets the review gate**, so the result is reviewed like any other change.
 
-  You don't configure that list in a file. **Name the formatters when you invoke campaign** ("use gofmt", or
-  "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
-  and campaign will pick it up on later runs. Say nothing and you get the built-in default set. Whatever it
-  resolves to is fixed once, at the start of the run, and written into the run's ledger `formatters` field —
-  `default` for the built-in set, `-` for the shortcut switched off, otherwise the tool ids you named — so a
-  later wake, or a fresh agent that picks the run up, uses the same list rather than quietly reverting to the
-  default.
+  What it does **not** guarantee is that the tool preserves the meaning of your program. Take `gofmt`: its
+  documentation (https://pkg.go.dev/cmd/gofmt) describes formatting behaviour and flags — it never actually
+  *states* a semantic-equivalence guarantee. "A pretty-printer that parses and re-prints your code can't
+  change what it means" is a reasonable inference, and it is **an inference, not a documented promise**. The
+  same is true of `gci` (its docs describe import ordering and grouping; they never say it neither adds nor
+  removes an import) and of `ruff format` (its formatter docs don't state the AST-equivalence guarantee you'd
+  be relying on — and your own Ruff config can turn on `format.docstring-code-format`, which rewrites code
+  inside docstrings). Enabling one of these means you have read that and accepted the risk.
+
+  There is one thing campaign **does** refuse, and the asymmetry is deliberate: **it refuses what is
+  documented to be unsafe; it does not bless what is merely undocumented.** `goimports` *adds* missing imports
+  and *removes* unreferenced ones — an added import runs that package's `init()`, and a guessed import can be
+  the wrong package. `prettier` rewrites the contents of tagged template literals. `gofumpt` applies extra
+  rewrite rules on top of gofmt's layout. Code rewriters (`modernize`, codemods) and every catch-all
+  `--fix`/`--write` linter flag change your program by design. Those are **documented facts**, so campaign
+  denies them outright — you cannot switch them on. Where the docs are simply silent, the call is yours.
+
+  **How to decide:** read the tool's own documentation, decide whether you accept the inference above, and
+  only then enable it. Whatever you enable, campaign still gates every commit the tool makes.
+
+  **Name the tools when you invoke campaign** ("use gofmt"), or **record a preference in memory** and campaign
+  will pick it up on later runs. There is no file to configure. Whatever it resolves to is fixed once, at the
+  start of the run, and written into the run's ledger `formatters` field — `-` when nothing is enabled (the
+  default), otherwise the tool ids you named — so a later wake, or a fresh agent that picks the run up, uses
+  the same list rather than quietly changing its mind.
 
   There is deliberately **no config file for this, and campaign will not read one from your repo** — not a
   file at the repo root, not `CLAUDE.md`, not anything else in the tree. Files in your repo are things a pull
@@ -213,7 +224,7 @@ flowchart TD
   has to defend against.
 
   Naming a tool is all you get to do. You do **not** supply a command, flags, or an argv — campaign owns the
-  exact command line for each tool it knows (`gofmt -w --`).
+  exact command line for each tool it knows.
   Flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a
   rewrite engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if
   you also get to pick *how* it runs, so campaign doesn't let you pick.
@@ -261,8 +272,8 @@ flowchart TD
   model. It never invokes the tool with no files: `gofmt` with no file operands reads standard input, which
   is not the run anyone asked for.
 
-  Every known tool has a default glob (`gofmt` → `**/*.go`), so you normally name
-  nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,
+  Every known tool has a default glob (`gofmt`/`gci` → `**/*.go`, `ruff format` → `**/*.py`), so you normally
+  name nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,
   never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion
   filter afterwards, every time, and nothing widens it: tests, check definitions, CI workflows, and tool
   config (`**/*_test.go`, `.github/**`, `.golangci.yml`, `pyproject.toml`, …) are removed no matter what
@@ -271,13 +282,9 @@ flowchart TD
 
   That filter is a pattern list, and a pattern list is **not complete** — it can't be. A repo-specific check
   written as ordinary source, say a Go checker at `tools/ci/check.go`, matches `**/*.go`, matches none of
-  those patterns, and does get formatted. That is fine, and it is worth being exact about why. What makes
-  this shortcut safe is **not** the list. It is that the tool is admitted only on a documented guarantee that
-  its output *means the same thing* as its input — so whatever it touches, it cannot change the meaning of.
-  A reformatted test asserts exactly what it asserted before; weakening a check takes a semantic change, and
-  the command campaign runs can't make one. (That is also why campaign is so strict about the command line
-  and the filenames: those are the parts that decide *what gets written*.) The filter is there to keep the
-  diff small and off the files a reviewer expects untouched — defence in depth, not the guarantee.
+  those patterns, and does get formatted by a tool you enabled. So be exact about what the filter is: it keeps
+  the tool's diff small and off the files a reviewer expects untouched — **defence in depth, and admittedly
+  incomplete**. It is not a reason to trust a tool, and campaign never presents it as one.
 
   Teaching campaign a genuinely new tool is a change to the skill — reviewed and gated like any other code
   change. And to be clear about what all this buys: the tool list comes from *you*, so the denylist and the

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -195,8 +195,10 @@ flowchart TD
   You don't configure that list in a file. **Name the formatters when you invoke campaign** ("use gofmt and
   gci", or "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
   and campaign will pick it up on later runs. Say nothing and you get the built-in default set. Whatever it
-  resolves to is fixed once, at the start of the run, and written into the run's ledger — so a later wake,
-  or a fresh agent that picks the run up, uses the same list rather than quietly reverting to the default.
+  resolves to is fixed once, at the start of the run, and written into the run's ledger `formatters` field —
+  `default` for the built-in set, `-` for the shortcut switched off, otherwise the tool ids you named — so a
+  later wake, or a fresh agent that picks the run up, uses the same list rather than quietly reverting to the
+  default.
 
   There is deliberately **no config file for this, and campaign will not read one from your repo** — not a
   file at the repo root, not `CLAUDE.md`, not anything else in the tree. Files in your repo are things a pull
@@ -224,6 +226,13 @@ flowchart TD
   names, and drops any candidate file whose name starts with `-` (it logs it and carries on with the rest).
   Campaign owns the *shape* of the command; the filenames in it are pull-request data, and get treated as
   data.
+
+  Spelling a path safely is not the same as knowing where it *leads*. A pull request can also add `link.go` —
+  a **symlink** whose target sits outside the worktree entirely. The name looks fine, but `gofmt -w -- link.go`
+  follows it and rewrites the file it points at. So campaign checks what each candidate resolves to, not just
+  how it is written: it drops symlinks, drops anything that isn't a plain regular file, and drops anything
+  whose fully-resolved real path lands outside the worktree. Each drop is logged; the rest of the run
+  continues.
 
   Every known tool has a default glob (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`), so you normally name
   nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -250,7 +250,7 @@ flowchart TD
   One layer further down, the same lesson generalises: **a name is not a location.** A pull request can add a
   symlinked *directory* — `safe/gh` pointing at `.github`. The candidate `safe/gh/actions/main.go` isn't a
   symlink itself, its real path is inside the worktree, it's a regular file with one link, and its name is
-  clean: it passes all six checks. But campaign's exclusion filter (below) protects `.github/**`, and
+  clean: it passes all six checks. But campaign's exclusion filter (below) lists `.github/**`, and
   `safe/gh/...` doesn't *look* like `.github/...` — so a **CI check definition** would be handed to the tool,
   with no model and no review. The fix is the general one: **every check that reasons about a path reasons
   about the path it resolves to.** The exclusion filter is matched against the resolved path as well as the
@@ -266,10 +266,18 @@ flowchart TD
   never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion
   filter afterwards, every time, and nothing widens it: tests, check definitions, CI workflows, and tool
   config (`**/*_test.go`, `.github/**`, `.golangci.yml`, `pyproject.toml`, …) are removed no matter what
-  your glob says — and matched against what each candidate **resolves to**, not just how it is spelled. The glob picks the candidates; campaign's filter protects the files that gate the review.
-  An exclusion list *you* maintain would eventually miss one, and campaign commits this tool's output without
-  a review pass — it must never be able to weaken the checks that gate it. (A glob that *directly* names a
-  protected path is refused outright.)
+  your glob says — and matched against what each candidate **resolves to**, not just how it is spelled.
+  (A glob that *directly* names a protected path is refused outright.)
+
+  That filter is a pattern list, and a pattern list is **not complete** — it can't be. A repo-specific check
+  written as ordinary source, say a Go checker at `tools/ci/check.go`, matches `**/*.go`, matches none of
+  those patterns, and does get formatted. That is fine, and it is worth being exact about why. What makes
+  this shortcut safe is **not** the list. It is that the tool is admitted only on a documented guarantee that
+  its output *means the same thing* as its input — so whatever it touches, it cannot change the meaning of.
+  A reformatted test asserts exactly what it asserted before; weakening a check takes a semantic change, and
+  the command campaign runs can't make one. (That is also why campaign is so strict about the command line
+  and the filenames: those are the parts that decide *what gets written*.) The filter is there to keep the
+  diff small and off the files a reviewer expects untouched — defence in depth, not the guarantee.
 
   Teaching campaign a genuinely new tool is a change to the skill — reviewed and gated like any other code
   change. And to be clear about what all this buys: the tool list comes from *you*, so the denylist and the

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -177,6 +177,26 @@ flowchart TD
 - Before it spends a review on a PR, it first clears anything that would waste one: it addresses any
   GitHub Copilot review comments, fixes failing CI, and rebases a PR that has fallen into conflict
   with the base branch — then reviews the clean result.
+- Some CI failures — pure formatting ones — it fixes by running the **formatter itself**, with no model
+  involved at all. A tool only qualifies if its own documentation guarantees the output is *semantically
+  equivalent* to the input (an AST-preserving pretty-printer, not a text munger); anything else, including
+  every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent. Out of the box
+  it knows the Go and Python formatters (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`). To teach
+  it your repo's formatter, add a committed `.gauntlet.yml` at the repo root:
+
+  ```yaml
+  formatters:
+    - id: gofmt
+      command: gofmt -w
+      files: "**/*.go"
+      guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer)."
+  ```
+
+  Every entry needs a `guarantee` — a pointer to where the tool *documents* that it preserves meaning. An
+  entry without one is refused and that failure just goes to the model instead. You can add tools, drop
+  built-in ones, or set `formatters: []` to turn the whole shortcut off. Two things you cannot do: relax
+  the guarantee rule, and have a config change apply to its own pull request — campaign reads
+  `.gauntlet.yml` from the **base branch**, so an edit to it only takes effect once that PR has merged.
 - It keeps a small `.gauntlet/history/` at the repo root (git-ignored, one file per run) to remember what past
   runs learned. That's the memory a fresh run carries over. Each fresh run also tidies that file,
   dropping entries that no longer apply to the current code — and when it isn't sure an entry is

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -239,6 +239,18 @@ flowchart TD
   whose fully-resolved real path lands outside the worktree. Each drop is logged; the rest of the run
   continues.
 
+  And below even that: a path check bounds where campaign *looks*, not what it *writes*. A **hardlink** is a
+  perfectly ordinary regular file, it is not a symlink, and its real path really is inside the worktree — but
+  it shares an *inode* with a file outside the tree, and `gofmt -w` rewrites the existing inode, so formatting
+  it changes the outside file too. It passes every check above. So campaign adds a sixth: it drops any
+  candidate whose **link count is greater than one**. A source file in a normal checkout has exactly one link;
+  anything with more is either a hardlink escape or something there is no reason to format. Logged, dropped,
+  run continues.
+
+  If the refusals empty the file set, campaign runs **nothing** for that tool and sends the failure to a
+  model. It never invokes the tool with no files: `gofmt` with no file operands reads standard input, which
+  is not the run anyone asked for.
+
   Every known tool has a default glob (`gofmt` → `**/*.go`), so you normally name
   nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,
   never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -247,6 +247,16 @@ flowchart TD
   anything with more is either a hardlink escape or something there is no reason to format. Logged, dropped,
   run continues.
 
+  One layer further down, the same lesson generalises: **a name is not a location.** A pull request can add a
+  symlinked *directory* — `safe/gh` pointing at `.github`. The candidate `safe/gh/actions/main.go` isn't a
+  symlink itself, its real path is inside the worktree, it's a regular file with one link, and its name is
+  clean: it passes all six checks. But campaign's exclusion filter (below) protects `.github/**`, and
+  `safe/gh/...` doesn't *look* like `.github/...` — so a **CI check definition** would be handed to the tool,
+  with no model and no review. The fix is the general one: **every check that reasons about a path reasons
+  about the path it resolves to.** The exclusion filter is matched against the resolved path as well as the
+  written one — either one matching is a refusal — and, as a seventh check and an explicit tripwire, campaign
+  drops any candidate with a **symlink anywhere in its directory path**.
+
   If the refusals empty the file set, campaign runs **nothing** for that tool and sends the failure to a
   model. It never invokes the tool with no files: `gofmt` with no file operands reads standard input, which
   is not the run anyone asked for.
@@ -256,7 +266,7 @@ flowchart TD
   never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion
   filter afterwards, every time, and nothing widens it: tests, check definitions, CI workflows, and tool
   config (`**/*_test.go`, `.github/**`, `.golangci.yml`, `pyproject.toml`, …) are removed no matter what
-  your glob says. The glob picks the candidates; campaign's filter protects the files that gate the review.
+  your glob says — and matched against what each candidate **resolves to**, not just how it is spelled. The glob picks the candidates; campaign's filter protects the files that gate the review.
   An exclusion list *you* maintain would eventually miss one, and campaign commits this tool's output without
   a review pass — it must never be able to weaken the checks that gate it. (A glob that *directly* names a
   protected path is refused outright.)

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -184,29 +184,32 @@ flowchart TD
   it knows a small table of tools: `gofmt`, `gofumpt`, `goimports`, `gci`, and `ruff format`. (`ruff
   format` only counts if your Ruff config leaves `format.docstring-code-format` off — with it on, Ruff
   reformats Python code *inside docstrings*, which changes what your strings contain. A tool's guarantee can
-  depend on how it's configured, so campaign checks your config before trusting it.) To configure how those
-  tools are run in your repo, add a committed `.gauntlet.yml` at the repo root:
+  depend on how it's configured, so campaign checks your config before trusting it.) To choose which of
+  those tools campaign runs in your repo, and over which files, add a committed `.gauntlet.yml` at the repo
+  root:
 
   ```yaml
   formatters:
-    - id: gofmt
-      command: ["gofmt", "-w"]      # an argv list, not a shell command line
-      files: "**/*.go"
-      guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer). Holds unconditionally."
+    - id: gofmt          # which known tool
+      files: "**/*.go"   # which files it may touch
   ```
 
-  `command` is an **argv list** and is run **without a shell**. The first element must be one of the tool
-  names campaign already knows — not a path, not a wrapper script (`./scripts/fmt.sh`), not a shell string
-  (`sh -c "…"`), and no `&&`, `|`, `;`, `>` or `$(…)` anywhere. You can configure a known tool's *flags and
-  files*; you cannot point campaign at an arbitrary binary, because campaign commits that tool's output
-  without review. Teaching campaign a genuinely new tool is a change to the skill, not to your config.
+  That is the whole schema: **`id` and `files`, nothing else.** You do **not** supply a command, flags, or
+  an argv — campaign owns the exact command line for each tool it knows (`gofmt -w`, `goimports -w`,
+  `gci write`, `ruff format`, …), and an entry that tries to supply one is refused. The reason is that flags
+  are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a rewrite
+  engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if you also
+  get to pick *how* it runs, so campaign doesn't let you pick.
 
-  Every entry also needs a `guarantee` — a pointer to where the tool *documents* that it preserves meaning,
-  including any conditions that guarantee depends on. An entry without one, or one campaign can't verify, is
-  refused and that failure just goes to the model instead. You can drop built-in tools, or set
-  `formatters: []` to turn the whole shortcut off. Two things you cannot do: relax the guarantee rule, and
-  have a config change apply to its own pull request — campaign reads `.gauntlet.yml` from the **base
-  branch**, so an edit to it only takes effect once that PR has merged.
+  `files` is also constrained: a glob that could reach a check definition, a config file, or a test
+  (`.github/**`, `.golangci.yml`, `**/*_test.go`, `pyproject.toml`, …) is refused. Campaign commits this
+  tool's output without a review pass, so it must never be able to weaken the checks that gate it.
+
+  You can drop built-in tools by omitting them, or set `formatters: []` to turn the whole shortcut off (then
+  every CI failure goes to a full-strength model — always a safe choice). Teaching campaign a genuinely new
+  tool is a change to the skill, not to your config. And a config change never applies to its own pull
+  request: campaign reads `.gauntlet.yml` from the **base branch**, so an edit to it only takes effect once
+  that PR has merged.
 
   To be clear about what this buys: `.gauntlet.yml` lives in your repo, so anyone who can edit it can
   already edit your CI workflows. These rules are a **guard against footguns**, not a security boundary

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -180,20 +180,25 @@ flowchart TD
 - Some CI failures — pure formatting ones — it fixes by running the **formatter itself**, with no model
   involved at all. A tool only qualifies if its own documentation guarantees the output is *semantically
   equivalent* to the input (an AST-preserving pretty-printer, not a text munger); anything else, including
-  every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent. The table is
-  deliberately **short** — three tools: `gofmt`, `gci`, and `ruff format`. (`ruff format` only counts if your
-  Ruff config leaves `format.docstring-code-format` off — with it on, Ruff reformats Python code *inside
-  docstrings*, which changes what your strings contain. A tool's guarantee can depend on how it's configured,
-  so campaign checks your config before trusting it.)
+  every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent.
 
-  Tools you might expect and won't find: **`goimports`**, because it *adds* missing imports and *removes*
-  unreferenced ones — adding an import runs that package's `init()`, and a guessed import can be the wrong
-  package; and **`gofumpt`**, because it applies extra rewrite rules on top of gofmt's layout and documents
-  them as a rule list, not as semantics-preserving. Both are formatters in the colloquial sense and neither
-  meets the bar, which is the point: the bar is the tool's own documentation, not the vibe of its diff.
+  The table holds exactly **one tool: `gofmt`**. That is small on purpose — it is what survived a rule that
+  demands a *documented* guarantee, quoted from the source. Everything else, **including all Python, JS and
+  other-language formatting**, goes to the session model, which is the safe default and is what happened
+  before this shortcut existed. It is not a limitation to work around: it is the rule working.
 
-  You don't configure that list in a file. **Name the formatters when you invoke campaign** ("use gofmt and
-  gci", or "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
+  Tools you might expect and won't find: **`ruff format`**, because the formatter docs we cite don't actually
+  state the AST-equivalence guarantee we'd be relying on; **`gci`**, because its docs describe import
+  ordering and grouping but never say it neither adds nor removes an import; **`goimports`**, because it
+  *adds* missing imports and *removes* unreferenced ones — adding an import runs that package's `init()`, and
+  a guessed import can be the wrong package; and **`gofumpt`**, because it applies extra rewrite rules on top
+  of gofmt's layout and documents them as a rule list, not as semantics-preserving. All four are formatters
+  in the colloquial sense and none meets the bar, which is the point: the bar is a *source that states the
+  guarantee*, not the tool's reputation or the vibe of its diff. Adding a tool is a change to the skill
+  itself, and it needs that source quoted in the table.
+
+  You don't configure that list in a file. **Name the formatters when you invoke campaign** ("use gofmt", or
+  "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
   and campaign will pick it up on later runs. Say nothing and you get the built-in default set. Whatever it
   resolves to is fixed once, at the start of the run, and written into the run's ledger `formatters` field —
   `default` for the built-in set, `-` for the shortcut switched off, otherwise the tool ids you named — so a
@@ -208,7 +213,7 @@ flowchart TD
   has to defend against.
 
   Naming a tool is all you get to do. You do **not** supply a command, flags, or an argv — campaign owns the
-  exact command line for each tool it knows (`gofmt -w --`, `gci write --`, `ruff format --`).
+  exact command line for each tool it knows (`gofmt -w --`).
   Flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a
   rewrite engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if
   you also get to pick *how* it runs, so campaign doesn't let you pick.
@@ -234,7 +239,7 @@ flowchart TD
   whose fully-resolved real path lands outside the worktree. Each drop is logged; the rest of the run
   continues.
 
-  Every known tool has a default glob (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`), so you normally name
+  Every known tool has a default glob (`gofmt` → `**/*.go`), so you normally name
   nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,
   never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion
   filter afterwards, every time, and nothing widens it: tests, check definitions, CI workflows, and tool

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -184,51 +184,48 @@ flowchart TD
   it knows a small table of tools: `gofmt`, `gofumpt`, `goimports`, `gci`, and `ruff format`. (`ruff
   format` only counts if your Ruff config leaves `format.docstring-code-format` off — with it on, Ruff
   reformats Python code *inside docstrings*, which changes what your strings contain. A tool's guarantee can
-  depend on how it's configured, so campaign checks your config before trusting it.) To choose which of
-  those tools campaign runs in your repo, and over which files, add a committed `.gauntlet.yml` at the repo
-  root:
+  depend on how it's configured, so campaign checks your config before trusting it.)
 
-  ```yaml
-  formatters:
-    - id: gofmt          # which known tool
-      files: "**/*.go"   # optional: a narrower glob than the tool's default
-  ```
+  You don't configure that list in a file. **Name the formatters when you invoke campaign** ("use gofmt and
+  goimports", or "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
+  and campaign will pick it up on later runs. Say nothing and you get the built-in default set. Whatever it
+  resolves to is fixed once, at the start of the run, and written into the run's ledger — so a later wake,
+  or a fresh agent that picks the run up, uses the same list rather than quietly reverting to the default.
 
-  That is the whole schema: **`id`, and optionally `files`, nothing else.** You do **not** supply a command,
-  flags, or an argv — campaign owns the exact command line for each tool it knows (`gofmt -w`,
-  `goimports -w`, `gci write`, `ruff format`, …), and an entry that tries to supply one is refused. The
-  reason is that flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag
-  turns it into a rewrite engine that changes `return true` into `return false`. Checking *which tool* runs
-  is not enough if you also get to pick *how* it runs, so campaign doesn't let you pick.
+  There is deliberately **no config file for this, and campaign will not read one from your repo** — not a
+  file at the repo root, not `CLAUDE.md`, not anything else in the tree. Files in your repo are things a pull
+  request can edit, and this list is what decides whether a change gets committed to that same pull request
+  *without a review pass*. If it lived in the repo, a pull request could widen the rules that govern its own
+  review. Keeping it out of the repo makes that impossible by construction, rather than something campaign
+  has to defend against.
+
+  Naming a tool is all you get to do. You do **not** supply a command, flags, or an argv — campaign owns the
+  exact command line for each tool it knows (`gofmt -w`, `goimports -w`, `gci write`, `ruff format`, …).
+  Flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a
+  rewrite engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if
+  you also get to pick *how* it runs, so campaign doesn't let you pick.
 
   Campaign also picks the **binary**, not just the command line. The tool runs inside the pull request's own
-  worktree, so it resolves the executable to an absolute path outside your repo before running it — a pull
-  request that ships a file called `gofmt` never gets executed. If the real tool can't be found outside the
-  repo, campaign refuses the shortcut and uses a model instead.
+  worktree, and that pull request is untrusted content, so campaign resolves the executable to an absolute
+  path outside your repo before running it — a pull request that ships a file called `gofmt` never gets
+  executed. If the real tool can't be found outside the repo, campaign refuses the shortcut and uses a model
+  instead.
 
-  Every known tool has a default glob (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`), so you can leave
-  `files` out entirely, and a repo with no `.gauntlet.yml` at all still has a well-defined file set. When you
-  do give a `files` glob it may only **narrow** the default, never widen it.
+  Every known tool has a default glob (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`), so you normally name
+  nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,
+  never widen it — and you should not try to write exclusions into it. Campaign applies its **own** exclusion
+  filter afterwards, every time, and nothing widens it: tests, check definitions, CI workflows, and tool
+  config (`**/*_test.go`, `.github/**`, `.golangci.yml`, `pyproject.toml`, …) are removed no matter what
+  your glob says. The glob picks the candidates; campaign's filter protects the files that gate the review.
+  An exclusion list *you* maintain would eventually miss one, and campaign commits this tool's output without
+  a review pass — it must never be able to weaken the checks that gate it. (A glob that *directly* names a
+  protected path is refused outright.)
 
-  You don't have to write exclusions into that glob, and you shouldn't: campaign applies its **own**
-  exclusion filter to the file set afterwards, every time, and your config cannot widen it. Tests, check
-  definitions, CI workflows, and tool config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
-  `pyproject.toml`, `.gauntlet.yml`, …) are removed no matter what your glob says. That is why `**/*.go` is
-  the right thing to write: the glob picks the candidates, campaign's filter protects the files that gate
-  the review. An exclusion list *you* maintain would eventually miss one, and campaign commits this tool's
-  output without a review pass — it must never be able to weaken the checks that gate it. (A glob that
-  *directly* names a protected path, like `files: ".golangci.yml"`, is still refused outright.)
-
-  You can drop built-in tools by omitting them, or set `formatters: []` to turn the whole shortcut off (then
-  every CI failure goes to a full-strength model — always a safe choice). Teaching campaign a genuinely new
-  tool is a change to the skill, not to your config. And a config change never applies to its own pull
-  request: campaign reads `.gauntlet.yml` from the **base branch**, so an edit to it only takes effect once
-  that PR has merged.
-
-  To be clear about what this buys: `.gauntlet.yml` lives in your repo, so anyone who can edit it can
-  already edit your CI workflows. These rules are a **guard against footguns**, not a security boundary
-  against someone with write access. What the base-branch rule genuinely prevents is a pull request widening
-  the rules that govern its own review.
+  Teaching campaign a genuinely new tool is a change to the skill — reviewed and gated like any other code
+  change. And to be clear about what all this buys: the tool list comes from *you*, so the denylist and the
+  narrow shape of the list are a **guard against footguns**, not a security boundary against yourself. The
+  real boundary is that the tool runs on untrusted pull-request content, which is why campaign resolves the
+  binary outside your repo and owns the exclusion filter itself.
 - It keeps a small `.gauntlet/history/` at the repo root (git-ignored, one file per run) to remember what past
   runs learned. That's the memory a fresh run carries over. Each fresh run also tidies that file,
   dropping entries that no longer apply to the current code — and when it isn't sure an entry is

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -191,19 +191,33 @@ flowchart TD
   ```yaml
   formatters:
     - id: gofmt          # which known tool
-      files: "**/*.go"   # which files it may touch
+      files: "**/*.go"   # optional: a narrower glob than the tool's default
   ```
 
-  That is the whole schema: **`id` and `files`, nothing else.** You do **not** supply a command, flags, or
-  an argv — campaign owns the exact command line for each tool it knows (`gofmt -w`, `goimports -w`,
-  `gci write`, `ruff format`, …), and an entry that tries to supply one is refused. The reason is that flags
-  are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a rewrite
-  engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if you also
-  get to pick *how* it runs, so campaign doesn't let you pick.
+  That is the whole schema: **`id`, and optionally `files`, nothing else.** You do **not** supply a command,
+  flags, or an argv — campaign owns the exact command line for each tool it knows (`gofmt -w`,
+  `goimports -w`, `gci write`, `ruff format`, …), and an entry that tries to supply one is refused. The
+  reason is that flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag
+  turns it into a rewrite engine that changes `return true` into `return false`. Checking *which tool* runs
+  is not enough if you also get to pick *how* it runs, so campaign doesn't let you pick.
 
-  `files` is also constrained: a glob that could reach a check definition, a config file, or a test
-  (`.github/**`, `.golangci.yml`, `**/*_test.go`, `pyproject.toml`, …) is refused. Campaign commits this
-  tool's output without a review pass, so it must never be able to weaken the checks that gate it.
+  Campaign also picks the **binary**, not just the command line. The tool runs inside the pull request's own
+  worktree, so it resolves the executable to an absolute path outside your repo before running it — a pull
+  request that ships a file called `gofmt` never gets executed. If the real tool can't be found outside the
+  repo, campaign refuses the shortcut and uses a model instead.
+
+  Every known tool has a default glob (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`), so you can leave
+  `files` out entirely, and a repo with no `.gauntlet.yml` at all still has a well-defined file set. When you
+  do give a `files` glob it may only **narrow** the default, never widen it.
+
+  You don't have to write exclusions into that glob, and you shouldn't: campaign applies its **own**
+  exclusion filter to the file set afterwards, every time, and your config cannot widen it. Tests, check
+  definitions, CI workflows, and tool config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
+  `pyproject.toml`, `.gauntlet.yml`, …) are removed no matter what your glob says. That is why `**/*.go` is
+  the right thing to write: the glob picks the candidates, campaign's filter protects the files that gate
+  the review. An exclusion list *you* maintain would eventually miss one, and campaign commits this tool's
+  output without a review pass — it must never be able to weaken the checks that gate it. (A glob that
+  *directly* names a protected path, like `files: ".golangci.yml"`, is still refused outright.)
 
   You can drop built-in tools by omitting them, or set `formatters: []` to turn the whole shortcut off (then
   every CI failure goes to a full-strength model — always a safe choice). Teaching campaign a genuinely new

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -181,22 +181,37 @@ flowchart TD
   involved at all. A tool only qualifies if its own documentation guarantees the output is *semantically
   equivalent* to the input (an AST-preserving pretty-printer, not a text munger); anything else, including
   every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent. Out of the box
-  it knows the Go and Python formatters (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`). To teach
-  it your repo's formatter, add a committed `.gauntlet.yml` at the repo root:
+  it knows a small table of tools: `gofmt`, `gofumpt`, `goimports`, `gci`, and `ruff format`. (`ruff
+  format` only counts if your Ruff config leaves `format.docstring-code-format` off — with it on, Ruff
+  reformats Python code *inside docstrings*, which changes what your strings contain. A tool's guarantee can
+  depend on how it's configured, so campaign checks your config before trusting it.) To configure how those
+  tools are run in your repo, add a committed `.gauntlet.yml` at the repo root:
 
   ```yaml
   formatters:
     - id: gofmt
-      command: gofmt -w
+      command: ["gofmt", "-w"]      # an argv list, not a shell command line
       files: "**/*.go"
-      guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer)."
+      guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer). Holds unconditionally."
   ```
 
-  Every entry needs a `guarantee` — a pointer to where the tool *documents* that it preserves meaning. An
-  entry without one is refused and that failure just goes to the model instead. You can add tools, drop
-  built-in ones, or set `formatters: []` to turn the whole shortcut off. Two things you cannot do: relax
-  the guarantee rule, and have a config change apply to its own pull request — campaign reads
-  `.gauntlet.yml` from the **base branch**, so an edit to it only takes effect once that PR has merged.
+  `command` is an **argv list** and is run **without a shell**. The first element must be one of the tool
+  names campaign already knows — not a path, not a wrapper script (`./scripts/fmt.sh`), not a shell string
+  (`sh -c "…"`), and no `&&`, `|`, `;`, `>` or `$(…)` anywhere. You can configure a known tool's *flags and
+  files*; you cannot point campaign at an arbitrary binary, because campaign commits that tool's output
+  without review. Teaching campaign a genuinely new tool is a change to the skill, not to your config.
+
+  Every entry also needs a `guarantee` — a pointer to where the tool *documents* that it preserves meaning,
+  including any conditions that guarantee depends on. An entry without one, or one campaign can't verify, is
+  refused and that failure just goes to the model instead. You can drop built-in tools, or set
+  `formatters: []` to turn the whole shortcut off. Two things you cannot do: relax the guarantee rule, and
+  have a config change apply to its own pull request — campaign reads `.gauntlet.yml` from the **base
+  branch**, so an edit to it only takes effect once that PR has merged.
+
+  To be clear about what this buys: `.gauntlet.yml` lives in your repo, so anyone who can edit it can
+  already edit your CI workflows. These rules are a **guard against footguns**, not a security boundary
+  against someone with write access. What the base-branch rule genuinely prevents is a pull request widening
+  the rules that govern its own review.
 - It keeps a small `.gauntlet/history/` at the repo root (git-ignored, one file per run) to remember what past
   runs learned. That's the memory a fresh run carries over. Each fresh run also tidies that file,
   dropping entries that no longer apply to the current code — and when it isn't sure an entry is

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -196,9 +196,11 @@ flowchart TD
   applies extra rewrite rules on top of layout. A formatter that only reformats, nothing more. It also never
   runs a binary out of the pull request's own tree (that's untrusted content), and never points a tool at a
   bare glob or a whole directory — it names the files it is fixing. And because reading the diff can only
-  show writes that land *inside* the repo, it refuses to format a file that could write outside it — a
-  symlink, a file under a symlinked directory, or a file sharing an inode with something else (a formatter
-  writes straight through those, and `git diff` shows nothing at all).
+  show writes that land *inside* the repo, it refuses to format a symlink or a file under a symlinked
+  directory: a formatter writes straight through those and `git diff` shows nothing at all. That last one is
+  a guard against a footgun, not a security boundary — campaign only ever gates same-repo pull requests, so
+  what it really prevents is a stray symlink sending the formatter off to reformat some unrelated file
+  elsewhere on your machine.
 
   **The honest version of the trade:** a cheap model reading a tool's diff is a good miss-catcher, not a
   proof. It can miss a semantic change. What backs it up is that the failing check has to pass, that the

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -180,14 +180,20 @@ flowchart TD
 - Some CI failures — pure formatting ones — it fixes by running the **formatter itself**, with no model
   involved at all. A tool only qualifies if its own documentation guarantees the output is *semantically
   equivalent* to the input (an AST-preserving pretty-printer, not a text munger); anything else, including
-  every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent. Out of the box
-  it knows a small table of tools: `gofmt`, `gofumpt`, `goimports`, `gci`, and `ruff format`. (`ruff
-  format` only counts if your Ruff config leaves `format.docstring-code-format` off — with it on, Ruff
-  reformats Python code *inside docstrings*, which changes what your strings contain. A tool's guarantee can
-  depend on how it's configured, so campaign checks your config before trusting it.)
+  every `--fix`-style linter and every code rewriter, goes to a full-strength fix subagent. The table is
+  deliberately **short** — three tools: `gofmt`, `gci`, and `ruff format`. (`ruff format` only counts if your
+  Ruff config leaves `format.docstring-code-format` off — with it on, Ruff reformats Python code *inside
+  docstrings*, which changes what your strings contain. A tool's guarantee can depend on how it's configured,
+  so campaign checks your config before trusting it.)
+
+  Tools you might expect and won't find: **`goimports`**, because it *adds* missing imports and *removes*
+  unreferenced ones — adding an import runs that package's `init()`, and a guessed import can be the wrong
+  package; and **`gofumpt`**, because it applies extra rewrite rules on top of gofmt's layout and documents
+  them as a rule list, not as semantics-preserving. Both are formatters in the colloquial sense and neither
+  meets the bar, which is the point: the bar is the tool's own documentation, not the vibe of its diff.
 
   You don't configure that list in a file. **Name the formatters when you invoke campaign** ("use gofmt and
-  goimports", or "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
+  gci", or "no formatters" to switch the shortcut off entirely), or **record a preference in memory**
   and campaign will pick it up on later runs. Say nothing and you get the built-in default set. Whatever it
   resolves to is fixed once, at the start of the run, and written into the run's ledger — so a later wake,
   or a fresh agent that picks the run up, uses the same list rather than quietly reverting to the default.
@@ -200,7 +206,7 @@ flowchart TD
   has to defend against.
 
   Naming a tool is all you get to do. You do **not** supply a command, flags, or an argv — campaign owns the
-  exact command line for each tool it knows (`gofmt -w`, `goimports -w`, `gci write`, `ruff format`, …).
+  exact command line for each tool it knows (`gofmt -w --`, `gci write --`, `ruff format --`).
   Flags are not cosmetic: `gofmt -w -r 'true -> false'` is still `gofmt`, but the `-r` flag turns it into a
   rewrite engine that changes `return true` into `return false`. Checking *which tool* runs is not enough if
   you also get to pick *how* it runs, so campaign doesn't let you pick.
@@ -210,6 +216,14 @@ flowchart TD
   path outside your repo before running it — a pull request that ships a file called `gofmt` never gets
   executed. If the real tool can't be found outside the repo, campaign refuses the shortcut and uses a model
   instead.
+
+  And it is careful about the **filenames** it hands the tool, because those come out of the pull request
+  too. A pull request can add a file called `-cpuprofile=prof.go`; it is a perfectly good match for `**/*.go`,
+  and `gofmt -w '-cpuprofile=prof.go' a.go` doesn't format it — it reads it as a *flag* and writes a CPU
+  profile. So campaign always passes `--` before the file list, always passes absolute paths rather than bare
+  names, and drops any candidate file whose name starts with `-` (it logs it and carries on with the rest).
+  Campaign owns the *shape* of the command; the filenames in it are pull-request data, and get treated as
+  data.
 
   Every known tool has a default glob (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`), so you normally name
   nothing but the tool. If you do narrow one to a subdirectory, the glob may only **narrow** the default,

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -195,7 +195,10 @@ flowchart TD
   runs that package's `init()`; `prettier` rewrites the contents of tagged template literals; `gofumpt`
   applies extra rewrite rules on top of layout. A formatter that only reformats, nothing more. It also never
   runs a binary out of the pull request's own tree (that's untrusted content), and never points a tool at a
-  bare glob or a whole directory — it names the files it is fixing.
+  bare glob or a whole directory — it names the files it is fixing. And because reading the diff can only
+  show writes that land *inside* the repo, it refuses to format a file that could write outside it — a
+  symlink, a file under a symlinked directory, or a file sharing an inode with something else (a formatter
+  writes straight through those, and `git diff` shows nothing at all).
 
   **The honest version of the trade:** a cheap model reading a tool's diff is a good miss-catcher, not a
   proof. It can miss a semantic change. What backs it up is that the failing check has to pass, that the

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -84,37 +84,59 @@ semantics-preserving. In a whitespace-significant language it can move behavior 
 formatter-clean — indenting `result.append("always")` under an `if` is a pure-indentation edit that turns
 `["always"]` into `[]`, and `ruff format` is perfectly happy with it.
 
-**The whitelist (exhaustive — a tool not listed IN is OUT):**
+**The LIST is configurable. The CRITERION is NOT.** The whitelist = the skill's **built-in defaults**,
+plus what the repo's `.gauntlet.yml` adds or removes. A hardcoded list is meaningless in a Rust/Java/Ruby
+repo; the criterion above is the safety property and is **NEVER overridable by config**.
 
-- **IN** — `gofmt`, `gofumpt`: AST-preserving Go pretty-printers; they re-print layout and never touch
+**Built-in defaults — IN:**
+
+- `gofmt`, `gofumpt`: AST-preserving Go pretty-printers; they re-print layout and never touch
   string-literal contents.
-- **IN** — `goimports`: import block only. `gci`: import grouping/ordering only — Go package init order
-  is by **dependency**, not by import order in a file.
-- **IN** — golangci-lint `whitespace`: Go-only, leading/trailing newlines **inside function bodies**.
-- **IN** — `ruff format`: verifies its output is AST-equivalent to the input.
-- **OUT** — `prettier`: it reformats the **contents** of tagged template literals (`` gql`…` ``,
-  `` css`…` ``), changing the runtime string the tag function receives. That is a semantic change made by
-  the tool itself.
-- **OUT** — any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer, which can rewrite
-  content inside string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks). A tool
-  that cannot promise it leaves literal content alone is NOT whitelisted.
-- **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
+- `goimports`: import block only. `gci`: import grouping/ordering only — Go package init order is by
+  **dependency**, not by import order in a file.
+- golangci-lint `whitespace`: Go-only, leading/trailing newlines **inside function bodies**.
+- `ruff format`: verifies its output is AST-equivalent to the input.
+
+**The DENYLIST — the skill's own, and config CANNOT widen past it. Refuse any entry that is:**
+
+- **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
+  changing the runtime string the tag function receives. That is a semantic change made by the tool itself.
+- any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer, which can rewrite content inside
+  string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks). A tool that cannot
+  promise it leaves literal content alone is NOT whitelisted.
+- every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3`, any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
   with a reversed or non-equivalent comparator): lint-clean, semantics changed.
-- **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes too.
-  A whitelisted run MUST invoke **only the whitelisted formatter**, NEVER a catch-all `--fix`.
+- every **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`,
+  or any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run MUST invoke
+  **only the whitelisted formatter**, NEVER a catch-all `--fix`.
+- anything whose command can touch a **check definition, config, or test** (the no-weakening prohibition —
+  a hard rule, not a preference).
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
+**Repo config — `.gauntlet.yml` at the repo root** (COMMITTED, unlike the git-ignored `.gauntlet/` tree).
+It may **append** formatter entries and **remove** built-ins; `formatters: []` disables the cheap path
+entirely (everything goes to the session model — always a safe choice). Every entry MUST carry `id`,
+`command`, `files`, and **`guarantee`** — a concrete pointer to the tool's *documented*
+semantic-equivalence behaviour. **An entry without a real guarantee is REFUSED, not silently accepted**;
+"it's just formatting" is NOT a guarantee. Schema, validation, and merge order: `stage-2-ci.md`.
+
+**NEVER read `.gauntlet.yml` from the PR's worktree or head — ALWAYS from the BASE branch**
+(`git show origin/<base>:.gauntlet.yml`). If campaign read the whitelist from the PR under review, a PR
+could **widen the whitelist that governs its own campaign** — adding a semantic rewriter and earning an
+unreviewed tool commit on its own head. That is self-gating in config form. A PR that edits `.gauntlet.yml`
+therefore takes effect only **after it merges**, gated like any other change.
+
 Eligibility is keyed on the **tool's IDENTITY and its documented guarantee** — NEVER on an impression that
 a failure "looks mechanical", and NEVER on the *category* "formatter". A vibes-based whitelist is the same
-unsound reasoning in a new hat. **Default is NOT whitelisted; unknown check or unlisted tool → session
-model.**
+unsound reasoning in a new hat. **Default deny, everywhere: unknown tool, unlisted tool, missing or
+unparseable config, or a refused entry → session model.** The cheap path is opt-in per tool, never inferred.
 
 | When | Action |
 |---|---|
-| **Whitelisted tool** (prefer always) | Run the **tool** in `<worktree>` — `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit + push — and **reset the gate exactly as any other PR-content change does** (`stage-2-ci.md`). **No model at all.** |
-| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the tool/check is not whitelisted, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
+| **Whitelisted tool** (prefer always) | Run the **tool** in `<worktree>` — the built-in default (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`) or the validated `command` from base-branch `.gauntlet.yml`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit + push — and **reset the gate exactly as any other PR-content change does** (`stage-2-ci.md`). **No model at all.** |
+| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the tool/check is not whitelisted, a config entry was **refused**, the config is missing/unparseable, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
 
 If the tool's output does not clear the failing check, or it touched a check definition, config, or test
 → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on the
@@ -123,9 +145,9 @@ model instead.
 
 **Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
 a tool bug, or a config/plugin that switches on non-formatting rules, is the whole of the exposure. Run
-whitelisted tools with the project's own config and no extra rule sets. Do NOT widen the whitelist past a
-guarantee you can point to, and NEVER re-derive its safety from the review gate: the whitelist stands on
-the TOOL being incapable of changing semantics, or it does not stand at all.
+whitelisted tools with the project's own config and no extra rule sets. Do NOT admit a `.gauntlet.yml`
+entry past a guarantee you can point to, and NEVER re-derive its safety from the review gate: the
+whitelist stands on the TOOL being incapable of changing semantics, or it does not stand at all.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's
@@ -220,5 +242,7 @@ Read stage refs only when that stage/action is due:
 - NEVER add "Test plan" section to PR bodies.
 - NEVER commit run/scratch files (the whole `.gauntlet/**` tree) — they are
   driver bookkeeping, not repo content. Stage only the specific source files a fix touches, by explicit
-  path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing).
+  path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing). The repo's
+  `.gauntlet.yml` (repo root) is NOT part of that tree: it is committed repo config, read from the **base**
+  branch (`files-and-ledger.md`, `stage-2-ci.md`).
 - NEVER `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable — the rest is carryover history.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -55,120 +55,44 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 |---|---|---|
 | Review pass (default reviewer) | **session model** | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
-| Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that gets merged, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
-| **CI-fix** | **session model** | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
+| Review-fix (after `NOT SATISFIED`) | **session model** | Authors code from scratch, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
+| **CI-fix — formatting/lint failure** | **`sonnet`** (**`haiku`** only when trivially mechanical) | **Downgraded ON PURPOSE.** It does not author a fix: it runs a deterministic formatter, **READS the resulting diff**, verifies it, and **escalates** anything it cannot verify (`references/stage-2-ci.md`). |
+| **CI-fix — everything else**, and every **escalation** from the cheap tier | **session model** | Authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. |
 
-**NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL**, and the reason is uniform. Every subagent here either
-*is* the gate (review passes), writes **code that gets merged** (CI-fix, review-fix), or produces the
-enumeration an expensive fix depends on (mapper). Nothing downstream *guarantees* a bad result is caught:
-CI misses a wrong-but-green fix, and the review gate is a miss-catcher, not a proof of correctness
-(`stage-2-review-gate.md`). And there is **no mechanical guard** that makes a weak model's edits safe to
-accept: a diff that *looks* like formatting is **not** a proof of semantic equivalence (see below). NEVER
-justify a downgrade by claiming something downstream will catch it.
+**The gate, the from-scratch fixes, and the mapper are NEVER downgraded**: a review pass *is* the gate; a
+review-fix and a session-model CI-fix author code; the mapper's under-map is invisible. **The formatting
+CI-fix tier IS downgraded, deliberately** — it does something narrower: run a tool and VERIFY its output.
 
-### The only cheap path — run a USER-ENABLED tool, no model at all
+### The cheap CI-fix tier — a model that runs a tool and READS the diff
 
-The ONE exception to a model dispatch: a failure whose fixer is a **known tool the USER enabled** is fixed by
-running the **tool** and committing its output. Zero model tokens.
+A formatting/lint failure goes to a **cheap** CI-fix subagent (`sonnet`; `haiku` only for a trivially
+mechanical failure), scoped to the failing check's logs, the failing file(s), and the worktree path. In
+order it: **classifies** the failure → **runs the formatter** (it picks the tool; campaign hands it no
+argv) → **READS THE RESULTING DIFF** and verifies it contains **only** what the fix should have produced,
+touched **no** file it did not intend, weakened **no** check/config/test, and that **re-running the exact
+failing check now passes** → **commits only then** → otherwise **ESCALATES to a session-model CI-fix
+subagent and patches nothing**. Escalation is a correct outcome, not a failure.
 
-**THE SKILL SHIPS WITH ZERO TOOLS ENABLED (`formatters` defaults to `-`), AND IT VOUCHES FOR NO TOOL.** Out
-of the box campaign runs **no tool** and **every** CI failure goes to the session model. The skill supplies
-the **MECHANISM** (below) and the **EVIDENCE** (what each tool's doc does and does not say); **the USER
-decides which tools to trust, enables them explicitly, and accepts that risk.** **The skill guarantees HOW a
-tool is run — NEVER WHAT the tool does.** Top-level invariants:
+Its prompt carries these **verbatim** (full text in `references/stage-2-ci.md`):
 
-- **The SKILL owns the exact argv.** The known-tools table in `references/stage-2-ci.md` fixes, per tool,
-  the precise argv campaign may execute. **NOTHING outside the skill supplies a command, flags, or argv.**
-  Flags carry the semantics: `gofmt -w -r 'true -> false'` rewrites `return true` into `return false` — same
-  known binary, no shell metacharacters, a pure rewrite engine. The tool list names **ids and globs only**.
-- **The SKILL resolves the binary — OUTSIDE the repo.** The tool runs in the PR's worktree, and the PR is
-  **untrusted content**. Resolve `argv[0]` to an **absolute** path via a `PATH` stripped of `.`, empty
-  entries, relative entries, the worktree and the repo root; the resolved executable **MUST live outside
-  the repo tree**. Resolves inside, or not at all → **REFUSE → session model**. A bare name resolved from a
-  `PATH` the PR can influence is arbitrary code execution on the no-model path.
-- **NORMALIZE THE FILE ARGV — filenames are PR-CONTROLLED DATA.** The skill owns the argv **SHAPE**; the
-  file operands are globbed from the **PR's worktree**, so they are **attacker-controlled data spliced into
-  argv** and MUST be normalized like any injection boundary. A PR that adds a file named
-  `-cpuprofile=prof.go` matches `**/*.go`, survives the exclusion filter, and `gofmt -w '-cpuprofile=prof.go'
-  a.go` **parses it as a FLAG** — exit 0, CPU profile written. So, every tool, every run: pass **`--`** before
-  the file list (end of options); pass each file as an **ABSOLUTE** (or `./`-prefixed) path, **NEVER a bare
-  relative name**; and **REFUSE any candidate name starting with `-`** after the filter — drop that file,
-  log it, do **NOT** abort the run. NEVER hand the glob itself to the tool. **NEVER invoke the tool with an
-  EMPTY operand set — `gofmt` with no operands READS STDIN**; empty → run nothing for that id → session model.
-- **A PATH RESOLVES — normalizing its SPELLING is not enough.** A PR can add `link.go` → a symlink out of the
-  tree; the name is clean, and `gofmt -w -- link.go` **follows it and rewrites the target OUTSIDE the
-  worktree**. So, after the exclusion filter and before the argv is built: **REFUSE any candidate that is a
-  SYMLINK** (`lstat`, never `stat`), **REFUSE any whose fully-resolved real path (`realpath`) is not
-  CONTAINED under the resolved worktree root**, and **REFUSE any that is not a REGULAR FILE**. Drop and log
-  each; do NOT abort. Empty set after refusals → session model.
-- **A PATH CHECK BOUNDS WHERE WE LOOK, NOT WHAT WE WRITE — the INODE can be aliased outside the tree.** A PR
-  can add `alias.go`, a **HARDLINK** sharing an inode with a file outside the worktree: a regular file, not a
-  symlink, `realpath` inside the tree — it passes every check above, and `gofmt -w` rewrites the **existing
-  inode**, mutating the outside alias. So also **REFUSE any candidate with a LINK COUNT > 1** (`stat` →
-  `st_nlink > 1`); a source file in a normal checkout has exactly one link. Drop and log it (reason:
-  `hardlink — nlink>1`); NEVER abort the run.
-- **EVERY CHECK THAT REASONS ABOUT A PATH MUST REASON ABOUT THE RESOLVED PATH — A NAME IS NOT A LOCATION.** A
-  PR can add a **symlinked DIRECTORY** `safe/gh -> .github`. The candidate `safe/gh/actions/main.go` is not
-  itself a symlink, its `realpath` is inside the worktree, it is a regular file with `nlink == 1` — it passes
-  every check above — while the **exclusion filter, matched on the SPELLED path, never sees `.github/**`**, so
-  a **check definition** reaches the tool. So: **apply the exclusion filter to the RESOLVED path as well as
-  the original — EITHER matches → REFUSE**; **AND REFUSE any candidate with a SYMLINK in ANY DIRECTORY
-  COMPONENT** (`lstat` each component from the worktree root down). The component check bounds **what we
-  write**; matching the filter on the resolved path keeps the filter honest. Both, every run.
-- **THE PIPELINE** (`stage-2-ci.md`): glob → **RESOLVE** → **FILTER on both the original and the resolved
-  path** → the **SEVEN** operand checks → argv. The seven: `--`; absolute/`./` paths; no `-`-leading names;
-  no symlinks; nothing resolving outside the worktree or non-regular; no `nlink > 1`; no symlinked directory
-  component.
-- **The tool list lives in the LEDGER, NEVER in the repo, and it is EMPTY by default.** It is the ledger
-  header's `formatters` field: resolved **once at run start** — explicit invocation, else a user preference
-  in memory, else **`-` (EMPTY: no tool, cheap path OFF)** — and **re-read from the header every wake**,
-  never re-derived from memory mid-run (same rule as `reviewer`). Two shapes only: **`-`** (the default;
-  never the word `none`, and there is **NO `default` value and no built-in set**) or known-tool ids each with
-  an optional **NARROWER** glob. **NEVER read it from repo content — not from a repo config file, not from
-  `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and enable a tool to
-  govern its own campaign. Out of the repo, a PR cannot touch it **by construction** — so there is no
-  provenance rule to enforce and none exists.
-- **"KNOWN" ≠ "TRUSTED". The skill vouches for NO tool.** A known-tools row means the skill knows how to run
-  that tool **safely** — it owns the argv, the resolution, the operand checks. It does **NOT** mean the tool
-  is safe to enable. **NEVER present a row as blessed, trusted, or recommended.** For each row `stage-2-ci.md`
-  states, separately: **what the skill guarantees** (mechanical, ours) and **what is NOT proven** (about the
-  tool). `gofmt`: the cited doc (https://pkg.go.dev/cmd/gofmt) documents formatting behaviour and the flags
-  `-w`/`-r`/`-s`; it **NEVER states a semantic-equivalence guarantee**. Our reading — a pretty-printer that
-  parses and re-prints cannot change meaning — is an **INFERENCE**. Same for `gci` and `ruff format`: neither
-  doc states the guarantee either. **Enabling a tool means accepting that inference.**
-- **Enabling a tool is an explicit USER act and an explicit RISK ACCEPTANCE.** The skill does not decide a
-  tool is safe — **the user does**. If asked whether a tool is safe, point at its "what is NOT proven" cell;
-  **NEVER answer "the skill guarantees it".**
-- **THE ASYMMETRY: the skill REFUSES what is DOCUMENTED to be unsafe; it does NOT bless what is merely
-  UNDOCUMENTED.** The **non-overridable DENYLIST** (config can NEVER enable one) holds tools whose own docs
-  say they change the program: **`goimports`** (ADDS/REMOVES imports — an added import runs its `init()`),
-  **`prettier`** (rewrites tagged-template contents), **`gofumpt`** (extra rewrite rules), semantic rewriters
-  (`modernize`, codemods), and **every catch-all `--fix`/`--write`**. That is a documented fact, so the skill
-  refuses it. Where no doc states a guarantee either way, the call is the **user's** (`stage-2-ci.md`).
-- **What the no-model path actually rests on:** **OURS** — the mechanism (exact argv, no flag appended,
-  trusted binary outside the repo, the seven operand checks, resolve-then-filter, no shell/glob/empty operand
-  set, gate reset on every commit); **THE USER'S** — the tool's behaviour, which no cited doc proves. NEVER
-  restate the second as a guarantee of the skill's. The **no-weakening prohibition is for the session-model
-  CI-fix subagent** — a model can change anything.
-- **The SKILL owns a non-overridable EXCLUSION FILTER — DEFENCE IN DEPTH, admittedly INCOMPLETE.** Applied to
-  every candidate's **RESOLVED** path and its original (**either** matches → REFUSE), every time: tests,
-  check definitions, CI/tool config, `.gauntlet/**` (`**/*_test.go`, `.github/**`, `.golangci.yml`,
-  `pyproject.toml`, …). It is an **enumerated pattern list: NOT complete and it cannot be** — a
-  repo-specific check written as ordinary source (`tools/ci/check.go`) matches `**/*.go`, matches none of
-  the patterns, and **is** formatted. **NEVER call it complete, exhaustive, or a reason to enable a tool.**
-  Its job is **blast radius** — keep the tool's diff off files a reviewer expects untouched. **NOTHING widens
-  it** (config may only narrow); NEVER make the user's glob carry the exclusions. So a `gofmt:**/*.go`
-  narrowing is correct — the glob selects, the filter trims.
-- **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`) — so even an enabled
-  tool's output is re-reviewed on the new SHA.
-- **Default deny — and the default IS deny.** `formatters` = `-`, tool not enabled, tool not in the table,
-  denylisted id, refused id, unresolvable binary, the tool did not fix it, the tool left residue, or the
-  failure needs any judgment → **session model**, set explicitly. NEVER hand it to a cheap model instead.
+- **NEVER make CI pass by weakening the check** — never delete or loosen an assertion, add `skip`/`xfail`,
+  disable or downgrade a lint rule, or raise a timeout. **Fix the cause.** If the check itself is
+  demonstrably wrong, say so explicitly and **escalate**; never silently rewrite it.
+- **NEVER use a catch-all fixer that applies SEMANTIC rules or a documented semantic rewriter** —
+  `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, any `--fix`/`--write` on a semantic linter;
+  `goimports` (it ADDS imports, and an added import runs its `init()`); `prettier` (it rewrites
+  tagged-template contents); `gofumpt`; `modernize`; codemods. **Use a formatter that only reformats.**
+- **NEVER execute a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**,
+  and a repo-supplied `gofmt` is arbitrary code execution. Run tools from the environment, not from the tree.
+- **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — **name the files** you are fixing.
 
-Full known-tools table (**exact skill-owned argv**, default glob, what the skill guarantees, what is NOT
-proven), the executable-resolution rule, the exclusion filter, the `formatters` resolution and validation,
-the non-overridable denylist, and the honest trust model → **`references/stage-2-ci.md`**.
+**State the risk, never overclaim:** a cheap model verifying a tool's diff is a **MISS-CATCHER, NOT A
+PROOF** — it can miss a semantic change. What backs it: the exact failing check must pass, it must escalate
+anything it cannot verify, and **every campaign commit still resets the gate and is re-reviewed by the full
+gauntlet** — which is itself a miss-catcher. **NEVER justify the cheap tier with "CI will catch it" or "the
+review gate will catch it."** This is a small, bounded risk the user has accepted, for a workflow that is
+cheaper **and** more capable than a full-strength subagent on every formatting failure.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's
@@ -219,7 +143,7 @@ Read stage refs only when that stage/action is due:
 - **One active driver:** lease controls ownership; never double-drive one run.
 - **Base branch is data:** read `base_branch` from ledger every wake; never assume `main`.
 - **Reviewer is data:** read `reviewer` from ledger every wake before dispatching any review; set once at run start, never re-derived from memory (else an explicit/preferred reviewer silently reverts to default on a self-wake or adoption).
-- **Tool list is data, and it is EMPTY by default:** read `formatters` from the ledger header every wake before running any tool; set once at run start from the **user** (invocation, else memory preference, else **`-`** — no tool enabled). NEVER from a repo file — repo content is PR content.
+- **Model is set explicitly on every subagent dispatch:** never let a dispatch inherit the session model by default. CI-fix on a formatting failure is cheap **by design**; review passes, review-fixes, and the mapper are never downgraded ("Subagent Dispatch").
 - **Remote branch cleanup isn't campaign's job:** campaign never passes `--delete-branch`; the repo's *Automatically delete head branches* setting governs the remote head branch. Local worktree/branch cleanup follows the per-PR `worktree_owned`/`branch_owned` flags.
 - **Review gate is tier-dependent:** `required(tier)` fresh, context-isolated `SATISFIED` verdicts on
   same live PR content + green CI — **1 if TRIVIAL, else 2** (any code/agent-doc/sensitive change is 2).
@@ -265,6 +189,5 @@ Read stage refs only when that stage/action is due:
 - NEVER commit run/scratch files (the whole `.gauntlet/**` tree) — they are
   driver bookkeeping, not repo content. Stage only the specific source files a fix touches, by explicit
   path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing). Campaign has
-  **no committed file of its own** — no repo-root config, and the tool list is a ledger header
-  field, never a repo file (`files-and-ledger.md`, `stage-2-ci.md`).
+  **no committed file of its own** — no repo-root config (`files-and-ledger.md`).
 - NEVER `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable — the rest is carryover history.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -101,9 +101,19 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   symlink, `realpath` inside the tree — it passes every check above, and `gofmt -w` rewrites the **existing
   inode**, mutating the outside alias. So also **REFUSE any candidate with a LINK COUNT > 1** (`stat` →
   `st_nlink > 1`); a source file in a normal checkout has exactly one link. Drop and log it (reason:
-  `hardlink — nlink>1`); NEVER abort the run. **Six checks in all** (`stage-2-ci.md`): `--`; absolute/`./`
-  paths; no `-`-leading names; no symlinks; nothing resolving outside the worktree or non-regular; no
-  `nlink > 1`.
+  `hardlink — nlink>1`); NEVER abort the run.
+- **EVERY CHECK THAT REASONS ABOUT A PATH MUST REASON ABOUT THE RESOLVED PATH — A NAME IS NOT A LOCATION.** A
+  PR can add a **symlinked DIRECTORY** `safe/gh -> .github`. The candidate `safe/gh/actions/main.go` is not
+  itself a symlink, its `realpath` is inside the worktree, it is a regular file with `nlink == 1` — it passes
+  every check above — while the **exclusion filter, matched on the SPELLED path, never sees `.github/**`**, so
+  a **check definition** reaches the tool. So: **apply the exclusion filter to the RESOLVED path as well as
+  the original — EITHER matches → REFUSE**; **AND REFUSE any candidate with a SYMLINK in ANY DIRECTORY
+  COMPONENT** (`lstat` each component from the worktree root down). The resolved-path filter is the
+  **guarantee**; the component check is the cheap **tripwire**. Both, every run.
+- **THE PIPELINE** (`stage-2-ci.md`): glob → **RESOLVE** → **FILTER on both the original and the resolved
+  path** → the **SEVEN** operand checks → argv. The seven: `--`; absolute/`./` paths; no `-`-leading names;
+  no symlinks; nothing resolving outside the worktree or non-regular; no `nlink > 1`; no symlinked directory
+  component.
 - **The whitelist lives in the LEDGER, NEVER in the repo.** It is the ledger header's `formatters` field:
   resolved **once at run start** — explicit invocation, else a user preference in memory, else the table's
   built-in defaults (`default`; the sentinel **`-`** — never the word `none` — turns the cheap path off)
@@ -113,8 +123,9 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and widen the
   whitelist that governs its own campaign. Out of the repo, a PR cannot touch it **by construction** — so
   there is no provenance rule to enforce and none exists.
-- **The SKILL owns a non-overridable EXCLUSION FILTER**, applied to the file set **after** the glob, every
-  time: no tests, no check definitions, no CI or tool config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
+- **The SKILL owns a non-overridable EXCLUSION FILTER**, applied to every candidate's **RESOLVED** path (and
+  its original — **either** matches → REFUSE), every time: no tests, no check definitions, no CI or tool
+  config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
   `pyproject.toml`, …). **NOTHING widens it.** So a `gofmt:**/*.go` narrowing is correct — the glob selects,
   the filter protects. NEVER make the user's glob carry the exclusions: a user-written exclusion list
   **will** omit something.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -67,121 +67,34 @@ CI misses a wrong-but-green fix, and the review gate is a miss-catcher, not a pr
 accept: a diff that *looks* like formatting is **not** a proof of semantic equivalence (see below). NEVER
 justify a downgrade by claiming something downstream will catch it.
 
-### The only cheap path — run the formatter TOOL, no model at all
+### The only cheap path — run a skill-owned formatter TOOL, no model at all
 
-Some CI failures need **no subagent**: run the fixer **tool** and commit its output. Zero model tokens,
-zero model risk.
+The ONE exception to a model dispatch: a whitelisted **formatting** failure is fixed by running the
+**tool** and committing its output. Zero model tokens, zero model risk. Top-level invariants:
 
-**THE CRITERION — a tool is whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to
-its input**: an AST-preserving pretty-printer, not a text munger. Whitelisting is **per-TOOL**, and the
-burden is the **tool's documented behaviour**. **If you cannot point to that guarantee, the tool is NOT
-whitelisted — use the session model.** There is NO blanket "formatters are safe" rule: a tool that looks
-like a formatter can still rewrite meaning (see `prettier`, below).
+- **The SKILL owns the exact argv.** The known-tools table in `references/stage-2-ci.md` fixes, per tool,
+  the precise argv campaign may execute. **Config NEVER supplies a command, flags, or argv.** Flags carry
+  the semantics: `gofmt -w -r 'true -> false'` rewrites `return true` into `return false` — same known
+  binary, no shell metacharacters, a pure rewrite engine. Letting config choose flags hands back exactly
+  the freedom the criterion exists to remove. An entry carrying `command`/`args`/`argv`/flags is **REFUSED**.
+- **Config picks only WHICH tool and over WHICH files.** A `.gauntlet.yml` entry carries **only `id` +
+  `files`**, and `files` MUST NOT be able to reach a **check definition, config, or test** path. A glob
+  that can → **REFUSED**.
+- **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
+  its output is SEMANTICALLY EQUIVALENT to its input, on the burden of the tool's **documented behaviour**.
+  There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to
+  a model hand-editing the same file, however formatting-like the diff looks (a pure-indentation edit moves
+  behavior in a whitespace-significant language and stays formatter-clean).
+- **Base branch only.** Read `.gauntlet.yml` from the base branch (`git show origin/<base>:.gauntlet.yml`),
+  NEVER from the PR's worktree or head — a PR must NEVER widen the whitelist that governs its own campaign.
+- **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`).
+- **Default deny.** Unknown or unlisted tool, refused entry, missing/unparseable config, the tool did not
+  fix it, the tool left residue, or the failure needs any judgment → **session model**, set explicitly.
+  NEVER hand it to a cheap model instead.
 
-The guarantee belongs to the whitelisted **tool's output** and to **nothing else**. It does **not**
-transfer to a model that hand-edits the same file: a diff that merely LOOKS like formatting is not
-semantics-preserving. In a whitespace-significant language it can move behavior while staying
-formatter-clean — indenting `result.append("always")` under an `if` is a pure-indentation edit that turns
-`["always"]` into `[]`, and `ruff format` is perfectly happy with it.
-
-**The LIST is configurable. The CRITERION is NOT.** The whitelist = the skill's **built-in defaults**, as
-the repo's `.gauntlet.yml` re-configures or removes them. A hardcoded set of *flags* is meaningless in a
-Rust/Java/Ruby repo; the criterion above is the safety property and is **NEVER overridable by config**.
-Config tunes **which known tools run, with which flags, over which files** — it can **NEVER introduce a
-binary outside the known-tools table** below.
-
-**Built-in defaults — the KNOWN-TOOLS TABLE.** These are the ONLY binaries campaign may execute on the
-no-model path. Adding a tool here is a **SKILL change**, NEVER a config change (`stage-2-ci.md`).
-
-| `id` | `argv[0]` | guarantee | precondition |
-|---|---|---|---|
-| `gofmt` | `gofmt` | AST-preserving Go pretty-printer; never touches string-literal contents | none |
-| `gofumpt` | `gofumpt` | same, stricter layout; never touches string-literal contents | none |
-| `goimports` | `goimports` | import block only | none |
-| `gci` | `gci` | import grouping/ordering only — Go init order is by **dependency**, not by import order | none |
-| `ruff format` | `ruff` | verifies its output is AST-equivalent to the input | repo's Ruff config does **NOT** enable `format.docstring-code-format` |
-
-**golangci-lint `whitespace` is NOT a default**: it has **no safe fixer** — its only fix path is the
-catch-all `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it.
-
-**A tool's guarantee can be CONDITIONAL on its CONFIGURATION.** `ruff format` with
-`format.docstring-code-format` enabled reformats Python code **inside docstrings** — it rewrites string
-contents, so its output is NOT AST-equivalent. Therefore: every `guarantee` MUST state the **conditions
-under which it holds**, and campaign MUST **verify those conditions hold in this repo** (read the tool's
-config from the **base** branch) before taking the no-model path. Condition violated, or undeterminable →
-**NOT whitelisted for this repo → session model.**
-
-**The DENYLIST — the skill's own, and config CANNOT widen past it. Refuse any entry that is:**
-
-- **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
-  changing the runtime string the tag function receives. That is a semantic change made by the tool itself.
-- any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer, which can rewrite content inside
-  string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks). A tool that cannot
-  promise it leaves literal content alone is NOT whitelisted.
-- every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3`, any rule that rewrites logic. A
-  `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
-  with a reversed or non-equivalent comparator): lint-clean, semantics changed.
-- every **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`,
-  or any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run MUST invoke
-  **only the whitelisted formatter**, NEVER a catch-all `--fix`.
-- anything whose command can touch a **check definition, config, or test** (the no-weakening prohibition —
-  a hard rule, not a preference).
-- **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
-  compile error, and any rule that rewrites logic.
-
-**Repo config — `.gauntlet.yml` at the repo root** (COMMITTED, unlike the git-ignored `.gauntlet/` tree).
-It **re-configures the flags and files of KNOWN tools** and **removes** built-ins; `formatters: []`
-disables the cheap path entirely (everything goes to the session model — always a safe choice). It can
-**NEVER introduce a binary that is not in the known-tools table.**
-
-**The command's SHAPE is constrained, not just the tool's category** — the attack is command
-*construction*: an entry can cite `gofmt`'s guarantee while executing `./scripts/fmt.sh`. So every entry
-MUST carry `id`, `command`, `files`, `guarantee`, and:
-
-- **`command` is an argv LIST** — `command: ["gofmt", "-w"]`. **Executed WITHOUT a shell.** NEVER `sh -c`,
-  NEVER `bash -c`, NEVER a shell string.
-- **REFUSE any shell metacharacter** in the argv — `&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks,
-  newlines. No legitimate formatter entry needs them.
-- **`argv[0]` MUST be a bare tool name in the known-tools table** — NOT a path (`./x`, `/usr/local/bin/x`),
-  NOT a wrapper script, NOT an alias, NOT `sh`/`env`/`xargs`.
-- **`guarantee` MUST state the conditions under which it holds**, and those conditions MUST **verify in
-  this repo**. Undeterminable → REFUSE. "It's just formatting" is NOT a guarantee.
-
-**Any entry failing ANY of these is REFUSED** — logged, ignored, and that failure routes to the **session
-model**. Full schema, validation, and merge order: `stage-2-ci.md`.
-
-**NEVER read `.gauntlet.yml` from the PR's worktree or head — ALWAYS from the BASE branch**
-(`git show origin/<base>:.gauntlet.yml`). If campaign read the whitelist from the PR under review, a PR
-could **widen the whitelist that governs its own campaign** — adding a semantic rewriter and earning an
-unreviewed tool commit on its own head. That is self-gating in config form. A PR that edits `.gauntlet.yml`
-therefore takes effect only **after it merges**, gated like any other change.
-
-**Trust model, stated honestly.** `.gauntlet.yml` comes from the base branch, so its author already has
-**write access to the repo** — the same access that can rewrite `.github/workflows`. The denylist and the
-command-shape rules are a **guard against footguns and accidental misuse, NOT a security boundary against a
-malicious committer**. NEVER claim otherwise. What the base-branch rule DOES buy is real and MUST be kept:
-**a PR under review cannot widen the whitelist that governs its own campaign.**
-
-Eligibility is keyed on the **tool's IDENTITY and its documented guarantee** — NEVER on an impression that
-a failure "looks mechanical", and NEVER on the *category* "formatter". A vibes-based whitelist is the same
-unsound reasoning in a new hat. **Default deny, everywhere: unknown tool, unlisted tool, missing or
-unparseable config, or a refused entry → session model.** The cheap path is opt-in per tool, never inferred.
-
-| When | Action |
-|---|---|
-| **Whitelisted tool** (prefer always) | Run the **tool** in `<worktree>`, **WITHOUT a shell**, from its validated **argv** — the built-in default (`["gofmt","-w"]`, `["gofumpt","-w"]`, `["goimports","-w"]`, `["gci","write"]`, `["ruff","format"]`) or the validated `command` from base-branch `.gauntlet.yml`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit + push — and **reset the gate exactly as any other PR-content change does** (`stage-2-ci.md`). **No model at all.** |
-| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the tool/check is not whitelisted, a config entry was **refused** (bad shape, unknown `argv[0]`, unverifiable guarantee condition), the config is missing/unparseable, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
-
-If the tool's output does not clear the failing check, or it touched a check definition, config, or test
-→ **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on the
-session model**. NEVER commit an unverified formatter run. NEVER hand a "formatting" failure to a cheap
-model instead.
-
-**Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
-a tool bug, or a config/plugin that switches on non-formatting rules, is the whole of the exposure. Run
-whitelisted tools with the project's own config and no extra rule sets. Do NOT admit a `.gauntlet.yml`
-entry past a guarantee you can point to, and NEVER re-derive its safety from the review gate: the
-whitelist stands on the TOOL being incapable of changing semantics, or it does not stand at all.
+Full known-tools table (each tool's **exact skill-owned argv**, guarantee, precondition), the
+`.gauntlet.yml` schema and validation, the non-overridable denylist, and the honest trust model →
+**`references/stage-2-ci.md`**.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -111,22 +111,26 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   **will** omit something.
 - **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
   its output is SEMANTICALLY EQUIVALENT to its input, on the burden of a **CITED SOURCE — a LINK to the
-  tool's own documentation**. Saying the word "documented" is NOT a citation. There is NO blanket
-  "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to a model hand-editing
-  the same file, however formatting-like the diff looks (a pure-indentation edit moves behavior in a
-  whitespace-significant language and stays formatter-clean).
-- **The table is SMALL on purpose — `gofmt`, `gci`, `ruff format`**, each cell carrying the doc LINK its
-  guarantee rests on (a claim with no source → the tool leaves the table). Fewer tools that provably hold
-  beats more that mostly do. `goimports` is **REJECTED** (it ADDS/REMOVES imports; an added import runs that
-  package's `init()`, and a guessed one can be the wrong package) and `gofumpt` is **REJECTED** (extra
-  rewrite rules beyond layout, documented as a rule list, never as semantics-preserving). NEVER re-add a
-  tool because it "is basically a formatter" — that reasoning is what put both of them here.
+  tool's own documentation, and the passage QUOTED in the cell**. Saying the word "documented" is NOT a
+  citation, and **a citation that does not SUPPORT its claim is WORSE than none** — it launders our own
+  belief as the source's. There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** —
+  it NEVER transfers to a model hand-editing the same file, however formatting-like the diff looks (a
+  pure-indentation edit moves behavior in a whitespace-significant language and stays formatter-clean).
+- **The table holds ONE tool — `gofmt`** (Go formatting), its cell quoting https://pkg.go.dev/cmd/gofmt.
+  **That is not a limitation to work around; it is the rule working**: it is what survived a bar that demands
+  a documented guarantee. **REJECTED**, each for a stated reason (`stage-2-ci.md`): **`ruff format`** (its
+  cited formatter docs state no AST-equivalence guarantee), **`gci`** (its cited docs never say it neither
+  adds nor removes an import), **`goimports`** (ADDS/REMOVES imports), **`gofumpt`** (extra rewrite rules,
+  documented as a rule list). **Every other CI failure — including ALL Python/JS/etc formatting — goes to
+  the SESSION MODEL**, which is the safe default and is what happened before this path existed. Adding a
+  tool is a **SKILL change** and the bar is **a source that STATES the guarantee, quoted**; "it's a
+  formatter", "it's probably fine", "it's widely used" are **NOT admissible**.
 - **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`).
 - **Default deny.** Unknown or unlisted tool, refused id, unresolvable binary, the tool did not fix it, the
   tool left residue, or the failure needs any judgment → **session model**, set explicitly. NEVER hand it to
   a cheap model instead.
 
-Full known-tools table (each tool's **exact skill-owned argv**, default glob, guarantee, precondition), the
+Full known-tools table (the tool's **exact skill-owned argv**, default glob, quoted guarantee), the
 executable-resolution rule, the exclusion filter, the `formatters` resolution and validation, the
 non-overridable denylist, and the honest trust model → **`references/stage-2-ci.md`**.
 

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -86,6 +86,8 @@ Its prompt carries these **verbatim** (full text in `references/stage-2-ci.md`):
 - **NEVER execute a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**,
   and a repo-supplied `gofmt` is arbitrary code execution. Run tools from the environment, not from the tree.
 - **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — **name the files** you are fixing.
+- **PREFLIGHT every file: REFUSE to format it if it is a symlink, sits under a symlinked directory, or has
+  `nlink > 1`** — diff review sees every write INSIDE the repo, but **never one that ESCAPES it**.
 
 **State the risk, never overclaim:** a cheap model verifying a tool's diff is a **MISS-CATCHER, NOT A
 PROOF** — it can miss a semantic change. What backs it: the exact failing check must pass, it must escalate

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -73,37 +73,39 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
 **tool** and committing its output. Zero model tokens, zero model risk. Top-level invariants:
 
 - **The SKILL owns the exact argv.** The known-tools table in `references/stage-2-ci.md` fixes, per tool,
-  the precise argv campaign may execute. **Config NEVER supplies a command, flags, or argv.** Flags carry
-  the semantics: `gofmt -w -r 'true -> false'` rewrites `return true` into `return false` — same known
-  binary, no shell metacharacters, a pure rewrite engine. Letting config choose flags hands back exactly
-  the freedom the criterion exists to remove. An entry carrying `command`/`args`/`argv`/flags is **REFUSED**.
+  the precise argv campaign may execute. **NOTHING outside the skill supplies a command, flags, or argv.**
+  Flags carry the semantics: `gofmt -w -r 'true -> false'` rewrites `return true` into `return false` — same
+  known binary, no shell metacharacters, a pure rewrite engine. The whitelist names **ids and globs only**.
 - **The SKILL resolves the binary — OUTSIDE the repo.** The tool runs in the PR's worktree, and the PR is
   **untrusted content**. Resolve `argv[0]` to an **absolute** path via a `PATH` stripped of `.`, empty
   entries, relative entries, the worktree and the repo root; the resolved executable **MUST live outside
   the repo tree**. Resolves inside, or not at all → **REFUSE → session model**. A bare name resolved from a
   `PATH` the PR can influence is arbitrary code execution on the no-model path.
-- **Config picks only WHICH tool and (optionally) a NARROWER file glob.** A `.gauntlet.yml` entry carries
-  **only `id` + optional `files`**; `files` may only narrow the tool's **default glob** in the table, never
-  widen it. Missing config → the table's defaults.
+- **The whitelist lives in the LEDGER, NEVER in the repo.** It is the ledger header's `formatters` field:
+  resolved **once at run start** — explicit invocation, else a user preference in memory, else the table's
+  built-in defaults (`none` turns the cheap path off) — and **re-read from the header every wake**, never
+  re-derived from memory mid-run (same rule as `reviewer`). It carries **known-tool ids + an optional
+  NARROWER glob**, nothing else. **NEVER read it from repo content — not from a repo config file, not from
+  `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and widen the
+  whitelist that governs its own campaign. Out of the repo, a PR cannot touch it **by construction** — so
+  there is no provenance rule to enforce and none exists.
 - **The SKILL owns a non-overridable EXCLUSION FILTER**, applied to the file set **after** the glob, every
   time: no tests, no check definitions, no CI or tool config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
-  `pyproject.toml`, `.gauntlet.yml`, …). **Config CANNOT widen it.** So `files: "**/*.go"` is correct — the
-  glob selects, the filter protects. NEVER make the user's glob carry the exclusions: a user-written
-  exclusion list **will** omit something.
+  `pyproject.toml`, …). **NOTHING widens it.** So a `gofmt:**/*.go` narrowing is correct — the glob selects,
+  the filter protects. NEVER make the user's glob carry the exclusions: a user-written exclusion list
+  **will** omit something.
 - **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
   its output is SEMANTICALLY EQUIVALENT to its input, on the burden of the tool's **documented behaviour**.
   There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to
   a model hand-editing the same file, however formatting-like the diff looks (a pure-indentation edit moves
   behavior in a whitespace-significant language and stays formatter-clean).
-- **Base branch only.** Read `.gauntlet.yml` from the base branch (`git show origin/<base>:.gauntlet.yml`),
-  NEVER from the PR's worktree or head — a PR must NEVER widen the whitelist that governs its own campaign.
 - **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`).
-- **Default deny.** Unknown or unlisted tool, refused entry, unparseable config, unresolvable binary, the
-  tool did not fix it, the tool left residue, or the failure needs any judgment → **session model**, set
-  explicitly. NEVER hand it to a cheap model instead.
+- **Default deny.** Unknown or unlisted tool, refused id, unresolvable binary, the tool did not fix it, the
+  tool left residue, or the failure needs any judgment → **session model**, set explicitly. NEVER hand it to
+  a cheap model instead.
 
 Full known-tools table (each tool's **exact skill-owned argv**, default glob, guarantee, precondition), the
-executable-resolution rule, the exclusion filter, the `.gauntlet.yml` schema and validation, the
+executable-resolution rule, the exclusion filter, the `formatters` resolution and validation, the
 non-overridable denylist, and the honest trust model → **`references/stage-2-ci.md`**.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
@@ -155,6 +157,7 @@ Read stage refs only when that stage/action is due:
 - **One active driver:** lease controls ownership; never double-drive one run.
 - **Base branch is data:** read `base_branch` from ledger every wake; never assume `main`.
 - **Reviewer is data:** read `reviewer` from ledger every wake before dispatching any review; set once at run start, never re-derived from memory (else an explicit/preferred reviewer silently reverts to default on a self-wake or adoption).
+- **Formatter whitelist is data:** read `formatters` from the ledger header every wake before running any tool; set once at run start from the **user** (invocation, else memory preference, else built-in defaults). NEVER from a repo file — repo content is PR content.
 - **Remote branch cleanup isn't campaign's job:** campaign never passes `--delete-branch`; the repo's *Automatically delete head branches* setting governs the remote head branch. Local worktree/branch cleanup follows the per-PR `worktree_owned`/`branch_owned` flags.
 - **Review gate is tier-dependent:** `required(tier)` fresh, context-isolated `SATISFIED` verdicts on
   same live PR content + green CI — **1 if TRIVIAL, else 2** (any code/agent-doc/sensitive change is 2).
@@ -199,7 +202,7 @@ Read stage refs only when that stage/action is due:
 - NEVER add "Test plan" section to PR bodies.
 - NEVER commit run/scratch files (the whole `.gauntlet/**` tree) — they are
   driver bookkeeping, not repo content. Stage only the specific source files a fix touches, by explicit
-  path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing). The repo's
-  `.gauntlet.yml` (repo root) is NOT part of that tree: it is committed repo config, read from the **base**
-  branch (`files-and-ledger.md`, `stage-2-ci.md`).
+  path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing). Campaign has
+  **no committed file of its own** — no repo-root config, and the formatter whitelist is a ledger header
+  field, never a repo file (`files-and-ledger.md`, `stage-2-ci.md`).
 - NEVER `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable — the rest is carryover history.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -67,15 +67,21 @@ CI misses a wrong-but-green fix, and the review gate is a miss-catcher, not a pr
 accept: a diff that *looks* like formatting is **not** a proof of semantic equivalence (see below). NEVER
 justify a downgrade by claiming something downstream will catch it.
 
-### The only cheap path — run a skill-owned formatter TOOL, no model at all
+### The only cheap path — run a USER-ENABLED tool, no model at all
 
-The ONE exception to a model dispatch: a whitelisted **formatting** failure is fixed by running the
-**tool** and committing its output. Zero model tokens, zero model risk. Top-level invariants:
+The ONE exception to a model dispatch: a failure whose fixer is a **known tool the USER enabled** is fixed by
+running the **tool** and committing its output. Zero model tokens.
+
+**THE SKILL SHIPS WITH ZERO TOOLS ENABLED (`formatters` defaults to `-`), AND IT VOUCHES FOR NO TOOL.** Out
+of the box campaign runs **no tool** and **every** CI failure goes to the session model. The skill supplies
+the **MECHANISM** (below) and the **EVIDENCE** (what each tool's doc does and does not say); **the USER
+decides which tools to trust, enables them explicitly, and accepts that risk.** **The skill guarantees HOW a
+tool is run — NEVER WHAT the tool does.** Top-level invariants:
 
 - **The SKILL owns the exact argv.** The known-tools table in `references/stage-2-ci.md` fixes, per tool,
   the precise argv campaign may execute. **NOTHING outside the skill supplies a command, flags, or argv.**
   Flags carry the semantics: `gofmt -w -r 'true -> false'` rewrites `return true` into `return false` — same
-  known binary, no shell metacharacters, a pure rewrite engine. The whitelist names **ids and globs only**.
+  known binary, no shell metacharacters, a pure rewrite engine. The tool list names **ids and globs only**.
 - **The SKILL resolves the binary — OUTSIDE the repo.** The tool runs in the PR's worktree, and the PR is
   **untrusted content**. Resolve `argv[0]` to an **absolute** path via a `PATH` stripped of `.`, empty
   entries, relative entries, the worktree and the repo root; the resolved executable **MUST live outside
@@ -114,55 +120,55 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   path** → the **SEVEN** operand checks → argv. The seven: `--`; absolute/`./` paths; no `-`-leading names;
   no symlinks; nothing resolving outside the worktree or non-regular; no `nlink > 1`; no symlinked directory
   component.
-- **The whitelist lives in the LEDGER, NEVER in the repo.** It is the ledger header's `formatters` field:
-  resolved **once at run start** — explicit invocation, else a user preference in memory, else the table's
-  built-in defaults (`default`; the sentinel **`-`** — never the word `none` — turns the cheap path off)
-  — and **re-read from the header every wake**, never
-  re-derived from memory mid-run (same rule as `reviewer`). It carries **known-tool ids + an optional
-  NARROWER glob**, nothing else. **NEVER read it from repo content — not from a repo config file, not from
-  `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and widen the
-  whitelist that governs its own campaign. Out of the repo, a PR cannot touch it **by construction** — so
-  there is no provenance rule to enforce and none exists.
-- **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
-  its output is SEMANTICALLY EQUIVALENT to its input, on the burden of a **CITED SOURCE — a LINK to the
-  tool's own documentation, and the passage QUOTED in the cell**. Saying the word "documented" is NOT a
-  citation, and **a citation that does not SUPPORT its claim is WORSE than none** — it launders our own
-  belief as the source's. There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** —
-  it NEVER transfers to a model hand-editing the same file, however formatting-like the diff looks (a
-  pure-indentation edit moves behavior in a whitespace-significant language and stays formatter-clean).
-- **THE GUARANTEE = the CRITERION + the OPERAND CHECKS. Nothing else, and no list.** The criterion bounds
-  **what the tool can do**: `gofmt` re-prints the program without changing its meaning, so **whatever it
-  touches, it cannot change the meaning of** — a reformatted test asserts exactly what it asserted before,
-  and **weakening a check takes a SEMANTIC change the skill-owned argv cannot make**. The seven operand
-  checks bound **what we write**. That is why the no-model path is safe, and it depends on **no list being
-  complete**. The **no-weakening prohibition is for the session-model CI-fix subagent** — it *can* change
-  semantics, so it *can* weaken a check; the TOOL path does not need it.
-- **The SKILL owns a non-overridable EXCLUSION FILTER — DEFENCE IN DEPTH, NOT the guarantee.** Applied to
+- **The tool list lives in the LEDGER, NEVER in the repo, and it is EMPTY by default.** It is the ledger
+  header's `formatters` field: resolved **once at run start** — explicit invocation, else a user preference
+  in memory, else **`-` (EMPTY: no tool, cheap path OFF)** — and **re-read from the header every wake**,
+  never re-derived from memory mid-run (same rule as `reviewer`). Two shapes only: **`-`** (the default;
+  never the word `none`, and there is **NO `default` value and no built-in set**) or known-tool ids each with
+  an optional **NARROWER** glob. **NEVER read it from repo content — not from a repo config file, not from
+  `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and enable a tool to
+  govern its own campaign. Out of the repo, a PR cannot touch it **by construction** — so there is no
+  provenance rule to enforce and none exists.
+- **"KNOWN" ≠ "TRUSTED". The skill vouches for NO tool.** A known-tools row means the skill knows how to run
+  that tool **safely** — it owns the argv, the resolution, the operand checks. It does **NOT** mean the tool
+  is safe to enable. **NEVER present a row as blessed, trusted, or recommended.** For each row `stage-2-ci.md`
+  states, separately: **what the skill guarantees** (mechanical, ours) and **what is NOT proven** (about the
+  tool). `gofmt`: the cited doc (https://pkg.go.dev/cmd/gofmt) documents formatting behaviour and the flags
+  `-w`/`-r`/`-s`; it **NEVER states a semantic-equivalence guarantee**. Our reading — a pretty-printer that
+  parses and re-prints cannot change meaning — is an **INFERENCE**. Same for `gci` and `ruff format`: neither
+  doc states the guarantee either. **Enabling a tool means accepting that inference.**
+- **Enabling a tool is an explicit USER act and an explicit RISK ACCEPTANCE.** The skill does not decide a
+  tool is safe — **the user does**. If asked whether a tool is safe, point at its "what is NOT proven" cell;
+  **NEVER answer "the skill guarantees it".**
+- **THE ASYMMETRY: the skill REFUSES what is DOCUMENTED to be unsafe; it does NOT bless what is merely
+  UNDOCUMENTED.** The **non-overridable DENYLIST** (config can NEVER enable one) holds tools whose own docs
+  say they change the program: **`goimports`** (ADDS/REMOVES imports — an added import runs its `init()`),
+  **`prettier`** (rewrites tagged-template contents), **`gofumpt`** (extra rewrite rules), semantic rewriters
+  (`modernize`, codemods), and **every catch-all `--fix`/`--write`**. That is a documented fact, so the skill
+  refuses it. Where no doc states a guarantee either way, the call is the **user's** (`stage-2-ci.md`).
+- **What the no-model path actually rests on:** **OURS** — the mechanism (exact argv, no flag appended,
+  trusted binary outside the repo, the seven operand checks, resolve-then-filter, no shell/glob/empty operand
+  set, gate reset on every commit); **THE USER'S** — the tool's behaviour, which no cited doc proves. NEVER
+  restate the second as a guarantee of the skill's. The **no-weakening prohibition is for the session-model
+  CI-fix subagent** — a model can change anything.
+- **The SKILL owns a non-overridable EXCLUSION FILTER — DEFENCE IN DEPTH, admittedly INCOMPLETE.** Applied to
   every candidate's **RESOLVED** path and its original (**either** matches → REFUSE), every time: tests,
   check definitions, CI/tool config, `.gauntlet/**` (`**/*_test.go`, `.github/**`, `.golangci.yml`,
   `pyproject.toml`, …). It is an **enumerated pattern list: NOT complete and it cannot be** — a
   repo-specific check written as ordinary source (`tools/ci/check.go`) matches `**/*.go`, matches none of
-  the patterns, and **is** formatted. **NEVER call it complete, exhaustive, or the reason the path is safe.**
+  the patterns, and **is** formatted. **NEVER call it complete, exhaustive, or a reason to enable a tool.**
   Its job is **blast radius** — keep the tool's diff off files a reviewer expects untouched. **NOTHING widens
   it** (config may only narrow); NEVER make the user's glob carry the exclusions. So a `gofmt:**/*.go`
   narrowing is correct — the glob selects, the filter trims.
-- **The table holds ONE tool — `gofmt`** (Go formatting), its cell quoting https://pkg.go.dev/cmd/gofmt.
-  **That is not a limitation to work around; it is the rule working**: it is what survived a bar that demands
-  a documented guarantee. **REJECTED**, each for a stated reason (`stage-2-ci.md`): **`ruff format`** (its
-  cited formatter docs state no AST-equivalence guarantee), **`gci`** (its cited docs never say it neither
-  adds nor removes an import), **`goimports`** (ADDS/REMOVES imports), **`gofumpt`** (extra rewrite rules,
-  documented as a rule list). **Every other CI failure — including ALL Python/JS/etc formatting — goes to
-  the SESSION MODEL**, which is the safe default and is what happened before this path existed. Adding a
-  tool is a **SKILL change** and the bar is **a source that STATES the guarantee, quoted**; "it's a
-  formatter", "it's probably fine", "it's widely used" are **NOT admissible**.
-- **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`).
-- **Default deny.** Unknown or unlisted tool, refused id, unresolvable binary, the tool did not fix it, the
-  tool left residue, or the failure needs any judgment → **session model**, set explicitly. NEVER hand it to
-  a cheap model instead.
+- **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`) — so even an enabled
+  tool's output is re-reviewed on the new SHA.
+- **Default deny — and the default IS deny.** `formatters` = `-`, tool not enabled, tool not in the table,
+  denylisted id, refused id, unresolvable binary, the tool did not fix it, the tool left residue, or the
+  failure needs any judgment → **session model**, set explicitly. NEVER hand it to a cheap model instead.
 
-Full known-tools table (the tool's **exact skill-owned argv**, default glob, quoted guarantee), the
-executable-resolution rule, the exclusion filter, the `formatters` resolution and validation, the
-non-overridable denylist, and the honest trust model → **`references/stage-2-ci.md`**.
+Full known-tools table (**exact skill-owned argv**, default glob, what the skill guarantees, what is NOT
+proven), the executable-resolution rule, the exclusion filter, the `formatters` resolution and validation,
+the non-overridable denylist, and the honest trust model → **`references/stage-2-ci.md`**.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's
@@ -213,7 +219,7 @@ Read stage refs only when that stage/action is due:
 - **One active driver:** lease controls ownership; never double-drive one run.
 - **Base branch is data:** read `base_branch` from ledger every wake; never assume `main`.
 - **Reviewer is data:** read `reviewer` from ledger every wake before dispatching any review; set once at run start, never re-derived from memory (else an explicit/preferred reviewer silently reverts to default on a self-wake or adoption).
-- **Formatter whitelist is data:** read `formatters` from the ledger header every wake before running any tool; set once at run start from the **user** (invocation, else memory preference, else built-in defaults). NEVER from a repo file — repo content is PR content.
+- **Tool list is data, and it is EMPTY by default:** read `formatters` from the ledger header every wake before running any tool; set once at run start from the **user** (invocation, else memory preference, else **`-`** — no tool enabled). NEVER from a repo file — repo content is PR content.
 - **Remote branch cleanup isn't campaign's job:** campaign never passes `--delete-branch`; the repo's *Automatically delete head branches* setting governs the remote head branch. Local worktree/branch cleanup follows the per-PR `worktree_owned`/`branch_owned` flags.
 - **Review gate is tier-dependent:** `required(tier)` fresh, context-isolated `SATISFIED` verdicts on
   same live PR content + green CI — **1 if TRIVIAL, else 2** (any code/agent-doc/sensitive change is 2).
@@ -259,6 +265,6 @@ Read stage refs only when that stage/action is due:
 - NEVER commit run/scratch files (the whole `.gauntlet/**` tree) — they are
   driver bookkeeping, not repo content. Stage only the specific source files a fix touches, by explicit
   path; never `git add -A`/`git add .`. Ensure `.gauntlet/` is git-ignored (add it if missing). Campaign has
-  **no committed file of its own** — no repo-root config, and the formatter whitelist is a ledger header
+  **no committed file of its own** — no repo-root config, and the tool list is a ledger header
   field, never a repo file (`files-and-ledger.md`, `stage-2-ci.md`).
 - NEVER `rm -rf .gauntlet/`; only `.gauntlet/tmp/**` is disposable — the rest is carryover history.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -69,45 +69,63 @@ justify a downgrade by claiming something downstream will catch it.
 
 ### The only cheap path — run the formatter TOOL, no model at all
 
-Some CI failures need **no subagent**. A whitelisted check has a fixer that is semantics-preserving **BY
-CONSTRUCTION** — it rewrites LAYOUT and cannot change program meaning. Run **the tool**; commit its
-output. Zero model tokens, zero model risk. The safety comes from the **tool's construction** — and from
-**nothing else**. It does **not** transfer to a model that hand-edits the same file: only the tool's own
-output is semantics-preserving. A hand-written diff that merely LOOKS like formatting is not. In a
-whitespace-significant language it can move behavior while staying formatter-clean — indenting
-`result.append("always")` under an `if` is a pure-indentation edit that turns `["always"]` into `[]`, and
-`ruff format` is perfectly happy with it.
+Some CI failures need **no subagent**: run the fixer **tool** and commit its output. Zero model tokens,
+zero model risk.
 
-**The whitelist (exhaustive in kind):**
+**THE CRITERION — a tool is whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to
+its input**: an AST-preserving pretty-printer, not a text munger. Whitelisting is **per-TOOL**, and the
+burden is the **tool's documented behaviour**. **If you cannot point to that guarantee, the tool is NOT
+whitelisted — use the session model.** There is NO blanket "formatters are safe" rule: a tool that looks
+like a formatter can still rewrite meaning (see `prettier`, below).
 
-- **IN** — pure formatting / import ordering: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
-  `whitespace`, `prettier`, `ruff format`.
+The guarantee belongs to the whitelisted **tool's output** and to **nothing else**. It does **not**
+transfer to a model that hand-edits the same file: a diff that merely LOOKS like formatting is not
+semantics-preserving. In a whitespace-significant language it can move behavior while staying
+formatter-clean — indenting `result.append("always")` under an `if` is a pure-indentation edit that turns
+`["always"]` into `[]`, and `ruff format` is perfectly happy with it.
+
+**The whitelist (exhaustive — a tool not listed IN is OUT):**
+
+- **IN** — `gofmt`, `gofumpt`: AST-preserving Go pretty-printers; they re-print layout and never touch
+  string-literal contents.
+- **IN** — `goimports`: import block only. `gci`: import grouping/ordering only — Go package init order
+  is by **dependency**, not by import order in a file.
+- **IN** — golangci-lint `whitespace`: Go-only, leading/trailing newlines **inside function bodies**.
+- **IN** — `ruff format`: verifies its output is AST-equivalent to the input.
+- **OUT** — `prettier`: it reformats the **contents** of tagged template literals (`` gql`…` ``,
+  `` css`…` ``), changing the runtime string the tag function receives. That is a semantic change made by
+  the tool itself.
+- **OUT** — any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer, which can rewrite
+  content inside string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks). A tool
+  that cannot promise it leaves literal content alone is NOT whitelisted.
 - **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
   with a reversed or non-equivalent comparator): lint-clean, semantics changed.
 - **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes too.
-  A whitelisted run MUST invoke **only the formatter**, NEVER a catch-all `--fix`.
+  A whitelisted run MUST invoke **only the whitelisted formatter**, NEVER a catch-all `--fix`.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
-Eligibility is keyed on **check / fixer IDENTITY** — NEVER on an impression that a failure "looks
-mechanical". A vibes-based whitelist is the same unsound reasoning in a new hat. **Default is NOT
-whitelisted; unknown check → session model.**
+Eligibility is keyed on the **tool's IDENTITY and its documented guarantee** — NEVER on an impression that
+a failure "looks mechanical", and NEVER on the *category* "formatter". A vibes-based whitelist is the same
+unsound reasoning in a new hat. **Default is NOT whitelisted; unknown check or unlisted tool → session
+model.**
 
 | When | Action |
 |---|---|
-| **Whitelisted formatter** (prefer always) | Run the **tool** in `<worktree>` — `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `prettier --write`, `ruff format`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit. **No model at all.** |
-| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the check is not whitelisted, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
+| **Whitelisted tool** (prefer always) | Run the **tool** in `<worktree>` — `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit + push — and **reset the gate exactly as any other PR-content change does** (`stage-2-ci.md`). **No model at all.** |
+| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the tool/check is not whitelisted, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
 
 If the tool's output does not clear the failing check, or it touched a check definition, config, or test
 → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on the
 session model**. NEVER commit an unverified formatter run. NEVER hand a "formatting" failure to a cheap
 model instead.
 
-**Residual risk, stated honestly:** it is small and specific — reordering imports could in principle
-change init side-effect order (blank/`_` imports). That is the whole of it. Do NOT widen the whitelist
-past it, and NEVER re-derive its safety from the review gate: the whitelist stands on the fixer being
-incapable of changing semantics, or it does not stand at all.
+**Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
+a tool bug, or a config/plugin that switches on non-formatting rules, is the whole of the exposure. Run
+whitelisted tools with the project's own config and no extra rule sets. Do NOT widen the whitelist past a
+guarantee you can point to, and NEVER re-derive its safety from the review gate: the whitelist stands on
+the TOOL being incapable of changing semantics, or it does not stand at all.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -53,16 +53,19 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 
 | Subagent | Model | Why |
 |---|---|---|
-| Review pass (default reviewer) | **session model** (do not downgrade) | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
+| Review pass (default reviewer) | **session model** | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
-| Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that a full review pass must then judge. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
+| Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that gets merged, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
+| **CI-fix** | **session model** | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
-| **CI-fix** | **`sonnet`** | The one safe downgrade — because **both** its failure modes are caught, by two different nets. *Fix didn't work* → CI stays red → re-dispatch. *Fix weakened the check* (gutted assertion, `skip`/`xfail`, disabled lint rule, raised timeout) → CI turns **green**, so CI does **not** catch it — the **review gate** does, reading the whole diff. Hence it is dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`). |
 
-**The rule behind the table: downgrade only where a bad result is caught by something else.** CI-fix is
-caught by CI *and* the review gate — CI alone is not enough, and never claim it is. Every other class
-either *is* the check (review passes) or feeds work into an expensive check (fixes, mapping), where a
-cheap wrong answer is paid for twice.
+**No class is downgraded, and the reason is uniform.** Every subagent here either *is* the gate (review
+passes), writes **code that gets merged** (CI-fix, review-fix), or produces the enumeration an expensive
+fix depends on (mapper). Nothing downstream *guarantees* a bad result is caught: CI misses a
+wrong-but-green fix, and the review gate is a miss-catcher, not a proof of correctness
+(`stage-2-review-gate.md`). So there is no class whose mistakes are reliably absorbed, and therefore no
+class where a cheaper model is free. NEVER justify a downgrade by claiming something downstream will
+catch it.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -77,9 +77,19 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   the semantics: `gofmt -w -r 'true -> false'` rewrites `return true` into `return false` — same known
   binary, no shell metacharacters, a pure rewrite engine. Letting config choose flags hands back exactly
   the freedom the criterion exists to remove. An entry carrying `command`/`args`/`argv`/flags is **REFUSED**.
-- **Config picks only WHICH tool and over WHICH files.** A `.gauntlet.yml` entry carries **only `id` +
-  `files`**, and `files` MUST NOT be able to reach a **check definition, config, or test** path. A glob
-  that can → **REFUSED**.
+- **The SKILL resolves the binary — OUTSIDE the repo.** The tool runs in the PR's worktree, and the PR is
+  **untrusted content**. Resolve `argv[0]` to an **absolute** path via a `PATH` stripped of `.`, empty
+  entries, relative entries, the worktree and the repo root; the resolved executable **MUST live outside
+  the repo tree**. Resolves inside, or not at all → **REFUSE → session model**. A bare name resolved from a
+  `PATH` the PR can influence is arbitrary code execution on the no-model path.
+- **Config picks only WHICH tool and (optionally) a NARROWER file glob.** A `.gauntlet.yml` entry carries
+  **only `id` + optional `files`**; `files` may only narrow the tool's **default glob** in the table, never
+  widen it. Missing config → the table's defaults.
+- **The SKILL owns a non-overridable EXCLUSION FILTER**, applied to the file set **after** the glob, every
+  time: no tests, no check definitions, no CI or tool config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
+  `pyproject.toml`, `.gauntlet.yml`, …). **Config CANNOT widen it.** So `files: "**/*.go"` is correct — the
+  glob selects, the filter protects. NEVER make the user's glob carry the exclusions: a user-written
+  exclusion list **will** omit something.
 - **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
   its output is SEMANTICALLY EQUIVALENT to its input, on the burden of the tool's **documented behaviour**.
   There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to
@@ -88,13 +98,13 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
 - **Base branch only.** Read `.gauntlet.yml` from the base branch (`git show origin/<base>:.gauntlet.yml`),
   NEVER from the PR's worktree or head — a PR must NEVER widen the whitelist that governs its own campaign.
 - **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`).
-- **Default deny.** Unknown or unlisted tool, refused entry, missing/unparseable config, the tool did not
-  fix it, the tool left residue, or the failure needs any judgment → **session model**, set explicitly.
-  NEVER hand it to a cheap model instead.
+- **Default deny.** Unknown or unlisted tool, refused entry, unparseable config, unresolvable binary, the
+  tool did not fix it, the tool left residue, or the failure needs any judgment → **session model**, set
+  explicitly. NEVER hand it to a cheap model instead.
 
-Full known-tools table (each tool's **exact skill-owned argv**, guarantee, precondition), the
-`.gauntlet.yml` schema and validation, the non-overridable denylist, and the honest trust model →
-**`references/stage-2-ci.md`**.
+Full known-tools table (each tool's **exact skill-owned argv**, default glob, guarantee, precondition), the
+executable-resolution rule, the exclusion filter, the `.gauntlet.yml` schema and validation, the
+non-overridable denylist, and the honest trust model → **`references/stage-2-ci.md`**.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -86,8 +86,9 @@ Its prompt carries these **verbatim** (full text in `references/stage-2-ci.md`):
 - **NEVER execute a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**,
   and a repo-supplied `gofmt` is arbitrary code execution. Run tools from the environment, not from the tree.
 - **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — **name the files** you are fixing.
-- **PREFLIGHT every file: REFUSE to format it if it is a symlink, sits under a symlinked directory, or has
-  `nlink > 1`** — diff review sees every write INSIDE the repo, but **never one that ESCAPES it**.
+- **PREFLIGHT every file: REFUSE to format it if it is a symlink or sits under a symlinked directory** —
+  diff review sees every write INSIDE the repo, but **never one that ESCAPES it**. A **footgun guard, NOT a
+  security boundary** (like the denylist): it prevents a stray reformat elsewhere on the machine.
 
 **State the risk, never overclaim:** a cheap model verifying a tool's diff is a **MISS-CATCHER, NOT A
 PROOF** — it can miss a semantic change. What backs it: the exact failing check must pass, it must escalate

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -89,9 +89,16 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   the file list (end of options); pass each file as an **ABSOLUTE** (or `./`-prefixed) path, **NEVER a bare
   relative name**; and **REFUSE any candidate name starting with `-`** after the filter — drop that file,
   log it, do **NOT** abort the run. NEVER hand the glob itself to the tool.
+- **A PATH RESOLVES — normalizing its SPELLING is not enough.** A PR can add `link.go` → a symlink out of the
+  tree; the name is clean, and `gofmt -w -- link.go` **follows it and rewrites the target OUTSIDE the
+  worktree**. So, after the exclusion filter and before the argv is built: **REFUSE any candidate that is a
+  SYMLINK** (`lstat`, never `stat`), **REFUSE any whose fully-resolved real path (`realpath`) is not
+  CONTAINED under the resolved worktree root**, and **REFUSE any that is not a REGULAR FILE**. Drop and log
+  each; do NOT abort. Empty set after refusals → session model.
 - **The whitelist lives in the LEDGER, NEVER in the repo.** It is the ledger header's `formatters` field:
   resolved **once at run start** — explicit invocation, else a user preference in memory, else the table's
-  built-in defaults (`none` turns the cheap path off) — and **re-read from the header every wake**, never
+  built-in defaults (`default`; the sentinel **`-`** — never the word `none` — turns the cheap path off)
+  — and **re-read from the header every wake**, never
   re-derived from memory mid-run (same rule as `reviewer`). It carries **known-tool ids + an optional
   NARROWER glob**, nothing else. **NEVER read it from repo content — not from a repo config file, not from
   `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and widen the
@@ -103,12 +110,14 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   the filter protects. NEVER make the user's glob carry the exclusions: a user-written exclusion list
   **will** omit something.
 - **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
-  its output is SEMANTICALLY EQUIVALENT to its input, on the burden of the tool's **documented behaviour**.
-  There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to
-  a model hand-editing the same file, however formatting-like the diff looks (a pure-indentation edit moves
-  behavior in a whitespace-significant language and stays formatter-clean).
-- **The table is SMALL on purpose — `gofmt`, `gci`, `ruff format`.** Fewer tools that provably hold beats
-  more that mostly do. `goimports` is **REJECTED** (it ADDS/REMOVES imports; an added import runs that
+  its output is SEMANTICALLY EQUIVALENT to its input, on the burden of a **CITED SOURCE — a LINK to the
+  tool's own documentation**. Saying the word "documented" is NOT a citation. There is NO blanket
+  "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to a model hand-editing
+  the same file, however formatting-like the diff looks (a pure-indentation edit moves behavior in a
+  whitespace-significant language and stays formatter-clean).
+- **The table is SMALL on purpose — `gofmt`, `gci`, `ruff format`**, each cell carrying the doc LINK its
+  guarantee rests on (a claim with no source → the tool leaves the table). Fewer tools that provably hold
+  beats more that mostly do. `goimports` is **REJECTED** (it ADDS/REMOVES imports; an added import runs that
   package's `init()`, and a guessed one can be the wrong package) and `gofumpt` is **REJECTED** (extra
   rewrite rules beyond layout, documented as a rule list, never as semantics-preserving). NEVER re-add a
   tool because it "is basically a formatter" — that reasoning is what put both of them here.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -56,23 +56,27 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 | Review pass (default reviewer) | **session model** | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
 | Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that gets merged, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
-| **CI-fix** | **session model** — except the formatter whitelist below | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
+| **CI-fix** | **session model** | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
 
-**No class is downgraded BY DEFAULT, and the reason is uniform.** Every subagent here either *is* the
-gate (review passes), writes **code that gets merged** (CI-fix, review-fix), or produces the enumeration
-an expensive fix depends on (mapper). Nothing downstream *guarantees* a bad result is caught: CI misses a
-wrong-but-green fix, and the review gate is a miss-catcher, not a proof of correctness
-(`stage-2-review-gate.md`). So no class's mistakes are reliably absorbed. NEVER justify a downgrade by
-claiming something downstream will catch it.
+**NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL**, and the reason is uniform. Every subagent here either
+*is* the gate (review passes), writes **code that gets merged** (CI-fix, review-fix), or produces the
+enumeration an expensive fix depends on (mapper). Nothing downstream *guarantees* a bad result is caught:
+CI misses a wrong-but-green fix, and the review gate is a miss-catcher, not a proof of correctness
+(`stage-2-review-gate.md`). And there is **no mechanical guard** that makes a weak model's edits safe to
+accept: a diff that *looks* like formatting is **not** a proof of semantic equivalence (see below). NEVER
+justify a downgrade by claiming something downstream will catch it.
 
-### The one exception — semantics-preserving formatters
+### The only cheap path — run the formatter TOOL, no model at all
 
-A cheaper path is allowed **only** when the failing check is a **total oracle** for the fix: re-running
-that same check *fully decides* whether the fix is correct, leaving no judgment over. A check is a total
-oracle **only because its fixer is semantics-preserving BY CONSTRUCTION** — it rewrites LAYOUT and cannot
-change program meaning at all. The guarantee comes from the **tool's construction**, never from a hope
-that a reviewer will notice. "A lint rule passed" is a strictly weaker claim and is NOT sufficient.
+Some CI failures need **no subagent**. A whitelisted check has a fixer that is semantics-preserving **BY
+CONSTRUCTION** — it rewrites LAYOUT and cannot change program meaning. Run **the tool**; commit its
+output. Zero model tokens, zero model risk. The safety comes from the **tool's construction** — and from
+**nothing else**. It does **not** transfer to a model that hand-edits the same file: only the tool's own
+output is semantics-preserving. A hand-written diff that merely LOOKS like formatting is not. In a
+whitespace-significant language it can move behavior while staying formatter-clean — indenting
+`result.append("always")` under an `if` is a pure-indentation edit that turns `["always"]` into `[]`, and
+`ruff format` is perfectly happy with it.
 
 **The whitelist (exhaustive in kind):**
 
@@ -80,40 +84,25 @@ that a reviewer will notice. "A lint rule passed" is a strictly weaker claim and
   `whitespace`, `prettier`, `ruff format`.
 - **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
-  with a reversed or non-equivalent comparator): lint-clean, semantics changed. So the check does **not**
-  fully verify its own fix, and it is NOT a total oracle.
+  with a reversed or non-equivalent comparator): lint-clean, semantics changed.
 - **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes too.
   A whitelisted run MUST invoke **only the formatter**, NEVER a catch-all `--fix`.
-- **NEVER whitelisted**, under any tier: a failing product test (making a test pass is not the same as
-  fixing the bug), a compile error, and any rule that rewrites logic.
+- **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
+  compile error, and any rule that rewrites logic.
 
 Eligibility is keyed on **check / fixer IDENTITY** — NEVER on an impression that a failure "looks
 mechanical". A vibes-based whitelist is the same unsound reasoning in a new hat. **Default is NOT
 whitelisted; unknown check → session model.**
 
-| Tier | When | Action |
-|---|---|---|
-| **0 — no subagent** (prefer always) | Whitelisted formatter has a deterministic fixer | Run the **tool**, not a model: `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `prettier --write`, `ruff format`. NEVER a catch-all `--fix`. Re-run the failing check, apply the acceptance criteria, commit. Zero tokens, zero model risk. |
-| **1 — cheap model, verified** | Whitelisted formatter, no usable fixer (or the fixer leaves residue) | Dispatch on `haiku` (pure mechanical rewrite) or `sonnet` (needs any reasoning). Apply the acceptance criteria below. |
-| **session model** | Everything else | Any failure whose oracle is judgment: failing product tests, compile errors, semantic lint rules, review-fixes, mapper, review passes. |
+| When | Action |
+|---|---|
+| **Whitelisted formatter** (prefer always) | Run the **tool** in `<worktree>` — `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `prettier --write`, `ruff format`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit. **No model at all.** |
+| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the check is not whitelisted, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
 
-Sending a model to hand-edit a formatting violation is both the most expensive and the least reliable
-way to do it — Tier 0 first, always.
-
-**Acceptance criteria (Tier 0 and Tier 1 alike).** ACCEPT the fix **only if all three hold**:
-
-- (a) re-running the **exact** failing check now **passes**; AND
-- (b) the diff touches **no check definition, config, or test**; AND
-- (c) the diff is **formatting-only** — whitespace, indentation, line breaks, and import-block
-  ordering/insertion/removal — and touches **NOTHING else**: no expression, call, argument, control flow,
-  or literal.
-
-Any point fails → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same
-failure on the session model**. NEVER patch a whitelisted fix in place; NEVER commit an unverified one;
-NEVER accept a "formatting" fix whose diff edits code.
-
-(c) is the mechanical guard that makes "changes no product behavior" **checkable rather than promised**:
-with the whitelist narrowed to formatters, a formatting-only diff cannot move behavior.
+If the tool's output does not clear the failing check, or it touched a check definition, config, or test
+→ **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on the
+session model**. NEVER commit an unverified formatter run. NEVER hand a "formatting" failure to a cheap
+model instead.
 
 **Residual risk, stated honestly:** it is small and specific — reordering imports could in principle
 change init side-effect order (blank/`_` imports). That is the whole of it. Do NOT widen the whitelist

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -108,8 +108,8 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   every check above — while the **exclusion filter, matched on the SPELLED path, never sees `.github/**`**, so
   a **check definition** reaches the tool. So: **apply the exclusion filter to the RESOLVED path as well as
   the original — EITHER matches → REFUSE**; **AND REFUSE any candidate with a SYMLINK in ANY DIRECTORY
-  COMPONENT** (`lstat` each component from the worktree root down). The resolved-path filter is the
-  **guarantee**; the component check is the cheap **tripwire**. Both, every run.
+  COMPONENT** (`lstat` each component from the worktree root down). The component check bounds **what we
+  write**; matching the filter on the resolved path keeps the filter honest. Both, every run.
 - **THE PIPELINE** (`stage-2-ci.md`): glob → **RESOLVE** → **FILTER on both the original and the resolved
   path** → the **SEVEN** operand checks → argv. The seven: `--`; absolute/`./` paths; no `-`-leading names;
   no symlinks; nothing resolving outside the worktree or non-regular; no `nlink > 1`; no symlinked directory
@@ -123,12 +123,6 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   `CLAUDE.md`, not from ANY repo file.** Repo content is PR content: a PR could edit it and widen the
   whitelist that governs its own campaign. Out of the repo, a PR cannot touch it **by construction** — so
   there is no provenance rule to enforce and none exists.
-- **The SKILL owns a non-overridable EXCLUSION FILTER**, applied to every candidate's **RESOLVED** path (and
-  its original — **either** matches → REFUSE), every time: no tests, no check definitions, no CI or tool
-  config (`**/*_test.go`, `.github/**`, `.golangci.yml`,
-  `pyproject.toml`, …). **NOTHING widens it.** So a `gofmt:**/*.go` narrowing is correct — the glob selects,
-  the filter protects. NEVER make the user's glob carry the exclusions: a user-written exclusion list
-  **will** omit something.
 - **The CRITERION is the skill's and is NEVER configurable**: a tool is whitelisted ONLY IF it guarantees
   its output is SEMANTICALLY EQUIVALENT to its input, on the burden of a **CITED SOURCE — a LINK to the
   tool's own documentation, and the passage QUOTED in the cell**. Saying the word "documented" is NOT a
@@ -136,6 +130,22 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   belief as the source's. There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** —
   it NEVER transfers to a model hand-editing the same file, however formatting-like the diff looks (a
   pure-indentation edit moves behavior in a whitespace-significant language and stays formatter-clean).
+- **THE GUARANTEE = the CRITERION + the OPERAND CHECKS. Nothing else, and no list.** The criterion bounds
+  **what the tool can do**: `gofmt` re-prints the program without changing its meaning, so **whatever it
+  touches, it cannot change the meaning of** — a reformatted test asserts exactly what it asserted before,
+  and **weakening a check takes a SEMANTIC change the skill-owned argv cannot make**. The seven operand
+  checks bound **what we write**. That is why the no-model path is safe, and it depends on **no list being
+  complete**. The **no-weakening prohibition is for the session-model CI-fix subagent** — it *can* change
+  semantics, so it *can* weaken a check; the TOOL path does not need it.
+- **The SKILL owns a non-overridable EXCLUSION FILTER — DEFENCE IN DEPTH, NOT the guarantee.** Applied to
+  every candidate's **RESOLVED** path and its original (**either** matches → REFUSE), every time: tests,
+  check definitions, CI/tool config, `.gauntlet/**` (`**/*_test.go`, `.github/**`, `.golangci.yml`,
+  `pyproject.toml`, …). It is an **enumerated pattern list: NOT complete and it cannot be** — a
+  repo-specific check written as ordinary source (`tools/ci/check.go`) matches `**/*.go`, matches none of
+  the patterns, and **is** formatted. **NEVER call it complete, exhaustive, or the reason the path is safe.**
+  Its job is **blast radius** — keep the tool's diff off files a reviewer expects untouched. **NOTHING widens
+  it** (config may only narrow); NEVER make the user's glob carry the exclusions. So a `gofmt:**/*.go`
+  narrowing is correct — the glob selects, the filter trims.
 - **The table holds ONE tool — `gofmt`** (Go formatting), its cell quoting https://pkg.go.dev/cmd/gofmt.
   **That is not a limitation to work around; it is the rule working**: it is what survived a bar that demands
   a documented guarantee. **REJECTED**, each for a stated reason (`stage-2-ci.md`): **`ruff format`** (its

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -45,6 +45,34 @@ events (see `references/stage-2-review-gate.md`). `scripts/ledger.py` is the sch
 `state.jsonl` — read/write the ledger header and per-PR rows **by field name** through it, never by column
 position (see `references/files-and-ledger.md`); pass its absolute path to subtasks the same way.
 
+## Subagent Dispatch — model per class
+
+Campaign spawns subagents for several jobs. **Set the model explicitly on every dispatch.** With no
+model set, a subagent inherits the session model (often the most expensive one) — so an unset model is
+a silent cost decision, taken by default, on every subagent this skill launches.
+
+| Subagent | Model | Why |
+|---|---|---|
+| Review pass (default reviewer) | **session model** (do not downgrade) | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
+| Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
+| Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that a full review pass must then judge. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
+| Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
+| **CI-fix** | **`sonnet`** | The one safe downgrade. Failure is **self-detecting**: a bad CI fix leaves CI red, which campaign re-dispatches, and a red check blocks the review pass anyway — so it cannot silently corrupt the gate. |
+
+**The rule behind the table: downgrade only where a bad result is caught by something else.** CI-fix is
+caught by CI. Every other class either *is* the check (review passes) or feeds work into an expensive
+check (fixes, mapping), where a cheap wrong answer is paid for twice.
+
+**The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
+`required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's
+subagent spend. Running an **external reviewer** (e.g. `codex exec`, see `references/reviewer.md`) moves
+that cost off the subagent pool entirely — the quality argument (reviewer diversity) and the cost
+argument point the same way.
+
+**Scope every fix subagent.** Give it the worktree path and the specific issue list, and tell it **not**
+to re-derive the whole diff or re-read the repo beyond the named files. An unscoped fixer re-reads
+everything it was already told.
+
 ## Load Discipline
 
 Read references on demand. Do NOT load every reference up front.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -88,13 +88,22 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   a.go` **parses it as a FLAG** — exit 0, CPU profile written. So, every tool, every run: pass **`--`** before
   the file list (end of options); pass each file as an **ABSOLUTE** (or `./`-prefixed) path, **NEVER a bare
   relative name**; and **REFUSE any candidate name starting with `-`** after the filter — drop that file,
-  log it, do **NOT** abort the run. NEVER hand the glob itself to the tool.
+  log it, do **NOT** abort the run. NEVER hand the glob itself to the tool. **NEVER invoke the tool with an
+  EMPTY operand set — `gofmt` with no operands READS STDIN**; empty → run nothing for that id → session model.
 - **A PATH RESOLVES — normalizing its SPELLING is not enough.** A PR can add `link.go` → a symlink out of the
   tree; the name is clean, and `gofmt -w -- link.go` **follows it and rewrites the target OUTSIDE the
   worktree**. So, after the exclusion filter and before the argv is built: **REFUSE any candidate that is a
   SYMLINK** (`lstat`, never `stat`), **REFUSE any whose fully-resolved real path (`realpath`) is not
   CONTAINED under the resolved worktree root**, and **REFUSE any that is not a REGULAR FILE**. Drop and log
   each; do NOT abort. Empty set after refusals → session model.
+- **A PATH CHECK BOUNDS WHERE WE LOOK, NOT WHAT WE WRITE — the INODE can be aliased outside the tree.** A PR
+  can add `alias.go`, a **HARDLINK** sharing an inode with a file outside the worktree: a regular file, not a
+  symlink, `realpath` inside the tree — it passes every check above, and `gofmt -w` rewrites the **existing
+  inode**, mutating the outside alias. So also **REFUSE any candidate with a LINK COUNT > 1** (`stat` →
+  `st_nlink > 1`); a source file in a normal checkout has exactly one link. Drop and log it (reason:
+  `hardlink — nlink>1`); NEVER abort the run. **Six checks in all** (`stage-2-ci.md`): `--`; absolute/`./`
+  paths; no `-`-leading names; no symlinks; nothing resolving outside the worktree or non-regular; no
+  `nlink > 1`.
 - **The whitelist lives in the LEDGER, NEVER in the repo.** It is the ledger header's `formatters` field:
   resolved **once at run start** — explicit invocation, else a user preference in memory, else the table's
   built-in defaults (`default`; the sentinel **`-`** — never the word `none` — turns the cheap path off)

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -81,6 +81,14 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   entries, relative entries, the worktree and the repo root; the resolved executable **MUST live outside
   the repo tree**. Resolves inside, or not at all → **REFUSE → session model**. A bare name resolved from a
   `PATH` the PR can influence is arbitrary code execution on the no-model path.
+- **NORMALIZE THE FILE ARGV — filenames are PR-CONTROLLED DATA.** The skill owns the argv **SHAPE**; the
+  file operands are globbed from the **PR's worktree**, so they are **attacker-controlled data spliced into
+  argv** and MUST be normalized like any injection boundary. A PR that adds a file named
+  `-cpuprofile=prof.go` matches `**/*.go`, survives the exclusion filter, and `gofmt -w '-cpuprofile=prof.go'
+  a.go` **parses it as a FLAG** — exit 0, CPU profile written. So, every tool, every run: pass **`--`** before
+  the file list (end of options); pass each file as an **ABSOLUTE** (or `./`-prefixed) path, **NEVER a bare
+  relative name**; and **REFUSE any candidate name starting with `-`** after the filter — drop that file,
+  log it, do **NOT** abort the run. NEVER hand the glob itself to the tool.
 - **The whitelist lives in the LEDGER, NEVER in the repo.** It is the ledger header's `formatters` field:
   resolved **once at run start** — explicit invocation, else a user preference in memory, else the table's
   built-in defaults (`none` turns the cheap path off) — and **re-read from the header every wake**, never
@@ -99,6 +107,11 @@ The ONE exception to a model dispatch: a whitelisted **formatting** failure is f
   There is NO blanket "formatters are safe" rule. The guarantee is the **TOOL's** — it NEVER transfers to
   a model hand-editing the same file, however formatting-like the diff looks (a pure-indentation edit moves
   behavior in a whitespace-significant language and stays formatter-clean).
+- **The table is SMALL on purpose — `gofmt`, `gci`, `ruff format`.** Fewer tools that provably hold beats
+  more that mostly do. `goimports` is **REJECTED** (it ADDS/REMOVES imports; an added import runs that
+  package's `init()`, and a guessed one can be the wrong package) and `gofumpt` is **REJECTED** (extra
+  rewrite rules beyond layout, documented as a rule list, never as semantics-preserving). NEVER re-add a
+  tool because it "is basically a formatter" — that reasoning is what put both of them here.
 - **A tool commit resets the gate** exactly like a subagent commit (`stage-2-ci.md`).
 - **Default deny.** Unknown or unlisted tool, refused id, unresolvable binary, the tool did not fix it, the
   tool left residue, or the failure needs any judgment → **session model**, set explicitly. NEVER hand it to

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -56,7 +56,7 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 | Review pass (default reviewer) | **session model** | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
 | Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that gets merged, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
-| **CI-fix** | **session model** — except the total-oracle whitelist below | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
+| **CI-fix** | **session model** — except the formatter whitelist below | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
 
 **No class is downgraded BY DEFAULT, and the reason is uniform.** Every subagent here either *is* the
@@ -66,37 +66,59 @@ wrong-but-green fix, and the review gate is a miss-catcher, not a proof of corre
 (`stage-2-review-gate.md`). So no class's mistakes are reliably absorbed. NEVER justify a downgrade by
 claiming something downstream will catch it.
 
-### The one exception — total-oracle checks
+### The one exception — semantics-preserving formatters
 
 A cheaper path is allowed **only** when the failing check is a **total oracle** for the fix: re-running
-that same check *fully decides* whether the fix is correct, leaving no judgment over. `gofmt` fully
-verifies a formatting fix; `golangci-lint` fully verifies a lint fix. A failing product test is **not** a
-total oracle — making the test pass is not the same as fixing the bug.
+that same check *fully decides* whether the fix is correct, leaving no judgment over. A check is a total
+oracle **only because its fixer is semantics-preserving BY CONSTRUCTION** — it rewrites LAYOUT and cannot
+change program meaning at all. The guarantee comes from the **tool's construction**, never from a hope
+that a reviewer will notice. "A lint rule passed" is a strictly weaker claim and is NOT sufficient.
 
-All three conditions MUST hold:
+**The whitelist (exhaustive in kind):**
 
-- (a) the failing check is a total oracle — re-running it fully verifies the fix; AND
-- (b) the fix is confined to what the check itself defines, changing **no product behavior**; AND
-- (c) the diff touches **no check definition, config, or test** (the no-weakening prohibition,
-  `stage-2-ci.md` — buying green by loosening the rule stays forbidden).
+- **IN** — pure formatting / import ordering: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
+  `whitespace`, `prettier`, `ruff format`.
+- **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
+  `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
+  with a reversed or non-equivalent comparator): lint-clean, semantics changed. So the check does **not**
+  fully verify its own fix, and it is NOT a total oracle.
+- **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes too.
+  A whitelisted run MUST invoke **only the formatter**, NEVER a catch-all `--fix`.
+- **NEVER whitelisted**, under any tier: a failing product test (making a test pass is not the same as
+  fixing the bug), a compile error, and any rule that rewrites logic.
 
-Eligibility is keyed on **check / linter rule IDENTITY** (`gofmt`, `goimports`, `golangci-lint` rules
-such as `modernize`, `gci`, `whitespace`) — NEVER on an impression that a failure "looks mechanical". A
-vibes-based whitelist is the same unsound reasoning in a new hat. **Default is NOT whitelisted; unknown
-check → session model.**
+Eligibility is keyed on **check / fixer IDENTITY** — NEVER on an impression that a failure "looks
+mechanical". A vibes-based whitelist is the same unsound reasoning in a new hat. **Default is NOT
+whitelisted; unknown check → session model.**
 
 | Tier | When | Action |
 |---|---|---|
-| **0 — no subagent** (prefer always) | Whitelisted check has a deterministic autofixer | Run the **tool**, not a model: `golangci-lint run --fix`, `gofmt -w`, `goimports -w`, `ruff --fix`, `prettier --write`. Re-run the failing check, commit. Zero tokens, zero model risk. |
-| **1 — cheap model, verified** | Whitelisted check, no autofixer (or autofixer leaves residue) | Dispatch on `haiku` (pure mechanical rewrite) or `sonnet` (needs any reasoning). ACCEPT **only if** re-running the exact failing check now passes AND the diff touches no check definition/config/test. Otherwise **discard** and re-dispatch on the session model. |
-| **session model** | Everything else | Any failure whose oracle is judgment: failing product tests, compile errors in real logic, review-fixes, mapper, review passes. |
+| **0 — no subagent** (prefer always) | Whitelisted formatter has a deterministic fixer | Run the **tool**, not a model: `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `prettier --write`, `ruff format`. NEVER a catch-all `--fix`. Re-run the failing check, apply the acceptance criteria, commit. Zero tokens, zero model risk. |
+| **1 — cheap model, verified** | Whitelisted formatter, no usable fixer (or the fixer leaves residue) | Dispatch on `haiku` (pure mechanical rewrite) or `sonnet` (needs any reasoning). Apply the acceptance criteria below. |
+| **session model** | Everything else | Any failure whose oracle is judgment: failing product tests, compile errors, semantic lint rules, review-fixes, mapper, review passes. |
 
 Sending a model to hand-edit a formatting violation is both the most expensive and the least reliable
 way to do it — Tier 0 first, always.
 
-**Residual risk, stated honestly:** an autofixer or a `modernize`-class rewrite CAN in rare cases change
-behavior. The review gate still reads the whole diff and is what catches that. The whitelist lowers
-**cost**; it does not remove the gate, and it is not a guarantee of correctness.
+**Acceptance criteria (Tier 0 and Tier 1 alike).** ACCEPT the fix **only if all three hold**:
+
+- (a) re-running the **exact** failing check now **passes**; AND
+- (b) the diff touches **no check definition, config, or test**; AND
+- (c) the diff is **formatting-only** — whitespace, indentation, line breaks, and import-block
+  ordering/insertion/removal — and touches **NOTHING else**: no expression, call, argument, control flow,
+  or literal.
+
+Any point fails → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same
+failure on the session model**. NEVER patch a whitelisted fix in place; NEVER commit an unverified one;
+NEVER accept a "formatting" fix whose diff edits code.
+
+(c) is the mechanical guard that makes "changes no product behavior" **checkable rather than promised**:
+with the whitelist narrowed to formatters, a formatting-only diff cannot move behavior.
+
+**Residual risk, stated honestly:** it is small and specific — reordering imports could in principle
+change init side-effect order (blank/`_` imports). That is the whole of it. Do NOT widen the whitelist
+past it, and NEVER re-derive its safety from the review gate: the whitelist stands on the fixer being
+incapable of changing semantics, or it does not stand at all.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -56,16 +56,47 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 | Review pass (default reviewer) | **session model** | It *is* the gate. A weaker verdict is a worse gate — the one thing never worth cheapening. |
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
 | Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that gets merged, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
-| **CI-fix** | **session model** | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
+| **CI-fix** | **session model** — except the total-oracle whitelist below | Also authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. Dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`), which constrains the fixer but proves nothing about the fix. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
 
-**No class is downgraded, and the reason is uniform.** Every subagent here either *is* the gate (review
-passes), writes **code that gets merged** (CI-fix, review-fix), or produces the enumeration an expensive
-fix depends on (mapper). Nothing downstream *guarantees* a bad result is caught: CI misses a
+**No class is downgraded BY DEFAULT, and the reason is uniform.** Every subagent here either *is* the
+gate (review passes), writes **code that gets merged** (CI-fix, review-fix), or produces the enumeration
+an expensive fix depends on (mapper). Nothing downstream *guarantees* a bad result is caught: CI misses a
 wrong-but-green fix, and the review gate is a miss-catcher, not a proof of correctness
-(`stage-2-review-gate.md`). So there is no class whose mistakes are reliably absorbed, and therefore no
-class where a cheaper model is free. NEVER justify a downgrade by claiming something downstream will
-catch it.
+(`stage-2-review-gate.md`). So no class's mistakes are reliably absorbed. NEVER justify a downgrade by
+claiming something downstream will catch it.
+
+### The one exception — total-oracle checks
+
+A cheaper path is allowed **only** when the failing check is a **total oracle** for the fix: re-running
+that same check *fully decides* whether the fix is correct, leaving no judgment over. `gofmt` fully
+verifies a formatting fix; `golangci-lint` fully verifies a lint fix. A failing product test is **not** a
+total oracle — making the test pass is not the same as fixing the bug.
+
+All three conditions MUST hold:
+
+- (a) the failing check is a total oracle — re-running it fully verifies the fix; AND
+- (b) the fix is confined to what the check itself defines, changing **no product behavior**; AND
+- (c) the diff touches **no check definition, config, or test** (the no-weakening prohibition,
+  `stage-2-ci.md` — buying green by loosening the rule stays forbidden).
+
+Eligibility is keyed on **check / linter rule IDENTITY** (`gofmt`, `goimports`, `golangci-lint` rules
+such as `modernize`, `gci`, `whitespace`) — NEVER on an impression that a failure "looks mechanical". A
+vibes-based whitelist is the same unsound reasoning in a new hat. **Default is NOT whitelisted; unknown
+check → session model.**
+
+| Tier | When | Action |
+|---|---|---|
+| **0 — no subagent** (prefer always) | Whitelisted check has a deterministic autofixer | Run the **tool**, not a model: `golangci-lint run --fix`, `gofmt -w`, `goimports -w`, `ruff --fix`, `prettier --write`. Re-run the failing check, commit. Zero tokens, zero model risk. |
+| **1 — cheap model, verified** | Whitelisted check, no autofixer (or autofixer leaves residue) | Dispatch on `haiku` (pure mechanical rewrite) or `sonnet` (needs any reasoning). ACCEPT **only if** re-running the exact failing check now passes AND the diff touches no check definition/config/test. Otherwise **discard** and re-dispatch on the session model. |
+| **session model** | Everything else | Any failure whose oracle is judgment: failing product tests, compile errors in real logic, review-fixes, mapper, review passes. |
+
+Sending a model to hand-edit a formatting violation is both the most expensive and the least reliable
+way to do it — Tier 0 first, always.
+
+**Residual risk, stated honestly:** an autofixer or a `modernize`-class rewrite CAN in rare cases change
+behavior. The review gate still reads the whole diff and is what catches that. The whitelist lowers
+**cost**; it does not remove the gate, and it is not a guarantee of correctness.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -57,11 +57,12 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
 | Review-fix (after `NOT SATISFIED`) | **session model** | Authors code that a full review pass must then judge. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
-| **CI-fix** | **`sonnet`** | The one safe downgrade. Failure is **self-detecting**: a bad CI fix leaves CI red, which campaign re-dispatches, and a red check blocks the review pass anyway — so it cannot silently corrupt the gate. |
+| **CI-fix** | **`sonnet`** | The one safe downgrade — because **both** its failure modes are caught, by two different nets. *Fix didn't work* → CI stays red → re-dispatch. *Fix weakened the check* (gutted assertion, `skip`/`xfail`, disabled lint rule, raised timeout) → CI turns **green**, so CI does **not** catch it — the **review gate** does, reading the whole diff. Hence it is dispatched under an explicit no-weakening prohibition (`stage-2-ci.md`). |
 
 **The rule behind the table: downgrade only where a bad result is caught by something else.** CI-fix is
-caught by CI. Every other class either *is* the check (review passes) or feeds work into an expensive
-check (fixes, mapping), where a cheap wrong answer is paid for twice.
+caught by CI *and* the review gate — CI alone is not enough, and never claim it is. Every other class
+either *is* the check (review passes) or feeds work into an expensive check (fixes, mapping), where a
+cheap wrong answer is paid for twice.
 
 **The biggest lever is not the model — it is the reviewer.** Review passes re-read the whole PR diff,
 `required(tier)` times per SHA, and re-run from scratch on every gate reset, so they dominate campaign's

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -84,18 +84,32 @@ semantics-preserving. In a whitespace-significant language it can move behavior 
 formatter-clean — indenting `result.append("always")` under an `if` is a pure-indentation edit that turns
 `["always"]` into `[]`, and `ruff format` is perfectly happy with it.
 
-**The LIST is configurable. The CRITERION is NOT.** The whitelist = the skill's **built-in defaults**,
-plus what the repo's `.gauntlet.yml` adds or removes. A hardcoded list is meaningless in a Rust/Java/Ruby
-repo; the criterion above is the safety property and is **NEVER overridable by config**.
+**The LIST is configurable. The CRITERION is NOT.** The whitelist = the skill's **built-in defaults**, as
+the repo's `.gauntlet.yml` re-configures or removes them. A hardcoded set of *flags* is meaningless in a
+Rust/Java/Ruby repo; the criterion above is the safety property and is **NEVER overridable by config**.
+Config tunes **which known tools run, with which flags, over which files** — it can **NEVER introduce a
+binary outside the known-tools table** below.
 
-**Built-in defaults — IN:**
+**Built-in defaults — the KNOWN-TOOLS TABLE.** These are the ONLY binaries campaign may execute on the
+no-model path. Adding a tool here is a **SKILL change**, NEVER a config change (`stage-2-ci.md`).
 
-- `gofmt`, `gofumpt`: AST-preserving Go pretty-printers; they re-print layout and never touch
-  string-literal contents.
-- `goimports`: import block only. `gci`: import grouping/ordering only — Go package init order is by
-  **dependency**, not by import order in a file.
-- golangci-lint `whitespace`: Go-only, leading/trailing newlines **inside function bodies**.
-- `ruff format`: verifies its output is AST-equivalent to the input.
+| `id` | `argv[0]` | guarantee | precondition |
+|---|---|---|---|
+| `gofmt` | `gofmt` | AST-preserving Go pretty-printer; never touches string-literal contents | none |
+| `gofumpt` | `gofumpt` | same, stricter layout; never touches string-literal contents | none |
+| `goimports` | `goimports` | import block only | none |
+| `gci` | `gci` | import grouping/ordering only — Go init order is by **dependency**, not by import order | none |
+| `ruff format` | `ruff` | verifies its output is AST-equivalent to the input | repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+
+**golangci-lint `whitespace` is NOT a default**: it has **no safe fixer** — its only fix path is the
+catch-all `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it.
+
+**A tool's guarantee can be CONDITIONAL on its CONFIGURATION.** `ruff format` with
+`format.docstring-code-format` enabled reformats Python code **inside docstrings** — it rewrites string
+contents, so its output is NOT AST-equivalent. Therefore: every `guarantee` MUST state the **conditions
+under which it holds**, and campaign MUST **verify those conditions hold in this repo** (read the tool's
+config from the **base** branch) before taking the no-model path. Condition violated, or undeterminable →
+**NOT whitelisted for this repo → session model.**
 
 **The DENYLIST — the skill's own, and config CANNOT widen past it. Refuse any entry that is:**
 
@@ -116,17 +130,37 @@ repo; the criterion above is the safety property and is **NEVER overridable by c
   compile error, and any rule that rewrites logic.
 
 **Repo config — `.gauntlet.yml` at the repo root** (COMMITTED, unlike the git-ignored `.gauntlet/` tree).
-It may **append** formatter entries and **remove** built-ins; `formatters: []` disables the cheap path
-entirely (everything goes to the session model — always a safe choice). Every entry MUST carry `id`,
-`command`, `files`, and **`guarantee`** — a concrete pointer to the tool's *documented*
-semantic-equivalence behaviour. **An entry without a real guarantee is REFUSED, not silently accepted**;
-"it's just formatting" is NOT a guarantee. Schema, validation, and merge order: `stage-2-ci.md`.
+It **re-configures the flags and files of KNOWN tools** and **removes** built-ins; `formatters: []`
+disables the cheap path entirely (everything goes to the session model — always a safe choice). It can
+**NEVER introduce a binary that is not in the known-tools table.**
+
+**The command's SHAPE is constrained, not just the tool's category** — the attack is command
+*construction*: an entry can cite `gofmt`'s guarantee while executing `./scripts/fmt.sh`. So every entry
+MUST carry `id`, `command`, `files`, `guarantee`, and:
+
+- **`command` is an argv LIST** — `command: ["gofmt", "-w"]`. **Executed WITHOUT a shell.** NEVER `sh -c`,
+  NEVER `bash -c`, NEVER a shell string.
+- **REFUSE any shell metacharacter** in the argv — `&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks,
+  newlines. No legitimate formatter entry needs them.
+- **`argv[0]` MUST be a bare tool name in the known-tools table** — NOT a path (`./x`, `/usr/local/bin/x`),
+  NOT a wrapper script, NOT an alias, NOT `sh`/`env`/`xargs`.
+- **`guarantee` MUST state the conditions under which it holds**, and those conditions MUST **verify in
+  this repo**. Undeterminable → REFUSE. "It's just formatting" is NOT a guarantee.
+
+**Any entry failing ANY of these is REFUSED** — logged, ignored, and that failure routes to the **session
+model**. Full schema, validation, and merge order: `stage-2-ci.md`.
 
 **NEVER read `.gauntlet.yml` from the PR's worktree or head — ALWAYS from the BASE branch**
 (`git show origin/<base>:.gauntlet.yml`). If campaign read the whitelist from the PR under review, a PR
 could **widen the whitelist that governs its own campaign** — adding a semantic rewriter and earning an
 unreviewed tool commit on its own head. That is self-gating in config form. A PR that edits `.gauntlet.yml`
 therefore takes effect only **after it merges**, gated like any other change.
+
+**Trust model, stated honestly.** `.gauntlet.yml` comes from the base branch, so its author already has
+**write access to the repo** — the same access that can rewrite `.github/workflows`. The denylist and the
+command-shape rules are a **guard against footguns and accidental misuse, NOT a security boundary against a
+malicious committer**. NEVER claim otherwise. What the base-branch rule DOES buy is real and MUST be kept:
+**a PR under review cannot widen the whitelist that governs its own campaign.**
 
 Eligibility is keyed on the **tool's IDENTITY and its documented guarantee** — NEVER on an impression that
 a failure "looks mechanical", and NEVER on the *category* "formatter". A vibes-based whitelist is the same
@@ -135,8 +169,8 @@ unparseable config, or a refused entry → session model.** The cheap path is op
 
 | When | Action |
 |---|---|
-| **Whitelisted tool** (prefer always) | Run the **tool** in `<worktree>` — the built-in default (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`) or the validated `command` from base-branch `.gauntlet.yml`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit + push — and **reset the gate exactly as any other PR-content change does** (`stage-2-ci.md`). **No model at all.** |
-| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the tool/check is not whitelisted, a config entry was **refused**, the config is missing/unparseable, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
+| **Whitelisted tool** (prefer always) | Run the **tool** in `<worktree>`, **WITHOUT a shell**, from its validated **argv** — the built-in default (`["gofmt","-w"]`, `["gofumpt","-w"]`, `["goimports","-w"]`, `["gci","write"]`, `["ruff","format"]`) or the validated `command` from base-branch `.gauntlet.yml`. NEVER a catch-all `--fix`. Re-run the **exact** failing check; it must pass and the diff must touch **no check definition, config, or test**. Then commit + push — and **reset the gate exactly as any other PR-content change does** (`stage-2-ci.md`). **No model at all.** |
+| **Everything else** | Dispatch the scoped CI-fix subagent on the **session model**, set explicitly. Covers: the tool did not fix it, the tool left residue, the tool/check is not whitelisted, a config entry was **refused** (bad shape, unknown `argv[0]`, unverifiable guarantee condition), the config is missing/unparseable, or the failure needs any judgment (product tests, compile errors, semantic lint rules, logic). |
 
 If the tool's output does not clear the failing check, or it touched a check definition, config, or test
 → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -29,7 +29,7 @@
   `.gauntlet/history/**`. A fix commit stages ONLY the specific source files it changes, by explicit
   path — never `git add -A` / `git add .`, which would sweep in run state. The tree must be
   git-ignored; add `.gauntlet/` to `.gitignore` if missing. Campaign has **NO committed file of its own** —
-  no repo-root config; the cheap path's tool list is the ledger header's `formatters` field, never a repo file.
+  no repo-root config.
 - NEVER `rm -rf .gauntlet/` — that destroys the durable carryover history. Only `.gauntlet/tmp/**` is
   disposable.
 - NEVER pass destructive instructions (delete, force-push, reset) to an external reviewer command
@@ -134,199 +134,54 @@
 - Prune `.gauntlet/history/` at every fresh run: drop only entries unambiguously moot against
   current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
   prune an entry you're unsure about.
-- **Set the model explicitly on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset
-  model silently inherits the session model — a cost decision taken by default. **NO SUBAGENT IS EVER RUN
-  ON A DOWNGRADED MODEL**: review passes and the subagent-fallback review *are* the gate; CI-fix and
-  review-fix write **code that gets merged**; the root-cause **mapper** feeds an expensive fix. Nothing
-  downstream *guarantees* a bad result is caught — CI misses a wrong-but-green fix, and the review gate is
-  a miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
-  catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
-  low-judgment, and an under-map is invisible.
-- **THE SKILL SHIPS WITH ZERO TOOLS ENABLED AND VOUCHES FOR NONE.** `formatters` defaults to **`-`** — no
-  tool runs, the cheap path is OFF, and **every** CI failure goes to the session model. The skill supplies
-  the **MECHANISM** and the **EVIDENCE**; **the USER decides which tools to trust, enables them explicitly,
-  and accepts that risk. The skill guarantees HOW a tool is run — NEVER WHAT the tool does.** NEVER enable a
-  tool on the user's behalf; NEVER answer "the skill guarantees it is safe".
-- **The only cheap path: a CI check whose fixer is a KNOWN tool the USER ENABLED — run the TOOL, no model at
-  all** (`SKILL.md`, "The only cheap path"; full table/schema/validation in `stage-2-ci.md`). Not enabled,
-  not known, or `formatters` = `-` → **session model**. There is **NO blanket "formatters are safe" rule**,
-  and whatever a tool does does **NOT** transfer to a model hand-editing the same file — a diff that *looks*
-  like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior in a
-  whitespace-significant language and stay formatter-clean).
-- **"KNOWN" ≠ "TRUSTED".** A known-tools row means the skill knows how to run that tool **safely** — it owns
-  the argv, the binary resolution, the operand checks. It does **NOT** mean the tool is safe to enable.
-  **NEVER present a row as blessed, trusted, whitelisted, or recommended by the skill.** Each row states,
-  separately, **what the skill guarantees** (mechanical, ours) and **what is NOT proven** (about the tool).
-- **WHAT THE NO-MODEL PATH RESTS ON — two things, and only one is ours.** (1) **OURS, the MECHANISM:**
-  skill-owned exact argv (no flag ever appended), `argv[0]` resolved to a trusted absolute executable
-  **outside the repo**, the **seven operand checks**, resolve-then-filter, no shell, no glob, no empty
-  operand set, and a **gate reset on every commit**. It bounds what we RUN and what we WRITE. (2) **THE
-  USER'S, the TOOL's behaviour:** whether it preserves meaning is **NOT stated by any doc we can cite** —
-  the user accepted that inference when enabling it. **NEVER restate (2) as a guarantee of the skill's, and
-  NEVER re-derive it from the exclusion filter.**
-- **THE SKILL OWNS THE EXACT ARGV; NOTHING ELSE SUPPLIES A COMMAND.** The known-tools table
-  (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w --`, `gci write --`, `ruff format --`, each
-  over that id's normalized files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
-  rewrites `return true` into `return false` with a known `argv[0]` and no shell metacharacters, so tool
-  identity alone is NOT sufficient. The tool list therefore carries **ids and globs only** — it can NEVER
-  name a `command`/`args`/`argv`/flag. NEVER append a flag to a table argv. Adding a tool, or changing an
-  argv, is a **SKILL change**.
-- **THE KNOWN TOOLS — `gofmt`, `gci`, `ruff format` — AND WHAT IS NOT PROVEN ABOUT EACH.** For `gofmt`, the
-  argv is `["gofmt","-w","--",<files>]`: **`-w`** — *"If a file's formatting is different from gofmt's,
-  overwrite it with gofmt's version"* — **CHANGES THE SOURCE and is the ONLY mutation the argv performs**;
-  **`-r`** (*"Apply the rewrite rule to the source before reformatting"*) and **`-s`** (*"Try to simplify
-  code"*) are the documented flags that apply a **non-formatting source TRANSFORMATION**, and **NEITHER is in
-  the argv**. **`-cpuprofile` is a separate documented flag that WRITES A FILE** (it does not transform the
-  source); it is named only because a FILENAME shaped like `-cpuprofile=x.go` is the injection repro. The doc
-  lists others still (`-l`, `-d`, `-e`, …). **GUARD — this claim has been stated wrongly THREE times: NEVER
-  say "exactly two flags", "the only two flags", or "the only flags that CHANGE the source". State ONLY the
-  TRANSFORMATION property.** **AND STATE, EVERY TIME, WHAT IS NOT PROVEN:** the cited doc
-  (https://pkg.go.dev/cmd/gofmt) **documents formatting behaviour and flags — it NEVER states a
-  semantic-equivalence guarantee**. Our reading (a pretty-printer that parses and re-prints cannot change
-  meaning) is an **INFERENCE**. Same for **`gci`** (https://github.com/daixiang0/gci — the cited docs describe
-  import ordering/grouping and **never state** it neither adds nor removes an import; the init-order argument
-  is OURS) and **`ruff format`** (https://docs.astral.sh/ruff/formatter/ — the cited docs state **no
-  AST/semantic-equivalence guarantee**, and the repo's own config may enable `format.docstring-code-format`,
-  which rewrites code inside docstrings). **Enabling any of them means accepting that inference.** NEVER
-  upgrade an inference into a guarantee; **FOLLOW a citation before trusting a cell** — a citation that does
-  not support its claim is WORSE than none.
-- **THE ASYMMETRY — state it, do not soften it: the skill REFUSES what is DOCUMENTED to be unsafe; it does
-  NOT bless what is merely UNDOCUMENTED — that call is the USER's.** A tool whose own doc says it changes the
-  program is **denylisted and config can NEVER enable it**. A tool whose doc says nothing either way sits in
-  the known-tools table: the skill will run it correctly **if the user enables it**, and claims nothing.
-- **NORMALIZE THE FILE ARGV — FILENAMES ARE PR-CONTROLLED DATA** (`stage-2-ci.md`). The skill owns the argv
-  **SHAPE**, not the operands: `<files>` is globbed from the **PR's worktree**, so every filename is
-  attacker-controlled data spliced into argv, and MUST be normalized like any injection boundary. **Repro:**
-  a PR adds a file named `-cpuprofile=prof.go`; it matches `**/*.go`, survives the exclusion filter, and
-  `gofmt -w '-cpuprofile=prof.go' a.go` exits 0 having parsed it as a **FLAG** and written a CPU profile —
-  trusted binary, skill-owned argv, no shell, no model, and PR content still steered the command. Therefore,
-  EVERY tool, EVERY run: (a) pass **`--`** before the file list — a tool without `--` NEVER enters the table;
-  (b) pass every file as an **ABSOLUTE** (or `./`-prefixed) path — **NEVER a bare relative name**, which is
-  belt-and-braces even if `--` fails; (c) **REFUSE any candidate name starting with `-`** — **DROP that file**
-  and log it; do **NOT** abort the run. NEVER pass the glob itself to the tool.
-  **NEVER invoke the tool with an EMPTY operand set — `gofmt` with no operands READS STDIN.** Empty set after
-  refusals → run nothing for that id → session model.
-- **A PATH IS DATA THAT RESOLVES — NORMALIZING ITS SPELLING IS NOT ENOUGH** (`stage-2-ci.md`). **Repro:** the
-  PR adds `link.go`, a **symlink** pointing outside the worktree. It matches `**/*.go`, survives the exclusion
-  filter, and its name is clean — and `gofmt -w -- link.go` **FOLLOWS it and rewrites the target OUTSIDE the
-  repo**. So, on every candidate — **AFTER the exclusion filter, BEFORE the argv is built**: **REFUSE a
-  SYMLINK** (`lstat` the candidate itself; NEVER `stat`, which follows the link and hides the very thing being
-  tested — a source file that must be formatted is never a symlink); **REFUSE a candidate whose fully-resolved
-  real path (`realpath`, symlinks followed, `..` collapsed) is not CONTAINED under the resolved worktree root**
-  (compare on a path-component boundary — `/wt-evil` is not under `/wt`); and **REFUSE a candidate that is not
-  a REGULAR FILE** (directory, device, fifo, socket). **DROP** each and **LOG** it (id, path, reason —
-  symlink escape / escapes the worktree / not a regular file); do NOT abort. Empty set → session model.
-- **A PATH CHECK BOUNDS WHERE WE LOOK; IT DOES NOT BOUND WHAT WE WRITE — THE INODE CAN BE ALIASED OUTSIDE THE
-  TREE** (`stage-2-ci.md`). **Repro:** the PR adds `alias.go`, a **HARDLINK** sharing an INODE with a file
-  outside the worktree. It is a **regular file**, it is **not a symlink** (`lstat` says regular), and its
-  **`realpath` is INSIDE the worktree** — it passes every check above. `gofmt -w` truncates and rewrites the
-  **EXISTING INODE**, so formatting it **MUTATES THE OUTSIDE ALIAS**. Therefore, the sixth check: **REFUSE any
-  candidate with a LINK COUNT > 1** (`stat` → `st_nlink > 1`). A source file in a normal checkout has exactly
-  **one** link; a multi-link file is a hardlink escape or something we have no reason to format. **DROP** and
-  **LOG** it (id, path, reason — `hardlink — nlink>1`); **NEVER abort the run**. Empty set → session model.
-- **EVERY CHECK THAT REASONS ABOUT A PATH MUST REASON ABOUT THE RESOLVED PATH — A NAME IS NOT A LOCATION**
-  (`stage-2-ci.md`). **Repro:** the PR adds a **symlinked DIRECTORY** `safe/gh -> .github`. The candidate
-  `safe/gh/actions/main.go` is **not itself a symlink**, its **`realpath` is INSIDE the worktree**, it is a
-  **regular file with `nlink == 1`**, and its name is clean — it passes all six checks above — while the
-  **exclusion filter, matched on the SPELLED path, never sees `.github/**`**. A **check definition** is handed
-  to the tool, with no model and no review. Therefore: **apply the skill-owned EXCLUSION FILTER to the
-  RESOLVED path as well as the original — EITHER matches → REFUSE**; **AND the seventh check: REFUSE any
-  candidate with a SYMLINK in ANY DIRECTORY COMPONENT** (walk the components from the resolved worktree root
-  down, `lstat` each; any symlink → **DROP** + **LOG**, reason `symlinked directory component` /
-  `excluded after resolution`). The component check bounds **what we write**; matching the filter on the
-  resolved path keeps the filter honest (it is **defence in depth**, never the guarantee). Run **BOTH**.
-  **THE PIPELINE:** glob → **RESOLVE** → **FILTER both spellings** → the **seven** checks → argv.
-- **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
-  in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
-  the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
-  runs with no model and no review**. Before every run, resolve `argv[0]` to an **absolute** path using a
-  `PATH` stripped of `.`, `..`, empty entries, **all relative entries**, the worktree, the repo root, and any
-  directory inside them; the resolved executable (symlinks followed) **MUST live OUTSIDE the repo/worktree
-  tree**. Resolves inside, or does not resolve → **REFUSE → session model**. NEVER run the tool with the
-  worktree on `PATH` or as the lookup base. NEVER execute a binary the PR could have supplied.
-- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER — DEFENCE IN DEPTH, ADMITTEDLY INCOMPLETE.** Applied to
-  the RESOLVED path **and** the original, EVERY time (**either** matches → REFUSE; a filter matched on the
-  spelling alone is defeated by a symlinked directory — see the resolved-path rule above). It drops tests
-  (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), check definitions
-  (`.github/**`, …), CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`, …), and
-  `.gauntlet/**`. **It is an enumerated PATTERN LIST: NOT complete, and it CANNOT be** — a repo-specific
-  check written as ordinary source (`tools/ci/check.go`) matches `**/*.go`, matches **none** of the
-  patterns, passes every operand check, and **is** handed to the tool. **NEVER call it complete or
-  exhaustive, and NEVER treat it as a reason to enable a tool.** Its
-  job is **BLAST RADIUS**: keep the tool's diff off files a reviewer expects untouched. **NOTHING widens it**
-  — config may only NARROW — and the tool list NEVER carries the exclusions itself: a user-written exclusion
-  list omits more and rots per-repo. The glob SELECTS; the filter TRIMS. A `gofmt:**/*.go` narrowing is
-  therefore VALID. A refusal of an obviously hostile glob catches **intent**.
-- **THE TOOL LIST LIVES IN THE LEDGER HEADER (`formatters`), NEVER IN A REPO FILE, AND IS EMPTY BY DEFAULT.**
-  Resolved **once at run start** from the **user** — explicit invocation, else a preference in memory, else
-  **`-`**. **The EMPTY sentinel is `-`, NEVER the word `none`, and there is NO `default` value and no built-in
-  set**: `-` (and an **unset** field) means **no tool enabled, cheap path OFF, every CI failure → session
-  model**. **Re-read it from the header every
-  wake; NEVER re-derive it from memory mid-run** (a wake may be a fresh agent instance — same rule and same
-  reason as `reviewer`). **NEVER take it from repo content: not from a repo-root config file, not from
-  `CLAUDE.md`, not from ANY file in the repo.** Repo content **is PR content** — a PR that could edit the
-  list could **enable a tool to govern its own campaign**, earning an unreviewed tool commit
-  on its own head (self-gating). Out of the repo, a PR cannot touch it **by construction**: there is no
-  provenance rule to enforce, and none exists — do NOT reintroduce one.
-- **The tool list carries EXACTLY known-tool ids + an OPTIONAL NARROWER glob** (`gofmt:internal/**/*.go`).
-  Every known tool has a **default glob** in the table (`gofmt`/`gci` → `**/*.go`, `ruff format` → `**/*.py`),
-  so an enabled id with no glob has a fully defined file set: that default, filtered. A glob may only
-  NARROW that default → a widening glob is REFUSED; so is an **obviously hostile** one that directly targets
-  a check def, config, or test (`gofmt:.golangci.yml`), or a repo-sweeping bare `**`/`.`. The user's list is
-  the WHOLE list — **there are no built-ins to replace**, and a known tool the user does not name is not run.
-  It **NEVER introduces a binary outside the known-tools table**. **Any id failing any rule is REFUSED** —
-  log it, ignore it, route that failure to the **session model**. NEVER silently honour a refused id.
-- **golangci-lint `whitespace` is NOT a known tool**: no safe fixer — its only fix path is the denylisted
-  catch-all `golangci-lint run --fix`. NEVER invent a command for it.
-- **NON-OVERRIDABLE DENYLIST — the ONE thing the skill REFUSES; config can NEVER enable one.** These are
-  **KNOWN-BAD: their own docs say they CHANGE the program** — a documented fact, not an inference:
-  **`goimports`** (ADDS missing imports and REMOVES unreferenced ones; an added import runs that package's
-  `init()`, and a guessed import can be the wrong package); **`prettier`** (reformats the contents of tagged
-  template literals — `` gql`…` ``, `` css`…` `` — changing the runtime string the tag receives);
-  **`gofumpt`** (extra rewrite rules beyond gofmt's layout, documented as a rule list of source-construct
-  edits; "it is basically gofmt" is NOT an argument); any
-  generic/unscoped "whitespace" or "trailing-whitespace" fixer that can touch string literals, heredocs, or
-  Markdown; every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3` (a `modernize` rewrite
-  can pass its own rule while changing behavior); every **catch-all fixer** — `golangci-lint run --fix`,
-  `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies
-  semantic rules (an enabled run invokes ONLY the table's argv). Failing product tests, compile errors,
-  and any rule that rewrites logic are NEVER fixed by a tool.
-- **TRUST MODEL — do NOT overclaim.** **The skill trusts NO tool: it enables none, and vouches for none.** It
-  owns **HOW** a tool runs, never **WHAT** it does. The tool list is the **user's** (invocation or their own
-  memory), not repo content, so there is no malicious-committer threat model there: the denylist and the
-  id-only shape are a **guard against footguns and accidental misuse, NOT a security
-  boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
-  the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**,
-  why the **file operands are normalized, resolved, checked for aliasing, AND filtered on the RESOLVED path**
-  (they are PR data spliced into
-  argv; a **symlink** among them walks the tool out of the tree, a **hardlink** walks the WRITE out of the
-  tree with every path check passing, and a **symlinked directory component** walks a candidate into an
-  **excluded** location while its spelling looks innocent), and why the exclusion filter is the skill's, not
-  the user's.
-- **Default deny, and the DEFAULT IS DENY.** Keyed on the **tool's IDENTITY and what the user enabled**, NEVER
-  on a failure "looking mechanical" or on the category "formatter". `formatters` = `-` (the default), tool not
-  enabled, tool not in the table, denylisted id, unresolvable binary, or a refused id → session model. The
-  cheap path is keyed to the table + the user's list, never inferred.
-  ACCEPT the tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**;
-  AND (b) the diff touches **no check definition, config, or test**. Either fails → **discard the work**
-  (reset the worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch
-  a tool run in place; NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
-- **An enabled TOOL's commit resets the gate exactly like a subagent's** (`stage-2-ci.md`, "Any campaign
-  commit to the PR head resets the gate"). Every commit campaign pushes to a PR head — CI-fix subagent,
-  review-fix subagent, or tool run with no model — MUST in the same step reset `reviews_ok` to 0 AND
-  restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, then relaunch the CI watch and
-  re-enter Stage 2a. NEVER treat a tool-written commit as exempt.
-- **Everything the tool does not fix → the scoped CI-fix subagent on the session model**, set explicitly:
-  no tool enabled (the default), tool left residue, check has no known tool, or the failure needs any
-  judgment.
-- A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
-  cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
-  green. **The prohibition is load-bearing THERE** — a session-model fixer *can* change semantics, so it
-  *can* weaken a check. On the tool path the mechanism (exact argv, checked operands) is what bounds the
-  write — **and the tool's own behaviour is the user's risk, not the skill's guarantee**.
+- **Set the model EXPLICITLY on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset model
+  silently inherits the session model — a cost decision taken by default.
+- **Model policy — NEVER DOWNGRADED: review passes, the subagent-fallback review, review-fixes, and the
+  root-cause mapper.** A review pass *is* the gate; a review-fix authors code from scratch; a session-model
+  CI-fix authors code that gets merged; the mapper's under-map is **invisible** ("read-only" is not
+  low-judgment). NEVER claim CI catches a bad fix — a wrong fix can turn CI green, and the review gate is a
+  miss-catcher, not a proof of correctness.
+- **Model policy — DOWNGRADED ON PURPOSE: the CI-fix subagent for a FORMATTING/LINT failure** — `sonnet`,
+  or `haiku` only when the failure is trivially mechanical (`stage-2-ci.md`). It does **not** author a fix:
+  it runs a deterministic formatter, **READS the resulting diff**, verifies it, and **escalates** anything
+  it cannot verify. **Everything else — failing product test, compile error, anything needing judgment — and
+  every ESCALATION from the cheap tier → the session model**, set explicitly.
+- **CLASSIFY the failure from the check logs BEFORE dispatching anything** — never dispatch straight off a
+  red check (`loop-control.md` step 3, `stage-2-ci.md`). The class picks the model.
+- **The cheap CI-fix subagent's job, in order:** classify → run the formatter (**it** picks the tool;
+  campaign hands it no argv) → **READ THE RESULTING DIFF** and verify that it contains ONLY what the fix
+  should have produced, that no unintended file was touched, that no check definition/config/test was
+  weakened, and that **re-running the exact failing check now PASSES** → commit **only** then → otherwise
+  **STOP, commit nothing, reset the worktree to the PR head, and ESCALATE** to a session-model CI-fix
+  subagent. **NEVER patch a failed cheap run in place.** Escalation is the correct outcome, not a failure.
+- **NO-WEAKENING PROHIBITION — verbatim into EVERY CI-fix subagent's prompt.** NEVER make CI pass by
+  weakening the check: NEVER delete or loosen an assertion, NEVER add `skip`/`xfail`, NEVER disable or
+  downgrade a lint rule, NEVER raise a timeout. **Fix the cause.** If the check itself is demonstrably
+  wrong, **say so explicitly and ESCALATE** — never silently rewrite it.
+- **DENYLIST — verbatim into the cheap CI-fix subagent's prompt. NEVER a catch-all fixer that applies
+  SEMANTIC rules, NEVER a documented semantic rewriter:** `golangci-lint run --fix`, `ruff --fix`,
+  `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies semantic rules;
+  **`goimports`** (it ADDS imports — an added import runs that package's `init()`); **`prettier`** (it
+  rewrites the contents of tagged template literals); **`gofumpt`** (extra rewrite rules beyond layout);
+  `modernize`, codemods, `pyupgrade`, `2to3`. **Use a formatter that only reformats.** Also: **NEVER execute
+  a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**, and a
+  repo-supplied `gofmt` is arbitrary code execution; run tools from the environment, not from the tree. And
+  **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — name the files being fixed.
+- **STATE THE RISK HONESTLY — a cheap model verifying a tool's diff is a MISS-CATCHER, NOT A PROOF.** It can
+  miss a semantic change. What backs it: the **exact failing check must pass**; the subagent **must escalate
+  anything it cannot verify**; and **every campaign commit still resets the gate and is re-reviewed by the
+  full gauntlet** — which is itself a miss-catcher. **NEVER claim the cheap tier is safe because "CI will
+  catch it" or "the review gate will catch it".** It is a small, bounded risk the user accepted, for a
+  workflow that is cheaper AND more capable than either a full-strength subagent on every formatting failure
+  or a hermetic no-model tool path.
+- **ANY campaign commit to the PR head resets the gate** (`stage-2-ci.md`, "Any campaign commit to the PR
+  head resets the gate") — cheap CI-fix, session-model CI-fix, or review-fix alike. In the SAME step: reset
+  `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, relaunch the CI
+  watch, and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
 - Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
-  That — with the tool-only formatter path and an external reviewer taking review passes off the subagent
-  pool — is where savings live. Never a downgraded model.
+  **Scope by defect, not by guess — name every file the defect touches.** That, plus an **external
+  reviewer** taking review passes off the subagent pool (**the single biggest cost lever** — review passes
+  dominate campaign's spend), is where savings live.
 - Default reviewer is Claude's own subagents; no external tool is required. Use the user's preferred
   reviewer when one is set (explicit invocation, or a preference in memory/`CLAUDE.md`/carryover). A
   different-model reviewer (e.g. Codex) is recommended for diversity but never required. See

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -29,7 +29,7 @@
   `.gauntlet/history/**`. A fix commit stages ONLY the specific source files it changes, by explicit
   path — never `git add -A` / `git add .`, which would sweep in run state. The tree must be
   git-ignored; add `.gauntlet/` to `.gitignore` if missing. Campaign has **NO committed file of its own** —
-  no repo-root config; the formatter whitelist is the ledger header's `formatters` field, never a repo file.
+  no repo-root config; the cheap path's tool list is the ledger header's `formatters` field, never a repo file.
 - NEVER `rm -rf .gauntlet/` — that destroys the durable carryover history. Only `.gauntlet/tmp/**` is
   disposable.
 - NEVER pass destructive instructions (delete, force-push, reset) to an external reviewer command
@@ -142,58 +142,58 @@
   a miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
   catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
   low-judgment, and an under-map is invisible.
-- **The only cheap path: a CI check whose fixer is a WHITELISTED TOOL — run the TOOL, no model at all**
-  (`SKILL.md`, "The only cheap path"; full table/schema/validation in `stage-2-ci.md`). **A tool is
-  whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an AST-preserving
-  pretty-printer, not a text munger — on the burden of a **CITED SOURCE: a LINK to the tool's own
-  documentation and the passage it rests on, QUOTED. The word "documented" is NOT a citation, and a citation
-  that does NOT SUPPORT its claim is WORSE than none** — it launders our own belief as the source's. Cannot
-  point to a source → NOT whitelisted → session model. There is **NO blanket "formatters are safe" rule**. The
-  guarantee is the TOOL's and does **NOT** transfer to a model hand-editing the same file — a diff that
-  *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
-  in a whitespace-significant language and stay formatter-clean).
-- **THE GUARANTEE = THE CRITERION + THE OPERAND CHECKS — no list is part of it.** The criterion bounds
-  **what the tool can do**: `gofmt` re-prints the program without changing its meaning, so **whatever it
-  touches, it CANNOT change the meaning of** — a reformatted test asserts exactly what it asserted before,
-  and **weakening a check requires a SEMANTIC change the skill-owned argv cannot make**. The **seven operand
-  checks** bound **what we write**. Together they are what make the no-model path safe, and they depend on
-  **NO list being complete**. NEVER re-derive that safety from the exclusion filter.
+- **THE SKILL SHIPS WITH ZERO TOOLS ENABLED AND VOUCHES FOR NONE.** `formatters` defaults to **`-`** — no
+  tool runs, the cheap path is OFF, and **every** CI failure goes to the session model. The skill supplies
+  the **MECHANISM** and the **EVIDENCE**; **the USER decides which tools to trust, enables them explicitly,
+  and accepts that risk. The skill guarantees HOW a tool is run — NEVER WHAT the tool does.** NEVER enable a
+  tool on the user's behalf; NEVER answer "the skill guarantees it is safe".
+- **The only cheap path: a CI check whose fixer is a KNOWN tool the USER ENABLED — run the TOOL, no model at
+  all** (`SKILL.md`, "The only cheap path"; full table/schema/validation in `stage-2-ci.md`). Not enabled,
+  not known, or `formatters` = `-` → **session model**. There is **NO blanket "formatters are safe" rule**,
+  and whatever a tool does does **NOT** transfer to a model hand-editing the same file — a diff that *looks*
+  like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior in a
+  whitespace-significant language and stay formatter-clean).
+- **"KNOWN" ≠ "TRUSTED".** A known-tools row means the skill knows how to run that tool **safely** — it owns
+  the argv, the binary resolution, the operand checks. It does **NOT** mean the tool is safe to enable.
+  **NEVER present a row as blessed, trusted, whitelisted, or recommended by the skill.** Each row states,
+  separately, **what the skill guarantees** (mechanical, ours) and **what is NOT proven** (about the tool).
+- **WHAT THE NO-MODEL PATH RESTS ON — two things, and only one is ours.** (1) **OURS, the MECHANISM:**
+  skill-owned exact argv (no flag ever appended), `argv[0]` resolved to a trusted absolute executable
+  **outside the repo**, the **seven operand checks**, resolve-then-filter, no shell, no glob, no empty
+  operand set, and a **gate reset on every commit**. It bounds what we RUN and what we WRITE. (2) **THE
+  USER'S, the TOOL's behaviour:** whether it preserves meaning is **NOT stated by any doc we can cite** —
+  the user accepted that inference when enabling it. **NEVER restate (2) as a guarantee of the skill's, and
+  NEVER re-derive it from the exclusion filter.**
 - **THE SKILL OWNS THE EXACT ARGV; NOTHING ELSE SUPPLIES A COMMAND.** The known-tools table
-  (`stage-2-ci.md`) fixes each tool's precise argv (today: `gofmt -w --` over that id's normalized files).
-  **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
+  (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w --`, `gci write --`, `ruff format --`, each
+  over that id's normalized files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
   rewrites `return true` into `return false` with a known `argv[0]` and no shell metacharacters, so tool
-  identity alone is NOT sufficient. The whitelist therefore carries **ids and globs only** — it can NEVER
+  identity alone is NOT sufficient. The tool list therefore carries **ids and globs only** — it can NEVER
   name a `command`/`args`/`argv`/flag. NEVER append a flag to a table argv. Adding a tool, or changing an
   argv, is a **SKILL change**.
-- **THE TABLE HOLDS ONE TOOL — `gofmt`. The criterion was applied TO OURSELVES.** Its cell quotes
-  https://pkg.go.dev/cmd/gofmt (*"Gofmt formats Go programs. It uses tabs for indentation and blanks for
-  alignment"*). **`-w`** — *"If a file's formatting is different from gofmt's, overwrite it with gofmt's
-  version"* — **CHANGES THE SOURCE: it writes the formatted result back to the file. That is what we WANT,
-  and it is the ONLY mutation the skill-owned argv performs.** **`-r`** — *"Apply the rewrite rule to the
-  source before reformatting"* — and **`-s`** — *"Try to simplify code"* — are the only documented flags that
-  apply a **non-formatting source TRANSFORMATION** (they change the PROGRAM, beyond re-printing it), and
-  **NEITHER is in the skill-owned argv**. **`-cpuprofile` is a separate documented flag that WRITES A FILE**
-  (it does not transform the source); it is named only because a FILENAME shaped like `-cpuprofile=x.go` is
-  the injection repro. The doc lists others still (`-l`, `-d`, `-e`, …). **GUARD — this claim has been stated
-  wrongly THREE times: NEVER say "exactly two flags", "the only two flags", or "the only flags that CHANGE
-  the source". State ONLY the TRANSFORMATION property.** Safety rests on: the argv is **skill-owned and
-  exact**; **NO flag is ever appended**; and
-  **no file operand can be read as a flag** (`--` + the operand-normalization rules) — the injection repro
-  below is a file named `-cpuprofile=prof.go`. Each `guarantee` cell MUST carry a **LINK to the tool's own doc and the passage
-  QUOTED**; **FOLLOW the link before trusting the cell** — a claim that cannot be tied to a source means the
-  tool comes **OUT of the table**. **The cheap path therefore covers Go formatting and NOTHING else; every
-  other CI failure — ALL Python/JS/etc formatting included — goes to the SESSION MODEL.** That is the safe
-  default, not a regression, and the small table is **the rule working — NEVER a limitation to route
-  around**. **REJECTED, and re-adding one is a SKILL change that must first defeat the reason** — the bar is
-  **a source that STATES the guarantee, quoted in the cell**; "it is a formatter" / "probably fine" /
-  "widely used" are NOT admissible: **`ruff format`** (https://docs.astral.sh/ruff/formatter/ — the cited
-  docs state **no AST-equivalence guarantee**); **`gci`** (https://github.com/daixiang0/gci — the cited docs
-  describe import ordering/grouping and **never state** it neither adds nor removes an import); `goimports`
-  (https://pkg.go.dev/golang.org/x/tools/cmd/goimports) — **ADDS missing imports and REMOVES unreferenced
-  ones**; an added import runs that package's `init()` and a guessed import can be the **wrong package** →
-  not semantics-preserving. `gofumpt` (https://github.com/mvdan/gofumpt) — **extra rewrite rules beyond
-  gofmt's layout**, stated as a rule list, **never** as semantics-preserving; "it is basically
-  gofmt" is NOT an argument. Fewer tools that provably hold beats more that mostly do.
+- **THE KNOWN TOOLS — `gofmt`, `gci`, `ruff format` — AND WHAT IS NOT PROVEN ABOUT EACH.** For `gofmt`, the
+  argv is `["gofmt","-w","--",<files>]`: **`-w`** — *"If a file's formatting is different from gofmt's,
+  overwrite it with gofmt's version"* — **CHANGES THE SOURCE and is the ONLY mutation the argv performs**;
+  **`-r`** (*"Apply the rewrite rule to the source before reformatting"*) and **`-s`** (*"Try to simplify
+  code"*) are the documented flags that apply a **non-formatting source TRANSFORMATION**, and **NEITHER is in
+  the argv**. **`-cpuprofile` is a separate documented flag that WRITES A FILE** (it does not transform the
+  source); it is named only because a FILENAME shaped like `-cpuprofile=x.go` is the injection repro. The doc
+  lists others still (`-l`, `-d`, `-e`, …). **GUARD — this claim has been stated wrongly THREE times: NEVER
+  say "exactly two flags", "the only two flags", or "the only flags that CHANGE the source". State ONLY the
+  TRANSFORMATION property.** **AND STATE, EVERY TIME, WHAT IS NOT PROVEN:** the cited doc
+  (https://pkg.go.dev/cmd/gofmt) **documents formatting behaviour and flags — it NEVER states a
+  semantic-equivalence guarantee**. Our reading (a pretty-printer that parses and re-prints cannot change
+  meaning) is an **INFERENCE**. Same for **`gci`** (https://github.com/daixiang0/gci — the cited docs describe
+  import ordering/grouping and **never state** it neither adds nor removes an import; the init-order argument
+  is OURS) and **`ruff format`** (https://docs.astral.sh/ruff/formatter/ — the cited docs state **no
+  AST/semantic-equivalence guarantee**, and the repo's own config may enable `format.docstring-code-format`,
+  which rewrites code inside docstrings). **Enabling any of them means accepting that inference.** NEVER
+  upgrade an inference into a guarantee; **FOLLOW a citation before trusting a cell** — a citation that does
+  not support its claim is WORSE than none.
+- **THE ASYMMETRY — state it, do not soften it: the skill REFUSES what is DOCUMENTED to be unsafe; it does
+  NOT bless what is merely UNDOCUMENTED — that call is the USER's.** A tool whose own doc says it changes the
+  program is **denylisted and config can NEVER enable it**. A tool whose doc says nothing either way sits in
+  the known-tools table: the skill will run it correctly **if the user enables it**, and claims nothing.
 - **NORMALIZE THE FILE ARGV — FILENAMES ARE PR-CONTROLLED DATA** (`stage-2-ci.md`). The skill owns the argv
   **SHAPE**, not the operands: `<files>` is globbed from the **PR's worktree**, so every filename is
   attacker-controlled data spliced into argv, and MUST be normalized like any injection boundary. **Repro:**
@@ -244,51 +244,57 @@
   directory inside them; the resolved executable (symlinks followed) **MUST live OUTSIDE the repo/worktree
   tree**. Resolves inside, or does not resolve → **REFUSE → session model**. NEVER run the tool with the
   worktree on `PATH` or as the lookup base. NEVER execute a binary the PR could have supplied.
-- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER — DEFENCE IN DEPTH, NOT THE GUARANTEE.** Applied to
+- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER — DEFENCE IN DEPTH, ADMITTEDLY INCOMPLETE.** Applied to
   the RESOLVED path **and** the original, EVERY time (**either** matches → REFUSE; a filter matched on the
   spelling alone is defeated by a symlinked directory — see the resolved-path rule above). It drops tests
   (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), check definitions
   (`.github/**`, …), CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`, …), and
   `.gauntlet/**`. **It is an enumerated PATTERN LIST: NOT complete, and it CANNOT be** — a repo-specific
   check written as ordinary source (`tools/ci/check.go`) matches `**/*.go`, matches **none** of the
-  patterns, passes every operand check, and **is** handed to the tool. **NEVER call it complete, exhaustive,
-  or the thing that makes the no-model path safe** (that is the criterion + the operand checks, above). Its
+  patterns, passes every operand check, and **is** handed to the tool. **NEVER call it complete or
+  exhaustive, and NEVER treat it as a reason to enable a tool.** Its
   job is **BLAST RADIUS**: keep the tool's diff off files a reviewer expects untouched. **NOTHING widens it**
-  — config may only NARROW — and the whitelist NEVER carries the exclusions itself: a user-written exclusion
+  — config may only NARROW — and the tool list NEVER carries the exclusions itself: a user-written exclusion
   list omits more and rots per-repo. The glob SELECTS; the filter TRIMS. A `gofmt:**/*.go` narrowing is
-  therefore VALID. A refusal of an obviously hostile glob catches **intent**, not weakening.
-- **THE FORMATTER WHITELIST LIVES IN THE LEDGER HEADER (`formatters`), NEVER IN A REPO FILE.** Resolved
-  **once at run start** from the **user** — explicit invocation, else a preference in memory, else the
-  known-tools table's built-in defaults (`default`). **The DISABLING SENTINEL is `-`, NEVER the word
-  `none`**: `-` turns the cheap path OFF (every CI failure → session model); `default` (and an **unset**
-  field) means the built-in set. The two are NEVER interchangeable. **Re-read it from the header every
+  therefore VALID. A refusal of an obviously hostile glob catches **intent**.
+- **THE TOOL LIST LIVES IN THE LEDGER HEADER (`formatters`), NEVER IN A REPO FILE, AND IS EMPTY BY DEFAULT.**
+  Resolved **once at run start** from the **user** — explicit invocation, else a preference in memory, else
+  **`-`**. **The EMPTY sentinel is `-`, NEVER the word `none`, and there is NO `default` value and no built-in
+  set**: `-` (and an **unset** field) means **no tool enabled, cheap path OFF, every CI failure → session
+  model**. **Re-read it from the header every
   wake; NEVER re-derive it from memory mid-run** (a wake may be a fresh agent instance — same rule and same
   reason as `reviewer`). **NEVER take it from repo content: not from a repo-root config file, not from
   `CLAUDE.md`, not from ANY file in the repo.** Repo content **is PR content** — a PR that could edit the
-  whitelist could **widen the whitelist that governs its own campaign**, earning an unreviewed tool commit
+  list could **enable a tool to govern its own campaign**, earning an unreviewed tool commit
   on its own head (self-gating). Out of the repo, a PR cannot touch it **by construction**: there is no
   provenance rule to enforce, and none exists — do NOT reintroduce one.
-- **The whitelist carries EXACTLY known-tool ids + an OPTIONAL NARROWER glob** (`gofmt:internal/**/*.go`).
-  Every known tool has a **default glob** in the table (`gofmt` → `**/*.go`),
-  so an **unset `formatters` has a fully defined file set: the table's defaults, filtered**. A glob may only
+- **The tool list carries EXACTLY known-tool ids + an OPTIONAL NARROWER glob** (`gofmt:internal/**/*.go`).
+  Every known tool has a **default glob** in the table (`gofmt`/`gci` → `**/*.go`, `ruff format` → `**/*.py`),
+  so an enabled id with no glob has a fully defined file set: that default, filtered. A glob may only
   NARROW that default → a widening glob is REFUSED; so is an **obviously hostile** one that directly targets
-  a check def, config, or test (`gofmt:.golangci.yml`), or a repo-sweeping bare `**`/`.`. A named list
-  **replaces** the built-ins — an omitted known tool is not run. It **NEVER introduces a binary outside the
-  known-tools table**. **Any id failing any rule is REFUSED** — log it, ignore it, route that failure to the
-  **session model**. NEVER silently honour a refused id.
-- **golangci-lint `whitespace` is NOT in the table**: no safe fixer — its only fix path is the denylisted
+  a check def, config, or test (`gofmt:.golangci.yml`), or a repo-sweeping bare `**`/`.`. The user's list is
+  the WHOLE list — **there are no built-ins to replace**, and a known tool the user does not name is not run.
+  It **NEVER introduces a binary outside the known-tools table**. **Any id failing any rule is REFUSED** —
+  log it, ignore it, route that failure to the **session model**. NEVER silently honour a refused id.
+- **golangci-lint `whitespace` is NOT a known tool**: no safe fixer — its only fix path is the denylisted
   catch-all `golangci-lint run --fix`. NEVER invent a command for it.
-- **NON-OVERRIDABLE DENYLIST — NOTHING widens it**: `prettier` — it reformats the contents of tagged
-  template literals (`` gql`…` ``, `` css`…` ``), changing the runtime string the tag receives; any
+- **NON-OVERRIDABLE DENYLIST — the ONE thing the skill REFUSES; config can NEVER enable one.** These are
+  **KNOWN-BAD: their own docs say they CHANGE the program** — a documented fact, not an inference:
+  **`goimports`** (ADDS missing imports and REMOVES unreferenced ones; an added import runs that package's
+  `init()`, and a guessed import can be the wrong package); **`prettier`** (reformats the contents of tagged
+  template literals — `` gql`…` ``, `` css`…` `` — changing the runtime string the tag receives);
+  **`gofumpt`** (extra rewrite rules beyond gofmt's layout, documented as a rule list of source-construct
+  edits; "it is basically gofmt" is NOT an argument); any
   generic/unscoped "whitespace" or "trailing-whitespace" fixer that can touch string literals, heredocs, or
   Markdown; every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3` (a `modernize` rewrite
   can pass its own rule while changing behavior); every **catch-all fixer** — `golangci-lint run --fix`,
   `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies
-  semantic rules (a whitelisted run invokes ONLY the table's argv). Failing product tests, compile errors,
-  and any rule that rewrites logic are NEVER whitelisted.
-- **TRUST MODEL — do NOT overclaim.** The formatter whitelist is the **user's** (invocation or their own
-  memory), not repo content, so there is no malicious-committer threat model here at all: the denylist, the
-  criterion, and the id-only shape are a **guard against footguns and accidental misuse, NOT a security
+  semantic rules (an enabled run invokes ONLY the table's argv). Failing product tests, compile errors,
+  and any rule that rewrites logic are NEVER fixed by a tool.
+- **TRUST MODEL — do NOT overclaim.** **The skill trusts NO tool: it enables none, and vouches for none.** It
+  owns **HOW** a tool runs, never **WHAT** it does. The tool list is the **user's** (invocation or their own
+  memory), not repo content, so there is no malicious-committer threat model there: the denylist and the
+  id-only shape are a **guard against footguns and accidental misuse, NOT a security
   boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
   the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**,
   why the **file operands are normalized, resolved, checked for aliasing, AND filtered on the RESOLVED path**
@@ -297,25 +303,27 @@
   tree with every path check passing, and a **symlinked directory component** walks a candidate into an
   **excluded** location while its spelling looks innocent), and why the exclusion filter is the skill's, not
   the user's.
-- **Default deny, everywhere.** Keyed on the **tool's IDENTITY and its CITED documented guarantee**, NEVER on a
-  failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, an unresolvable
-  binary, or a refused id → session model (an **unset** `formatters` header is not one of these: it means
-  the table's defaults). The cheap path is keyed to the table, never inferred.
+- **Default deny, and the DEFAULT IS DENY.** Keyed on the **tool's IDENTITY and what the user enabled**, NEVER
+  on a failure "looking mechanical" or on the category "formatter". `formatters` = `-` (the default), tool not
+  enabled, tool not in the table, denylisted id, unresolvable binary, or a refused id → session model. The
+  cheap path is keyed to the table + the user's list, never inferred.
   ACCEPT the tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**;
   AND (b) the diff touches **no check definition, config, or test**. Either fails → **discard the work**
   (reset the worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch
-  a formatter run in place; NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
-- **A whitelisted TOOL's commit resets the gate exactly like a subagent's** (`stage-2-ci.md`, "Any campaign
+  a tool run in place; NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
+- **An enabled TOOL's commit resets the gate exactly like a subagent's** (`stage-2-ci.md`, "Any campaign
   commit to the PR head resets the gate"). Every commit campaign pushes to a PR head — CI-fix subagent,
   review-fix subagent, or tool run with no model — MUST in the same step reset `reviews_ok` to 0 AND
   restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, then relaunch the CI watch and
   re-enter Stage 2a. NEVER treat a tool-written commit as exempt.
 - **Everything the tool does not fix → the scoped CI-fix subagent on the session model**, set explicitly:
-  tool left residue, check not whitelisted, or the failure needs any judgment.
+  no tool enabled (the default), tool left residue, check has no known tool, or the failure needs any
+  judgment.
 - A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
   cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
   green. **The prohibition is load-bearing THERE** — a session-model fixer *can* change semantics, so it
-  *can* weaken a check. **The TOOL path does not need it: the tool cannot weaken what it cannot change.**
+  *can* weaken a check. On the tool path the mechanism (exact argv, checked operands) is what bounds the
+  write — **and the tool's own behaviour is the user's risk, not the skill's guarantee**.
 - Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
   That — with the tool-only formatter path and an external reviewer taking review passes off the subagent
   pool — is where savings live. Never a downgraded model.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -141,16 +141,24 @@
   miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
   catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
   low-judgment, and an under-map is invisible.
-- **The only sanctioned downgrade: a total-oracle CI check** (`SKILL.md`, "The one exception";
-  `stage-2-ci.md`). Allowed IFF (a) re-running the failing check **fully verifies** its own fix
-  (`gofmt`, `goimports`, `golangci-lint` rules), AND (b) the fix changes **no product behavior**, AND (c)
-  the diff touches **no check definition, config, or test**. **Tier 0 — run the autofixer tool, no
-  subagent at all** (`golangci-lint run --fix`, `gofmt -w`, `prettier --write`, …); **Tier 1** — no
-  autofixer → cheap model (`haiku`/`sonnet`), ACCEPT only if the exact failing check now passes and the
-  diff touches no check/config/test, else **discard and re-dispatch on the session model**. Keyed on
-  **check/linter rule IDENTITY**, NEVER on a failure "looking mechanical". Default is NOT whitelisted;
-  unknown check → session model. Failing product tests are NEVER whitelisted. The review gate still reads
-  the whole diff — the whitelist lowers cost, not the gate.
+- **The only sanctioned downgrade: a CI check whose fixer is a semantics-preserving formatter**
+  (`SKILL.md`, "The one exception"; `stage-2-ci.md`). Such a check is a total oracle **only because its
+  fixer cannot change program meaning at all** — the guarantee comes from the TOOL's construction, NEVER
+  from the review gate noticing. **IN**: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
+  `whitespace`, `prettier`, `ruff format`. **OUT**: `modernize` and every other semantic rewriter (a
+  `modernize` rewrite can pass its own rule while changing behavior), plus blanket
+  `golangci-lint run --fix` and blanket `ruff --fix` — a whitelisted run MUST invoke only the formatter,
+  NEVER a catch-all `--fix`. Failing product tests, compile errors, and any rule that rewrites logic are
+  NEVER whitelisted. Keyed on **check/fixer IDENTITY**, NEVER on a failure "looking mechanical". Default
+  is NOT whitelisted; unknown check → session model. **Tier 0 — run the formatter tool, no subagent at
+  all**; **Tier 1** — no usable fixer → cheap model (`haiku`/`sonnet`).
+  **Acceptance criteria (Tier 0 and Tier 1 alike).** ACCEPT the fix **only if all three hold**: (a)
+  re-running the **exact** failing check now **passes**; AND (b) the diff touches **no check definition,
+  config, or test**; AND (c) the diff is **formatting-only** — whitespace, indentation, line breaks, and
+  import-block ordering/insertion/removal — and touches **NOTHING else**: no expression, call, argument,
+  control flow, or literal. Any point fails → **discard the work** (reset the worktree to the PR head)
+  and **re-dispatch the same failure on the session model**. NEVER patch a whitelisted fix in place;
+  NEVER commit an unverified one; NEVER accept a "formatting" fix whose diff edits code.
 - A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
   cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
   green.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -133,6 +133,15 @@
 - Prune `.gauntlet/history/` at every fresh run: drop only entries unambiguously moot against
   current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
   prune an entry you're unsure about.
+- **Set the model explicitly on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset
+  model silently inherits the session model — a cost decision taken by default. Only **CI-fix** is
+  downgraded (**`sonnet`**), because its failure is self-detecting: bad fix → CI stays red → re-dispatch,
+  and a red check blocks the review pass anyway. Review passes, the subagent-fallback review, review-fixes,
+  and the root-cause **mapper** all stay on the **session model** — the first two *are* the gate, and the
+  last two feed an expensive check, so a cheap wrong answer is paid for twice. NEVER downgrade the mapper
+  on the grounds that it is "read-only": read-only is not low-judgment, and an under-map is invisible.
+- Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
+  That, not the model tier, is where fix-subagent savings live.
 - Default reviewer is Claude's own subagents; no external tool is required. Use the user's preferred
   reviewer when one is set (explicit invocation, or a preference in memory/`CLAUDE.md`/carryover). A
   different-model reviewer (e.g. Codex) is recommended for diversity but never required. See

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -167,6 +167,14 @@
   a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**, and a
   repo-supplied `gofmt` is arbitrary code execution; run tools from the environment, not from the tree. And
   **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — name the files being fixed.
+- **PREFLIGHT — verbatim into the cheap CI-fix subagent's prompt. Before formatting a file, REFUSE it if it
+  can write outside the repo:** it **IS a symlink** (`lstat`, not `stat`), **any directory component of its
+  path is a symlink**, or it has **more than one hard link** (`nlink > 1`). Refuse = don't format it, log it,
+  carry on; nothing left to format → **ESCALATE**. The PR is **UNTRUSTED CONTENT** and these aliases are
+  **attacker-placeable**. **THE PRINCIPLE, and nothing beyond it:** diff review covers everything the tool
+  writes **INSIDE** the repo — the model sees it and escalates; it **CANNOT see a write that ESCAPES** the
+  repo (`gofmt -w` writes *through* a symlink or hardlinked inode; `git diff` shows nothing). These three
+  checks exist for **that blind spot alone**.
 - **STATE THE RISK HONESTLY — a cheap model verifying a tool's diff is a MISS-CATCHER, NOT A PROOF.** It can
   miss a semantic change. What backs it: the **exact failing check must pass**; the subagent **must escalate
   anything it cannot verify**; and **every campaign commit still resets the gate and is re-reviewed by the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -134,36 +134,37 @@
   current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
   prune an entry you're unsure about.
 - **Set the model explicitly on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset
-  model silently inherits the session model — a cost decision taken by default. **NO class is downgraded
-  BY DEFAULT**: review passes and the subagent-fallback review *are* the gate; CI-fix and review-fix write
-  **code that gets merged**; the root-cause **mapper** feeds an expensive fix. Nothing downstream
-  *guarantees* a bad result is caught — CI misses a wrong-but-green fix, and the review gate is a
-  miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
+  model silently inherits the session model — a cost decision taken by default. **NO SUBAGENT IS EVER RUN
+  ON A DOWNGRADED MODEL**: review passes and the subagent-fallback review *are* the gate; CI-fix and
+  review-fix write **code that gets merged**; the root-cause **mapper** feeds an expensive fix. Nothing
+  downstream *guarantees* a bad result is caught — CI misses a wrong-but-green fix, and the review gate is
+  a miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
   catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
   low-judgment, and an under-map is invisible.
-- **The only sanctioned downgrade: a CI check whose fixer is a semantics-preserving formatter**
-  (`SKILL.md`, "The one exception"; `stage-2-ci.md`). Such a check is a total oracle **only because its
-  fixer cannot change program meaning at all** — the guarantee comes from the TOOL's construction, NEVER
-  from the review gate noticing. **IN**: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
-  `whitespace`, `prettier`, `ruff format`. **OUT**: `modernize` and every other semantic rewriter (a
-  `modernize` rewrite can pass its own rule while changing behavior), plus blanket
-  `golangci-lint run --fix` and blanket `ruff --fix` — a whitelisted run MUST invoke only the formatter,
-  NEVER a catch-all `--fix`. Failing product tests, compile errors, and any rule that rewrites logic are
-  NEVER whitelisted. Keyed on **check/fixer IDENTITY**, NEVER on a failure "looking mechanical". Default
-  is NOT whitelisted; unknown check → session model. **Tier 0 — run the formatter tool, no subagent at
-  all**; **Tier 1** — no usable fixer → cheap model (`haiku`/`sonnet`).
-  **Acceptance criteria (Tier 0 and Tier 1 alike).** ACCEPT the fix **only if all three hold**: (a)
-  re-running the **exact** failing check now **passes**; AND (b) the diff touches **no check definition,
-  config, or test**; AND (c) the diff is **formatting-only** — whitespace, indentation, line breaks, and
-  import-block ordering/insertion/removal — and touches **NOTHING else**: no expression, call, argument,
-  control flow, or literal. Any point fails → **discard the work** (reset the worktree to the PR head)
-  and **re-dispatch the same failure on the session model**. NEVER patch a whitelisted fix in place;
-  NEVER commit an unverified one; NEVER accept a "formatting" fix whose diff edits code.
+- **The only cheap path: a whitelisted CI check whose fixer is a semantics-preserving formatter — run the
+  TOOL, no model at all** (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`). The safety comes from the
+  TOOL's construction: its output cannot change program meaning. That guarantee does **NOT** transfer to a
+  model hand-editing the same file — a diff that *looks* like formatting is NOT a proof of semantic
+  equivalence (a pure-indentation edit can move behavior in a whitespace-significant language and still be
+  formatter-clean), so there is no diff-shape guard that would make a cheap model's edit safe to accept.
+  **IN**: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`, `whitespace`, `prettier`,
+  `ruff format`. **OUT**: `modernize` and every other semantic rewriter (a `modernize` rewrite can pass its
+  own rule while changing behavior), plus blanket `golangci-lint run --fix` and blanket `ruff --fix` — a
+  whitelisted run MUST invoke only the formatter, NEVER a catch-all `--fix`. Failing product tests, compile
+  errors, and any rule that rewrites logic are NEVER whitelisted. Keyed on **check/fixer IDENTITY**, NEVER
+  on a failure "looking mechanical". Default is NOT whitelisted; unknown check → session model. ACCEPT the
+  tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**; AND (b) the
+  diff touches **no check definition, config, or test**. Either fails → **discard the work** (reset the
+  worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch a
+  formatter run in place; NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
+- **Everything the tool does not fix → the scoped CI-fix subagent on the session model**, set explicitly:
+  tool left residue, check not whitelisted, or the failure needs any judgment.
 - A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
   cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
   green.
 - Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
-  That, not the model tier, is where fix-subagent savings live.
+  That — with the tool-only formatter path and an external reviewer taking review passes off the subagent
+  pool — is where savings live. Never a downgraded model.
 - Default reviewer is Claude's own subagents; no external tool is required. Use the user's preferred
   reviewer when one is set (explicit invocation, or a preference in memory/`CLAUDE.md`/carryover). A
   different-model reviewer (e.g. Codex) is recommended for diversity but never required. See

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -134,13 +134,23 @@
   current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
   prune an entry you're unsure about.
 - **Set the model explicitly on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset
-  model silently inherits the session model — a cost decision taken by default. **NO class is
-  downgraded**: review passes and the subagent-fallback review *are* the gate; CI-fix and review-fix write
+  model silently inherits the session model — a cost decision taken by default. **NO class is downgraded
+  BY DEFAULT**: review passes and the subagent-fallback review *are* the gate; CI-fix and review-fix write
   **code that gets merged**; the root-cause **mapper** feeds an expensive fix. Nothing downstream
   *guarantees* a bad result is caught — CI misses a wrong-but-green fix, and the review gate is a
   miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
   catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
   low-judgment, and an under-map is invisible.
+- **The only sanctioned downgrade: a total-oracle CI check** (`SKILL.md`, "The one exception";
+  `stage-2-ci.md`). Allowed IFF (a) re-running the failing check **fully verifies** its own fix
+  (`gofmt`, `goimports`, `golangci-lint` rules), AND (b) the fix changes **no product behavior**, AND (c)
+  the diff touches **no check definition, config, or test**. **Tier 0 — run the autofixer tool, no
+  subagent at all** (`golangci-lint run --fix`, `gofmt -w`, `prettier --write`, …); **Tier 1** — no
+  autofixer → cheap model (`haiku`/`sonnet`), ACCEPT only if the exact failing check now passes and the
+  diff touches no check/config/test, else **discard and re-dispatch on the session model**. Keyed on
+  **check/linter rule IDENTITY**, NEVER on a failure "looking mechanical". Default is NOT whitelisted;
+  unknown check → session model. Failing product tests are NEVER whitelisted. The review gate still reads
+  the whole diff — the whitelist lowers cost, not the gate.
 - A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
   cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
   green.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -161,8 +161,13 @@
   argv, is a **SKILL change**.
 - **THE TABLE HOLDS ONE TOOL — `gofmt`. The criterion was applied TO OURSELVES.** Its cell quotes
   https://pkg.go.dev/cmd/gofmt (*"Gofmt formats Go programs. It uses tabs for indentation and blanks for
-  alignment"*; the two flags that make it do more are **`-r`** and **`-s`**, and **neither is in the
-  skill-owned argv**). Each `guarantee` cell MUST carry a **LINK to the tool's own doc and the passage
+  alignment"*; of the flags the doc lists, the only two that **CHANGE THE SOURCE** are **`-r`** — *"Apply the
+  rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* — and **neither
+  is in the skill-owned argv**). **That claim is about SOURCE-CHANGING flags ONLY — the doc lists others
+  (`-l`, `-d`, `-e`, `-cpuprofile`, …), and `-cpuprofile` WRITES A FILE.** NEVER restate it as "gofmt has
+  only two flags". Safety rests on: the argv is **skill-owned and exact**; **NO flag is ever appended**; and
+  **no file operand can be read as a flag** (`--` + the operand-normalization rules) — the injection repro
+  below is a file named `-cpuprofile=prof.go`. Each `guarantee` cell MUST carry a **LINK to the tool's own doc and the passage
   QUOTED**; **FOLLOW the link before trusting the cell** — a claim that cannot be tied to a source means the
   tool comes **OUT of the table**. **The cheap path therefore covers Go formatting and NOTHING else; every
   other CI failure — ALL Python/JS/etc formatting included — goes to the SESSION MODEL.** That is the safe
@@ -187,7 +192,8 @@
   (b) pass every file as an **ABSOLUTE** (or `./`-prefixed) path — **NEVER a bare relative name**, which is
   belt-and-braces even if `--` fails; (c) **REFUSE any candidate name starting with `-`** — **DROP that file**
   and log it; do **NOT** abort the run. NEVER pass the glob itself to the tool.
-  Empty set after refusals → run nothing for that id → session model.
+  **NEVER invoke the tool with an EMPTY operand set — `gofmt` with no operands READS STDIN.** Empty set after
+  refusals → run nothing for that id → session model.
 - **A PATH IS DATA THAT RESOLVES — NORMALIZING ITS SPELLING IS NOT ENOUGH** (`stage-2-ci.md`). **Repro:** the
   PR adds `link.go`, a **symlink** pointing outside the worktree. It matches `**/*.go`, survives the exclusion
   filter, and its name is clean — and `gofmt -w -- link.go` **FOLLOWS it and rewrites the target OUTSIDE the
@@ -198,6 +204,14 @@
   (compare on a path-component boundary — `/wt-evil` is not under `/wt`); and **REFUSE a candidate that is not
   a REGULAR FILE** (directory, device, fifo, socket). **DROP** each and **LOG** it (id, path, reason —
   symlink escape / escapes the worktree / not a regular file); do NOT abort. Empty set → session model.
+- **A PATH CHECK BOUNDS WHERE WE LOOK; IT DOES NOT BOUND WHAT WE WRITE — THE INODE CAN BE ALIASED OUTSIDE THE
+  TREE** (`stage-2-ci.md`). **Repro:** the PR adds `alias.go`, a **HARDLINK** sharing an INODE with a file
+  outside the worktree. It is a **regular file**, it is **not a symlink** (`lstat` says regular), and its
+  **`realpath` is INSIDE the worktree** — it passes every check above. `gofmt -w` truncates and rewrites the
+  **EXISTING INODE**, so formatting it **MUTATES THE OUTSIDE ALIAS**. Therefore, the sixth check: **REFUSE any
+  candidate with a LINK COUNT > 1** (`stat` → `st_nlink > 1`). A source file in a normal checkout has exactly
+  **one** link; a multi-link file is a hardlink escape or something we have no reason to format. **DROP** and
+  **LOG** it (id, path, reason — `hardlink — nlink>1`); **NEVER abort the run**. Empty set → session model.
 - **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
   in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
   the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
@@ -247,8 +261,9 @@
   criterion, and the id-only shape are a **guard against footguns and accidental misuse, NOT a security
   boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
   the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**,
-  why the **file operands are normalized AND resolved** (they are PR data spliced into argv, and a symlink
-  among them walks the tool out of the tree), and why the exclusion filter is the skill's, not the user's.
+  why the **file operands are normalized, resolved, AND checked for aliasing** (they are PR data spliced into
+  argv; a **symlink** among them walks the tool out of the tree, and a **hardlink** walks the WRITE out of the
+  tree with every path check passing), and why the exclusion filter is the skill's, not the user's.
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and its CITED documented guarantee**, NEVER on a
   failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, an unresolvable
   binary, or a refused id → session model (an **unset** `formatters` header is not one of these: it means

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -151,12 +151,30 @@
   *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
   in a whitespace-significant language and stay formatter-clean).
 - **THE SKILL OWNS THE EXACT ARGV; NOTHING ELSE SUPPLIES A COMMAND.** The known-tools table
-  (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`,
-  `ruff format`, each over that id's files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
+  (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w --`, `gci write --`, `ruff format --`, each
+  over that id's normalized files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
   rewrites `return true` into `return false` with a known `argv[0]` and no shell metacharacters, so tool
   identity alone is NOT sufficient. The whitelist therefore carries **ids and globs only** — it can NEVER
   name a `command`/`args`/`argv`/flag. NEVER append a flag to a table argv. Adding a tool, or changing an
   argv, is a **SKILL change**.
+- **THE TABLE IS SMALL, AND THE CRITERION IS APPLIED HONESTLY — `gofmt`, `gci`, `ruff format`.** Each
+  `guarantee` MUST cite what the tool **DOCUMENTS**, never a paraphrase of "it's a formatter". **REJECTED,
+  and re-adding one is a SKILL change that must first defeat the reason**: `goimports` — documented to **ADD
+  missing imports and REMOVE unreferenced ones**; an added import runs that package's `init()` and a guessed
+  import can be the **wrong package** → not semantics-preserving. `gofumpt` — **extra rewrite rules beyond
+  `go/printer` layout**, documented as a rule list, **never** as semantics-preserving; "it is basically
+  gofmt" is NOT an argument. Fewer tools that provably hold beats more that mostly do.
+- **NORMALIZE THE FILE ARGV — FILENAMES ARE PR-CONTROLLED DATA** (`stage-2-ci.md`). The skill owns the argv
+  **SHAPE**, not the operands: `<files>` is globbed from the **PR's worktree**, so every filename is
+  attacker-controlled data spliced into argv, and MUST be normalized like any injection boundary. **Repro:**
+  a PR adds a file named `-cpuprofile=prof.go`; it matches `**/*.go`, survives the exclusion filter, and
+  `gofmt -w '-cpuprofile=prof.go' a.go` exits 0 having parsed it as a **FLAG** and written a CPU profile —
+  trusted binary, skill-owned argv, no shell, no model, and PR content still steered the command. Therefore,
+  EVERY tool, EVERY run: (a) pass **`--`** before the file list — a tool without `--` NEVER enters the table;
+  (b) pass every file as an **ABSOLUTE** (or `./`-prefixed) path — **NEVER a bare relative name**, which is
+  belt-and-braces even if `--` fails; (c) **REFUSE any candidate name starting with `-`** after the exclusion
+  filter — **DROP that file** and log it; do **NOT** abort the run. NEVER pass the glob itself to the tool.
+  Empty set after refusals → run nothing for that id → session model.
 - **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
   in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
   the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
@@ -210,8 +228,9 @@
   memory), not repo content, so there is no malicious-committer threat model here at all: the denylist, the
   criterion, and the id-only shape are a **guard against footguns and accidental misuse, NOT a security
   boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
-  the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**
-  and why the exclusion filter is the skill's, not the user's.
+  the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**,
+  why the **file operands are normalized** (they are PR data spliced into argv), and why the exclusion filter
+  is the skill's, not the user's.
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
   failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, an unresolvable
   binary, or a refused id → session model (an **unset** `formatters` header is not one of these: it means

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -134,16 +134,16 @@
   current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
   prune an entry you're unsure about.
 - **Set the model explicitly on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset
-  model silently inherits the session model — a cost decision taken by default. Only **CI-fix** is
-  downgraded (**`sonnet`**), because both its failure modes are caught, by two different nets: *fix didn't
-  work* → CI stays red → re-dispatch; *fix weakened the check* → CI turns **green**, so CI misses it and
-  the **review gate** catches it on the full diff. NEVER claim CI catches everything. A CI-fix subagent
-  MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the cause, NEVER gut an
-  assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force green.
-  Review passes, the subagent-fallback review, review-fixes,
-  and the root-cause **mapper** all stay on the **session model** — the first two *are* the gate, and the
-  last two feed an expensive check, so a cheap wrong answer is paid for twice. NEVER downgrade the mapper
-  on the grounds that it is "read-only": read-only is not low-judgment, and an under-map is invisible.
+  model silently inherits the session model — a cost decision taken by default. **NO class is
+  downgraded**: review passes and the subagent-fallback review *are* the gate; CI-fix and review-fix write
+  **code that gets merged**; the root-cause **mapper** feeds an expensive fix. Nothing downstream
+  *guarantees* a bad result is caught — CI misses a wrong-but-green fix, and the review gate is a
+  miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
+  catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
+  low-judgment, and an under-map is invisible.
+- A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
+  cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
+  green.
 - Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
   That, not the model tier, is where fix-subagent savings live.
 - Default reviewer is Claude's own subagents; no external tool is required. Use the user's preferred

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -158,13 +158,30 @@
   identity alone is NOT sufficient. A `.gauntlet.yml` entry that supplies `command`/`args`/`argv`/flags is
   **REFUSED**. NEVER append a flag to a table argv. Adding a tool, or changing an argv, is a **SKILL change**,
   NEVER a config change.
-- **`.gauntlet.yml` entries carry EXACTLY `id` + `files`** — which known tool, and the glob it may touch.
-  `files` MUST NOT be able to reach a **check definition, config, or test** path (`.golangci.yml`,
-  `.github/**`, `**/*_test.go`, `test/**`, `tests/**`, `conftest.py`, `pyproject.toml`, `ruff.toml`,
-  `.gauntlet.yml`, a repo-sweeping `**`) → REFUSE. That is the no-weakening prohibition enforced at the
-  config layer. Entries **remove** built-ins by omission; `formatters: []` disables the cheap path entirely.
-  They **NEVER introduce a binary outside the known-tools table**. **Any entry failing any rule is REFUSED**
-  — log it, ignore it, route that failure to the **session model**. NEVER silently honour a refused entry.
+- **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
+  in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
+  the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
+  runs with no model and no review**. Before every run, resolve `argv[0]` to an **absolute** path using a
+  `PATH` stripped of `.`, `..`, empty entries, **all relative entries**, the worktree, the repo root, and any
+  directory inside them; the resolved executable (symlinks followed) **MUST live OUTSIDE the repo/worktree
+  tree**. Resolves inside, or does not resolve → **REFUSE → session model**. NEVER run the tool with the
+  worktree on `PATH` or as the lookup base. NEVER execute a binary the PR could have supplied.
+- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER, applied AFTER the glob, EVERY time** — no tests
+  (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), no check definitions
+  (`.github/**`, …), no CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`,
+  `.gauntlet.yml`, …). **Config CANNOT widen it**, and config NEVER carries the exclusions itself: a
+  user-written exclusion list **will** omit something. The glob SELECTS; the FILTER protects. `files:
+  "**/*.go"` is therefore VALID — the filter drops the test files. The **filter is the guarantee**; a
+  refusal is only a signal.
+- **`.gauntlet.yml` entries carry EXACTLY `id` + OPTIONAL `files`** — which known tool, and at most a
+  **NARROWER** glob. Every known tool has a **default glob** in the table (`gofmt` → `**/*.go`, `ruff
+  format` → `**/*.py`, …), so a **missing config has a fully defined file set: the table's defaults,
+  filtered**. `files` may only NARROW that default → a widening glob is REFUSED; so is an **obviously
+  hostile** one that directly targets a check def, config, or test (`files: ".golangci.yml"`), or a
+  repo-sweeping bare `**`/`.`. Entries **remove** built-ins by omission; `formatters: []` disables the cheap
+  path entirely. They **NEVER introduce a binary outside the known-tools table**. **Any entry failing any
+  rule is REFUSED** — log it, ignore it, route that failure to the **session model**. NEVER silently honour
+  a refused entry.
 - **A tool's guarantee can be CONDITIONAL on its CONFIGURATION**: `ruff format` verifies AST equivalence
   **only while the repo's Ruff config does NOT enable `format.docstring-code-format`** (that setting
   reformats Python code inside docstrings — rewrites string contents → NOT AST-equivalent). Campaign MUST
@@ -191,8 +208,9 @@
   malicious committer**. NEVER present them as one. What the base-branch rule DOES buy is real and MUST be
   kept: **a PR under review cannot widen the whitelist that governs its own campaign.**
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
-  failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, missing or
-  unparseable config, or a refused entry → session model. The cheap path is opt-in per tool, never inferred.
+  failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, **unparseable**
+  config, an unresolvable binary, or a refused entry → session model (a **missing** config is not one of
+  these: it means the table's defaults). The cheap path is keyed to the table, never inferred.
   ACCEPT the tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**;
   AND (b) the diff touches **no check definition, config, or test**. Either fails → **discard the work**
   (reset the worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -28,7 +28,9 @@
   `.gauntlet/tmp/**` (ledger, plans, progress, review/CI outputs, lease) and the carryover tree
   `.gauntlet/history/**`. A fix commit stages ONLY the specific source files it changes, by explicit
   path — never `git add -A` / `git add .`, which would sweep in run state. The tree must be
-  git-ignored; add `.gauntlet/` to `.gitignore` if missing.
+  git-ignored; add `.gauntlet/` to `.gitignore` if missing. The repo-root `.gauntlet.yml` is NOT in that
+  tree — it is COMMITTED repo config (the formatter whitelist), read from the **base** branch, never from a
+  PR head.
 - NEVER `rm -rf .gauntlet/` — that destroys the durable carryover history. Only `.gauntlet/tmp/**` is
   disposable.
 - NEVER pass destructive instructions (delete, force-push, reset) to an external reviewer command
@@ -150,23 +152,38 @@
   proof of semantic equivalence (a pure-indentation edit can move behavior in a whitespace-significant
   language and still be formatter-clean), so there is no diff-shape guard that would make a cheap model's
   edit safe to accept.
-  **IN**: `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents),
-  `goimports` (import block only), `gci` (import grouping/ordering only — Go init order is by dependency,
-  not by import order), golangci-lint `whitespace` (Go: leading/trailing newlines inside function bodies),
-  `ruff format` (verifies AST equivalence of its output).
-  **OUT**: `prettier` — it reformats the contents of tagged template literals (`` gql`…` ``, `` css`…` ``),
-  changing the runtime string the tag receives; any generic/unscoped "whitespace" or "trailing-whitespace"
-  fixer that can touch string literals, heredocs, or Markdown; `modernize` and every other semantic
-  rewriter (a `modernize` rewrite can pass its own rule while changing behavior); plus blanket
-  `golangci-lint run --fix` and blanket `ruff --fix` — a whitelisted run MUST invoke only the whitelisted
-  formatter, NEVER a catch-all `--fix`. Failing product tests, compile errors, and any rule that rewrites
-  logic are NEVER whitelisted. Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
-  failure "looking mechanical" or on the category "formatter". Default is NOT whitelisted; unknown check or
-  unlisted tool → session model. ACCEPT the tool's run **only if both hold**: (a) re-running the **exact**
-  failing check now **passes**; AND (b) the diff touches **no check definition, config, or test**. Either
-  fails → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on
-  the session model**. NEVER patch a formatter run in place; NEVER commit an unverified one; NEVER hand the
-  failure to a cheap model instead.
+  **The LIST is repo-configurable; the CRITERION is NOT.** Whitelist = built-in **defaults** merged with the
+  repo's `.gauntlet.yml`, never a fixed list (a fixed list is meaningless in a Rust/Java/Ruby repo).
+  **Built-in defaults (IN)**: `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch
+  string-literal contents), `goimports` (import block only), `gci` (import grouping/ordering only — Go init
+  order is by dependency, not by import order), golangci-lint `whitespace` (Go: leading/trailing newlines
+  inside function bodies), `ruff format` (verifies AST equivalence of its output).
+  **NON-OVERRIDABLE DENYLIST — config CANNOT widen it**: `prettier` — it reformats the contents of tagged
+  template literals (`` gql`…` ``, `` css`…` ``), changing the runtime string the tag receives; any
+  generic/unscoped "whitespace" or "trailing-whitespace" fixer that can touch string literals, heredocs, or
+  Markdown; every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3` (a `modernize` rewrite
+  can pass its own rule while changing behavior); every **catch-all fixer** — `golangci-lint run --fix`,
+  `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies
+  semantic rules (a whitelisted run MUST invoke only the whitelisted formatter); and anything whose command
+  can touch a **check definition, config, or test** (the no-weakening prohibition — a hard rule). Failing
+  product tests, compile errors, and any rule that rewrites logic are NEVER whitelisted.
+- **`.gauntlet.yml` (repo root, COMMITTED — NOT under the git-ignored `.gauntlet/` tree) is read from the
+  BASE branch, NEVER from the PR's worktree/head** (`git show origin/<base>:.gauntlet.yml`; `stage-2-ci.md`).
+  Reading it from the PR would let a PR **widen the whitelist that governs its own campaign** — a semantic
+  rewriter admitted by the PR under review, earning an unreviewed tool commit on its own head. That is
+  self-gating in config form. A PR that edits `.gauntlet.yml` takes effect only **after it merges**.
+  Entries may **append** tools or **remove** built-ins; `formatters: []` disables the cheap path entirely.
+  Every entry MUST carry `id`, `command`, `files`, and **`guarantee`** — a concrete pointer to the tool's
+  DOCUMENTED semantic-equivalence behaviour. "It's just formatting" is NOT a guarantee. **An entry with no
+  real guarantee, or one hitting the denylist, is REFUSED** — log it, ignore it, route that failure to the
+  session model. NEVER silently honour a denied entry.
+- **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
+  failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, missing or
+  unparseable config, or a refused entry → session model. The cheap path is opt-in per tool, never inferred.
+  ACCEPT the tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**;
+  AND (b) the diff touches **no check definition, config, or test**. Either fails → **discard the work**
+  (reset the worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch
+  a formatter run in place; NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 - **A whitelisted TOOL's commit resets the gate exactly like a subagent's** (`stage-2-ci.md`, "Any campaign
   commit to the PR head resets the gate"). Every commit campaign pushes to a PR head — CI-fix subagent,
   review-fix subagent, or tool run with no model — MUST in the same step reset `reviews_ok` to 0 AND

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -163,18 +163,22 @@
   `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies semantic rules;
   **`goimports`** (it ADDS imports — an added import runs that package's `init()`); **`prettier`** (it
   rewrites the contents of tagged template literals); **`gofumpt`** (extra rewrite rules beyond layout);
-  `modernize`, codemods, `pyupgrade`, `2to3`. **Use a formatter that only reformats.** Also: **NEVER execute
+  `modernize`, codemods, `pyupgrade`, `2to3`. **Use a formatter that only reformats.** (A guard against
+  **footguns and accidental misuse — NOT a security boundary** against a malicious committer.) Also: **NEVER execute
   a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**, and a
   repo-supplied `gofmt` is arbitrary code execution; run tools from the environment, not from the tree. And
   **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — name the files being fixed.
-- **PREFLIGHT — verbatim into the cheap CI-fix subagent's prompt. Before formatting a file, REFUSE it if it
-  can write outside the repo:** it **IS a symlink** (`lstat`, not `stat`), **any directory component of its
-  path is a symlink**, or it has **more than one hard link** (`nlink > 1`). Refuse = don't format it, log it,
-  carry on; nothing left to format → **ESCALATE**. The PR is **UNTRUSTED CONTENT** and these aliases are
-  **attacker-placeable**. **THE PRINCIPLE, and nothing beyond it:** diff review covers everything the tool
-  writes **INSIDE** the repo — the model sees it and escalates; it **CANNOT see a write that ESCAPES** the
-  repo (`gofmt -w` writes *through* a symlink or hardlinked inode; `git diff` shows nothing). These three
-  checks exist for **that blind spot alone**.
+- **PREFLIGHT — verbatim into the cheap CI-fix subagent's prompt. Before formatting a file, REFUSE it if the
+  write can land outside the worktree:** it **IS a symlink** (`lstat`, not `stat`), or **any directory
+  component of its path is a symlink**. Refuse = don't format it, log it, carry on; nothing left to format →
+  **ESCALATE**. **THE PRINCIPLE, and nothing beyond it:** diff review covers everything the tool writes
+  **INSIDE** the repo — the model sees it and escalates; it **CANNOT see a write that ESCAPES** the repo
+  (`gofmt -w` writes *through* a symlink; `git diff` shows nothing). These two checks exist for **that blind
+  spot alone**. **A FOOTGUN GUARD, NOT A SECURITY BOUNDARY — never present it as one**, exactly like the
+  denylist: campaign adopts **same-repo PRs only** (`pr-adoption.md`), so whoever commits the symlink already
+  has repo write access. The realistic harm is **a source file elsewhere on the machine gets reformatted** —
+  a parser-backed formatter writes only its rendering of source it PARSED (a generic TEXT formatter rewrites
+  whatever it is handed: bigger exposure). Worth one `lstat`: it stops a real accident.
 - **STATE THE RISK HONESTLY — a cheap model verifying a tool's diff is a MISS-CATCHER, NOT A PROOF.** It can
   miss a semantic change. What backs it: the **exact failing check must pass**; the subagent **must escalate
   anything it cannot verify**; and **every campaign commit still resets the gate and is re-reviewed by the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -161,11 +161,17 @@
   argv, is a **SKILL change**.
 - **THE TABLE HOLDS ONE TOOL — `gofmt`. The criterion was applied TO OURSELVES.** Its cell quotes
   https://pkg.go.dev/cmd/gofmt (*"Gofmt formats Go programs. It uses tabs for indentation and blanks for
-  alignment"*; of the flags the doc lists, the only two that **CHANGE THE SOURCE** are **`-r`** — *"Apply the
-  rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* — and **neither
-  is in the skill-owned argv**). **That claim is about SOURCE-CHANGING flags ONLY — the doc lists others
-  (`-l`, `-d`, `-e`, `-cpuprofile`, …), and `-cpuprofile` WRITES A FILE.** NEVER restate it as "gofmt has
-  only two flags". Safety rests on: the argv is **skill-owned and exact**; **NO flag is ever appended**; and
+  alignment"*). **`-w`** — *"If a file's formatting is different from gofmt's, overwrite it with gofmt's
+  version"* — **CHANGES THE SOURCE: it writes the formatted result back to the file. That is what we WANT,
+  and it is the ONLY mutation the skill-owned argv performs.** **`-r`** — *"Apply the rewrite rule to the
+  source before reformatting"* — and **`-s`** — *"Try to simplify code"* — are the only documented flags that
+  apply a **non-formatting source TRANSFORMATION** (they change the PROGRAM, beyond re-printing it), and
+  **NEITHER is in the skill-owned argv**. **`-cpuprofile` is a separate documented flag that WRITES A FILE**
+  (it does not transform the source); it is named only because a FILENAME shaped like `-cpuprofile=x.go` is
+  the injection repro. The doc lists others still (`-l`, `-d`, `-e`, …). **GUARD — this claim has been stated
+  wrongly THREE times: NEVER say "exactly two flags", "the only two flags", or "the only flags that CHANGE
+  the source". State ONLY the TRANSFORMATION property.** Safety rests on: the argv is **skill-owned and
+  exact**; **NO flag is ever appended**; and
   **no file operand can be read as a flag** (`--` + the operand-normalization rules) — the injection repro
   below is a file named `-cpuprofile=prof.go`. Each `guarantee` cell MUST carry a **LINK to the tool's own doc and the passage
   QUOTED**; **FOLLOW the link before trusting the cell** — a claim that cannot be tied to a source means the
@@ -212,6 +218,18 @@
   candidate with a LINK COUNT > 1** (`stat` → `st_nlink > 1`). A source file in a normal checkout has exactly
   **one** link; a multi-link file is a hardlink escape or something we have no reason to format. **DROP** and
   **LOG** it (id, path, reason — `hardlink — nlink>1`); **NEVER abort the run**. Empty set → session model.
+- **EVERY CHECK THAT REASONS ABOUT A PATH MUST REASON ABOUT THE RESOLVED PATH — A NAME IS NOT A LOCATION**
+  (`stage-2-ci.md`). **Repro:** the PR adds a **symlinked DIRECTORY** `safe/gh -> .github`. The candidate
+  `safe/gh/actions/main.go` is **not itself a symlink**, its **`realpath` is INSIDE the worktree**, it is a
+  **regular file with `nlink == 1`**, and its name is clean — it passes all six checks above — while the
+  **exclusion filter, matched on the SPELLED path, never sees `.github/**`**. A **check definition** is handed
+  to the tool, with no model and no review. Therefore: **apply the skill-owned EXCLUSION FILTER to the
+  RESOLVED path as well as the original — EITHER matches → REFUSE**; **AND the seventh check: REFUSE any
+  candidate with a SYMLINK in ANY DIRECTORY COMPONENT** (walk the components from the resolved worktree root
+  down, `lstat` each; any symlink → **DROP** + **LOG**, reason `symlinked directory component` /
+  `excluded after resolution`). The resolved-path filter is the **guarantee**; the component check is the
+  cheap explicit **tripwire**. Run **BOTH**. **THE PIPELINE:** glob → **RESOLVE** → **FILTER both spellings**
+  → the **seven** checks → argv.
 - **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
   in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
   the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
@@ -220,10 +238,13 @@
   directory inside them; the resolved executable (symlinks followed) **MUST live OUTSIDE the repo/worktree
   tree**. Resolves inside, or does not resolve → **REFUSE → session model**. NEVER run the tool with the
   worktree on `PATH` or as the lookup base. NEVER execute a binary the PR could have supplied.
-- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER, applied AFTER the glob, EVERY time** — no tests
+- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER, applied to the RESOLVED path, EVERY time** — no tests
   (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), no check definitions
   (`.github/**`, …), no CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`, …).
-  **NOTHING widens it**, and the whitelist NEVER carries the exclusions itself: a user-written exclusion
+  **Match the patterns against BOTH the candidate's original path AND its `realpath` taken relative to the
+  resolved worktree root — EITHER matches → REFUSE** (a filter matched on the spelling alone is defeated by a
+  symlinked directory; see the resolved-path rule above). **NOTHING widens it**, and the whitelist NEVER
+  carries the exclusions itself: a user-written exclusion
   list **will** omit something. The glob SELECTS; the FILTER protects. A `gofmt:**/*.go` narrowing is
   therefore VALID — the filter drops the test files. The **filter is the guarantee**; a refusal is only a
   signal.
@@ -261,9 +282,12 @@
   criterion, and the id-only shape are a **guard against footguns and accidental misuse, NOT a security
   boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
   the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**,
-  why the **file operands are normalized, resolved, AND checked for aliasing** (they are PR data spliced into
-  argv; a **symlink** among them walks the tool out of the tree, and a **hardlink** walks the WRITE out of the
-  tree with every path check passing), and why the exclusion filter is the skill's, not the user's.
+  why the **file operands are normalized, resolved, checked for aliasing, AND filtered on the RESOLVED path**
+  (they are PR data spliced into
+  argv; a **symlink** among them walks the tool out of the tree, a **hardlink** walks the WRITE out of the
+  tree with every path check passing, and a **symlinked directory component** walks a candidate into an
+  **excluded** location while its spelling looks innocent), and why the exclusion filter is the skill's, not
+  the user's.
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and its CITED documented guarantee**, NEVER on a
   failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, an unresolvable
   binary, or a refused id → session model (an **unset** `formatters` header is not one of these: it means

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -152,13 +152,24 @@
   proof of semantic equivalence (a pure-indentation edit can move behavior in a whitespace-significant
   language and still be formatter-clean), so there is no diff-shape guard that would make a cheap model's
   edit safe to accept.
-  **The LIST is repo-configurable; the CRITERION is NOT.** Whitelist = built-in **defaults** merged with the
-  repo's `.gauntlet.yml`, never a fixed list (a fixed list is meaningless in a Rust/Java/Ruby repo).
-  **Built-in defaults (IN)**: `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch
-  string-literal contents), `goimports` (import block only), `gci` (import grouping/ordering only — Go init
-  order is by dependency, not by import order), golangci-lint `whitespace` (Go: leading/trailing newlines
-  inside function bodies), `ruff format` (verifies AST equivalence of its output).
-  **NON-OVERRIDABLE DENYLIST — config CANNOT widen it**: `prettier` — it reformats the contents of tagged
+  **The LIST is repo-configurable; the CRITERION is NOT.** Whitelist = built-in **defaults**, as the repo's
+  `.gauntlet.yml` re-configures (flags, files) or removes them — a fixed set of flags is meaningless in a
+  Rust/Java/Ruby repo.
+  **Built-in defaults — the KNOWN-TOOLS TABLE, the ONLY binaries campaign may run on the no-model path**:
+  `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents), `goimports`
+  (import block only), `gci` (import grouping/ordering only — Go init order is by dependency, not by import
+  order), `ruff format` (verifies AST equivalence of its output) — **only while the repo's Ruff config does
+  NOT enable `format.docstring-code-format`** (that setting reformats Python code inside docstrings, i.e.
+  rewrites string contents → NOT AST-equivalent). **Adding a tool to this table is a SKILL change, NEVER a
+  config change.**
+  **golangci-lint `whitespace` is REMOVED from the defaults**: no safe fixer — its only fix path is the
+  denylisted catch-all `golangci-lint run --fix`. NEVER invent a command for it.
+- **A tool's guarantee can be CONDITIONAL on its CONFIGURATION** (`ruff format`, above). Therefore: every
+  `guarantee` MUST **state the conditions under which it holds**, and campaign MUST **verify those
+  conditions hold in THIS repo** (read the tool's config from the **base** branch) before taking the
+  no-model path. Condition enabled/violated, or **undeterminable** → NOT whitelisted for this repo →
+  session model. Default deny; NEVER assume a default.
+- **NON-OVERRIDABLE DENYLIST — config CANNOT widen it**: `prettier` — it reformats the contents of tagged
   template literals (`` gql`…` ``, `` css`…` ``), changing the runtime string the tag receives; any
   generic/unscoped "whitespace" or "trailing-whitespace" fixer that can touch string literals, heredocs, or
   Markdown; every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3` (a `modernize` rewrite
@@ -172,11 +183,31 @@
   Reading it from the PR would let a PR **widen the whitelist that governs its own campaign** — a semantic
   rewriter admitted by the PR under review, earning an unreviewed tool commit on its own head. That is
   self-gating in config form. A PR that edits `.gauntlet.yml` takes effect only **after it merges**.
-  Entries may **append** tools or **remove** built-ins; `formatters: []` disables the cheap path entirely.
-  Every entry MUST carry `id`, `command`, `files`, and **`guarantee`** — a concrete pointer to the tool's
-  DOCUMENTED semantic-equivalence behaviour. "It's just formatting" is NOT a guarantee. **An entry with no
-  real guarantee, or one hitting the denylist, is REFUSED** — log it, ignore it, route that failure to the
-  session model. NEVER silently honour a denied entry.
+  Entries may **re-configure the flags/files of a KNOWN tool** or **remove** built-ins; `formatters: []`
+  disables the cheap path entirely. They may **NEVER introduce a binary outside the known-tools table**.
+- **CONSTRAIN THE COMMAND'S SHAPE, not just the tool's category** — the attack is command *construction*:
+  an entry can cite `gofmt`'s guarantee while executing `./scripts/fmt.sh` (a wrapper that rewrites product
+  code), `sh -c "gofmt -w . && ruff --fix ."`, or a PATH-shadowed `gofmt`. Checking fields, `guarantee`
+  text, and tool *categories* does NOT stop that. Every entry MUST carry `id`, `command`, `files`,
+  `guarantee`, AND:
+  - **`command` is an argv LIST** — `["gofmt", "-w"]` — **executed WITHOUT a shell**. NEVER `sh -c`, NEVER
+    `bash -c`, NEVER a shell string.
+  - **REFUSE any shell metacharacter** in the argv: `&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks,
+    newlines. No legitimate formatter entry needs them.
+  - **`argv[0]` MUST be a BARE TOOL NAME from the known-tools table** — NOT a path (`./x`,
+    `/usr/local/bin/x`), NOT a wrapper script, NOT an alias, NOT `sh`/`bash`/`env`/`xargs`. Contains `/` →
+    REFUSE. Not in the table → REFUSE.
+  - **`guarantee`** is a concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour AND
+    **states the conditions under which it holds**, and those conditions **verify in this repo**. "It's just
+    formatting" is NOT a guarantee.
+
+  **Any entry failing ANY of the above, or hitting the denylist, is REFUSED** — log it, ignore it, route
+  that failure to the **session model**. NEVER silently honour a denied entry.
+- **TRUST MODEL — do NOT overclaim.** `.gauntlet.yml` is read from the base branch, so its author already
+  has **write access to the repo** — the same access that can rewrite `.github/workflows`. The denylist and
+  the command-shape rules are a **guard against footguns and accidental misuse, NOT a security boundary
+  against a malicious committer**. NEVER present them as one. What the base-branch rule DOES buy is real and
+  MUST be kept: **a PR under review cannot widen the whitelist that governs its own campaign.**
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
   failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, missing or
   unparseable config, or a refused entry → session model. The cheap path is opt-in per tool, never inferred.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -145,8 +145,9 @@
 - **The only cheap path: a CI check whose fixer is a WHITELISTED TOOL — run the TOOL, no model at all**
   (`SKILL.md`, "The only cheap path"; full table/schema/validation in `stage-2-ci.md`). **A tool is
   whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an AST-preserving
-  pretty-printer, not a text munger — on the burden of the tool's **documented behaviour**. Cannot point to
-  that guarantee → NOT whitelisted → session model. There is **NO blanket "formatters are safe" rule**. The
+  pretty-printer, not a text munger — on the burden of a **CITED SOURCE: a LINK to the tool's own
+  documentation and the passage it rests on. The word "documented" is NOT a citation.** Cannot point to a
+  source → NOT whitelisted → session model. There is **NO blanket "formatters are safe" rule**. The
   guarantee is the TOOL's and does **NOT** transfer to a model hand-editing the same file — a diff that
   *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
   in a whitespace-significant language and stay formatter-clean).
@@ -158,11 +159,18 @@
   name a `command`/`args`/`argv`/flag. NEVER append a flag to a table argv. Adding a tool, or changing an
   argv, is a **SKILL change**.
 - **THE TABLE IS SMALL, AND THE CRITERION IS APPLIED HONESTLY — `gofmt`, `gci`, `ruff format`.** Each
-  `guarantee` MUST cite what the tool **DOCUMENTS**, never a paraphrase of "it's a formatter". **REJECTED,
-  and re-adding one is a SKILL change that must first defeat the reason**: `goimports` — documented to **ADD
-  missing imports and REMOVE unreferenced ones**; an added import runs that package's `init()` and a guessed
-  import can be the **wrong package** → not semantics-preserving. `gofumpt` — **extra rewrite rules beyond
-  `go/printer` layout**, documented as a rule list, **never** as semantics-preserving; "it is basically
+  `guarantee` cell MUST carry a **LINK to the tool's own doc** plus what that doc says — `gofmt`
+  (https://pkg.go.dev/cmd/gofmt: `go/printer` layout; the non-preserving flags are `-r` and `-s`, and
+  **neither is in the skill-owned argv**), `gci` (https://github.com/daixiang0/gci: sorts/groups EXISTING
+  imports; adds none, removes none), `ruff format` (https://docs.astral.sh/ruff/formatter/: verifies its
+  output is **AST-equivalent**, conditional on `format.docstring-code-format` being off —
+  https://docs.astral.sh/ruff/settings/#format_docstring-code-format). **An unsourced "documented as …" is
+  NOT a citation** — a claim that cannot be tied to a source means the tool comes **OUT of the table**.
+  **REJECTED, and re-adding one is a SKILL change that must first defeat the reason**: `goimports`
+  (https://pkg.go.dev/golang.org/x/tools/cmd/goimports) — **ADDS missing imports and REMOVES unreferenced
+  ones**; an added import runs that package's `init()` and a guessed import can be the **wrong package** →
+  not semantics-preserving. `gofumpt` (https://github.com/mvdan/gofumpt) — **extra rewrite rules beyond
+  `go/printer` layout**, stated as a rule list, **never** as semantics-preserving; "it is basically
   gofmt" is NOT an argument. Fewer tools that provably hold beats more that mostly do.
 - **NORMALIZE THE FILE ARGV — FILENAMES ARE PR-CONTROLLED DATA** (`stage-2-ci.md`). The skill owns the argv
   **SHAPE**, not the operands: `<files>` is globbed from the **PR's worktree**, so every filename is
@@ -172,9 +180,19 @@
   trusted binary, skill-owned argv, no shell, no model, and PR content still steered the command. Therefore,
   EVERY tool, EVERY run: (a) pass **`--`** before the file list — a tool without `--` NEVER enters the table;
   (b) pass every file as an **ABSOLUTE** (or `./`-prefixed) path — **NEVER a bare relative name**, which is
-  belt-and-braces even if `--` fails; (c) **REFUSE any candidate name starting with `-`** after the exclusion
-  filter — **DROP that file** and log it; do **NOT** abort the run. NEVER pass the glob itself to the tool.
+  belt-and-braces even if `--` fails; (c) **REFUSE any candidate name starting with `-`** — **DROP that file**
+  and log it; do **NOT** abort the run. NEVER pass the glob itself to the tool.
   Empty set after refusals → run nothing for that id → session model.
+- **A PATH IS DATA THAT RESOLVES — NORMALIZING ITS SPELLING IS NOT ENOUGH** (`stage-2-ci.md`). **Repro:** the
+  PR adds `link.go`, a **symlink** pointing outside the worktree. It matches `**/*.go`, survives the exclusion
+  filter, and its name is clean — and `gofmt -w -- link.go` **FOLLOWS it and rewrites the target OUTSIDE the
+  repo**. So, on every candidate — **AFTER the exclusion filter, BEFORE the argv is built**: **REFUSE a
+  SYMLINK** (`lstat` the candidate itself; NEVER `stat`, which follows the link and hides the very thing being
+  tested — a source file that must be formatted is never a symlink); **REFUSE a candidate whose fully-resolved
+  real path (`realpath`, symlinks followed, `..` collapsed) is not CONTAINED under the resolved worktree root**
+  (compare on a path-component boundary — `/wt-evil` is not under `/wt`); and **REFUSE a candidate that is not
+  a REGULAR FILE** (directory, device, fifo, socket). **DROP** each and **LOG** it (id, path, reason —
+  symlink escape / escapes the worktree / not a regular file); do NOT abort. Empty set → session model.
 - **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
   in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
   the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
@@ -192,7 +210,9 @@
   signal.
 - **THE FORMATTER WHITELIST LIVES IN THE LEDGER HEADER (`formatters`), NEVER IN A REPO FILE.** Resolved
   **once at run start** from the **user** — explicit invocation, else a preference in memory, else the
-  known-tools table's built-in defaults; `none` turns the cheap path OFF. **Re-read it from the header every
+  known-tools table's built-in defaults (`default`). **The DISABLING SENTINEL is `-`, NEVER the word
+  `none`**: `-` turns the cheap path OFF (every CI failure → session model); `default` (and an **unset**
+  field) means the built-in set. The two are NEVER interchangeable. **Re-read it from the header every
   wake; NEVER re-derive it from memory mid-run** (a wake may be a fresh agent instance — same rule and same
   reason as `reviewer`). **NEVER take it from repo content: not from a repo-root config file, not from
   `CLAUDE.md`, not from ANY file in the repo.** Repo content **is PR content** — a PR that could edit the
@@ -229,9 +249,9 @@
   criterion, and the id-only shape are a **guard against footguns and accidental misuse, NOT a security
   boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
   the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**,
-  why the **file operands are normalized** (they are PR data spliced into argv), and why the exclusion filter
-  is the skill's, not the user's.
-- **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
+  why the **file operands are normalized AND resolved** (they are PR data spliced into argv, and a symlink
+  among them walks the tool out of the tree), and why the exclusion filter is the skill's, not the user's.
+- **Default deny, everywhere.** Keyed on the **tool's IDENTITY and its CITED documented guarantee**, NEVER on a
   failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, an unresolvable
   binary, or a refused id → session model (an **unset** `formatters` header is not one of these: it means
   the table's defaults). The cheap path is keyed to the table, never inferred.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -152,6 +152,12 @@
   guarantee is the TOOL's and does **NOT** transfer to a model hand-editing the same file — a diff that
   *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
   in a whitespace-significant language and stay formatter-clean).
+- **THE GUARANTEE = THE CRITERION + THE OPERAND CHECKS — no list is part of it.** The criterion bounds
+  **what the tool can do**: `gofmt` re-prints the program without changing its meaning, so **whatever it
+  touches, it CANNOT change the meaning of** — a reformatted test asserts exactly what it asserted before,
+  and **weakening a check requires a SEMANTIC change the skill-owned argv cannot make**. The **seven operand
+  checks** bound **what we write**. Together they are what make the no-model path safe, and they depend on
+  **NO list being complete**. NEVER re-derive that safety from the exclusion filter.
 - **THE SKILL OWNS THE EXACT ARGV; NOTHING ELSE SUPPLIES A COMMAND.** The known-tools table
   (`stage-2-ci.md`) fixes each tool's precise argv (today: `gofmt -w --` over that id's normalized files).
   **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
@@ -227,9 +233,9 @@
   RESOLVED path as well as the original — EITHER matches → REFUSE**; **AND the seventh check: REFUSE any
   candidate with a SYMLINK in ANY DIRECTORY COMPONENT** (walk the components from the resolved worktree root
   down, `lstat` each; any symlink → **DROP** + **LOG**, reason `symlinked directory component` /
-  `excluded after resolution`). The resolved-path filter is the **guarantee**; the component check is the
-  cheap explicit **tripwire**. Run **BOTH**. **THE PIPELINE:** glob → **RESOLVE** → **FILTER both spellings**
-  → the **seven** checks → argv.
+  `excluded after resolution`). The component check bounds **what we write**; matching the filter on the
+  resolved path keeps the filter honest (it is **defence in depth**, never the guarantee). Run **BOTH**.
+  **THE PIPELINE:** glob → **RESOLVE** → **FILTER both spellings** → the **seven** checks → argv.
 - **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
   in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
   the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
@@ -238,16 +244,19 @@
   directory inside them; the resolved executable (symlinks followed) **MUST live OUTSIDE the repo/worktree
   tree**. Resolves inside, or does not resolve → **REFUSE → session model**. NEVER run the tool with the
   worktree on `PATH` or as the lookup base. NEVER execute a binary the PR could have supplied.
-- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER, applied to the RESOLVED path, EVERY time** — no tests
-  (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), no check definitions
-  (`.github/**`, …), no CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`, …).
-  **Match the patterns against BOTH the candidate's original path AND its `realpath` taken relative to the
-  resolved worktree root — EITHER matches → REFUSE** (a filter matched on the spelling alone is defeated by a
-  symlinked directory; see the resolved-path rule above). **NOTHING widens it**, and the whitelist NEVER
-  carries the exclusions itself: a user-written exclusion
-  list **will** omit something. The glob SELECTS; the FILTER protects. A `gofmt:**/*.go` narrowing is
-  therefore VALID — the filter drops the test files. The **filter is the guarantee**; a refusal is only a
-  signal.
+- **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER — DEFENCE IN DEPTH, NOT THE GUARANTEE.** Applied to
+  the RESOLVED path **and** the original, EVERY time (**either** matches → REFUSE; a filter matched on the
+  spelling alone is defeated by a symlinked directory — see the resolved-path rule above). It drops tests
+  (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), check definitions
+  (`.github/**`, …), CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`, …), and
+  `.gauntlet/**`. **It is an enumerated PATTERN LIST: NOT complete, and it CANNOT be** — a repo-specific
+  check written as ordinary source (`tools/ci/check.go`) matches `**/*.go`, matches **none** of the
+  patterns, passes every operand check, and **is** handed to the tool. **NEVER call it complete, exhaustive,
+  or the thing that makes the no-model path safe** (that is the criterion + the operand checks, above). Its
+  job is **BLAST RADIUS**: keep the tool's diff off files a reviewer expects untouched. **NOTHING widens it**
+  — config may only NARROW — and the whitelist NEVER carries the exclusions itself: a user-written exclusion
+  list omits more and rots per-repo. The glob SELECTS; the filter TRIMS. A `gofmt:**/*.go` narrowing is
+  therefore VALID. A refusal of an obviously hostile glob catches **intent**, not weakening.
 - **THE FORMATTER WHITELIST LIVES IN THE LEDGER HEADER (`formatters`), NEVER IN A REPO FILE.** Resolved
   **once at run start** from the **user** — explicit invocation, else a preference in memory, else the
   known-tools table's built-in defaults (`default`). **The DISABLING SENTINEL is `-`, NEVER the word
@@ -305,7 +314,8 @@
   tool left residue, check not whitelisted, or the failure needs any judgment.
 - A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the
   cause, NEVER gut an assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force
-  green.
+  green. **The prohibition is load-bearing THERE** — a session-model fixer *can* change semantics, so it
+  *can* weaken a check. **The TOOL path does not need it: the tool cannot weaken what it cannot change.**
 - Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
   That — with the tool-only formatter path and an external reviewer taking review passes off the subagent
   pool — is where savings live. Never a downgraded model.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -144,70 +144,52 @@
   catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
   low-judgment, and an under-map is invisible.
 - **The only cheap path: a CI check whose fixer is a WHITELISTED TOOL — run the TOOL, no model at all**
-  (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`). **A tool is whitelisted ONLY IF it guarantees its
-  output is SEMANTICALLY EQUIVALENT to its input** — an AST-preserving pretty-printer, not a text munger —
-  and the burden is the tool's **documented behaviour**. Cannot point to that guarantee → NOT whitelisted →
-  session model. There is **NO blanket "formatters are safe" rule**. The guarantee is the TOOL's, and does
-  **NOT** transfer to a model hand-editing the same file — a diff that *looks* like formatting is NOT a
-  proof of semantic equivalence (a pure-indentation edit can move behavior in a whitespace-significant
-  language and still be formatter-clean), so there is no diff-shape guard that would make a cheap model's
-  edit safe to accept.
-  **The LIST is repo-configurable; the CRITERION is NOT.** Whitelist = built-in **defaults**, as the repo's
-  `.gauntlet.yml` re-configures (flags, files) or removes them — a fixed set of flags is meaningless in a
-  Rust/Java/Ruby repo.
-  **Built-in defaults — the KNOWN-TOOLS TABLE, the ONLY binaries campaign may run on the no-model path**:
-  `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents), `goimports`
-  (import block only), `gci` (import grouping/ordering only — Go init order is by dependency, not by import
-  order), `ruff format` (verifies AST equivalence of its output) — **only while the repo's Ruff config does
-  NOT enable `format.docstring-code-format`** (that setting reformats Python code inside docstrings, i.e.
-  rewrites string contents → NOT AST-equivalent). **Adding a tool to this table is a SKILL change, NEVER a
-  config change.**
-  **golangci-lint `whitespace` is REMOVED from the defaults**: no safe fixer — its only fix path is the
-  denylisted catch-all `golangci-lint run --fix`. NEVER invent a command for it.
-- **A tool's guarantee can be CONDITIONAL on its CONFIGURATION** (`ruff format`, above). Therefore: every
-  `guarantee` MUST **state the conditions under which it holds**, and campaign MUST **verify those
-  conditions hold in THIS repo** (read the tool's config from the **base** branch) before taking the
-  no-model path. Condition enabled/violated, or **undeterminable** → NOT whitelisted for this repo →
-  session model. Default deny; NEVER assume a default.
+  (`SKILL.md`, "The only cheap path"; full table/schema/validation in `stage-2-ci.md`). **A tool is
+  whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an AST-preserving
+  pretty-printer, not a text munger — on the burden of the tool's **documented behaviour**. Cannot point to
+  that guarantee → NOT whitelisted → session model. There is **NO blanket "formatters are safe" rule**. The
+  guarantee is the TOOL's and does **NOT** transfer to a model hand-editing the same file — a diff that
+  *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
+  in a whitespace-significant language and stay formatter-clean).
+- **THE SKILL OWNS THE EXACT ARGV; CONFIG NEVER SUPPLIES A COMMAND.** The known-tools table
+  (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`,
+  `ruff format`, each over the entry's files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
+  rewrites `return true` into `return false` with a known `argv[0]` and no shell metacharacters, so tool
+  identity alone is NOT sufficient. A `.gauntlet.yml` entry that supplies `command`/`args`/`argv`/flags is
+  **REFUSED**. NEVER append a flag to a table argv. Adding a tool, or changing an argv, is a **SKILL change**,
+  NEVER a config change.
+- **`.gauntlet.yml` entries carry EXACTLY `id` + `files`** — which known tool, and the glob it may touch.
+  `files` MUST NOT be able to reach a **check definition, config, or test** path (`.golangci.yml`,
+  `.github/**`, `**/*_test.go`, `test/**`, `tests/**`, `conftest.py`, `pyproject.toml`, `ruff.toml`,
+  `.gauntlet.yml`, a repo-sweeping `**`) → REFUSE. That is the no-weakening prohibition enforced at the
+  config layer. Entries **remove** built-ins by omission; `formatters: []` disables the cheap path entirely.
+  They **NEVER introduce a binary outside the known-tools table**. **Any entry failing any rule is REFUSED**
+  — log it, ignore it, route that failure to the **session model**. NEVER silently honour a refused entry.
+- **A tool's guarantee can be CONDITIONAL on its CONFIGURATION**: `ruff format` verifies AST equivalence
+  **only while the repo's Ruff config does NOT enable `format.docstring-code-format`** (that setting
+  reformats Python code inside docstrings — rewrites string contents → NOT AST-equivalent). Campaign MUST
+  **verify each precondition holds in THIS repo** (read the tool's config from the **base** branch) before
+  taking the no-model path. Violated or **undeterminable** → NOT whitelisted for this repo → session model.
+- **golangci-lint `whitespace` is NOT in the table**: no safe fixer — its only fix path is the denylisted
+  catch-all `golangci-lint run --fix`. NEVER invent a command for it.
 - **NON-OVERRIDABLE DENYLIST — config CANNOT widen it**: `prettier` — it reformats the contents of tagged
   template literals (`` gql`…` ``, `` css`…` ``), changing the runtime string the tag receives; any
   generic/unscoped "whitespace" or "trailing-whitespace" fixer that can touch string literals, heredocs, or
   Markdown; every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3` (a `modernize` rewrite
   can pass its own rule while changing behavior); every **catch-all fixer** — `golangci-lint run --fix`,
   `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies
-  semantic rules (a whitelisted run MUST invoke only the whitelisted formatter); and anything whose command
-  can touch a **check definition, config, or test** (the no-weakening prohibition — a hard rule). Failing
-  product tests, compile errors, and any rule that rewrites logic are NEVER whitelisted.
+  semantic rules (a whitelisted run invokes ONLY the table's argv). Failing product tests, compile errors,
+  and any rule that rewrites logic are NEVER whitelisted.
 - **`.gauntlet.yml` (repo root, COMMITTED — NOT under the git-ignored `.gauntlet/` tree) is read from the
   BASE branch, NEVER from the PR's worktree/head** (`git show origin/<base>:.gauntlet.yml`; `stage-2-ci.md`).
-  Reading it from the PR would let a PR **widen the whitelist that governs its own campaign** — a semantic
-  rewriter admitted by the PR under review, earning an unreviewed tool commit on its own head. That is
-  self-gating in config form. A PR that edits `.gauntlet.yml` takes effect only **after it merges**.
-  Entries may **re-configure the flags/files of a KNOWN tool** or **remove** built-ins; `formatters: []`
-  disables the cheap path entirely. They may **NEVER introduce a binary outside the known-tools table**.
-- **CONSTRAIN THE COMMAND'S SHAPE, not just the tool's category** — the attack is command *construction*:
-  an entry can cite `gofmt`'s guarantee while executing `./scripts/fmt.sh` (a wrapper that rewrites product
-  code), `sh -c "gofmt -w . && ruff --fix ."`, or a PATH-shadowed `gofmt`. Checking fields, `guarantee`
-  text, and tool *categories* does NOT stop that. Every entry MUST carry `id`, `command`, `files`,
-  `guarantee`, AND:
-  - **`command` is an argv LIST** — `["gofmt", "-w"]` — **executed WITHOUT a shell**. NEVER `sh -c`, NEVER
-    `bash -c`, NEVER a shell string.
-  - **REFUSE any shell metacharacter** in the argv: `&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks,
-    newlines. No legitimate formatter entry needs them.
-  - **`argv[0]` MUST be a BARE TOOL NAME from the known-tools table** — NOT a path (`./x`,
-    `/usr/local/bin/x`), NOT a wrapper script, NOT an alias, NOT `sh`/`bash`/`env`/`xargs`. Contains `/` →
-    REFUSE. Not in the table → REFUSE.
-  - **`guarantee`** is a concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour AND
-    **states the conditions under which it holds**, and those conditions **verify in this repo**. "It's just
-    formatting" is NOT a guarantee.
-
-  **Any entry failing ANY of the above, or hitting the denylist, is REFUSED** — log it, ignore it, route
-  that failure to the **session model**. NEVER silently honour a denied entry.
-- **TRUST MODEL — do NOT overclaim.** `.gauntlet.yml` is read from the base branch, so its author already
-  has **write access to the repo** — the same access that can rewrite `.github/workflows`. The denylist and
-  the command-shape rules are a **guard against footguns and accidental misuse, NOT a security boundary
-  against a malicious committer**. NEVER present them as one. What the base-branch rule DOES buy is real and
-  MUST be kept: **a PR under review cannot widen the whitelist that governs its own campaign.**
+  Reading it from the PR would let a PR **widen the whitelist that governs its own campaign**, earning an
+  unreviewed tool commit on its own head — self-gating in config form. A PR that edits `.gauntlet.yml` takes
+  effect only **after it merges**.
+- **TRUST MODEL — do NOT overclaim.** `.gauntlet.yml` is base-branch content, so its author already has
+  **write access to the repo** — the same access that can rewrite `.github/workflows`. The denylist and the
+  schema rules are a **guard against footguns and accidental misuse, NOT a security boundary against a
+  malicious committer**. NEVER present them as one. What the base-branch rule DOES buy is real and MUST be
+  kept: **a PR under review cannot widen the whitelist that governs its own campaign.**
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
   failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, missing or
   unparseable config, or a refused entry → session model. The cheap path is opt-in per tool, never inferred.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -146,31 +146,36 @@
   (`SKILL.md`, "The only cheap path"; full table/schema/validation in `stage-2-ci.md`). **A tool is
   whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an AST-preserving
   pretty-printer, not a text munger — on the burden of a **CITED SOURCE: a LINK to the tool's own
-  documentation and the passage it rests on. The word "documented" is NOT a citation.** Cannot point to a
-  source → NOT whitelisted → session model. There is **NO blanket "formatters are safe" rule**. The
+  documentation and the passage it rests on, QUOTED. The word "documented" is NOT a citation, and a citation
+  that does NOT SUPPORT its claim is WORSE than none** — it launders our own belief as the source's. Cannot
+  point to a source → NOT whitelisted → session model. There is **NO blanket "formatters are safe" rule**. The
   guarantee is the TOOL's and does **NOT** transfer to a model hand-editing the same file — a diff that
   *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
   in a whitespace-significant language and stay formatter-clean).
 - **THE SKILL OWNS THE EXACT ARGV; NOTHING ELSE SUPPLIES A COMMAND.** The known-tools table
-  (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w --`, `gci write --`, `ruff format --`, each
-  over that id's normalized files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
+  (`stage-2-ci.md`) fixes each tool's precise argv (today: `gofmt -w --` over that id's normalized files).
+  **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
   rewrites `return true` into `return false` with a known `argv[0]` and no shell metacharacters, so tool
   identity alone is NOT sufficient. The whitelist therefore carries **ids and globs only** — it can NEVER
   name a `command`/`args`/`argv`/flag. NEVER append a flag to a table argv. Adding a tool, or changing an
   argv, is a **SKILL change**.
-- **THE TABLE IS SMALL, AND THE CRITERION IS APPLIED HONESTLY — `gofmt`, `gci`, `ruff format`.** Each
-  `guarantee` cell MUST carry a **LINK to the tool's own doc** plus what that doc says — `gofmt`
-  (https://pkg.go.dev/cmd/gofmt: `go/printer` layout; the non-preserving flags are `-r` and `-s`, and
-  **neither is in the skill-owned argv**), `gci` (https://github.com/daixiang0/gci: sorts/groups EXISTING
-  imports; adds none, removes none), `ruff format` (https://docs.astral.sh/ruff/formatter/: verifies its
-  output is **AST-equivalent**, conditional on `format.docstring-code-format` being off —
-  https://docs.astral.sh/ruff/settings/#format_docstring-code-format). **An unsourced "documented as …" is
-  NOT a citation** — a claim that cannot be tied to a source means the tool comes **OUT of the table**.
-  **REJECTED, and re-adding one is a SKILL change that must first defeat the reason**: `goimports`
+- **THE TABLE HOLDS ONE TOOL — `gofmt`. The criterion was applied TO OURSELVES.** Its cell quotes
+  https://pkg.go.dev/cmd/gofmt (*"Gofmt formats Go programs. It uses tabs for indentation and blanks for
+  alignment"*; the two flags that make it do more are **`-r`** and **`-s`**, and **neither is in the
+  skill-owned argv**). Each `guarantee` cell MUST carry a **LINK to the tool's own doc and the passage
+  QUOTED**; **FOLLOW the link before trusting the cell** — a claim that cannot be tied to a source means the
+  tool comes **OUT of the table**. **The cheap path therefore covers Go formatting and NOTHING else; every
+  other CI failure — ALL Python/JS/etc formatting included — goes to the SESSION MODEL.** That is the safe
+  default, not a regression, and the small table is **the rule working — NEVER a limitation to route
+  around**. **REJECTED, and re-adding one is a SKILL change that must first defeat the reason** — the bar is
+  **a source that STATES the guarantee, quoted in the cell**; "it is a formatter" / "probably fine" /
+  "widely used" are NOT admissible: **`ruff format`** (https://docs.astral.sh/ruff/formatter/ — the cited
+  docs state **no AST-equivalence guarantee**); **`gci`** (https://github.com/daixiang0/gci — the cited docs
+  describe import ordering/grouping and **never state** it neither adds nor removes an import); `goimports`
   (https://pkg.go.dev/golang.org/x/tools/cmd/goimports) — **ADDS missing imports and REMOVES unreferenced
   ones**; an added import runs that package's `init()` and a guessed import can be the **wrong package** →
   not semantics-preserving. `gofumpt` (https://github.com/mvdan/gofumpt) — **extra rewrite rules beyond
-  `go/printer` layout**, stated as a rule list, **never** as semantics-preserving; "it is basically
+  gofmt's layout**, stated as a rule list, **never** as semantics-preserving; "it is basically
   gofmt" is NOT an argument. Fewer tools that provably hold beats more that mostly do.
 - **NORMALIZE THE FILE ARGV — FILENAMES ARE PR-CONTROLLED DATA** (`stage-2-ci.md`). The skill owns the argv
   **SHAPE**, not the operands: `<files>` is globbed from the **PR's worktree**, so every filename is
@@ -220,20 +225,13 @@
   on its own head (self-gating). Out of the repo, a PR cannot touch it **by construction**: there is no
   provenance rule to enforce, and none exists — do NOT reintroduce one.
 - **The whitelist carries EXACTLY known-tool ids + an OPTIONAL NARROWER glob** (`gofmt:internal/**/*.go`).
-  Every known tool has a **default glob** in the table (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`, …),
+  Every known tool has a **default glob** in the table (`gofmt` → `**/*.go`),
   so an **unset `formatters` has a fully defined file set: the table's defaults, filtered**. A glob may only
   NARROW that default → a widening glob is REFUSED; so is an **obviously hostile** one that directly targets
   a check def, config, or test (`gofmt:.golangci.yml`), or a repo-sweeping bare `**`/`.`. A named list
   **replaces** the built-ins — an omitted known tool is not run. It **NEVER introduces a binary outside the
   known-tools table**. **Any id failing any rule is REFUSED** — log it, ignore it, route that failure to the
   **session model**. NEVER silently honour a refused id.
-- **A tool's guarantee can be CONDITIONAL on its CONFIGURATION**: `ruff format` verifies AST equivalence
-  **only while the repo's Ruff config does NOT enable `format.docstring-code-format`** (that setting
-  reformats Python code inside docstrings — rewrites string contents → NOT AST-equivalent). Campaign MUST
-  **verify each precondition holds in THIS repo** — read the tool's config **in the worktree the tool will
-  run in**, since that is the config the tool will obey — before taking the no-model path. Violated or
-  **undeterminable** → NOT whitelisted for this repo → session model. A PR that switches the condition ON
-  widens nothing: it **loses** the cheap path.
 - **golangci-lint `whitespace` is NOT in the table**: no safe fixer — its only fix path is the denylisted
   catch-all `golangci-lint run --fix`. NEVER invent a command for it.
 - **NON-OVERRIDABLE DENYLIST — NOTHING widens it**: `prettier` — it reformats the contents of tagged

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -135,8 +135,12 @@
   prune an entry you're unsure about.
 - **Set the model explicitly on EVERY subagent dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset
   model silently inherits the session model — a cost decision taken by default. Only **CI-fix** is
-  downgraded (**`sonnet`**), because its failure is self-detecting: bad fix → CI stays red → re-dispatch,
-  and a red check blocks the review pass anyway. Review passes, the subagent-fallback review, review-fixes,
+  downgraded (**`sonnet`**), because both its failure modes are caught, by two different nets: *fix didn't
+  work* → CI stays red → re-dispatch; *fix weakened the check* → CI turns **green**, so CI misses it and
+  the **review gate** catches it on the full diff. NEVER claim CI catches everything. A CI-fix subagent
+  MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the cause, NEVER gut an
+  assertion, add `skip`/`xfail`, disable a lint rule, or raise a timeout to force green.
+  Review passes, the subagent-fallback review, review-fixes,
   and the root-cause **mapper** all stay on the **session model** — the first two *are* the gate, and the
   last two feed an expensive check, so a cheap wrong answer is paid for twice. NEVER downgrade the mapper
   on the grounds that it is "read-only": read-only is not low-judgment, and an under-map is invisible.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -28,9 +28,8 @@
   `.gauntlet/tmp/**` (ledger, plans, progress, review/CI outputs, lease) and the carryover tree
   `.gauntlet/history/**`. A fix commit stages ONLY the specific source files it changes, by explicit
   path — never `git add -A` / `git add .`, which would sweep in run state. The tree must be
-  git-ignored; add `.gauntlet/` to `.gitignore` if missing. The repo-root `.gauntlet.yml` is NOT in that
-  tree — it is COMMITTED repo config (the formatter whitelist), read from the **base** branch, never from a
-  PR head.
+  git-ignored; add `.gauntlet/` to `.gitignore` if missing. Campaign has **NO committed file of its own** —
+  no repo-root config; the formatter whitelist is the ledger header's `formatters` field, never a repo file.
 - NEVER `rm -rf .gauntlet/` — that destroys the durable carryover history. Only `.gauntlet/tmp/**` is
   disposable.
 - NEVER pass destructive instructions (delete, force-push, reset) to an external reviewer command
@@ -151,13 +150,13 @@
   guarantee is the TOOL's and does **NOT** transfer to a model hand-editing the same file — a diff that
   *looks* like formatting is NOT a proof of semantic equivalence (a pure-indentation edit can move behavior
   in a whitespace-significant language and stay formatter-clean).
-- **THE SKILL OWNS THE EXACT ARGV; CONFIG NEVER SUPPLIES A COMMAND.** The known-tools table
+- **THE SKILL OWNS THE EXACT ARGV; NOTHING ELSE SUPPLIES A COMMAND.** The known-tools table
   (`stage-2-ci.md`) fixes each tool's precise argv (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`,
-  `ruff format`, each over the entry's files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
+  `ruff format`, each over that id's files). **Flags carry the semantics** — `gofmt -w -r 'true -> false'`
   rewrites `return true` into `return false` with a known `argv[0]` and no shell metacharacters, so tool
-  identity alone is NOT sufficient. A `.gauntlet.yml` entry that supplies `command`/`args`/`argv`/flags is
-  **REFUSED**. NEVER append a flag to a table argv. Adding a tool, or changing an argv, is a **SKILL change**,
-  NEVER a config change.
+  identity alone is NOT sufficient. The whitelist therefore carries **ids and globs only** — it can NEVER
+  name a `command`/`args`/`argv`/flag. NEVER append a flag to a table argv. Adding a tool, or changing an
+  argv, is a **SKILL change**.
 - **RESOLVE `argv[0]` TO A TRUSTED ABSOLUTE EXECUTABLE OUTSIDE THE REPO** (`stage-2-ci.md`). The tool runs
   in the PR's worktree and **the PR under review is untrusted content**: a bare name resolved from a `PATH`
   the PR can influence lets it ship its own `gofmt` and earns it **arbitrary code execution on the path that
@@ -168,28 +167,38 @@
   worktree on `PATH` or as the lookup base. NEVER execute a binary the PR could have supplied.
 - **THE SKILL OWNS A NON-OVERRIDABLE EXCLUSION FILTER, applied AFTER the glob, EVERY time** — no tests
   (`**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `conftest.py`, …), no check definitions
-  (`.github/**`, …), no CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`,
-  `.gauntlet.yml`, …). **Config CANNOT widen it**, and config NEVER carries the exclusions itself: a
-  user-written exclusion list **will** omit something. The glob SELECTS; the FILTER protects. `files:
-  "**/*.go"` is therefore VALID — the filter drops the test files. The **filter is the guarantee**; a
-  refusal is only a signal.
-- **`.gauntlet.yml` entries carry EXACTLY `id` + OPTIONAL `files`** — which known tool, and at most a
-  **NARROWER** glob. Every known tool has a **default glob** in the table (`gofmt` → `**/*.go`, `ruff
-  format` → `**/*.py`, …), so a **missing config has a fully defined file set: the table's defaults,
-  filtered**. `files` may only NARROW that default → a widening glob is REFUSED; so is an **obviously
-  hostile** one that directly targets a check def, config, or test (`files: ".golangci.yml"`), or a
-  repo-sweeping bare `**`/`.`. Entries **remove** built-ins by omission; `formatters: []` disables the cheap
-  path entirely. They **NEVER introduce a binary outside the known-tools table**. **Any entry failing any
-  rule is REFUSED** — log it, ignore it, route that failure to the **session model**. NEVER silently honour
-  a refused entry.
+  (`.github/**`, …), no CI/tool/build config (`.golangci.yml`, `ruff.toml`, `pyproject.toml`, …).
+  **NOTHING widens it**, and the whitelist NEVER carries the exclusions itself: a user-written exclusion
+  list **will** omit something. The glob SELECTS; the FILTER protects. A `gofmt:**/*.go` narrowing is
+  therefore VALID — the filter drops the test files. The **filter is the guarantee**; a refusal is only a
+  signal.
+- **THE FORMATTER WHITELIST LIVES IN THE LEDGER HEADER (`formatters`), NEVER IN A REPO FILE.** Resolved
+  **once at run start** from the **user** — explicit invocation, else a preference in memory, else the
+  known-tools table's built-in defaults; `none` turns the cheap path OFF. **Re-read it from the header every
+  wake; NEVER re-derive it from memory mid-run** (a wake may be a fresh agent instance — same rule and same
+  reason as `reviewer`). **NEVER take it from repo content: not from a repo-root config file, not from
+  `CLAUDE.md`, not from ANY file in the repo.** Repo content **is PR content** — a PR that could edit the
+  whitelist could **widen the whitelist that governs its own campaign**, earning an unreviewed tool commit
+  on its own head (self-gating). Out of the repo, a PR cannot touch it **by construction**: there is no
+  provenance rule to enforce, and none exists — do NOT reintroduce one.
+- **The whitelist carries EXACTLY known-tool ids + an OPTIONAL NARROWER glob** (`gofmt:internal/**/*.go`).
+  Every known tool has a **default glob** in the table (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`, …),
+  so an **unset `formatters` has a fully defined file set: the table's defaults, filtered**. A glob may only
+  NARROW that default → a widening glob is REFUSED; so is an **obviously hostile** one that directly targets
+  a check def, config, or test (`gofmt:.golangci.yml`), or a repo-sweeping bare `**`/`.`. A named list
+  **replaces** the built-ins — an omitted known tool is not run. It **NEVER introduces a binary outside the
+  known-tools table**. **Any id failing any rule is REFUSED** — log it, ignore it, route that failure to the
+  **session model**. NEVER silently honour a refused id.
 - **A tool's guarantee can be CONDITIONAL on its CONFIGURATION**: `ruff format` verifies AST equivalence
   **only while the repo's Ruff config does NOT enable `format.docstring-code-format`** (that setting
   reformats Python code inside docstrings — rewrites string contents → NOT AST-equivalent). Campaign MUST
-  **verify each precondition holds in THIS repo** (read the tool's config from the **base** branch) before
-  taking the no-model path. Violated or **undeterminable** → NOT whitelisted for this repo → session model.
+  **verify each precondition holds in THIS repo** — read the tool's config **in the worktree the tool will
+  run in**, since that is the config the tool will obey — before taking the no-model path. Violated or
+  **undeterminable** → NOT whitelisted for this repo → session model. A PR that switches the condition ON
+  widens nothing: it **loses** the cheap path.
 - **golangci-lint `whitespace` is NOT in the table**: no safe fixer — its only fix path is the denylisted
   catch-all `golangci-lint run --fix`. NEVER invent a command for it.
-- **NON-OVERRIDABLE DENYLIST — config CANNOT widen it**: `prettier` — it reformats the contents of tagged
+- **NON-OVERRIDABLE DENYLIST — NOTHING widens it**: `prettier` — it reformats the contents of tagged
   template literals (`` gql`…` ``, `` css`…` ``), changing the runtime string the tag receives; any
   generic/unscoped "whitespace" or "trailing-whitespace" fixer that can touch string literals, heredocs, or
   Markdown; every **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3` (a `modernize` rewrite
@@ -197,20 +206,16 @@
   `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies
   semantic rules (a whitelisted run invokes ONLY the table's argv). Failing product tests, compile errors,
   and any rule that rewrites logic are NEVER whitelisted.
-- **`.gauntlet.yml` (repo root, COMMITTED — NOT under the git-ignored `.gauntlet/` tree) is read from the
-  BASE branch, NEVER from the PR's worktree/head** (`git show origin/<base>:.gauntlet.yml`; `stage-2-ci.md`).
-  Reading it from the PR would let a PR **widen the whitelist that governs its own campaign**, earning an
-  unreviewed tool commit on its own head — self-gating in config form. A PR that edits `.gauntlet.yml` takes
-  effect only **after it merges**.
-- **TRUST MODEL — do NOT overclaim.** `.gauntlet.yml` is base-branch content, so its author already has
-  **write access to the repo** — the same access that can rewrite `.github/workflows`. The denylist and the
-  schema rules are a **guard against footguns and accidental misuse, NOT a security boundary against a
-  malicious committer**. NEVER present them as one. What the base-branch rule DOES buy is real and MUST be
-  kept: **a PR under review cannot widen the whitelist that governs its own campaign.**
+- **TRUST MODEL — do NOT overclaim.** The formatter whitelist is the **user's** (invocation or their own
+  memory), not repo content, so there is no malicious-committer threat model here at all: the denylist, the
+  criterion, and the id-only shape are a **guard against footguns and accidental misuse, NOT a security
+  boundary**. NEVER present them as one. What IS a boundary: **the tool runs on UNTRUSTED PR CONTENT inside
+  the PR's worktree** — which is exactly why `argv[0]` resolves to a trusted executable **outside the repo**
+  and why the exclusion filter is the skill's, not the user's.
 - **Default deny, everywhere.** Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
-  failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, **unparseable**
-  config, an unresolvable binary, or a refused entry → session model (a **missing** config is not one of
-  these: it means the table's defaults). The cheap path is keyed to the table, never inferred.
+  failure "looking mechanical" or on the category "formatter". Unknown check, unlisted tool, an unresolvable
+  binary, or a refused id → session model (an **unset** `formatters` header is not one of these: it means
+  the table's defaults). The cheap path is keyed to the table, never inferred.
   ACCEPT the tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**;
   AND (b) the diff touches **no check definition, config, or test**. Either fails → **discard the work**
   (reset the worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -141,22 +141,37 @@
   a miss-catcher, not a proof of correctness — so no class's mistakes are reliably absorbed. NEVER claim CI
   catches a bad fix. NEVER downgrade the mapper on the grounds that it is "read-only": read-only is not
   low-judgment, and an under-map is invisible.
-- **The only cheap path: a whitelisted CI check whose fixer is a semantics-preserving formatter — run the
-  TOOL, no model at all** (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`). The safety comes from the
-  TOOL's construction: its output cannot change program meaning. That guarantee does **NOT** transfer to a
-  model hand-editing the same file — a diff that *looks* like formatting is NOT a proof of semantic
-  equivalence (a pure-indentation edit can move behavior in a whitespace-significant language and still be
-  formatter-clean), so there is no diff-shape guard that would make a cheap model's edit safe to accept.
-  **IN**: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`, `whitespace`, `prettier`,
-  `ruff format`. **OUT**: `modernize` and every other semantic rewriter (a `modernize` rewrite can pass its
-  own rule while changing behavior), plus blanket `golangci-lint run --fix` and blanket `ruff --fix` — a
-  whitelisted run MUST invoke only the formatter, NEVER a catch-all `--fix`. Failing product tests, compile
-  errors, and any rule that rewrites logic are NEVER whitelisted. Keyed on **check/fixer IDENTITY**, NEVER
-  on a failure "looking mechanical". Default is NOT whitelisted; unknown check → session model. ACCEPT the
-  tool's run **only if both hold**: (a) re-running the **exact** failing check now **passes**; AND (b) the
-  diff touches **no check definition, config, or test**. Either fails → **discard the work** (reset the
-  worktree to the PR head) and **re-dispatch the same failure on the session model**. NEVER patch a
-  formatter run in place; NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
+- **The only cheap path: a CI check whose fixer is a WHITELISTED TOOL — run the TOOL, no model at all**
+  (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`). **A tool is whitelisted ONLY IF it guarantees its
+  output is SEMANTICALLY EQUIVALENT to its input** — an AST-preserving pretty-printer, not a text munger —
+  and the burden is the tool's **documented behaviour**. Cannot point to that guarantee → NOT whitelisted →
+  session model. There is **NO blanket "formatters are safe" rule**. The guarantee is the TOOL's, and does
+  **NOT** transfer to a model hand-editing the same file — a diff that *looks* like formatting is NOT a
+  proof of semantic equivalence (a pure-indentation edit can move behavior in a whitespace-significant
+  language and still be formatter-clean), so there is no diff-shape guard that would make a cheap model's
+  edit safe to accept.
+  **IN**: `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents),
+  `goimports` (import block only), `gci` (import grouping/ordering only — Go init order is by dependency,
+  not by import order), golangci-lint `whitespace` (Go: leading/trailing newlines inside function bodies),
+  `ruff format` (verifies AST equivalence of its output).
+  **OUT**: `prettier` — it reformats the contents of tagged template literals (`` gql`…` ``, `` css`…` ``),
+  changing the runtime string the tag receives; any generic/unscoped "whitespace" or "trailing-whitespace"
+  fixer that can touch string literals, heredocs, or Markdown; `modernize` and every other semantic
+  rewriter (a `modernize` rewrite can pass its own rule while changing behavior); plus blanket
+  `golangci-lint run --fix` and blanket `ruff --fix` — a whitelisted run MUST invoke only the whitelisted
+  formatter, NEVER a catch-all `--fix`. Failing product tests, compile errors, and any rule that rewrites
+  logic are NEVER whitelisted. Keyed on the **tool's IDENTITY and documented guarantee**, NEVER on a
+  failure "looking mechanical" or on the category "formatter". Default is NOT whitelisted; unknown check or
+  unlisted tool → session model. ACCEPT the tool's run **only if both hold**: (a) re-running the **exact**
+  failing check now **passes**; AND (b) the diff touches **no check definition, config, or test**. Either
+  fails → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same failure on
+  the session model**. NEVER patch a formatter run in place; NEVER commit an unverified one; NEVER hand the
+  failure to a cheap model instead.
+- **A whitelisted TOOL's commit resets the gate exactly like a subagent's** (`stage-2-ci.md`, "Any campaign
+  commit to the PR head resets the gate"). Every commit campaign pushes to a PR head — CI-fix subagent,
+  review-fix subagent, or tool run with no model — MUST in the same step reset `reviews_ok` to 0 AND
+  restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, then relaunch the CI watch and
+  re-enter Stage 2a. NEVER treat a tool-written commit as exempt.
 - **Everything the tool does not fix → the scoped CI-fix subagent on the session model**, set explicitly:
   tool left residue, check not whitelisted, or the failure needs any judgment.
 - A CI-fix subagent MUST be dispatched under the no-weakening prohibition (`stage-2-ci.md`): fix the

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -71,7 +71,7 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "formatters": "gofmt,gci"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "formatters": "gofmt"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
@@ -83,8 +83,9 @@ once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once f
 "The reviewer"), `formatters` (the cheap CI path's tool whitelist; set once, see below and `stage-2-ci.md`).
 
 `formatters` — the ONLY source of the formatter whitelist. A **scalar** with exactly three shapes:
-comma-separated known-tool ids (`gofmt,gci`), each id optionally suffixed `:<glob>` to **narrow** that
-tool's default glob (`gofmt:internal/**/*.go`); `default` = the known-tools table's built-in default set
+comma-separated known-tool ids (today the table holds exactly one: `gofmt`), each id optionally suffixed
+`:<glob>` to **narrow** that tool's default glob (`gofmt:internal/**/*.go`); `default` = the known-tools
+table's built-in default set
 (also `ledger.py`'s default when the field was never written); `-` = the **DISABLING SENTINEL** — the cheap
 path is OFF and every CI failure goes to the session model. **The sentinel is `-`; the word `none` is NEVER
 written to this field** (a user asking for "no formatters"/"none" gets `-`). `default` and `-` are NEVER

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -42,11 +42,11 @@ file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh r
 **Campaign has NO committed file — no repo-root config, nothing.** The whole `.gauntlet/**` tree is
 git-ignored driver bookkeeping, and that is the extent of campaign's on-disk footprint.
 
-In particular the **formatter whitelist is NOT a repo file.** It is the ledger header's `formatters` field
-(below), resolved once at run start from the **user** — explicit invocation, else a preference in memory,
-else the known-tools table's built-in defaults (`stage-2-ci.md`). **NEVER take it from repo content: not
+In particular the **cheap-CI-path tool list is NOT a repo file.** It is the ledger header's `formatters`
+field (below), resolved once at run start from the **user** — explicit invocation, else a preference in
+memory, else **`-`: EMPTY, no tool enabled** (`stage-2-ci.md`). **NEVER take it from repo content: not
 from a repo-root config file, not from `CLAUDE.md`, not from ANY file in the repo.** Repo content is PR
-content — a PR could edit it and thereby widen the whitelist that governs its own campaign. Keeping the
+content — a PR could edit it and thereby enable a tool to govern its own campaign. Keeping the
 list out of the repo makes that impossible **by construction**, so no provenance rule is needed and none
 exists.
 
@@ -80,23 +80,29 @@ Header-record fields: `run_id` (this run's identity — namespaces its dir/label
 `base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
 once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
 `reviewer` (`default` (Claude subagents) | `codex` | `<other>` — the selected reviewer; set once, see
-"The reviewer"), `formatters` (the cheap CI path's tool whitelist; set once, see below and `stage-2-ci.md`).
+"The reviewer"), `formatters` (the cheap CI path's **user-enabled** tool list — **empty by default**; set
+once, see below and `stage-2-ci.md`).
 
-`formatters` — the ONLY source of the formatter whitelist. A **scalar** with exactly three shapes:
-comma-separated known-tool ids (today the table holds exactly one: `gofmt`), each id optionally suffixed
-`:<glob>` to **narrow** that tool's default glob (`gofmt:internal/**/*.go`); `default` = the known-tools
-table's built-in default set
-(also `ledger.py`'s default when the field was never written); `-` = the **DISABLING SENTINEL** — the cheap
-path is OFF and every CI failure goes to the session model. **The sentinel is `-`; the word `none` is NEVER
-written to this field** (a user asking for "no formatters"/"none" gets `-`). `default` and `-` are NEVER
-interchangeable. Resolved **once at run start** — explicit
-invocation, else a user preference from memory, else `default` — and **re-read from this header every
-wake**, never re-derived from memory mid-run (a wake may be a fresh agent instance; same rule and same
-reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign commits NO file of its own").
-An id not in the known-tools table, a widening glob, or a glob directly targeting a check def/config/test
-is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, the
+`formatters` — the ONLY source of the tool list. A **scalar** with exactly **two** shapes:
+
+- **`-`** — **EMPTY: no tool enabled, cheap path OFF**, every CI failure to the session model. This is the
+  **DEFAULT** (and `ledger.py`'s value when the field was never written): **the skill ships with ZERO tools
+  enabled and vouches for none.** The sentinel is `-`; the word `none` is NEVER written to this field (a
+  user asking for "no formatters"/"none" gets `-`). **There is NO `default` value and no built-in set** — if
+  a legacy header carries `default`, treat it as `-`.
+- comma-separated **known-tool ids** the USER enabled (`gofmt`, `gci`, `ruff format`), each optionally
+  suffixed `:<glob>` to **narrow** that tool's default glob (`gofmt:internal/**/*.go`).
+
+Resolved **once at run start** — explicit invocation, else a user preference from memory, else `-` — and
+**re-read from this header every wake**, never re-derived from memory mid-run (a wake may be a fresh agent
+instance; same rule and same reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign
+commits NO file of its own"). **Enabling a tool is a USER decision and a USER risk acceptance: the skill
+guarantees HOW a tool is run, never WHAT it does** (`stage-2-ci.md`).
+An id not in the known-tools table, a **denylisted** id (config can never enable one), a widening glob, or a
+glob directly targeting a check def/config/test is REFUSED (`stage-2-ci.md`); the skill still owns each
+tool's exact argv, its binary resolution, the
 non-overridable exclusion filter — applied to each candidate's **RESOLVED** path as well as its original,
-**either** match → refuse; **defence in depth, NOT the guarantee — an incomplete pattern list, never
+**either** match → refuse; **defence in depth, admittedly incomplete — never
 described as complete** (`stage-2-ci.md`) — and the seven file-operand checks (`--` + absolute/`./` paths; refuse
 `-`-leading names, symlinks, symlinked directory components, paths resolving outside the worktree or
 non-regular files, and files with `nlink > 1` (hardlinks); NEVER invoke the tool with an empty operand set).

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -37,44 +37,18 @@ carryover history with it. Scratch cleanup targets `.gauntlet/tmp/**` and nothin
 The history tree keeps **one file per run** (`<run-id>.md`) so concurrent runs never clobber a shared
 file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh runs and carryover".
 
-### `.gauntlet.yml` — the one COMMITTED file
+### Campaign commits NO file of its own
 
-| Path | Committed? | What |
-|------|-----------|------|
-| `.gauntlet/**` | **NO** — git-ignored driver bookkeeping | run scratch + carryover history (above) |
-| `.gauntlet.yml` | **YES** — repo content, reviewed like any other file | the repo's formatter whitelist (`stage-2-ci.md`) |
+**Campaign has NO committed file — no repo-root config, nothing.** The whole `.gauntlet/**` tree is
+git-ignored driver bookkeeping, and that is the extent of campaign's on-disk footprint.
 
-`.gauntlet.yml` sits at the **repo root**, NOT inside `.gauntlet/` — it is repo configuration, not run
-state, and it is the only gauntlet file that belongs in git. It selects **which of the skill's KNOWN tools
-run, and at most a NARROWER file glob**, on the cheap CI path (built-in defaults, narrowed or removed by
-repo entries; `formatters: []` disables the path; **missing file → the table's defaults**). **The SKILL
-owns each tool's exact argv, its default glob, and the binary it resolves; config NEVER supplies a command,
-flags, or argv** — flags carry semantics (`gofmt -w -r 'true -> false'` is a rewrite engine). Config can
-NEVER relax the whitelisting **criterion**, widen the denylist, widen the **exclusion filter**, or
-**introduce a binary outside the skill's known-tools table**.
-
-Schema — each entry carries **EXACTLY these fields**:
-
-| field | rule |
-|---|---|
-| `id` | **required**. The known tool's id (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`). Not in the table → REFUSE. |
-| `files` | **optional**. May only **NARROW** the tool's default glob in the known-tools table (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`, …); a widening glob → REFUSE. Omitted → the default. An **obviously hostile** glob directly targeting a check def, config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`), or a repo-sweeping bare `**`/`.` → REFUSE. |
-
-**Any other key — `command`, `args`, `argv`, `flags`, `guarantee` — REFUSES the entry.** The guarantee and
-the argv are the skill's, in the known-tools table (`stage-2-ci.md`), not the repo's to state or choose.
-
-**The glob NEVER carries the exclusions.** The skill applies a **non-overridable exclusion filter** to the
-file set *after* the glob — every time, config or no config — dropping tests, check definitions, and CI/tool
-config (`stage-2-ci.md`). So `files: "**/*.go"` is valid and correct: the glob selects, the filter protects.
-**Config CANNOT widen the filter.**
-
-**Any entry failing any of these is REFUSED** — logged, ignored, failure routed to the session model.
-
-**ALWAYS read it from the BASE branch — `git show origin/<base>:.gauntlet.yml` — NEVER from a PR's
-worktree or head.** A PR that could supply its own whitelist would be widening the gate that governs it.
-Because it is base-branch content, its author already has repo write access: these rules are a **footgun
-guard, NOT a security boundary** against a malicious committer. Full validation and merge semantics:
-`stage-2-ci.md`.
+In particular the **formatter whitelist is NOT a repo file.** It is the ledger header's `formatters` field
+(below), resolved once at run start from the **user** — explicit invocation, else a preference in memory,
+else the known-tools table's built-in defaults (`stage-2-ci.md`). **NEVER take it from repo content: not
+from a repo-root config file, not from `CLAUDE.md`, not from ANY file in the repo.** Repo content is PR
+content — a PR could edit it and thereby widen the whitelist that governs its own campaign. Keeping the
+list out of the repo makes that impossible **by construction**, so no provenance rule is needed and none
+exists.
 
 ### The ledger — `state.jsonl`
 
@@ -92,12 +66,12 @@ act on it without reconciling against gh (and any existing worktree) first.
 
 The store is **JSONL** — one JSON object per line, `cat`/`grep`/`jq`-able. The first line is the
 run-config header record (`{"type": "header", …}` — `run_id`, `base_branch`, `api_changes`, `reviewer`,
-re-read every wake, see Constraints and "Run identity and concurrency"); each
+`formatters`, re-read every wake, see Constraints and "Run identity and concurrency"); each
 following line is one adopted PR's row record (`{"type": "row", …}`). Every record is **self-describing**
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "default"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "formatters": "gofmt,goimports"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
@@ -106,7 +80,18 @@ Header-record fields: `run_id` (this run's identity — namespaces its dir/label
 `base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
 once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
 `reviewer` (`default` (Claude subagents) | `codex` | `<other>` — the selected reviewer; set once, see
-"The reviewer").
+"The reviewer"), `formatters` (the cheap CI path's tool whitelist; set once, see below and `stage-2-ci.md`).
+
+`formatters` — the ONLY source of the formatter whitelist. A **scalar**: comma-separated known-tool ids
+(`gofmt,goimports`), each id optionally suffixed `:<glob>` to **narrow** that tool's default glob
+(`gofmt:internal/**/*.go`); `default` = the known-tools table's built-in default set; `-` = **none**, the
+cheap path is OFF and every CI failure goes to the session model. Resolved **once at run start** — explicit
+invocation, else a user preference from memory, else `default` — and **re-read from this header every
+wake**, never re-derived from memory mid-run (a wake may be a fresh agent instance; same rule and same
+reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign commits NO file of its own").
+An id not in the known-tools table, a widening glob, or a glob directly targeting a check def/config/test
+is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, and the
+non-overridable exclusion filter.
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -42,14 +42,6 @@ file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh r
 **Campaign has NO committed file — no repo-root config, nothing.** The whole `.gauntlet/**` tree is
 git-ignored driver bookkeeping, and that is the extent of campaign's on-disk footprint.
 
-In particular the **cheap-CI-path tool list is NOT a repo file.** It is the ledger header's `formatters`
-field (below), resolved once at run start from the **user** — explicit invocation, else a preference in
-memory, else **`-`: EMPTY, no tool enabled** (`stage-2-ci.md`). **NEVER take it from repo content: not
-from a repo-root config file, not from `CLAUDE.md`, not from ANY file in the repo.** Repo content is PR
-content — a PR could edit it and thereby enable a tool to govern its own campaign. Keeping the
-list out of the repo makes that impossible **by construction**, so no provenance rule is needed and none
-exists.
-
 ### The ledger — `state.jsonl`
 
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is
@@ -66,12 +58,12 @@ act on it without reconciling against gh (and any existing worktree) first.
 
 The store is **JSONL** — one JSON object per line, `cat`/`grep`/`jq`-able. The first line is the
 run-config header record (`{"type": "header", …}` — `run_id`, `base_branch`, `api_changes`, `reviewer`,
-`formatters`, re-read every wake, see Constraints and "Run identity and concurrency"); each
+re-read every wake, see Constraints and "Run identity and concurrency"); each
 following line is one adopted PR's row record (`{"type": "row", …}`). Every record is **self-describing**
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "formatters": "gofmt"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
@@ -80,32 +72,7 @@ Header-record fields: `run_id` (this run's identity — namespaces its dir/label
 `base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
 once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
 `reviewer` (`default` (Claude subagents) | `codex` | `<other>` — the selected reviewer; set once, see
-"The reviewer"), `formatters` (the cheap CI path's **user-enabled** tool list — **empty by default**; set
-once, see below and `stage-2-ci.md`).
-
-`formatters` — the ONLY source of the tool list. A **scalar** with exactly **two** shapes:
-
-- **`-`** — **EMPTY: no tool enabled, cheap path OFF**, every CI failure to the session model. This is the
-  **DEFAULT** (and `ledger.py`'s value when the field was never written): **the skill ships with ZERO tools
-  enabled and vouches for none.** The sentinel is `-`; the word `none` is NEVER written to this field (a
-  user asking for "no formatters"/"none" gets `-`). **There is NO `default` value and no built-in set** — if
-  a legacy header carries `default`, treat it as `-`.
-- comma-separated **known-tool ids** the USER enabled (`gofmt`, `gci`, `ruff format`), each optionally
-  suffixed `:<glob>` to **narrow** that tool's default glob (`gofmt:internal/**/*.go`).
-
-Resolved **once at run start** — explicit invocation, else a user preference from memory, else `-` — and
-**re-read from this header every wake**, never re-derived from memory mid-run (a wake may be a fresh agent
-instance; same rule and same reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign
-commits NO file of its own"). **Enabling a tool is a USER decision and a USER risk acceptance: the skill
-guarantees HOW a tool is run, never WHAT it does** (`stage-2-ci.md`).
-An id not in the known-tools table, a **denylisted** id (config can never enable one), a widening glob, or a
-glob directly targeting a check def/config/test is REFUSED (`stage-2-ci.md`); the skill still owns each
-tool's exact argv, its binary resolution, the
-non-overridable exclusion filter — applied to each candidate's **RESOLVED** path as well as its original,
-**either** match → refuse; **defence in depth, admittedly incomplete — never
-described as complete** (`stage-2-ci.md`) — and the seven file-operand checks (`--` + absolute/`./` paths; refuse
-`-`-leading names, symlinks, symlinked directory components, paths resolving outside the worktree or
-non-regular files, and files with `nlink > 1` (hardlinks); NEVER invoke the tool with an empty operand set).
+"The reviewer").
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -82,16 +82,20 @@ once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once f
 `reviewer` (`default` (Claude subagents) | `codex` | `<other>` — the selected reviewer; set once, see
 "The reviewer"), `formatters` (the cheap CI path's tool whitelist; set once, see below and `stage-2-ci.md`).
 
-`formatters` — the ONLY source of the formatter whitelist. A **scalar**: comma-separated known-tool ids
-(`gofmt,gci`), each id optionally suffixed `:<glob>` to **narrow** that tool's default glob
-(`gofmt:internal/**/*.go`); `default` = the known-tools table's built-in default set; `-` = **none**, the
-cheap path is OFF and every CI failure goes to the session model. Resolved **once at run start** — explicit
+`formatters` — the ONLY source of the formatter whitelist. A **scalar** with exactly three shapes:
+comma-separated known-tool ids (`gofmt,gci`), each id optionally suffixed `:<glob>` to **narrow** that
+tool's default glob (`gofmt:internal/**/*.go`); `default` = the known-tools table's built-in default set
+(also `ledger.py`'s default when the field was never written); `-` = the **DISABLING SENTINEL** — the cheap
+path is OFF and every CI failure goes to the session model. **The sentinel is `-`; the word `none` is NEVER
+written to this field** (a user asking for "no formatters"/"none" gets `-`). `default` and `-` are NEVER
+interchangeable. Resolved **once at run start** — explicit
 invocation, else a user preference from memory, else `default` — and **re-read from this header every
 wake**, never re-derived from memory mid-run (a wake may be a fresh agent instance; same rule and same
 reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign commits NO file of its own").
 An id not in the known-tools table, a widening glob, or a glob directly targeting a check def/config/test
-is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, and the
-non-overridable exclusion filter.
+is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, the
+non-overridable exclusion filter, and the file-operand rules (`--` + absolute paths; refuse `-`-leading
+names, symlinks, non-regular files, and paths resolving outside the worktree).
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -95,8 +95,9 @@ wake**, never re-derived from memory mid-run (a wake may be a fresh agent instan
 reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign commits NO file of its own").
 An id not in the known-tools table, a widening glob, or a glob directly targeting a check def/config/test
 is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, the
-non-overridable exclusion filter, and the file-operand rules (`--` + absolute paths; refuse `-`-leading
-names, symlinks, non-regular files, and paths resolving outside the worktree).
+non-overridable exclusion filter, and the file-operand rules (`--` + absolute/`./` paths; refuse `-`-leading
+names, symlinks, paths resolving outside the worktree or non-regular files, and files with `nlink > 1`
+(hardlinks); NEVER invoke the tool with an empty operand set).
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -37,6 +37,22 @@ carryover history with it. Scratch cleanup targets `.gauntlet/tmp/**` and nothin
 The history tree keeps **one file per run** (`<run-id>.md`) so concurrent runs never clobber a shared
 file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh runs and carryover".
 
+### `.gauntlet.yml` — the one COMMITTED file
+
+| Path | Committed? | What |
+|------|-----------|------|
+| `.gauntlet/**` | **NO** — git-ignored driver bookkeeping | run scratch + carryover history (above) |
+| `.gauntlet.yml` | **YES** — repo content, reviewed like any other file | the repo's formatter whitelist (`stage-2-ci.md`) |
+
+`.gauntlet.yml` sits at the **repo root**, NOT inside `.gauntlet/` — it is repo configuration, not run
+state, and it is the only gauntlet file that belongs in git. It configures the **list** of whitelisted
+formatter tools for the cheap CI path (built-in defaults + repo entries; `formatters: []` disables the
+path). It can NEVER relax the whitelisting **criterion** or widen the denylist.
+
+**ALWAYS read it from the BASE branch — `git show origin/<base>:.gauntlet.yml` — NEVER from a PR's
+worktree or head.** A PR that could supply its own whitelist would be widening the gate that governs it.
+Schema, validation, and merge semantics: `stage-2-ci.md`.
+
 ### The ledger — `state.jsonl`
 
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -45,13 +45,27 @@ file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh r
 | `.gauntlet.yml` | **YES** — repo content, reviewed like any other file | the repo's formatter whitelist (`stage-2-ci.md`) |
 
 `.gauntlet.yml` sits at the **repo root**, NOT inside `.gauntlet/` — it is repo configuration, not run
-state, and it is the only gauntlet file that belongs in git. It configures the **list** of whitelisted
-formatter tools for the cheap CI path (built-in defaults + repo entries; `formatters: []` disables the
-path). It can NEVER relax the whitelisting **criterion** or widen the denylist.
+state, and it is the only gauntlet file that belongs in git. It configures **which of the skill's KNOWN
+tools run, with which flags, over which files**, on the cheap CI path (built-in defaults, re-configured or
+removed by repo entries; `formatters: []` disables the path). It can NEVER relax the whitelisting
+**criterion**, widen the denylist, or **introduce a binary outside the skill's known-tools table**.
+
+Schema — each entry MUST carry:
+
+| field | rule |
+|---|---|
+| `id` | the known tool's id (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`) |
+| `command` | an **argv LIST**, e.g. `["gofmt", "-w"]` — **run WITHOUT a shell**. NEVER a shell string, NEVER `sh -c`/`bash -c`. **No shell metacharacters** (`&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks, newlines). **`argv[0]` MUST be a bare tool name from the known-tools table** — never a path, wrapper script, or alias. |
+| `files` | glob scoping the run |
+| `guarantee` | concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour **and the conditions under which it holds** — which campaign MUST verify in this repo |
+
+**Any entry failing any of these is REFUSED** — logged, ignored, failure routed to the session model.
 
 **ALWAYS read it from the BASE branch — `git show origin/<base>:.gauntlet.yml` — NEVER from a PR's
 worktree or head.** A PR that could supply its own whitelist would be widening the gate that governs it.
-Schema, validation, and merge semantics: `stage-2-ci.md`.
+Because it is base-branch content, its author already has repo write access: these rules are a **footgun
+guard, NOT a security boundary** against a malicious committer. Full validation and merge semantics:
+`stage-2-ci.md`.
 
 ### The ledger — `state.jsonl`
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -71,7 +71,7 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "formatters": "gofmt,goimports"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "formatters": "gofmt,gci"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
@@ -83,7 +83,7 @@ once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once f
 "The reviewer"), `formatters` (the cheap CI path's tool whitelist; set once, see below and `stage-2-ci.md`).
 
 `formatters` — the ONLY source of the formatter whitelist. A **scalar**: comma-separated known-tool ids
-(`gofmt,goimports`), each id optionally suffixed `:<glob>` to **narrow** that tool's default glob
+(`gofmt,gci`), each id optionally suffixed `:<glob>` to **narrow** that tool's default glob
 (`gofmt:internal/**/*.go`); `default` = the known-tools table's built-in default set; `-` = **none**, the
 cheap path is OFF and every CI failure goes to the session model. Resolved **once at run start** — explicit
 invocation, else a user preference from memory, else `default` — and **re-read from this header every

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -45,19 +45,22 @@ file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh r
 | `.gauntlet.yml` | **YES** — repo content, reviewed like any other file | the repo's formatter whitelist (`stage-2-ci.md`) |
 
 `.gauntlet.yml` sits at the **repo root**, NOT inside `.gauntlet/` — it is repo configuration, not run
-state, and it is the only gauntlet file that belongs in git. It configures **which of the skill's KNOWN
-tools run, with which flags, over which files**, on the cheap CI path (built-in defaults, re-configured or
-removed by repo entries; `formatters: []` disables the path). It can NEVER relax the whitelisting
-**criterion**, widen the denylist, or **introduce a binary outside the skill's known-tools table**.
+state, and it is the only gauntlet file that belongs in git. It selects **which of the skill's KNOWN tools
+run, over which files**, on the cheap CI path (built-in defaults, re-scoped or removed by repo entries;
+`formatters: []` disables the path). **The SKILL owns each tool's exact argv; config NEVER supplies a
+command, flags, or argv** — flags carry semantics (`gofmt -w -r 'true -> false'` is a rewrite engine).
+Config can NEVER relax the whitelisting **criterion**, widen the denylist, or **introduce a binary outside
+the skill's known-tools table**.
 
-Schema — each entry MUST carry:
+Schema — each entry carries **EXACTLY these two fields**:
 
 | field | rule |
 |---|---|
-| `id` | the known tool's id (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`) |
-| `command` | an **argv LIST**, e.g. `["gofmt", "-w"]` — **run WITHOUT a shell**. NEVER a shell string, NEVER `sh -c`/`bash -c`. **No shell metacharacters** (`&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks, newlines). **`argv[0]` MUST be a bare tool name from the known-tools table** — never a path, wrapper script, or alias. |
-| `files` | glob scoping the run |
-| `guarantee` | concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour **and the conditions under which it holds** — which campaign MUST verify in this repo |
+| `id` | the known tool's id (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`). Not in the table → REFUSE. |
+| `files` | glob scoping the run. MUST NOT be able to match a **check definition, config, or test** path (`.golangci.yml`, `.github/**`, `**/*_test.go`, `test/**`, `tests/**`, `conftest.py`, `pyproject.toml`, `ruff.toml`, `.gauntlet.yml`, or a repo-sweeping `**`) → REFUSE. |
+
+**Any other key — `command`, `args`, `argv`, `flags`, `guarantee` — REFUSES the entry.** The guarantee and
+the argv are the skill's, in the known-tools table (`stage-2-ci.md`), not the repo's to state or choose.
 
 **Any entry failing any of these is REFUSED** — logged, ignored, failure routed to the session model.
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -96,7 +96,8 @@ reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign commi
 An id not in the known-tools table, a widening glob, or a glob directly targeting a check def/config/test
 is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, the
 non-overridable exclusion filter — applied to each candidate's **RESOLVED** path as well as its original,
-**either** match → refuse — and the seven file-operand checks (`--` + absolute/`./` paths; refuse
+**either** match → refuse; **defence in depth, NOT the guarantee — an incomplete pattern list, never
+described as complete** (`stage-2-ci.md`) — and the seven file-operand checks (`--` + absolute/`./` paths; refuse
 `-`-leading names, symlinks, symlinked directory components, paths resolving outside the worktree or
 non-regular files, and files with `nlink > 1` (hardlinks); NEVER invoke the tool with an empty operand set).
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -95,9 +95,10 @@ wake**, never re-derived from memory mid-run (a wake may be a fresh agent instan
 reason as `reviewer`). **NEVER derived from any repo file** (see "Campaign commits NO file of its own").
 An id not in the known-tools table, a widening glob, or a glob directly targeting a check def/config/test
 is REFUSED (`stage-2-ci.md`); the skill still owns each tool's exact argv, its binary resolution, the
-non-overridable exclusion filter, and the file-operand rules (`--` + absolute/`./` paths; refuse `-`-leading
-names, symlinks, paths resolving outside the worktree or non-regular files, and files with `nlink > 1`
-(hardlinks); NEVER invoke the tool with an empty operand set).
+non-overridable exclusion filter — applied to each candidate's **RESOLVED** path as well as its original,
+**either** match → refuse — and the seven file-operand checks (`--` + absolute/`./` paths; refuse
+`-`-leading names, symlinks, symlinked directory components, paths resolving outside the worktree or
+non-regular files, and files with `nlink > 1` (hardlinks); NEVER invoke the tool with an empty operand set).
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -46,21 +46,27 @@ file. Everything else stays ephemeral under the per-run `<rundir>`. See "Fresh r
 
 `.gauntlet.yml` sits at the **repo root**, NOT inside `.gauntlet/` — it is repo configuration, not run
 state, and it is the only gauntlet file that belongs in git. It selects **which of the skill's KNOWN tools
-run, over which files**, on the cheap CI path (built-in defaults, re-scoped or removed by repo entries;
-`formatters: []` disables the path). **The SKILL owns each tool's exact argv; config NEVER supplies a
-command, flags, or argv** — flags carry semantics (`gofmt -w -r 'true -> false'` is a rewrite engine).
-Config can NEVER relax the whitelisting **criterion**, widen the denylist, or **introduce a binary outside
-the skill's known-tools table**.
+run, and at most a NARROWER file glob**, on the cheap CI path (built-in defaults, narrowed or removed by
+repo entries; `formatters: []` disables the path; **missing file → the table's defaults**). **The SKILL
+owns each tool's exact argv, its default glob, and the binary it resolves; config NEVER supplies a command,
+flags, or argv** — flags carry semantics (`gofmt -w -r 'true -> false'` is a rewrite engine). Config can
+NEVER relax the whitelisting **criterion**, widen the denylist, widen the **exclusion filter**, or
+**introduce a binary outside the skill's known-tools table**.
 
-Schema — each entry carries **EXACTLY these two fields**:
+Schema — each entry carries **EXACTLY these fields**:
 
 | field | rule |
 |---|---|
-| `id` | the known tool's id (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`). Not in the table → REFUSE. |
-| `files` | glob scoping the run. MUST NOT be able to match a **check definition, config, or test** path (`.golangci.yml`, `.github/**`, `**/*_test.go`, `test/**`, `tests/**`, `conftest.py`, `pyproject.toml`, `ruff.toml`, `.gauntlet.yml`, or a repo-sweeping `**`) → REFUSE. |
+| `id` | **required**. The known tool's id (`gofmt`, `gofumpt`, `goimports`, `gci`, `ruff format`). Not in the table → REFUSE. |
+| `files` | **optional**. May only **NARROW** the tool's default glob in the known-tools table (`gofmt` → `**/*.go`, `ruff format` → `**/*.py`, …); a widening glob → REFUSE. Omitted → the default. An **obviously hostile** glob directly targeting a check def, config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`), or a repo-sweeping bare `**`/`.` → REFUSE. |
 
 **Any other key — `command`, `args`, `argv`, `flags`, `guarantee` — REFUSES the entry.** The guarantee and
 the argv are the skill's, in the known-tools table (`stage-2-ci.md`), not the repo's to state or choose.
+
+**The glob NEVER carries the exclusions.** The skill applies a **non-overridable exclusion filter** to the
+file set *after* the glob — every time, config or no config — dropping tests, check definitions, and CI/tool
+config (`stage-2-ci.md`). So `files: "**/*.go"` is valid and correct: the glob selects, the filter protects.
+**Config CANNOT widen the filter.**
 
 **Any entry failing any of these is REFUSED** — logged, ignored, failure routed to the session model.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -53,9 +53,9 @@ blocks; each completion is its own wake.
      isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
      turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, `reviewer`, and `formatters` from the ledger
      header — they govern namespacing, the merge/diff target, API-change handling, which reviewer runs
-     the review passes, and which formatter tools the cheap CI path may run, and must be
+     the review passes, and which tools (if any — none by default) the cheap CI path may run, and must be
      consulted fresh each wake, never from memory (a wake may be a fresh agent instance that just
-     adopted the run, so an explicit/preferred reviewer or formatter list would otherwise
+     adopted the run, so an explicit/preferred reviewer or tool list would otherwise
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",
      `stage-2-ci.md`, "PR adoption"). Refresh
      the lease. This is the path every `--run` self-wake takes.
@@ -169,8 +169,9 @@ blocks; each completion is its own wake.
      fresh-subagent fallback. A failed launch yields no verdict: it never touches `reviews_ok` and
      never bumps the row's `attempts`;
    - CI red and no fix is already in flight for that PR/SHA → **CLASSIFY the failure first (Stage 2b,
-     "Whitelist classification") — never dispatch a subagent straight off a red check.** A **whitelisted
-     formatting** failure runs the **TOOL, with no model at all**; **everything else** gets a scoped CI-fix
+     "Tool classification") — never dispatch a subagent straight off a red check.** A failure whose fixer is a
+     known tool the **user ENABLED** runs the **TOOL, with no model at all**; **everything else** — including
+     the default state, in which **no tool is enabled** — gets a scoped CI-fix
      subagent on the **session model**, set explicitly and NEVER downgraded. Either way the resulting commit
      **resets the gate** (Stage 2b, "Any campaign commit to the PR head resets the gate"). The table, the
      skill-owned argv, the exclusion filter, and the file-operand checks live in `stage-2-ci.md` — follow

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -168,8 +168,13 @@ blocks; each completion is its own wake.
      files, which a surviving process could still write to); a dead `launch_attempt: 2` →
      fresh-subagent fallback. A failed launch yields no verdict: it never touches `reviews_ok` and
      never bumps the row's `attempts`;
-   - CI red and no CI-fix subagent is already in flight for that PR/SHA → dispatch a scoped fix
-     subagent (Stage 2b); different PRs may fix CI concurrently within the cap.
+   - CI red and no fix is already in flight for that PR/SHA → **CLASSIFY the failure first (Stage 2b,
+     "Whitelist classification") — never dispatch a subagent straight off a red check.** A **whitelisted
+     formatting** failure runs the **TOOL, with no model at all**; **everything else** gets a scoped CI-fix
+     subagent on the **session model**, set explicitly and NEVER downgraded. Either way the resulting commit
+     **resets the gate** (Stage 2b, "Any campaign commit to the PR head resets the gate"). The table, the
+     skill-owned argv, the exclusion filter, and the file-operand checks live in `stage-2-ci.md` — follow
+     them there; do NOT restate them here. Different PRs may fix CI concurrently within the cap.
    - CI snapshot reads `pending` for a PR whose watch task has already exited → **relaunch the watch
      in this same wake**. A pending PR must never sit unwatched until the heartbeat; the heartbeat is
      a fallback, not the mechanism.

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -51,13 +51,13 @@ blocks; each completion is its own wake.
      `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
      isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
-     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, `reviewer`, and `formatters` from the ledger
-     header — they govern namespacing, the merge/diff target, API-change handling, which reviewer runs
-     the review passes, and which tools (if any — none by default) the cheap CI path may run, and must be
+     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, and `reviewer` from the ledger
+     header — they govern namespacing, the merge/diff target, API-change handling, and which reviewer runs
+     the review passes, and must be
      consulted fresh each wake, never from memory (a wake may be a fresh agent instance that just
-     adopted the run, so an explicit/preferred reviewer or tool list would otherwise
+     adopted the run, so an explicit/preferred reviewer would otherwise
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",
-     `stage-2-ci.md`, "PR adoption"). Refresh
+     "PR adoption"). Refresh
      the lease. This is the path every `--run` self-wake takes.
    - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no
@@ -168,14 +168,15 @@ blocks; each completion is its own wake.
      files, which a surviving process could still write to); a dead `launch_attempt: 2` →
      fresh-subagent fallback. A failed launch yields no verdict: it never touches `reviews_ok` and
      never bumps the row's `attempts`;
-   - CI red and no fix is already in flight for that PR/SHA → **CLASSIFY the failure first (Stage 2b,
-     "Tool classification") — never dispatch a subagent straight off a red check.** A failure whose fixer is a
-     known tool the **user ENABLED** runs the **TOOL, with no model at all**; **everything else** — including
-     the default state, in which **no tool is enabled** — gets a scoped CI-fix
-     subagent on the **session model**, set explicitly and NEVER downgraded. Either way the resulting commit
-     **resets the gate** (Stage 2b, "Any campaign commit to the PR head resets the gate"). The table, the
-     skill-owned argv, the exclusion filter, and the file-operand checks live in `stage-2-ci.md` — follow
-     them there; do NOT restate them here. Different PRs may fix CI concurrently within the cap.
+   - CI red and no fix is already in flight for that PR/SHA → **CLASSIFY the failure from the check logs
+     first (Stage 2b, "Classify, then set the model") — never dispatch a subagent straight off a red
+     check.** The class picks the model, set **explicitly**: a **formatting/lint** failure → a scoped CI-fix
+     subagent on a **cheap** model (`sonnet`; `haiku` only when trivially mechanical), which runs a
+     formatter, **reads the resulting diff**, and **escalates** anything it cannot verify; **everything
+     else** — and every **escalation** — → a scoped CI-fix subagent on the **session model**. Either way the
+     resulting commit **resets the gate** (Stage 2b, "Any campaign commit to the PR head resets the gate").
+     The subagent's job order, the no-weakening prohibition, and the denylist live in `stage-2-ci.md` —
+     follow them there; do NOT restate them here. Different PRs may fix CI concurrently within the cap.
    - CI snapshot reads `pending` for a PR whose watch task has already exited → **relaunch the watch
      in this same wake**. A pending PR must never sit unwatched until the heartbeat; the heartbeat is
      a fallback, not the mechanism.

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -51,13 +51,13 @@ blocks; each completion is its own wake.
      `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
      isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
-     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, and `reviewer` from the ledger
-     header — they govern namespacing, the merge/diff target, API-change handling, and which reviewer runs
-     the review passes, and must be
+     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, `reviewer`, and `formatters` from the ledger
+     header — they govern namespacing, the merge/diff target, API-change handling, which reviewer runs
+     the review passes, and which formatter tools the cheap CI path may run, and must be
      consulted fresh each wake, never from memory (a wake may be a fresh agent instance that just
-     adopted the run, so an explicit/preferred reviewer would otherwise
+     adopted the run, so an explicit/preferred reviewer or formatter list would otherwise
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",
-     "PR adoption"). Refresh
+     `stage-2-ci.md`, "PR adoption"). Refresh
      the lease. This is the path every `--run` self-wake takes.
    - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -33,14 +33,14 @@ change voids the tally). A PR that takes several fix rounds can therefore spend 
 An external reviewer moves all of that off the subagent pool. When recommending Codex for diversity,
 say so: it is the change that most reduces token spend, not the model tier of any individual subagent.
 
-**Review passes themselves are never downgraded.** Whether the reviewer is a Claude subagent or the
+**NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.** Whether the reviewer is a Claude subagent or the
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
-gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). No other class is
-downgraded by default either: the fix subagents write code that gets merged, and nothing downstream
-guarantees a bad fix is caught. The **only** exception is a CI failure whose fixer is a
-semantics-preserving formatter (`SKILL.md`, "The one exception"; `stage-2-ci.md`) — never a review pass. Save tokens by moving review
-passes to an external reviewer and by scoping every fix subagent — never by cheapening a model on a
-judgment call.
+gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). Neither is any other
+class: the fix subagents write code that gets merged, and nothing downstream guarantees a bad fix is
+caught. The only cheap path is a whitelisted CI formatter, and it is cheap because it runs the **tool**
+with **no model at all** (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`) — never a review pass. Save
+tokens by moving review passes to an external reviewer and by scoping every fix subagent — never by
+cheapening a model.
 
 ### Running the default reviewer — Claude subagents
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -33,15 +33,13 @@ change voids the tally). A PR that takes several fix rounds can therefore spend 
 An external reviewer moves all of that off the subagent pool. When recommending Codex for diversity,
 say so: it is the change that most reduces token spend, not the model tier of any individual subagent.
 
-**NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.** Whether the reviewer is a Claude subagent or the
+**A REVIEW PASS IS NEVER RUN ON A DOWNGRADED MODEL.** Whether the reviewer is a Claude subagent or the
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
-gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). Neither is any other
-class: the fix subagents write code that gets merged, and nothing downstream guarantees a bad fix is
-caught. The only cheap path is a CI **tool the user has explicitly enabled** (the skill ships with none, and
-vouches for none) — and it is cheap because it runs the **tool**
-with **no model at all** (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`) — never a review pass. Save
-tokens by moving review passes to an external reviewer and by scoping every fix subagent — never by
-cheapening a model.
+gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). The **one** deliberate
+downgrade in this skill is the CI-fix subagent for a **formatting/lint** failure (`stage-2-ci.md`), which
+runs a formatter and **verifies its diff** rather than authoring a fix — never a review pass. Save tokens on
+review by moving passes to an external reviewer and by scoping every fix subagent — never by cheapening a
+verdict.
 
 ### Running the default reviewer — Claude subagents
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -26,6 +26,18 @@ same-model re-roll can miss — recommend it to the user for a stronger gauntlet
 user has set it as their preference. It is never mandatory: the default Claude-subagent path is a
 complete, valid reviewer.
 
+**An external reviewer is also the single biggest cost lever — the quality and cost arguments agree.**
+Review passes dominate campaign's subagent spend: each one re-reads the **whole** `origin/<base>...HEAD`
+diff, runs `required(tier)` times per SHA, and re-runs **from scratch** on every gate reset (a content
+change voids the tally). A PR that takes several fix rounds can therefore spend many full-diff passes.
+An external reviewer moves all of that off the subagent pool. When recommending Codex for diversity,
+say so: it is the change that most reduces token spend, not the model tier of any individual subagent.
+
+**Review passes themselves are never downgraded.** Whether the reviewer is a Claude subagent or the
+subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
+gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). Cheapen the fixes
+that CI can catch, never the check itself.
+
 ### Running the default reviewer — Claude subagents
 
 The reviewer's only job is the **Stage 2a per-PR review pass**: spawn a **fresh** subagent to review

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -36,9 +36,11 @@ say so: it is the change that most reduces token spend, not the model tier of an
 **Review passes themselves are never downgraded.** Whether the reviewer is a Claude subagent or the
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
 gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). No other class is
-downgraded either: the fix subagents write code that gets merged, and nothing downstream guarantees a bad
-fix is caught. Save tokens by moving review passes to an external reviewer and by scoping every fix
-subagent — never by cheapening a model.
+downgraded by default either: the fix subagents write code that gets merged, and nothing downstream
+guarantees a bad fix is caught. The **only** exception is a CI failure whose check is a total oracle
+(`SKILL.md`, "The one exception"; `stage-2-ci.md`) — never a review pass. Save tokens by moving review
+passes to an external reviewer and by scoping every fix subagent — never by cheapening a model on a
+judgment call.
 
 ### Running the default reviewer — Claude subagents
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -37,8 +37,8 @@ say so: it is the change that most reduces token spend, not the model tier of an
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
 gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). No other class is
 downgraded by default either: the fix subagents write code that gets merged, and nothing downstream
-guarantees a bad fix is caught. The **only** exception is a CI failure whose check is a total oracle
-(`SKILL.md`, "The one exception"; `stage-2-ci.md`) — never a review pass. Save tokens by moving review
+guarantees a bad fix is caught. The **only** exception is a CI failure whose fixer is a
+semantics-preserving formatter (`SKILL.md`, "The one exception"; `stage-2-ci.md`) — never a review pass. Save tokens by moving review
 passes to an external reviewer and by scoping every fix subagent — never by cheapening a model on a
 judgment call.
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -37,7 +37,8 @@ say so: it is the change that most reduces token spend, not the model tier of an
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
 gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). Neither is any other
 class: the fix subagents write code that gets merged, and nothing downstream guarantees a bad fix is
-caught. The only cheap path is a whitelisted CI formatter, and it is cheap because it runs the **tool**
+caught. The only cheap path is a whitelisted CI **tool** — one that guarantees semantic equivalence of its
+output — and it is cheap because it runs the **tool**
 with **no model at all** (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`) — never a review pass. Save
 tokens by moving review passes to an external reviewer and by scoping every fix subagent — never by
 cheapening a model.

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -35,8 +35,10 @@ say so: it is the change that most reduces token spend, not the model tier of an
 
 **Review passes themselves are never downgraded.** Whether the reviewer is a Claude subagent or the
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
-gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). Cheapen the fixes
-that CI can catch, never the check itself.
+gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). No other class is
+downgraded either: the fix subagents write code that gets merged, and nothing downstream guarantees a bad
+fix is caught. Save tokens by moving review passes to an external reviewer and by scoping every fix
+subagent — never by cheapening a model.
 
 ### Running the default reviewer — Claude subagents
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -37,8 +37,8 @@ say so: it is the change that most reduces token spend, not the model tier of an
 subagent fallback for a failed external reviewer, the pass runs on the **session model** — it *is* the
 gate, and a weaker verdict is simply a worse gate (`SKILL.md`, "Subagent Dispatch"). Neither is any other
 class: the fix subagents write code that gets merged, and nothing downstream guarantees a bad fix is
-caught. The only cheap path is a whitelisted CI **tool** — one that guarantees semantic equivalence of its
-output — and it is cheap because it runs the **tool**
+caught. The only cheap path is a CI **tool the user has explicitly enabled** (the skill ships with none, and
+vouches for none) — and it is cheap because it runs the **tool**
 with **no model at all** (`SKILL.md`, "The only cheap path"; `stage-2-ci.md`) — never a review pass. Save
 tokens by moving review passes to an external reviewer and by scoping every fix subagent — never by
 cheapening a model.

--- a/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
@@ -34,6 +34,14 @@ escalation rung, which forces this pass no later than the 2nd `NOT SATISFIED` on
    it finds the sites next to its diff and misses the caller two layers up or the code path it has no
    handle on. A mapper carries no fix pressure, so it maps the space exhaustively — which is the point.
    Enumeration and fix are two subagents, in that order, always.
+
+   **Run the mapper on the session model — do NOT downgrade it because it is "read-only."**
+   Read-only is not low-judgment: this subagent derives the axes, enumerates every cell, and confirms
+   each gap with a `file:line` and a working repro. A weaker model **under-maps** — it returns a
+   plausible, tidy, *incomplete* table — which is precisely the failure this whole two-subagent split
+   exists to prevent, and an under-map is invisible: the gaps it misses look exactly like cells that
+   were never there. The cheap version of this subagent defeats its own purpose (`SKILL.md`,
+   "Subagent Dispatch").
 3. **One batch-fix round** for all confirmed gaps. Route every site through **ONE shared
    chokepoint/helper** so the cells can't diverge again. Add a test per cell.
 4. **Resume the gauntlet** on the batched result — the review gate's `required(tier)` fresh,

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -20,7 +20,7 @@ row by column position:
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
 
-  **Classify the failure first** (see "Total-oracle classification" below). Not whitelisted →
+  **Classify the failure first** (see "Whitelist classification" below). Not whitelisted →
   **dispatch on the session model** — set the model explicitly, and do NOT downgrade it (`SKILL.md`,
   "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream validates it: a
   wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in product code no
@@ -43,44 +43,60 @@ row by column position:
   (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the watch
   immediately and re-enter 2a.
 
-#### Total-oracle classification
+#### Whitelist classification — semantics-preserving formatters only
 
-Before dispatching anything, decide whether the failing check is a **total oracle** for its fix:
-re-running that same check *fully decides* correctness, leaving no judgment over (`SKILL.md`, "The one
-exception"). All three MUST hold:
+Before dispatching anything, decide whether the failing check is **whitelisted**. A check qualifies as a
+**total oracle** — re-running it *fully decides* correctness, leaving no judgment over — **only because
+its fixer is semantics-preserving BY CONSTRUCTION**: it rewrites LAYOUT and cannot change program meaning
+at all (`SKILL.md`, "The one exception"). The guarantee comes from the **tool's construction**, never
+from a hope that a reviewer will notice. "A lint rule passed" is a strictly weaker claim and is NOT
+sufficient.
 
-- (a) the failing check fully verifies its own fix on re-run; AND
-- (b) the fix is confined to what the check itself defines — **no product behavior changes**; AND
-- (c) the resulting diff touches **no check definition, config, or test** (the no-weakening prohibition
-  above, now doing double duty as a guard).
+- **IN** — pure formatting / import ordering: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
+  `whitespace`, `prettier`, `ruff format`.
+- **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
+  `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
+  with a reversed or non-equivalent comparator): lint-clean, semantics changed. The check does NOT fully
+  verify its own fix, so it is NOT a total oracle.
+- **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes
+  too. A whitelisted run MUST invoke **only the formatter**, NEVER a catch-all `--fix`.
+- **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
+  compile error, and any rule that rewrites logic.
 
-Key it on the **check / linter rule IDENTITY** from the failing check's output — `gofmt`, `goimports`,
-`golangci-lint` rules (`modernize`, `gci`, `whitespace`, …) — NEVER on a judgment that the failure
-"looks mechanical". **Default is NOT whitelisted. Unknown check → session model.** A failing product
-test is NEVER whitelisted: making a test pass is not the same as fixing the bug. Compile errors in real
-logic are NEVER whitelisted.
+Key it on the **check / fixer IDENTITY** from the failing check's output — NEVER on a judgment that the
+failure "looks mechanical". **Default is NOT whitelisted. Unknown check → session model.**
 
 Then, in order:
 
-1. **Tier 0 — no subagent (prefer this always).** Whitelisted check with a deterministic autofixer →
-   run the **tool** in `<worktree>`: `golangci-lint run --fix`, `gofmt -w`, `goimports -w`,
-   `ruff --fix`, `prettier --write`, etc. Re-run the exact failing check. Passes → commit + push, no
-   model spend at all. Dispatching a model to hand-edit a formatting violation is both the most
-   expensive and the LEAST reliable way to do it.
-2. **Tier 1 — cheap model, verified.** Whitelisted check with no autofixer, or an autofixer that ran but
-   left residue → dispatch the scoped CI-fix subagent on `haiku` (pure mechanical rewrite) or `sonnet`
-   (needs any reasoning). Set the model explicitly. **Verify before accepting**: re-run the exact
-   failing check in `<worktree>` AND inspect the diff. ACCEPT only if the check now **passes** AND the
-   diff touches **no check definition, config, or test** and changes no product behavior.
-3. **Discard and escalate.** Verification fails on any point (check still red, diff touches a check/
-   config/test, behavior moved) → **discard the work** (`git checkout -- .` / reset the worktree to the
-   PR head) and re-dispatch the same failure on the **session model**. NEVER patch up a Tier-1 fix in
-   place; NEVER commit an unverified Tier-1 diff.
-4. **Everything else → session model**, per the red-CI dispatch above.
+1. **Tier 0 — no subagent (prefer this always).** Whitelisted formatter with a deterministic fixer → run
+   the **tool** in `<worktree>`: `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`,
+   `prettier --write`, `ruff format`. NEVER a catch-all `--fix`. Then apply the acceptance criteria
+   below. Passes → commit + push, no model spend at all. Dispatching a model to hand-edit a formatting
+   violation is both the most expensive and the LEAST reliable way to do it.
+2. **Tier 1 — cheap model, verified.** Whitelisted formatter with no usable fixer, or a fixer that ran
+   but left residue → dispatch the scoped CI-fix subagent on `haiku` (pure mechanical rewrite) or
+   `sonnet` (needs any reasoning). Set the model explicitly. Then apply the acceptance criteria below.
+3. **Everything else → session model**, per the red-CI dispatch above.
 
-The review gate still reads the whole diff for every commit a tier produces. The whitelist lowers
-**cost**, never the gate. An autofixer or `modernize`-class rewrite CAN in rare cases change behavior —
-the gate is what catches that; this is not a guarantee of correctness.
+**Acceptance criteria (Tier 0 and Tier 1 alike).** ACCEPT the fix **only if all three hold**:
+
+- (a) re-running the **exact** failing check now **passes**; AND
+- (b) the diff touches **no check definition, config, or test**; AND
+- (c) the diff is **formatting-only** — whitespace, indentation, line breaks, and import-block
+  ordering/insertion/removal — and touches **NOTHING else**: no expression, call, argument, control flow,
+  or literal.
+
+Any point fails → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same
+failure on the session model**. NEVER patch a whitelisted fix in place; NEVER commit an unverified one;
+NEVER accept a "formatting" fix whose diff edits code.
+
+(c) is the mechanical guard that makes "changes no product behavior" **checkable rather than promised**:
+with the whitelist narrowed to formatters, a formatting-only diff cannot move behavior.
+
+**Residual risk, stated honestly:** it is small and specific — reordering imports could in principle
+change init side-effect order (blank/`_` imports). That is the whole of it. Do NOT widen the whitelist
+past it, and NEVER re-derive its safety from the review gate: the whitelist stands on the fixer being
+incapable of changing semantics, or it does not stand at all.
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -20,11 +20,12 @@ row by column position:
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
 
-  **Dispatch it on the session model** — set the model explicitly, and do NOT downgrade it
-  (`SKILL.md`, "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream
-  validates it: a wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in
-  product code no check covers — and the review gate is a miss-catcher, not a proof of correctness. A
-  green check means the check passed, never that the fix is right. NEVER claim CI catches a bad fix.
+  **Classify the failure first** (see "Total-oracle classification" below). Not whitelisted →
+  **dispatch on the session model** — set the model explicitly, and do NOT downgrade it (`SKILL.md`,
+  "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream validates it: a
+  wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in product code no
+  check covers — and the review gate is a miss-catcher, not a proof of correctness. A green check means
+  the check passed, never that the fix is right. NEVER claim CI catches a bad fix.
 
   **Scope it**: give it the failing check's logs, the specific failing file(s), and the worktree path,
   and tell it NOT to re-derive the whole diff or read beyond what the failure touches.
@@ -41,6 +42,45 @@ row by column position:
   gauntlet-reviewing`) — the gate and its label move together, never one without the other
   (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the watch
   immediately and re-enter 2a.
+
+#### Total-oracle classification
+
+Before dispatching anything, decide whether the failing check is a **total oracle** for its fix:
+re-running that same check *fully decides* correctness, leaving no judgment over (`SKILL.md`, "The one
+exception"). All three MUST hold:
+
+- (a) the failing check fully verifies its own fix on re-run; AND
+- (b) the fix is confined to what the check itself defines — **no product behavior changes**; AND
+- (c) the resulting diff touches **no check definition, config, or test** (the no-weakening prohibition
+  above, now doing double duty as a guard).
+
+Key it on the **check / linter rule IDENTITY** from the failing check's output — `gofmt`, `goimports`,
+`golangci-lint` rules (`modernize`, `gci`, `whitespace`, …) — NEVER on a judgment that the failure
+"looks mechanical". **Default is NOT whitelisted. Unknown check → session model.** A failing product
+test is NEVER whitelisted: making a test pass is not the same as fixing the bug. Compile errors in real
+logic are NEVER whitelisted.
+
+Then, in order:
+
+1. **Tier 0 — no subagent (prefer this always).** Whitelisted check with a deterministic autofixer →
+   run the **tool** in `<worktree>`: `golangci-lint run --fix`, `gofmt -w`, `goimports -w`,
+   `ruff --fix`, `prettier --write`, etc. Re-run the exact failing check. Passes → commit + push, no
+   model spend at all. Dispatching a model to hand-edit a formatting violation is both the most
+   expensive and the LEAST reliable way to do it.
+2. **Tier 1 — cheap model, verified.** Whitelisted check with no autofixer, or an autofixer that ran but
+   left residue → dispatch the scoped CI-fix subagent on `haiku` (pure mechanical rewrite) or `sonnet`
+   (needs any reasoning). Set the model explicitly. **Verify before accepting**: re-run the exact
+   failing check in `<worktree>` AND inspect the diff. ACCEPT only if the check now **passes** AND the
+   diff touches **no check definition, config, or test** and changes no product behavior.
+3. **Discard and escalate.** Verification fails on any point (check still red, diff touches a check/
+   config/test, behavior moved) → **discard the work** (`git checkout -- .` / reset the worktree to the
+   PR head) and re-dispatch the same failure on the **session model**. NEVER patch up a Tier-1 fix in
+   place; NEVER commit an unverified Tier-1 diff.
+4. **Everything else → session model**, per the red-CI dispatch above.
+
+The review gate still reads the whole diff for every commit a tier produces. The whitelist lowers
+**cost**, never the gate. An autofixer or `modernize`-class rewrite CAN in rare cases change behavior —
+the gate is what catches that; this is not a guarantee of correctness.
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -92,24 +92,36 @@ The ONLY binaries campaign may execute on the no-model path, in the ONLY form it
 `formatters` header field, with the skill's **exclusion filter** applied afterwards — always (both below).
 Adding a tool, changing an argv, or changing a default glob is a **SKILL change** (gated, reviewed).
 
-| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee | precondition — MUST hold in THIS repo |
+| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — what the tool DOCUMENTS | precondition — MUST hold in THIS repo |
 |---|---|---|---|---|
-| `gofmt` | `["gofmt", "-w", <files>]` | `**/*.go` | AST-preserving Go pretty-printer (`go/printer`); never alters string-literal contents | none |
-| `gofumpt` | `["gofumpt", "-w", <files>]` | `**/*.go` | same printer, stricter layout rules; never alters string-literal contents | none |
-| `goimports` | `["goimports", "-w", <files>]` | `**/*.go` | rewrites the **import block only** | none |
-| `gci` | `["gci", "write", <files>]` | `**/*.go` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
-| `ruff format` | `["ruff", "format", <files>]` | `**/*.py` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | documented as a pretty-printer: it parses the file and re-prints the AST with `go/printer` (tabs to indent, blanks to align). With no `-r` and no `-s` it applies **no rewrite rule**; comments and string-literal contents are reproduced verbatim | none |
+| `gci` | `["gci", "write", "--", <files>]` | `**/*.go` | documented as controlling **import ORDER and GROUPING** and nothing else: it sorts existing imports into sections. It does **NOT add** an import and does **NOT remove** one, so no `init()` set changes; Go's package init order is by **dependency**, not by import position in a file | none |
+| `ruff format` | `["ruff", "format", "--", <files>]` | `**/*.py` | documented to **verify its own output is AST-equivalent** to the input (it compares the parsed trees and refuses a formatting that would change them) | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
 
 Every tool has a default glob, so an **unnarrowed formatter list has a fully defined file set**: the
 table's defaults, filtered. NEVER invent a default glob for a tool; NEVER widen one.
+
+**A `guarantee` cell MUST cite what the tool DOCUMENTS.** "It is a formatter", "the diff looks
+mechanical", "it feels safe" are NOT guarantees and have repeatedly been wrong. No citable documented
+guarantee → the tool does NOT go in the table.
 
 **NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
 the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
 shell string.
 
-**REMOVED — golangci-lint `whitespace`**: no safe fixer exists for it. Its only fix path is the catch-all
-`golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
-failure goes to the session model.
+**REMOVED — tools that FAIL the criterion.** They are not "not configured"; they are **rejected**, and
+re-adding one is a SKILL change that must first defeat the reason below:
+
+- **`goimports`** — documented to **ADD missing imports and REMOVE unreferenced ones**. Adding an import
+  runs that package's `init()`; a guessed import can resolve to the **wrong package**. Changing the set of
+  imports is not semantics-preserving. NOT a formatter for this purpose.
+- **`gofumpt`** — a stricter gofmt that applies **EXTRA rewrite rules** beyond `go/printer` layout, and its
+  rules are documented as a rule LIST, **not** as semantics-preserving. It edits source constructs, not just
+  whitespace. It does not meet the criterion; being "gofmt-like" is not an argument. NEVER re-add it on the
+  grounds that it "is basically a formatter".
+- **golangci-lint `whitespace`** — no safe fixer exists. Its only fix path is the catch-all
+  `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
+  failure goes to the session model.
 
 #### RESOLVE argv[0] TO A TRUSTED ABSOLUTE EXECUTABLE — OUTSIDE THE REPO
 
@@ -132,7 +144,45 @@ Before execution, EVERY time:
 
 Run the tool with the **worktree as CWD** but **NEVER with the worktree on `PATH`** and NEVER with the
 worktree as the lookup base. Pass the **resolved absolute path** as `argv[0]`; the rest of the argv is the
-table's, unchanged.
+table's, unchanged — with the file operands NORMALIZED per the next rule.
+
+#### NORMALIZE THE FILE ARGV — filenames are PR-CONTROLLED DATA
+
+The skill owns the argv **SHAPE**. It does **NOT** own the file operands: `<files>` comes from globbing the
+**PR's worktree**, so every filename in it is **attacker-controlled data spliced into argv**. Data spliced
+into argv MUST be normalized — exactly like any other injection boundary. Owning the shape is NOT owning
+the argv.
+
+**The repro — a filename that is an OPTION** (this is why the rule exists, do NOT delete it):
+
+```
+# The PR adds a file literally named:  -cpuprofile=prof.go
+# It matches **/*.go. It survives the exclusion filter. It is passed as a file operand:
+gofmt -w '-cpuprofile=prof.go' a.go     # exit 0 — gofmt parsed it as a FLAG, and wrote a CPU profile
+```
+
+argv[0] was the trusted binary, the argv was the table's, no shell was involved, no model ran — and PR
+content still changed what the command **did** and what it **touched**. A bare relative filename is not a
+path; it is a token the tool is free to parse as an option.
+
+**EVERY tool, EVERY run, ALL THREE — no exceptions:**
+
+1. **END-OF-OPTIONS.** Pass `--` immediately before the file list. Every tool in the table accepts it
+   (`gofmt`/Go `flag`, `gci`/pflag, `ruff`/clap), and the table's argv already carries it. Nothing after
+   `--` can be read as a flag. A tool that has no `--` NEVER enters the table.
+2. **NEVER PASS A BARE RELATIVE NAME.** Pass each file as a path that **cannot be mistaken for an option**:
+   an **ABSOLUTE** path (worktree root joined to the relative path) — or, if a tool needs relative paths, a
+   **`./`-prefixed** one. Belt-and-braces: this holds even for a tool whose `--` handling is broken.
+3. **REFUSE a candidate whose basename or path starts with `-`** (checked AFTER the exclusion filter). A
+   legitimate source file is NEVER named that way. **DROP that file from the set — do NOT abort the run**,
+   and **LOG it**: the id, the refused filename, and why.
+
+Refusing files can empty the set → then run NOTHING for that id and route the failure to the session model
+("Empty file set after filtering" below). Refusing a file NEVER widens anything and NEVER fails the PR.
+
+**NEVER pass the glob itself to the tool** (`gofmt -w .`, `gofmt -w '**/*.go'`) — that hands file selection
+to the tool and bypasses the exclusion filter AND this normalization. Campaign expands, filters, refuses,
+normalizes, and passes the resulting **explicit path list**.
 
 #### A tool's guarantee can be CONDITIONAL on its configuration
 
@@ -205,7 +255,12 @@ drops `**/*_test.go` and everything else it must not touch. The user never enume
 that gate the review, and it MUST be logged and refused rather than silently emptied by the filter. But the
 refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
 
-**Empty file set after filtering → run NOTHING for that id** and route the failure to the session model.
+**AFTER the filter, the file argv is still PR data**: refuse every surviving `-`-leading name and normalize
+the rest ("NORMALIZE THE FILE ARGV" above). The filter decides *which* files are touched; the normalization
+decides that they are read as **files at all** and not as flags. Both, every run.
+
+**Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
+the session model.
 
 #### The formatter list — resolved at run start, stored in the ledger, NEVER in repo content
 
@@ -247,7 +302,9 @@ as one.
 
 What IS a security boundary: **the tool runs on UNTRUSTED PR CONTENT, inside the PR's worktree.** That is
 why `argv[0]` is resolved to a trusted absolute executable **outside the repo** ("RESOLVE argv[0]" above),
-and why the exclusion filter is the skill's and not the user's.
+why the **file operands are normalized** — they come from the PR's tree, so they are attacker-controlled
+data spliced into argv ("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the skill's and
+not the user's.
 
 #### VALIDATION — an id in the `formatters` list is ACCEPTED only if ALL of these hold
 
@@ -280,7 +337,8 @@ Then, in order:
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
    **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
    the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
-   glob, **exclusion filter applied**). NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
+   glob, **exclusion filter applied**, then **`-`-leading names refused and the operands normalized —
+   `--` + absolute/`./` paths**). NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
    **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
    definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
    above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -14,13 +14,15 @@ row by column position:
   leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
   pending PR must never sit unwatched waiting for the heartbeat.
 - **red** → any failing line → **stop any review pass in flight on that PR first** (Loop control
-  step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then
-  diagnose from the check logs and dispatch a scoped CI-fix subagent into `<worktree>` — the PR row's
+  step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then diagnose
+  from the check logs and **CLASSIFY the failure** ("Whitelist classification" below) **before dispatching
+  anything**. Whitelisted formatting failure → run the **TOOL, no model**. Everything else → a scoped
+  CI-fix subagent into `<worktree>` — the PR row's
   ledger `worktree` column value, the single source of truth for this PR's checkout path (created at
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
 
-  **Classify the failure first** (see "Whitelist classification" below). Not whitelisted →
+  Not whitelisted →
   **dispatch on the session model** — set the model explicitly, and do NOT downgrade it (`SKILL.md`,
   "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream validates it: a
   wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in product code no
@@ -95,16 +97,26 @@ Adding a tool, changing an argv, or changing a default glob is a **SKILL change*
 
 | `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — the SOURCE, then what it says |
 |---|---|---|---|
-| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines the behaviour: *"Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment."* Of the flags it documents, **exactly two CHANGE THE SOURCE**: **`-r`** — *"Apply the rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* (it lists the source transformations `-s` performs). **NEITHER is in the skill-owned argv**, and nothing may append one |
+| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines the behaviour: *"Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment."* **`-w`** — *"If a file's formatting is different from gofmt's, overwrite it with gofmt's version"* — **writes the formatted result back to the file. That is what we WANT: it is the ONLY mutation the skill-owned argv performs.** **`-r`** — *"Apply the rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* — are the only documented flags that apply a **non-formatting source TRANSFORMATION**: they change the PROGRAM, beyond re-printing it. **NEITHER is in the skill-owned argv**, and nothing may append one |
 
-**Read that cell for EXACTLY what it says.** It says `-r` and `-s` are the only documented flags that
-**rewrite the source**. It does **NOT** say they are the only documented flags: the doc lists others (`-l`,
-`-d`, `-e`, `-cpuprofile`, …), and **`-cpuprofile` WRITES A FILE**. NEVER restate the claim as "gofmt has
-only two flags" — that is broader than the source, and it is false. The safety of this cell rests on
-**three** things, all of them ours: the argv is **skill-owned and exact** (`["gofmt","-w","--",<files>]`);
-**NO flag may ever be appended** to it; and **no file operand can be read as a flag** (`--`, plus the
-operand-normalization rules below). That last one is not theoretical — the injection repro below is a file
-literally named `-cpuprofile=prof.go`.
+**Read that cell for EXACTLY what it says — and state ONLY the TRANSFORMATION property.** `-r` and `-s` are
+the only documented flags that **transform the source beyond re-printing it**. That is the whole claim.
+
+- **`-w` CHANGES THE SOURCE** — it overwrites the file with gofmt's result. It is in our argv on purpose;
+  it is the only mutation the argv performs. NEVER write a sentence that implies `-w` leaves the source
+  alone.
+- **`-cpuprofile` is a separate documented flag that WRITES A FILE** — it does not transform the source. It
+  is named here only because a FILENAME shaped like `-cpuprofile=x.go` is the injection repro below.
+- The doc lists others still (`-l`, `-d`, `-e`, …).
+
+**GUARD — this claim has been stated wrongly THREE times.** NEVER say "exactly two flags", "the only two
+flags", or "the only flags that CHANGE the source". All three are false. The property is
+**source-TRANSFORMING**, and nothing broader.
+
+The safety of this cell rests on **three** things, all of them ours: the argv is **skill-owned and exact**
+(`["gofmt","-w","--",<files>]`); **NO flag may ever be appended** to it; and **no file operand can be read as
+a flag** (`--`, plus the operand-normalization rules below). That last one is not theoretical — the injection
+repro below is a file literally named `-cpuprofile=prof.go`.
 
 **ONE tool. That is the whole table**, and it is small **on purpose**: it is what survived a rule that
 demands a **documented** guarantee, quoted from the source. Every tool has a default glob, so an
@@ -224,7 +236,27 @@ containment of the **DATA**. A hardlink is a regular file whose path is inside t
 is shared with a path outside it: it defeats the symlink check (it is not a link) and the containment check
 (its real path is inside). Reason on record: **hardlink — nlink>1**.
 
-**EVERY tool, EVERY run, ALL SIX — no exceptions:**
+**The fourth repro — a SYMLINKED DIRECTORY COMPONENT, which defeats the EXCLUSION FILTER** (the filter was
+applied to the SPELLING, not to the LOCATION):
+
+```
+# The PR adds a symlink DIRECTORY:  safe/gh  ->  .github
+# Candidate: safe/gh/actions/main.go
+#   - not itself a symlink (lstat says regular file)   - realpath is INSIDE the worktree (.github/… is in-tree)
+#   - a regular file, nlink == 1                       - name has no leading `-`
+#   - and `safe/gh/**` does NOT match the filter's `.github/**`
+gofmt -w -- /wt/safe/gh/actions/main.go   # a CHECK DEFINITION, handed to the tool. Every earlier check passed.
+```
+
+**THE PRINCIPLE — the generalisation of every round above: EVERY check that reasons about a path MUST reason
+about the RESOLVED path. A NAME IS NOT A LOCATION.** The exclusion filter is a check about a path, so it too
+must run on what the path RESOLVES TO — matching `safe/gh/actions/main.go` against `.github/**` asks the
+wrong question. Reason on record: **symlinked directory component / excluded after resolution**.
+
+**THE PIPELINE, in this order, every tool, every run:** expand the glob → **RESOLVE** each candidate →
+**FILTER on BOTH the original and the resolved path** → run the **seven** operand checks → build the argv.
+
+**EVERY tool, EVERY run, ALL SEVEN — no exceptions:**
 
 1. **END-OF-OPTIONS.** Pass `--` immediately before the file list. Every tool in the table accepts it
    (`gofmt`, via Go's `flag` package), and the table's argv already carries it. Nothing after `--` can be
@@ -247,11 +279,18 @@ is shared with a path outside it: it defeats the symlink check (it is not a link
    `st_nlink > 1` → DROP it. A source file in a normal checkout has **exactly one link**. A multi-link file
    is either a **hardlink escape** (the inode is aliased outside the tree, and `gofmt -w` rewrites the
    INODE) or something we have **no reason to format** — either way it does not get handed to the tool.
+7. **REFUSE a candidate with a SYMLINK in ANY DIRECTORY COMPONENT of its path.** Walk the components from
+   the resolved worktree root down (`wt/safe`, `wt/safe/gh`, `wt/safe/gh/actions`, …) and `lstat` **each**;
+   ANY component that is a symlink → DROP the candidate. Check 4 only tests the LAST component, so a
+   symlinked directory slips a candidate past it — and past the exclusion filter, which was matched on the
+   SPELLED path. A source file that must be formatted **never** sits under a symlinked directory. This check
+   is the cheap explicit tripwire; **the resolved-path exclusion filter is the guarantee** — run BOTH.
 
-**Checks 3–6 run AFTER the exclusion filter and BEFORE the argv is built** — the filter decides which
-candidates survive; these decide which surviving candidates are handed to the tool at all. Every refusal:
-**DROP that file from the set — do NOT abort the run** — and **LOG it**: the id, the refused path, and the
-reason (`-`-leading name / symlink / escapes the worktree / not a regular file / hardlink — nlink>1).
+**The exclusion filter runs on the ORIGINAL and on the RESOLVED path; checks 3–7 run AFTER it and BEFORE the
+argv is built** — the filter decides which candidates survive; these decide which surviving candidates are
+handed to the tool at all. Every refusal: **DROP that file from the set — do NOT abort the run** — and **LOG
+it**: the id, the refused path, and the reason (`-`-leading name / symlink / escapes the worktree / not a
+regular file / hardlink — nlink>1 / symlinked directory component / excluded after resolution).
 
 Refusing files can empty the set → then run NOTHING for that id and route the failure to the session model
 ("Empty file set after filtering" below). Refusing a file NEVER widens anything and NEVER fails the PR.
@@ -289,12 +328,19 @@ Key it on the **tool's IDENTITY and its CITED documented guarantee** — NEVER o
 unresolvable binary, or a refused id → session model.** (An **unset** `formatters` header is not a
 refusal: it means the known-tools table's defaults.)
 
-#### THE SKILL-OWNED EXCLUSION FILTER — applied AFTER the glob, EVERY time
+#### THE SKILL-OWNED EXCLUSION FILTER — applied to the RESOLVED path, EVERY time
+
+**MATCH THE FILTER AGAINST WHAT THE PATH RESOLVES TO, NOT AGAINST HOW IT IS SPELLED.** For every candidate,
+`realpath` it (every symlink followed, `..` collapsed), take that real path **relative to the resolved
+worktree root**, and match the patterns below against **BOTH** the original path AND the resolved one.
+**EITHER matches → REFUSE.** A filter matched only on the spelling is defeated by one symlinked directory
+(`safe/gh -> .github`; the fourth repro above), which hands a **check definition** to the tool with every
+other check passing. **A NAME IS NOT A LOCATION.**
 
 **The glob SELECTS candidates. The FILTER decides what is touched.** After expanding the tool's file set
-(its default glob, narrowed by any validated per-id glob), campaign **REMOVES** every path below — always,
-regardless of what the glob said. **NOTHING widens this filter, and the formatter list NEVER carries the
-exclusions itself.**
+(its default glob, narrowed by any validated per-id glob) and resolving each candidate, campaign **REMOVES**
+every path below — always, regardless of what the glob said. **NOTHING widens this filter, and the formatter
+list NEVER carries the exclusions itself.**
 
 Excluded — never handed to a tool, never in a tool commit:
 
@@ -319,11 +365,12 @@ that gate the review, and it MUST be logged and refused rather than silently emp
 refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
 
 **AFTER the filter, the file argv is still PR data**: of every surviving candidate, refuse the `-`-leading
-names, the **symlinks**, anything whose **real path escapes the worktree** or is **not a regular file**, and
-anything with **`nlink > 1`**; normalize what is left ("NORMALIZE THE FILE ARGV" above). The filter decides
-*which* candidates survive; the normalization decides that what is handed to the tool is read as a **file**
-and not a flag, that it is a **real file INSIDE the tree** and not a link out of it, and that its **INODE is
-not aliased outside the tree**. All of it, every run.
+names, the **symlinks**, anything with a **symlink in any directory component**, anything whose **real path
+escapes the worktree** or is **not a regular file**, and anything with **`nlink > 1`**; normalize what is left
+("NORMALIZE THE FILE ARGV" above — all **seven** checks). The filter decides *which* candidates survive; the
+normalization decides that what is handed to the tool is read as a **file** and not a flag, that it is a
+**real file INSIDE the tree** and not a link out of it, that no directory on the way to it is a link, and that
+its **INODE is not aliased outside the tree**. All of it, every run.
 
 **Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
 the session model. **NEVER invoke the tool with zero operands** — `gofmt` with no operands reads **stdin**.
@@ -377,10 +424,12 @@ as one.
 
 What IS a security boundary: **the tool runs on UNTRUSTED PR CONTENT, inside the PR's worktree.** That is
 why `argv[0]` is resolved to a trusted absolute executable **outside the repo** ("RESOLVE argv[0]" above),
-why the **file operands are normalized, resolved, AND checked for aliasing** — they come from the PR's tree,
-so they are attacker-controlled data spliced into argv; a symlink among them makes the tool write **outside
-the worktree**, and a **hardlink** makes it write outside the worktree while every path check passes
-("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the skill's and not the user's.
+why the **file operands are normalized, resolved, checked for aliasing, AND filtered on the RESOLVED path** —
+they come from the PR's tree, so they are attacker-controlled data spliced into argv; a symlink among them
+makes the tool write **outside the worktree**, a **hardlink** makes it write outside the worktree while every
+path check passes, and a **symlinked directory component** walks a candidate into an **excluded** location
+while the spelled path looks innocent ("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the
+skill's and not the user's.
 
 #### VALIDATION — an id in the `formatters` list is ACCEPTED only if ALL of these hold
 
@@ -413,7 +462,8 @@ Then, in order:
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
    **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
    the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
-   glob, **exclusion filter applied**, then **`-`-leading names, symlinks, non-regular files, paths whose
+   glob, each candidate **RESOLVED**, the **exclusion filter applied to BOTH its original and its resolved
+   path**, then **`-`-leading names, symlinks, symlinked directory components, non-regular files, paths whose
    real path escapes the worktree, and files with `nlink > 1` all refused, and the operands normalized —
    `--` + absolute/`./` paths**). **NEVER run the tool with an EMPTY operand set** (`gofmt` with no operands
    reads stdin) — empty → session model. NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -21,11 +21,24 @@ row by column position:
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
 
   **Dispatch it on `sonnet`** (`model: "sonnet"`), not the session model — the one sanctioned
-  downgrade in this skill (`SKILL.md`, "Subagent Dispatch"). It is safe here *because the failure is
-  self-detecting*: a bad CI fix leaves CI red, campaign re-dispatches, and a red check blocks the
-  review pass regardless — so a weaker fix can never silently reach the gate. **Scope it**: give it
-  the failing check's logs, the specific failing file(s), and the worktree path, and tell it NOT to
-  re-derive the whole diff or read beyond what the failure touches.
+  downgrade in this skill (`SKILL.md`, "Subagent Dispatch"). It is safe because **both** of its
+  failure modes are caught — but by two different mechanisms, not by CI alone:
+  - *fix didn't work* → CI stays red → campaign re-dispatches, and a red check blocks the review pass
+    regardless. CI catches this one.
+  - *fix weakened the check* (gutted assertion, `skip`/`xfail`, disabled lint rule, raised timeout) →
+    **CI turns green, so CI does NOT catch it.** It is caught by the **review gate**, which reads the
+    whole `origin/<base>...HEAD` diff and sees the weakened check as the code change it is.
+
+  Never claim "CI catches everything" — it does not. Both nets must stay in place.
+
+  **Scope it**: give it the failing check's logs, the specific failing file(s), and the worktree path,
+  and tell it NOT to re-derive the whole diff or read beyond what the failure touches.
+
+  **Tell it, verbatim in its prompt**: it MUST fix the *cause* of the failure. It MUST NEVER make CI
+  pass by weakening the check — NEVER delete or loosen an assertion, NEVER add `skip`/`xfail`, NEVER
+  disable or downgrade a lint rule, NEVER raise a timeout — UNLESS the check itself is demonstrably
+  wrong, in which case it MUST say so explicitly and name the change in its output so the review gate
+  can judge it.
 
   Its fix commits + pushes to the PR's **own head branch**
   → code changed → **reset `reviews_ok` to 0 AND, in that same step, restore `gauntlet-reviewing` if

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -68,12 +68,13 @@ same file does NOT inherit it, however formatting-like its diff looks. A pure-in
 behavior in a whitespace-significant language and still be formatter-clean, so there is no diff-shape
 guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
 
-**The SKILL owns the exact argv. Config does NOT supply a command.** The known-tools table below fixes,
-per tool, the precise argv campaign may execute. The repo's `.gauntlet.yml` selects **only which of those
-tools run, over which files**. The **CRITERION** is the skill's and is **NEVER configurable** — no config
-key relaxes it.
+**The SKILL owns the exact argv. NOTHING else supplies a command.** The known-tools table below fixes,
+per tool, the precise argv campaign may execute. The run's **`formatters` ledger header field** selects
+**only which of those tools run, over which files** ("The formatter list" below). The **CRITERION** is the
+skill's and is **NEVER configurable**.
 
-**WHY config gets no flags — the flags carry the semantics.** Tool identity is NOT sufficient:
+**WHY nothing outside the skill gets flags — the flags carry the semantics.** Tool identity is NOT
+sufficient:
 
 ```
 gofmt -w -r 'true -> false'     # argv[0] is gofmt. A known tool. No shell metacharacters.
@@ -81,15 +82,15 @@ gofmt -w -r 'true -> false'     # argv[0] is gofmt. A known tool. No shell metac
 
 `-r` turns `gofmt` from a pretty-printer into a **rewrite engine**: it rewrites `return true` into
 `return false`. It would pass every identity check, every metacharacter check, and every denylist check.
-So campaign REMOVES the degree of freedom instead of trying to police it: a config entry that supplies
-`command`, `args`, `argv`, or any flag is **REFUSED**.
+So campaign REMOVES the degree of freedom instead of trying to police it: the formatter list carries
+**ids and globs only** — it can NEVER name a `command`, `args`, `argv`, or a flag.
 
 #### The KNOWN-TOOLS TABLE — the skill's, argv and all
 
 The ONLY binaries campaign may execute on the no-model path, in the ONLY form it may execute them.
-`<files>` = the tool's **default glob**, optionally NARROWED by the entry's validated `files`, with the
-skill's **exclusion filter** applied afterwards — always (both below). Adding a tool, changing an argv, or
-changing a default glob is a **SKILL change** (gated, reviewed), NEVER a config change.
+`<files>` = the tool's **default glob**, optionally NARROWED by a validated per-id glob from the
+`formatters` header field, with the skill's **exclusion filter** applied afterwards — always (both below).
+Adding a tool, changing an argv, or changing a default glob is a **SKILL change** (gated, reviewed).
 
 | `id` | argv — **skill-owned, exact** | default `files` glob | guarantee | precondition — MUST hold in THIS repo |
 |---|---|---|---|---|
@@ -99,8 +100,8 @@ changing a default glob is a **SKILL change** (gated, reviewed), NEVER a config 
 | `gci` | `["gci", "write", <files>]` | `**/*.go` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
 | `ruff format` | `["ruff", "format", <files>]` | `**/*.py` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
 
-Every tool has a default glob, so a **missing `.gauntlet.yml` has a fully defined file set**: the table's
-defaults, filtered. NEVER invent a default glob for a tool; NEVER widen one.
+Every tool has a default glob, so an **unnarrowed formatter list has a fully defined file set**: the
+table's defaults, filtered. NEVER invent a default glob for a tool; NEVER widen one.
 
 **NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
 the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
@@ -144,14 +145,16 @@ AST-equivalent. The AST-equivalence guarantee holds **only while that setting is
 - The table states the **conditions under which each guarantee holds**. A guarantee with unstated
   conditions is not a guarantee.
 - Campaign MUST **verify those conditions hold in THIS repo** before taking the no-model path — read the
-  repo's tool config (for Ruff: `pyproject.toml` `[tool.ruff.format]`, `ruff.toml`/`.ruff.toml`) on the
-  **base branch**, the same provenance rule as `.gauntlet.yml`.
+  repo's tool config **in the worktree the tool will run in** (for Ruff: `pyproject.toml`
+  `[tool.ruff.format]`, `ruff.toml`/`.ruff.toml`). That is the config the tool will actually obey, so it is
+  the one that must be checked. A PR that switches the condition ON does not widen anything — it **loses**
+  the cheap path and goes to the session model.
 - Condition enabled, OR **cannot be determined** → the tool is **NOT whitelisted for this repo** →
   session model. Default deny; NEVER assume a default.
 
-#### NON-OVERRIDABLE DENYLIST — the skill's; `.gauntlet.yml` CANNOT widen past it
+#### NON-OVERRIDABLE DENYLIST — the skill's; NOTHING widens past it
 
-Nothing below is ever admitted to the table, and no config entry may name it:
+Nothing below is ever admitted to the table, and the formatter list may NEVER name it:
 
 - **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
   changing the runtime string the tag function receives — a semantic change made by the tool itself.
@@ -169,16 +172,16 @@ Nothing below is ever admitted to the table, and no config entry may name it:
   compile error, and any rule that rewrites logic.
 
 Key it on the **tool's IDENTITY and its documented guarantee** — NEVER on a judgment that the failure
-"looks mechanical", NEVER on the category "formatter". **Default deny. Unknown check, unlisted tool,
-UNPARSEABLE config, an unresolvable binary, or a refused entry → session model.** (A **missing** config is
-not a refusal: it means the known-tools table's defaults.)
+"looks mechanical", NEVER on the category "formatter". **Default deny. Unknown check, unlisted tool, an
+unresolvable binary, or a refused id → session model.** (An **unset** `formatters` header is not a
+refusal: it means the known-tools table's defaults.)
 
 #### THE SKILL-OWNED EXCLUSION FILTER — applied AFTER the glob, EVERY time
 
 **The glob SELECTS candidates. The FILTER decides what is touched.** After expanding the tool's file set
-(its default glob, narrowed by any validated `files`), campaign **REMOVES** every path below — always,
-regardless of what the glob said, whether or not a config exists. **Config CANNOT widen this filter, and
-NEVER carries the exclusions itself.**
+(its default glob, narrowed by any validated per-id glob), campaign **REMOVES** every path below — always,
+regardless of what the glob said. **NOTHING widens this filter, and the formatter list NEVER carries the
+exclusions itself.**
 
 Excluded — never handed to a tool, never in a tool commit:
 
@@ -187,107 +190,106 @@ Excluded — never handed to a tool, never in a tool commit:
 - **check definitions / CI**: `.github/**`, `.gitlab-ci.yml`, `Makefile`, `**/*.mk`, any CI workflow file
 - **tool / lint / build config**: `.golangci.yml`/`.golangci.yaml`, `ruff.toml`/`.ruff.toml`,
   `pyproject.toml`, `setup.cfg`, `tox.ini`, `.editorconfig`, `.pre-commit-config.yaml`
-- **campaign's own config**: `.gauntlet.yml`, and the git-ignored `.gauntlet/**`
+- **campaign's own run state**: the git-ignored `.gauntlet/**`
 - anything else that **defines, configures, or is** a check
 
 **WHY the filter and not the glob:** an exclusion list a **USER** writes will omit something — one forgotten
 pattern and a tool commit lands on a check definition with no model and no review. The skill owns the list,
 so it is complete and it cannot rot per-repo. **A repo-relative filter is the guarantee; a refusal is not.**
 
-Therefore `files: "**/*.go"` is **VALID and CORRECT**: the glob selects the Go files, the filter drops
-`**/*_test.go` and everything else it must not touch. The user never enumerates an exclusion.
+Therefore a `gofmt:**/*.go` narrowing is **VALID and CORRECT**: the glob selects the Go files, the filter
+drops `**/*_test.go` and everything else it must not touch. The user never enumerates an exclusion.
 
-**Still REFUSE an OBVIOUSLY HOSTILE glob** — one that targets an excluded path **DIRECTLY** (`files:
-".golangci.yml"`, `files: ".github/**"`, `files: "**/*_test.go"`): it is a config trying to weaken the
-checks that gate it, and it MUST be logged and refused rather than silently emptied by the filter. But the
+**Still REFUSE an OBVIOUSLY HOSTILE glob** — one that targets an excluded path **DIRECTLY**
+(`gofmt:.golangci.yml`, `gofmt:.github/**`, `gofmt:**/*_test.go`): it is an attempt to weaken the checks
+that gate the review, and it MUST be logged and refused rather than silently emptied by the filter. But the
 refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
 
-**Empty file set after filtering → run NOTHING for that entry** and route the failure to the session model.
+**Empty file set after filtering → run NOTHING for that id** and route the failure to the session model.
 
-#### Repo config — `.gauntlet.yml`, read from the BASE branch
+#### The formatter list — resolved at run start, stored in the ledger, NEVER in repo content
 
-A hardcoded tool list is meaningless in a Rust/Java/Ruby repo, so the **selection** is repo-configurable —
-the argv is not. The file lives at the **repo root** and is **COMMITTED** — it is NOT under the git-ignored
-`.gauntlet/` tree (`files-and-ledger.md`).
+A hardcoded tool list is meaningless in a Rust/Java/Ruby repo, so the **selection** is configurable — the
+argv is not. **The selection comes from the USER, and it is NEVER read from any file in the repo.**
 
-**Each entry carries EXACTLY: `id` (required) and `files` (optional). Nothing else.**
+**Resolve ONCE at run start**, then record it in the ledger header field `formatters`
+(`files-and-ledger.md`) — the same resolve-once / record-in-the-header pattern the `reviewer` field
+follows ("The reviewer", `reviewer.md`). Priority order:
 
-```yaml
-formatters:
-  - id: gofmt              # MUST be an id in the known-tools table; the skill owns its argv
-    files: "**/*.go"       # OPTIONAL — may only NARROW the tool's default glob; omit to take the default
-```
+1. **Explicit invocation.** The user named formatters for this run → use them.
+2. **User preference from memory.** A recorded preference (a memory entry, or a prior run's carryover)
+   naming preferred formatters → use it. Do NOT invent a preference; use one only when it actually exists.
+3. **Built-in defaults.** No preference → the known-tools table's default set, each with its default glob.
 
-**`files` may only NARROW the tool's default glob, NEVER widen it.** A `files` glob that matches paths the
-default does not (e.g. `**/*` for `gofmt`, whose default is `**/*.go`) → **REFUSE**. Omitted `files` → the
-table's default. Either way the exclusion filter applies.
+The user may also name **`none`** → the cheap path is **OFF** for this run; every CI failure goes to the
+session model. Always a safe choice.
 
-**Read it from the BASE branch, NEVER from the PR's worktree or head:**
+**Re-read `formatters` from the ledger header on EVERY wake, before any tool run. NEVER re-derive it from
+memory mid-run** — a wake may be a fresh agent instance, and re-deriving would silently revert an explicit
+choice (identical rule, identical reason, to `reviewer`).
 
-```
-git show origin/<base>:.gauntlet.yml
-```
+**NEVER take the formatter list from repo content — NOT from a repo-root config file, NOT from
+`CLAUDE.md`, NOT from ANY file in the repo.** Repo content **is PR content**: a PR can edit it. A whitelist
+a PR can edit is a whitelist a PR can **widen to govern its own campaign** — selecting a tool and a glob and
+earning an unreviewed tool commit on its own head. That is the self-gating hazard, and it is why the list
+lives in the ledger (git-ignored run state, `files-and-ledger.md`) and comes from the user. `CLAUDE.md` is
+NOT an exception: it is worktree-loaded repo content, so a PR can edit it too.
 
-**NEVER read `.gauntlet.yml` from the PR under review.** If campaign took the whitelist from the PR's own
-head, a PR could **widen the whitelist that governs its own campaign** — selecting a tool and a glob and
-earning an unreviewed tool commit on its own head. That is the self-gating hazard in config form. A PR that
-edits `.gauntlet.yml` therefore takes effect only **after it merges**, gated like any other change.
+Because the list can never come from the repo, **a PR cannot touch it BY CONSTRUCTION.** No provenance rule
+is needed, and none exists — do NOT reintroduce one.
 
 #### TRUST MODEL — say it plainly
 
-`.gauntlet.yml` is read from the **base branch**, so it is authored by people with **write access to the
-repo** — the same people who can already edit `.github/workflows` and make CI do anything. The denylist and
-the schema rules are therefore a **guard against footguns and accidental misuse, NOT a security boundary
-against a malicious committer.** NEVER present them as one.
+The formatter list is the **user's**, given at invocation or from their own memory — not repo content, so
+there is no "malicious committer" to defend against here. The denylist, the criterion, and the id-only
+shape are a **guard against footguns and accidental misuse**, NOT a security boundary. NEVER present them
+as one.
 
-What the base-branch rule DOES buy is real, and MUST be kept: **a PR under review cannot widen the
-whitelist that governs its own campaign.** That is the property being defended.
+What IS a security boundary: **the tool runs on UNTRUSTED PR CONTENT, inside the PR's worktree.** That is
+why `argv[0]` is resolved to a trusted absolute executable **outside the repo** ("RESOLVE argv[0]" above),
+and why the exclusion filter is the skill's and not the user's.
 
-#### VALIDATION — an entry is ACCEPTED only if ALL of these hold
+#### VALIDATION — an id in the `formatters` list is ACCEPTED only if ALL of these hold
 
-1. **`id` present; `files` optional. NOTHING else.**
-2. **NO `command`, `args`, `argv`, `flags`, or any other key** — any of them → **REFUSE**. The skill owns
-   the argv; config that supplies one is trying to re-open the `gofmt -r` hole. A shell string anywhere →
-   REFUSE, and campaign never runs a shell regardless.
-3. **`id` is in the known-tools table.** Not in the table → REFUSE. Config NEVER introduces a binary; it
-   selects one. The binary is resolved to a **trusted absolute executable outside the repo** ("RESOLVE
+1. **The value carries EXACTLY an `id`, and OPTIONALLY a narrowing glob. NOTHING else.** No `command`, no
+   `args`/`argv`, no flags — the skill owns the argv, and anything supplying one re-opens the `gofmt -r`
+   hole. Campaign never runs a shell regardless.
+2. **The `id` is in the known-tools table.** Not in the table → REFUSE. The list NEVER introduces a binary;
+   it selects one. The binary is resolved to a **trusted absolute executable outside the repo** ("RESOLVE
    argv[0]" above) — NEVER from a `PATH` the repo or the PR can influence. Unresolvable, or resolving
    inside the repo/worktree → REFUSE.
-4. **`files`, if present, only NARROWS the tool's default glob** — it MUST NOT match anything outside it.
+3. **The glob, if present, only NARROWS the tool's default glob** — it MUST NOT match anything outside it.
    Widening → REFUSE. And REFUSE an **obviously hostile** glob that directly targets a check definition,
    config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`, …), or a repo-sweeping bare `**`/`.`.
-   The **exclusion filter still applies to every accepted entry** — the refusal catches intent, the filter
-   is the guarantee.
-5. **The table's precondition for that `id` VERIFIES in this repo** (see "conditional on its
+   The **exclusion filter still applies to every accepted id** — the refusal catches intent, the filter is
+   the guarantee.
+4. **The table's precondition for that `id` VERIFIES in this repo** (see "conditional on its
    configuration"). Cannot verify → REFUSE.
 
-**REFUSING means: log the entry and why, IGNORE it, and route that failure to the session model. NEVER
-silently honour a refused entry.** Refusing one entry does not invalidate the others.
+**REFUSING means: log the id and why, IGNORE it, and route that failure to the session model. NEVER
+silently honour a refused id.** Refusing one id does not invalidate the others.
 
-**Merge semantics:** start from the built-in defaults (**the known-tools table's ids, each with its default
-glob**); the repo's `formatters:` list **replaces** them by `id` — an entry NARROWS the `files` of a known
-tool of the same `id`, and a built-in the repo omits while listing others is **removed** for that repo (e.g.
-a repo that does not want `gci` simply lists the ones it wants). An entry whose `id` is not a known tool is
-REFUSED, not appended. `formatters: []` **disables the cheap path entirely** — every failure goes to the
-session model, always a safe choice. **Missing file → the table's built-in defaults, each with its default
-glob, exclusion filter applied as always** — NEVER an invented or broadened default. **Unparseable file →
-cheap path OFF for this run** (default deny; never guess at a half-parsed whitelist).
+**Resolution semantics:** an explicit or preferred list **replaces** the built-in defaults — a known tool
+the user omits while naming others is **not run** (a user who does not want `gci` simply names the ones
+they want). An id that is not a known tool is REFUSED, not appended. `none` **disables the cheap path
+entirely**. No explicit list and no preference → the table's built-in defaults, each with its default glob,
+exclusion filter applied as always — NEVER an invented or broadened default.
 
 Then, in order:
 
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
    **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
    the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
-   `files`, **exclusion filter applied**). NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
+   glob, **exclusion filter applied**). NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
    **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
    definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
    above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
    watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
    dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
-   whitelisted, the config entry was refused, the config is **unparseable**, the binary **cannot be
-   resolved to a trusted executable outside the repo**, the filtered file set is **empty**, or the failure
-   needs any judgment. (A **missing** config is NOT in this list — it means the table's defaults.)
+   whitelisted, the id was refused, `formatters` is `none`, the binary **cannot be resolved to a trusted
+   executable outside the repo**, the filtered file set is **empty**, or the failure needs any judgment.
+   (An **unset** `formatters` header is NOT in this list — it means the table's defaults.)
 
 If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
 head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -284,7 +284,8 @@ wrong question. Reason on record: **symlinked directory component / excluded aft
    ANY component that is a symlink → DROP the candidate. Check 4 only tests the LAST component, so a
    symlinked directory slips a candidate past it — and past the exclusion filter, which was matched on the
    SPELLED path. A source file that must be formatted **never** sits under a symlinked directory. This check
-   is the cheap explicit tripwire; **the resolved-path exclusion filter is the guarantee** — run BOTH.
+   is load-bearing: it bounds **what we write**. Matching the exclusion filter on the resolved path too is
+   **defence in depth, NOT the guarantee** ("THE SKILL-OWNED EXCLUSION FILTER" below) — run BOTH anyway.
 
 **The exclusion filter runs on the ORIGINAL and on the RESOLVED path; checks 3–7 run AFTER it and BEFORE the
 argv is built** — the filter decides which candidates survive; these decide which surviving candidates are
@@ -318,8 +319,9 @@ Nothing below is ever admitted to the table, and the formatter list may NEVER na
 - a **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, or
   any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run invokes **only the
   table's argv**, NEVER a catch-all `--fix`.
-- any run that can touch a **check definition, config, or test** — the no-weakening prohibition, a hard
-  rule, not a preference. Enforced by the skill's **exclusion filter** below, NEVER by trusting a glob.
+- any run that can make a **SEMANTIC** change — this is the criterion from the other side. A tool that can
+  change meaning can WEAKEN a check, and no path filter fixes that. **NEVER admit a tool on the strength of
+  the exclusion filter** ("WHAT MAKES THE NO-MODEL PATH SAFE" below): the filter is not the guarantee.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
@@ -328,21 +330,49 @@ Key it on the **tool's IDENTITY and its CITED documented guarantee** — NEVER o
 unresolvable binary, or a refused id → session model.** (An **unset** `formatters` header is not a
 refusal: it means the known-tools table's defaults.)
 
-#### THE SKILL-OWNED EXCLUSION FILTER — applied to the RESOLVED path, EVERY time
+#### WHAT MAKES THE NO-MODEL PATH SAFE — the CRITERION and the OPERAND CHECKS
 
-**MATCH THE FILTER AGAINST WHAT THE PATH RESOLVES TO, NOT AGAINST HOW IT IS SPELLED.** For every candidate,
-`realpath` it (every symlink followed, `..` collapsed), take that real path **relative to the resolved
-worktree root**, and match the patterns below against **BOTH** the original path AND the resolved one.
-**EITHER matches → REFUSE.** A filter matched only on the spelling is defeated by one symlinked directory
-(`safe/gh -> .github`; the fourth repro above), which hands a **check definition** to the tool with every
-other check passing. **A NAME IS NOT A LOCATION.**
+Two things. Both mechanical. Neither is a list of paths.
 
-**The glob SELECTS candidates. The FILTER decides what is touched.** After expanding the tool's file set
-(its default glob, narrowed by any validated per-id glob) and resolving each candidate, campaign **REMOVES**
-every path below — always, regardless of what the glob said. **NOTHING widens this filter, and the formatter
-list NEVER carries the exclusions itself.**
+1. **The CRITERION bounds WHAT THE TOOL CAN DO.** A tool is admitted ONLY on a documented
+   semantic-equivalence guarantee, quoted from its own source (the known-tools table above). `gofmt`
+   re-prints the program without changing its meaning. **So whatever it touches, it CANNOT change the
+   meaning of.** A reformatted test asserts exactly what it asserted before. A reformatted check definition
+   checks exactly what it checked before. **Weakening a check requires a SEMANTIC change, and the
+   skill-owned argv CANNOT make one.**
+2. **The OPERAND CHECKS bound WHAT WE WRITE.** Resolve the path; refuse `-`-leading names, symlinks (last
+   component AND any directory component), a real path outside the worktree, non-regular files, `nlink > 1`;
+   pass `--`; NEVER a glob; NEVER an empty operand set ("NORMALIZE THE FILE ARGV" above).
 
-Excluded — never handed to a tool, never in a tool commit:
+**That is the whole guarantee, and it depends on NO list being complete.** NEVER re-derive the safety of
+this path from the exclusion filter below.
+
+**The no-weakening prohibition belongs to the SESSION-MODEL CI-fix subagent** — it CAN make semantic
+changes, so it CAN weaken a check, so the prohibition is load-bearing there and goes verbatim into its
+prompt ("red" above). **The TOOL path does not need it: the tool cannot weaken what it cannot change.**
+
+#### THE SKILL-OWNED EXCLUSION FILTER — defence in depth, NOT the guarantee
+
+**It is an enumerated PATTERN LIST. It is NOT complete and CANNOT BE.** A repo-specific check implemented as
+ordinary source — a Go checker at `tools/ci/check.go` — matches `**/*.go`, matches **NONE** of the patterns
+below, passes every operand check, and **IS handed to the tool and committed with no model.** That is the
+honest state of it. **NEVER describe this filter as complete, exhaustive, or as the thing that makes the
+no-model path safe.** The path is safe for the reason above, not because of this list.
+
+**Its purpose is BLAST RADIUS: keep the tool's diff small and off files a reviewer expects untouched.** It
+is NOT what prevents weakening — weakening is already impossible for a semantics-preserving tool.
+
+**Skill-owned. Config may NARROW it, NEVER widen it, and the formatter list NEVER carries the exclusions
+itself** — a user-written exclusion list omits more, and rots per-repo. So `gofmt:**/*.go` is VALID: the
+glob SELECTS, the filter TRIMS.
+
+**Match it against BOTH the original path AND the RESOLVED one — EITHER matches → REFUSE.** `realpath` each
+candidate (symlinks followed, `..` collapsed), take that real path relative to the resolved worktree root.
+A filter matched only on the spelling is defeated by one symlinked directory (`safe/gh -> .github`; the
+fourth repro above): if we apply the filter at all, apply it to the location and not the name. **A NAME IS
+NOT A LOCATION.**
+
+Excluded — dropped from the tool's file set:
 
 - **tests**: `**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `**/__tests__/**`, `conftest.py`,
   `**/test_*.py`, `**/*_test.py`, `**/*.spec.*`, `**/*.test.*`
@@ -350,27 +380,15 @@ Excluded — never handed to a tool, never in a tool commit:
 - **tool / lint / build config**: `.golangci.yml`/`.golangci.yaml`, `ruff.toml`/`.ruff.toml`,
   `pyproject.toml`, `setup.cfg`, `tox.ini`, `.editorconfig`, `.pre-commit-config.yaml`
 - **campaign's own run state**: the git-ignored `.gauntlet/**`
-- anything else that **defines, configures, or is** a check
-
-**WHY the filter and not the glob:** an exclusion list a **USER** writes will omit something — one forgotten
-pattern and a tool commit lands on a check definition with no model and no review. The skill owns the list,
-so it is complete and it cannot rot per-repo. **A repo-relative filter is the guarantee; a refusal is not.**
-
-Therefore a `gofmt:**/*.go` narrowing is **VALID and CORRECT**: the glob selects the Go files, the filter
-drops `**/*_test.go` and everything else it must not touch. The user never enumerates an exclusion.
 
 **Still REFUSE an OBVIOUSLY HOSTILE glob** — one that targets an excluded path **DIRECTLY**
-(`gofmt:.golangci.yml`, `gofmt:.github/**`, `gofmt:**/*_test.go`): it is an attempt to weaken the checks
-that gate the review, and it MUST be logged and refused rather than silently emptied by the filter. But the
-refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
+(`gofmt:.golangci.yml`, `gofmt:.github/**`, `gofmt:**/*_test.go`): LOG it and REFUSE it rather than let the
+filter silently empty it. It catches **intent**, which is worth catching even where the tool could do no
+harm.
 
-**AFTER the filter, the file argv is still PR data**: of every surviving candidate, refuse the `-`-leading
-names, the **symlinks**, anything with a **symlink in any directory component**, anything whose **real path
-escapes the worktree** or is **not a regular file**, and anything with **`nlink > 1`**; normalize what is left
-("NORMALIZE THE FILE ARGV" above — all **seven** checks). The filter decides *which* candidates survive; the
-normalization decides that what is handed to the tool is read as a **file** and not a flag, that it is a
-**real file INSIDE the tree** and not a link out of it, that no directory on the way to it is a link, and that
-its **INODE is not aliased outside the tree**. All of it, every run.
+**AFTER the filter, the file argv is still PR data**: run all **seven** operand checks on every surviving
+candidate ("NORMALIZE THE FILE ARGV" above). The filter only decides *which* candidates survive; the operand
+checks are what bound the write. Every run.
 
 **Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
 the session model. **NEVER invoke the tool with zero operands** — `gofmt` with no operands reads **stdin**.
@@ -443,8 +461,8 @@ skill's and not the user's.
 3. **The glob, if present, only NARROWS the tool's default glob** — it MUST NOT match anything outside it.
    Widening → REFUSE. And REFUSE an **obviously hostile** glob that directly targets a check definition,
    config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`, …), or a repo-sweeping bare `**`/`.`.
-   The **exclusion filter still applies to every accepted id** — the refusal catches intent, the filter is
-   the guarantee.
+   The **exclusion filter still applies to every accepted id** — but it is NOT the guarantee: the refusal
+   catches intent, the **criterion + the operand checks** are what make the run safe.
 
 **REFUSING means: log the id and why, IGNORE it, and route that failure to the session model. NEVER
 silently honour a refused id.** Refusing one id does not invalidate the others.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -20,16 +20,11 @@ row by column position:
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
 
-  **Dispatch it on `sonnet`** (`model: "sonnet"`), not the session model — the one sanctioned
-  downgrade in this skill (`SKILL.md`, "Subagent Dispatch"). It is safe because **both** of its
-  failure modes are caught — but by two different mechanisms, not by CI alone:
-  - *fix didn't work* → CI stays red → campaign re-dispatches, and a red check blocks the review pass
-    regardless. CI catches this one.
-  - *fix weakened the check* (gutted assertion, `skip`/`xfail`, disabled lint rule, raised timeout) →
-    **CI turns green, so CI does NOT catch it.** It is caught by the **review gate**, which reads the
-    whole `origin/<base>...HEAD` diff and sees the weakened check as the code change it is.
-
-  Never claim "CI catches everything" — it does not. Both nets must stay in place.
+  **Dispatch it on the session model** — set the model explicitly, and do NOT downgrade it
+  (`SKILL.md`, "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream
+  validates it: a wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in
+  product code no check covers — and the review gate is a miss-catcher, not a proof of correctness. A
+  green check means the check passed, never that the fix is right. NEVER claim CI catches a bad fix.
 
   **Scope it**: give it the failing check's logs, the specific failing file(s), and the worktree path,
   and tell it NOT to re-derive the whole diff or read beyond what the failure touches.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -15,14 +15,14 @@ row by column position:
   pending PR must never sit unwatched waiting for the heartbeat.
 - **red** → any failing line → **stop any review pass in flight on that PR first** (Loop control
   step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then diagnose
-  from the check logs and **CLASSIFY the failure** ("Whitelist classification" below) **before dispatching
-  anything**. Whitelisted formatting failure → run the **TOOL, no model**. Everything else → a scoped
-  CI-fix subagent into `<worktree>` — the PR row's
+  from the check logs and **CLASSIFY the failure** ("Tool classification" below) **before dispatching
+  anything**. A failure whose fixer is a known tool **the user ENABLED for this run** → run the **TOOL, no
+  model**. Everything else → a scoped CI-fix subagent into `<worktree>` — the PR row's
   ledger `worktree` column value, the single source of truth for this PR's checkout path (created at
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
   `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
 
-  Not whitelisted →
+  No enabled known tool for it (the default state — **campaign ships with NO tool enabled**) →
   **dispatch on the session model** — set the model explicitly, and do NOT downgrade it (`SKILL.md`,
   "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream validates it: a
   wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in product code no
@@ -44,7 +44,7 @@ row by column position:
 #### Any campaign commit to the PR head resets the gate
 
 **THE RULE — every commit campaign pushes to a PR's head branch is a PR-content change, whatever wrote
-it: a CI-fix subagent, a review-fix subagent, or a whitelisted TOOL run with no model at all.** Every one
+it: a CI-fix subagent, a review-fix subagent, or an enabled TOOL run with no model at all.** Every one
 of them MUST, in the same step:
 
 - **reset `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
@@ -57,24 +57,35 @@ of them MUST, in the same step:
 NEVER treat a tool-written commit as exempt: the verdicts on the old SHA describe content that no longer
 exists, and a `gauntlet-accepted` label on it is a false public claim.
 
-#### Whitelist classification — run the skill-owned TOOL, or the session model
+#### Tool classification — run an ENABLED KNOWN tool, or the session model
 
-Before dispatching anything, decide whether the failing check's fixer is a **whitelisted tool**. **A tool
-is whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an
-AST-preserving pretty-printer, not a text munger — and the burden is a **CITED SOURCE: a LINK to the tool's
-own documentation and the passage it rests on.** Saying the word "documented" is NOT a citation.
-**Cannot point to a source → NOT whitelisted → session model.** There is NO blanket "formatters are
-safe" rule.
+**THE SKILL SHIPS WITH ZERO TOOLS ENABLED. `formatters` defaults to `-`.** Out of the box campaign runs
+**no tool at all** and **every** CI failure goes to the session model. Enabling a tool is an explicit
+**USER** act ("The tool list" below).
 
-That guarantee belongs to the whitelisted **tool's output** and to nothing else — a model hand-editing the
-same file does NOT inherit it, however formatting-like its diff looks. A pure-indentation edit can move
-behavior in a whitespace-significant language and still be formatter-clean, so there is no diff-shape
-guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
+**The skill makes NO safety claim about ANY tool.** It supplies the **MECHANISM** (the exact argv, the
+binary resolution, the seven operand checks, the exclusion filter, the gate reset) and the **EVIDENCE**
+(what each tool's own doc does and does not say). **The USER decides which tools to trust, and accepts that
+risk.** State it plainly, every time it comes up: **the skill guarantees HOW a tool is run — NEVER WHAT the
+tool does.**
+
+Before dispatching anything, decide whether the failing check's fixer is a **KNOWN tool that this run's
+`formatters` header ENABLES**. Not enabled, not known, or `formatters` is `-` → **session model**. Default
+deny; there is no blanket "formatters are safe" rule, and campaign NEVER infers a tool from the failure
+"looking mechanical".
+
+**"KNOWN" MEANS THE SKILL KNOWS HOW TO RUN IT SAFELY — IT DOES NOT MEAN "SAFE TO ENABLE".** The skill owns
+that tool's exact argv, its operand checks, and its resolution rules. It does **NOT** vouch for the tool.
+**NEVER present a known-tools row as blessed, trusted, whitelisted, or recommended by the skill.**
+
+Whatever a tool does, it does NOT transfer to a model hand-editing the same file — a pure-indentation edit
+can move behavior in a whitespace-significant language and still be formatter-clean, so there is no
+diff-shape guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED
+MODEL.**
 
 **The SKILL owns the exact argv. NOTHING else supplies a command.** The known-tools table below fixes,
 per tool, the precise argv campaign may execute. The run's **`formatters` ledger header field** selects
-**only which of those tools run, over which files** ("The formatter list" below). The **CRITERION** is the
-skill's and is **NEVER configurable**.
+**only which of those tools run, over which files** ("The tool list" below).
 
 **WHY nothing outside the skill gets flags — the flags carry the semantics.** Tool identity is NOT
 sufficient:
@@ -85,88 +96,50 @@ gofmt -w -r 'true -> false'     # argv[0] is gofmt. A known tool. No shell metac
 
 `-r` turns `gofmt` from a pretty-printer into a **rewrite engine**: it rewrites `return true` into
 `return false`. It would pass every identity check, every metacharacter check, and every denylist check.
-So campaign REMOVES the degree of freedom instead of trying to police it: the formatter list carries
+So campaign REMOVES the degree of freedom instead of trying to police it: the tool list carries
 **ids and globs only** — it can NEVER name a `command`, `args`, `argv`, or a flag.
 
-#### The KNOWN-TOOLS TABLE — the skill's, argv and all
+#### The KNOWN-TOOLS TABLE — what the SKILL guarantees, and what is NOT proven
 
-The ONLY binaries campaign may execute on the no-model path, in the ONLY form it may execute them.
-`<files>` = the tool's **default glob**, optionally NARROWED by a validated per-id glob from the
-`formatters` header field, with the skill's **exclusion filter** applied afterwards — always (both below).
-Adding a tool, changing an argv, or changing a default glob is a **SKILL change** (gated, reviewed).
+**A row is NOT an endorsement.** These are the ONLY binaries campaign may execute on the no-model path, in
+the ONLY form it may execute them — **and ONLY when the user has enabled them.** `<files>` = the tool's
+**default glob**, optionally NARROWED by a validated per-id glob from the `formatters` header field, with
+the skill's **exclusion filter** applied afterwards — always (both below). Adding a tool, changing an argv,
+or changing a default glob is a **SKILL change** (gated, reviewed).
 
-| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — the SOURCE, then what it says |
-|---|---|---|---|
-| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines the behaviour: *"Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment."* **`-w`** — *"If a file's formatting is different from gofmt's, overwrite it with gofmt's version"* — **writes the formatted result back to the file. That is what we WANT: it is the ONLY mutation the skill-owned argv performs.** **`-r`** — *"Apply the rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* — are the only documented flags that apply a **non-formatting source TRANSFORMATION**: they change the PROGRAM, beyond re-printing it. **NEITHER is in the skill-owned argv**, and nothing may append one |
+Every row's **"what the skill guarantees"** is the same mechanical set, and it is ALL the skill guarantees:
+the argv is **skill-owned and exact**; **NO flag is ever appended**; `argv[0]` is resolved to a **trusted
+absolute executable OUTSIDE the repo** via a sanitized `PATH`; the **seven operand checks** run on every
+candidate; **resolve-then-filter** (the exclusion filter matches the original AND the resolved path); the
+tool is run **without a shell**, **never with a glob**, **never with an empty operand set**; and **any commit
+it makes RESETS the gate**.
 
-**Read that cell for EXACTLY what it says — and state ONLY the TRANSFORMATION property.** `-r` and `-s` are
-the only documented flags that **transform the source beyond re-printing it**. That is the whole claim.
+| `id` | argv — **skill-owned, exact** | default `files` glob | what the skill guarantees (mechanical, OURS) | what is NOT proven (about the TOOL) |
+|---|---|---|---|---|
+| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | Exactly the argv on the left, over checked operands. `-w` (*"If a file's formatting is different from gofmt's, overwrite it with gofmt's version"*) is the ONLY mutation it performs. `-r` (*"Apply the rewrite rule to the source before reformatting"*) and `-s` (*"Try to simplify code"*) are the documented flags that TRANSFORM the source beyond re-printing it — **neither is in the argv, and nothing may append one** | **The cited doc (https://pkg.go.dev/cmd/gofmt) documents formatting behaviour and flags. It NEVER states a semantic-equivalence guarantee.** Our reading — a pretty-printer that parses and re-prints cannot change program meaning — is an **INFERENCE, not a documented guarantee**. **Enabling `gofmt` means accepting that inference.** |
+| `gci` | `["gci", "write", "--", <files>]` | `**/*.go` | Exactly the argv on the left, over checked operands. `write` is the ONLY subcommand; no section/custom-order flag is ever appended | **The cited docs (https://github.com/daixiang0/gci) describe import ORDERING and GROUPING. They NEVER state that gci neither adds nor removes an import**, and never state semantic equivalence. The Go init-order argument (imports drive `init()`; reordering them does not) is **OURS, an INFERENCE**. **Enabling `gci` means accepting it.** |
+| `ruff format` | `["ruff", "format", "--", <files>]` | `**/*.py` | Exactly the argv on the left, over checked operands. No `--fix`, no `--select`, no config flag is ever appended; the repo's own Ruff config governs | **The cited docs (https://docs.astral.sh/ruff/formatter/) describe formatting behaviour. They do NOT state an AST/semantic-equivalence guarantee** we can rely on. Separately, `format.docstring-code-format` (https://docs.astral.sh/ruff/settings/#format_docstring-code-format) reformats code **inside docstrings** — i.e. rewrites string CONTENTS — and it is the **repo's config**, not ours, that decides whether it is on. **Enabling `ruff format` means accepting both.** |
 
-- **`-w` CHANGES THE SOURCE** — it overwrites the file with gofmt's result. It is in our argv on purpose;
-  it is the only mutation the argv performs. NEVER write a sentence that implies `-w` leaves the source
-  alone.
-- **`-cpuprofile` is a separate documented flag that WRITES A FILE** — it does not transform the source. It
-  is named here only because a FILENAME shaped like `-cpuprofile=x.go` is the injection repro below.
-- The doc lists others still (`-l`, `-d`, `-e`, …).
+**THE ASYMMETRY — say it, do not soften it:** the skill **REFUSES what is documented to be unsafe**; it
+**does NOT bless what is merely undocumented — that call is the USER's.** A tool whose docs say it CHANGES
+the program is **denied and cannot be enabled** ("NON-OVERRIDABLE DENYLIST" below) — that is a documented
+fact, so the skill can and does refuse it. A tool whose docs say nothing either way sits in the table above:
+the skill will run it correctly **if you enable it**, and it makes **no claim** that doing so is safe.
 
-**GUARD — this claim has been stated wrongly THREE times.** NEVER say "exactly two flags", "the only two
-flags", or "the only flags that CHANGE the source". All three are false. The property is
-**source-TRANSFORMING**, and nothing broader.
-
-The safety of this cell rests on **three** things, all of them ours: the argv is **skill-owned and exact**
-(`["gofmt","-w","--",<files>]`); **NO flag may ever be appended** to it; and **no file operand can be read as
-a flag** (`--`, plus the operand-normalization rules below). That last one is not theoretical — the injection
-repro below is a file literally named `-cpuprofile=prof.go`.
-
-**ONE tool. That is the whole table**, and it is small **on purpose**: it is what survived a rule that
-demands a **documented** guarantee, quoted from the source. Every tool has a default glob, so an
-**unnarrowed formatter list has a fully defined file set**: the table's defaults, filtered. NEVER invent a
-default glob for a tool; NEVER widen one.
-
-**The cheap path therefore covers Go formatting and NOTHING else.** Every other CI failure — **including
-ALL Python/JS/other-language formatting** — goes to the **session model**. That is the safe default, and it
-is **NOT a regression**: it is what happened before this path existed. NEVER treat the table's size as a
-limitation to route around — it is the rule working.
-
-**Adding a tool is a SKILL change (gated, reviewed), and the bar is a SOURCE THAT STATES THE GUARANTEE,
-QUOTED IN THE CELL.** "It is a formatter", "it is probably fine", "it is widely used", "the diff looks
-mechanical" are **NOT admissible**.
-
-**A `guarantee` cell MUST carry a LINK to the tool's own documentation AND the passage it rests on,
-QUOTED.** The WORD "documented" is not evidence — an unsourced "documented as a pretty-printer" is the same
-category-assertion that this table exists to kill. **FOLLOW the link before you trust the cell: a citation
-that does not SUPPORT the claim is WORSE than no citation** — it launders our own reasoning as the source's.
-**A claim that cannot be tied to a source → the tool comes OUT of the table.** No exception, including for
-tools already in it — `ruff format` and `gci` were removed by exactly this rule (below).
+**A "what is NOT proven" cell MUST carry a LINK to the tool's own documentation and say exactly what that
+doc does and does NOT state. NEVER upgrade an inference into a guarantee.** The word "documented" is not
+evidence, and **a citation that does not SUPPORT its claim is WORSE than none** — it launders our belief as
+the source's. **FOLLOW the link before you trust a cell.** `gofmt`, `gci` and `ruff format` were once
+presented as *proven* semantics-preserving on exactly such citations; none of the three docs says so, and
+the honest table says so instead of removing the tools and pretending the question was settled.
 
 **NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
 the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
 shell string.
 
-**REMOVED — tools that FAIL the criterion.** They are not "not configured"; they are **rejected**, and
-re-adding one is a SKILL change that must first defeat the reason below:
-
-- **`ruff format`** — **REJECTED for now.** Its formatter docs, **as cited**
-  (https://docs.astral.sh/ruff/formatter/), do **NOT state an AST-equivalence guarantee**. The tool may well
-  be safe; the whitelist admits tools on **DOCUMENTED** guarantees, never on reputation or on our belief.
-  A citation that does not support its claim is **WORSE than no citation** — the claim was laundered through
-  the link. Re-admitting it requires **a source that ACTUALLY STATES the guarantee, QUOTED in the cell** — a
-  SKILL change.
-- **`gci`** — **REJECTED for now.** The cited project docs (https://github.com/daixiang0/gci) describe import
-  **ordering/grouping** but do **NOT state** that gci never adds and never removes an import. The Go
-  init-order argument previously in that cell was **ours**, presented as the source's. Same rule: find a
-  source that states the guarantee and quote it, or gci stays out.
-- **`goimports`** (https://pkg.go.dev/golang.org/x/tools/cmd/goimports) — its own doc says it updates the
-  import lines: it **ADDS missing imports and REMOVES unreferenced ones**. Adding an import runs that
-  package's `init()`; a guessed import can resolve to the **wrong package**. Changing the set of imports is
-  not semantics-preserving. NOT a formatter for this purpose.
-- **`gofumpt`** (https://github.com/mvdan/gofumpt) — a stricter gofmt that applies **EXTRA rewrite rules**
-  beyond `go/printer` layout, and its README states them as a rule LIST, **never** as a semantics-preserving
-  guarantee. It edits source constructs, not just whitespace. It does not meet the criterion; being
-  "gofmt-like" is not an argument. NEVER re-add it on the grounds that it "is basically a formatter".
-- **golangci-lint `whitespace`** — no safe fixer exists. Its only fix path is the catch-all
-  `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
-  failure goes to the session model.
+**golangci-lint `whitespace` is NOT a known tool** — no safe fixer exists: its only fix path is the
+catch-all `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a
+`whitespace` failure goes to the session model.
 
 #### RESOLVE argv[0] TO A TRUSTED ABSOLUTE EXECUTABLE — OUTSIDE THE REPO
 
@@ -285,7 +258,8 @@ wrong question. Reason on record: **symlinked directory component / excluded aft
    symlinked directory slips a candidate past it — and past the exclusion filter, which was matched on the
    SPELLED path. A source file that must be formatted **never** sits under a symlinked directory. This check
    is load-bearing: it bounds **what we write**. Matching the exclusion filter on the resolved path too is
-   **defence in depth, NOT the guarantee** ("THE SKILL-OWNED EXCLUSION FILTER" below) — run BOTH anyway.
+   **defence in depth, NEVER a substitute for this check** ("THE SKILL-OWNED EXCLUSION FILTER" below) — run
+   BOTH anyway.
 
 **The exclusion filter runs on the ORIGINAL and on the RESOLVED path; checks 3–7 run AFTER it and BEFORE the
 argv is built** — the filter decides which candidates survive; these decide which surviving candidates are
@@ -305,64 +279,68 @@ model. Check the set is non-empty **immediately before building the argv**, ever
 to the tool and bypasses the exclusion filter AND this normalization. Campaign expands, filters, refuses,
 normalizes, and passes the resulting **explicit path list**.
 
-#### NON-OVERRIDABLE DENYLIST — the skill's; NOTHING widens past it
+#### NON-OVERRIDABLE DENYLIST — the ONE thing the skill REFUSES
 
-Nothing below is ever admitted to the table, and the formatter list may NEVER name it:
+**These are KNOWN-BAD: their own docs say they CHANGE the program. That is a documented FACT, not an
+inference — so the skill refuses them, and NO config can enable one.** Nothing below is ever admitted to
+the known-tools table, and the tool list may NEVER name it:
 
+- **`goimports`** (https://pkg.go.dev/golang.org/x/tools/cmd/goimports): its doc says it **ADDS missing
+  imports and REMOVES unreferenced ones**. An added import runs that package's `init()`; a guessed import
+  can resolve to the **wrong package**. Documented to change the program.
 - **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
-  changing the runtime string the tag function receives — a semantic change made by the tool itself.
+  changing the runtime string the tag function receives — documented, and a semantic change.
+- **`gofumpt`** (https://github.com/mvdan/gofumpt): applies **EXTRA rewrite rules** beyond gofmt's layout,
+  documented as a rule LIST of source-construct edits. "It is basically gofmt" is NOT an argument.
 - any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer that can rewrite content inside
   string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks).
 - a **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3`, any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
   with a reversed or non-equivalent comparator): lint-clean, semantics changed.
-- a **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, or
-  any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run invokes **only the
-  table's argv**, NEVER a catch-all `--fix`.
-- any run that can make a **SEMANTIC** change — this is the criterion from the other side. A tool that can
-  change meaning can WEAKEN a check, and no path filter fixes that. **NEVER admit a tool on the strength of
-  the exclusion filter** ("WHAT MAKES THE NO-MODEL PATH SAFE" below): the filter is not the guarantee.
-- **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
+- every **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`,
+  or **any `--fix`/`--write` flag** on a linter that applies semantic rules. An enabled run invokes **only
+  the table's argv**, NEVER a catch-all `--fix`.
+- **NEVER a fixer at all**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
-Key it on the **tool's IDENTITY and its CITED documented guarantee** — NEVER on a judgment that the failure
-"looks mechanical", NEVER on the category "formatter". **Default deny. Unknown check, unlisted tool, an
-unresolvable binary, or a refused id → session model.** (An **unset** `formatters` header is not a
-refusal: it means the known-tools table's defaults.)
+**THE ASYMMETRY IS THE POINT: the skill refuses what is DOCUMENTED to be unsafe; it does NOT bless what is
+merely UNDOCUMENTED — that call is the user's** (the known-tools table above). Key the denial on the tool's
+**IDENTITY and its own documentation** — NEVER on a judgment that a failure "looks mechanical", NEVER on the
+category "formatter". **Default deny: unknown check, tool not in the table, tool not enabled, `formatters`
+= `-` (the default), an unresolvable binary, or a refused id → session model.**
 
-#### WHAT MAKES THE NO-MODEL PATH SAFE — the CRITERION and the OPERAND CHECKS
+#### WHAT THE NO-MODEL PATH ACTUALLY RESTS ON — say it honestly
 
-Two things. Both mechanical. Neither is a list of paths.
+Two things, and only one of them is ours.
 
-1. **The CRITERION bounds WHAT THE TOOL CAN DO.** A tool is admitted ONLY on a documented
-   semantic-equivalence guarantee, quoted from its own source (the known-tools table above). `gofmt`
-   re-prints the program without changing its meaning. **So whatever it touches, it CANNOT change the
-   meaning of.** A reformatted test asserts exactly what it asserted before. A reformatted check definition
-   checks exactly what it checked before. **Weakening a check requires a SEMANTIC change, and the
-   skill-owned argv CANNOT make one.**
-2. **The OPERAND CHECKS bound WHAT WE WRITE.** Resolve the path; refuse `-`-leading names, symlinks (last
-   component AND any directory component), a real path outside the worktree, non-regular files, `nlink > 1`;
-   pass `--`; NEVER a glob; NEVER an empty operand set ("NORMALIZE THE FILE ARGV" above).
+1. **OURS — the MECHANISM.** The skill-owned exact argv (no flag ever appended), `argv[0]` resolved to a
+   trusted absolute executable **outside the repo**, the **seven operand checks**, resolve-then-filter, no
+   shell, no glob, no empty operand set, and the **gate reset on any commit**. This bounds **WHAT WE
+   RUN and WHAT WE WRITE**, mechanically, every run.
+2. **THE USER'S — the TOOL's behaviour.** Whether the tool preserves the meaning of what it touches is
+   **NOT proven by any doc we can cite** (the table above). The user enabled it; the user accepted that
+   inference. **NEVER restate it as a guarantee of the skill's, and NEVER re-derive it from the exclusion
+   filter below.**
 
-**That is the whole guarantee, and it depends on NO list being complete.** NEVER re-derive the safety of
-this path from the exclusion filter below.
+So: **a reformatted check definition is only as safe as the tool the user trusted.** That is exactly why the
+exclusion filter keeps tests, check definitions and CI config out of the tool's file set — **defence in
+depth**, and admittedly incomplete.
 
-**The no-weakening prohibition belongs to the SESSION-MODEL CI-fix subagent** — it CAN make semantic
-changes, so it CAN weaken a check, so the prohibition is load-bearing there and goes verbatim into its
-prompt ("red" above). **The TOOL path does not need it: the tool cannot weaken what it cannot change.**
+**The no-weakening prohibition belongs to the SESSION-MODEL CI-fix subagent** — it is a model, it can make
+any change, so the prohibition is load-bearing there and goes verbatim into its prompt ("red" above). It is
+not a substitute for the mechanism on the tool path, and the mechanism is not a substitute for it.
 
-#### THE SKILL-OWNED EXCLUSION FILTER — defence in depth, NOT the guarantee
+#### THE SKILL-OWNED EXCLUSION FILTER — defence in depth, admittedly INCOMPLETE
 
 **It is an enumerated PATTERN LIST. It is NOT complete and CANNOT BE.** A repo-specific check implemented as
 ordinary source — a Go checker at `tools/ci/check.go` — matches `**/*.go`, matches **NONE** of the patterns
 below, passes every operand check, and **IS handed to the tool and committed with no model.** That is the
-honest state of it. **NEVER describe this filter as complete, exhaustive, or as the thing that makes the
-no-model path safe.** The path is safe for the reason above, not because of this list.
+honest state of it. **NEVER describe this filter as complete or exhaustive.**
 
 **Its purpose is BLAST RADIUS: keep the tool's diff small and off files a reviewer expects untouched.** It
-is NOT what prevents weakening — weakening is already impossible for a semantics-preserving tool.
+is a mitigation, not a proof — and it is not a reason to enable a tool.
 
-**Skill-owned. Config may NARROW it, NEVER widen it, and the formatter list NEVER carries the exclusions
+**Skill-owned. Config may NARROW it, NEVER widen it, and the tool list NEVER carries the exclusions
 itself** — a user-written exclusion list omits more, and rots per-repo. So `gofmt:**/*.go` is VALID: the
 glob SELECTS, the filter TRIMS.
 
@@ -393,39 +371,47 @@ checks are what bound the write. Every run.
 **Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
 the session model. **NEVER invoke the tool with zero operands** — `gofmt` with no operands reads **stdin**.
 
-#### The formatter list — resolved at run start, stored in the ledger, NEVER in repo content
+#### The tool list — EMPTY by default, resolved at run start, stored in the ledger, NEVER in repo content
 
-A hardcoded tool list is meaningless in a Rust/Java/Ruby repo, so the **selection** is configurable — the
-argv is not. **The selection comes from the USER, and it is NEVER read from any file in the repo.**
+**The default is EMPTY. Nothing is enabled unless the USER enables it.** A hardcoded tool list is
+meaningless in a Rust/Java/Ruby repo — and, more to the point, **the skill is not the one who gets to decide
+a tool is safe.** The selection comes from the USER; the argv never does. **It is NEVER read from any file
+in the repo.**
 
 **Resolve ONCE at run start**, then record it in the ledger header field `formatters`
 (`files-and-ledger.md`) — the same resolve-once / record-in-the-header pattern the `reviewer` field
 follows ("The reviewer", `reviewer.md`). Priority order:
 
-1. **Explicit invocation.** The user named formatters for this run → use them.
+1. **Explicit invocation.** The user named tools for this run → use them.
 2. **User preference from memory.** A recorded preference (a memory entry, or a prior run's carryover)
-   naming preferred formatters → use it. Do NOT invent a preference; use one only when it actually exists.
-3. **Built-in defaults.** No preference → the known-tools table's default set, each with its default glob.
+   naming preferred tools → use it. Do NOT invent a preference; use one only when it actually exists.
+3. **EMPTY — `-`.** No explicit list and no preference → **no tool runs; the cheap path is OFF; every CI
+   failure goes to the session model.** This is the default and it is NEVER "the table's tools". There is
+   **NO built-in set** — do NOT invent one.
 
-**The header field has exactly three shapes — NEVER any other spelling:**
+**The header field has exactly two shapes — NEVER any other spelling:**
 
-- `default` — the known-tools table's **built-in set**, each with its default glob. Also `ledger.py`'s
-  default when the field was never written.
-- `-` — the **DISABLING SENTINEL**: the cheap path is **OFF** for this run; every CI failure goes to the
-  session model. Always a safe choice. **The sentinel is `-` — NEVER the word `none`.** A user who says
-  "no formatters" / "none" is asking for this; campaign writes **`-`** into the header.
+- `-` — **EMPTY: no tool enabled, cheap path OFF.** The **default**, and `ledger.py`'s value when the field
+  was never written. **The sentinel is `-` — NEVER the word `none`, NEVER the word `default`.** A user who
+  says "no formatters" / "none" is asking for this; campaign writes **`-`**.
 - a comma-separated list of known-tool ids, each optionally `:<glob>`-suffixed (`gofmt:internal/**/*.go`).
 
-`default` (built-ins ON) and `-` (cheap path OFF) are **NEVER interchangeable**. An **unset/absent** field
-means `default`, NOT `-`.
+An **unset/absent** field means `-`. **There is no `default` value any more; if you see one, treat it as
+`-`** and rewrite the header.
+
+**Enabling a tool is a RISK ACCEPTANCE by the user.** When the user names one, campaign runs it exactly as
+the table says — and makes **no claim** that the tool preserves meaning. Every commit it makes still resets
+the gate, so it is re-reviewed like any other content change. If the user asks whether a tool is safe: point
+at that tool's **"what is NOT proven"** cell and let them decide. **NEVER answer "yes, the skill guarantees
+it".**
 
 **Re-read `formatters` from the ledger header on EVERY wake, before any tool run. NEVER re-derive it from
 memory mid-run** — a wake may be a fresh agent instance, and re-deriving would silently revert an explicit
 choice (identical rule, identical reason, to `reviewer`).
 
-**NEVER take the formatter list from repo content — NOT from a repo-root config file, NOT from
-`CLAUDE.md`, NOT from ANY file in the repo.** Repo content **is PR content**: a PR can edit it. A whitelist
-a PR can edit is a whitelist a PR can **widen to govern its own campaign** — selecting a tool and a glob and
+**NEVER take the tool list from repo content — NOT from a repo-root config file, NOT from
+`CLAUDE.md`, NOT from ANY file in the repo.** Repo content **is PR content**: a PR can edit it. A tool list
+a PR can edit is a list a PR can **widen to govern its own campaign** — selecting a tool and a glob and
 earning an unreviewed tool commit on its own head. That is the self-gating hazard, and it is why the list
 lives in the ledger (git-ignored run state, `files-and-ledger.md`) and comes from the user. `CLAUDE.md` is
 NOT an exception: it is worktree-loaded repo content, so a PR can edit it too.
@@ -435,8 +421,12 @@ is needed, and none exists — do NOT reintroduce one.
 
 #### TRUST MODEL — say it plainly
 
-The formatter list is the **user's**, given at invocation or from their own memory — not repo content, so
-there is no "malicious committer" to defend against here. The denylist, the criterion, and the id-only
+**The skill trusts NO tool. It ships with none enabled and vouches for none.** What it owns is **HOW** a
+tool is run, never **WHAT** the tool does. The user enables tools and thereby accepts the risk; the skill's
+denylist refuses only what a tool's own doc says is unsafe.
+
+The tool list is the **user's**, given at invocation or from their own memory — not repo content, so
+there is no "malicious committer" to defend against there. The denylist and the id-only
 shape are a **guard against footguns and accidental misuse**, NOT a security boundary. NEVER present them
 as one.
 
@@ -455,29 +445,27 @@ skill's and not the user's.
    `args`/`argv`, no flags — the skill owns the argv, and anything supplying one re-opens the `gofmt -r`
    hole. Campaign never runs a shell regardless.
 2. **The `id` is in the known-tools table.** Not in the table → REFUSE. The list NEVER introduces a binary;
-   it selects one. The binary is resolved to a **trusted absolute executable outside the repo** ("RESOLVE
-   argv[0]" above) — NEVER from a `PATH` the repo or the PR can influence. Unresolvable, or resolving
-   inside the repo/worktree → REFUSE.
+   it selects one. **A denylisted id (`goimports`, `prettier`, `gofumpt`, any catch-all `--fix`, …) is
+   REFUSED no matter who names it** — config cannot enable it. The binary is resolved to a **trusted
+   absolute executable outside the repo** ("RESOLVE argv[0]" above) — NEVER from a `PATH` the repo or the PR
+   can influence. Unresolvable, or resolving inside the repo/worktree → REFUSE.
 3. **The glob, if present, only NARROWS the tool's default glob** — it MUST NOT match anything outside it.
    Widening → REFUSE. And REFUSE an **obviously hostile** glob that directly targets a check definition,
    config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`, …), or a repo-sweeping bare `**`/`.`.
-   The **exclusion filter still applies to every accepted id** — but it is NOT the guarantee: the refusal
-   catches intent, the **criterion + the operand checks** are what make the run safe.
+   The **exclusion filter still applies to every accepted id** — defence in depth, never a reason to trust
+   the tool.
 
 **REFUSING means: log the id and why, IGNORE it, and route that failure to the session model. NEVER
 silently honour a refused id.** Refusing one id does not invalidate the others.
 
-**Resolution semantics:** an explicit or preferred list **replaces** the built-in defaults — a known tool
-the user omits while naming others is **not run**. An id that is not a known tool (anything but `gofmt`
-today — `ruff format`, `gci`, `goimports`, `gofumpt`, …) is **REFUSED**, not appended: that failure goes to
-the session model. **`-`** (the disabling sentinel)
-**disables the cheap path entirely**. No explicit list and no preference → `default`: the table's built-in
-defaults, each with its default glob, exclusion filter applied as always — NEVER an invented or broadened
-default.
+**Resolution semantics:** the user's list is the WHOLE list — there are **no built-ins to replace**. A known
+tool the user does not name is **not run**. An id that is not a known tool, or is denylisted, is **REFUSED**,
+not appended: that failure goes to the session model. **`-`** (the default, and an unset field) means **no
+tool runs at all**.
 
 Then, in order:
 
-1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
+1. **An ENABLED known tool for this failure → run the TOOL, no model.** In `<worktree>`, run the
    **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
    the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
    glob, each candidate **RESOLVED**, the **exclusion filter applied to BOTH its original and its resolved
@@ -490,22 +478,22 @@ Then, in order:
    above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
    watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
-   dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
-   whitelisted, the id was refused, `formatters` is **`-`** (cheap path off), the binary **cannot be
-   resolved to a trusted executable outside the repo**, the filtered file set is **empty**, or the failure
-   needs any judgment. (An **unset** `formatters` header, or `default`, is NOT in this list — it means the
-   table's defaults.)
+   dispatch above. Covers: **`formatters` is `-` — the DEFAULT, so this is the DEFAULT ROUTE for every CI
+   failure**; the tool is known but **not enabled**; the tool did not fix it; the tool left residue; the
+   tool/check is not in the table; the id was refused; the binary **cannot be resolved to a trusted
+   executable outside the repo**; the filtered file set is **empty**; or the failure needs any judgment.
 
 If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
-head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;
+head) and **re-dispatch the same failure on the session model**. NEVER patch a tool run in place;
 NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 
-**Residual risk, stated honestly:** the whitelist stands on the binary actually BEING the tool (what the
-outside-the-repo resolution buys) and on each tool's documented guarantee — a tool bug, or a repo
-config/plugin that switches on non-formatting rules, is the rest of the exposure.
-Run whitelisted tools with the project's own config and no extra rule sets, and NEVER re-derive the
-whitelist's safety from the review gate: it stands on the TOOL being incapable of changing semantics, or it
-does not stand at all.
+**Residual risk, stated honestly:** on this path campaign guarantees the **mechanism** — the binary really is
+the tool (what the outside-the-repo resolution buys), the argv is the table's, the operands are checked. It
+does **NOT** guarantee the tool preserves meaning: **no cited doc states that, the user accepted that
+inference when enabling the tool**, and a tool bug or a repo config/plugin that switches on non-formatting
+rules is the rest of the exposure. Run enabled tools with the project's own config and no extra rule sets.
+**NEVER re-derive this path's safety from the review gate, and NEVER upgrade the user's risk acceptance into
+a claim of the skill's.**
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -95,7 +95,16 @@ Adding a tool, changing an argv, or changing a default glob is a **SKILL change*
 
 | `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — the SOURCE, then what it says |
 |---|---|---|---|
-| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines the behaviour: *"Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment."* It documents exactly two flags that make gofmt do MORE than format: **`-r`** — *"Apply the rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* (it lists the source transformations `-s` performs). **NEITHER is in the skill-owned argv**, and nothing may append one |
+| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines the behaviour: *"Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment."* Of the flags it documents, **exactly two CHANGE THE SOURCE**: **`-r`** — *"Apply the rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* (it lists the source transformations `-s` performs). **NEITHER is in the skill-owned argv**, and nothing may append one |
+
+**Read that cell for EXACTLY what it says.** It says `-r` and `-s` are the only documented flags that
+**rewrite the source**. It does **NOT** say they are the only documented flags: the doc lists others (`-l`,
+`-d`, `-e`, `-cpuprofile`, …), and **`-cpuprofile` WRITES A FILE**. NEVER restate the claim as "gofmt has
+only two flags" — that is broader than the source, and it is false. The safety of this cell rests on
+**three** things, all of them ours: the argv is **skill-owned and exact** (`["gofmt","-w","--",<files>]`);
+**NO flag may ever be appended** to it; and **no file operand can be read as a flag** (`--`, plus the
+operand-normalization rules below). That last one is not theoretical — the injection repro below is a file
+literally named `-cpuprofile=prof.go`.
 
 **ONE tool. That is the whole table**, and it is small **on purpose**: it is what survived a rule that
 demands a **documented** guarantee, quoted from the source. Every tool has a default glob, so an
@@ -201,7 +210,21 @@ gofmt -w -- /wt/link.go                  # gofmt FOLLOWED the symlink and rewrot
 absolute path, no leading `-`) says nothing about what the kernel opens. So campaign checks what each
 candidate RESOLVES TO, not just how it is spelled. Reason on record: **symlink escape**.
 
-**EVERY tool, EVERY run, ALL FIVE — no exceptions:**
+**The third repro — a HARDLINK, which passes both checks above** (this is the layer BELOW `realpath`):
+
+```
+# The PR adds a hardlink:  alias.go  →  same INODE as /home/user/other-repo/x.go
+# It is a REGULAR file. It is NOT a symlink (lstat says regular). Its realpath is INSIDE the worktree.
+gofmt -w -- /wt/alias.go                 # gofmt rewrote the INODE — the outside alias changed too
+```
+
+**A path check bounds where we LOOK; it does NOT bound what we WRITE — the inode can be aliased outside the
+tree.** `gofmt -w` truncates and rewrites the **EXISTING INODE**, so containment of the **PATH** is not
+containment of the **DATA**. A hardlink is a regular file whose path is inside the worktree and whose data
+is shared with a path outside it: it defeats the symlink check (it is not a link) and the containment check
+(its real path is inside). Reason on record: **hardlink — nlink>1**.
+
+**EVERY tool, EVERY run, ALL SIX — no exceptions:**
 
 1. **END-OF-OPTIONS.** Pass `--` immediately before the file list. Every tool in the table accepts it
    (`gofmt`, via Go's `flag` package), and the table's argv already carries it. Nothing after `--` can be
@@ -220,14 +243,23 @@ candidate RESOLVES TO, not just how it is spelled. Reason on record: **symlink e
    path-component boundary, never a bare prefix match (`/wt-evil` is not under `/wt`); and (b) the resolved
    target is a **REGULAR FILE** — a directory, device, fifo, or socket is REFUSED. Escapes the tree, or is
    not a regular file → DROP it.
+6. **REFUSE a candidate whose LINK COUNT is greater than 1.** `stat` the candidate and read `st_nlink`;
+   `st_nlink > 1` → DROP it. A source file in a normal checkout has **exactly one link**. A multi-link file
+   is either a **hardlink escape** (the inode is aliased outside the tree, and `gofmt -w` rewrites the
+   INODE) or something we have **no reason to format** — either way it does not get handed to the tool.
 
-**Checks 3–5 run AFTER the exclusion filter and BEFORE the argv is built** — the filter decides which
+**Checks 3–6 run AFTER the exclusion filter and BEFORE the argv is built** — the filter decides which
 candidates survive; these decide which surviving candidates are handed to the tool at all. Every refusal:
 **DROP that file from the set — do NOT abort the run** — and **LOG it**: the id, the refused path, and the
-reason (`-`-leading name / symlink / escapes the worktree / not a regular file).
+reason (`-`-leading name / symlink / escapes the worktree / not a regular file / hardlink — nlink>1).
 
 Refusing files can empty the set → then run NOTHING for that id and route the failure to the session model
 ("Empty file set after filtering" below). Refusing a file NEVER widens anything and NEVER fails the PR.
+
+**NEVER INVOKE THE TOOL WITH AN EMPTY OPERAND SET.** `gofmt` with no file operands **reads stdin** and
+writes the formatted result to stdout — a run that is not the run we intended, on input we did not choose.
+An empty set is NOT "a no-op run": it is **run NOTHING for that id**, and route the failure to the session
+model. Check the set is non-empty **immediately before building the argv**, every time.
 
 **NEVER pass the glob itself to the tool** (`gofmt -w .`, `gofmt -w '**/*.go'`) — that hands file selection
 to the tool and bypasses the exclusion filter AND this normalization. Campaign expands, filters, refuses,
@@ -287,13 +319,14 @@ that gate the review, and it MUST be logged and refused rather than silently emp
 refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
 
 **AFTER the filter, the file argv is still PR data**: of every surviving candidate, refuse the `-`-leading
-names, the **symlinks**, and anything whose **real path escapes the worktree** or is **not a regular file**;
-normalize what is left ("NORMALIZE THE FILE ARGV" above). The filter decides *which* candidates survive; the
-normalization decides that what is handed to the tool is read as a **file** and not a flag, and that it is a
-**real file INSIDE the tree** and not a link out of it. Both, every run.
+names, the **symlinks**, anything whose **real path escapes the worktree** or is **not a regular file**, and
+anything with **`nlink > 1`**; normalize what is left ("NORMALIZE THE FILE ARGV" above). The filter decides
+*which* candidates survive; the normalization decides that what is handed to the tool is read as a **file**
+and not a flag, that it is a **real file INSIDE the tree** and not a link out of it, and that its **INODE is
+not aliased outside the tree**. All of it, every run.
 
 **Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
-the session model.
+the session model. **NEVER invoke the tool with zero operands** — `gofmt` with no operands reads **stdin**.
 
 #### The formatter list — resolved at run start, stored in the ledger, NEVER in repo content
 
@@ -344,10 +377,10 @@ as one.
 
 What IS a security boundary: **the tool runs on UNTRUSTED PR CONTENT, inside the PR's worktree.** That is
 why `argv[0]` is resolved to a trusted absolute executable **outside the repo** ("RESOLVE argv[0]" above),
-why the **file operands are normalized AND resolved** — they come from the PR's tree, so they are
-attacker-controlled data spliced into argv, and a symlink among them makes the tool write **outside the
-worktree** ("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the skill's and not the
-user's.
+why the **file operands are normalized, resolved, AND checked for aliasing** — they come from the PR's tree,
+so they are attacker-controlled data spliced into argv; a symlink among them makes the tool write **outside
+the worktree**, and a **hardlink** makes it write outside the worktree while every path check passes
+("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the skill's and not the user's.
 
 #### VALIDATION — an id in the `formatters` list is ACCEPTED only if ALL of these hold
 
@@ -380,9 +413,10 @@ Then, in order:
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
    **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
    the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
-   glob, **exclusion filter applied**, then **`-`-leading names, symlinks, non-regular files, and paths whose
-   real path escapes the worktree all refused, and the operands normalized — `--` + absolute/`./` paths**).
-   NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
+   glob, **exclusion filter applied**, then **`-`-leading names, symlinks, non-regular files, paths whose
+   real path escapes the worktree, and files with `nlink > 1` all refused, and the operands normalized —
+   `--` + absolute/`./` paths**). **NEVER run the tool with an EMPTY operand set** (`gofmt` with no operands
+   reads stdin) — empty → session model. NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
    **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
    definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
    above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -36,54 +36,81 @@ row by column position:
   wrong, in which case it MUST say so explicitly and name the change in its output so the review gate
   can judge it.
 
-  Its fix commits + pushes to the PR's **own head branch**
-  → code changed → **reset `reviews_ok` to 0 AND, in that same step, restore `gauntlet-reviewing` if
-  the PR carries `gauntlet-accepted`** (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label
-  gauntlet-reviewing`) — the gate and its label move together, never one without the other
-  (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the watch
-  immediately and re-enter 2a.
+  Its fix commits + pushes to the PR's **own head branch** → **apply the gate reset** below
+  ("Any campaign commit to the PR head resets the gate").
 
-#### Whitelist classification — run the formatter TOOL, or the session model
+#### Any campaign commit to the PR head resets the gate
 
-Before dispatching anything, decide whether the failing check is **whitelisted**. A check is whitelisted
-**only because its fixer is semantics-preserving BY CONSTRUCTION**: it rewrites LAYOUT and cannot change
-program meaning at all (`SKILL.md`, "The only cheap path"). That guarantee belongs to **the tool's
-output** and to nothing else — a model hand-editing the same file does NOT inherit it, however
-formatting-like its diff looks. A pure-indentation edit can move behavior in a whitespace-significant
-language and still be formatter-clean, so there is no diff-shape guard that makes a cheap model's edit
-safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
+**THE RULE — every commit campaign pushes to a PR's head branch is a PR-content change, whatever wrote
+it: a CI-fix subagent, a review-fix subagent, or a whitelisted TOOL run with no model at all.** Every one
+of them MUST, in the same step:
 
-- **IN** — pure formatting / import ordering: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
-  `whitespace`, `prettier`, `ruff format`.
+- **reset `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
+  (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing`) — the gate and its
+  label move together, never one without the other (`stage-2-review-gate.md`, "Status labels mirror the
+  review gate");
+- **relaunch the CI watch immediately**;
+- **re-enter Stage 2a.**
+
+NEVER treat a tool-written commit as exempt: the verdicts on the old SHA describe content that no longer
+exists, and a `gauntlet-accepted` label on it is a false public claim.
+
+#### Whitelist classification — run the whitelisted TOOL, or the session model
+
+Before dispatching anything, decide whether the failing check's fixer is a **whitelisted tool**. **A tool
+is whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an
+AST-preserving pretty-printer, not a text munger — and the burden is the tool's **documented behaviour**
+(`SKILL.md`, "The only cheap path"). **Cannot point to that guarantee → NOT whitelisted → session
+model.** There is NO blanket "formatters are safe" rule.
+
+That guarantee belongs to the whitelisted **tool's output** and to nothing else — a model hand-editing the
+same file does NOT inherit it, however formatting-like its diff looks. A pure-indentation edit can move
+behavior in a whitespace-significant language and still be formatter-clean, so there is no diff-shape
+guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
+
+- **IN** — `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents);
+  `goimports` (import block only); `gci` (import grouping/ordering only — Go package init order is by
+  **dependency**, not by import order in a file); golangci-lint `whitespace` (Go: leading/trailing
+  newlines inside function bodies only); `ruff format` (verifies its output is AST-equivalent to the
+  input).
+- **OUT** — `prettier`: it reformats the **contents** of tagged template literals (`` gql`…` ``,
+  `` css`…` ``), changing the runtime string the tag function receives — a semantic change made by the
+  tool itself.
+- **OUT** — any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer that can rewrite
+  content inside string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks).
 - **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
   with a reversed or non-equivalent comparator): lint-clean, semantics changed.
 - **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes
-  too. A whitelisted run MUST invoke **only the formatter**, NEVER a catch-all `--fix`.
+  too. A whitelisted run MUST invoke **only the whitelisted formatter**, NEVER a catch-all `--fix`.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
-Key it on the **check / fixer IDENTITY** from the failing check's output — NEVER on a judgment that the
-failure "looks mechanical". **Default is NOT whitelisted. Unknown check → session model.**
+Key it on the **tool's IDENTITY and its documented guarantee** — NEVER on a judgment that the failure
+"looks mechanical", NEVER on the category "formatter". **Default is NOT whitelisted. Unknown check or
+unlisted tool → session model.**
 
 Then, in order:
 
-1. **Whitelisted formatter → run the TOOL, no model (prefer this always).** In `<worktree>`: `gofmt -w`,
-   `gofumpt -w`, `goimports -w`, `gci write`, `prettier --write`, `ruff format`. NEVER a catch-all
-   `--fix`. ACCEPT only if **both** hold: re-running the **exact** failing check now **passes**, AND the
-   diff touches **no check definition, config, or test**. Then commit + push — **zero model spend**.
+1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`: `gofmt -w`,
+   `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`. NEVER a catch-all `--fix`. ACCEPT only if
+   **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
+   definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
+   above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
+   watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
-   dispatch above. Covers: the tool did not fix it, the tool left residue, the check is not whitelisted,
-   or the failure needs any judgment.
+   dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
+   whitelisted, or the failure needs any judgment.
 
 If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
 head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;
 NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 
-**Residual risk, stated honestly:** it is small and specific — reordering imports could in principle
-change init side-effect order (blank/`_` imports). That is the whole of it. Do NOT widen the whitelist
-past it, and NEVER re-derive its safety from the review gate: the whitelist stands on the fixer being
-incapable of changing semantics, or it does not stand at all.
+**Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
+a tool bug, or a config/plugin that switches on non-formatting rules, is the whole of the exposure. Run
+whitelisted tools with the project's own config and no extra rule sets. Do NOT widen the whitelist past a
+guarantee you can point to, and NEVER re-derive its safety from the review gate: the whitelist stands on
+the TOOL being incapable of changing semantics, or it does not stand at all.
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -68,17 +68,45 @@ same file does NOT inherit it, however formatting-like its diff looks. A pure-in
 behavior in a whitespace-significant language and still be formatter-clean, so there is no diff-shape
 guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
 
-The **LIST** of whitelisted tools is the skill's **built-in defaults** merged with the repo's
-`.gauntlet.yml`. The **CRITERION** above is the skill's and is **NEVER configurable** — no config key
-relaxes it.
+The **LIST** of whitelisted tools is the skill's **built-in defaults**, as the repo's `.gauntlet.yml`
+re-configures (flags, files) or removes them. The **CRITERION** above is the skill's and is **NEVER
+configurable** — no config key relaxes it. Config **NEVER introduces a binary outside the known-tools
+table** below.
 
-**Built-in defaults — IN:**
+#### The KNOWN-TOOLS TABLE — the built-in defaults
 
-- `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents);
-  `goimports` (import block only); `gci` (import grouping/ordering only — Go package init order is by
-  **dependency**, not by import order in a file); golangci-lint `whitespace` (Go: leading/trailing
-  newlines inside function bodies only); `ruff format` (verifies its output is AST-equivalent to the
-  input).
+This table is the **skill's**. It is the ONLY set of binaries campaign may execute on the no-model path.
+A repo may configure a known tool's **flags and files**; it may **NEVER introduce a binary that is not in
+this table**. Adding a genuinely new tool here is a **SKILL change** (gated, reviewed), NEVER a config
+change.
+
+| `id` | `argv[0]` | guarantee | precondition — MUST hold in THIS repo |
+|---|---|---|---|
+| `gofmt` | `gofmt` | AST-preserving Go pretty-printer (`go/printer`); never alters string-literal contents | none |
+| `gofumpt` | `gofumpt` | same printer, stricter layout rules; never alters string-literal contents | none |
+| `goimports` | `goimports` | rewrites the **import block only** | none |
+| `gci` | `gci` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
+| `ruff format` | `ruff` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+
+**REMOVED — golangci-lint `whitespace`**: no safe fixer exists for it. Its only fix path is the catch-all
+`golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
+failure goes to the session model.
+
+#### A tool's guarantee can be CONDITIONAL on its configuration
+
+`ruff format` is the worked example. With `format.docstring-code-format` enabled, Ruff **reformats Python
+code inside docstrings** — it rewrites the contents of a string literal, so its output is **NOT**
+AST-equivalent. The AST-equivalence guarantee holds **only while that setting is OFF** (its default).
+
+**The general rule:**
+
+- A `guarantee` MUST state **the conditions under which it holds**. A guarantee with unstated conditions
+  is not a guarantee → REFUSE the entry.
+- Campaign MUST **verify those conditions hold in THIS repo** before taking the no-model path — read the
+  repo's tool config (for Ruff: `pyproject.toml` `[tool.ruff.format]`, `ruff.toml`/`.ruff.toml`) on the
+  **base branch**, the same provenance rule as `.gauntlet.yml`.
+- Condition enabled, OR **cannot be determined** → the tool is **NOT whitelisted for this repo** →
+  session model. Default deny; NEVER assume a default.
 
 **NON-OVERRIDABLE DENYLIST — the skill's; `.gauntlet.yml` CANNOT widen past it. REFUSE any entry that is:**
 
@@ -107,12 +135,14 @@ A hardcoded list is meaningless in a Rust/Java/Ruby repo, so the LIST is repo-co
 at the **repo root** and is **COMMITTED** — it is NOT under the git-ignored `.gauntlet/` tree
 (`files-and-ledger.md`).
 
+`command` is an **argv LIST**, never a shell string:
+
 ```yaml
 formatters:
   - id: gofmt
-    command: gofmt -w
+    command: ["gofmt", "-w"]           # argv list — argv[0] MUST be a known tool
     files: "**/*.go"
-    guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer)."
+    guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer). Holds unconditionally."
 ```
 
 **Read it from the BASE branch, NEVER from the PR's worktree or head:**
@@ -126,31 +156,60 @@ head, a PR could **widen the whitelist that governs its own campaign** — add a
 an unreviewed tool commit on its own head. That is the self-gating hazard in config form. A PR that edits
 `.gauntlet.yml` therefore takes effect only **after it merges**, gated like any other change.
 
-**Validate every entry. An entry is ACCEPTED only if ALL hold:**
+#### TRUST MODEL — say it plainly
 
-1. it carries all four fields — `id`, `command`, `files`, `guarantee`;
-2. `guarantee` is a **concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour** (which
-   printer/AST check, what it is documented never to touch). "It's just formatting", "safe", "we always run
-   it" are **NOT** guarantees → REFUSE;
-3. `command` hits **nothing on the denylist** above — no catch-all `--fix`/`--write`, no semantic rewriter,
+`.gauntlet.yml` is read from the **base branch**, so it is authored by people with **write access to the
+repo** — the same people who can already edit `.github/workflows` and make CI do anything. The denylist and
+the command-shape rules are therefore a **guard against footguns and accidental misuse, NOT a security
+boundary against a malicious committer.** NEVER present them as one.
+
+What the base-branch rule DOES buy is real, and MUST be kept: **a PR under review cannot widen the
+whitelist that governs its own campaign.** That is the property being defended.
+
+#### VALIDATION — the command's SHAPE, not just the tool's category
+
+The attack is **command construction**, not tool category: an entry can cite `gofmt`'s guarantee while
+executing a wrapper that rewrites product code. Validating the `guarantee` text and the denylist alone
+does NOT stop that. **Constrain the shape of the command.**
+
+**An entry is ACCEPTED only if ALL of these hold:**
+
+1. **All four fields present** — `id`, `command`, `files`, `guarantee`.
+2. **`command` is an argv LIST** — `["gofmt", "-w"]`. A **shell string is REFUSED**. It is executed
+   **WITHOUT a shell**: NEVER via `sh -c`, `bash -c`, `os.system`, or any shell string.
+3. **NO shell metacharacters anywhere in the argv** — `&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks,
+   newlines. **No legitimate formatter entry needs them.** Any occurrence → REFUSE.
+4. **`argv[0]` is a BARE TOOL NAME in the known-tools table** above. NOT a path (`./scripts/fmt.sh`,
+   `/usr/local/bin/gofmt`, `../x`), NOT a wrapper script, NOT an alias, NOT `sh`/`bash`/`env`/`xargs`.
+   Contains `/` → REFUSE. Not in the table → REFUSE. A repo configures the **flags and files** of a known
+   tool; it NEVER introduces an arbitrary binary. Resolve it from `PATH` at run time and NEVER honour a
+   PATH entry the repo's own config injected.
+5. **`guarantee` is a concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour** (which
+   printer/AST check, what it is documented never to touch) **AND states the conditions under which it
+   holds**. "It's just formatting", "safe", "we always run it" are **NOT** guarantees → REFUSE.
+6. **The stated conditions VERIFY in this repo** (see "conditional on its configuration" above).
+   Cannot verify → REFUSE.
+7. **`command` hits nothing on the denylist** below — no catch-all `--fix`/`--write`, no semantic rewriter,
    nothing that can touch a check definition, config, or test.
 
 **REFUSING means: log the entry and why, IGNORE it, and route that failure to the session model. NEVER
 silently honour a denied entry.** Refusing one entry does not invalidate the others.
 
 **Merge semantics:** start from the built-in defaults; the repo's `formatters:` list **replaces** them by
-`id` — an entry appends a new tool or overrides a built-in of the same `id`, and a built-in the repo omits
-while listing others is **removed** for that repo (e.g. a repo that does not want `gci` simply lists the
-ones it wants). `formatters: []` **disables the cheap path entirely** — every failure goes to the session
-model, always a safe choice. **Missing file → built-in defaults only. Unparseable file → cheap path OFF for
-this run** (default deny; never guess at a half-parsed whitelist).
+`id` — an entry re-configures the flags/files of a known tool of the same `id`, and a built-in the repo
+omits while listing others is **removed** for that repo (e.g. a repo that does not want `gci` simply lists
+the ones it wants). An entry whose `argv[0]` is not a known tool is REFUSED, not appended.
+`formatters: []` **disables the cheap path entirely** — every failure goes to the session model, always a
+safe choice. **Missing file → built-in defaults only. Unparseable file → cheap path OFF for this run**
+(default deny; never guess at a half-parsed whitelist).
 
 Then, in order:
 
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the entry's
-   exact `command` — built-in (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`) or the
-   validated `command` from base-branch `.gauntlet.yml` — scoped to its `files` glob. NEVER a catch-all
-   `--fix`. ACCEPT only if **both** hold: re-running the **exact** failing check now **passes**, AND the
+   validated **argv** — built-in (`["gofmt","-w"]`, `["gofumpt","-w"]`, `["goimports","-w"]`,
+   `["gci","write"]`, `["ruff","format"]`) or the validated `command` from base-branch `.gauntlet.yml` —
+   **executed WITHOUT a shell**, scoped to its `files` glob. NEVER a catch-all `--fix`. ACCEPT only if
+   **both** hold: re-running the **exact** failing check now **passes**, AND the
    diff touches **no check definition, config, or test**. Then commit + push — **zero model spend** — and
    **apply the gate reset** above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0
    + relabel, relaunch the watch, re-enter 2a. A tool commit gates exactly like a subagent commit.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -18,8 +18,16 @@ row by column position:
   diagnose from the check logs and dispatch a scoped CI-fix subagent into `<worktree>` — the PR row's
   ledger `worktree` column value, the single source of truth for this PR's checkout path (created at
   adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
-  `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout). Its fix
-  commits + pushes to the PR's **own head branch**
+  `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
+
+  **Dispatch it on `sonnet`** (`model: "sonnet"`), not the session model — the one sanctioned
+  downgrade in this skill (`SKILL.md`, "Subagent Dispatch"). It is safe here *because the failure is
+  self-detecting*: a bad CI fix leaves CI red, campaign re-dispatches, and a red check blocks the
+  review pass regardless — so a weaker fix can never silently reach the gate. **Scope it**: give it
+  the failing check's logs, the specific failing file(s), and the worktree path, and tell it NOT to
+  re-derive the whole diff or read beyond what the failure touches.
+
+  Its fix commits + pushes to the PR's **own head branch**
   → code changed → **reset `reviews_ok` to 0 AND, in that same step, restore `gauntlet-reviewing` if
   the PR carries `gauntlet-accepted`** (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label
   gauntlet-reviewing`) — the gate and its label move together, never one without the other

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -68,39 +68,96 @@ same file does NOT inherit it, however formatting-like its diff looks. A pure-in
 behavior in a whitespace-significant language and still be formatter-clean, so there is no diff-shape
 guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
 
-- **IN** — `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents);
+The **LIST** of whitelisted tools is the skill's **built-in defaults** merged with the repo's
+`.gauntlet.yml`. The **CRITERION** above is the skill's and is **NEVER configurable** — no config key
+relaxes it.
+
+**Built-in defaults — IN:**
+
+- `gofmt`, `gofumpt` (AST-preserving Go pretty-printers; never touch string-literal contents);
   `goimports` (import block only); `gci` (import grouping/ordering only — Go package init order is by
   **dependency**, not by import order in a file); golangci-lint `whitespace` (Go: leading/trailing
   newlines inside function bodies only); `ruff format` (verifies its output is AST-equivalent to the
   input).
-- **OUT** — `prettier`: it reformats the **contents** of tagged template literals (`` gql`…` ``,
-  `` css`…` ``), changing the runtime string the tag function receives — a semantic change made by the
-  tool itself.
-- **OUT** — any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer that can rewrite
-  content inside string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks).
-- **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
+
+**NON-OVERRIDABLE DENYLIST — the skill's; `.gauntlet.yml` CANNOT widen past it. REFUSE any entry that is:**
+
+- **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
+  changing the runtime string the tag function receives — a semantic change made by the tool itself.
+- any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer that can rewrite content inside
+  string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks).
+- a **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3`, any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
   with a reversed or non-equivalent comparator): lint-clean, semantics changed.
-- **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes
-  too. A whitelisted run MUST invoke **only the whitelisted formatter**, NEVER a catch-all `--fix`.
+- a **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, or
+  any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run MUST invoke **only
+  the whitelisted formatter**, NEVER a catch-all `--fix`.
+- anything whose command can touch a **check definition, config, or test** — the no-weakening prohibition,
+  a hard rule, not a preference.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
 Key it on the **tool's IDENTITY and its documented guarantee** — NEVER on a judgment that the failure
-"looks mechanical", NEVER on the category "formatter". **Default is NOT whitelisted. Unknown check or
-unlisted tool → session model.**
+"looks mechanical", NEVER on the category "formatter". **Default deny. Unknown check, unlisted tool,
+missing/unparseable config, or a refused entry → session model.**
+
+#### Repo config — `.gauntlet.yml`, read from the BASE branch
+
+A hardcoded list is meaningless in a Rust/Java/Ruby repo, so the LIST is repo-configurable. The file lives
+at the **repo root** and is **COMMITTED** — it is NOT under the git-ignored `.gauntlet/` tree
+(`files-and-ledger.md`).
+
+```yaml
+formatters:
+  - id: gofmt
+    command: gofmt -w
+    files: "**/*.go"
+    guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer)."
+```
+
+**Read it from the BASE branch, NEVER from the PR's worktree or head:**
+
+```
+git show origin/<base>:.gauntlet.yml
+```
+
+**NEVER read `.gauntlet.yml` from the PR under review.** If campaign took the whitelist from the PR's own
+head, a PR could **widen the whitelist that governs its own campaign** — add a semantic rewriter and earn
+an unreviewed tool commit on its own head. That is the self-gating hazard in config form. A PR that edits
+`.gauntlet.yml` therefore takes effect only **after it merges**, gated like any other change.
+
+**Validate every entry. An entry is ACCEPTED only if ALL hold:**
+
+1. it carries all four fields — `id`, `command`, `files`, `guarantee`;
+2. `guarantee` is a **concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour** (which
+   printer/AST check, what it is documented never to touch). "It's just formatting", "safe", "we always run
+   it" are **NOT** guarantees → REFUSE;
+3. `command` hits **nothing on the denylist** above — no catch-all `--fix`/`--write`, no semantic rewriter,
+   nothing that can touch a check definition, config, or test.
+
+**REFUSING means: log the entry and why, IGNORE it, and route that failure to the session model. NEVER
+silently honour a denied entry.** Refusing one entry does not invalidate the others.
+
+**Merge semantics:** start from the built-in defaults; the repo's `formatters:` list **replaces** them by
+`id` — an entry appends a new tool or overrides a built-in of the same `id`, and a built-in the repo omits
+while listing others is **removed** for that repo (e.g. a repo that does not want `gci` simply lists the
+ones it wants). `formatters: []` **disables the cheap path entirely** — every failure goes to the session
+model, always a safe choice. **Missing file → built-in defaults only. Unparseable file → cheap path OFF for
+this run** (default deny; never guess at a half-parsed whitelist).
 
 Then, in order:
 
-1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`: `gofmt -w`,
-   `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`. NEVER a catch-all `--fix`. ACCEPT only if
-   **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
-   definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
-   above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
-   watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
+1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the entry's
+   exact `command` — built-in (`gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`, `ruff format`) or the
+   validated `command` from base-branch `.gauntlet.yml` — scoped to its `files` glob. NEVER a catch-all
+   `--fix`. ACCEPT only if **both** hold: re-running the **exact** failing check now **passes**, AND the
+   diff touches **no check definition, config, or test**. Then commit + push — **zero model spend** — and
+   **apply the gate reset** above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0
+   + relabel, relaunch the watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
    dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
-   whitelisted, or the failure needs any judgment.
+   whitelisted, the config entry was refused, the config is missing/unparseable, or the failure needs any
+   judgment.
 
 If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
 head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;
@@ -108,9 +165,9 @@ NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 
 **Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
 a tool bug, or a config/plugin that switches on non-formatting rules, is the whole of the exposure. Run
-whitelisted tools with the project's own config and no extra rule sets. Do NOT widen the whitelist past a
-guarantee you can point to, and NEVER re-derive its safety from the review gate: the whitelist stands on
-the TOOL being incapable of changing semantics, or it does not stand at all.
+whitelisted tools with the project's own config and no extra rule sets. Do NOT admit a `.gauntlet.yml`
+entry past a guarantee you can point to, and NEVER re-derive its safety from the review gate: the
+whitelist stands on the TOOL being incapable of changing semantics, or it does not stand at all.
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -43,21 +43,21 @@ row by column position:
   (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the watch
   immediately and re-enter 2a.
 
-#### Whitelist classification — semantics-preserving formatters only
+#### Whitelist classification — run the formatter TOOL, or the session model
 
-Before dispatching anything, decide whether the failing check is **whitelisted**. A check qualifies as a
-**total oracle** — re-running it *fully decides* correctness, leaving no judgment over — **only because
-its fixer is semantics-preserving BY CONSTRUCTION**: it rewrites LAYOUT and cannot change program meaning
-at all (`SKILL.md`, "The one exception"). The guarantee comes from the **tool's construction**, never
-from a hope that a reviewer will notice. "A lint rule passed" is a strictly weaker claim and is NOT
-sufficient.
+Before dispatching anything, decide whether the failing check is **whitelisted**. A check is whitelisted
+**only because its fixer is semantics-preserving BY CONSTRUCTION**: it rewrites LAYOUT and cannot change
+program meaning at all (`SKILL.md`, "The only cheap path"). That guarantee belongs to **the tool's
+output** and to nothing else — a model hand-editing the same file does NOT inherit it, however
+formatting-like its diff looks. A pure-indentation edit can move behavior in a whitespace-significant
+language and still be formatter-clean, so there is no diff-shape guard that makes a cheap model's edit
+safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
 
 - **IN** — pure formatting / import ordering: `gofmt`, `gofumpt`, `goimports` (import block only), `gci`,
   `whitespace`, `prettier`, `ruff format`.
 - **OUT** — every **semantic rewriter**, including `modernize` and any rule that rewrites logic. A
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
-  with a reversed or non-equivalent comparator): lint-clean, semantics changed. The check does NOT fully
-  verify its own fix, so it is NOT a total oracle.
+  with a reversed or non-equivalent comparator): lint-clean, semantics changed.
 - **OUT** — blanket `golangci-lint run --fix` and blanket `ruff --fix`: they apply semantic autofixes
   too. A whitelisted run MUST invoke **only the formatter**, NEVER a catch-all `--fix`.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
@@ -68,30 +68,17 @@ failure "looks mechanical". **Default is NOT whitelisted. Unknown check → sess
 
 Then, in order:
 
-1. **Tier 0 — no subagent (prefer this always).** Whitelisted formatter with a deterministic fixer → run
-   the **tool** in `<worktree>`: `gofmt -w`, `gofumpt -w`, `goimports -w`, `gci write`,
-   `prettier --write`, `ruff format`. NEVER a catch-all `--fix`. Then apply the acceptance criteria
-   below. Passes → commit + push, no model spend at all. Dispatching a model to hand-edit a formatting
-   violation is both the most expensive and the LEAST reliable way to do it.
-2. **Tier 1 — cheap model, verified.** Whitelisted formatter with no usable fixer, or a fixer that ran
-   but left residue → dispatch the scoped CI-fix subagent on `haiku` (pure mechanical rewrite) or
-   `sonnet` (needs any reasoning). Set the model explicitly. Then apply the acceptance criteria below.
-3. **Everything else → session model**, per the red-CI dispatch above.
+1. **Whitelisted formatter → run the TOOL, no model (prefer this always).** In `<worktree>`: `gofmt -w`,
+   `gofumpt -w`, `goimports -w`, `gci write`, `prettier --write`, `ruff format`. NEVER a catch-all
+   `--fix`. ACCEPT only if **both** hold: re-running the **exact** failing check now **passes**, AND the
+   diff touches **no check definition, config, or test**. Then commit + push — **zero model spend**.
+2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
+   dispatch above. Covers: the tool did not fix it, the tool left residue, the check is not whitelisted,
+   or the failure needs any judgment.
 
-**Acceptance criteria (Tier 0 and Tier 1 alike).** ACCEPT the fix **only if all three hold**:
-
-- (a) re-running the **exact** failing check now **passes**; AND
-- (b) the diff touches **no check definition, config, or test**; AND
-- (c) the diff is **formatting-only** — whitespace, indentation, line breaks, and import-block
-  ordering/insertion/removal — and touches **NOTHING else**: no expression, call, argument, control flow,
-  or literal.
-
-Any point fails → **discard the work** (reset the worktree to the PR head) and **re-dispatch the same
-failure on the session model**. NEVER patch a whitelisted fix in place; NEVER commit an unverified one;
-NEVER accept a "formatting" fix whose diff edits code.
-
-(c) is the mechanical guard that makes "changes no product behavior" **checkable rather than promised**:
-with the whitelist narrowed to formatters, a formatting-only diff cannot move behavior.
+If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
+head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;
+NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 
 **Residual risk, stated honestly:** it is small and specific — reordering imports could in principle
 change init side-effect order (blank/`_` imports). That is the whole of it. Do NOT widen the whitelist

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -93,20 +93,30 @@ The ONLY binaries campaign may execute on the no-model path, in the ONLY form it
 `formatters` header field, with the skill's **exclusion filter** applied afterwards — always (both below).
 Adding a tool, changing an argv, or changing a default glob is a **SKILL change** (gated, reviewed).
 
-| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — the SOURCE, then what it says | precondition — MUST hold in THIS repo |
-|---|---|---|---|---|
-| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines gofmt as formatting Go source with `go/printer` layout (tabs to indent, blanks to align), and lists the two flags that make it do MORE than that: **`-r` (apply a rewrite rule)** and **`-s` (simplify code)**. **Neither is in the skill-owned argv**, and nothing may append one; without them gofmt applies no rewrite rule at all | (none) |
-| `gci` | `["gci", "write", "--", <files>]` | `**/*.go` | **gci — https://github.com/daixiang0/gci**. The project documents its scope as controlling **import ORDER and GROUPING**: it sorts and groups the imports **already present** into sections. It does **NOT add** an import and does **NOT remove** one → the `init()` set cannot change; Go's package init order is by **dependency**, never by an import's position in a file | (none) |
-| `ruff format` | `["ruff", "format", "--", <files>]` | `**/*.py` | **Ruff formatter — https://docs.astral.sh/ruff/formatter/**. The docs state the formatter **verifies its own output is AST-equivalent** to the input and refuses a formatting that would change the tree. The docs also define **`format.docstring-code-format`** (https://docs.astral.sh/ruff/settings/#format_docstring-code-format), which formats code **inside docstrings** — i.e. rewrites string CONTENTS — so the AST-equivalence guarantee holds only while it is OFF (its documented default) | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — the SOURCE, then what it says |
+|---|---|---|---|
+| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines the behaviour: *"Gofmt formats Go programs. It uses tabs for indentation and blanks for alignment."* It documents exactly two flags that make gofmt do MORE than format: **`-r`** — *"Apply the rewrite rule to the source before reformatting"* — and **`-s`** — *"Try to simplify code"* (it lists the source transformations `-s` performs). **NEITHER is in the skill-owned argv**, and nothing may append one |
 
-Every tool has a default glob, so an **unnarrowed formatter list has a fully defined file set**: the
-table's defaults, filtered. NEVER invent a default glob for a tool; NEVER widen one.
+**ONE tool. That is the whole table**, and it is small **on purpose**: it is what survived a rule that
+demands a **documented** guarantee, quoted from the source. Every tool has a default glob, so an
+**unnarrowed formatter list has a fully defined file set**: the table's defaults, filtered. NEVER invent a
+default glob for a tool; NEVER widen one.
 
-**A `guarantee` cell MUST carry a LINK to the tool's own documentation, plus what that doc says.** The
-WORD "documented" is not evidence — an unsourced "documented as a pretty-printer" is the same
-category-assertion that this table exists to kill. "It is a formatter", "the diff looks mechanical", "it
-feels safe" are not guarantees and have repeatedly been wrong. **A claim that cannot be tied to a source
-→ the tool comes OUT of the table.** No exception, including for tools already in it.
+**The cheap path therefore covers Go formatting and NOTHING else.** Every other CI failure — **including
+ALL Python/JS/other-language formatting** — goes to the **session model**. That is the safe default, and it
+is **NOT a regression**: it is what happened before this path existed. NEVER treat the table's size as a
+limitation to route around — it is the rule working.
+
+**Adding a tool is a SKILL change (gated, reviewed), and the bar is a SOURCE THAT STATES THE GUARANTEE,
+QUOTED IN THE CELL.** "It is a formatter", "it is probably fine", "it is widely used", "the diff looks
+mechanical" are **NOT admissible**.
+
+**A `guarantee` cell MUST carry a LINK to the tool's own documentation AND the passage it rests on,
+QUOTED.** The WORD "documented" is not evidence — an unsourced "documented as a pretty-printer" is the same
+category-assertion that this table exists to kill. **FOLLOW the link before you trust the cell: a citation
+that does not SUPPORT the claim is WORSE than no citation** — it launders our own reasoning as the source's.
+**A claim that cannot be tied to a source → the tool comes OUT of the table.** No exception, including for
+tools already in it — `ruff format` and `gci` were removed by exactly this rule (below).
 
 **NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
 the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
@@ -115,6 +125,16 @@ shell string.
 **REMOVED — tools that FAIL the criterion.** They are not "not configured"; they are **rejected**, and
 re-adding one is a SKILL change that must first defeat the reason below:
 
+- **`ruff format`** — **REJECTED for now.** Its formatter docs, **as cited**
+  (https://docs.astral.sh/ruff/formatter/), do **NOT state an AST-equivalence guarantee**. The tool may well
+  be safe; the whitelist admits tools on **DOCUMENTED** guarantees, never on reputation or on our belief.
+  A citation that does not support its claim is **WORSE than no citation** — the claim was laundered through
+  the link. Re-admitting it requires **a source that ACTUALLY STATES the guarantee, QUOTED in the cell** — a
+  SKILL change.
+- **`gci`** — **REJECTED for now.** The cited project docs (https://github.com/daixiang0/gci) describe import
+  **ordering/grouping** but do **NOT state** that gci never adds and never removes an import. The Go
+  init-order argument previously in that cell was **ours**, presented as the source's. Same rule: find a
+  source that states the guarantee and quote it, or gci stays out.
 - **`goimports`** (https://pkg.go.dev/golang.org/x/tools/cmd/goimports) — its own doc says it updates the
   import lines: it **ADDS missing imports and REMOVES unreferenced ones**. Adding an import runs that
   package's `init()`; a guessed import can resolve to the **wrong package**. Changing the set of imports is
@@ -184,8 +204,8 @@ candidate RESOLVES TO, not just how it is spelled. Reason on record: **symlink e
 **EVERY tool, EVERY run, ALL FIVE — no exceptions:**
 
 1. **END-OF-OPTIONS.** Pass `--` immediately before the file list. Every tool in the table accepts it
-   (`gofmt`/Go `flag`, `gci`/pflag, `ruff`/clap), and the table's argv already carries it. Nothing after
-   `--` can be read as a flag. A tool that has no `--` NEVER enters the table.
+   (`gofmt`, via Go's `flag` package), and the table's argv already carries it. Nothing after `--` can be
+   read as a flag. A tool that has no `--` NEVER enters the table.
 2. **NEVER PASS A BARE RELATIVE NAME.** Pass each file as a path that **cannot be mistaken for an option**:
    an **ABSOLUTE** path (worktree root joined to the relative path) — or, if a tool needs relative paths, a
    **`./`-prefixed** one. Belt-and-braces: this holds even for a tool whose `--` handling is broken.
@@ -212,25 +232,6 @@ Refusing files can empty the set → then run NOTHING for that id and route the 
 **NEVER pass the glob itself to the tool** (`gofmt -w .`, `gofmt -w '**/*.go'`) — that hands file selection
 to the tool and bypasses the exclusion filter AND this normalization. Campaign expands, filters, refuses,
 normalizes, and passes the resulting **explicit path list**.
-
-#### A tool's guarantee can be CONDITIONAL on its configuration
-
-`ruff format` is the worked example. With **`format.docstring-code-format`**
-(https://docs.astral.sh/ruff/settings/#format_docstring-code-format) enabled, Ruff **reformats Python
-code inside docstrings** — it rewrites the contents of a string literal, so its output is **NOT**
-AST-equivalent. The AST-equivalence guarantee holds **only while that setting is OFF** (its default).
-
-**The general rule:**
-
-- The table states the **conditions under which each guarantee holds**. A guarantee with unstated
-  conditions is not a guarantee.
-- Campaign MUST **verify those conditions hold in THIS repo** before taking the no-model path — read the
-  repo's tool config **in the worktree the tool will run in** (for Ruff: `pyproject.toml`
-  `[tool.ruff.format]`, `ruff.toml`/`.ruff.toml`). That is the config the tool will actually obey, so it is
-  the one that must be checked. A PR that switches the condition ON does not widen anything — it **loses**
-  the cheap path and goes to the session model.
-- Condition enabled, OR **cannot be determined** → the tool is **NOT whitelisted for this repo** →
-  session model. Default deny; NEVER assume a default.
 
 #### NON-OVERRIDABLE DENYLIST — the skill's; NOTHING widens past it
 
@@ -315,7 +316,7 @@ follows ("The reviewer", `reviewer.md`). Priority order:
 - `-` — the **DISABLING SENTINEL**: the cheap path is **OFF** for this run; every CI failure goes to the
   session model. Always a safe choice. **The sentinel is `-` — NEVER the word `none`.** A user who says
   "no formatters" / "none" is asking for this; campaign writes **`-`** into the header.
-- a comma-separated list of known-tool ids, each optionally `:<glob>`-suffixed (`gofmt,gci:internal/**/*.go`).
+- a comma-separated list of known-tool ids, each optionally `:<glob>`-suffixed (`gofmt:internal/**/*.go`).
 
 `default` (built-ins ON) and `-` (cheap path OFF) are **NEVER interchangeable**. An **unset/absent** field
 means `default`, NOT `-`.
@@ -362,15 +363,14 @@ user's.
    config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`, …), or a repo-sweeping bare `**`/`.`.
    The **exclusion filter still applies to every accepted id** — the refusal catches intent, the filter is
    the guarantee.
-4. **The table's precondition for that `id` VERIFIES in this repo** (see "conditional on its
-   configuration"). Cannot verify → REFUSE.
 
 **REFUSING means: log the id and why, IGNORE it, and route that failure to the session model. NEVER
 silently honour a refused id.** Refusing one id does not invalidate the others.
 
 **Resolution semantics:** an explicit or preferred list **replaces** the built-in defaults — a known tool
-the user omits while naming others is **not run** (a user who does not want `gci` simply names the ones
-they want). An id that is not a known tool is REFUSED, not appended. **`-`** (the disabling sentinel)
+the user omits while naming others is **not run**. An id that is not a known tool (anything but `gofmt`
+today — `ruff format`, `gci`, `goimports`, `gofumpt`, …) is **REFUSED**, not appended: that failure goes to
+the session model. **`-`** (the disabling sentinel)
 **disables the cheap path entirely**. No explicit list and no preference → `default`: the table's built-in
 defaults, each with its default glob, exclusion filter applied as always — NEVER an invented or broadened
 default.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -59,8 +59,9 @@ exists, and a `gauntlet-accepted` label on it is a false public claim.
 
 Before dispatching anything, decide whether the failing check's fixer is a **whitelisted tool**. **A tool
 is whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an
-AST-preserving pretty-printer, not a text munger — and the burden is the tool's **documented behaviour**.
-**Cannot point to that guarantee → NOT whitelisted → session model.** There is NO blanket "formatters are
+AST-preserving pretty-printer, not a text munger — and the burden is a **CITED SOURCE: a LINK to the tool's
+own documentation and the passage it rests on.** Saying the word "documented" is NOT a citation.
+**Cannot point to a source → NOT whitelisted → session model.** There is NO blanket "formatters are
 safe" rule.
 
 That guarantee belongs to the whitelisted **tool's output** and to nothing else — a model hand-editing the
@@ -92,18 +93,20 @@ The ONLY binaries campaign may execute on the no-model path, in the ONLY form it
 `formatters` header field, with the skill's **exclusion filter** applied afterwards — always (both below).
 Adding a tool, changing an argv, or changing a default glob is a **SKILL change** (gated, reviewed).
 
-| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — what the tool DOCUMENTS | precondition — MUST hold in THIS repo |
+| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee — the SOURCE, then what it says | precondition — MUST hold in THIS repo |
 |---|---|---|---|---|
-| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | documented as a pretty-printer: it parses the file and re-prints the AST with `go/printer` (tabs to indent, blanks to align). With no `-r` and no `-s` it applies **no rewrite rule**; comments and string-literal contents are reproduced verbatim | none |
-| `gci` | `["gci", "write", "--", <files>]` | `**/*.go` | documented as controlling **import ORDER and GROUPING** and nothing else: it sorts existing imports into sections. It does **NOT add** an import and does **NOT remove** one, so no `init()` set changes; Go's package init order is by **dependency**, not by import position in a file | none |
-| `ruff format` | `["ruff", "format", "--", <files>]` | `**/*.py` | documented to **verify its own output is AST-equivalent** to the input (it compares the parsed trees and refuses a formatting that would change them) | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | **`cmd/gofmt` — https://pkg.go.dev/cmd/gofmt**. The doc defines gofmt as formatting Go source with `go/printer` layout (tabs to indent, blanks to align), and lists the two flags that make it do MORE than that: **`-r` (apply a rewrite rule)** and **`-s` (simplify code)**. **Neither is in the skill-owned argv**, and nothing may append one; without them gofmt applies no rewrite rule at all | (none) |
+| `gci` | `["gci", "write", "--", <files>]` | `**/*.go` | **gci — https://github.com/daixiang0/gci**. The project documents its scope as controlling **import ORDER and GROUPING**: it sorts and groups the imports **already present** into sections. It does **NOT add** an import and does **NOT remove** one → the `init()` set cannot change; Go's package init order is by **dependency**, never by an import's position in a file | (none) |
+| `ruff format` | `["ruff", "format", "--", <files>]` | `**/*.py` | **Ruff formatter — https://docs.astral.sh/ruff/formatter/**. The docs state the formatter **verifies its own output is AST-equivalent** to the input and refuses a formatting that would change the tree. The docs also define **`format.docstring-code-format`** (https://docs.astral.sh/ruff/settings/#format_docstring-code-format), which formats code **inside docstrings** — i.e. rewrites string CONTENTS — so the AST-equivalence guarantee holds only while it is OFF (its documented default) | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
 
 Every tool has a default glob, so an **unnarrowed formatter list has a fully defined file set**: the
 table's defaults, filtered. NEVER invent a default glob for a tool; NEVER widen one.
 
-**A `guarantee` cell MUST cite what the tool DOCUMENTS.** "It is a formatter", "the diff looks
-mechanical", "it feels safe" are NOT guarantees and have repeatedly been wrong. No citable documented
-guarantee → the tool does NOT go in the table.
+**A `guarantee` cell MUST carry a LINK to the tool's own documentation, plus what that doc says.** The
+WORD "documented" is not evidence — an unsourced "documented as a pretty-printer" is the same
+category-assertion that this table exists to kill. "It is a formatter", "the diff looks mechanical", "it
+feels safe" are not guarantees and have repeatedly been wrong. **A claim that cannot be tied to a source
+→ the tool comes OUT of the table.** No exception, including for tools already in it.
 
 **NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
 the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
@@ -112,13 +115,14 @@ shell string.
 **REMOVED — tools that FAIL the criterion.** They are not "not configured"; they are **rejected**, and
 re-adding one is a SKILL change that must first defeat the reason below:
 
-- **`goimports`** — documented to **ADD missing imports and REMOVE unreferenced ones**. Adding an import
-  runs that package's `init()`; a guessed import can resolve to the **wrong package**. Changing the set of
-  imports is not semantics-preserving. NOT a formatter for this purpose.
-- **`gofumpt`** — a stricter gofmt that applies **EXTRA rewrite rules** beyond `go/printer` layout, and its
-  rules are documented as a rule LIST, **not** as semantics-preserving. It edits source constructs, not just
-  whitespace. It does not meet the criterion; being "gofmt-like" is not an argument. NEVER re-add it on the
-  grounds that it "is basically a formatter".
+- **`goimports`** (https://pkg.go.dev/golang.org/x/tools/cmd/goimports) — its own doc says it updates the
+  import lines: it **ADDS missing imports and REMOVES unreferenced ones**. Adding an import runs that
+  package's `init()`; a guessed import can resolve to the **wrong package**. Changing the set of imports is
+  not semantics-preserving. NOT a formatter for this purpose.
+- **`gofumpt`** (https://github.com/mvdan/gofumpt) — a stricter gofmt that applies **EXTRA rewrite rules**
+  beyond `go/printer` layout, and its README states them as a rule LIST, **never** as a semantics-preserving
+  guarantee. It edits source constructs, not just whitespace. It does not meet the criterion; being
+  "gofmt-like" is not an argument. NEVER re-add it on the grounds that it "is basically a formatter".
 - **golangci-lint `whitespace`** — no safe fixer exists. Its only fix path is the catch-all
   `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
   failure goes to the session model.
@@ -165,7 +169,19 @@ argv[0] was the trusted binary, the argv was the table's, no shell was involved,
 content still changed what the command **did** and what it **touched**. A bare relative filename is not a
 path; it is a token the tool is free to parse as an option.
 
-**EVERY tool, EVERY run, ALL THREE — no exceptions:**
+**The second repro — a filename that RESOLVES OUT OF THE TREE** (normalizing the SPELLING is not enough):
+
+```
+# The PR adds a symlink:  link.go -> /home/user/.ssh/authorized_keys   (or ../../other-repo/x.go)
+# It matches **/*.go. It survives the exclusion filter. Its NAME is clean: no leading `-`.
+gofmt -w -- /wt/link.go                  # gofmt FOLLOWED the symlink and rewrote its TARGET
+```
+
+**A path is DATA THAT RESOLVES, and resolution can escape the tree.** Spelling the operand safely (`--`,
+absolute path, no leading `-`) says nothing about what the kernel opens. So campaign checks what each
+candidate RESOLVES TO, not just how it is spelled. Reason on record: **symlink escape**.
+
+**EVERY tool, EVERY run, ALL FIVE — no exceptions:**
 
 1. **END-OF-OPTIONS.** Pass `--` immediately before the file list. Every tool in the table accepts it
    (`gofmt`/Go `flag`, `gci`/pflag, `ruff`/clap), and the table's argv already carries it. Nothing after
@@ -173,9 +189,22 @@ path; it is a token the tool is free to parse as an option.
 2. **NEVER PASS A BARE RELATIVE NAME.** Pass each file as a path that **cannot be mistaken for an option**:
    an **ABSOLUTE** path (worktree root joined to the relative path) — or, if a tool needs relative paths, a
    **`./`-prefixed** one. Belt-and-braces: this holds even for a tool whose `--` handling is broken.
-3. **REFUSE a candidate whose basename or path starts with `-`** (checked AFTER the exclusion filter). A
-   legitimate source file is NEVER named that way. **DROP that file from the set — do NOT abort the run**,
-   and **LOG it**: the id, the refused filename, and why.
+3. **REFUSE a candidate whose basename or path starts with `-`.** A legitimate source file is NEVER named
+   that way.
+4. **REFUSE a candidate that is a SYMLINK.** `lstat` the candidate itself (NEVER `stat` — `stat` follows the
+   link and hides exactly what is being tested). Symlink → DROP it. **A source file that must be formatted is
+   never a symlink**, and the tool would open and rewrite the link's TARGET.
+5. **REFUSE a candidate that does not RESOLVE INSIDE THE WORKTREE, or is not a REGULAR FILE.** Fully resolve
+   the candidate (`realpath` — every symlink followed, `..` collapsed), likewise resolve the worktree root,
+   then require: (a) the real path is **CONTAINED under the resolved worktree root** — string-compare on a
+   path-component boundary, never a bare prefix match (`/wt-evil` is not under `/wt`); and (b) the resolved
+   target is a **REGULAR FILE** — a directory, device, fifo, or socket is REFUSED. Escapes the tree, or is
+   not a regular file → DROP it.
+
+**Checks 3–5 run AFTER the exclusion filter and BEFORE the argv is built** — the filter decides which
+candidates survive; these decide which surviving candidates are handed to the tool at all. Every refusal:
+**DROP that file from the set — do NOT abort the run** — and **LOG it**: the id, the refused path, and the
+reason (`-`-leading name / symlink / escapes the worktree / not a regular file).
 
 Refusing files can empty the set → then run NOTHING for that id and route the failure to the session model
 ("Empty file set after filtering" below). Refusing a file NEVER widens anything and NEVER fails the PR.
@@ -186,7 +215,8 @@ normalizes, and passes the resulting **explicit path list**.
 
 #### A tool's guarantee can be CONDITIONAL on its configuration
 
-`ruff format` is the worked example. With `format.docstring-code-format` enabled, Ruff **reformats Python
+`ruff format` is the worked example. With **`format.docstring-code-format`**
+(https://docs.astral.sh/ruff/settings/#format_docstring-code-format) enabled, Ruff **reformats Python
 code inside docstrings** — it rewrites the contents of a string literal, so its output is **NOT**
 AST-equivalent. The AST-equivalence guarantee holds **only while that setting is OFF** (its default).
 
@@ -221,7 +251,7 @@ Nothing below is ever admitted to the table, and the formatter list may NEVER na
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
-Key it on the **tool's IDENTITY and its documented guarantee** — NEVER on a judgment that the failure
+Key it on the **tool's IDENTITY and its CITED documented guarantee** — NEVER on a judgment that the failure
 "looks mechanical", NEVER on the category "formatter". **Default deny. Unknown check, unlisted tool, an
 unresolvable binary, or a refused id → session model.** (An **unset** `formatters` header is not a
 refusal: it means the known-tools table's defaults.)
@@ -255,9 +285,11 @@ drops `**/*_test.go` and everything else it must not touch. The user never enume
 that gate the review, and it MUST be logged and refused rather than silently emptied by the filter. But the
 refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
 
-**AFTER the filter, the file argv is still PR data**: refuse every surviving `-`-leading name and normalize
-the rest ("NORMALIZE THE FILE ARGV" above). The filter decides *which* files are touched; the normalization
-decides that they are read as **files at all** and not as flags. Both, every run.
+**AFTER the filter, the file argv is still PR data**: of every surviving candidate, refuse the `-`-leading
+names, the **symlinks**, and anything whose **real path escapes the worktree** or is **not a regular file**;
+normalize what is left ("NORMALIZE THE FILE ARGV" above). The filter decides *which* candidates survive; the
+normalization decides that what is handed to the tool is read as a **file** and not a flag, and that it is a
+**real file INSIDE the tree** and not a link out of it. Both, every run.
 
 **Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
 the session model.
@@ -276,8 +308,17 @@ follows ("The reviewer", `reviewer.md`). Priority order:
    naming preferred formatters → use it. Do NOT invent a preference; use one only when it actually exists.
 3. **Built-in defaults.** No preference → the known-tools table's default set, each with its default glob.
 
-The user may also name **`none`** → the cheap path is **OFF** for this run; every CI failure goes to the
-session model. Always a safe choice.
+**The header field has exactly three shapes — NEVER any other spelling:**
+
+- `default` — the known-tools table's **built-in set**, each with its default glob. Also `ledger.py`'s
+  default when the field was never written.
+- `-` — the **DISABLING SENTINEL**: the cheap path is **OFF** for this run; every CI failure goes to the
+  session model. Always a safe choice. **The sentinel is `-` — NEVER the word `none`.** A user who says
+  "no formatters" / "none" is asking for this; campaign writes **`-`** into the header.
+- a comma-separated list of known-tool ids, each optionally `:<glob>`-suffixed (`gofmt,gci:internal/**/*.go`).
+
+`default` (built-ins ON) and `-` (cheap path OFF) are **NEVER interchangeable**. An **unset/absent** field
+means `default`, NOT `-`.
 
 **Re-read `formatters` from the ledger header on EVERY wake, before any tool run. NEVER re-derive it from
 memory mid-run** — a wake may be a fresh agent instance, and re-deriving would silently revert an explicit
@@ -302,9 +343,10 @@ as one.
 
 What IS a security boundary: **the tool runs on UNTRUSTED PR CONTENT, inside the PR's worktree.** That is
 why `argv[0]` is resolved to a trusted absolute executable **outside the repo** ("RESOLVE argv[0]" above),
-why the **file operands are normalized** — they come from the PR's tree, so they are attacker-controlled
-data spliced into argv ("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the skill's and
-not the user's.
+why the **file operands are normalized AND resolved** — they come from the PR's tree, so they are
+attacker-controlled data spliced into argv, and a symlink among them makes the tool write **outside the
+worktree** ("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the skill's and not the
+user's.
 
 #### VALIDATION — an id in the `formatters` list is ACCEPTED only if ALL of these hold
 
@@ -328,26 +370,29 @@ silently honour a refused id.** Refusing one id does not invalidate the others.
 
 **Resolution semantics:** an explicit or preferred list **replaces** the built-in defaults — a known tool
 the user omits while naming others is **not run** (a user who does not want `gci` simply names the ones
-they want). An id that is not a known tool is REFUSED, not appended. `none` **disables the cheap path
-entirely**. No explicit list and no preference → the table's built-in defaults, each with its default glob,
-exclusion filter applied as always — NEVER an invented or broadened default.
+they want). An id that is not a known tool is REFUSED, not appended. **`-`** (the disabling sentinel)
+**disables the cheap path entirely**. No explicit list and no preference → `default`: the table's built-in
+defaults, each with its default glob, exclusion filter applied as always — NEVER an invented or broadened
+default.
 
 Then, in order:
 
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
    **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
    the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
-   glob, **exclusion filter applied**, then **`-`-leading names refused and the operands normalized —
-   `--` + absolute/`./` paths**). NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
+   glob, **exclusion filter applied**, then **`-`-leading names, symlinks, non-regular files, and paths whose
+   real path escapes the worktree all refused, and the operands normalized — `--` + absolute/`./` paths**).
+   NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
    **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
    definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
    above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
    watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
    dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
-   whitelisted, the id was refused, `formatters` is `none`, the binary **cannot be resolved to a trusted
-   executable outside the repo**, the filtered file set is **empty**, or the failure needs any judgment.
-   (An **unset** `formatters` header is NOT in this list — it means the table's defaults.)
+   whitelisted, the id was refused, `formatters` is **`-`** (cheap path off), the binary **cannot be
+   resolved to a trusted executable outside the repo**, the filtered file set is **empty**, or the failure
+   needs any judgment. (An **unset** `formatters` header, or `default`, is NOT in this list — it means the
+   table's defaults.)
 
 If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
 head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -87,16 +87,20 @@ So campaign REMOVES the degree of freedom instead of trying to police it: a conf
 #### The KNOWN-TOOLS TABLE — the skill's, argv and all
 
 The ONLY binaries campaign may execute on the no-model path, in the ONLY form it may execute them.
-`<files>` = the paths matched by the entry's validated `files` glob. Adding a tool, or changing an argv,
-is a **SKILL change** (gated, reviewed), NEVER a config change.
+`<files>` = the tool's **default glob**, optionally NARROWED by the entry's validated `files`, with the
+skill's **exclusion filter** applied afterwards — always (both below). Adding a tool, changing an argv, or
+changing a default glob is a **SKILL change** (gated, reviewed), NEVER a config change.
 
-| `id` | argv — **skill-owned, exact** | guarantee | precondition — MUST hold in THIS repo |
-|---|---|---|---|
-| `gofmt` | `["gofmt", "-w", <files>]` | AST-preserving Go pretty-printer (`go/printer`); never alters string-literal contents | none |
-| `gofumpt` | `["gofumpt", "-w", <files>]` | same printer, stricter layout rules; never alters string-literal contents | none |
-| `goimports` | `["goimports", "-w", <files>]` | rewrites the **import block only** | none |
-| `gci` | `["gci", "write", <files>]` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
-| `ruff format` | `["ruff", "format", <files>]` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+| `id` | argv — **skill-owned, exact** | default `files` glob | guarantee | precondition — MUST hold in THIS repo |
+|---|---|---|---|---|
+| `gofmt` | `["gofmt", "-w", <files>]` | `**/*.go` | AST-preserving Go pretty-printer (`go/printer`); never alters string-literal contents | none |
+| `gofumpt` | `["gofumpt", "-w", <files>]` | `**/*.go` | same printer, stricter layout rules; never alters string-literal contents | none |
+| `goimports` | `["goimports", "-w", <files>]` | `**/*.go` | rewrites the **import block only** | none |
+| `gci` | `["gci", "write", <files>]` | `**/*.go` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
+| `ruff format` | `["ruff", "format", <files>]` | `**/*.py` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+
+Every tool has a default glob, so a **missing `.gauntlet.yml` has a fully defined file set**: the table's
+defaults, filtered. NEVER invent a default glob for a tool; NEVER widen one.
 
 **NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
 the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
@@ -105,6 +109,29 @@ shell string.
 **REMOVED — golangci-lint `whitespace`**: no safe fixer exists for it. Its only fix path is the catch-all
 `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
 failure goes to the session model.
+
+#### RESOLVE argv[0] TO A TRUSTED ABSOLUTE EXECUTABLE — OUTSIDE THE REPO
+
+**The tool runs IN THE PR'S WORKTREE, and the PR under review is UNTRUSTED CONTENT.** A bare name resolved
+from a `PATH` the PR can influence — `.`, an empty entry, a repo-local `bin/`, any relative directory —
+lets the PR ship a file called `gofmt` and have campaign **execute it**. The argv would be exactly the
+table's; the BINARY would be the attacker's. That is arbitrary code execution on the path that runs with
+**no model and no review**. The table's names are identifiers, NEVER things to hand to a `PATH` lookup as-is.
+
+Before execution, EVERY time:
+
+1. **Resolve `argv[0]` to an ABSOLUTE path**, using a **sanitized PATH** built by REMOVING: `.`, `..`, any
+   empty entry (a leading/trailing/doubled `:` — an empty entry means the CWD), any RELATIVE entry, the
+   worktree, the repo root, and any directory INSIDE either. NEVER resolve against the ambient `PATH`
+   unfiltered; NEVER let the repo's own files or config inject a `PATH` entry.
+2. **The resolved executable MUST live OUTSIDE the repo/worktree tree.** Resolve symlinks too — a symlink
+   outside pointing inside is still the PR's binary. Inside the tree → **REFUSE**.
+3. **Cannot resolve → REFUSE.** No fallback, no search elsewhere, no install.
+4. **REFUSE means: session model.** NEVER execute a binary the PR could have supplied.
+
+Run the tool with the **worktree as CWD** but **NEVER with the worktree on `PATH`** and NEVER with the
+worktree as the lookup base. Pass the **resolved absolute path** as `argv[0]`; the rest of the argv is the
+table's, unchanged.
 
 #### A tool's guarantee can be CONDITIONAL on its configuration
 
@@ -137,13 +164,45 @@ Nothing below is ever admitted to the table, and no config entry may name it:
   any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run invokes **only the
   table's argv**, NEVER a catch-all `--fix`.
 - any run that can touch a **check definition, config, or test** — the no-weakening prohibition, a hard
-  rule, not a preference. Enforced at the config layer by the `files` constraint below.
+  rule, not a preference. Enforced by the skill's **exclusion filter** below, NEVER by trusting a glob.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
 Key it on the **tool's IDENTITY and its documented guarantee** — NEVER on a judgment that the failure
 "looks mechanical", NEVER on the category "formatter". **Default deny. Unknown check, unlisted tool,
-missing/unparseable config, or a refused entry → session model.**
+UNPARSEABLE config, an unresolvable binary, or a refused entry → session model.** (A **missing** config is
+not a refusal: it means the known-tools table's defaults.)
+
+#### THE SKILL-OWNED EXCLUSION FILTER — applied AFTER the glob, EVERY time
+
+**The glob SELECTS candidates. The FILTER decides what is touched.** After expanding the tool's file set
+(its default glob, narrowed by any validated `files`), campaign **REMOVES** every path below — always,
+regardless of what the glob said, whether or not a config exists. **Config CANNOT widen this filter, and
+NEVER carries the exclusions itself.**
+
+Excluded — never handed to a tool, never in a tool commit:
+
+- **tests**: `**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `**/__tests__/**`, `conftest.py`,
+  `**/test_*.py`, `**/*_test.py`, `**/*.spec.*`, `**/*.test.*`
+- **check definitions / CI**: `.github/**`, `.gitlab-ci.yml`, `Makefile`, `**/*.mk`, any CI workflow file
+- **tool / lint / build config**: `.golangci.yml`/`.golangci.yaml`, `ruff.toml`/`.ruff.toml`,
+  `pyproject.toml`, `setup.cfg`, `tox.ini`, `.editorconfig`, `.pre-commit-config.yaml`
+- **campaign's own config**: `.gauntlet.yml`, and the git-ignored `.gauntlet/**`
+- anything else that **defines, configures, or is** a check
+
+**WHY the filter and not the glob:** an exclusion list a **USER** writes will omit something — one forgotten
+pattern and a tool commit lands on a check definition with no model and no review. The skill owns the list,
+so it is complete and it cannot rot per-repo. **A repo-relative filter is the guarantee; a refusal is not.**
+
+Therefore `files: "**/*.go"` is **VALID and CORRECT**: the glob selects the Go files, the filter drops
+`**/*_test.go` and everything else it must not touch. The user never enumerates an exclusion.
+
+**Still REFUSE an OBVIOUSLY HOSTILE glob** — one that targets an excluded path **DIRECTLY** (`files:
+".golangci.yml"`, `files: ".github/**"`, `files: "**/*_test.go"`): it is a config trying to weaken the
+checks that gate it, and it MUST be logged and refused rather than silently emptied by the filter. But the
+refusal is a **signal**, NEVER the guarantee — the filter is what makes the run safe.
+
+**Empty file set after filtering → run NOTHING for that entry** and route the failure to the session model.
 
 #### Repo config — `.gauntlet.yml`, read from the BASE branch
 
@@ -151,13 +210,17 @@ A hardcoded tool list is meaningless in a Rust/Java/Ruby repo, so the **selectio
 the argv is not. The file lives at the **repo root** and is **COMMITTED** — it is NOT under the git-ignored
 `.gauntlet/` tree (`files-and-ledger.md`).
 
-**Each entry carries EXACTLY two fields: `id` and `files`. Nothing else.**
+**Each entry carries EXACTLY: `id` (required) and `files` (optional). Nothing else.**
 
 ```yaml
 formatters:
   - id: gofmt              # MUST be an id in the known-tools table; the skill owns its argv
-    files: "**/*.go"       # glob this tool may touch — MUST NOT reach a check def, config, or test
+    files: "**/*.go"       # OPTIONAL — may only NARROW the tool's default glob; omit to take the default
 ```
+
+**`files` may only NARROW the tool's default glob, NEVER widen it.** A `files` glob that matches paths the
+default does not (e.g. `**/*` for `gofmt`, whose default is `**/*.go`) → **REFUSE**. Omitted `files` → the
+table's default. Either way the exclusion filter applies.
 
 **Read it from the BASE branch, NEVER from the PR's worktree or head:**
 
@@ -182,52 +245,57 @@ whitelist that governs its own campaign.** That is the property being defended.
 
 #### VALIDATION — an entry is ACCEPTED only if ALL of these hold
 
-1. **EXACTLY the fields `id` and `files`.** Both present.
+1. **`id` present; `files` optional. NOTHING else.**
 2. **NO `command`, `args`, `argv`, `flags`, or any other key** — any of them → **REFUSE**. The skill owns
    the argv; config that supplies one is trying to re-open the `gofmt -r` hole. A shell string anywhere →
    REFUSE, and campaign never runs a shell regardless.
 3. **`id` is in the known-tools table.** Not in the table → REFUSE. Config NEVER introduces a binary; it
-   selects one. Resolve the binary from `PATH` at run time and NEVER honour a `PATH` entry the repo's own
-   config injected.
-4. **`files` is a glob that CANNOT match a check definition, config, or test path.** REFUSE any glob that
-   can reach `.golangci.yml`, `.github/**`, `**/*_test.go`, `test/**`, `tests/**`, `conftest.py`,
-   `pyproject.toml`, `ruff.toml`/`.ruff.toml`, `.gauntlet.yml`, or any other check/config/test path. A
-   bare `**` or `.` that sweeps the repo → REFUSE. This is the no-weakening prohibition, enforced at the
-   config layer instead of trusted to the tool.
+   selects one. The binary is resolved to a **trusted absolute executable outside the repo** ("RESOLVE
+   argv[0]" above) — NEVER from a `PATH` the repo or the PR can influence. Unresolvable, or resolving
+   inside the repo/worktree → REFUSE.
+4. **`files`, if present, only NARROWS the tool's default glob** — it MUST NOT match anything outside it.
+   Widening → REFUSE. And REFUSE an **obviously hostile** glob that directly targets a check definition,
+   config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`, …), or a repo-sweeping bare `**`/`.`.
+   The **exclusion filter still applies to every accepted entry** — the refusal catches intent, the filter
+   is the guarantee.
 5. **The table's precondition for that `id` VERIFIES in this repo** (see "conditional on its
    configuration"). Cannot verify → REFUSE.
 
 **REFUSING means: log the entry and why, IGNORE it, and route that failure to the session model. NEVER
 silently honour a refused entry.** Refusing one entry does not invalidate the others.
 
-**Merge semantics:** start from the built-in defaults; the repo's `formatters:` list **replaces** them by
-`id` — an entry re-scopes the `files` of a known tool of the same `id`, and a built-in the repo omits while
-listing others is **removed** for that repo (e.g. a repo that does not want `gci` simply lists the ones it
-wants). An entry whose `id` is not a known tool is REFUSED, not appended. `formatters: []` **disables the
-cheap path entirely** — every failure goes to the session model, always a safe choice. **Missing file →
-built-in defaults only. Unparseable file → cheap path OFF for this run** (default deny; never guess at a
-half-parsed whitelist).
+**Merge semantics:** start from the built-in defaults (**the known-tools table's ids, each with its default
+glob**); the repo's `formatters:` list **replaces** them by `id` — an entry NARROWS the `files` of a known
+tool of the same `id`, and a built-in the repo omits while listing others is **removed** for that repo (e.g.
+a repo that does not want `gci` simply lists the ones it wants). An entry whose `id` is not a known tool is
+REFUSED, not appended. `formatters: []` **disables the cheap path entirely** — every failure goes to the
+session model, always a safe choice. **Missing file → the table's built-in defaults, each with its default
+glob, exclusion filter applied as always** — NEVER an invented or broadened default. **Unparseable file →
+cheap path OFF for this run** (default deny; never guess at a half-parsed whitelist).
 
 Then, in order:
 
 1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
-   **table's exact argv** for that `id`, **WITHOUT a shell**, over the paths its validated `files` glob
-   matches. NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if **both** hold: re-running the
-   **exact** failing check now **passes**, AND the diff touches **no check definition, config, or test**.
-   Then commit + push — **zero model spend** — and **apply the gate reset** above ("Any campaign commit to
-   the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the watch, re-enter 2a. A tool
-   commit gates exactly like a subagent commit.
+   **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
+   the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
+   `files`, **exclusion filter applied**). NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
+   **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
+   definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
+   above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
+   watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
    dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
-   whitelisted, the config entry was refused, the config is missing/unparseable, or the failure needs any
-   judgment.
+   whitelisted, the config entry was refused, the config is **unparseable**, the binary **cannot be
+   resolved to a trusted executable outside the repo**, the filtered file set is **empty**, or the failure
+   needs any judgment. (A **missing** config is NOT in this list — it means the table's defaults.)
 
 If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
 head) and **re-dispatch the same failure on the session model**. NEVER patch a formatter run in place;
 NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 
-**Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
-a tool bug, or a repo config/plugin that switches on non-formatting rules, is the whole of the exposure.
+**Residual risk, stated honestly:** the whitelist stands on the binary actually BEING the tool (what the
+outside-the-repo resolution buys) and on each tool's documented guarantee — a tool bug, or a repo
+config/plugin that switches on non-formatting rules, is the rest of the exposure.
 Run whitelisted tools with the project's own config and no extra rule sets, and NEVER re-derive the
 whitelist's safety from the review gate: it stands on the TOOL being incapable of changing semantics, or it
 does not stand at all.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -55,38 +55,52 @@ of them MUST, in the same step:
 NEVER treat a tool-written commit as exempt: the verdicts on the old SHA describe content that no longer
 exists, and a `gauntlet-accepted` label on it is a false public claim.
 
-#### Whitelist classification — run the whitelisted TOOL, or the session model
+#### Whitelist classification — run the skill-owned TOOL, or the session model
 
 Before dispatching anything, decide whether the failing check's fixer is a **whitelisted tool**. **A tool
 is whitelisted ONLY IF it guarantees its output is SEMANTICALLY EQUIVALENT to its input** — an
-AST-preserving pretty-printer, not a text munger — and the burden is the tool's **documented behaviour**
-(`SKILL.md`, "The only cheap path"). **Cannot point to that guarantee → NOT whitelisted → session
-model.** There is NO blanket "formatters are safe" rule.
+AST-preserving pretty-printer, not a text munger — and the burden is the tool's **documented behaviour**.
+**Cannot point to that guarantee → NOT whitelisted → session model.** There is NO blanket "formatters are
+safe" rule.
 
 That guarantee belongs to the whitelisted **tool's output** and to nothing else — a model hand-editing the
 same file does NOT inherit it, however formatting-like its diff looks. A pure-indentation edit can move
 behavior in a whitespace-significant language and still be formatter-clean, so there is no diff-shape
 guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED MODEL.**
 
-The **LIST** of whitelisted tools is the skill's **built-in defaults**, as the repo's `.gauntlet.yml`
-re-configures (flags, files) or removes them. The **CRITERION** above is the skill's and is **NEVER
-configurable** — no config key relaxes it. Config **NEVER introduces a binary outside the known-tools
-table** below.
+**The SKILL owns the exact argv. Config does NOT supply a command.** The known-tools table below fixes,
+per tool, the precise argv campaign may execute. The repo's `.gauntlet.yml` selects **only which of those
+tools run, over which files**. The **CRITERION** is the skill's and is **NEVER configurable** — no config
+key relaxes it.
 
-#### The KNOWN-TOOLS TABLE — the built-in defaults
+**WHY config gets no flags — the flags carry the semantics.** Tool identity is NOT sufficient:
 
-This table is the **skill's**. It is the ONLY set of binaries campaign may execute on the no-model path.
-A repo may configure a known tool's **flags and files**; it may **NEVER introduce a binary that is not in
-this table**. Adding a genuinely new tool here is a **SKILL change** (gated, reviewed), NEVER a config
-change.
+```
+gofmt -w -r 'true -> false'     # argv[0] is gofmt. A known tool. No shell metacharacters.
+```
 
-| `id` | `argv[0]` | guarantee | precondition — MUST hold in THIS repo |
+`-r` turns `gofmt` from a pretty-printer into a **rewrite engine**: it rewrites `return true` into
+`return false`. It would pass every identity check, every metacharacter check, and every denylist check.
+So campaign REMOVES the degree of freedom instead of trying to police it: a config entry that supplies
+`command`, `args`, `argv`, or any flag is **REFUSED**.
+
+#### The KNOWN-TOOLS TABLE — the skill's, argv and all
+
+The ONLY binaries campaign may execute on the no-model path, in the ONLY form it may execute them.
+`<files>` = the paths matched by the entry's validated `files` glob. Adding a tool, or changing an argv,
+is a **SKILL change** (gated, reviewed), NEVER a config change.
+
+| `id` | argv — **skill-owned, exact** | guarantee | precondition — MUST hold in THIS repo |
 |---|---|---|---|
-| `gofmt` | `gofmt` | AST-preserving Go pretty-printer (`go/printer`); never alters string-literal contents | none |
-| `gofumpt` | `gofumpt` | same printer, stricter layout rules; never alters string-literal contents | none |
-| `goimports` | `goimports` | rewrites the **import block only** | none |
-| `gci` | `gci` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
-| `ruff format` | `ruff` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+| `gofmt` | `["gofmt", "-w", <files>]` | AST-preserving Go pretty-printer (`go/printer`); never alters string-literal contents | none |
+| `gofumpt` | `["gofumpt", "-w", <files>]` | same printer, stricter layout rules; never alters string-literal contents | none |
+| `goimports` | `["goimports", "-w", <files>]` | rewrites the **import block only** | none |
+| `gci` | `["gci", "write", <files>]` | import grouping/ordering **only** — Go package init order is by **dependency**, not by import order in a file | none |
+| `ruff format` | `["ruff", "format", <files>]` | verifies its output is **AST-equivalent** to the input | the repo's Ruff config does **NOT** enable `format.docstring-code-format` |
+
+**NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
+the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
+shell string.
 
 **REMOVED — golangci-lint `whitespace`**: no safe fixer exists for it. Its only fix path is the catch-all
 `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a `whitespace`
@@ -100,15 +114,17 @@ AST-equivalent. The AST-equivalence guarantee holds **only while that setting is
 
 **The general rule:**
 
-- A `guarantee` MUST state **the conditions under which it holds**. A guarantee with unstated conditions
-  is not a guarantee → REFUSE the entry.
+- The table states the **conditions under which each guarantee holds**. A guarantee with unstated
+  conditions is not a guarantee.
 - Campaign MUST **verify those conditions hold in THIS repo** before taking the no-model path — read the
   repo's tool config (for Ruff: `pyproject.toml` `[tool.ruff.format]`, `ruff.toml`/`.ruff.toml`) on the
   **base branch**, the same provenance rule as `.gauntlet.yml`.
 - Condition enabled, OR **cannot be determined** → the tool is **NOT whitelisted for this repo** →
   session model. Default deny; NEVER assume a default.
 
-**NON-OVERRIDABLE DENYLIST — the skill's; `.gauntlet.yml` CANNOT widen past it. REFUSE any entry that is:**
+#### NON-OVERRIDABLE DENYLIST — the skill's; `.gauntlet.yml` CANNOT widen past it
+
+Nothing below is ever admitted to the table, and no config entry may name it:
 
 - **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
   changing the runtime string the tag function receives — a semantic change made by the tool itself.
@@ -118,10 +134,10 @@ AST-equivalent. The AST-equivalence guarantee holds **only while that setting is
   `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
   with a reversed or non-equivalent comparator): lint-clean, semantics changed.
 - a **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, or
-  any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run MUST invoke **only
-  the whitelisted formatter**, NEVER a catch-all `--fix`.
-- anything whose command can touch a **check definition, config, or test** — the no-weakening prohibition,
-  a hard rule, not a preference.
+  any `--fix`/`--write` flag on a linter that applies semantic rules. A whitelisted run invokes **only the
+  table's argv**, NEVER a catch-all `--fix`.
+- any run that can touch a **check definition, config, or test** — the no-weakening prohibition, a hard
+  rule, not a preference. Enforced at the config layer by the `files` constraint below.
 - **NEVER whitelisted**: a failing product test (making a test pass is not the same as fixing the bug), a
   compile error, and any rule that rewrites logic.
 
@@ -131,18 +147,16 @@ missing/unparseable config, or a refused entry → session model.**
 
 #### Repo config — `.gauntlet.yml`, read from the BASE branch
 
-A hardcoded list is meaningless in a Rust/Java/Ruby repo, so the LIST is repo-configurable. The file lives
-at the **repo root** and is **COMMITTED** — it is NOT under the git-ignored `.gauntlet/` tree
-(`files-and-ledger.md`).
+A hardcoded tool list is meaningless in a Rust/Java/Ruby repo, so the **selection** is repo-configurable —
+the argv is not. The file lives at the **repo root** and is **COMMITTED** — it is NOT under the git-ignored
+`.gauntlet/` tree (`files-and-ledger.md`).
 
-`command` is an **argv LIST**, never a shell string:
+**Each entry carries EXACTLY two fields: `id` and `files`. Nothing else.**
 
 ```yaml
 formatters:
-  - id: gofmt
-    command: ["gofmt", "-w"]           # argv list — argv[0] MUST be a known tool
-    files: "**/*.go"
-    guarantee: "AST-preserving pretty-printer; never alters string-literal contents (go/printer). Holds unconditionally."
+  - id: gofmt              # MUST be an id in the known-tools table; the skill owns its argv
+    files: "**/*.go"       # glob this tool may touch — MUST NOT reach a check def, config, or test
 ```
 
 **Read it from the BASE branch, NEVER from the PR's worktree or head:**
@@ -152,67 +166,57 @@ git show origin/<base>:.gauntlet.yml
 ```
 
 **NEVER read `.gauntlet.yml` from the PR under review.** If campaign took the whitelist from the PR's own
-head, a PR could **widen the whitelist that governs its own campaign** — add a semantic rewriter and earn
-an unreviewed tool commit on its own head. That is the self-gating hazard in config form. A PR that edits
-`.gauntlet.yml` therefore takes effect only **after it merges**, gated like any other change.
+head, a PR could **widen the whitelist that governs its own campaign** — selecting a tool and a glob and
+earning an unreviewed tool commit on its own head. That is the self-gating hazard in config form. A PR that
+edits `.gauntlet.yml` therefore takes effect only **after it merges**, gated like any other change.
 
 #### TRUST MODEL — say it plainly
 
 `.gauntlet.yml` is read from the **base branch**, so it is authored by people with **write access to the
 repo** — the same people who can already edit `.github/workflows` and make CI do anything. The denylist and
-the command-shape rules are therefore a **guard against footguns and accidental misuse, NOT a security
-boundary against a malicious committer.** NEVER present them as one.
+the schema rules are therefore a **guard against footguns and accidental misuse, NOT a security boundary
+against a malicious committer.** NEVER present them as one.
 
 What the base-branch rule DOES buy is real, and MUST be kept: **a PR under review cannot widen the
 whitelist that governs its own campaign.** That is the property being defended.
 
-#### VALIDATION — the command's SHAPE, not just the tool's category
+#### VALIDATION — an entry is ACCEPTED only if ALL of these hold
 
-The attack is **command construction**, not tool category: an entry can cite `gofmt`'s guarantee while
-executing a wrapper that rewrites product code. Validating the `guarantee` text and the denylist alone
-does NOT stop that. **Constrain the shape of the command.**
-
-**An entry is ACCEPTED only if ALL of these hold:**
-
-1. **All four fields present** — `id`, `command`, `files`, `guarantee`.
-2. **`command` is an argv LIST** — `["gofmt", "-w"]`. A **shell string is REFUSED**. It is executed
-   **WITHOUT a shell**: NEVER via `sh -c`, `bash -c`, `os.system`, or any shell string.
-3. **NO shell metacharacters anywhere in the argv** — `&&`, `||`, `;`, `|`, `>`, `<`, `$(`, backticks,
-   newlines. **No legitimate formatter entry needs them.** Any occurrence → REFUSE.
-4. **`argv[0]` is a BARE TOOL NAME in the known-tools table** above. NOT a path (`./scripts/fmt.sh`,
-   `/usr/local/bin/gofmt`, `../x`), NOT a wrapper script, NOT an alias, NOT `sh`/`bash`/`env`/`xargs`.
-   Contains `/` → REFUSE. Not in the table → REFUSE. A repo configures the **flags and files** of a known
-   tool; it NEVER introduces an arbitrary binary. Resolve it from `PATH` at run time and NEVER honour a
-   PATH entry the repo's own config injected.
-5. **`guarantee` is a concrete pointer to the tool's DOCUMENTED semantic-equivalence behaviour** (which
-   printer/AST check, what it is documented never to touch) **AND states the conditions under which it
-   holds**. "It's just formatting", "safe", "we always run it" are **NOT** guarantees → REFUSE.
-6. **The stated conditions VERIFY in this repo** (see "conditional on its configuration" above).
-   Cannot verify → REFUSE.
-7. **`command` hits nothing on the denylist** below — no catch-all `--fix`/`--write`, no semantic rewriter,
-   nothing that can touch a check definition, config, or test.
+1. **EXACTLY the fields `id` and `files`.** Both present.
+2. **NO `command`, `args`, `argv`, `flags`, or any other key** — any of them → **REFUSE**. The skill owns
+   the argv; config that supplies one is trying to re-open the `gofmt -r` hole. A shell string anywhere →
+   REFUSE, and campaign never runs a shell regardless.
+3. **`id` is in the known-tools table.** Not in the table → REFUSE. Config NEVER introduces a binary; it
+   selects one. Resolve the binary from `PATH` at run time and NEVER honour a `PATH` entry the repo's own
+   config injected.
+4. **`files` is a glob that CANNOT match a check definition, config, or test path.** REFUSE any glob that
+   can reach `.golangci.yml`, `.github/**`, `**/*_test.go`, `test/**`, `tests/**`, `conftest.py`,
+   `pyproject.toml`, `ruff.toml`/`.ruff.toml`, `.gauntlet.yml`, or any other check/config/test path. A
+   bare `**` or `.` that sweeps the repo → REFUSE. This is the no-weakening prohibition, enforced at the
+   config layer instead of trusted to the tool.
+5. **The table's precondition for that `id` VERIFIES in this repo** (see "conditional on its
+   configuration"). Cannot verify → REFUSE.
 
 **REFUSING means: log the entry and why, IGNORE it, and route that failure to the session model. NEVER
-silently honour a denied entry.** Refusing one entry does not invalidate the others.
+silently honour a refused entry.** Refusing one entry does not invalidate the others.
 
 **Merge semantics:** start from the built-in defaults; the repo's `formatters:` list **replaces** them by
-`id` — an entry re-configures the flags/files of a known tool of the same `id`, and a built-in the repo
-omits while listing others is **removed** for that repo (e.g. a repo that does not want `gci` simply lists
-the ones it wants). An entry whose `argv[0]` is not a known tool is REFUSED, not appended.
-`formatters: []` **disables the cheap path entirely** — every failure goes to the session model, always a
-safe choice. **Missing file → built-in defaults only. Unparseable file → cheap path OFF for this run**
-(default deny; never guess at a half-parsed whitelist).
+`id` — an entry re-scopes the `files` of a known tool of the same `id`, and a built-in the repo omits while
+listing others is **removed** for that repo (e.g. a repo that does not want `gci` simply lists the ones it
+wants). An entry whose `id` is not a known tool is REFUSED, not appended. `formatters: []` **disables the
+cheap path entirely** — every failure goes to the session model, always a safe choice. **Missing file →
+built-in defaults only. Unparseable file → cheap path OFF for this run** (default deny; never guess at a
+half-parsed whitelist).
 
 Then, in order:
 
-1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the entry's
-   validated **argv** — built-in (`["gofmt","-w"]`, `["gofumpt","-w"]`, `["goimports","-w"]`,
-   `["gci","write"]`, `["ruff","format"]`) or the validated `command` from base-branch `.gauntlet.yml` —
-   **executed WITHOUT a shell**, scoped to its `files` glob. NEVER a catch-all `--fix`. ACCEPT only if
-   **both** hold: re-running the **exact** failing check now **passes**, AND the
-   diff touches **no check definition, config, or test**. Then commit + push — **zero model spend** — and
-   **apply the gate reset** above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0
-   + relabel, relaunch the watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
+1. **Whitelisted tool → run the TOOL, no model (prefer this always).** In `<worktree>`, run the
+   **table's exact argv** for that `id`, **WITHOUT a shell**, over the paths its validated `files` glob
+   matches. NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if **both** hold: re-running the
+   **exact** failing check now **passes**, AND the diff touches **no check definition, config, or test**.
+   Then commit + push — **zero model spend** — and **apply the gate reset** above ("Any campaign commit to
+   the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the watch, re-enter 2a. A tool
+   commit gates exactly like a subagent commit.
 2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
    dispatch above. Covers: the tool did not fix it, the tool left residue, the tool/check is not
    whitelisted, the config entry was refused, the config is missing/unparseable, or the failure needs any
@@ -223,10 +227,10 @@ head) and **re-dispatch the same failure on the session model**. NEVER patch a f
 NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
 
 **Residual risk, stated honestly:** the whitelist is only as strong as each tool's documented guarantee —
-a tool bug, or a config/plugin that switches on non-formatting rules, is the whole of the exposure. Run
-whitelisted tools with the project's own config and no extra rule sets. Do NOT admit a `.gauntlet.yml`
-entry past a guarantee you can point to, and NEVER re-derive its safety from the review gate: the
-whitelist stands on the TOOL being incapable of changing semantics, or it does not stand at all.
+a tool bug, or a repo config/plugin that switches on non-formatting rules, is the whole of the exposure.
+Run whitelisted tools with the project's own config and no extra rule sets, and NEVER re-derive the
+whitelist's safety from the review gate: it stands on the TOOL being incapable of changing semantics, or it
+does not stand at all.
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -14,38 +14,19 @@ row by column position:
   leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
   pending PR must never sit unwatched waiting for the heartbeat.
 - **red** → any failing line → **stop any review pass in flight on that PR first** (Loop control
-  step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then diagnose
-  from the check logs and **CLASSIFY the failure** ("Tool classification" below) **before dispatching
-  anything**. A failure whose fixer is a known tool **the user ENABLED for this run** → run the **TOOL, no
-  model**. Everything else → a scoped CI-fix subagent into `<worktree>` — the PR row's
+  step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then
+  **CLASSIFY the failure** from the check logs ("Classify, then set the model" below) **before
+  dispatching anything**, and dispatch a **scoped CI-fix subagent** into `<worktree>` — the PR row's
   ledger `worktree` column value, the single source of truth for this PR's checkout path (created at
-  adoption/pre-review per `pr-adoption.md`; the ledger-recorded `<worktree>` path — default
-  `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout).
-
-  No enabled known tool for it (the default state — **campaign ships with NO tool enabled**) →
-  **dispatch on the session model** — set the model explicitly, and do NOT downgrade it (`SKILL.md`,
-  "Subagent Dispatch"). Its output is **code that gets merged**, and nothing downstream validates it: a
-  wrong fix can turn CI **green** — by weakening the check, or by being plain wrong in product code no
-  check covers — and the review gate is a miss-catcher, not a proof of correctness. A green check means
-  the check passed, never that the fix is right. NEVER claim CI catches a bad fix.
-
-  **Scope it**: give it the failing check's logs, the specific failing file(s), and the worktree path,
-  and tell it NOT to re-derive the whole diff or read beyond what the failure touches.
-
-  **Tell it, verbatim in its prompt**: it MUST fix the *cause* of the failure. It MUST NEVER make CI
-  pass by weakening the check — NEVER delete or loosen an assertion, NEVER add `skip`/`xfail`, NEVER
-  disable or downgrade a lint rule, NEVER raise a timeout — UNLESS the check itself is demonstrably
-  wrong, in which case it MUST say so explicitly and name the change in its output so the review gate
-  can judge it.
-
-  Its fix commits + pushes to the PR's **own head branch** → **apply the gate reset** below
-  ("Any campaign commit to the PR head resets the gate").
+  adoption/pre-review per `pr-adoption.md`; default `.worktrees/<headRefName>` when campaign creates
+  it, else a reused existing checkout). Its fix commits + pushes to the PR's **own head branch** →
+  **apply the gate reset** below.
 
 #### Any campaign commit to the PR head resets the gate
 
 **THE RULE — every commit campaign pushes to a PR's head branch is a PR-content change, whatever wrote
-it: a CI-fix subagent, a review-fix subagent, or an enabled TOOL run with no model at all.** Every one
-of them MUST, in the same step:
+it: a cheap CI-fix subagent, a session-model CI-fix subagent, or a review-fix subagent.** Every one of
+them MUST, in the same step:
 
 - **reset `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
   (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing`) — the gate and its
@@ -54,446 +35,78 @@ of them MUST, in the same step:
 - **relaunch the CI watch immediately**;
 - **re-enter Stage 2a.**
 
-NEVER treat a tool-written commit as exempt: the verdicts on the old SHA describe content that no longer
-exists, and a `gauntlet-accepted` label on it is a false public claim.
-
-#### Tool classification — run an ENABLED KNOWN tool, or the session model
-
-**THE SKILL SHIPS WITH ZERO TOOLS ENABLED. `formatters` defaults to `-`.** Out of the box campaign runs
-**no tool at all** and **every** CI failure goes to the session model. Enabling a tool is an explicit
-**USER** act ("The tool list" below).
-
-**The skill makes NO safety claim about ANY tool.** It supplies the **MECHANISM** (the exact argv, the
-binary resolution, the seven operand checks, the exclusion filter, the gate reset) and the **EVIDENCE**
-(what each tool's own doc does and does not say). **The USER decides which tools to trust, and accepts that
-risk.** State it plainly, every time it comes up: **the skill guarantees HOW a tool is run — NEVER WHAT the
-tool does.**
-
-Before dispatching anything, decide whether the failing check's fixer is a **KNOWN tool that this run's
-`formatters` header ENABLES**. Not enabled, not known, or `formatters` is `-` → **session model**. Default
-deny; there is no blanket "formatters are safe" rule, and campaign NEVER infers a tool from the failure
-"looking mechanical".
-
-**"KNOWN" MEANS THE SKILL KNOWS HOW TO RUN IT SAFELY — IT DOES NOT MEAN "SAFE TO ENABLE".** The skill owns
-that tool's exact argv, its operand checks, and its resolution rules. It does **NOT** vouch for the tool.
-**NEVER present a known-tools row as blessed, trusted, whitelisted, or recommended by the skill.**
-
-Whatever a tool does, it does NOT transfer to a model hand-editing the same file — a pure-indentation edit
-can move behavior in a whitespace-significant language and still be formatter-clean, so there is no
-diff-shape guard that makes a cheap model's edit safe to accept. **NO SUBAGENT IS EVER RUN ON A DOWNGRADED
-MODEL.**
-
-**The SKILL owns the exact argv. NOTHING else supplies a command.** The known-tools table below fixes,
-per tool, the precise argv campaign may execute. The run's **`formatters` ledger header field** selects
-**only which of those tools run, over which files** ("The tool list" below).
-
-**WHY nothing outside the skill gets flags — the flags carry the semantics.** Tool identity is NOT
-sufficient:
-
-```
-gofmt -w -r 'true -> false'     # argv[0] is gofmt. A known tool. No shell metacharacters.
-```
-
-`-r` turns `gofmt` from a pretty-printer into a **rewrite engine**: it rewrites `return true` into
-`return false`. It would pass every identity check, every metacharacter check, and every denylist check.
-So campaign REMOVES the degree of freedom instead of trying to police it: the tool list carries
-**ids and globs only** — it can NEVER name a `command`, `args`, `argv`, or a flag.
-
-#### The KNOWN-TOOLS TABLE — what the SKILL guarantees, and what is NOT proven
-
-**A row is NOT an endorsement.** These are the ONLY binaries campaign may execute on the no-model path, in
-the ONLY form it may execute them — **and ONLY when the user has enabled them.** `<files>` = the tool's
-**default glob**, optionally NARROWED by a validated per-id glob from the `formatters` header field, with
-the skill's **exclusion filter** applied afterwards — always (both below). Adding a tool, changing an argv,
-or changing a default glob is a **SKILL change** (gated, reviewed).
-
-Every row's **"what the skill guarantees"** is the same mechanical set, and it is ALL the skill guarantees:
-the argv is **skill-owned and exact**; **NO flag is ever appended**; `argv[0]` is resolved to a **trusted
-absolute executable OUTSIDE the repo** via a sanitized `PATH`; the **seven operand checks** run on every
-candidate; **resolve-then-filter** (the exclusion filter matches the original AND the resolved path); the
-tool is run **without a shell**, **never with a glob**, **never with an empty operand set**; and **any commit
-it makes RESETS the gate**.
-
-| `id` | argv — **skill-owned, exact** | default `files` glob | what the skill guarantees (mechanical, OURS) | what is NOT proven (about the TOOL) |
-|---|---|---|---|---|
-| `gofmt` | `["gofmt", "-w", "--", <files>]` | `**/*.go` | Exactly the argv on the left, over checked operands. `-w` (*"If a file's formatting is different from gofmt's, overwrite it with gofmt's version"*) is the ONLY mutation it performs. `-r` (*"Apply the rewrite rule to the source before reformatting"*) and `-s` (*"Try to simplify code"*) are the documented flags that TRANSFORM the source beyond re-printing it — **neither is in the argv, and nothing may append one** | **The cited doc (https://pkg.go.dev/cmd/gofmt) documents formatting behaviour and flags. It NEVER states a semantic-equivalence guarantee.** Our reading — a pretty-printer that parses and re-prints cannot change program meaning — is an **INFERENCE, not a documented guarantee**. **Enabling `gofmt` means accepting that inference.** |
-| `gci` | `["gci", "write", "--", <files>]` | `**/*.go` | Exactly the argv on the left, over checked operands. `write` is the ONLY subcommand; no section/custom-order flag is ever appended | **The cited docs (https://github.com/daixiang0/gci) describe import ORDERING and GROUPING. They NEVER state that gci neither adds nor removes an import**, and never state semantic equivalence. The Go init-order argument (imports drive `init()`; reordering them does not) is **OURS, an INFERENCE**. **Enabling `gci` means accepting it.** |
-| `ruff format` | `["ruff", "format", "--", <files>]` | `**/*.py` | Exactly the argv on the left, over checked operands. No `--fix`, no `--select`, no config flag is ever appended; the repo's own Ruff config governs | **The cited docs (https://docs.astral.sh/ruff/formatter/) describe formatting behaviour. They do NOT state an AST/semantic-equivalence guarantee** we can rely on. Separately, `format.docstring-code-format` (https://docs.astral.sh/ruff/settings/#format_docstring-code-format) reformats code **inside docstrings** — i.e. rewrites string CONTENTS — and it is the **repo's config**, not ours, that decides whether it is on. **Enabling `ruff format` means accepting both.** |
-
-**THE ASYMMETRY — say it, do not soften it:** the skill **REFUSES what is documented to be unsafe**; it
-**does NOT bless what is merely undocumented — that call is the USER's.** A tool whose docs say it CHANGES
-the program is **denied and cannot be enabled** ("NON-OVERRIDABLE DENYLIST" below) — that is a documented
-fact, so the skill can and does refuse it. A tool whose docs say nothing either way sits in the table above:
-the skill will run it correctly **if you enable it**, and it makes **no claim** that doing so is safe.
-
-**A "what is NOT proven" cell MUST carry a LINK to the tool's own documentation and say exactly what that
-doc does and does NOT state. NEVER upgrade an inference into a guarantee.** The word "documented" is not
-evidence, and **a citation that does not SUPPORT its claim is WORSE than none** — it launders our belief as
-the source's. **FOLLOW the link before you trust a cell.** `gofmt`, `gci` and `ruff format` were once
-presented as *proven* semantics-preserving on exactly such citations; none of the three docs says so, and
-the honest table says so instead of removing the tools and pretending the question was settled.
-
-**NEVER append a flag to a table argv.** NEVER `-r`, NEVER `-s`, NEVER a catch-all `--fix`, NEVER anything
-the table does not list. Execute it **WITHOUT a shell** — never `sh -c`, `bash -c`, `os.system`, or any
-shell string.
-
-**golangci-lint `whitespace` is NOT a known tool** — no safe fixer exists: its only fix path is the
-catch-all `golangci-lint run --fix`, which the denylist forbids. NEVER invent a command for it; a
-`whitespace` failure goes to the session model.
-
-#### RESOLVE argv[0] TO A TRUSTED ABSOLUTE EXECUTABLE — OUTSIDE THE REPO
-
-**The tool runs IN THE PR'S WORKTREE, and the PR under review is UNTRUSTED CONTENT.** A bare name resolved
-from a `PATH` the PR can influence — `.`, an empty entry, a repo-local `bin/`, any relative directory —
-lets the PR ship a file called `gofmt` and have campaign **execute it**. The argv would be exactly the
-table's; the BINARY would be the attacker's. That is arbitrary code execution on the path that runs with
-**no model and no review**. The table's names are identifiers, NEVER things to hand to a `PATH` lookup as-is.
-
-Before execution, EVERY time:
-
-1. **Resolve `argv[0]` to an ABSOLUTE path**, using a **sanitized PATH** built by REMOVING: `.`, `..`, any
-   empty entry (a leading/trailing/doubled `:` — an empty entry means the CWD), any RELATIVE entry, the
-   worktree, the repo root, and any directory INSIDE either. NEVER resolve against the ambient `PATH`
-   unfiltered; NEVER let the repo's own files or config inject a `PATH` entry.
-2. **The resolved executable MUST live OUTSIDE the repo/worktree tree.** Resolve symlinks too — a symlink
-   outside pointing inside is still the PR's binary. Inside the tree → **REFUSE**.
-3. **Cannot resolve → REFUSE.** No fallback, no search elsewhere, no install.
-4. **REFUSE means: session model.** NEVER execute a binary the PR could have supplied.
-
-Run the tool with the **worktree as CWD** but **NEVER with the worktree on `PATH`** and NEVER with the
-worktree as the lookup base. Pass the **resolved absolute path** as `argv[0]`; the rest of the argv is the
-table's, unchanged — with the file operands NORMALIZED per the next rule.
-
-#### NORMALIZE THE FILE ARGV — filenames are PR-CONTROLLED DATA
-
-The skill owns the argv **SHAPE**. It does **NOT** own the file operands: `<files>` comes from globbing the
-**PR's worktree**, so every filename in it is **attacker-controlled data spliced into argv**. Data spliced
-into argv MUST be normalized — exactly like any other injection boundary. Owning the shape is NOT owning
-the argv.
-
-**The repro — a filename that is an OPTION** (this is why the rule exists, do NOT delete it):
-
-```
-# The PR adds a file literally named:  -cpuprofile=prof.go
-# It matches **/*.go. It survives the exclusion filter. It is passed as a file operand:
-gofmt -w '-cpuprofile=prof.go' a.go     # exit 0 — gofmt parsed it as a FLAG, and wrote a CPU profile
-```
-
-argv[0] was the trusted binary, the argv was the table's, no shell was involved, no model ran — and PR
-content still changed what the command **did** and what it **touched**. A bare relative filename is not a
-path; it is a token the tool is free to parse as an option.
-
-**The second repro — a filename that RESOLVES OUT OF THE TREE** (normalizing the SPELLING is not enough):
-
-```
-# The PR adds a symlink:  link.go -> /home/user/.ssh/authorized_keys   (or ../../other-repo/x.go)
-# It matches **/*.go. It survives the exclusion filter. Its NAME is clean: no leading `-`.
-gofmt -w -- /wt/link.go                  # gofmt FOLLOWED the symlink and rewrote its TARGET
-```
-
-**A path is DATA THAT RESOLVES, and resolution can escape the tree.** Spelling the operand safely (`--`,
-absolute path, no leading `-`) says nothing about what the kernel opens. So campaign checks what each
-candidate RESOLVES TO, not just how it is spelled. Reason on record: **symlink escape**.
-
-**The third repro — a HARDLINK, which passes both checks above** (this is the layer BELOW `realpath`):
-
-```
-# The PR adds a hardlink:  alias.go  →  same INODE as /home/user/other-repo/x.go
-# It is a REGULAR file. It is NOT a symlink (lstat says regular). Its realpath is INSIDE the worktree.
-gofmt -w -- /wt/alias.go                 # gofmt rewrote the INODE — the outside alias changed too
-```
-
-**A path check bounds where we LOOK; it does NOT bound what we WRITE — the inode can be aliased outside the
-tree.** `gofmt -w` truncates and rewrites the **EXISTING INODE**, so containment of the **PATH** is not
-containment of the **DATA**. A hardlink is a regular file whose path is inside the worktree and whose data
-is shared with a path outside it: it defeats the symlink check (it is not a link) and the containment check
-(its real path is inside). Reason on record: **hardlink — nlink>1**.
-
-**The fourth repro — a SYMLINKED DIRECTORY COMPONENT, which defeats the EXCLUSION FILTER** (the filter was
-applied to the SPELLING, not to the LOCATION):
-
-```
-# The PR adds a symlink DIRECTORY:  safe/gh  ->  .github
-# Candidate: safe/gh/actions/main.go
-#   - not itself a symlink (lstat says regular file)   - realpath is INSIDE the worktree (.github/… is in-tree)
-#   - a regular file, nlink == 1                       - name has no leading `-`
-#   - and `safe/gh/**` does NOT match the filter's `.github/**`
-gofmt -w -- /wt/safe/gh/actions/main.go   # a CHECK DEFINITION, handed to the tool. Every earlier check passed.
-```
-
-**THE PRINCIPLE — the generalisation of every round above: EVERY check that reasons about a path MUST reason
-about the RESOLVED path. A NAME IS NOT A LOCATION.** The exclusion filter is a check about a path, so it too
-must run on what the path RESOLVES TO — matching `safe/gh/actions/main.go` against `.github/**` asks the
-wrong question. Reason on record: **symlinked directory component / excluded after resolution**.
-
-**THE PIPELINE, in this order, every tool, every run:** expand the glob → **RESOLVE** each candidate →
-**FILTER on BOTH the original and the resolved path** → run the **seven** operand checks → build the argv.
-
-**EVERY tool, EVERY run, ALL SEVEN — no exceptions:**
-
-1. **END-OF-OPTIONS.** Pass `--` immediately before the file list. Every tool in the table accepts it
-   (`gofmt`, via Go's `flag` package), and the table's argv already carries it. Nothing after `--` can be
-   read as a flag. A tool that has no `--` NEVER enters the table.
-2. **NEVER PASS A BARE RELATIVE NAME.** Pass each file as a path that **cannot be mistaken for an option**:
-   an **ABSOLUTE** path (worktree root joined to the relative path) — or, if a tool needs relative paths, a
-   **`./`-prefixed** one. Belt-and-braces: this holds even for a tool whose `--` handling is broken.
-3. **REFUSE a candidate whose basename or path starts with `-`.** A legitimate source file is NEVER named
-   that way.
-4. **REFUSE a candidate that is a SYMLINK.** `lstat` the candidate itself (NEVER `stat` — `stat` follows the
-   link and hides exactly what is being tested). Symlink → DROP it. **A source file that must be formatted is
-   never a symlink**, and the tool would open and rewrite the link's TARGET.
-5. **REFUSE a candidate that does not RESOLVE INSIDE THE WORKTREE, or is not a REGULAR FILE.** Fully resolve
-   the candidate (`realpath` — every symlink followed, `..` collapsed), likewise resolve the worktree root,
-   then require: (a) the real path is **CONTAINED under the resolved worktree root** — string-compare on a
-   path-component boundary, never a bare prefix match (`/wt-evil` is not under `/wt`); and (b) the resolved
-   target is a **REGULAR FILE** — a directory, device, fifo, or socket is REFUSED. Escapes the tree, or is
-   not a regular file → DROP it.
-6. **REFUSE a candidate whose LINK COUNT is greater than 1.** `stat` the candidate and read `st_nlink`;
-   `st_nlink > 1` → DROP it. A source file in a normal checkout has **exactly one link**. A multi-link file
-   is either a **hardlink escape** (the inode is aliased outside the tree, and `gofmt -w` rewrites the
-   INODE) or something we have **no reason to format** — either way it does not get handed to the tool.
-7. **REFUSE a candidate with a SYMLINK in ANY DIRECTORY COMPONENT of its path.** Walk the components from
-   the resolved worktree root down (`wt/safe`, `wt/safe/gh`, `wt/safe/gh/actions`, …) and `lstat` **each**;
-   ANY component that is a symlink → DROP the candidate. Check 4 only tests the LAST component, so a
-   symlinked directory slips a candidate past it — and past the exclusion filter, which was matched on the
-   SPELLED path. A source file that must be formatted **never** sits under a symlinked directory. This check
-   is load-bearing: it bounds **what we write**. Matching the exclusion filter on the resolved path too is
-   **defence in depth, NEVER a substitute for this check** ("THE SKILL-OWNED EXCLUSION FILTER" below) — run
-   BOTH anyway.
-
-**The exclusion filter runs on the ORIGINAL and on the RESOLVED path; checks 3–7 run AFTER it and BEFORE the
-argv is built** — the filter decides which candidates survive; these decide which surviving candidates are
-handed to the tool at all. Every refusal: **DROP that file from the set — do NOT abort the run** — and **LOG
-it**: the id, the refused path, and the reason (`-`-leading name / symlink / escapes the worktree / not a
-regular file / hardlink — nlink>1 / symlinked directory component / excluded after resolution).
-
-Refusing files can empty the set → then run NOTHING for that id and route the failure to the session model
-("Empty file set after filtering" below). Refusing a file NEVER widens anything and NEVER fails the PR.
-
-**NEVER INVOKE THE TOOL WITH AN EMPTY OPERAND SET.** `gofmt` with no file operands **reads stdin** and
-writes the formatted result to stdout — a run that is not the run we intended, on input we did not choose.
-An empty set is NOT "a no-op run": it is **run NOTHING for that id**, and route the failure to the session
-model. Check the set is non-empty **immediately before building the argv**, every time.
-
-**NEVER pass the glob itself to the tool** (`gofmt -w .`, `gofmt -w '**/*.go'`) — that hands file selection
-to the tool and bypasses the exclusion filter AND this normalization. Campaign expands, filters, refuses,
-normalizes, and passes the resulting **explicit path list**.
-
-#### NON-OVERRIDABLE DENYLIST — the ONE thing the skill REFUSES
-
-**These are KNOWN-BAD: their own docs say they CHANGE the program. That is a documented FACT, not an
-inference — so the skill refuses them, and NO config can enable one.** Nothing below is ever admitted to
-the known-tools table, and the tool list may NEVER name it:
-
-- **`goimports`** (https://pkg.go.dev/golang.org/x/tools/cmd/goimports): its doc says it **ADDS missing
-  imports and REMOVES unreferenced ones**. An added import runs that package's `init()`; a guessed import
-  can resolve to the **wrong package**. Documented to change the program.
-- **`prettier`**: it reformats the **contents** of tagged template literals (`` gql`…` ``, `` css`…` ``),
-  changing the runtime string the tag function receives — documented, and a semantic change.
-- **`gofumpt`** (https://github.com/mvdan/gofumpt): applies **EXTRA rewrite rules** beyond gofmt's layout,
-  documented as a rule LIST of source-construct edits. "It is basically gofmt" is NOT an argument.
-- any **generic or unscoped** "whitespace" / "trailing-whitespace" fixer that can rewrite content inside
-  string literals, heredocs, or Markdown (e.g. trailing double-space hard breaks).
-- a **semantic rewriter** — `modernize`, codemods, `pyupgrade`, `2to3`, any rule that rewrites logic. A
-  `modernize` rewrite can PASS its own rule while CHANGING BEHAVIOR (e.g. `sort.Slice` → `slices.SortFunc`
-  with a reversed or non-equivalent comparator): lint-clean, semantics changed.
-- every **catch-all fixer** — `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`,
-  or **any `--fix`/`--write` flag** on a linter that applies semantic rules. An enabled run invokes **only
-  the table's argv**, NEVER a catch-all `--fix`.
-- **NEVER a fixer at all**: a failing product test (making a test pass is not the same as fixing the bug), a
-  compile error, and any rule that rewrites logic.
-
-**THE ASYMMETRY IS THE POINT: the skill refuses what is DOCUMENTED to be unsafe; it does NOT bless what is
-merely UNDOCUMENTED — that call is the user's** (the known-tools table above). Key the denial on the tool's
-**IDENTITY and its own documentation** — NEVER on a judgment that a failure "looks mechanical", NEVER on the
-category "formatter". **Default deny: unknown check, tool not in the table, tool not enabled, `formatters`
-= `-` (the default), an unresolvable binary, or a refused id → session model.**
-
-#### WHAT THE NO-MODEL PATH ACTUALLY RESTS ON — say it honestly
-
-Two things, and only one of them is ours.
-
-1. **OURS — the MECHANISM.** The skill-owned exact argv (no flag ever appended), `argv[0]` resolved to a
-   trusted absolute executable **outside the repo**, the **seven operand checks**, resolve-then-filter, no
-   shell, no glob, no empty operand set, and the **gate reset on any commit**. This bounds **WHAT WE
-   RUN and WHAT WE WRITE**, mechanically, every run.
-2. **THE USER'S — the TOOL's behaviour.** Whether the tool preserves the meaning of what it touches is
-   **NOT proven by any doc we can cite** (the table above). The user enabled it; the user accepted that
-   inference. **NEVER restate it as a guarantee of the skill's, and NEVER re-derive it from the exclusion
-   filter below.**
-
-So: **a reformatted check definition is only as safe as the tool the user trusted.** That is exactly why the
-exclusion filter keeps tests, check definitions and CI config out of the tool's file set — **defence in
-depth**, and admittedly incomplete.
-
-**The no-weakening prohibition belongs to the SESSION-MODEL CI-fix subagent** — it is a model, it can make
-any change, so the prohibition is load-bearing there and goes verbatim into its prompt ("red" above). It is
-not a substitute for the mechanism on the tool path, and the mechanism is not a substitute for it.
-
-#### THE SKILL-OWNED EXCLUSION FILTER — defence in depth, admittedly INCOMPLETE
-
-**It is an enumerated PATTERN LIST. It is NOT complete and CANNOT BE.** A repo-specific check implemented as
-ordinary source — a Go checker at `tools/ci/check.go` — matches `**/*.go`, matches **NONE** of the patterns
-below, passes every operand check, and **IS handed to the tool and committed with no model.** That is the
-honest state of it. **NEVER describe this filter as complete or exhaustive.**
-
-**Its purpose is BLAST RADIUS: keep the tool's diff small and off files a reviewer expects untouched.** It
-is a mitigation, not a proof — and it is not a reason to enable a tool.
-
-**Skill-owned. Config may NARROW it, NEVER widen it, and the tool list NEVER carries the exclusions
-itself** — a user-written exclusion list omits more, and rots per-repo. So `gofmt:**/*.go` is VALID: the
-glob SELECTS, the filter TRIMS.
-
-**Match it against BOTH the original path AND the RESOLVED one — EITHER matches → REFUSE.** `realpath` each
-candidate (symlinks followed, `..` collapsed), take that real path relative to the resolved worktree root.
-A filter matched only on the spelling is defeated by one symlinked directory (`safe/gh -> .github`; the
-fourth repro above): if we apply the filter at all, apply it to the location and not the name. **A NAME IS
-NOT A LOCATION.**
-
-Excluded — dropped from the tool's file set:
-
-- **tests**: `**/*_test.go`, `test/**`, `tests/**`, `**/testdata/**`, `**/__tests__/**`, `conftest.py`,
-  `**/test_*.py`, `**/*_test.py`, `**/*.spec.*`, `**/*.test.*`
-- **check definitions / CI**: `.github/**`, `.gitlab-ci.yml`, `Makefile`, `**/*.mk`, any CI workflow file
-- **tool / lint / build config**: `.golangci.yml`/`.golangci.yaml`, `ruff.toml`/`.ruff.toml`,
-  `pyproject.toml`, `setup.cfg`, `tox.ini`, `.editorconfig`, `.pre-commit-config.yaml`
-- **campaign's own run state**: the git-ignored `.gauntlet/**`
-
-**Still REFUSE an OBVIOUSLY HOSTILE glob** — one that targets an excluded path **DIRECTLY**
-(`gofmt:.golangci.yml`, `gofmt:.github/**`, `gofmt:**/*_test.go`): LOG it and REFUSE it rather than let the
-filter silently empty it. It catches **intent**, which is worth catching even where the tool could do no
-harm.
-
-**AFTER the filter, the file argv is still PR data**: run all **seven** operand checks on every surviving
-candidate ("NORMALIZE THE FILE ARGV" above). The filter only decides *which* candidates survive; the operand
-checks are what bound the write. Every run.
-
-**Empty file set after filtering (or after refusals) → run NOTHING for that id** and route the failure to
-the session model. **NEVER invoke the tool with zero operands** — `gofmt` with no operands reads **stdin**.
-
-#### The tool list — EMPTY by default, resolved at run start, stored in the ledger, NEVER in repo content
-
-**The default is EMPTY. Nothing is enabled unless the USER enables it.** A hardcoded tool list is
-meaningless in a Rust/Java/Ruby repo — and, more to the point, **the skill is not the one who gets to decide
-a tool is safe.** The selection comes from the USER; the argv never does. **It is NEVER read from any file
-in the repo.**
-
-**Resolve ONCE at run start**, then record it in the ledger header field `formatters`
-(`files-and-ledger.md`) — the same resolve-once / record-in-the-header pattern the `reviewer` field
-follows ("The reviewer", `reviewer.md`). Priority order:
-
-1. **Explicit invocation.** The user named tools for this run → use them.
-2. **User preference from memory.** A recorded preference (a memory entry, or a prior run's carryover)
-   naming preferred tools → use it. Do NOT invent a preference; use one only when it actually exists.
-3. **EMPTY — `-`.** No explicit list and no preference → **no tool runs; the cheap path is OFF; every CI
-   failure goes to the session model.** This is the default and it is NEVER "the table's tools". There is
-   **NO built-in set** — do NOT invent one.
-
-**The header field has exactly two shapes — NEVER any other spelling:**
-
-- `-` — **EMPTY: no tool enabled, cheap path OFF.** The **default**, and `ledger.py`'s value when the field
-  was never written. **The sentinel is `-` — NEVER the word `none`, NEVER the word `default`.** A user who
-  says "no formatters" / "none" is asking for this; campaign writes **`-`**.
-- a comma-separated list of known-tool ids, each optionally `:<glob>`-suffixed (`gofmt:internal/**/*.go`).
-
-An **unset/absent** field means `-`. **There is no `default` value any more; if you see one, treat it as
-`-`** and rewrite the header.
-
-**Enabling a tool is a RISK ACCEPTANCE by the user.** When the user names one, campaign runs it exactly as
-the table says — and makes **no claim** that the tool preserves meaning. Every commit it makes still resets
-the gate, so it is re-reviewed like any other content change. If the user asks whether a tool is safe: point
-at that tool's **"what is NOT proven"** cell and let them decide. **NEVER answer "yes, the skill guarantees
-it".**
-
-**Re-read `formatters` from the ledger header on EVERY wake, before any tool run. NEVER re-derive it from
-memory mid-run** — a wake may be a fresh agent instance, and re-deriving would silently revert an explicit
-choice (identical rule, identical reason, to `reviewer`).
-
-**NEVER take the tool list from repo content — NOT from a repo-root config file, NOT from
-`CLAUDE.md`, NOT from ANY file in the repo.** Repo content **is PR content**: a PR can edit it. A tool list
-a PR can edit is a list a PR can **widen to govern its own campaign** — selecting a tool and a glob and
-earning an unreviewed tool commit on its own head. That is the self-gating hazard, and it is why the list
-lives in the ledger (git-ignored run state, `files-and-ledger.md`) and comes from the user. `CLAUDE.md` is
-NOT an exception: it is worktree-loaded repo content, so a PR can edit it too.
-
-Because the list can never come from the repo, **a PR cannot touch it BY CONSTRUCTION.** No provenance rule
-is needed, and none exists — do NOT reintroduce one.
-
-#### TRUST MODEL — say it plainly
-
-**The skill trusts NO tool. It ships with none enabled and vouches for none.** What it owns is **HOW** a
-tool is run, never **WHAT** the tool does. The user enables tools and thereby accepts the risk; the skill's
-denylist refuses only what a tool's own doc says is unsafe.
-
-The tool list is the **user's**, given at invocation or from their own memory — not repo content, so
-there is no "malicious committer" to defend against there. The denylist and the id-only
-shape are a **guard against footguns and accidental misuse**, NOT a security boundary. NEVER present them
-as one.
-
-What IS a security boundary: **the tool runs on UNTRUSTED PR CONTENT, inside the PR's worktree.** That is
-why `argv[0]` is resolved to a trusted absolute executable **outside the repo** ("RESOLVE argv[0]" above),
-why the **file operands are normalized, resolved, checked for aliasing, AND filtered on the RESOLVED path** —
-they come from the PR's tree, so they are attacker-controlled data spliced into argv; a symlink among them
-makes the tool write **outside the worktree**, a **hardlink** makes it write outside the worktree while every
-path check passes, and a **symlinked directory component** walks a candidate into an **excluded** location
-while the spelled path looks innocent ("NORMALIZE THE FILE ARGV" above) — and why the exclusion filter is the
-skill's and not the user's.
-
-#### VALIDATION — an id in the `formatters` list is ACCEPTED only if ALL of these hold
-
-1. **The value carries EXACTLY an `id`, and OPTIONALLY a narrowing glob. NOTHING else.** No `command`, no
-   `args`/`argv`, no flags — the skill owns the argv, and anything supplying one re-opens the `gofmt -r`
-   hole. Campaign never runs a shell regardless.
-2. **The `id` is in the known-tools table.** Not in the table → REFUSE. The list NEVER introduces a binary;
-   it selects one. **A denylisted id (`goimports`, `prettier`, `gofumpt`, any catch-all `--fix`, …) is
-   REFUSED no matter who names it** — config cannot enable it. The binary is resolved to a **trusted
-   absolute executable outside the repo** ("RESOLVE argv[0]" above) — NEVER from a `PATH` the repo or the PR
-   can influence. Unresolvable, or resolving inside the repo/worktree → REFUSE.
-3. **The glob, if present, only NARROWS the tool's default glob** — it MUST NOT match anything outside it.
-   Widening → REFUSE. And REFUSE an **obviously hostile** glob that directly targets a check definition,
-   config, or test (`.golangci.yml`, `.github/**`, `**/*_test.go`, …), or a repo-sweeping bare `**`/`.`.
-   The **exclusion filter still applies to every accepted id** — defence in depth, never a reason to trust
-   the tool.
-
-**REFUSING means: log the id and why, IGNORE it, and route that failure to the session model. NEVER
-silently honour a refused id.** Refusing one id does not invalidate the others.
-
-**Resolution semantics:** the user's list is the WHOLE list — there are **no built-ins to replace**. A known
-tool the user does not name is **not run**. An id that is not a known tool, or is denylisted, is **REFUSED**,
-not appended: that failure goes to the session model. **`-`** (the default, and an unset field) means **no
-tool runs at all**.
-
-Then, in order:
-
-1. **An ENABLED known tool for this failure → run the TOOL, no model.** In `<worktree>`, run the
-   **table's exact argv** for that `id` with `argv[0]` **resolved to a trusted absolute executable outside
-   the repo**, **WITHOUT a shell**, over the tool's file set (default glob, narrowed by any validated
-   glob, each candidate **RESOLVED**, the **exclusion filter applied to BOTH its original and its resolved
-   path**, then **`-`-leading names, symlinks, symlinked directory components, non-regular files, paths whose
-   real path escapes the worktree, and files with `nlink > 1` all refused, and the operands normalized —
-   `--` + absolute/`./` paths**). **NEVER run the tool with an EMPTY operand set** (`gofmt` with no operands
-   reads stdin) — empty → session model. NEVER add a flag; NEVER a catch-all `--fix`. ACCEPT only if
-   **both** hold: re-running the **exact** failing check now **passes**, AND the diff touches **no check
-   definition, config, or test**. Then commit + push — **zero model spend** — and **apply the gate reset**
-   above ("Any campaign commit to the PR head resets the gate"): `reviews_ok` to 0 + relabel, relaunch the
-   watch, re-enter 2a. A tool commit gates exactly like a subagent commit.
-2. **Everything else → the scoped CI-fix subagent on the session model**, set explicitly, per the red-CI
-   dispatch above. Covers: **`formatters` is `-` — the DEFAULT, so this is the DEFAULT ROUTE for every CI
-   failure**; the tool is known but **not enabled**; the tool did not fix it; the tool left residue; the
-   tool/check is not in the table; the id was refused; the binary **cannot be resolved to a trusted
-   executable outside the repo**; the filtered file set is **empty**; or the failure needs any judgment.
-
-If the tool's run fails either acceptance point → **discard the work** (reset the worktree to the PR
-head) and **re-dispatch the same failure on the session model**. NEVER patch a tool run in place;
-NEVER commit an unverified one; NEVER hand the failure to a cheap model instead.
-
-**Residual risk, stated honestly:** on this path campaign guarantees the **mechanism** — the binary really is
-the tool (what the outside-the-repo resolution buys), the argv is the table's, the operands are checked. It
-does **NOT** guarantee the tool preserves meaning: **no cited doc states that, the user accepted that
-inference when enabling the tool**, and a tool bug or a repo config/plugin that switches on non-formatting
-rules is the rest of the exposure. Run enabled tools with the project's own config and no extra rule sets.
-**NEVER re-derive this path's safety from the review gate, and NEVER upgrade the user's risk acceptance into
-a claim of the skill's.**
+The verdicts on the old SHA describe content that no longer exists, and a `gauntlet-accepted` label on
+it is a false public claim. NEVER exempt a commit because it "only reformatted".
+
+#### Classify, then set the model — never dispatch straight off a red check
+
+**Set the model EXPLICITLY on every dispatch** (`SKILL.md`, "Subagent Dispatch"). An unset model
+silently inherits the session model — a cost decision taken by default. Classify the failure from the
+check logs FIRST; the class picks the model:
+
+| Failure class | Model | Why |
+|---|---|---|
+| **Formatting / lint** — the fix is exactly what a standard formatter or autofixer produces | **`sonnet`** (**`haiku`** only when the failure is trivially mechanical) | It does NOT author a fix from scratch: it runs a deterministic tool, **READS the resulting diff**, verifies it, and **escalates** anything it cannot verify. Downgraded **on purpose**. |
+| **Everything else** — failing product test, compile error, flake, anything needing judgment — **and every escalation from the cheap subagent** | **session model** | It authors code that gets merged, and nothing downstream validates it. |
+
+**Scope every CI-fix subagent, both tiers:** give it the failing check's logs, the specific failing
+file(s), and the worktree path. Tell it **NOT** to re-derive the whole diff or read beyond what the
+failure touches.
+
+#### The cheap CI-fix subagent — run the tool, READ the diff, ESCALATE
+
+The point of putting a model here is that **something LOOKS at what happened before it is committed**.
+Its job, in order:
+
+1. **CLASSIFY** the failure from the check logs.
+2. **FIX IT.** For a formatting/lint failure, that is running the standard formatter for that language.
+   It **chooses the tool** — campaign does not hand it a command line — subject to the hard rules below.
+3. **READ THE RESULTING DIFF.** This step is not optional and is not a formality. Verify **all** of:
+   - the diff contains **ONLY** what the fix should have produced (a formatting fix produces formatting);
+   - **no file it did not intend to touch** was touched;
+   - **no check definition, config, or test was weakened**;
+   - **re-running the exact failing check now PASSES.**
+4. **COMMIT** only if every one of those holds — then apply the gate reset above.
+5. **ESCALATE, never patch.** If the check still fails, the diff contains anything it cannot explain, it
+   needed to change product logic, or it cannot verify the result → **STOP**, commit nothing, reset the
+   worktree to the PR head, and hand the failure to a **session-model** CI-fix subagent. **Escalation is
+   the correct outcome, not a failure** — it is what the tier is for.
+
+**HARD RULES — give these to the cheap subagent VERBATIM in its prompt:**
+
+- **NEVER make CI pass by weakening the check.** NEVER delete or loosen an assertion, NEVER add
+  `skip`/`xfail`, NEVER disable or downgrade a lint rule, NEVER raise a timeout. **Fix the cause.** If the
+  check itself is demonstrably wrong, **say so explicitly and ESCALATE** — never silently rewrite it.
+- **NEVER use a catch-all fixer that applies SEMANTIC rules**, and never a documented semantic rewriter.
+  Denied outright: `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any
+  `--fix`/`--write` flag on a linter that applies semantic rules; **`goimports`** (it ADDS imports — an
+  added import runs that package's `init()`); **`prettier`** (it rewrites the contents of tagged template
+  literals); **`gofumpt`** (extra rewrite rules beyond layout); `modernize`, codemods, `pyupgrade`, `2to3`.
+  **Use a formatter that only reformats.**
+- **NEVER execute a binary from inside the repo/worktree.** The PR under review is **UNTRUSTED CONTENT**:
+  a repo-supplied `gofmt` is arbitrary code execution. Run tools from the **environment**, never from the
+  tree.
+- **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`). **Name the files you are fixing.**
+- **A failing product test, a compile error, and any change to product logic are NEVER yours.** Escalate.
+
+#### The risk, stated honestly
+
+A cheap model verifying a tool's diff is a **MISS-CATCHER, NOT A PROOF.** It can miss a semantic change.
+
+What backs it: the **exact failing check must pass**; the subagent **must escalate anything it cannot
+verify**; and **every commit campaign pushes is still gated by the full review gauntlet** — any campaign
+commit to the PR head resets `reviews_ok` to 0, restores `gauntlet-reviewing`, relaunches the CI watch,
+and re-enters Stage 2a on the session model.
+
+This trades a **small, bounded risk** for a workflow that is **cheaper AND more capable** than either a
+full-strength subagent on every formatting failure or a hermetic no-model tool path. **The user accepts
+that trade.**
+
+**NEVER claim the cheap path is safe because "CI will catch it" or "the review gate will catch it."** CI
+tells you a check passed, never that the fix is right; the review gate is a miss-catcher, not a proof of
+correctness (`stage-2-review-gate.md`). Say that plainly whenever the question comes up.
+
+---
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code alone — always confirm against the re-polled snapshot.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -60,7 +60,8 @@ Its job, in order:
 
 1. **CLASSIFY** the failure from the check logs.
 2. **FIX IT.** For a formatting/lint failure, that is running the standard formatter for that language.
-   It **chooses the tool** — campaign does not hand it a command line — subject to the hard rules below.
+   It **chooses the tool** — campaign does not hand it a command line — subject to the hard rules below,
+   and it **PREFLIGHTS every file** before formatting it (hard rules: symlink / symlinked parent / `nlink > 1`).
 3. **READ THE RESULTING DIFF.** This step is not optional and is not a formality. Verify **all** of:
    - the diff contains **ONLY** what the fix should have produced (a formatting fix produces formatting);
    - **no file it did not intend to touch** was touched;
@@ -87,6 +88,20 @@ Its job, in order:
   a repo-supplied `gofmt` is arbitrary code execution. Run tools from the **environment**, never from the
   tree.
 - **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`). **Name the files you are fixing.**
+- **PREFLIGHT EVERY FILE BEFORE FORMATTING IT — refuse any file that can write outside the repo:**
+  - it **IS a symlink** (`lstat`, never `stat`);
+  - **ANY directory component of its path is a symlink**;
+  - it has **more than one hard link** (`nlink > 1`).
+
+  Refuse = **do not format that file**; log it; carry on with the rest. If nothing is left to format,
+  **ESCALATE**. The PR under review is **UNTRUSTED CONTENT** and these aliases are **attacker-placeable**
+  — same reason you never execute a binary from inside the repo.
+
+  **THE PRINCIPLE — do not generalise it into anything more.** Diff review covers everything the tool
+  writes **INSIDE** the repo: the model SEES it and escalates (an injected `-cpuprofile=prof.go` writes
+  `prof.go` in the tree — visible). It **CANNOT see a write that ESCAPES the repo**: `gofmt -w` writes
+  **through** a symlink or a hardlinked inode, the bytes land outside the worktree, and `git diff` shows
+  **NOTHING**. These three checks exist for **exactly that blind spot, and for nothing else.**
 - **A failing product test, a compile error, and any change to product logic are NEVER yours.** Escalate.
 
 #### The risk, stated honestly

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -61,7 +61,7 @@ Its job, in order:
 1. **CLASSIFY** the failure from the check logs.
 2. **FIX IT.** For a formatting/lint failure, that is running the standard formatter for that language.
    It **chooses the tool** — campaign does not hand it a command line — subject to the hard rules below,
-   and it **PREFLIGHTS every file** before formatting it (hard rules: symlink / symlinked parent / `nlink > 1`).
+   and it **PREFLIGHTS every file** before formatting it (hard rules: symlink / symlinked parent).
 3. **READ THE RESULTING DIFF.** This step is not optional and is not a formality. Verify **all** of:
    - the diff contains **ONLY** what the fix should have produced (a formatting fix produces formatting);
    - **no file it did not intend to touch** was touched;
@@ -83,25 +83,35 @@ Its job, in order:
   `--fix`/`--write` flag on a linter that applies semantic rules; **`goimports`** (it ADDS imports — an
   added import runs that package's `init()`); **`prettier`** (it rewrites the contents of tagged template
   literals); **`gofumpt`** (extra rewrite rules beyond layout); `modernize`, codemods, `pyupgrade`, `2to3`.
-  **Use a formatter that only reformats.**
+  **Use a formatter that only reformats.** (A guard against **footguns and accidental misuse — NOT a
+  security boundary** against a malicious committer; so is the PREFLIGHT below.)
 - **NEVER execute a binary from inside the repo/worktree.** The PR under review is **UNTRUSTED CONTENT**:
   a repo-supplied `gofmt` is arbitrary code execution. Run tools from the **environment**, never from the
   tree.
 - **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`). **Name the files you are fixing.**
-- **PREFLIGHT EVERY FILE BEFORE FORMATTING IT — refuse any file that can write outside the repo:**
+- **PREFLIGHT EVERY FILE BEFORE FORMATTING IT — refuse it if the write can land outside the worktree:**
   - it **IS a symlink** (`lstat`, never `stat`);
-  - **ANY directory component of its path is a symlink**;
-  - it has **more than one hard link** (`nlink > 1`).
+  - **ANY directory component of its path is a symlink**.
 
   Refuse = **do not format that file**; log it; carry on with the rest. If nothing is left to format,
-  **ESCALATE**. The PR under review is **UNTRUSTED CONTENT** and these aliases are **attacker-placeable**
-  — same reason you never execute a binary from inside the repo.
+  **ESCALATE**.
 
   **THE PRINCIPLE — do not generalise it into anything more.** Diff review covers everything the tool
   writes **INSIDE** the repo: the model SEES it and escalates (an injected `-cpuprofile=prof.go` writes
   `prof.go` in the tree — visible). It **CANNOT see a write that ESCAPES the repo**: `gofmt -w` writes
-  **through** a symlink or a hardlinked inode, the bytes land outside the worktree, and `git diff` shows
-  **NOTHING**. These three checks exist for **exactly that blind spot, and for nothing else.**
+  **through** a symlink, the bytes land outside the worktree, and `git diff` shows **NOTHING**. These two
+  checks exist for **exactly that blind spot, and for nothing else.**
+
+  **STATE IT HONESTLY — a FOOTGUN GUARD, NOT A SECURITY BOUNDARY. NEVER present it as one.** It cannot be
+  used to inject bytes: a parser-backed formatter writes only its own rendering of source it PARSED — aim
+  the link at `~/.ssh/authorized_keys` and `gofmt` fails to parse it and writes **NOTHING**. The realistic
+  harm is **a source file elsewhere on the machine gets reformatted** — surprising, semantically harmless.
+  (A generic TEXT formatter — a whitespace trimmer rewrites whatever it is handed — is a bigger exposure
+  than a parser-backed one; weigh that when picking a tool.) And it is no defence against a malicious
+  committer: campaign adopts **same-repo PRs only** (forks refused — `pr-adoption.md`), so whoever commits
+  the symlink already has repo write access and could just edit `.github/workflows`. **Keep it anyway:**
+  one `lstat` stops a real accident — a vendored symlink walking the formatter out of the tree to leave a
+  confusing dirty file in another project.
 - **A failing product test, a compile error, and any change to product logic are NEVER yours.** Escalate.
 
 #### The risk, stated honestly

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -361,7 +361,7 @@ As each verdict lands, tally it for the SHA it ran on:
   second review was spent on this broken commit.)
 
   **Run the review-fix on the session model — no subagent is ever run on a downgraded model**
-  (`SKILL.md`, "Subagent Dispatch"). The one cheap path — running a whitelisted formatter **tool** with no
+  (`SKILL.md`, "Subagent Dispatch"). The one cheap path — running a whitelisted **tool** with no
   model at all (`stage-2-ci.md`) — cannot fix a review defect. Its output is **code that gets merged**, and its only
   judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
@@ -456,7 +456,7 @@ that drop `reviews_ok` to 0):
 |---|---|
 | `NOT SATISFIED` verdict lands | this file, verdict tally |
 | Review-fix commit pushed | this file, verdict tally |
-| CI-fix commit pushed | `stage-2-ci.md` |
+| CI-fix commit pushed — by the subagent **or** by a whitelisted-tool run with no model | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
 | Conflict-resolving rebase | `stage-3-merge.md` |
 | Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -360,9 +360,9 @@ As each verdict lands, tally it for the SHA it ran on:
   skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
   second review was spent on this broken commit.)
 
-  **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch").
-  A review defect is a judgment call, never a formatting-only fix, so the one CI-fix exception
-  (`stage-2-ci.md`) does NOT apply here. Its output is **code that gets merged**, and its only
+  **Run the review-fix on the session model — no subagent is ever run on a downgraded model**
+  (`SKILL.md`, "Subagent Dispatch"). The one cheap path — running a whitelisted formatter **tool** with no
+  model at all (`stage-2-ci.md`) — cannot fix a review defect. Its output is **code that gets merged**, and its only
   judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
   and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -360,9 +360,10 @@ As each verdict lands, tally it for the SHA it ran on:
   skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
   second review was spent on this broken commit.)
 
-  **Run the review-fix on the session model — no subagent is ever run on a downgraded model**
-  (`SKILL.md`, "Subagent Dispatch"). The one cheap path — running a user-enabled **tool** with no
-  model at all (`stage-2-ci.md`) — cannot fix a review defect. Its output is **code that gets merged**, and its only
+  **Run the review-fix on the session model — NEVER downgraded** (`SKILL.md`, "Subagent Dispatch"). The one
+  deliberate downgrade in this skill is the CI-fix subagent for a **formatting/lint** failure, which runs a
+  formatter and verifies its diff (`stage-2-ci.md`); a review defect is **authored code**, and this subagent
+  writes it from scratch. Its output is **code that gets merged**, and its only
   judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
   and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half
@@ -456,7 +457,7 @@ that drop `reviews_ok` to 0):
 |---|---|
 | `NOT SATISFIED` verdict lands | this file, verdict tally |
 | Review-fix commit pushed | this file, verdict tally |
-| CI-fix commit pushed — by the subagent **or** by an enabled-tool run with no model | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
+| CI-fix commit pushed — cheap tier **or** session-model tier | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
 | Conflict-resolving rebase | `stage-3-merge.md` |
 | Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -360,8 +360,9 @@ As each verdict lands, tally it for the SHA it ran on:
   skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
   second review was spent on this broken commit.)
 
-  **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch";
-  no fix subagent is downgraded, CI-fix included). Its output is **code that gets merged**, and its only
+  **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch").
+  A review defect is a judgment call, never a total-oracle check, so the one CI-fix exception
+  (`stage-2-ci.md`) does NOT apply here. Its output is **code that gets merged**, and its only
   judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
   and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -361,7 +361,7 @@ As each verdict lands, tally it for the SHA it ran on:
   second review was spent on this broken commit.)
 
   **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch").
-  A review defect is a judgment call, never a total-oracle check, so the one CI-fix exception
+  A review defect is a judgment call, never a formatting-only fix, so the one CI-fix exception
   (`stage-2-ci.md`) does NOT apply here. Its output is **code that gets merged**, and its only
   judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -361,12 +361,14 @@ As each verdict lands, tally it for the SHA it ran on:
   second review was spent on this broken commit.)
 
   **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch").
-  Unlike a CI fix, a weak review fix is not self-detecting: it produces a plausible-looking commit that
-  a *full* review pass must then judge, and when that pass returns `NOT SATISFIED` the gate resets and
-  the whole diff is re-reviewed. A cheap wrong fix is therefore paid for twice, and it is the expensive
-  half that pays. **Scope it** instead — hand it the worktree path and the concrete issue list, and tell
-  it NOT to re-derive the whole diff or read beyond the files those issues name; that is where the
-  savings are, not in the model tier.
+  A CI fix has a cheap net under it (a fix that does not work leaves CI red); a review fix has **no
+  cheap net at all** — its only judge is another full review pass. A weak review fix produces a
+  plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets, and the whole diff
+  is re-reviewed. A cheap wrong fix is therefore paid for twice, and it is the expensive half that pays.
+  **Scope it** instead — hand it the worktree path and the concrete issue list, and tell it NOT to
+  re-derive the whole diff or read beyond the files those issues name; that is where the savings are,
+  not in the model tier. **Scope by defect, not by guess:** name every file the defect actually touches,
+  or the fixer will faithfully leave the sites you forgot to list.
 - **SATISFIED** → record it (bump `reviews_ok` via `ledger.py … set --pr <N> --reviews_ok <count>`, by
   field name). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -360,11 +360,12 @@ As each verdict lands, tally it for the SHA it ran on:
   skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
   second review was spent on this broken commit.)
 
-  **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch").
-  A CI fix has a cheap net under it (a fix that does not work leaves CI red); a review fix has **no
-  cheap net at all** — its only judge is another full review pass. A weak review fix produces a
-  plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets, and the whole diff
-  is re-reviewed. A cheap wrong fix is therefore paid for twice, and it is the expensive half that pays.
+  **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch";
+  no fix subagent is downgraded, CI-fix included). Its output is **code that gets merged**, and its only
+  judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
+  weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
+  and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half
+  that pays. Worst case the pass misses it and the defect merges.
   **Scope it** instead — hand it the worktree path and the concrete issue list, and tell it NOT to
   re-derive the whole diff or read beyond the files those issues name; that is where the savings are,
   not in the model tier. **Scope by defect, not by guess:** name every file the defect actually touches,

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -361,7 +361,7 @@ As each verdict lands, tally it for the SHA it ran on:
   second review was spent on this broken commit.)
 
   **Run the review-fix on the session model — no subagent is ever run on a downgraded model**
-  (`SKILL.md`, "Subagent Dispatch"). The one cheap path — running a whitelisted **tool** with no
+  (`SKILL.md`, "Subagent Dispatch"). The one cheap path — running a user-enabled **tool** with no
   model at all (`stage-2-ci.md`) — cannot fix a review defect. Its output is **code that gets merged**, and its only
   judge is another full review pass — which is a miss-catcher, not a proof of correctness. Best case, a
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
@@ -456,7 +456,7 @@ that drop `reviews_ok` to 0):
 |---|---|
 | `NOT SATISFIED` verdict lands | this file, verdict tally |
 | Review-fix commit pushed | this file, verdict tally |
-| CI-fix commit pushed — by the subagent **or** by a whitelisted-tool run with no model | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
+| CI-fix commit pushed — by the subagent **or** by an enabled-tool run with no model | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
 | Conflict-resolving rebase | `stage-3-merge.md` |
 | Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -359,6 +359,14 @@ As each verdict lands, tally it for the SHA it ran on:
   commits + pushes → HEAD advances (a second gate reset — relabel again if the first was somehow
   skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
   second review was spent on this broken commit.)
+
+  **Run the review-fix on the session model — do NOT downgrade it** (`SKILL.md`, "Subagent Dispatch").
+  Unlike a CI fix, a weak review fix is not self-detecting: it produces a plausible-looking commit that
+  a *full* review pass must then judge, and when that pass returns `NOT SATISFIED` the gate resets and
+  the whole diff is re-reviewed. A cheap wrong fix is therefore paid for twice, and it is the expensive
+  half that pays. **Scope it** instead — hand it the worktree path and the concrete issue list, and tell
+  it NOT to re-derive the whole diff or read beyond the files those issues name; that is where the
+  savings are, not in the model tier.
 - **SATISFIED** → record it (bump `reviews_ok` via `ledger.py … set --pr <N> --reviews_ok <count>`, by
   field name). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -27,11 +27,13 @@ HEADER_DEFAULTS = {
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
-    # Cheap-CI-path formatter whitelist. "default" = the known-tools table's built-in
-    # set; "-" = none (cheap path off); else comma-separated known-tool ids, each
-    # optionally suffixed ":<glob>" to narrow that tool's default glob. Resolved once at
-    # run start from the user (invocation, else memory preference) — NEVER from repo
-    # content, which is PR content.
+    # Cheap-CI-path formatter whitelist. Exactly three shapes: "default" = the known-tools
+    # table's built-in set (this default, i.e. the field was never written); "-" = the
+    # DISABLING SENTINEL, cheap path off (never the word "none"); else comma-separated
+    # known-tool ids, each optionally suffixed ":<glob>" to narrow that tool's default
+    # glob. "default" and "-" are never interchangeable. Resolved once at run start from
+    # the user (invocation, else memory preference) — NEVER from repo content, which is
+    # PR content.
     "formatters": "default",
 }
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -21,20 +21,12 @@ from typing import NoReturn
 
 # --- schema (owned here, once) ------------------------------------------------
 
-HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "formatters")
+HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer")
 HEADER_DEFAULTS = {
     "run_id": "-",
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
-    # Cheap-CI-path tool list. The skill ships with ZERO tools enabled and vouches for
-    # none: the default is "-" = EMPTY, cheap path OFF, every CI failure to the session
-    # model (never the word "none", and there is no "default" value / built-in set).
-    # The only other shape: comma-separated known-tool ids, each optionally suffixed
-    # ":<glob>" to narrow that tool's default glob. Enabling a tool is an explicit USER
-    # act and an explicit risk acceptance. Resolved once at run start from the user
-    # (invocation, else memory preference) — NEVER from repo content, which is PR content.
-    "formatters": "-",
 }
 
 ROW_FIELDS = (

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -21,12 +21,18 @@ from typing import NoReturn
 
 # --- schema (owned here, once) ------------------------------------------------
 
-HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer")
+HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "formatters")
 HEADER_DEFAULTS = {
     "run_id": "-",
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
+    # Cheap-CI-path formatter whitelist. "default" = the known-tools table's built-in
+    # set; "-" = none (cheap path off); else comma-separated known-tool ids, each
+    # optionally suffixed ":<glob>" to narrow that tool's default glob. Resolved once at
+    # run start from the user (invocation, else memory preference) — NEVER from repo
+    # content, which is PR content.
+    "formatters": "default",
 }
 
 ROW_FIELDS = (

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -27,14 +27,14 @@ HEADER_DEFAULTS = {
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
-    # Cheap-CI-path formatter whitelist. Exactly three shapes: "default" = the known-tools
-    # table's built-in set (this default, i.e. the field was never written); "-" = the
-    # DISABLING SENTINEL, cheap path off (never the word "none"); else comma-separated
-    # known-tool ids, each optionally suffixed ":<glob>" to narrow that tool's default
-    # glob. "default" and "-" are never interchangeable. Resolved once at run start from
-    # the user (invocation, else memory preference) — NEVER from repo content, which is
-    # PR content.
-    "formatters": "default",
+    # Cheap-CI-path tool list. The skill ships with ZERO tools enabled and vouches for
+    # none: the default is "-" = EMPTY, cheap path OFF, every CI failure to the session
+    # model (never the word "none", and there is no "default" value / built-in set).
+    # The only other shape: comma-separated known-tool ids, each optionally suffixed
+    # ":<glob>" to narrow that tool's default glob. Enabling a tool is an explicit USER
+    # act and an explicit risk acceptance. Resolved once at run start from the user
+    # (invocation, else memory preference) — NEVER from repo content, which is PR content.
+    "formatters": "-",
 }
 
 ROW_FIELDS = (


### PR DESCRIPTION
- campaign never set a model or agent type, so every subagent inherited the session model — a cost decision taken silently by default
- only CI-fix is downgraded (`sonnet`): its failure is self-detecting (bad fix → CI stays red → re-dispatch; a red check blocks the review pass regardless)
- review passes, fallback reviews, review-fixes and the root-cause mapper stay on the session model — the first two *are* the gate, the last two feed an expensive check, so a cheap wrong answer is paid for twice
- mapper explicitly must NOT be downgraded for being "read-only": read-only ≠ low-judgment, and an under-map is invisible
- names the external reviewer as the largest token lever (review passes re-read the whole diff, per tier, and restart on every gate reset), and scopes fix subagents to their issue list