### PR TITLE
pin ci status to head_sha

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -170,43 +170,62 @@ Read stage refs only when that stage/action is due:
   changes it (a park does NOT lower `reviews_ok`, so guard on `status` at every dispatch AND mutation
   site). Sole exception: its CI watch keeps running — observing is not mutating. Keep driving the other
   PRs; unpark only on the user's answer (`references/loop-control.md`, "parked-status guard").
-- **No green by watch exit:** derive CI from re-polled `gh pr checks` snapshot.
 - **No green from ONE CHECK FAMILY, no green by watch exit, no green from an unpinned snapshot, no green
   from a PARTIAL one, no green from a SUPERSEDED one, no green while a DECLARED REQUIRED CHECK is
   missing:** GitHub has **two** check families — **Checks** (check runs) and **legacy commit statuses**
   (Jenkins, CircleCI, many bots) — and **a failing commit status is INVISIBLE to `/check-runs`**. Derive CI
-  from a source covering **both**, pinned to the current `head_sha`:
-  `gh pr view <pr> --json headRefOid,statusCheckRollup` returns both families **and** the head SHA in one
-  payload (`__typename` `CheckRun` → `.name`/`.status`/`.conclusion`; `StatusContext` → `.context`/`.state`
-  — no `.conclusion`, and `ERROR` is a failure). Never read the *combined* status `.state` (it is `pending`
-  on **zero** statuses). `gh pr checks` is not pinned to a commit and will report the PREVIOUS commit's
-  passing checks right after a push. Fetch **ATOMICALLY** — temp file **inside `<rundir>`** (`mv` is atomic
-  only within a filesystem), promoted onto the **SHA-scoped** `ci-<pr>-<head_sha>.txt` (first line
+  from **both**, pinned to the current `head_sha`, with **each family judged ONLY from the fetch that
+  carries both its IDENTITY and its RESULT**: check runs from the **SHA-pinned `--paginate` REST
+  check-runs** fetch (one row = `.head_sha` + `.name` + `.app.id` + `.status` + `.conclusion`), commit
+  statuses from the **rollup** (`gh pr view <pr> --json headRefOid,statusCheckRollup`; `StatusContext` →
+  `.context`/`.state` — no `.conclusion`, and `ERROR` is a failure; its `CheckRun` entries are **witnesses**
+  for the cross-fetch agreement test, **never verdicts**). Never read the *combined* status `.state` (it is
+  `pending` on **zero** statuses). `gh pr checks` is not pinned to a commit and will report the PREVIOUS
+  commit's passing checks right after a push. Fetch **ATOMICALLY** — temp file **inside `<rundir>`** (`mv`
+  is atomic only within a filesystem), promoted onto the **SHA-scoped** `ci-<pr>-<head_sha>.txt` (first line
   `# sha: <head_sha>`, emitted by the same query as the rows) only if **every** fetch exits 0;
   a fetch redirected straight onto the snapshot leaves the rows that arrived on disk when it dies. **Prove
   the SOURCE is complete (both families), prove the snapshot is COMPLETE (`--paginate` on every REST fetch;
-  a rollup at its ~100-context cap is truncated → pending), prove its `# sha:` matches the ledger's current
-  `head_sha`, and prove EVERYTHING YOU EXPECT TO SEE IS THERE, before parsing it** — a watch launched for
+  a rollup at its ~100-context cap is truncated → pending), prove every SHA in it (the `# sha:` line and
+  every `checkrun` row's) matches the ledger's current `head_sha`, and prove EVERYTHING YOU EXPECT TO SEE IS
+  THERE, before parsing it** — a watch launched for
   an older SHA can finish after the head advanced; absent, partial, or mismatched → `ci = pending`,
   relaunch, NEVER green (`references/stage-2-ci.md`).
+- **NEVER JOIN TWO OBSERVATIONS TAKEN AT DIFFERENT TIMES AND READ THE RESULT AS ONE.** A check's
+  **identity** and its **result** must come from the **SAME row of the SAME fetch** — identity from one
+  fetch joined to a result from another is a **mixed-time artifact**: the earlier fetch sees app 999's
+  same-named `build` succeed, the required app-123 `build` registers after it, the later fetch proves app
+  123's `build` exists → presence passes, all-success passes, **green for a check never observed passing**.
+  **The two fetches ARE still taken at different times — make their DISAGREEMENT the signal:** same
+  `head_sha` on both, same **set of check runs** across them; a run in one and not the other means the state
+  was still **MOVING** → `ci = pending`, refetch, **NEVER green** (`references/stage-2-ci.md`).
 - **Registered ≠ expected, and the right NAME is not the right PRODUCER.** Checks register
   **asynchronously**, so an all-success snapshot can simply predate the check that would have failed. Read
   the declared required checks from **BOTH** classic branch protection **and rulesets** (a repo can use
   either or both) and take the **UNION**: **green requires every required check PRESENT and successful** —
   one unregistered → `ci = pending`, NEVER green. **Where the declaration binds an app** (`app_id` /
-  `integration_id`), match the **producer** too — the check run's `.app.id`, from the SHA-pinned check-runs
-  fetch — or a same-named check from **another** app satisfies the test while the required one has not run.
-  **Where it binds no app, any producer of that name satisfies it.**
+  `integration_id`), match the **producer** too — a single check-runs row whose name **and** `app.id` match
+  **and which carries the passing result** — or a same-named check from **another** app satisfies the test
+  while the required one has not run. **Where it binds no app, any producer of that name satisfies it.**
 - **THREE STATES, NEVER TWO — DECLARED / NONE DECLARED / CANNOT READ. "I cannot see any" is NOT "there are
   none."** `branches/<base>/protection/required_status_checks` **404s both** when the branch is unprotected
-  **and** when the token lacks **Administration: read**. **NONE DECLARED** is provable **only** when the
-  required-set read **SUCCEEDED and came back EMPTY** — registration completeness then **CANNOT be proven**,
+  **and** when the token lacks **Administration: read**. **NONE DECLARED** is provable **only** when **BOTH**
+  reads **SUCCEEDED and came back EMPTY** — and a classic 404 counts only when
+  `gh api repos/<owner>/<repo> --jq '.permissions.admin'` returns **`true`**, proving the token may actually
+  look. **The rulesets read succeeding vouches for NOTHING here: rulesets need only Metadata: read, classic
+  protection needs Administration: read — a permissive endpoint's success is never evidence about a
+  restricted endpoint's error.** Under NONE DECLARED, registration completeness **CANNOT be proven**,
   and green means only *"every check registered by the time we looked had passed"*: **state that residual
-  risk; never claim it away.** **CANNOT READ** (404/403 without admin, any error on either endpoint) is
-  **UNKNOWN — not "none declared"**: never fall through to the weaker rule, record the uncertainty, and
+  risk; never claim it away.** **CANNOT READ** (an undisambiguated 404/403, any error on either endpoint) is
+  **UNKNOWN — not "none declared"**: never fall through to the weaker rule, and
   never claim registration completeness. **Prefer the rulesets endpoint — it needs no admin, and the
   classic endpoint cannot see rulesets at all.** **NEVER infer the ABSENCE of a requirement from an ERROR
   that also means "you may not look"** (`references/stage-2-ci.md`, "The registration gap").
+- **A STATE YOU CANNOT PERSIST IS A STATE YOU DO NOT HAVE — `required_set` on the PR row, DEFAULT
+  `unknown`.** Write every required-set read's outcome through `scripts/ledger.py … set --pr <N>
+  --required-set declared|none|unknown`; kept only in a wake's head it dies at the next context loss and the
+  three states collapse back to two. The final report reads that field, not a memory
+  (`references/files-and-ledger.md`, `references/bailout-and-final-report.md`).
 - **NEVER merge without GitHub's own verdict: `MERGEABLE` + `mergeStateStatus == CLEAN`.** GitHub computes
   it knowing the required-check set; campaign's snapshot does not. `BLOCKED` (required check missing/failing)
   and `UNSTABLE` (non-required check failing) both mean **do not merge**. It does not prove unregistered

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -171,6 +171,46 @@ Read stage refs only when that stage/action is due:
   site). Sole exception: its CI watch keeps running — observing is not mutating. Keep driving the other
   PRs; unpark only on the user's answer (`references/loop-control.md`, "parked-status guard").
 - **No green by watch exit:** derive CI from re-polled `gh pr checks` snapshot.
+- **No green from ONE CHECK FAMILY, no green by watch exit, no green from an unpinned snapshot, no green
+  from a PARTIAL one, no green from a SUPERSEDED one, no green while a DECLARED REQUIRED CHECK is
+  missing:** GitHub has **two** check families — **Checks** (check runs) and **legacy commit statuses**
+  (Jenkins, CircleCI, many bots) — and **a failing commit status is INVISIBLE to `/check-runs`**. Derive CI
+  from a source covering **both**, pinned to the current `head_sha`:
+  `gh pr view <pr> --json headRefOid,statusCheckRollup` returns both families **and** the head SHA in one
+  payload (`__typename` `CheckRun` → `.name`/`.status`/`.conclusion`; `StatusContext` → `.context`/`.state`
+  — no `.conclusion`, and `ERROR` is a failure). Never read the *combined* status `.state` (it is `pending`
+  on **zero** statuses). `gh pr checks` is not pinned to a commit and will report the PREVIOUS commit's
+  passing checks right after a push. Fetch **ATOMICALLY** — temp file **inside `<rundir>`** (`mv` is atomic
+  only within a filesystem), promoted onto the **SHA-scoped** `ci-<pr>-<head_sha>.txt` (first line
+  `# sha: <head_sha>`, emitted by the same query as the rows) only if **every** fetch exits 0;
+  a fetch redirected straight onto the snapshot leaves the rows that arrived on disk when it dies. **Prove
+  the SOURCE is complete (both families), prove the snapshot is COMPLETE (`--paginate` on every REST fetch;
+  a rollup at its ~100-context cap is truncated → pending), prove its `# sha:` matches the ledger's current
+  `head_sha`, and prove EVERYTHING YOU EXPECT TO SEE IS THERE, before parsing it** — a watch launched for
+  an older SHA can finish after the head advanced; absent, partial, or mismatched → `ci = pending`,
+  relaunch, NEVER green (`references/stage-2-ci.md`).
+- **Registered ≠ expected, and the right NAME is not the right PRODUCER.** Checks register
+  **asynchronously**, so an all-success snapshot can simply predate the check that would have failed. Read
+  the declared required checks from **BOTH** classic branch protection **and rulesets** (a repo can use
+  either or both) and take the **UNION**: **green requires every required check PRESENT and successful** —
+  one unregistered → `ci = pending`, NEVER green. **Where the declaration binds an app** (`app_id` /
+  `integration_id`), match the **producer** too — the check run's `.app.id`, from the SHA-pinned check-runs
+  fetch — or a same-named check from **another** app satisfies the test while the required one has not run.
+  **Where it binds no app, any producer of that name satisfies it.**
+- **THREE STATES, NEVER TWO — DECLARED / NONE DECLARED / CANNOT READ. "I cannot see any" is NOT "there are
+  none."** `branches/<base>/protection/required_status_checks` **404s both** when the branch is unprotected
+  **and** when the token lacks **Administration: read**. **NONE DECLARED** is provable **only** when the
+  required-set read **SUCCEEDED and came back EMPTY** — registration completeness then **CANNOT be proven**,
+  and green means only *"every check registered by the time we looked had passed"*: **state that residual
+  risk; never claim it away.** **CANNOT READ** (404/403 without admin, any error on either endpoint) is
+  **UNKNOWN — not "none declared"**: never fall through to the weaker rule, record the uncertainty, and
+  never claim registration completeness. **Prefer the rulesets endpoint — it needs no admin, and the
+  classic endpoint cannot see rulesets at all.** **NEVER infer the ABSENCE of a requirement from an ERROR
+  that also means "you may not look"** (`references/stage-2-ci.md`, "The registration gap").
+- **NEVER merge without GitHub's own verdict: `MERGEABLE` + `mergeStateStatus == CLEAN`.** GitHub computes
+  it knowing the required-check set; campaign's snapshot does not. `BLOCKED` (required check missing/failing)
+  and `UNSTABLE` (non-required check failing) both mean **do not merge**. It does not prove unregistered
+  checks are absent — require it anyway, never overclaim it (`references/stage-3-merge.md`).
 - **Public API changes require user confirmation** unless the ledger's `api_changes` field is `allowed`.
 
 ## Wake Skeleton

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -45,6 +45,19 @@ When the loop exits, summarize:
   least-certain area it named — `required(tier)` lines, so two for a STANDARD/HIGH PR and one for a
   TRIVIAL PR), and a flag when two accepting passes name the same area. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
+- **CI verification gap** — state which of the three required-set states the run was in (`stage-2-ci.md`,
+  "Three states, never two"), because it changes what `ci = green` was allowed to mean:
+  - **DECLARED** → campaign verified every required check registered (and, where the declaration binds an
+    app, that it came from that app) and passed.
+  - **NONE DECLARED** (the required-set read **succeeded and was empty**) → registration completeness is
+    **unprovable**; green means only *"every check that had registered by the time we looked had passed"*.
+    Report it as a **residual risk** and name the remedy: declare the checks required.
+  - **CANNOT READ** (404/403 without **Administration: read**, or any error on the protection **or**
+    rulesets endpoint) → the expected set was **UNKNOWN**. **Say so explicitly. NEVER report it as "no
+    required checks are declared"** — that asserts something the run never observed. State that a required
+    check may have existed and been missing, that campaign could not tell, and that the merge gate rested
+    on GitHub's own `mergeStateStatus == CLEAN` — **GitHub** verified the required set; **campaign did
+    not**.
 - **Aborted** — PR number + slug, why, pointer to `abort-<id>.md`.
 - **Skipped (API-declined)** — any PR whose API-changing fix the user was asked about and declined,
   with the change each would have needed.

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -45,19 +45,24 @@ When the loop exits, summarize:
   least-certain area it named — `required(tier)` lines, so two for a STANDARD/HIGH PR and one for a
   TRIVIAL PR), and a flag when two accepting passes name the same area. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
