### PR TITLE
bump gauntlet to 0.1.3

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"


### PR DESCRIPTION
Cuts a release so installed plugin copies pick up the content already on `main`.

`plugin.json`'s `version` is the plugin cache key: installed copies only refresh when it changes. `main` currently carries the content of #24 and #27 while `plugin.json` still says `0.1.2` — so **every installed copy is stale right now**, running the old content while claiming to be current.

Version bump only; no content changes.

## Why this lands before the CI-derivation series

CI-status derivation is gate machinery, so the PRs that rewrite it (superseding #26) must be gated by the *installed* campaign, never by their own branch content. This PR establishes **0.1.3 as the trusted stage-0** for that series. No further release should be cut mid-series — otherwise a half-finished CI rewrite becomes the gate that judges the rest of itself, which is exactly how a branch with a broken green rule would feed itself a false `ci = green`.