-- **CI verification gap** — state which of the three required-set states the run was in (`stage-2-ci.md`,
-  "Three states, never two"), because it changes what `ci = green` was allowed to mean:
-  - **DECLARED** → campaign verified every required check registered (and, where the declaration binds an
+- **CI verification gap** — state, **per merged PR**, which of the three required-set states it was in,
+  **READ FROM THE LEDGER ROW's `required_set` FIELD — never from memory** (`ledger.py --file <state.jsonl>
+  get --pr <N> --field required_set`; `files-and-ledger.md`). A run can span context losses and driver
+  handovers, so the field is the **only** durable record; an unwritten field reads `unknown`, which is the
+  correct fail-safe. The state changes what `ci = green` was allowed to mean (`stage-2-ci.md`, "Three
+  states, never two"):
+  - **`declared`** → campaign verified every required check registered (and, where the declaration binds an
     app, that it came from that app) and passed.
-  - **NONE DECLARED** (the required-set read **succeeded and was empty**) → registration completeness is
+  - **`none`** (**BOTH** required-set reads **succeeded and came back empty** — a classic 404 only counts
+    when `.permissions.admin == true` proved the token could read it) → registration completeness is
     **unprovable**; green means only *"every check that had registered by the time we looked had passed"*.
     Report it as a **residual risk** and name the remedy: declare the checks required.
-  - **CANNOT READ** (404/403 without **Administration: read**, or any error on the protection **or**
-    rulesets endpoint) → the expected set was **UNKNOWN**. **Say so explicitly. NEVER report it as "no
-    required checks are declared"** — that asserts something the run never observed. State that a required
-    check may have existed and been missing, that campaign could not tell, and that the merge gate rested
-    on GitHub's own `mergeStateStatus == CLEAN` — **GitHub** verified the required set; **campaign did
-    not**.
+  - **`unknown`** (**CANNOT READ** — an undisambiguated 404/403, any error on the protection **or**
+    rulesets endpoint, or a read that never ran) → the expected set was **UNKNOWN**. **Say so explicitly.
+    NEVER report it as "no required checks are declared"** — that asserts something the run never observed.
+    State that a required check may have existed and been missing, that campaign could not tell, and that
+    the merge gate rested on GitHub's own `mergeStateStatus == CLEAN` — **GitHub** verified the required
+    set; **campaign did not**.
 - **Aborted** — PR number + slug, why, pointer to `abort-<id>.md`.
 - **Skipped (API-declined)** — any PR whose API-changing fix the user was asked about and declined,
   with the change each would have needed.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -254,29 +254,43 @@
 - **CI status covers BOTH CHECK FAMILIES, pinned to `head_sha`.** GitHub reports CI through **two**
   independent APIs — **Checks** (check runs) and **legacy commit statuses** (Jenkins, CircleCI, many bots).
   **A failing commit status is INVISIBLE to the check-runs endpoint**, so a check-runs-only snapshot reads
-  nonempty and all-success while a Jenkins status is red → false green. Derive `ci` from a source covering
-  **both**: `gh pr view <pr> --json headRefOid,statusCheckRollup` returns both families **and** the head
-  SHA in ONE payload (`__typename` = `CheckRun` → `.name`/`.status`/`.conclusion`; `StatusContext` →
-  `.context`/`.state`, values `SUCCESS`/`FAILURE`/`PENDING`/`ERROR` — **no `.conclusion`; `ERROR` is a
-  failure**). **NEVER** use the *combined* status `.state`: it reads `pending` when there are **zero**
+  nonempty and all-success while a Jenkins status is red → false green. It takes **TWO fetches**, and
+  **each family is judged ONLY from the fetch that carries both its IDENTITY and its RESULT**: check runs
+  from the **SHA-pinned `--paginate` REST check-runs** fetch (one row = `.head_sha` + `.name` + `.app.id` +
+  `.status` + `.conclusion` — **the only source of a check-run verdict**), commit statuses from the
+  **rollup** (`gh pr view <pr> --json headRefOid,statusCheckRollup`), whose `StatusContext` rows carry
+  `.context`/`.state` (values `SUCCESS`/`FAILURE`/`PENDING`/`ERROR` — **no `.conclusion`; `ERROR` is a
+  failure**) and whose `CheckRun` entries are kept **only** as `rollup-checkrun` **witnesses**, never as
+  verdicts. **NEVER** use the *combined* status `.state`: it reads `pending` when there are **zero**
   statuses, so pending is its only safe reading — enumerate the individual contexts. Fetch **ATOMICALLY**
   (temp file **inside `<rundir>`** — `mv` is an atomic rename only *within* a filesystem — promoted onto
   the **SHA-scoped** `ci-<pr>-<head_sha>.txt` only if **every** fetch exits 0, with `# sha: <head_sha>` as
   its first line, emitted by the same query as the rows; NEVER redirect a fetch straight onto the parsed
-  snapshot). Green needs **≥1 row, every check run `COMPLETED`+`SUCCESS`, every status `SUCCESS`, AND
-  every DECLARED required check present (name **and** producer) and successful** (see the next rules; zero
-  rows is NOT green) — never from the `--watch` exit code (it can exit 0 on pending/unregistered checks).
-  **The artifact is pinned too, not just the query:** **VERIFY the snapshot's `# sha:` equals
-  the ledger's current `head_sha` BEFORE parsing it** — a watch launched for an older SHA can finish
-  after the head advanced, and its checks say nothing about the current head. Absent, partial, mismatched,
-  or a rollup at its context cap (a truncated window is a partial fetch) → `ci = pending`, relaunch the
-  watch, **NEVER green** (a superseded snapshot is expected; discard it). **`--paginate` stays REQUIRED on
-  every REST fetch.** **SIX questions, SIX sources:** the **families queried** say whether a whole class of
-  failure could even appear; the **fetches' exit status** says whether the snapshot is complete enough to
-  parse at all (a partial fetch is NOT evidence → `ci = pending`, never green); the **`# sha:` stamp** says
-  whether it is about this commit; the **required-set read's outcome** says whether we even KNOW what to
-  expect; the **declared required-check set** says whether everything expected is THERE and from the right
-  producer; the **file's contents** say green/red/pending. No green, no merge. See `stage-2-ci.md`.
+  snapshot). Green needs **≥1 row, every check run `COMPLETED`+`SUCCESS`, every status `SUCCESS`, the two
+  fetches AGREEING, AND every DECLARED required check present (name **and** producer) and successful** (see
+  the next rules; zero rows is NOT green) — never from the `--watch` exit code (it can exit 0 on
+  pending/unregistered checks).
+  **The artifact is pinned too, not just the query:** **VERIFY that every SHA in the snapshot — the
+  `# sha:` line AND every `checkrun` row's — equals the ledger's current `head_sha` BEFORE parsing it** — a
+  watch launched for an older SHA can finish after the head advanced, and its checks say nothing about the
+  current head. Absent, partial, mismatched, or a rollup at its context cap (a truncated window is a
+  partial fetch) → `ci = pending`, relaunch the watch, **NEVER green** (a superseded snapshot is expected;
+  discard it). **`--paginate` stays REQUIRED on every REST fetch.**
+- **NEVER JOIN TWO OBSERVATIONS TAKEN AT DIFFERENT TIMES AND READ THE RESULT AS ONE.** A check's
+  **IDENTITY** and its **RESULT** MUST come from the **SAME row of the SAME fetch**. Taking identity from
+  one fetch and the result from another is a **MIXED-TIME ARTIFACT**: the earlier fetch sees app 999's
+  same-named `build` succeed, the required app-123 `build` registers **after** it, the later fetch proves a
+  `build` from app 123 exists — presence passes, all-success passes, and `ci = green` is recorded for a
+  check **never observed passing**. **The two fetches are still taken at different times — so make their
+  DISAGREEMENT the signal:** they MUST stamp the same `head_sha` and agree on the **set of check runs**;
+  a run present in one and absent from the other means the state was still **MOVING** → `ci = pending`,
+  refetch, **NEVER green**. **SEVEN questions, SEVEN sources:** the **families queried** say whether a whole
+  class of failure could even appear; the **fetches' exit status** says whether the snapshot is complete
+  enough to parse at all (a partial fetch is NOT evidence → `ci = pending`, never green); the **SHA stamps**
+  say whether it is about this commit; the **cross-fetch agreement** says whether any verdict may be drawn
+  from it at all; the **required-set read's outcome** says whether we even KNOW what to expect; the
+  **declared required-check set** says whether everything expected is THERE and from the right producer;
+  the **file's contents** say green/red/pending. No green, no merge. See `stage-2-ci.md`.
 - **PROVE THE EXPECTED CHECKS REGISTERED, FROM THE RIGHT PRODUCER — "all registered runs passed" is NOT
   "all expected checks passed", and the right NAME is NOT the right PRODUCER.** Checks register
   **asynchronously**: a fast lint can complete before a slower workflow — or a GitHub App check — even
@@ -285,26 +299,38 @@
   other's declarations) and take the **UNION**. **Green REQUIRES every required check PRESENT in the
   snapshot and successful**; one that has not registered → `ci = pending`, relaunch the watch, **NEVER
   green**. **Where the declaration BINDS AN APP** (`app_id` / `integration_id`), the presence test MUST
-  match the **producer** too — the check run's `.app.id`, from the SHA-pinned check-runs fetch (the rollup
-  does not carry it) — because a same-named check from **another** app satisfying a name-only test is a
-  false green from the **wrong producer**. **Where the declaration binds NO app, ANY producer of that name
+  match the **producer** too — a **single `checkrun` row** whose name **and** `app_id` match **and which
+  carries the result**, never a presence proven by one fetch and a success proven by another — because a
+  same-named check from **another** app satisfying a name-only test is a false green from the **wrong
+  producer**. **Where the declaration binds NO app, ANY producer of that name
   satisfies it** — do not over-tighten that, or CI wedges at `pending` forever.
 - **THREE STATES, NEVER TWO — DECLARED / NONE DECLARED / CANNOT READ. "I cannot see any" is NOT "there are
   none."** `branches/<base>/protection/required_status_checks` **404s BOTH** when the branch is unprotected
   **AND** when the token lacks **Administration: read**. **DECLARED** (union of protection + rulesets is
   non-empty) → green requires every required check present (with producer identity) and successful.
-  **NONE DECLARED** — provable **only** when the required-set read **SUCCEEDED and came back EMPTY** →
-  registration completeness **CANNOT BE PROVEN** (not by campaign, not by the check-runs API, not by
+  **NONE DECLARED** — provable **only** when **BOTH** reads **SUCCEEDED and came back EMPTY**, and a
+  classic **404 counts only when `gh api repos/<owner>/<repo> --jq '.permissions.admin'` returns `true`**,
+  proving the token may actually look. **NEVER let the RULESETS read vouch for the CLASSIC one: rulesets
+  need only Metadata: read, classic protection needs Administration: read — a permissive endpoint's success
+  is NEVER evidence about a restricted endpoint's error.** Under NONE DECLARED registration completeness
+  **CANNOT BE PROVEN** (not by campaign, not by the check-runs API, not by
   `mergeStateStatus` — GitHub cannot block on a check it does not know about either); `ci = green` then
   means only *"every check that had registered by the time we looked had passed"*. **Say that plainly as a
-  residual risk; NEVER claim it is closed.** **CANNOT READ** (404/403 without Administration: read, any
-  error on either endpoint) → **UNKNOWN, and UNKNOWN IS NOT "NONE DECLARED"** — do **NOT** silently fall
-  through to the weaker rule; **record the uncertainty, never claim registration completeness, and never
+  residual risk; NEVER claim it is closed.** **CANNOT READ** (an undisambiguated 404/403, any error on
+  either endpoint, an admin probe that did not return `true`) → **UNKNOWN, and UNKNOWN IS NOT "NONE
+  DECLARED"** — do **NOT** silently fall
+  through to the weaker rule; **never claim registration completeness, and never
   state or imply "no required checks are declared"** — a required check may exist and be missing, and
   campaign cannot tell. **Prefer the rulesets endpoint: it needs NO admin, and the classic endpoint cannot
   see rulesets at all.** **NEVER infer the ABSENCE of a requirement from an ERROR that also means "you may
   not look."** The real remedy is the user declaring required checks (`stage-2-ci.md`, "The registration
   gap").
+- **PERSIST THE REQUIRED-SET STATE — `required_set` on the PR row, DEFAULT `unknown`. A STATE YOU CANNOT
+  PERSIST IS A STATE YOU DO NOT HAVE.** Write every required-set read's outcome through
+  `scripts/ledger.py … set --pr <N> --required-set declared|none|unknown` (`files-and-ledger.md`). Kept only
+  in a wake's head, CANNOT READ and NONE DECLARED become **indistinguishable** at the next context loss or
+  driver resume and the three states collapse to two. The final report states the CI verification gap
+  **from this field, never from memory** (`bailout-and-final-report.md`).
 - **NEVER MERGE WITHOUT GITHUB'S OWN VERDICT: `gh pr view <pr> --json mergeable,mergeStateStatus` MUST
   read `MERGEABLE` + `mergeStateStatus == CLEAN`.** It is a load-bearing precondition, not a sanity check:
   GitHub computes it knowing the repo's required-check set, which campaign's snapshot does not. `BLOCKED` =

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -53,7 +53,8 @@
   slot. Refill the slot with the next due review.
 - Reconcile from ONE batched `gh pr list --label gauntlet-run-<run-id> --json …` snapshot per wake
   (`<rundir>/prs.json`); per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth
-  stays the re-polled `gh pr checks` snapshot.
+  stays the **both-family** check state pinned to `head_sha` (Stage 2b) — never an unpinned
+  `gh pr checks` snapshot.
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs
   immediately, ask the user asynchronously, and fold the answer in as its own wake.
 - Public API surface/behavior changes need user confirmation by default (see Constraints). The
@@ -250,8 +251,67 @@
   error — *not* a real finding list / `VERDICT:` line), retry once, then do the equivalent work with
   your own subagents: a fresh, context-isolated subagent review pass in
   Stage 2a. The gate is unchanged — note any fallback pass in the report. See "The reviewer".
-- CI status comes from a re-polled `gh pr checks` snapshot with **zero fail AND zero pending lines** —
-  never from the `--watch` exit code (it can exit 0 on pending/unregistered checks). No green, no merge.
+- **CI status covers BOTH CHECK FAMILIES, pinned to `head_sha`.** GitHub reports CI through **two**
+  independent APIs — **Checks** (check runs) and **legacy commit statuses** (Jenkins, CircleCI, many bots).
+  **A failing commit status is INVISIBLE to the check-runs endpoint**, so a check-runs-only snapshot reads
+  nonempty and all-success while a Jenkins status is red → false green. Derive `ci` from a source covering
+  **both**: `gh pr view <pr> --json headRefOid,statusCheckRollup` returns both families **and** the head
+  SHA in ONE payload (`__typename` = `CheckRun` → `.name`/`.status`/`.conclusion`; `StatusContext` →
+  `.context`/`.state`, values `SUCCESS`/`FAILURE`/`PENDING`/`ERROR` — **no `.conclusion`; `ERROR` is a
+  failure**). **NEVER** use the *combined* status `.state`: it reads `pending` when there are **zero**
+  statuses, so pending is its only safe reading — enumerate the individual contexts. Fetch **ATOMICALLY**
+  (temp file **inside `<rundir>`** — `mv` is an atomic rename only *within* a filesystem — promoted onto
+  the **SHA-scoped** `ci-<pr>-<head_sha>.txt` only if **every** fetch exits 0, with `# sha: <head_sha>` as
+  its first line, emitted by the same query as the rows; NEVER redirect a fetch straight onto the parsed
+  snapshot). Green needs **≥1 row, every check run `COMPLETED`+`SUCCESS`, every status `SUCCESS`, AND
+  every DECLARED required check present (name **and** producer) and successful** (see the next rules; zero
+  rows is NOT green) — never from the `--watch` exit code (it can exit 0 on pending/unregistered checks).
+  **The artifact is pinned too, not just the query:** **VERIFY the snapshot's `# sha:` equals
+  the ledger's current `head_sha` BEFORE parsing it** — a watch launched for an older SHA can finish
+  after the head advanced, and its checks say nothing about the current head. Absent, partial, mismatched,
+  or a rollup at its context cap (a truncated window is a partial fetch) → `ci = pending`, relaunch the
+  watch, **NEVER green** (a superseded snapshot is expected; discard it). **`--paginate` stays REQUIRED on
+  every REST fetch.** **SIX questions, SIX sources:** the **families queried** say whether a whole class of
+  failure could even appear; the **fetches' exit status** says whether the snapshot is complete enough to
+  parse at all (a partial fetch is NOT evidence → `ci = pending`, never green); the **`# sha:` stamp** says
+  whether it is about this commit; the **required-set read's outcome** says whether we even KNOW what to
+  expect; the **declared required-check set** says whether everything expected is THERE and from the right
+  producer; the **file's contents** say green/red/pending. No green, no merge. See `stage-2-ci.md`.
+- **PROVE THE EXPECTED CHECKS REGISTERED, FROM THE RIGHT PRODUCER — "all registered runs passed" is NOT
+  "all expected checks passed", and the right NAME is NOT the right PRODUCER.** Checks register
+  **asynchronously**: a fast lint can complete before a slower workflow — or a GitHub App check — even
+  exists, and that snapshot is nonempty and all-success. Read the declared required checks from **BOTH**
+  classic branch protection **and rulesets** (a repo can use either or both; neither endpoint sees the
+  other's declarations) and take the **UNION**. **Green REQUIRES every required check PRESENT in the
+  snapshot and successful**; one that has not registered → `ci = pending`, relaunch the watch, **NEVER
+  green**. **Where the declaration BINDS AN APP** (`app_id` / `integration_id`), the presence test MUST
+  match the **producer** too — the check run's `.app.id`, from the SHA-pinned check-runs fetch (the rollup
+  does not carry it) — because a same-named check from **another** app satisfying a name-only test is a
+  false green from the **wrong producer**. **Where the declaration binds NO app, ANY producer of that name
+  satisfies it** — do not over-tighten that, or CI wedges at `pending` forever.
+- **THREE STATES, NEVER TWO — DECLARED / NONE DECLARED / CANNOT READ. "I cannot see any" is NOT "there are
+  none."** `branches/<base>/protection/required_status_checks` **404s BOTH** when the branch is unprotected
+  **AND** when the token lacks **Administration: read**. **DECLARED** (union of protection + rulesets is
+  non-empty) → green requires every required check present (with producer identity) and successful.
+  **NONE DECLARED** — provable **only** when the required-set read **SUCCEEDED and came back EMPTY** →
+  registration completeness **CANNOT BE PROVEN** (not by campaign, not by the check-runs API, not by
+  `mergeStateStatus` — GitHub cannot block on a check it does not know about either); `ci = green` then
+  means only *"every check that had registered by the time we looked had passed"*. **Say that plainly as a
+  residual risk; NEVER claim it is closed.** **CANNOT READ** (404/403 without Administration: read, any
+  error on either endpoint) → **UNKNOWN, and UNKNOWN IS NOT "NONE DECLARED"** — do **NOT** silently fall
+  through to the weaker rule; **record the uncertainty, never claim registration completeness, and never
+  state or imply "no required checks are declared"** — a required check may exist and be missing, and
+  campaign cannot tell. **Prefer the rulesets endpoint: it needs NO admin, and the classic endpoint cannot
+  see rulesets at all.** **NEVER infer the ABSENCE of a requirement from an ERROR that also means "you may
+  not look."** The real remedy is the user declaring required checks (`stage-2-ci.md`, "The registration
+  gap").
+- **NEVER MERGE WITHOUT GITHUB'S OWN VERDICT: `gh pr view <pr> --json mergeable,mergeStateStatus` MUST
+  read `MERGEABLE` + `mergeStateStatus == CLEAN`.** It is a load-bearing precondition, not a sanity check:
+  GitHub computes it knowing the repo's required-check set, which campaign's snapshot does not. `BLOCKED` =
+  a required check missing or failing → back to Stage 2, never merge; `UNSTABLE` = a non-required check
+  failing → handle as red, never merge; `BEHIND`/`DIRTY`/`CONFLICTING` → refresh the PR. **Anything but
+  `CLEAN` → NEVER merge.** It still does **NOT** prove unregistered checks don't exist — GitHub cannot block
+  on a check it does not know about either. Require it; never overclaim it (`stage-3-merge.md`).
 - The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -14,7 +14,7 @@ files from colliding — see "Run identity and concurrency".
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
 | `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1) |
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
-| `ci-<pr>.txt` | Latest `gh pr checks` snapshot for a PR (re-polled after the watch, not the watch stream) |
+| `ci-<pr>-<sha>.txt` | The PR's check state at **`<sha>`**, covering **BOTH check families** — check runs **and** legacy commit statuses (`gh pr view <pr> --json headRefOid,statusCheckRollup`, re-polled after the watch — never the watch stream, never an unpinned `gh pr checks` snapshot, and **never `/check-runs` alone**, which cannot see a failing Jenkins/CircleCI **commit status**). Rows are `checkrun\t<name>\t<status>\t<conclusion>` and `status\t<context>\t<state>`, plus `app\t<name>\t<app.id>` rows from the SHA-pinned `--paginate` check-runs fetch when a required check **binds an app**. **SHA-SCOPED in the FILENAME and stamped in its FIRST LINE** (`# sha: <full sha>`, emitted by the same query as the rows, so stamp and rows can never describe different commits). Written **ATOMICALLY**: fetches go to a temp file **inside `<rundir>`** (same filesystem → `mv` is an atomic rename) and are promoted here only if **every** fetch exits 0, so this file is **always a COMPLETE snapshot**. **Before parsing, the consumer MUST verify `# sha:` equals the ledger's current `head_sha`** — absent, partial, mismatched, or a rollup at its context cap (truncated = partial) → `ci = pending`, relaunch the watch, **NEVER green**. A snapshot for a superseded SHA is expected (the head advances under a running watch) and is simply discarded. It lists only the checks that had **REGISTERED** when it was taken, so it is **NOT** self-evidently the whole set: every **declared** required check must be present in it — **matched on producer where the declaration binds an app** — and successful before it may be read as green (`stage-2-ci.md`) |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
@@ -47,7 +47,8 @@ git-ignored driver bookkeeping, and that is the extent of campaign's on-disk foo
 
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is
 GitHub via `gh`, plus local worktrees** (`gh pr list/view` for PRs and merged/open state, each PR's
-`headRefOid` from `gh` — keyed by PR number — for the live head SHA, `gh pr checks` for live CI, and
+`headRefOid` from `gh` — keyed by PR number — for the live head SHA, **both check families** (check runs
+**and** commit statuses) pinned to that SHA for live CI, and
 the **active launch attempt's** review output files for which verdicts exist on which SHA —
 `review-<pr>-<n>.txt` for attempt 1, `review-<pr>-<n>.a<k>.txt` after a relaunch, counting only the
 attempt named in that pass's `pass_identity`, so a relaunch's verdict is never missed and a dead
@@ -117,7 +118,21 @@ Header field notes (the header fields above; per-row fields follow):
   tiers").
 - `tier` — the adaptive review tier derived from `head_sha`: `TRIVIAL` | `STANDARD` | `HIGH`. Re-derived
   every wake and re-triaged on any content change; drives `required(tier)` and the review depth.
-- `ci` — `green` / `red` / `pending` / `none` for `head_sha`.
+- `ci` — `green` / `red` / `pending` / `none` for `head_sha`. `green` requires a complete, SHA-verified
+  snapshot **covering BOTH check families** (check runs **and** commit statuses — a check-runs-only
+  snapshot cannot see a failing Jenkins status) with **≥1 row, every check run `COMPLETED`+`SUCCESS`, every
+  commit status `SUCCESS`** (`ERROR` is a **failure**), **AND every DECLARED required check present in it
+  and successful — matched on the check run's `.app.id` wherever the declaration binds an app** (a
+  same-named check from another producer does **not** satisfy it; where no app is bound, any producer of
+  that name does). A declared required check that has not registered → `pending`, never `green`.
+  **The required-set read has THREE outcomes, never two:** where it **SUCCEEDED and came back EMPTY**
+  (**NONE DECLARED**), `green` means only *"every check that had registered by the time we looked had
+  passed"* — registration completeness is unprovable there; where it **CANNOT BE READ** (404/403 without
+  **Administration: read**, any error on either the protection or the rulesets endpoint), the expected set
+  is **UNKNOWN — which is NOT "none declared"**: record the uncertainty on the row, never claim
+  registration completeness, and never imply no required checks exist (`stage-2-ci.md`, "The registration
+  gap"). `ci = green` alone **never** authorizes a merge: Stage 3 also requires GitHub's `MERGEABLE` +
+  `mergeStateStatus == CLEAN`.
 - `attempts` — task attempts so far (for the retry-once bailout).
 - `started` — wall-clock start of the current attempt (for the 1-hour cap).
 - `api_approval` — durable record of the user's decision on this PR's API-changing fix: `-`

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -14,7 +14,7 @@ files from colliding — see "Run identity and concurrency".
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
 | `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1) |
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
-| `ci-<pr>-<sha>.txt` | The PR's check state at **`<sha>`**, covering **BOTH check families** — check runs **and** legacy commit statuses (`gh pr view <pr> --json headRefOid,statusCheckRollup`, re-polled after the watch — never the watch stream, never an unpinned `gh pr checks` snapshot, and **never `/check-runs` alone**, which cannot see a failing Jenkins/CircleCI **commit status**). Rows are `checkrun\t<name>\t<status>\t<conclusion>` and `status\t<context>\t<state>`, plus `app\t<name>\t<app.id>` rows from the SHA-pinned `--paginate` check-runs fetch when a required check **binds an app**. **SHA-SCOPED in the FILENAME and stamped in its FIRST LINE** (`# sha: <full sha>`, emitted by the same query as the rows, so stamp and rows can never describe different commits). Written **ATOMICALLY**: fetches go to a temp file **inside `<rundir>`** (same filesystem → `mv` is an atomic rename) and are promoted here only if **every** fetch exits 0, so this file is **always a COMPLETE snapshot**. **Before parsing, the consumer MUST verify `# sha:` equals the ledger's current `head_sha`** — absent, partial, mismatched, or a rollup at its context cap (truncated = partial) → `ci = pending`, relaunch the watch, **NEVER green**. A snapshot for a superseded SHA is expected (the head advances under a running watch) and is simply discarded. It lists only the checks that had **REGISTERED** when it was taken, so it is **NOT** self-evidently the whole set: every **declared** required check must be present in it — **matched on producer where the declaration binds an app** — and successful before it may be read as green (`stage-2-ci.md`) |
+| `ci-<pr>-<sha>.txt` | The PR's check state at **`<sha>`**, covering **BOTH check families** — check runs **and** legacy commit statuses (never the watch stream, never an unpinned `gh pr checks` snapshot, and **never `/check-runs` alone**, which cannot see a failing Jenkins/CircleCI **commit status**). **TWO fetches, and each family is judged ONLY from the one that carries both its IDENTITY and its RESULT** (`stage-2-ci.md`, "The same-observation rule"): (1) the **SHA-pinned `--paginate` REST check-runs** fetch → `checkrun\t<head_sha>\t<name>\t<app_id>\t<status>\t<conclusion>` (one row = the commit, the producer **and** the result — **the only source of a check-run verdict**; `-` app_id = unbound); (2) the **rollup** (`gh pr view <pr> --json headRefOid,statusCheckRollup`, re-polled after the watch) → `status\t<context>\t<state>` for the family (1) cannot see, plus `rollup-checkrun\t<name>` **WITNESS** rows used **only** for the cross-fetch agreement test, **never as a verdict**. **SHA-SCOPED in the FILENAME, stamped in its FIRST LINE** (`# sha: <full sha>`, from the same payload as the rollup rows) **and on every `checkrun` row** (stamped by GitHub per run). Written **ATOMICALLY**: both fetches go to a temp file **inside `<rundir>`** (same filesystem → `mv` is an atomic rename) and are promoted here only if **every** fetch exits 0, so this file is **always a COMPLETE snapshot**. **Before parsing, the consumer MUST verify that every SHA in it (the `# sha:` line AND every `checkrun` row's) equals the ledger's current `head_sha`, AND that the two fetches agree on the SET of check-run names** — the fetches are taken at **different times**, so a run present in one and absent from the other means the state was still **MOVING**. Absent, partial, mismatched, disagreeing, or a rollup at its context cap (truncated = partial) → `ci = pending`, relaunch the watch, **NEVER green**. A snapshot for a superseded SHA is expected (the head advances under a running watch) and is simply discarded. It lists only the checks that had **REGISTERED** when it was taken, so it is **NOT** self-evidently the whole set: every **declared** required check must be present in it — **matched on producer where the declaration binds an app, with presence and success read off the SAME row** — before it may be read as green (`stage-2-ci.md`) |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
@@ -66,8 +66,8 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 
 ```
 {"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex"}
-{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
-{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
+{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "required_set": "declared", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "mergeable"}
+{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "required_set": "unknown", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
 
 Header-record fields: `run_id` (this run's identity — namespaces its dir/label/wakes; set once),
@@ -121,18 +121,28 @@ Header field notes (the header fields above; per-row fields follow):
 - `ci` — `green` / `red` / `pending` / `none` for `head_sha`. `green` requires a complete, SHA-verified
   snapshot **covering BOTH check families** (check runs **and** commit statuses — a check-runs-only
   snapshot cannot see a failing Jenkins status) with **≥1 row, every check run `COMPLETED`+`SUCCESS`, every
-  commit status `SUCCESS`** (`ERROR` is a **failure**), **AND every DECLARED required check present in it
-  and successful — matched on the check run's `.app.id` wherever the declaration binds an app** (a
-  same-named check from another producer does **not** satisfy it; where no app is bound, any producer of
-  that name does). A declared required check that has not registered → `pending`, never `green`.
-  **The required-set read has THREE outcomes, never two:** where it **SUCCEEDED and came back EMPTY**
-  (**NONE DECLARED**), `green` means only *"every check that had registered by the time we looked had
-  passed"* — registration completeness is unprovable there; where it **CANNOT BE READ** (404/403 without
-  **Administration: read**, any error on either the protection or the rulesets endpoint), the expected set
-  is **UNKNOWN — which is NOT "none declared"**: record the uncertainty on the row, never claim
-  registration completeness, and never imply no required checks exist (`stage-2-ci.md`, "The registration
-  gap"). `ci = green` alone **never** authorizes a merge: Stage 3 also requires GitHub's `MERGEABLE` +
-  `mergeStateStatus == CLEAN`.
+  commit status `SUCCESS`** (`ERROR` is a **failure**), **the two fetches agreeing on the head SHA and on
+  the set of check runs** (they are taken at **different times**; a disagreement means the state was still
+  moving → `pending`), **AND every DECLARED required check present in it and successful — matched on the
+  check run's `app_id` wherever the declaration binds an app, with its PRESENCE and its SUCCESS read off
+  the SAME row of the SAME fetch** (a same-named check from another producer does **not** satisfy it; where
+  no app is bound, any producer of that name does). **NEVER join rows across fetches to reach a verdict**
+  (`stage-2-ci.md`, "The same-observation rule"). A declared required check that has not registered →
+  `pending`, never `green`. `ci = green` alone **never** authorizes a merge: Stage 3 also requires GitHub's
+  `MERGEABLE` + `mergeStateStatus == CLEAN`.
+- `required_set` — the outcome of the **required-check-set read** for this PR's base, **persisted** so the
+  three states survive a context loss or a driver resume: `declared` (protection ∪ rulesets read
+  **succeeded**, union **non-empty** — registration completeness is **PROVABLE**, and green requires every
+  required check present-and-successful) | `none` (**BOTH** reads genuinely **succeeded and came back
+  empty** — a classic 404 counts only when `.permissions.admin == true` proves the token may actually look;
+  registration completeness is **unprovable**, and green means only *"every check that had registered by
+  the time we looked had passed"*) | `unknown` (**CANNOT READ** — any unexplained error on either endpoint;
+  the expected set is **UNKNOWN, which is NOT "none declared"**: never claim registration completeness,
+  never imply no required checks exist). **`unknown` is the DEFAULT** — the fail-safe is uncertainty, never
+  a claim of completeness. Written every wake the required set is read, through `scripts/ledger.py … set
+  --pr <N> --required-set <state>`; read back by the final report (`bailout-and-final-report.md`), which
+  states the CI verification gap **from this field, not from memory** (`stage-2-ci.md`, "Three states,
+  never two" and "The registration gap").
 - `attempts` — task attempts so far (for the retry-once bailout).
 - `started` — wall-clock start of the current attempt (for the 1-hour cap).
 - `api_approval` — durable record of the user's decision on this PR's API-changing fix: `-`

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -51,7 +51,7 @@ blocks; each completion is its own wake.
      **one batched snapshot per wake** —
      `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
-     isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
+     isn't enough (merge-gate CI truth stays the check runs pinned to `head_sha`, Stage 2b). Wake
      turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, and `reviewer` from the ledger
      header — they govern namespacing, the merge/diff target, API-change handling, and which reviewer runs
      the review passes, and must be
@@ -125,11 +125,48 @@ blocks; each completion is its own wake.
    reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
-2. **Fold in completions.** For any background task that finished (CI watch → `ci-<pr>.txt`; review →
+2. **Fold in completions.** For any background task that finished (CI watch → `ci-<pr>-<sha>.txt`;
+   review →
    the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
    writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and
    only the attempt named in the current `pass_identity` is read or counted (Stage 2a); CI/review fix),
    record the result against the SHA it ran on and act per Stage 2.
+
+   **For a CI watch, PROVE THE SNAPSHOT BELONGS TO THE CURRENT HEAD BEFORE PARSING IT.** Read the
+   ledger's current `head_sha`, open `<rundir>/ci-<pr>-<head_sha>.txt`, and confirm its `# sha:` line
+   equals that `head_sha`. **Absent, partial, or mismatched → `ci = pending`, relaunch the watch,
+   NEVER green** — a missing/partial file means the fetch did not complete; a mismatched one describes a
+   **superseded commit** and says nothing about the current head. **NEVER parse a snapshot you cannot
+   prove is about the SHA in the ledger.** A watch finishing for a SHA the PR has already moved past is
+   **expected, not an error** (campaign pushes fixes constantly, and every commit advances the head): its
+   result is **discarded**, and the relaunched watch observes the new head (`stage-2-ci.md`).
+
+   **The snapshot MUST cover BOTH CHECK FAMILIES** — check runs **and** legacy commit statuses. A failing
+   Jenkins/CircleCI **commit status is invisible** to `/commits/<sha>/check-runs`, so a check-runs-only
+   snapshot reads nonempty and all-success while the build is red. Derive it from
+   `gh pr view <pr> --json headRefOid,statusCheckRollup`, which returns both families **and** the head SHA
+   in one payload; a `StatusContext` has `.state` (not `.conclusion`), and `ERROR` is a **failure**
+   (`stage-2-ci.md`).
+
+   **Then PROVE THE EXPECTED CHECKS REGISTERED, FROM THE RIGHT PRODUCER.** An all-success snapshot proves
+   only that every **registered** run passed — checks register asynchronously, so a slow workflow or a
+   GitHub App check may not have appeared yet. Read the repo's **declared required checks** for `<base>`
+   from **BOTH** classic branch protection **and rulesets**, and take the **UNION** — neither endpoint sees
+   the other's declarations: **every declared required check MUST be PRESENT in the snapshot and
+   successful**, else `ci = pending`, relaunch the watch, **NEVER green**. **Where the declaration binds an
+   app** (`app_id` / `integration_id`), match the check run's **`.app.id`** too — a same-named check from
+   another producer does **NOT** satisfy it; **where it binds no app, any producer of that name does.**
+
+   **THREE STATES, NEVER TWO — and "I cannot see any" is NOT "there are none."** The classic
+   `protection/required_status_checks` endpoint **404s both** when the branch is unprotected **and** when
+   the token lacks **Administration: read**. **NONE DECLARED** is provable **only** when the required-set
+   read **SUCCEEDED and came back EMPTY** — registration completeness then **cannot be proven**, and green
+   means only *"every check registered by the time we looked had passed"*, a residual risk closed only by
+   the user declaring required checks. **CANNOT READ** (404/403 without admin, any error on either
+   endpoint) is **UNKNOWN — NOT "none declared"**: do **not** fall through to the weaker rule, **record the
+   uncertainty on the PR row and in the report**, and never claim registration completeness. **Prefer the
+   rulesets endpoint — it needs no admin, and the classic endpoint cannot see rulesets at all**
+   (`stage-2-ci.md`, "The registration gap").
 3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,
    not just the PR/job that woke you. Launch every due action that fits a free slot before returning.
    Launch only what is actually due *and not already in flight* (check ground truth first, never the
@@ -226,7 +263,9 @@ blocks; each completion is its own wake.
      conflict-resolving rebase) while a review is in flight on that PR → **stop that review task
      first** (its verdict can only describe a SHA the fix is about to replace); the freed slot goes
      to the next due review.
-   - mergeable **and not parked** → queue for serialized merge drain.
+   - mergeable **and not parked** — live `head_sha` matches, `reviews_ok >= required(tier)`,
+     `ci == green`, **and GitHub reports `MERGEABLE` + `mergeStateStatus == CLEAN`** (anything else,
+     `BLOCKED`/`UNSTABLE` included, is NOT mergeable — Stage 3) → queue for serialized merge drain.
    Treat ~8 as a **rolling concurrency cap**, not a wave size: keep up to ~8 CI-fix subagents and ~8
    review processes in flight, refilling each free slot immediately; queue the rest. **Launch, do not
    wait — never barrier on a group of PRs before dispatching the next.**

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -133,8 +133,9 @@ blocks; each completion is its own wake.
    record the result against the SHA it ran on and act per Stage 2.
 
    **For a CI watch, PROVE THE SNAPSHOT BELONGS TO THE CURRENT HEAD BEFORE PARSING IT.** Read the
-   ledger's current `head_sha`, open `<rundir>/ci-<pr>-<head_sha>.txt`, and confirm its `# sha:` line
-   equals that `head_sha`. **Absent, partial, or mismatched → `ci = pending`, relaunch the watch,
+   ledger's current `head_sha`, open `<rundir>/ci-<pr>-<head_sha>.txt`, and confirm **every SHA in it** —
+   the `# sha:` line **and** every `checkrun` row's `<head_sha>` field — equals that `head_sha`.
+   **Absent, partial, or mismatched → `ci = pending`, relaunch the watch,
    NEVER green** — a missing/partial file means the fetch did not complete; a mismatched one describes a
    **superseded commit** and says nothing about the current head. **NEVER parse a snapshot you cannot
    prove is about the SHA in the ledger.** A watch finishing for a SHA the PR has already moved past is
@@ -143,10 +144,19 @@ blocks; each completion is its own wake.
 
    **The snapshot MUST cover BOTH CHECK FAMILIES** — check runs **and** legacy commit statuses. A failing
    Jenkins/CircleCI **commit status is invisible** to `/commits/<sha>/check-runs`, so a check-runs-only
-   snapshot reads nonempty and all-success while the build is red. Derive it from
-   `gh pr view <pr> --json headRefOid,statusCheckRollup`, which returns both families **and** the head SHA
-   in one payload; a `StatusContext` has `.state` (not `.conclusion`), and `ERROR` is a **failure**
-   (`stage-2-ci.md`).
+   snapshot reads nonempty and all-success while the build is red. It takes **TWO fetches**, and **each
+   family is judged ONLY from the fetch that carries both its IDENTITY and its RESULT**: check-run verdicts
+   come **exclusively** from the SHA-pinned `--paginate` REST check-runs rows (commit + `name` + `app.id` +
+   `status` + `conclusion`, all in ONE row); commit-status verdicts come from the rollup's `StatusContext`
+   rows (`gh pr view <pr> --json headRefOid,statusCheckRollup`), which has `.state` (not `.conclusion`),
+   where `ERROR` is a **failure** (`stage-2-ci.md`).
+
+   **NEVER JOIN ROWS ACROSS FETCHES TO REACH A VERDICT** — identity from one fetch plus a result from
+   another is a **MIXED-TIME ARTIFACT** and manufactures a false green. **The two fetches are still taken
+   at DIFFERENT TIMES: make their DISAGREEMENT the signal.** If they do not agree on the head SHA, or on
+   the **set of check runs** (a run present in one and absent from the other — the rollup's
+   `rollup-checkrun` rows are witnesses for exactly this test, never verdicts), the check state was still
+   **MOVING** → `ci = pending`, refetch, **NEVER green** (`stage-2-ci.md`, "The same-observation rule").
 
    **Then PROVE THE EXPECTED CHECKS REGISTERED, FROM THE RIGHT PRODUCER.** An all-success snapshot proves
    only that every **registered** run passed — checks register asynchronously, so a slow workflow or a
@@ -159,14 +169,25 @@ blocks; each completion is its own wake.
 
    **THREE STATES, NEVER TWO — and "I cannot see any" is NOT "there are none."** The classic
    `protection/required_status_checks` endpoint **404s both** when the branch is unprotected **and** when
-   the token lacks **Administration: read**. **NONE DECLARED** is provable **only** when the required-set
-   read **SUCCEEDED and came back EMPTY** — registration completeness then **cannot be proven**, and green
+   the token lacks **Administration: read**. **NONE DECLARED** is provable **only** when **BOTH** reads
+   **SUCCEEDED and came back EMPTY** — and a classic **404 counts as succeeded-and-empty ONLY if
+   `gh api repos/<owner>/<repo> --jq '.permissions.admin'` returns `true`**, proving the token really may
+   look. **The rulesets read succeeding proves NOTHING about it: rulesets need only Metadata: read, the
+   classic endpoint needs Administration: read — NEVER let the permissive endpoint's success vouch for the
+   restricted one's error.** Under NONE DECLARED, registration completeness **cannot be proven**, and green
    means only *"every check registered by the time we looked had passed"*, a residual risk closed only by
-   the user declaring required checks. **CANNOT READ** (404/403 without admin, any error on either
-   endpoint) is **UNKNOWN — NOT "none declared"**: do **not** fall through to the weaker rule, **record the
-   uncertainty on the PR row and in the report**, and never claim registration completeness. **Prefer the
+   the user declaring required checks. **CANNOT READ** (an undisambiguated 404/403, any error on either
+   endpoint, or an admin probe that did not return `true`) is **UNKNOWN — NOT "none declared"**: do **not**
+   fall through to the weaker rule, and never claim registration completeness. **Prefer the
    rulesets endpoint — it needs no admin, and the classic endpoint cannot see rulesets at all**
    (`stage-2-ci.md`, "The registration gap").
+
+   **PERSIST THE STATE — `required_set` on the PR row, or it does not exist.** Write the outcome of every
+   required-set read through `scripts/ledger.py … set --pr <N> --required-set declared|none|unknown`
+   (`files-and-ledger.md`). A state kept only in this wake's head is **gone** at the next context loss or
+   driver resume, and CANNOT READ then becomes indistinguishable from NONE DECLARED — the three states
+   collapsing back to two. **`unknown` is the DEFAULT**: a row whose read never succeeded is `unknown`,
+   never `none`. The final report reads **this field**, not a memory (`bailout-and-final-report.md`).
 3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,
    not just the PR/job that woke you. Launch every due action that fits a free slot before returning.
    Launch only what is actually due *and not already in flight* (check ground truth first, never the

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -207,10 +207,47 @@ For each `#PR` to adopt:
    settles; immediately after, **re-poll a fresh snapshot** — that snapshot, not the watch, is what you
    read:
 
+   The re-poll MUST cover **BOTH CHECK FAMILIES** — check runs **and** legacy commit statuses. Polling
+   `/commits/<sha>/check-runs` alone leaves the **entire commit-status family unread**, so a failing
+   Jenkins/CircleCI status is **invisible** and the snapshot reads nonempty and all-success
+   (`stage-2-ci.md`, "Two check families").
+
+   It MUST also be **ATOMIC** and **SHA-SCOPED**: fetch to a temp file **inside `<rundir>`** and
+   promote it to `ci-<pr>-<head_sha>.txt` — SHA-stamped in its first line — **only if every fetch
+   succeeded**. A fetch writes as it goes, so redirecting it straight onto the parsed
+   snapshot leaves the rows that arrived on disk when it dies partway — a nonempty, all-success
+   **partial** snapshot the parser would read as green (`stage-2-ci.md`, "SIX questions, SIX sources").
+   A failed fetch is **NOT EVIDENCE**: `ci = pending`, relaunch the watch, **NEVER** green. Nor is a
+   snapshot missing a **declared required check** — checks register asynchronously, so the consumer must
+   also prove every required check is PRESENT, **from the producer the declaration binds it to**, before
+   reading it as green (`stage-2-ci.md`).
+
    ```
-   # run in background. ';' (not '&&') so the re-poll ALWAYS runs, even when --watch exits non-zero on failure
-   gh pr checks <pr> --watch ; gh pr checks <pr> > <rundir>/ci-<pr>.txt
+   # run in background. ';' (not '&&') so the pinned re-poll ALWAYS runs, even when --watch exits non-zero
+   tmp="$(mktemp -p <rundir>)"   # temp INSIDE <rundir>: mv is an atomic rename only WITHIN a filesystem
+   # BOTH families + the head SHA out of ONE payload: CheckRun rows and StatusContext rows.
+   gh pr checks <pr> --watch ; if gh pr view <pr> --json headRefOid,statusCheckRollup --jq '
+          "# sha: \(.headRefOid)",
+          (.statusCheckRollup[] |
+            if .__typename == "CheckRun"
+            then "checkrun\t\(.name)\t\(.status)\t\(.conclusion)"
+            else "status\t\(.context)\t\(.state)" end)' > "$tmp"; then
+     mv "$tmp" <rundir>/ci-<pr>-<head_sha>.txt   # complete, SHA-stamped — safe to parse
+   else
+     rm -f "$tmp"                     # partial/failed fetch — NOT evidence of anything
+   fi
    ```
+
+   When a declared required check **binds an app** (`app_id` / `integration_id`), also append the
+   producer-bearing rows — `gh api --paginate repos/<owner>/<repo>/commits/<head_sha>/check-runs --jq
+   '.check_runs[] | "app\t\(.name)\t\(.app.id)"' >> "$tmp"` — inside the same `if`, so both fetches are
+   promoted by the same atomic `mv`; the rollup does not carry `.app.id` (`stage-2-ci.md`, "Right name is
+   not right producer").
+
+   `<head_sha>` is the SHA this watch was launched for — the artifact is named and stamped for **that**
+   commit, never for "the PR". The head may have advanced by the time the watch returns; the consumer
+   verifies the stamp against the ledger's current `head_sha` and **discards a superseded snapshot**
+   (`stage-2-ci.md`). That is **expected, not an error**.
 
    Don't launch a duplicate watch for a PR that already has a live one (Loop control tracks in-flight
    watches).

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -210,13 +210,17 @@ For each `#PR` to adopt:
    The re-poll MUST cover **BOTH CHECK FAMILIES** — check runs **and** legacy commit statuses. Polling
    `/commits/<sha>/check-runs` alone leaves the **entire commit-status family unread**, so a failing
    Jenkins/CircleCI status is **invisible** and the snapshot reads nonempty and all-success
-   (`stage-2-ci.md`, "Two check families").
+   (`stage-2-ci.md`, "Two check families"). It takes **TWO fetches**, and **each family is judged ONLY
+   from the fetch that carries both its IDENTITY and its RESULT** — check runs from the SHA-pinned
+   `--paginate` REST fetch (commit + name + `app.id` + status + conclusion in **one row**), commit statuses
+   from the rollup. **NEVER join rows across fetches to reach a verdict** (`stage-2-ci.md`, "The
+   same-observation rule").
 
    It MUST also be **ATOMIC** and **SHA-SCOPED**: fetch to a temp file **inside `<rundir>`** and
-   promote it to `ci-<pr>-<head_sha>.txt` — SHA-stamped in its first line — **only if every fetch
-   succeeded**. A fetch writes as it goes, so redirecting it straight onto the parsed
+   promote it to `ci-<pr>-<head_sha>.txt` — SHA-stamped in its first line **and on every `checkrun` row** —
+   **only if every fetch succeeded**. A fetch writes as it goes, so redirecting it straight onto the parsed
    snapshot leaves the rows that arrived on disk when it dies partway — a nonempty, all-success
-   **partial** snapshot the parser would read as green (`stage-2-ci.md`, "SIX questions, SIX sources").
+   **partial** snapshot the parser would read as green (`stage-2-ci.md`, "SEVEN questions, SEVEN sources").
    A failed fetch is **NOT EVIDENCE**: `ci = pending`, relaunch the watch, **NEVER** green. Nor is a
    snapshot missing a **declared required check** — checks register asynchronously, so the consumer must
    also prove every required check is PRESENT, **from the producer the declaration binds it to**, before
@@ -225,24 +229,30 @@ For each `#PR` to adopt:
    ```
    # run in background. ';' (not '&&') so the pinned re-poll ALWAYS runs, even when --watch exits non-zero
    tmp="$(mktemp -p <rundir>)"   # temp INSIDE <rundir>: mv is an atomic rename only WITHIN a filesystem
-   # BOTH families + the head SHA out of ONE payload: CheckRun rows and StatusContext rows.
+   # (1) ROLLUP — the commit-status family (2) cannot see, + the head SHA ('# sha:' first line), +
+   #     `rollup-checkrun` WITNESS rows (name only) used ONLY for the cross-fetch agreement test below,
+   #     NEVER as a verdict (the rollup carries no app.id, so it cannot identify a run).
+   # (2) CHECK RUNS — the ONLY source of a check-run verdict: one row = commit + identity + result.
    gh pr checks <pr> --watch ; if gh pr view <pr> --json headRefOid,statusCheckRollup --jq '
           "# sha: \(.headRefOid)",
           (.statusCheckRollup[] |
             if .__typename == "CheckRun"
-            then "checkrun\t\(.name)\t\(.status)\t\(.conclusion)"
-            else "status\t\(.context)\t\(.state)" end)' > "$tmp"; then
-     mv "$tmp" <rundir>/ci-<pr>-<head_sha>.txt   # complete, SHA-stamped — safe to parse
+            then "rollup-checkrun\t\(.name)"
+            else "status\t\(.context)\t\(.state)" end)' > "$tmp" \
+     && gh api --paginate repos/<owner>/<repo>/commits/<head_sha>/check-runs --jq '
+          .check_runs[] |
+          "checkrun\t\(.head_sha)\t\(.name)\t\(.app.id // "-")\t\(.status|ascii_upcase)\t\((.conclusion // "null")|ascii_upcase)"
+       ' >> "$tmp"; then
+     mv "$tmp" <rundir>/ci-<pr>-<head_sha>.txt   # BOTH fetches exited 0 — complete, SHA-stamped, safe to parse
    else
      rm -f "$tmp"                     # partial/failed fetch — NOT evidence of anything
    fi
    ```
 
-   When a declared required check **binds an app** (`app_id` / `integration_id`), also append the
-   producer-bearing rows — `gh api --paginate repos/<owner>/<repo>/commits/<head_sha>/check-runs --jq
-   '.check_runs[] | "app\t\(.name)\t\(.app.id)"' >> "$tmp"` — inside the same `if`, so both fetches are
-   promoted by the same atomic `mv`; the rollup does not carry `.app.id` (`stage-2-ci.md`, "Right name is
-   not right producer").
+   **The two fetches are taken at DIFFERENT TIMES.** They MUST agree — same head SHA everywhere, same set
+   of check-run names across the `checkrun` and `rollup-checkrun` rows. **A run present in one and absent
+   from the other means the check state was still MOVING → `ci = pending`, refetch, NEVER green**
+   (`stage-2-ci.md`, "The two fetches are still taken at different times").
 
    `<head_sha>` is the SHA this watch was launched for — the artifact is named and stamped for **that**
    commit, never for "the PR". The head may have advanced by the time the watch returns; the consumer

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -1,9 +1,10 @@
 ### 2b. CI (event-driven)
 
 Each PR has a background task that waits on `gh pr checks --watch`. The watch only **blocks**; it is
-never the source of truth. When the task completes, a wake derives `ci` and writes the `ci`/`reviews_ok`
-result through `scripts/ledger.py … set --pr <N> --ci <state> [--reviews_ok 0]` **by field name**
-(`files-and-ledger.md`), never by hand-editing the row by column position.
+never the source of truth. When the task completes, a wake derives `ci` and writes the
+`ci`/`reviews_ok`/`required_set` result through
+`scripts/ledger.py … set --pr <N> --ci <state> [--required-set declared|none|unknown] [--reviews_ok 0]`
+**by field name** (`files-and-ledger.md`), never by hand-editing the row by column position.
 
 **Derive `ci` from BOTH check families, PINNED TO `head_sha` — never from an unpinned PR-level snapshot.**
 `gh pr checks <pr>` is **not pinned to a commit**: right after a push, the new commit's checks have not
@@ -25,20 +26,30 @@ succeeds, one Jenkins commit status **FAILS** → a check-runs-only snapshot is 
 → `ci = green`. **FALSE.** Deriving CI from `/check-runs` alone does not read a partial set of the
 evidence; it leaves **AN ENTIRE FAMILY UNREAD.**
 
-**The snapshot MUST cover BOTH families.** `gh pr view <pr> --json headRefOid,statusCheckRollup` returns
-both in **ONE** response, and `headRefOid` comes from the **same payload** — so the SHA stamp and the rows
-it stamps cannot disagree. Each `statusCheckRollup[]` entry is discriminated by `__typename`:
+**The snapshot MUST cover BOTH families — and EACH family is judged from the ONE fetch that carries both
+its IDENTITY and its RESULT** ("The same-observation rule", below):
+
+| Family | Judged from | The row carries |
+|---|---|---|
+| **Check runs** | the **SHA-pinned `--paginate` REST check-runs fetch** — the **only** source of a check-run verdict | the commit (`.head_sha`), the **identity** (`.name` **and** `.app.id`) **and** the **result** (`.status`, `.conclusion`) — all in **one row of one payload** |
+| **Commit statuses** | the **rollup** (`gh pr view <pr> --json headRefOid,statusCheckRollup`) — the check-runs endpoint **CANNOT SEE** this family, so the rollup stays **REQUIRED** | the **identity** (`.context`) **and** the **result** (`.state`) — again in one row |
+
+The rollup's `headRefOid` comes from the **same payload** as its rows, so that SHA stamp and the rows it
+stamps cannot disagree. Each `statusCheckRollup[]` entry is discriminated by `__typename`:
 
 | `__typename` | Family | Name field | Result field | Result values |
 |---|---|---|---|---|
-| `CheckRun` | Checks | `.name` | `.conclusion` (with `.status`) | `.status`: `QUEUED`/`IN_PROGRESS`/`COMPLETED`; `.conclusion`: `SUCCESS`/`FAILURE`/`TIMED_OUT`/`CANCELLED`/`ACTION_REQUIRED`/… (null until completed) |
+| `CheckRun` | Checks | `.name` | **NOT USED — the rollup carries no `.app.id`, so it can never identify a check run. Emitted as a `rollup-checkrun` WITNESS row for the cross-fetch agreement test only, NEVER as a verdict.** | — |
 | `StatusContext` | Commit statuses | `.context` | `.state` (there is **no** `.conclusion`) | `SUCCESS`/`FAILURE`/`PENDING`/`ERROR` |
 
-**These are UPPERCASE** (GraphQL enums), unlike the REST endpoints' lowercase `completed`/`success`. A
-`StatusContext` has **NO `.status`/`.conclusion` pair** — it has a single `.state`, and `ERROR` is a
-**failure**, not a curiosity. **Never write a parser that reads `.conclusion` on every row: a
-`StatusContext` yields `null` there, and a `null` conclusion that gets treated as "not a failure" is
-exactly the false green this section exists to prevent.**
+**The rollup's values are UPPERCASE** (GraphQL enums); the **REST** check-runs endpoint's are **lowercase**
+(`completed`/`success`). The fetch below `ascii_upcase`s the REST values so **one** casing reaches the
+parser — but never assume it: a parser that string-compares `SUCCESS` against a raw REST `success` reads a
+passing check as not-passing (wedged at pending) or, worse, an unnormalized comparison quietly matches
+nothing. A `StatusContext` has **NO `.status`/`.conclusion` pair** — it has a single `.state`, and `ERROR`
+is a **failure**, not a curiosity. **Never write a parser that reads `.conclusion` on every row: a
+`status` row has none, and a missing conclusion that gets treated as "not a failure" is exactly the false
+green this section exists to prevent.**
 
 **NEVER derive the legacy family's verdict from the COMBINED status `state`** (`/commits/<sha>/status`'s
 top-level `.state`). It reads **`pending` when there are ZERO statuses** — indistinguishable from
@@ -59,39 +70,78 @@ checks**. Pinning the QUERY is not enough: the **ARTIFACT** must carry the SHA i
 
 ```
 tmp="$(mktemp -p <rundir>)"        # temp INSIDE <rundir>: mv is an atomic rename only WITHIN a filesystem
-# BOTH families + the SHA they belong to, out of ONE payload. The '# sha:' line is emitted by the SAME
-# query that emits the rows, so the stamp can never describe a different commit than the rows do.
+
+# (1) ROLLUP — the COMMIT-STATUS family, which (2) CANNOT SEE, + the SHA GitHub says the head is NOW (the
+#     '# sha:' first line, from the same payload as the rows). Its CheckRun entries are emitted as
+#     `rollup-checkrun` WITNESS rows (name only): they exist ONLY for the cross-fetch agreement test
+#     below and are NEVER read as a verdict — the rollup carries no app.id and so cannot identify a run.
+# (2) CHECK RUNS — pinned to <head_sha> BY THE URL, and the ONLY source of a check-run verdict. ONE row
+#     carries the commit, the IDENTITY (name + app.id) AND the RESULT (status + conclusion), so no
+#     check-run judgment ever has to be joined to another fetch. REST values are lowercase -> upcased to
+#     the rollup's casing. An unbound run has no app -> '-'; an unfinished run has conclusion null.
+# The ORDER is not a guard and proves nothing — the agreement test below is what catches a moving head.
 if gh pr view <pr> --json headRefOid,statusCheckRollup --jq '
       "# sha: \(.headRefOid)",
       (.statusCheckRollup[] |
         if .__typename == "CheckRun"
-        then "checkrun\t\(.name)\t\(.status)\t\(.conclusion)"
-        else "status\t\(.context)\t\(.state)" end)' > "$tmp"; then
-  mv "$tmp" <rundir>/ci-<pr>-<head_sha>.txt   # complete, SHA-stamped — safe to parse
+        then "rollup-checkrun\t\(.name)"
+        else "status\t\(.context)\t\(.state)" end)' > "$tmp" \
+&& gh api --paginate repos/<owner>/<repo>/commits/<head_sha>/check-runs --jq '
+      .check_runs[] |
+      "checkrun\t\(.head_sha)\t\(.name)\t\(.app.id // "-")\t\(.status|ascii_upcase)\t\((.conclusion // "null")|ascii_upcase)"
+   ' >> "$tmp"; then
+  mv "$tmp" <rundir>/ci-<pr>-<head_sha>.txt   # BOTH fetches exited 0 — complete, SHA-stamped, safe to parse
 else
   rm -f "$tmp"                     # partial/failed fetch — NOT evidence of anything
   # ci = pending; relaunch the watch; NEVER parse a partial snapshot, NEVER green
 fi
 ```
 
-`<head_sha>` in the FILENAME is the SHA the watch was launched for; the `# sha:` line **inside** is the
-SHA GitHub says the head is **now**. The consumer checks **both** against the ledger's current `head_sha`
-(below). They disagree exactly when the head moved under the watch — **expected**, and it means
+**BOTH fetches must exit 0** before the snapshot is promoted — a failure in either one is a partial
+snapshot, which is **NOT EVIDENCE** → `ci = pending`, **NEVER green**. The check-runs fetch is **NOT
+optional and NOT conditional on an app binding**: it is where **every** check-run verdict comes from.
+
+`<head_sha>` in the FILENAME is the SHA the watch was launched for — it is also what pins the check-runs
+URL, and it is stamped onto every `checkrun` row by GitHub itself (`.head_sha`). The `# sha:` line is the
+SHA the rollup says the head is **now**. The consumer checks **all** of them against the ledger's current
+`head_sha` (below). They disagree exactly when the head moved under the watch — **expected**, and it means
 **discard**, never green.
 
-**PRODUCER IDENTITY — the rollup carries no `app.id`.** If (and only if) the declared required-check set
-carries an **app binding** (`app_id` / `integration_id` — see "Prove the expected checks registered"),
-**also** fetch the SHA-pinned check runs **with their producer**, appending into the **same** temp file so
-it is promoted by the **same** atomic `mv`:
+#### THE SAME-OBSERVATION RULE — identity and result from ONE fetch, NEVER joined across two
 
-```
-gh api --paginate repos/<owner>/<repo>/commits/<head_sha>/check-runs \
-  --jq '.check_runs[] | "app\t\(.name)\t\(.app.id)"' >> "$tmp"
-```
+**A check's IDENTITY and its RESULT MUST come from THE SAME OBSERVATION. NEVER JOIN ROWS ACROSS FETCHES
+TO REACH A VERDICT.**
 
-**BOTH fetches must exit 0** before the snapshot is promoted — a failure in either one is a partial
-snapshot, which is **NOT EVIDENCE**. If an app-bound required check's producer cannot be resolved from
-the promoted snapshot, its presence is **NOT PROVEN** → `ci = pending`, **NEVER green**.
+The design this replaced did exactly that, and it is a **MIXED-TIME ARTIFACT** that manufactures a false
+green. The rollup carried `name` + result but **no `app.id`**; a check-runs sidecar carried `name` +
+`app.id` but **no result**; the parser **JOINED** them. At **T1** the rollup sees app **999**'s same-named
+`build` **SUCCEED**. The required app-**123** `build` registers **after T1**. At **T2** the sidecar shows a
+`build` from app 123 **EXISTS**. The presence test passes (identity from **T2**); the all-rows-success test
+passes (results from **T1**) → **`ci = green` while app 123's check was NEVER OBSERVED PASSING.** Two
+snapshots taken at two different moments, read as if they were one.
+
+**The fix is NOT an ordering trick.** It is that a `checkrun` row now carries its **commit**, its
+**identity** (`name` + `app.id`) and its **result** (`status` + `conclusion`) **together**, so every
+check-run judgment — including every app-bound required check's **PRESENCE** *and* its **SUCCESS** — is
+made from **that one row of that one fetch**. A `status` row likewise carries its own `context` and
+`state`. **No verdict is ever assembled from two fetches.**
+
+#### THE TWO FETCHES ARE STILL TAKEN AT DIFFERENT TIMES — make their DISAGREEMENT the signal
+
+**Do NOT invent a proof that they are simultaneous: THEY ARE NOT.** They are two reads of a **moving**
+head. The only sound response is to **detect the movement and refuse to conclude**:
+
+- **They MUST agree on the COMMIT.** Every `checkrun` row's `<head_sha>` field **and** the rollup's
+  `# sha:` line MUST equal the ledger's current `head_sha`. Any one of them differing → the head moved
+  under the fetches → **`ci = pending`, refetch, NEVER green.**
+- **They MUST agree on the SET OF CHECK RUNS.** Compare the `checkrun` rows' names against the
+  `rollup-checkrun` witness rows' names. **A run present in one and absent from the other means the check
+  state was still MOVING while we read it** → **`ci = pending`, refetch, NEVER green.** This is precisely
+  the app-123 race above: the run that registers *between* the fetches appears in one list and not the
+  other. **The disagreement IS the signal.** NEVER reconcile it, NEVER take the union, NEVER prefer "the
+  one that looks more complete", NEVER order the fetches so the race "cannot happen" — it can.
+- **`rollup-checkrun` rows are WITNESSES, NOT VERDICTS.** They exist for that comparison and for nothing
+  else. **NEVER read a check run's result, producer, or presence-as-a-required-check off them.**
 
 **`mktemp -p <rundir>` is REQUIRED — NEVER plain `mktemp`.** Plain `mktemp` lands in `$TMPDIR`
 (usually `/tmp`), typically a **different filesystem** from `<rundir>` (which lives in the repo tree).
@@ -115,20 +165,28 @@ only the runs it can SEE. A failing or pending run on page 2 is invisible.
 **The rollup is a BOUNDED WINDOW too — prove you saw ALL of it.** `statusCheckRollup` is a GraphQL
 connection that `gh` requests with a fixed cap (currently the **last 100** contexts). A PR whose combined
 check-run + status-context count reaches that cap gets a **silently TRUNCATED** snapshot — the dropped
-`--paginate` defect wearing a different hat. **If the rollup comes back AT the cap, the set is not proven
-complete → `ci = pending`, NEVER green.** Fall back to the paginated REST endpoints for **BOTH** families
-— `/commits/<head_sha>/check-runs` **and** `/commits/<head_sha>/status`, enumerating `.statuses[]` (REST
-values are **lowercase**; **never** read the combined top-level `.state`) — and stamp `# sha: <head_sha>`
-onto the result as before.
+`--paginate` defect wearing a different hat. It truncates **both** of the things the rollup supplies: the
+`StatusContext` rows the commit-status verdict is made from, **and** the `rollup-checkrun` witnesses the
+agreement test is made from. **If the rollup comes back AT the cap, neither is proven complete →
+`ci = pending`, NEVER green.** Fall back to the paginated REST commit-status endpoint —
+`/commits/<head_sha>/status`, enumerating `.statuses[]` (REST values are **lowercase**; **never** read the
+combined top-level `.state`) — for the status family, and to `/commits/<head_sha>/check-runs` for the
+witnesses; stamp `# sha: <head_sha>` onto the result as before. (Check-run **verdicts** already come from
+the paginated REST fetch and are unaffected by the cap.)
 
 #### VERIFY THE SNAPSHOT'S SHA BEFORE PARSING IT
 
 **NEVER parse a snapshot you cannot prove belongs to the current head.** Before reading any check rows:
 
 1. Read the ledger's current `head_sha` for the PR.
-2. Open `<rundir>/ci-<pr>-<head_sha>.txt` and confirm its `# sha:` line equals that `head_sha`.
-3. **Missing file, or a `# sha:` line that does not match → `ci = pending`, relaunch the watch, NEVER
-   green.** The snapshot describes a commit that no longer matters. **Discard it. NEVER parse it.**
+2. Open `<rundir>/ci-<pr>-<head_sha>.txt` and confirm **every SHA in it** equals that `head_sha`: the
+   `# sha:` line (the rollup's) **and** the `<head_sha>` field on **every** `checkrun` row (the REST
+   fetch's, stamped by GitHub per run).
+3. Confirm the two fetches **AGREE ON THE SET OF CHECK RUNS** — the `checkrun` rows' names and the
+   `rollup-checkrun` witness rows' names are the **same set**.
+4. **Missing file, a SHA that does not match, or a set disagreement → `ci = pending`, relaunch the watch,
+   NEVER green.** A mismatched SHA means the snapshot describes a commit that no longer matters; a set
+   disagreement means the check state was still moving while we read it. **Discard it. NEVER parse it.**
 
 **A watch that finishes for a superseded SHA is NOT an error — it is EXPECTED.** The head advanced under
 it. Its result is simply **discarded**; the relaunched watch observes the current head. NEVER "fix" this
@@ -174,16 +232,49 @@ it against a repo, got 404, concluded "no branch protection", and was right **on
 **did** have a ruleset, which that endpoint cannot see. Had the ruleset declared required checks, the
 method would have reported "none declared."
 
+**AND (b) SUCCEEDING VOUCHES FOR NOTHING ABOUT (a).** They are guarded by **different permissions**:
+**(b) rulesets needs only Metadata: read; (a) classic branch protection needs Administration: read.** A
+token with Metadata but not Administration reads (b) **perfectly** and gets a 404 from (a) **because it
+may not look**. So "(b) answered, therefore the branch's rules are readable" is **FALSE** — it is the
+same "I cannot see any is not there are none" bug, wearing the mask of *a different, more permissive
+endpoint's success*. Causal chain: the repo **HAS** classic required checks; the token lacks
+Administration; (a) → **404**; (b) → **empty**; the read is called **NONE DECLARED**; an early successful
+check records **green while a classic required check is missing entirely.**
+
+**DISAMBIGUATE THE 404 — prove the token may actually look, or it is CANNOT READ:**
+
+```
+# Does this token have Administration: read on the repo? Available on a plain repo read.
+gh api repos/<owner>/<repo> --jq '.permissions.admin'     # true => a 404 from (a) really does mean "unprotected"
+```
+
+**`true` is the ONLY answer that disambiguates.** `false`, absent, null, or an error on this call →
+**the 404 is UNEXPLAINED** → **CANNOT READ**, never NONE DECLARED.
+
 **Classify the read into exactly one of THREE states. NEVER fold the third into the second:**
 
 | State | How you get there | What green requires |
 |---|---|---|
 | **DECLARED** | (a) and/or (b) **succeeded** and the union is **non-empty** | Every required check **PRESENT** in the snapshot — **matched by producer identity** (below) — **and successful**. One that has not registered → `ci = pending`, **NEVER green**. This is the **only** configuration in which registration completeness can be **PROVEN**. |
-| **NONE DECLARED** | **Provable only when the required-set read SUCCEEDED and came back EMPTY** — (b) succeeded and returned no `required_status_checks` rule, **and** (a) either succeeded-and-empty or 404'd **while (b) proves the branch's rules are readable and declare none** | There is **NO expected set**; registration completeness **CANNOT BE PROVEN** — not by campaign, not by the check-runs API, and **not by `mergeStateStatus`** (GitHub cannot block on a check it does not know about either). **SAY SO** — "The registration gap" below. |
-| **CANNOT READ** | **Any** error on **either** endpoint that is not a proven-empty read: 404/403 on (a) **without** Administration: read, any error on (b), a network/rate-limit failure, a malformed response | **UNKNOWN — and UNKNOWN IS NOT "NONE DECLARED."** Do **NOT** silently fall through to the weaker rule. **Record the uncertainty on the PR row and in the report; NEVER claim registration completeness; NEVER state or imply "no required checks are declared."** A required check **may** exist and **may** be missing from the snapshot, and you cannot tell. Retry the read (it may be transient), and **prefer the rulesets endpoint — it needs no admin.** If it still cannot be read, the merge gate rests on GitHub's own `mergeStateStatus == CLEAN` alone (`stage-3-merge.md`) — which **does** know the required set — and campaign must say plainly that **it** could not verify it. |
+| **NONE DECLARED** | **BOTH reads genuinely SUCCEEDED and BOTH came back EMPTY.** (b) succeeded and returned no `required_status_checks` rule, **AND** (a) either **succeeded**-and-empty **or** 404'd **while `.permissions.admin == true` PROVES the token has Administration: read** — i.e. the 404 is proven to mean *unprotected*, not *you may not look*. **(b)'s success is NOT a substitute for that proof: it needs only Metadata: read and says NOTHING about (a).** | There is **NO expected set**; registration completeness **CANNOT BE PROVEN** — not by campaign, not by the check-runs API, and **not by `mergeStateStatus`** (GitHub cannot block on a check it does not know about either). **SAY SO** — "The registration gap" below. |
+| **CANNOT READ** | **Anything else.** Any error on **either** endpoint that is not a proven-empty read: an (a) 404/403 whose cause is **not disambiguated** by `.permissions.admin == true` (false, absent, unknown, or the admin probe itself errored), any error on (b), a network/rate-limit failure, a malformed response | **UNKNOWN — and UNKNOWN IS NOT "NONE DECLARED."** Do **NOT** silently fall through to the weaker rule. **Record it durably on the PR row — `required_set = unknown` via `scripts/ledger.py` (`files-and-ledger.md`) — and in the report; NEVER claim registration completeness; NEVER state or imply "no required checks are declared."** A required check **may** exist and **may** be missing from the snapshot, and you cannot tell. Retry the read (it may be transient), and **prefer the rulesets endpoint — it needs no admin.** If it still cannot be read, the merge gate rests on GitHub's own `mergeStateStatus == CLEAN` alone (`stage-3-merge.md`) — which **does** know the required set — and campaign must say plainly that **it** could not verify it. |
+
+**RECORD THE STATE WHERE IT SURVIVES — `required_set` on the PR row.** The three states are useless if
+they live only in this wake's head: a context loss or a driver resume would leave CANNOT READ and NONE
+DECLARED **indistinguishable**, and the three states would silently collapse back to two. Write the
+outcome of every required-set read to the PR row through `scripts/ledger.py`:
+
+```
+ledger.py --file <state.jsonl> set --pr <N> --required-set declared|none|unknown
+```
+
+**`unknown` is the DEFAULT** (a row that has never had a successful read is `unknown`, not `none`) — the
+fail-safe is **uncertainty**, never a claim of completeness. The final report reads **this field**, not a
+memory (`bailout-and-final-report.md`).
 
 **THE RULE, stated so it cannot be misread: an ERROR that also means "you may not look" is NEVER evidence
-that there is nothing to see. NEVER infer the ABSENCE of a requirement from a failure to read it.**
+that there is nothing to see. NEVER infer the ABSENCE of a requirement from a failure to read it — and
+NEVER let a MORE PERMISSIVE endpoint's success vouch for a MORE RESTRICTED endpoint's error.**
 
 ##### RIGHT NAME IS NOT RIGHT PRODUCER — match the app too
 
@@ -194,16 +285,19 @@ has **not registered yet**. A name-only presence test sees `build` + success →
 PRODUCER**, while the check that actually gates the branch has not run.
 
 - **Required check declares an app binding** (`app_id`/`integration_id` **non-null**) → the presence test
-  MUST match **BOTH** the name **AND** the producer: a snapshot check run whose `.name` equals the context
-  **AND** whose `.app.id` equals that `app_id`. A same-named run from any other app **DOES NOT SATISFY
-  IT.** (`.app.id` comes from the SHA-pinned check-runs fetch — the rollup does not carry it. If the
-  producer cannot be resolved, the check is **NOT PROVEN PRESENT** → `ci = pending`, **NEVER green**.)
+  MUST match **BOTH** the name **AND** the producer: a **single `checkrun` row** whose `<name>` equals the
+  context **AND** whose `<app_id>` equals that `app_id` — **and that SAME row must carry `COMPLETED` +
+  `SUCCESS`.** Presence and success are read **off the one row**, from the one fetch that observed both.
+  **NEVER satisfy the presence test from one fetch and the success test from another** ("The
+  same-observation rule"). A same-named run from any other app **DOES NOT SATISFY IT**, and a row with a
+  `-` producer (the run reports no app) satisfies no app-bound requirement. If no such row exists, the
+  check is **NOT PROVEN PRESENT** → `ci = pending`, **NEVER green**.
 - **Required check declares NO app binding** (`app_id`/`integration_id` **null**) → **ANY producer of that
   name satisfies it.** Do **NOT** over-tighten this: an unbound requirement is genuinely name-only, and
   demanding a producer match there would wedge CI at `pending` forever. Legacy **commit statuses** are
   matched by **context name** the same way.
 
-#### SIX questions, SIX sources — never collapse them
+#### SEVEN questions, SEVEN sources — never collapse them
 
 This is where the defect came from: "never trust exit status, only contents" is right for **deciding**
 green/red/pending, and WRONG as a reason to ignore whether the snapshot is COMPLETE.
@@ -216,13 +310,22 @@ green/red/pending, and WRONG as a reason to ignore whether the snapshot is COMPL
   whether the snapshot is usable **at all**. A failed or partial fetch is **NOT EVIDENCE** — it is
   `ci = pending`, relaunch the watch, and **NEVER** green. NEVER parse a partial snapshot. A rollup at its
   context cap is partial too.
-- **Is the evidence about THIS commit?** → the snapshot's **`# sha:` line** (and its filename) decides
-  whether it may be parsed at all. It MUST equal the ledger's current `head_sha`; if not, the snapshot
-  is about a superseded commit — discard it, `ci = pending`, relaunch, **NEVER** green.
+- **Is the evidence about THIS commit?** → the snapshot's **`# sha:` line**, **every `checkrun` row's
+  `<head_sha>`**, and its filename decide whether it may be parsed at all. All MUST equal the ledger's
+  current `head_sha`; if not, the snapshot is about a superseded commit — discard it, `ci = pending`,
+  relaunch, **NEVER** green.
+- **Is each verdict made from ONE OBSERVATION — and did the two fetches AGREE?** → **identity and result
+  MUST come from the SAME row of the SAME fetch**; a verdict **JOINED** across two fetches taken at two
+  different times is a **MIXED-TIME ARTIFACT**, not evidence. And because the two fetches genuinely are
+  taken at different times, **their DISAGREEMENT about the set of check runs means the state was still
+  MOVING** → `ci = pending`, refetch, **NEVER** green.
 - **Do we KNOW what we expect to see?** → the **REQUIRED-SET READ's outcome** decides whether the next
-  question can be answered at all. **DECLARED / NONE DECLARED / CANNOT READ — three states, never two.**
-  **CANNOT READ is NOT "none declared"**: an error that also means "you may not look" is never evidence
-  that there is nothing to see. Record the uncertainty; never claim completeness.
+  question can be answered at all. **DECLARED / NONE DECLARED / CANNOT READ — three states, never two**,
+  and the state is **PERSISTED** on the PR row (`required_set`, defaulting to `unknown`), never held in a
+  head that the next context loss empties. **CANNOT READ is NOT "none declared"**: an error that also means
+  "you may not look" is never evidence that there is nothing to see — and a **permissive** endpoint
+  answering (rulesets: Metadata read) never vouches for a **restricted** one erroring (classic protection:
+  Administration read). Record the uncertainty; never claim completeness.
 - **Is EVERYTHING WE EXPECT TO SEE THERE, FROM THE RIGHT PRODUCER?** → the **REQUIRED-CHECK SET** (classic
   protection **∪** rulesets) decides whether the snapshot is **COMPLETE AS A SET**. Every required check
   MUST be **present** — **matched on `app.id` too wherever the declaration binds an app** — and
@@ -233,8 +336,9 @@ green/red/pending, and WRONG as a reason to ignore whether the snapshot is COMPL
 - The **WATCH** is none of them: `gh pr checks --watch` only **blocks**. **NEVER infer green from its exit
   code** (it can exit 0 on pending/unregistered checks).
 
-**The pattern — this is the EIGHTH instance of the same defect class in this file: green derived from
-evidence that is INCOMPLETE, or ABOUT THE WRONG THING.**
+**The pattern — this is the ELEVENTH instance of the same defect class in this file: green derived from
+evidence that is INCOMPLETE, or ABOUT THE WRONG THING. Instances 9 and 10 are the class REPRODUCING
+INSIDE THE FIX FOR THE CLASS — read them as proof that the pattern is not "handled".**
 
 1. **unpinned QUERY** → the **WRONG COMMIT's** checks;
 2. **no `--paginate`** → only **PAGE 1**;
@@ -245,29 +349,43 @@ evidence that is INCOMPLETE, or ABOUT THE WRONG THING.**
    a failing Jenkins status invisible;
 7. **NAME-ONLY REQUIRED-CHECK MATCH** → the **WRONG PRODUCER's** same-named check, counted as the
    required one;
-8. **"404 = NOT DECLARED"** → an **UNREADABLE** required-set, read as an **EMPTY** one.
+8. **"404 = NOT DECLARED"** → an **UNREADABLE** required-set, read as an **EMPTY** one;
+9. **RESULTS AND IDENTITY JOINED ACROSS TWO FETCHES TAKEN AT DIFFERENT TIMES** → a required check proven
+   **PRESENT** by the later fetch and proven **PASSING** by the earlier one, which never saw it — a
+   **MIXED-TIME** verdict about a check that was **never observed passing**;
+10. **AN ABSENCE INFERRED FROM AN ERROR BECAUSE A DIFFERENT, MORE PERMISSIVE ENDPOINT ANSWERED** → the
+    **rulesets** read (Metadata: read) succeeding, taken as proof that the **classic protection** 404
+    (Administration: read) meant *unprotected* rather than *you may not look*;
+11. **A RULE THAT SAYS "RECORD IT" INTO A FIELD THAT DOES NOT EXIST** → CANNOT READ written nowhere
+    durable, so the next context loss collapses the three states back to two and the uncertainty vanishes.
 
 Every one produced a nonempty, all-success snapshot that was not the truth about the current head.
 **Before you parse a snapshot: PROVE THE SOURCE IS COMPLETE (no unread check family), PROVE IT IS
-COMPLETE (no missing page, no partial fetch), PROVE IT IS ABOUT THE COMMIT YOU CARE ABOUT, PROVE YOU KNOW
-WHAT YOU EXPECT TO SEE — and PROVE THAT EVERYTHING YOU EXPECT IS THERE, WITH THE IDENTITY YOU EXPECT.**
+COMPLETE (no missing page, no partial fetch), PROVE IT IS ABOUT THE COMMIT YOU CARE ABOUT, PROVE EVERY
+VERDICT COMES FROM ONE OBSERVATION, PROVE YOU KNOW WHAT YOU EXPECT TO SEE — and PROVE THAT EVERYTHING YOU
+EXPECT IS THERE, WITH THE IDENTITY YOU EXPECT.**
 
-**And the rule the eighth instance adds, which generalises past CI: NEVER INFER THE ABSENCE OF A
-REQUIREMENT FROM AN ERROR THAT ALSO MEANS "YOU MAY NOT LOOK." "I cannot see any" is NOT "there are
-none."**
+**And the rules instances 8–11 add, which generalise past CI: NEVER INFER THE ABSENCE OF A REQUIREMENT
+FROM AN ERROR THAT ALSO MEANS "YOU MAY NOT LOOK" — "I cannot see any" is NOT "there are none". NEVER JOIN
+TWO OBSERVATIONS TAKEN AT DIFFERENT TIMES AND READ THE RESULT AS ONE. NEVER LET A PERMISSIVE ENDPOINT'S
+SUCCESS VOUCH FOR A RESTRICTED ENDPOINT'S ERROR. AND A STATE YOU CANNOT PERSIST IS A STATE YOU DO NOT
+HAVE.**
 
-Then decide **from the complete, SHA-verified file's contents**:
+Then decide **from the complete, SHA-verified, cross-fetch-agreeing file's contents**:
 
 - **green** → the snapshot lists **≥1 row**; **every** `checkrun` row has `status = COMPLETED` and
-  `conclusion = SUCCESS`; **every** `status` row has `state = SUCCESS`; **AND every DECLARED required
-  check is present among them — matched on producer where the declaration binds an app — and successful.**
+  `conclusion = SUCCESS`; **every** `status` row has `state = SUCCESS`; the two fetches **agree** (same
+  `head_sha` everywhere, same set of check-run names); **AND every DECLARED required check is present
+  among them — each proven present AND successful from the SAME row, matched on producer where the
+  declaration binds an app.**
   Zero rows is **NOT** green — it means nothing has registered yet. Where **none** are declared, `green`
   means **only** *"every check that had registered by the time we looked had passed"* — read "The
-  registration gap" and never claim more than that. Where the required set **CANNOT BE READ**, green
-  carries the **stronger** caveat that a required check may exist and be missing, and campaign **cannot
-  tell** — never silently treat it as "none declared".
-- **pending** → no usable snapshot (any fetch failed, file absent, rollup at its context cap, or its
-  `# sha:` does not match the ledger's current `head_sha`), zero rows listed, any `checkrun` row not yet
+  registration gap" and never claim more than that. Where the required set **CANNOT BE READ**
+  (`required_set = unknown`), green carries the **stronger** caveat that a required check may exist and be
+  missing, and campaign **cannot tell** — never silently treat it as "none declared".
+- **pending** → no usable snapshot (any fetch failed, file absent, rollup at its context cap, a `# sha:`
+  or `checkrun` row SHA that does not match the ledger's current `head_sha`, **or the two fetches
+  disagreeing about the set of check runs**), zero rows listed, any `checkrun` row not yet
   `COMPLETED`, any `status` row in `PENDING`, **or any declared required check ABSENT from the snapshot
   (name **and** producer), or present but not yet finished** → leave `ci = pending` and, if the watch task
   has exited, **relaunch it in this same wake** — a pending PR must never sit unwatched waiting for the
@@ -299,12 +417,13 @@ coming. A check that registers later could still **FAIL** after `ci = green` was
 "NONE DECLARED" language above says *we know there is no expected set*. **CANNOT READ says we do not know
 whether there is one.** A required check may be declared, may be missing from the snapshot, and campaign
 **cannot tell** — so it must **NEVER** reuse the "none declared" wording, which would assert something it
-did not observe. Record the failed read, name the endpoint and the reason (missing **Administration:
-read** is the common one), and say plainly: **the expected set could not be read, so registration
-completeness is not merely unproven — it is unknown.** Retry, and **prefer the rulesets endpoint, which
-needs no admin.** GitHub's `mergeStateStatus == CLEAN` still applies at merge and **does** know the
-required set (`stage-3-merge.md`) — lean on it, and be explicit that it is GitHub verifying that, not
-campaign.
+did not observe. **Record the failed read DURABLY — `required_set = unknown` on the PR row via
+`scripts/ledger.py`, not in this wake's head** — name the endpoint and the reason (missing
+**Administration: read** is the common one; a **rulesets** read succeeding does **not** excuse it), and say
+plainly: **the expected set could not be read, so registration completeness is not merely unproven — it is
+unknown.** Retry, and **prefer the rulesets endpoint, which needs no admin.** GitHub's
+`mergeStateStatus == CLEAN` still applies at merge and **does** know the required set (`stage-3-merge.md`)
+— lean on it, and be explicit that it is GitHub verifying that, not campaign.
 
 **Never write `ci = green` unconditionally after a watch returns.** The write MUST be conditional on the
 parsed contents above. A guard that runs beside the write rather than gating it is not a guard — this is
@@ -440,9 +559,13 @@ watch's exit code, never derive CI from **one check family** (check runs **and**
 never parse a snapshot whose fetch did not succeed, never parse a snapshot whose
 `# sha:` does not match the ledger's current `head_sha`, never accept checks that are not pinned to
 the current `head_sha`, never call it green while a **declared required check** has not registered **from
-the producer the declaration binds it to**, never read an **unreadable** required-set as an **empty** one
-— and never merge unless GitHub itself reports `MERGEABLE` + `mergeStateStatus == CLEAN`
-(`stage-3-merge.md`).
+the producer the declaration binds it to**, never read an **unreadable** required-set as an **empty** one,
+**never join two observations taken at different times and read the result as one** (identity and result
+come from the **same** row of the **same** fetch; a disagreement **between** fetches means `pending`),
+**never let a permissive endpoint's success vouch for a restricted endpoint's error** (rulesets answering
+proves nothing about a classic-protection 404 — prove `.permissions.admin`), **and never rely on a state
+you cannot persist: `required_set` lives on the PR row, defaulting to `unknown`** — and never merge unless
+GitHub itself reports `MERGEABLE` + `mergeStateStatus == CLEAN` (`stage-3-merge.md`).
 
 CI fixes serialize only within one PR/SHA. Different PRs with red CI may run scoped CI-fix subagents
 concurrently within the dispatcher cap.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -1,29 +1,327 @@
 ### 2b. CI (event-driven)
 
-Each PR has a background task that waits on `gh pr checks --watch`, then **re-polls** `gh pr checks
-<pr>` into `ci-<pr>.txt`. The watch only blocks; the re-polled snapshot is the source of truth. When
-the task completes, a wake reads the file and decides `ci` **from the file's contents — never from
-the watch exit code** — and writes the `ci`/`reviews_ok` result through `scripts/ledger.py … set --pr
-<N> --ci <state> [--reviews_ok 0]` **by field name** (`files-and-ledger.md`), never by hand-editing the
-row by column position:
+Each PR has a background task that waits on `gh pr checks --watch`. The watch only **blocks**; it is
+never the source of truth. When the task completes, a wake derives `ci` and writes the `ci`/`reviews_ok`
+result through `scripts/ledger.py … set --pr <N> --ci <state> [--reviews_ok 0]` **by field name**
+(`files-and-ledger.md`), never by hand-editing the row by column position.
 
-- **green** → ONLY if the snapshot shows **zero failing lines AND zero pending lines** and the
-  expected checks are actually present. `gh pr checks --watch` can exit 0 while checks are still
-  pending or have not yet registered, so a clean exit is not evidence of green.
-- **pending** → any line still pending, or the expected checks haven't appeared yet → not green;
-  leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
-  pending PR must never sit unwatched waiting for the heartbeat.
-- **red** → **if the PR is PARKED** (`status` = `awaiting-user` / `awaiting-api`), record `ci = red` and
-  **dispatch NO fix** — a parked PR dispatches nothing until the user answers (`loop-control.md` step 3).
-  The **watch keeps running** either way: watching is observation, not work-dispatch, so a parked PR's CI
-  state stays fresh. Otherwise → any failing line → **stop any review pass in flight on that PR first** (Loop control
-  step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then
-  **CLASSIFY the failure** from the check logs ("Classify, then set the model" below) **before
-  dispatching anything**, and dispatch a **scoped CI-fix subagent** into `<worktree>` — the PR row's
-  ledger `worktree` column value, the single source of truth for this PR's checkout path (created at
-  adoption/pre-review per `pr-adoption.md`; default `.worktrees/<headRefName>` when campaign creates
-  it, else a reused existing checkout). Its fix commits + pushes to the PR's **own head branch** →
-  **apply the gate reset** below.
+**Derive `ci` from BOTH check families, PINNED TO `head_sha` — never from an unpinned PR-level snapshot.**
+`gh pr checks <pr>` is **not pinned to a commit**: right after a push, the new commit's checks have not
+registered yet, so it happily returns the **previous** commit's passing checks. Reading that snapshot
+records a green that belongs to code the PR no longer contains — a false green on a SHA nothing ever
+tested. The ledger pins `ci` to `head_sha`, so the query that fills it MUST pin too:
+
+#### TWO CHECK FAMILIES — reading one of them is reading HALF the evidence
+
+**GitHub reports CI through TWO INDEPENDENT APIs, and a failure in either one blocks nothing you cannot
+see:**
+
+- **Checks** — check runs (`/commits/<sha>/check-runs`). GitHub Actions, most modern Apps.
+- **Commit statuses** — the legacy status API (`/commits/<sha>/status`). **Jenkins, CircleCI, Buildkite,
+  Travis, and a large fraction of third-party bots still report here.**
+
+**A failing commit status is COMPLETELY INVISIBLE to the check-runs endpoint.** One Actions check run
+succeeds, one Jenkins commit status **FAILS** → a check-runs-only snapshot is **nonempty and all-success**
+→ `ci = green`. **FALSE.** Deriving CI from `/check-runs` alone does not read a partial set of the
+evidence; it leaves **AN ENTIRE FAMILY UNREAD.**
+
+**The snapshot MUST cover BOTH families.** `gh pr view <pr> --json headRefOid,statusCheckRollup` returns
+both in **ONE** response, and `headRefOid` comes from the **same payload** — so the SHA stamp and the rows
+it stamps cannot disagree. Each `statusCheckRollup[]` entry is discriminated by `__typename`:
+
+| `__typename` | Family | Name field | Result field | Result values |
+|---|---|---|---|---|
+| `CheckRun` | Checks | `.name` | `.conclusion` (with `.status`) | `.status`: `QUEUED`/`IN_PROGRESS`/`COMPLETED`; `.conclusion`: `SUCCESS`/`FAILURE`/`TIMED_OUT`/`CANCELLED`/`ACTION_REQUIRED`/… (null until completed) |
+| `StatusContext` | Commit statuses | `.context` | `.state` (there is **no** `.conclusion`) | `SUCCESS`/`FAILURE`/`PENDING`/`ERROR` |
+
+**These are UPPERCASE** (GraphQL enums), unlike the REST endpoints' lowercase `completed`/`success`. A
+`StatusContext` has **NO `.status`/`.conclusion` pair** — it has a single `.state`, and `ERROR` is a
+**failure**, not a curiosity. **Never write a parser that reads `.conclusion` on every row: a
+`StatusContext` yields `null` there, and a `null` conclusion that gets treated as "not a failure" is
+exactly the false green this section exists to prevent.**
+
+**NEVER derive the legacy family's verdict from the COMBINED status `state`** (`/commits/<sha>/status`'s
+top-level `.state`). It reads **`pending` when there are ZERO statuses** — indistinguishable from
+"statuses are still running". It is not a verdict: **the only safe reading of a combined `pending` is
+`pending`, NEVER green.** Enumerate the individual contexts (`statusCheckRollup`'s `StatusContext` rows,
+or `.statuses[]`) and judge each one; a family with **zero** contexts contributes nothing, which is not
+the same as a family that is pending.
+
+**The snapshot is SHA-SCOPED — `ci-<pr>-<head_sha>.txt` — and NAMES ITS SHA in its first line.** A
+shared, SHA-less `ci-<pr>.txt` is a false-green machine: a watch launched for SHA **A** can finish
+**after** the PR has advanced to SHA **B** (campaign pushes fixes constantly; every commit resets the
+gate and moves the head). It fetches A's checks correctly, writes them into the shared file, and the
+consumer parses them against the ledger's current `head_sha` (**B**) — recording **green for B on A's
+checks**. Pinning the QUERY is not enough: the **ARTIFACT** must carry the SHA it describes, in its
+**name** and in its **contents**.
+
+**Fetch ATOMICALLY — NEVER redirect a fetch straight onto the snapshot the parser reads:**
+
+```
+tmp="$(mktemp -p <rundir>)"        # temp INSIDE <rundir>: mv is an atomic rename only WITHIN a filesystem
+# BOTH families + the SHA they belong to, out of ONE payload. The '# sha:' line is emitted by the SAME
+# query that emits the rows, so the stamp can never describe a different commit than the rows do.
+if gh pr view <pr> --json headRefOid,statusCheckRollup --jq '
+      "# sha: \(.headRefOid)",
+      (.statusCheckRollup[] |
+        if .__typename == "CheckRun"
+        then "checkrun\t\(.name)\t\(.status)\t\(.conclusion)"
+        else "status\t\(.context)\t\(.state)" end)' > "$tmp"; then
+  mv "$tmp" <rundir>/ci-<pr>-<head_sha>.txt   # complete, SHA-stamped — safe to parse
+else
+  rm -f "$tmp"                     # partial/failed fetch — NOT evidence of anything
+  # ci = pending; relaunch the watch; NEVER parse a partial snapshot, NEVER green
+fi
+```
+
+`<head_sha>` in the FILENAME is the SHA the watch was launched for; the `# sha:` line **inside** is the
+SHA GitHub says the head is **now**. The consumer checks **both** against the ledger's current `head_sha`
+(below). They disagree exactly when the head moved under the watch — **expected**, and it means
+**discard**, never green.
+
+**PRODUCER IDENTITY — the rollup carries no `app.id`.** If (and only if) the declared required-check set
+carries an **app binding** (`app_id` / `integration_id` — see "Prove the expected checks registered"),
+**also** fetch the SHA-pinned check runs **with their producer**, appending into the **same** temp file so
+it is promoted by the **same** atomic `mv`:
+
+```
+gh api --paginate repos/<owner>/<repo>/commits/<head_sha>/check-runs \
+  --jq '.check_runs[] | "app\t\(.name)\t\(.app.id)"' >> "$tmp"
+```
+
+**BOTH fetches must exit 0** before the snapshot is promoted — a failure in either one is a partial
+snapshot, which is **NOT EVIDENCE**. If an app-bound required check's producer cannot be resolved from
+the promoted snapshot, its presence is **NOT PROVEN** → `ci = pending`, **NEVER green**.
+
+**`mktemp -p <rundir>` is REQUIRED — NEVER plain `mktemp`.** Plain `mktemp` lands in `$TMPDIR`
+(usually `/tmp`), typically a **different filesystem** from `<rundir>` (which lives in the repo tree).
+`mv` is an **atomic rename only within one filesystem**; across filesystems it degrades to
+**copy + unlink**, so the destination is **visible mid-copy** — precisely the partial-file state the
+temp-file dance exists to prevent. A temp file in `<rundir>` makes the promotion a same-directory
+rename. (It also obeys the project rule: scratch goes under `<rundir>`, **NEVER** `/tmp`.)
+
+**Any fetch writes AS IT GOES** — `gh --paginate` streams each page as it arrives, and a single response
+streams as it downloads. `> <rundir>/ci-<pr>-<head_sha>.txt` truncates the snapshot and then streams into
+it, so a fetch that dies partway — network error, rate limit, timeout, SIGTERM — leaves **the rows that
+already arrived on disk**. Parse that and you read a nonempty, all-success file and record **green for a
+SHA whose CI was never fully observed**. The temp file + `mv` makes the snapshot appear **only when every
+fetch completed**.
+
+**`--paginate` is REQUIRED on every REST fetch — NEVER drop it.** `gh api` fetches **one page** unless
+told otherwise, and the check-runs endpoint pages at **30**. A commit with more check runs than one page —
+any matrix build — puts the rest on page 2, and a rule that says "**every** run passed" then evaluates
+only the runs it can SEE. A failing or pending run on page 2 is invisible.
+
+**The rollup is a BOUNDED WINDOW too — prove you saw ALL of it.** `statusCheckRollup` is a GraphQL
+connection that `gh` requests with a fixed cap (currently the **last 100** contexts). A PR whose combined
+check-run + status-context count reaches that cap gets a **silently TRUNCATED** snapshot — the dropped
+`--paginate` defect wearing a different hat. **If the rollup comes back AT the cap, the set is not proven
+complete → `ci = pending`, NEVER green.** Fall back to the paginated REST endpoints for **BOTH** families
+— `/commits/<head_sha>/check-runs` **and** `/commits/<head_sha>/status`, enumerating `.statuses[]` (REST
+values are **lowercase**; **never** read the combined top-level `.state`) — and stamp `# sha: <head_sha>`
+onto the result as before.
+
+#### VERIFY THE SNAPSHOT'S SHA BEFORE PARSING IT
+
+**NEVER parse a snapshot you cannot prove belongs to the current head.** Before reading any check rows:
+
+1. Read the ledger's current `head_sha` for the PR.
+2. Open `<rundir>/ci-<pr>-<head_sha>.txt` and confirm its `# sha:` line equals that `head_sha`.
+3. **Missing file, or a `# sha:` line that does not match → `ci = pending`, relaunch the watch, NEVER
+   green.** The snapshot describes a commit that no longer matters. **Discard it. NEVER parse it.**
+
+**A watch that finishes for a superseded SHA is NOT an error — it is EXPECTED.** The head advanced under
+it. Its result is simply **discarded**; the relaunched watch observes the current head. NEVER "fix" this
+by trusting the stale result, and NEVER treat the mismatch as a bug to work around.
+
+#### PROVE THE EXPECTED CHECKS REGISTERED — a nonempty snapshot is not a COMPLETE one
+
+**"Every run in the snapshot passed" proves every **REGISTERED** run passed. It does NOT prove every
+**EXPECTED** check has **REGISTERED**.** Checks register **ASYNCHRONOUSLY**: a 5-second lint can complete
+and register before a slower workflow — or a GitHub App check — even **EXISTS**. A snapshot taken at that
+moment is pinned, paginated, atomic and SHA-stamped, and **STILL WRONG**: nonempty, all-success → green,
+while the check that would have failed **has not appeared yet**. We already reject the ZERO case; this is
+the SOME case.
+
+The **WATCH cannot supply the missing proof** — it only **BLOCKS**, it is **NEVER evidence**.
+
+**When the repo DECLARES required checks, that declaration IS the expected set. READ IT — from BOTH
+places it can live.** A repo may use classic branch protection, rulesets, or **both**; neither endpoint
+sees the other's declarations:
+
+```
+# (a) classic branch protection. REQUIRES the token to have Administration: read.
+gh api repos/<owner>/<repo>/branches/<base>/protection/required_status_checks \
+  --jq '.checks[] | "\(.context)\t\(.app_id)"'      # app_id is null when unbound
+
+# (b) rulesets. Readable WITHOUT admin — and the classic endpoint CANNOT SEE these.
+gh api repos/<owner>/<repo>/rules/branches/<base> \
+  --jq '.[] | select(.type=="required_status_checks")
+             | .parameters.required_status_checks[] | "\(.context)\t\(.integration_id)"'
+```
+
+The expected set is the **UNION** of both. **Read both — always.** Prefer (b) precisely because it needs
+no admin: a token that cannot read (a) can still read (b), and a required check declared only in a
+ruleset is invisible to (a) at **any** permission level.
+
+##### "I CANNOT SEE ANY" IS NOT "THERE ARE NONE" — three states, NEVER two
+
+**A 404 from the classic protection endpoint does NOT mean "not declared."** That endpoint 404s **BOTH**
+when the branch is unprotected **AND** when the token lacks **Administration: read**. Collapsing those two
+into "not declared" **silently downgrades to the weaker rule** and permits green with a required check
+missing. **This is not hypothetical — it has already happened to an operator of this skill**, who queried
+it against a repo, got 404, concluded "no branch protection", and was right **only by luck**: the repo
+**did** have a ruleset, which that endpoint cannot see. Had the ruleset declared required checks, the
+method would have reported "none declared."
+
+**Classify the read into exactly one of THREE states. NEVER fold the third into the second:**
+
+| State | How you get there | What green requires |
+|---|---|---|
+| **DECLARED** | (a) and/or (b) **succeeded** and the union is **non-empty** | Every required check **PRESENT** in the snapshot — **matched by producer identity** (below) — **and successful**. One that has not registered → `ci = pending`, **NEVER green**. This is the **only** configuration in which registration completeness can be **PROVEN**. |
+| **NONE DECLARED** | **Provable only when the required-set read SUCCEEDED and came back EMPTY** — (b) succeeded and returned no `required_status_checks` rule, **and** (a) either succeeded-and-empty or 404'd **while (b) proves the branch's rules are readable and declare none** | There is **NO expected set**; registration completeness **CANNOT BE PROVEN** — not by campaign, not by the check-runs API, and **not by `mergeStateStatus`** (GitHub cannot block on a check it does not know about either). **SAY SO** — "The registration gap" below. |
+| **CANNOT READ** | **Any** error on **either** endpoint that is not a proven-empty read: 404/403 on (a) **without** Administration: read, any error on (b), a network/rate-limit failure, a malformed response | **UNKNOWN — and UNKNOWN IS NOT "NONE DECLARED."** Do **NOT** silently fall through to the weaker rule. **Record the uncertainty on the PR row and in the report; NEVER claim registration completeness; NEVER state or imply "no required checks are declared."** A required check **may** exist and **may** be missing from the snapshot, and you cannot tell. Retry the read (it may be transient), and **prefer the rulesets endpoint — it needs no admin.** If it still cannot be read, the merge gate rests on GitHub's own `mergeStateStatus == CLEAN` alone (`stage-3-merge.md`) — which **does** know the required set — and campaign must say plainly that **it** could not verify it. |
+
+**THE RULE, stated so it cannot be misread: an ERROR that also means "you may not look" is NEVER evidence
+that there is nothing to see. NEVER infer the ABSENCE of a requirement from a failure to read it.**
+
+##### RIGHT NAME IS NOT RIGHT PRODUCER — match the app too
+
+**A required check can be bound to a specific APP** — `app_id` in classic branch protection,
+`integration_id` in a ruleset. When it is, **the name alone does not identify it**: required check `build`
+from app **123**; app **999** also reports a check named `build`, and it **succeeds**; app 123's `build`
+has **not registered yet**. A name-only presence test sees `build` + success → **green, from the WRONG
+PRODUCER**, while the check that actually gates the branch has not run.
+
+- **Required check declares an app binding** (`app_id`/`integration_id` **non-null**) → the presence test
+  MUST match **BOTH** the name **AND** the producer: a snapshot check run whose `.name` equals the context
+  **AND** whose `.app.id` equals that `app_id`. A same-named run from any other app **DOES NOT SATISFY
+  IT.** (`.app.id` comes from the SHA-pinned check-runs fetch — the rollup does not carry it. If the
+  producer cannot be resolved, the check is **NOT PROVEN PRESENT** → `ci = pending`, **NEVER green**.)
+- **Required check declares NO app binding** (`app_id`/`integration_id` **null**) → **ANY producer of that
+  name satisfies it.** Do **NOT** over-tighten this: an unbound requirement is genuinely name-only, and
+  demanding a producer match there would wedge CI at `pending` forever. Legacy **commit statuses** are
+  matched by **context name** the same way.
+
+#### SIX questions, SIX sources — never collapse them
+
+This is where the defect came from: "never trust exit status, only contents" is right for **deciding**
+green/red/pending, and WRONG as a reason to ignore whether the snapshot is COMPLETE.
+
+- **Did we read every evidence SOURCE?** → the **SET OF FAMILIES QUERIED** decides whether an entire class
+  of failures was even **capable** of appearing. **Checks AND commit statuses — both.** A source you never
+  queried reports nothing, and "nothing" parses as "nothing wrong". A check-runs-only snapshot cannot see a
+  failing Jenkins status **at all**.
+- **Did we get all the evidence from them?** → the **FETCH's exit status** (of **every** fetch) decides
+  whether the snapshot is usable **at all**. A failed or partial fetch is **NOT EVIDENCE** — it is
+  `ci = pending`, relaunch the watch, and **NEVER** green. NEVER parse a partial snapshot. A rollup at its
+  context cap is partial too.
+- **Is the evidence about THIS commit?** → the snapshot's **`# sha:` line** (and its filename) decides
+  whether it may be parsed at all. It MUST equal the ledger's current `head_sha`; if not, the snapshot
+  is about a superseded commit — discard it, `ci = pending`, relaunch, **NEVER** green.
+- **Do we KNOW what we expect to see?** → the **REQUIRED-SET READ's outcome** decides whether the next
+  question can be answered at all. **DECLARED / NONE DECLARED / CANNOT READ — three states, never two.**
+  **CANNOT READ is NOT "none declared"**: an error that also means "you may not look" is never evidence
+  that there is nothing to see. Record the uncertainty; never claim completeness.
+- **Is EVERYTHING WE EXPECT TO SEE THERE, FROM THE RIGHT PRODUCER?** → the **REQUIRED-CHECK SET** (classic
+  protection **∪** rulesets) decides whether the snapshot is **COMPLETE AS A SET**. Every required check
+  MUST be **present** — **matched on `app.id` too wherever the declaration binds an app** — and
+  successful; one that has not registered → `ci = pending`, relaunch, **NEVER** green. **Where none are
+  declared, this question HAS NO ANSWER** — see "The registration gap".
+- **What does the evidence say?** → the **FILE's contents** decide **green / red / pending** — never a
+  command's exit status.
+- The **WATCH** is none of them: `gh pr checks --watch` only **blocks**. **NEVER infer green from its exit
+  code** (it can exit 0 on pending/unregistered checks).
+
+**The pattern — this is the EIGHTH instance of the same defect class in this file: green derived from
+evidence that is INCOMPLETE, or ABOUT THE WRONG THING.**
+
+1. **unpinned QUERY** → the **WRONG COMMIT's** checks;
+2. **no `--paginate`** → only **PAGE 1**;
+3. **partial fetch** → only the pages that **ARRIVED**;
+4. **SHA-less ARTIFACT** → a snapshot for a **SUPERSEDED COMMIT**, parsed as current;
+5. **UNREGISTERED CHECKS** → only the checks that had **APPEARED**, parsed as the whole set;
+6. **ONE CHECK FAMILY** → only **CHECK RUNS**, with the whole legacy **COMMIT-STATUS** family unread —
+   a failing Jenkins status invisible;
+7. **NAME-ONLY REQUIRED-CHECK MATCH** → the **WRONG PRODUCER's** same-named check, counted as the
+   required one;
+8. **"404 = NOT DECLARED"** → an **UNREADABLE** required-set, read as an **EMPTY** one.
+
+Every one produced a nonempty, all-success snapshot that was not the truth about the current head.
+**Before you parse a snapshot: PROVE THE SOURCE IS COMPLETE (no unread check family), PROVE IT IS
+COMPLETE (no missing page, no partial fetch), PROVE IT IS ABOUT THE COMMIT YOU CARE ABOUT, PROVE YOU KNOW
+WHAT YOU EXPECT TO SEE — and PROVE THAT EVERYTHING YOU EXPECT IS THERE, WITH THE IDENTITY YOU EXPECT.**
+
+**And the rule the eighth instance adds, which generalises past CI: NEVER INFER THE ABSENCE OF A
+REQUIREMENT FROM AN ERROR THAT ALSO MEANS "YOU MAY NOT LOOK." "I cannot see any" is NOT "there are
+none."**
+
+Then decide **from the complete, SHA-verified file's contents**:
+
+- **green** → the snapshot lists **≥1 row**; **every** `checkrun` row has `status = COMPLETED` and
+  `conclusion = SUCCESS`; **every** `status` row has `state = SUCCESS`; **AND every DECLARED required
+  check is present among them — matched on producer where the declaration binds an app — and successful.**
+  Zero rows is **NOT** green — it means nothing has registered yet. Where **none** are declared, `green`
+  means **only** *"every check that had registered by the time we looked had passed"* — read "The
+  registration gap" and never claim more than that. Where the required set **CANNOT BE READ**, green
+  carries the **stronger** caveat that a required check may exist and be missing, and campaign **cannot
+  tell** — never silently treat it as "none declared".
+- **pending** → no usable snapshot (any fetch failed, file absent, rollup at its context cap, or its
+  `# sha:` does not match the ledger's current `head_sha`), zero rows listed, any `checkrun` row not yet
+  `COMPLETED`, any `status` row in `PENDING`, **or any declared required check ABSENT from the snapshot
+  (name **and** producer), or present but not yet finished** → leave `ci = pending` and, if the watch task
+  has exited, **relaunch it in this same wake** — a pending PR must never sit unwatched waiting for the
+  heartbeat.
+- **red** → any `checkrun` row whose conclusion is `FAILURE` / `TIMED_OUT` / `CANCELLED` /
+  `ACTION_REQUIRED`, **or any `status` row whose state is `FAILURE` or `ERROR`** (`ERROR` is a failure —
+  never shrug it off as a glitch).
+
+#### The registration gap — stated honestly, NEVER papered over
+
+**When the repo declares NO required checks, campaign CANNOT prove that every check it should have seen
+had registered when it looked.** The check-runs API reports what EXISTS; it cannot report what is still
+coming. A check that registers later could still **FAIL** after `ci = green` was recorded. That is a
+**RESIDUAL RISK, not a solved problem. NEVER describe it as closed.**
+
+**Mitigations — they are MITIGATIONS, not PROOFS. NEVER present any of them as one:**
+
+- the **watch settles first** — `gh pr checks --watch` blocks until the checks it can see have finished,
+  so the snapshot is taken late, not at push time. It narrows the window; it does not close it.
+- **`mergeStateStatus == CLEAN` is REQUIRED at the merge gate** (`stage-3-merge.md`) — it catches a
+  check that HAS registered and is failing or still pending (with no required checks declared, a failing
+  check reads `UNSTABLE`, not `CLEAN`). **It does NOT prove registration completeness**: GitHub cannot
+  block on a check it does not know about either.
+- **THE ACTUAL REMEDY IS THE USER'S:** declaring the checks **REQUIRED** in branch protection or a
+  ruleset gives campaign an expected set to verify, and GitHub a set to block on. **That — and only
+  that — closes the gap for real.** Say so when the question comes up.
+
+**When the required set CANNOT BE READ, the gap is WIDER, not the same — and it is a DIFFERENT gap.** The
+"NONE DECLARED" language above says *we know there is no expected set*. **CANNOT READ says we do not know
+whether there is one.** A required check may be declared, may be missing from the snapshot, and campaign
+**cannot tell** — so it must **NEVER** reuse the "none declared" wording, which would assert something it
+did not observe. Record the failed read, name the endpoint and the reason (missing **Administration:
+read** is the common one), and say plainly: **the expected set could not be read, so registration
+completeness is not merely unproven — it is unknown.** Retry, and **prefer the rulesets endpoint, which
+needs no admin.** GitHub's `mergeStateStatus == CLEAN` still applies at merge and **does** know the
+required set (`stage-3-merge.md`) — lean on it, and be explicit that it is GitHub verifying that, not
+campaign.
+
+**Never write `ci = green` unconditionally after a watch returns.** The write MUST be conditional on the
+parsed contents above. A guard that runs beside the write rather than gating it is not a guard — this is
+a real failure mode: the watch exits, the snapshot is stale or empty, and `green` is recorded anyway.
+
+**On `red`: FIRST, is the PR PARKED?** If `status` is `awaiting-user` or `awaiting-api`, record `ci = red`
+and **dispatch NO fix** — a parked PR is FROZEN and campaign takes no action that MUTATES it until the
+user answers (`loop-control.md` step 3, "parked-status guard"). The **watch keeps running** either way:
+watching is **observation, not work-dispatch**, so a parked PR's CI state stays fresh while it waits.
+
+**Otherwise:** **stop any review pass in flight on that PR first** (Loop control step 3 — the fix will
+replace its SHA, so the verdict is already void; free the slot), then **CLASSIFY the failure** from the
+check logs ("Classify, then set the model" below) **before dispatching anything**, and dispatch a
+**scoped CI-fix subagent** into `<worktree>` — the PR row's ledger `worktree` column value, the single
+source of truth for this PR's checkout path (created at adoption/pre-review per `pr-adoption.md`;
+default `.worktrees/<headRefName>` when campaign creates it, else a reused existing checkout). Its fix
+commits + pushes to the PR's **own head branch** → **apply the gate reset** below.
 
 #### Any campaign commit to the PR head resets the gate
 
@@ -137,8 +435,14 @@ correctness (`stage-2-review-gate.md`). Say that plainly whenever the question c
 
 ---
 
-Every CI failure must be handled; never merge over a red or pending check, and never infer green from
-the watch's exit code alone — always confirm against the re-polled snapshot.
+Every CI failure must be handled; never merge over a red or pending check, never infer green from the
+watch's exit code, never derive CI from **one check family** (check runs **and** commit statuses — both),
+never parse a snapshot whose fetch did not succeed, never parse a snapshot whose
+`# sha:` does not match the ledger's current `head_sha`, never accept checks that are not pinned to
+the current `head_sha`, never call it green while a **declared required check** has not registered **from
+the producer the declaration binds it to**, never read an **unreadable** required-set as an **empty** one
+— and never merge unless GitHub itself reports `MERGEABLE` + `mergeStateStatus == CLEAN`
+(`stage-3-merge.md`).
 
 CI fixes serialize only within one PR/SHA. Different PRs with red CI may run scoped CI-fix subagents
 concurrently within the dispatcher cap.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -33,9 +33,10 @@ only that **nothing GitHub knows about is failing or pending**. It catches a reg
 failing or still running; it does not close the registration gap (`stage-2-ci.md`, "The registration
 gap"). **Require it anyway — and NEVER claim it proves more than it does.**
 
-**When campaign COULD NOT READ the required-check set** (the classic protection endpoint 404s **both** on
-an unprotected branch **and** without **Administration: read** — `stage-2-ci.md`, "Three states, never
-two"), this precondition is doing **more** of the work, not less: GitHub **does** know the required set and
+**When campaign COULD NOT READ the required-check set** (`required_set = unknown` on the PR row — the
+classic protection endpoint 404s **both** on an unprotected branch **and** without **Administration:
+read**, and the rulesets endpoint answering proves nothing about that 404 — `stage-2-ci.md`, "Three states,
+never two"), this precondition is doing **more** of the work, not less: GitHub **does** know the required set and
 will report `BLOCKED` if one is missing or failing, even though campaign cannot enumerate it. **That does
 NOT license treating the unreadable set as empty**, and it does **NOT** relax anything here — `MERGEABLE` +
 `CLEAN` was already mandatory. Say plainly in the report which one verified the required set: **GitHub

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -2,9 +2,10 @@
 
 A PR is mergeable when it is **NOT parked** AND the **live PR head SHA** —
 `gh pr view <pr> --json headRefOid --jq .headRefOid`, keyed by the PR number from the ledger row —
-equals the ledger `head_sha` AND `reviews_ok >= required(tier)` AND `ci == green` — i.e.
-`required(tier)` SATISFIED verdicts (1 if `tier == TRIVIAL`, else 2) and green CI all recorded
-against the live tip. (An adopted PR may have no local worktree checked out, so use the PR's own head
+equals the ledger `head_sha` AND `reviews_ok >= required(tier)` AND `ci == green` **AND GitHub's own
+verdict is `mergeable == MERGEABLE` and `mergeStateStatus == CLEAN`** — i.e. `required(tier)` SATISFIED
+verdicts (1 if `tier == TRIVIAL`, else 2) and green CI all recorded against the live tip, **and GitHub
+agrees the tip is clean**. (An adopted PR may have no local worktree checked out, so use the PR's own head
 via `gh`, never a local `git rev-parse HEAD`.)
 
 **The parked-status guard binds the merge (`loop-control.md` step 3).** A PR whose `status` is
@@ -14,14 +15,41 @@ not lower `reviews_ok`, so a rule that reads only the counters would merge a PR 
 or API change the user has not yet ruled on. Only the user's answer unparks it (`status` back to
 `in_review`); until then it is skipped, never merged.
 
+**GITHUB'S VERDICT IS A HARD MERGE PRECONDITION — NEVER MERGE WITHOUT IT.**
+`gh pr view <pr> --json mergeable,mergeStateStatus` MUST read **`MERGEABLE`** + **`CLEAN`**. It is
+**load-bearing**, not a sanity check: GitHub computes it **knowing the repo's required-check set**, which
+our own snapshot does not.
+
+- **`BLOCKED`** → a **required check is missing or failing**, or a required review is absent. **NEVER
+  merge.** Treat as `ci = pending`: relaunch the watch, re-enter Stage 2.
+- **`UNSTABLE`** → a **non-required check is failing**. **NEVER merge** — campaign requires **all** checks
+  green, not just required ones. Handle it as a red check (Stage 2b).
+- **`BEHIND` / `DIRTY` / `CONFLICTING`** → refresh the PR per step 6 instead of merging it.
+- **Anything other than `CLEAN`** → **NEVER merge.** There is no "close enough" state.
+
+**STATE ITS LIMIT HONESTLY — `CLEAN` does NOT prove that every expected check REGISTERED.** GitHub cannot
+block on a check it does not know about, so where the repo declares **no** required checks, `CLEAN` proves
+only that **nothing GitHub knows about is failing or pending**. It catches a registered check that is
+failing or still running; it does not close the registration gap (`stage-2-ci.md`, "The registration
+gap"). **Require it anyway — and NEVER claim it proves more than it does.**
+
+**When campaign COULD NOT READ the required-check set** (the classic protection endpoint 404s **both** on
+an unprotected branch **and** without **Administration: read** — `stage-2-ci.md`, "Three states, never
+two"), this precondition is doing **more** of the work, not less: GitHub **does** know the required set and
+will report `BLOCKED` if one is missing or failing, even though campaign cannot enumerate it. **That does
+NOT license treating the unreadable set as empty**, and it does **NOT** relax anything here — `MERGEABLE` +
+`CLEAN` was already mandatory. Say plainly in the report which one verified the required set: **GitHub
+did; campaign could not.** **NEVER report "no required checks are declared" off a read that failed.**
+
 1. **Serialize merge operations, not wakes.** A wake may merge multiple PRs, but only one at a time.
    Before each merge, re-confirm the PR is still **not parked** and that both gates still hold against the live PR head SHA
    (`gh pr view <pr> --json headRefOid --jq .headRefOid`, PR number from the ledger row) — a late push
    may have moved the tip past the recorded `head_sha` and reset the gates —
    **and re-fetch `origin/<base>` and re-check
-   `gh pr view <pr> --json mergeable,mergeStateStatus`** — a concurrent run sharing this base may
-   have advanced it since the PR was last reviewed. If it now reads `BEHIND`/`DIRTY`/`CONFLICTING`,
-   refresh the PR per step 6 instead of merging it.
+   `gh pr view <pr> --json mergeable,mergeStateStatus`, which MUST read `MERGEABLE` + `CLEAN`** — a
+   concurrent run sharing this base may have advanced it since the PR was last reviewed, and a check may
+   have registered or failed since the snapshot was taken. Anything other than `CLEAN` → do NOT merge:
+   `BEHIND`/`DIRTY`/`CONFLICTING` → refresh the PR per step 6; `BLOCKED`/`UNSTABLE` → back to Stage 2.
 2. Push guard: `gh pr view <pr> --json state --jq .state` (PR number from the ledger row) must be
    `OPEN`.
 3. Merge — always `gh pr merge <pr> --squash` (use the repo's prevailing merge method if not squash),
@@ -122,9 +150,9 @@ or API change the user has not yet ruled on. Only the user's answer unparks it (
      --remove-label gauntlet-accepted --add-label gauntlet-reviewing`) — the gate and its label move
      together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Then relaunch the CI
      watch and re-enter Stage 2.
-   - Still open, **not parked**, mergeable, not behind/dirty/conflicting, same live `head_sha`,
+   - Still open, **not parked**, `mergeable == MERGEABLE` with `mergeStateStatus == CLEAN`, same live `head_sha`,
      `reviews_ok >= required(tier)`, and `ci == green` → still immediately mergeable; return to step 1
-     in the same wake.
+     in the same wake. Any other `mergeStateStatus` → NOT mergeable.
 
 Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -31,13 +31,18 @@ HEADER_DEFAULTS = {
 
 ROW_FIELDS = (
     "id", "slug", "branch", "worktree", "worktree_owned", "branch_owned", "pr",
-    "head_sha", "reviews_ok", "ci", "tier", "attempts", "started",
+    "head_sha", "reviews_ok", "ci", "required_set", "tier", "attempts", "started",
     "api_approval", "status",
 )
+# `required_set` records the outcome of the required-check-set read (declared | none |
+# unknown). It DEFAULTS TO `unknown`: a row that has never had a successful read must not
+# read as "no required checks are declared" — the fail-safe is uncertainty, never a claim
+# of completeness (`references/stage-2-ci.md`, "Three states, never two").
 ROW_DEFAULTS = {
     "id": "-", "slug": "-", "branch": "-", "worktree": "-", "worktree_owned": "-",
     "branch_owned": "-", "pr": "-", "head_sha": "-", "reviews_ok": "0", "ci": "pending",
-    "tier": "-", "attempts": "0", "started": "-", "api_approval": "-", "status": "pending",
+    "required_set": "unknown", "tier": "-", "attempts": "0", "started": "-",
+    "api_approval": "-", "status": "pending",
 }
 
 


### PR DESCRIPTION
- `gh pr checks` is not pinned to a commit: right after a push it returns the PREVIOUS commit's passing checks, so the skill's own instruction ("derive ci from the re-polled `gh pr checks` snapshot") can record a green for code the PR no longer contains
- found by dogfooding, not by review — it produced a false green on a live run in this repo
- CI is now derived from `gh api .../commits/<head_sha>/check-runs`: green requires ≥1 run, all `completed`, all `success`; zero runs is NOT green
- adds the explicit rule that the ledger write MUST be gated on the parsed contents — a guard that runs beside the write instead of gating it is not a guard
- propagated to all 6 sites that repeated the unpinned instruction