### PR TITLE
pin CI evidence to head_sha and read both check families

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -170,7 +170,9 @@ Read stage refs only when that stage/action is due:
   changes it (a park does NOT lower `reviews_ok`, so guard on `status` at every dispatch AND mutation
   site). Sole exception: its CI watch keeps running — observing is not mutating. Keep driving the other
   PRs; unpark only on the user's answer (`references/loop-control.md`, "parked-status guard").
-- **No green by watch exit:** derive CI from re-polled `gh pr checks` snapshot.
+- **No green by watch exit:** derive CI from a **SHA-pinned** snapshot of **both** check families
+  (`check-runs` **and** commit `status`), verified against `head_sha` before parsing. **NEVER from `gh pr
+  checks`** — its output carries **no SHA** (`references/stage-2-ci.md`).
 - **Public API changes require user confirmation** unless the ledger's `api_changes` field is `allowed`.
 
 ## Wake Skeleton

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -257,9 +257,18 @@
   Stage 2a. The gate is unchanged — note any fallback pass in the report. See "The reviewer".
 - CI status comes from a **SHA-pinned** snapshot of **BOTH** check families (`commits/<head_sha>/check-runs`
   **and** `commits/<head_sha>/status`), `--paginate`d, promoted atomically, and **SHA-verified before
-  parsing**, with **zero failing AND zero pending rows**. **NEVER from `gh pr checks`** — its output
-  carries **no SHA**, so it can report the **previous** commit's passing checks. **NEVER from the
-  `--watch` exit code** — it can exit 0 with checks unregistered. No green, no merge.
+  parsing**. **NEVER from `gh pr checks`** — its output carries **no SHA**, so it can report the
+  **previous** commit's passing checks. **NEVER from the `--watch` exit code** — it can exit 0 with
+  checks unregistered. No green, no merge.
+  **The DECIDE rule in `stage-2-ci.md` ("DECIDE from the verified file's contents") is THE definition of
+  green — do not restate it, read it.** What a summary must never lose: green needs **≥1 registered
+  evidence row** — **zero rows is NOT green** (nothing has registered yet), and **every** observed row
+  must pass **under the current DECIDE rules** — which is **NOT** the same, weaker test as "no failing
+  and no pending row". Two gaps are **open and disclosed** in `stage-2-ci.md`, and a green claim must
+  respect both: the **REGISTRATION GAP** — green proves only that *what had registered* passed, **never**
+  that the required set is complete; and the **CLASSIFICATION GAP** — the conclusion set the rules map is
+  **not exhaustive** (`SKIPPED` / `NEUTRAL` / `STARTUP_FAILURE` / `STALE` match no rule). **NEVER claim
+  more from a green than those rules and gaps allow.**
 - The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -58,7 +58,7 @@
   `--label gauntlet-run-<run-id>` or `--limit 1000`**: without `--label` the snapshot escapes the run's
   scope and reconcile would act on **other runs' PRs**, and without `--limit` `gh pr list` silently caps
   at **30**. Per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth stays the
-  re-polled `gh pr checks` snapshot.
+  SHA-pinned, SHA-verified snapshot of **both** check families (Stage 2b).
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs
   immediately, ask the user asynchronously, and fold the answer in as its own wake.
 - Public API surface/behavior changes need user confirmation by default (see Constraints). The
@@ -255,8 +255,11 @@
   error — *not* a real finding list / `VERDICT:` line), retry once, then do the equivalent work with
   your own subagents: a fresh, context-isolated subagent review pass in
   Stage 2a. The gate is unchanged — note any fallback pass in the report. See "The reviewer".
-- CI status comes from a re-polled `gh pr checks` snapshot with **zero fail AND zero pending lines** —
-  never from the `--watch` exit code (it can exit 0 on pending/unregistered checks). No green, no merge.
+- CI status comes from a **SHA-pinned** snapshot of **BOTH** check families (`commits/<head_sha>/check-runs`
+  **and** `commits/<head_sha>/status`), `--paginate`d, promoted atomically, and **SHA-verified before
+  parsing**, with **zero failing AND zero pending rows**. **NEVER from `gh pr checks`** — its output
+  carries **no SHA**, so it can report the **previous** commit's passing checks. **NEVER from the
+  `--watch` exit code** — it can exit 0 with checks unregistered. No green, no merge.
 - The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -14,7 +14,7 @@ files from colliding — see "Run identity and concurrency".
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
 | `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1) |
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
-| `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, fetched after the watch, promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
+| `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, fetched **BY THE WAKE** after the watch completes (**the watch never writes it**), promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -14,7 +14,7 @@ files from colliding — see "Run identity and concurrency".
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
 | `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1) |
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
-| `ci-<pr>.txt` | Latest `gh pr checks` snapshot for a PR (re-polled after the watch, not the watch stream) |
+| `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, fetched after the watch, promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
@@ -82,7 +82,8 @@ git-ignored driver bookkeeping, and that is the extent of campaign's on-disk foo
 
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is
 GitHub via `gh`, plus local worktrees** (`gh pr list/view` for PRs and merged/open state, each PR's
-`headRefOid` from `gh` — keyed by PR number — for the live head SHA, `gh pr checks` for live CI, and
+`headRefOid` from `gh` — keyed by PR number — for the live head SHA, a **SHA-pinned** `check-runs` +
+commit-`status` fetch for live CI, and
 the **active launch attempt's** review output files for which verdicts exist on which SHA —
 `review-<pr>-<n>.txt` for attempt 1, `review-<pr>-<n>.a<k>.txt` after a relaunch, counting only the
 attempt named in that pass's `pass_identity`, so a relaunch's verdict is never missed and a dead

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -136,10 +136,12 @@ blocks; each completion is its own wake.
    reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
-2. **Fold in completions.** For any background task that finished (CI watch → a **fresh SHA-pinned
-   snapshot** `ci-<pr>-<head_sha>.txt`, which is **never parsed until its stamp is verified against the
-   ledger's `head_sha`** and is **never** decided from the watch's exit code — Stage 2b, "VERIFY THE
-   STAMP BEFORE PARSING"; review →
+2. **Fold in completions.** For any background task that finished (CI watch → **a WAKE, not an artifact**:
+   the watch **only blocks** and produces **nothing**, so **this wake** performs the SHA-pinned fetch of
+   both check families, **promotes** it atomically to `ci-<pr>-<head_sha>.txt` and **verifies** its stamp
+   against the ledger's **current** `head_sha` before parsing a single line of it — the CI state is
+   **never** decided from the watch's exit code (Stage 2b, "WHO DOES WHAT" and "VERIFY THE STAMP BEFORE
+   PARSING"); review →
    the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
    writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and
    only the attempt named in the current `pass_identity` is read or counted (Stage 2a); CI/review fix),

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -61,7 +61,8 @@ blocks; each completion is its own wake.
      ```
 
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
-     isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
+     isn't enough (merge-gate CI truth stays the SHA-pinned, SHA-verified snapshot of **both** check
+     families, Stage 2b). Wake
      turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, and `reviewer` from the ledger
      header — they govern namespacing, the merge/diff target, API-change handling, and which reviewer runs
      the review passes, and must be

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -136,7 +136,10 @@ blocks; each completion is its own wake.
    reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
-2. **Fold in completions.** For any background task that finished (CI watch → `ci-<pr>.txt`; review →
+2. **Fold in completions.** For any background task that finished (CI watch → a **fresh SHA-pinned
+   snapshot** `ci-<pr>-<head_sha>.txt`, which is **never parsed until its stamp is verified against the
+   ledger's `head_sha`** and is **never** decided from the watch's exit code — Stage 2b, "VERIFY THE
+   STAMP BEFORE PARSING"; review →
    the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
    writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and
    only the attempt named in the current `pass_identity` is read or counted (Stage 2a); CI/review fix),

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -212,18 +212,22 @@ For each `#PR` to adopt:
    head branch on `origin`.
 
 6. **Ensure a live CI watch when `ci = pending`.** Every adopted PR whose CI state is unknown gets a
-   background watch so a settling run wakes the driver. The `--watch` only **blocks** until the run
-   settles; immediately after, **re-poll a fresh snapshot** — that snapshot, not the watch, is what you
-   read:
+   background watch so a settling run wakes the driver. **The backgrounded command is the watch and
+   NOTHING ELSE** — its **ONLY** job is to **block** until the run settles, so that **its completion
+   becomes a wake**:
 
    ```
-   # run in background. ';' (not '&&') so the FETCH ALWAYS runs, even when --watch exits non-zero on failure.
-   # The watch only BLOCKS — it is never evidence. The evidence is the SHA-pinned fetch of BOTH check
-   # families, promoted atomically and stamped with the head_sha it describes: see stage-2-ci.md,
-   # "FETCH — pinned to the SHA, paginated, and BOTH check families". NEVER derive CI from `gh pr checks`:
-   # its output carries NO SHA, so it can report the PREVIOUS commit's passing checks.
-   gh pr checks <pr> --watch ; <SHA-pinned fetch of both families -> <rundir>/ci-<pr>-<head_sha>.txt>
+   # run in background. This is the WHOLE command: it BLOCKS, and that is all it does.
+   gh pr checks <pr> --watch
    ```
+
+   **The background task does NOT fetch, and does NOT write `<rundir>/ci-<pr>-<head_sha>.txt`.** The watch
+   only **blocks** — it is **never evidence**, and its exit code is **never** a CI verdict. The evidence is
+   the SHA-pinned fetch of **both** check families, which the **WAKE** performs, promotes atomically, and
+   verifies against the ledger's current `head_sha` before parsing (Stage 2b, `stage-2-ci.md` — "WHO DOES
+   WHAT" and "FETCH — pinned to the SHA"). Only the wake knows the SHA the ledger currently holds, so only
+   the wake can pin the fetch to it. **NEVER derive CI from `gh pr checks`:** its output carries **NO SHA**,
+   so it can report the **previous** commit's passing checks.
 
    Don't launch a duplicate watch for a PR that already has a live one (Loop control tracks in-flight
    watches).

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -217,8 +217,12 @@ For each `#PR` to adopt:
    read:
 
    ```
-   # run in background. ';' (not '&&') so the re-poll ALWAYS runs, even when --watch exits non-zero on failure
-   gh pr checks <pr> --watch ; gh pr checks <pr> > <rundir>/ci-<pr>.txt
+   # run in background. ';' (not '&&') so the FETCH ALWAYS runs, even when --watch exits non-zero on failure.
+   # The watch only BLOCKS — it is never evidence. The evidence is the SHA-pinned fetch of BOTH check
+   # families, promoted atomically and stamped with the head_sha it describes: see stage-2-ci.md,
+   # "FETCH — pinned to the SHA, paginated, and BOTH check families". NEVER derive CI from `gh pr checks`:
+   # its output carries NO SHA, so it can report the PREVIOUS commit's passing checks.
+   gh pr checks <pr> --watch ; <SHA-pinned fetch of both families -> <rundir>/ci-<pr>-<head_sha>.txt>
    ```
 
    Don't launch a duplicate watch for a PR that already has a live one (Loop control tracks in-flight

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -13,28 +13,34 @@ report the **previous** commit's passing checks, and the ledger records a **gree
 longer contains**. This produced a false green on a live run in this repo, found by dogfooding rather
 than by review. Use `gh pr checks --watch` to **wait**; never to decide.
 
-#### FETCH — pinned to the SHA, paginated, and BOTH check families
+#### FETCH — pinned to the SHA, paginated, BOTH check families, and emitted as JSONL
 
 A source you never queried reports nothing, and "nothing" parses as "nothing wrong". Read **both**:
 
 ```sh
 # (1) CHECK RUNS — pinned to <head_sha> BY THE URL, and the only source of a check-run verdict.
-#     ONE row carries the commit, the IDENTITY (name + app.id + details_url) AND the RESULT (status +
-#     conclusion), so no check-run judgment is ever joined across two fetches. `details_url` is the
+#     ONE object carries the commit, the IDENTITY (name + app_id + id) AND the RESULT (status +
+#     conclusion), so no check-run judgment is ever joined across two fetches. `id` is `details_url`, the
 #     CROSS-SOURCE identity the containment test below compares on — REST `.details_url` and rollup
-#     `.detailsUrl` are the SAME VALUE. REST is lowercase -> upcased.
+#     `.detailsUrl` are the SAME VALUE. REST status/conclusion are lowercase -> upcased.
 gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/check-runs" \
-  --jq ".check_runs[] | \"checkrun <head_sha> \(.name) \(.app.id // \"-\") \(.status|ascii_upcase) \(.conclusion // \"-\"|ascii_upcase) \(.details_url // \"-\")\""
+  --jq '.check_runs[] | {row:"checkrun", sha:"<head_sha>", name:.name, app_id:(.app.id|tostring),
+                         status:(.status|ascii_upcase),
+                         conclusion:((.conclusion // "-")|ascii_upcase),
+                         id:(.details_url // "-")}'
 
 # (2) COMMIT STATUSES — the legacy family, which (1) CANNOT SEE.
 gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/status" \
-  --jq ".statuses[] | \"status <head_sha> \(.context) \(.state|ascii_upcase)\""
+  --jq '.statuses[] | {row:"status", sha:"<head_sha>", context:.context, state:(.state|ascii_upcase)}'
 
 # (3) ROLLUP — WITNESSES ONLY (identity, no verdict). Used ONLY for the containment test below.
 #     The rollup carries no app.id and no commit oid, so it can NEVER be read as a verdict.
 gh pr view <pr> --json statusCheckRollup \
-  --jq '.statusCheckRollup[]? | select(.__typename=="CheckRun") | "witness \(.name) \(.detailsUrl)"'
+  --jq '.statusCheckRollup[]? | select(.__typename=="CheckRun") | {row:"witness", name:.name, id:.detailsUrl}'
 ```
+
+Each `--jq` above emits **one compact JSON object per line** — the artifact is **JSONL**, the same
+machine-read convention as `state.jsonl` and the review plan/progress files (`files-and-ledger.md`).
 
 - **`--paginate` is MANDATORY** — `/check-runs` pages at **30**; without it you parse page one and call
   it the whole set.
@@ -53,19 +59,29 @@ Write to a temp file **inside `<rundir>`** (same filesystem ⇒ `mv` is an atomi
 
 ```sh
 tmp="<rundir>/.ci-<pr>.$$"      # INSIDE <rundir>, so the mv below cannot cross a filesystem
-printf '# sha: %s\n' "<head_sha>" > "$tmp"
+printf '{"row":"header","sha":"%s"}\n' "<head_sha>" > "$tmp"
 #   ... append the three fetches above ...
 mv "$tmp" "<rundir>/ci-<pr>-<head_sha>.txt"
 ```
 
-The artifact's row format — **every EVIDENCE row (`checkrun`, `status`) carries the SHA it is about**:
+The artifact is **JSONL: EVERY line is one JSON object, with NO exceptions** — the header included. There
+is no comment line, no plain-text line, and nothing to special-case: read the file line by line and parse
+each line as JSON. Four `row` types, distinguished by the `row` field — and **every EVIDENCE row
+(`checkrun`, `status`) carries the SHA it is about**:
 
-```
-# sha: <head_sha>
-checkrun <head_sha> <name> <app.id|-> <STATUS> <CONCLUSION|-> <details_url|->
-status   <head_sha> <context> <STATE>
-witness  <name> <detailsUrl>
-```
+| `row` | Fields | Meaning |
+|---|---|---|
+| `header` | `sha` | The `head_sha` the whole file describes. Exactly one, first line. |
+| `checkrun` | `sha`, `name`, `app_id`, `status`, `conclusion`, `id` | Check-run **identity AND verdict**. `conclusion` is `"-"` when absent; `id` is `details_url` (`"-"` when absent). |
+| `status` | `sha`, `context`, `state` | Commit-status **verdict**. |
+| `witness` | `name`, `id` | Rollup **identity only** — **no `sha`, no verdict**. `id` is `detailsUrl`. |
+
+**WHY JSONL, and NOT a space-delimited row: CHECK-RUN NAMES AND STATUS CONTEXTS CONTAIN SPACES.** This
+repo's own two checks are named **`Lint scripts`** and **`Validate plugins`**. A positional parser handed
+`checkrun <sha> Lint scripts 15368 COMPLETED SUCCESS <url>` cannot tell where the name ends and the next
+field begins — it reads name=`Lint`, app_id=`scripts`, and **every** rule below (SHA verification,
+containment, DECIDE) then reads garbage out of shifted fields. In JSON a value containing spaces is just a
+string. **A machine-read artifact must NEVER require guessing where a field ends.**
 
 **`witness` rows are IDENTITY-ONLY, SHA-LESS, and NEVER a verdict.** They exist for **one** purpose: the
 containment test below. **NEVER write a SHA onto a witness row** — the rollup **carries no commit oid at
@@ -73,9 +89,9 @@ all**, so any SHA on that row would be one *we* invented, not one the API vouche
 evidence**. Their SHA-lessness is exactly **WHY** they can never be read as evidence about a commit, and
 why they are exempt from the verify rule instead of being patched into it.
 
-The `detailsUrl` on a witness row is **not** a SHA and not a verdict: it is the **cross-source identity**
-the containment test counts on. It is safe to carry precisely because it is inert — nothing reads a
-result off it.
+The `id` on a witness row (the rollup's `detailsUrl`) is **not** a SHA and not a verdict: it is the
+**cross-source identity** the containment test counts on. It is safe to carry precisely because it is
+inert — nothing reads a result off it.
 
 **If ANY fetch fails, the snapshot is NOT EVIDENCE.** `--paginate` leaves **partial output on disk** when
 it dies mid-run, and an error body lands in the redirect target. A failed or partial fetch → `ci =
@@ -83,26 +99,28 @@ pending`, refetch — **NEVER** parse it, and **NEVER** promote it.
 
 #### VERIFY THE STAMP BEFORE PARSING
 
-Parse the file **only** if the `# sha:` header, **every `checkrun` and `status` row's SHA**, **and** the
-filename all equal the ledger's current `head_sha`. **`witness` rows are EXEMPT** — they carry no SHA and
-no verdict. Any mismatch means the snapshot describes a **superseded commit** → discard it, `ci =
-pending`, refetch. **NEVER** green off it, and never "fix up" the mismatch.
+Parse the file **only** if the `header` row's `.sha`, **every `checkrun` and `status` row's `.sha`**,
+**and** the filename all equal the ledger's current `head_sha`. **`witness` rows are EXEMPT** — they carry
+**no `sha` field at all** and no verdict. Any mismatch means the snapshot describes a **superseded commit**
+→ discard it, `ci = pending`, refetch. **NEVER** green off it, and never "fix up" the mismatch. A line that
+**does not parse as JSON** is a corrupt snapshot — treat it exactly like a failed fetch: `ci = pending`,
+refetch.
 
 **The ledger write is GATED ON the parsed contents.** A guard that runs *beside* the write is not a
 guard.
 
-#### CROSS-FETCH AGREEMENT — MULTISET containment on `details_url`, NOT equality
+#### CROSS-FETCH AGREEMENT — MULTISET containment on `.id`, NOT equality
 
 The fetches are taken at different times, so they can disagree. But the correct test is **containment**,
 not equality — and it is compared on the **identity**, **counting occurrences**:
 
-> **REST ⊇ rollup-witnesses, as MULTISETS over `details_url`.** The identity of a check run is its
-> **`details_url`** (REST `.details_url` ≡ rollup `.detailsUrl` — the **same value**, carrying the Actions
-> job id). For **every** identity, require `count_REST(identity) >= count_rollup(identity)`. If **any**
-> rollup identity appears **FEWER** times in the `checkrun` rows than in the `witness` rows → the REST read
-> is **missing evidence** → `ci = pending`, refetch. A **REST-only** row is **FINE** — it can only *add*
-> evidence and cannot hide a failure, because the REST row carries **identity AND verdict in the same
-> row**.
+> **REST ⊇ rollup-witnesses, as MULTISETS over the `.id` field.** The identity of a check run is its
+> **`details_url`**, carried as `.id` on **both** row types (REST `.details_url` ≡ rollup `.detailsUrl` —
+> the **same value**, carrying the Actions job id). For **every** identity, require
+> `count_checkrun(id) >= count_witness(id)`. If **any** `witness` row's `.id` appears **FEWER** times among
+> the `checkrun` rows than among the `witness` rows → the REST read is **missing evidence** → `ci =
+> pending`, refetch. A **REST-only** row is **FINE** — it can only *add* evidence and cannot hide a
+> failure, because the `checkrun` row carries **identity AND verdict in the same row**.
 
 **NEVER compare on NAME, and NEVER compare as a SET — CHECK-RUN NAMES ARE NOT UNIQUE.** Matrix jobs and
 reusable workflows routinely emit many runs sharing one name: a live `Homebrew/homebrew-core` commit
@@ -134,15 +152,20 @@ change replaces **where the evidence comes from**, not **what it means** — it 
 regresses nor improves the classification. The total classification over the real enum lands in the
 **next PR in this series**. **NEVER read these bullets as complete.**
 
-- **green** → the snapshot lists **≥1 row**; **every** `checkrun` row is `COMPLETED` + `SUCCESS`; **every**
-  `status` row is `SUCCESS`; and containment holds. **Zero rows is NOT green** — it means nothing has
-  registered yet.
-- **pending** → no usable snapshot (any fetch failed, the file is absent, a SHA does not match, or
-  containment fails), zero rows, or any `checkrun` row not yet `COMPLETED` / any `status` row `PENDING`
-  → leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
-  pending PR must never sit unwatched waiting for the heartbeat.
-- **red** → any `checkrun` row whose conclusion is `FAILURE` / `TIMED_OUT` / `CANCELLED` /
-  `ACTION_REQUIRED`, or any `status` row whose state is `FAILURE` or `ERROR` (**`ERROR` is a failure** —
+Read verdicts from the JSON fields: `.status` and `.conclusion` on `checkrun` rows, `.state` on `status`
+rows. The `header` and `witness` rows hold **no verdict** and are never consulted here. "Rows" below means
+**evidence rows** — `checkrun` + `status`; the `header` row does not count toward any of them.
+
+- **green** → the snapshot lists **≥1 evidence row**; **every** `checkrun` row has `.status` `COMPLETED`
+  and `.conclusion` `SUCCESS`; **every** `status` row has `.state` `SUCCESS`; and containment holds.
+  **Zero evidence rows is NOT green** — it means nothing has registered yet.
+- **pending** → no usable snapshot (any fetch failed, the file is absent, a line does not parse as JSON, a
+  `.sha` does not match, or containment fails), zero evidence rows, or any `checkrun` row whose `.status`
+  is not yet `COMPLETED` / any `status` row whose `.state` is `PENDING` → leave `ci = pending` and, if the
+  watch task has exited, **relaunch it in this same wake** — a pending PR must never sit unwatched waiting
+  for the heartbeat.
+- **red** → any `checkrun` row whose `.conclusion` is `FAILURE` / `TIMED_OUT` / `CANCELLED` /
+  `ACTION_REQUIRED`, or any `status` row whose `.state` is `FAILURE` or `ERROR` (**`ERROR` is a failure** —
   never shrug it off as a glitch).
 
   **If the PR is PARKED** (`status` = `awaiting-user` / `awaiting-api`), record `ci = red` and

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -64,10 +64,14 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
 - **`--paginate` is MANDATORY** — `/check-runs` pages at **30**; without it you parse page one and call
   it the whole set.
 - **BOTH families are MANDATORY.** A failing Jenkins/CircleCI **commit status is genuinely invisible** to
-  `/check-runs`: a Kubernetes commit carrying **2 live statuses** reports `check_runs.total_count = 0`.
-- **NEVER read the combined status `.state` as a verdict.** It reports **`pending` at ZERO statuses**
-  (`repos/cli/cli/commits/trunk/status` → `{"state":"pending","total_count":0}`) — an absence, read as a
-  verdict, is a lie in both directions.
+  `/check-runs`: a commit can carry **live commit statuses** while `/check-runs` reports
+  `check_runs.total_count = 0` for that very commit. Read only one family and the other's failures are
+  simply **absent** from your evidence — and an absence parses as "nothing wrong".
+- **NEVER read the combined status `.state` as a verdict.** A commit carrying **ZERO** statuses reports
+  `{"state":"pending","total_count":0}` — an absence, read as a verdict, is a lie in both directions.
+  (Illustrative, and expected to drift: observed on 2026-07-13 on
+  `repos/cli/cli/commits/trunk/status`. Whether *that* commit still carries zero statuses is a **live
+  fact that changes**; the API's behavior **at zero** is the permanent point.)
 - **Honest limit, not a proof:** `/check-runs` is capped at the **1000 most recent check suites**.
   `--paginate` defeats page-size truncation; it does **not** prove completeness at extreme scale. Say
   that, and never claim more.
@@ -197,10 +201,14 @@ exists to prevent, reproduced inside the guard meant to catch it. **Comparing on
 what closes it** — and the null/duplicate guard above is what keeps that identity meaningful.
 
 **NEVER require the two sets to be EQUAL — that never terminates.** GitHub's rollup **omits
-`dynamic`-event check suites BY DESIGN**: on `microsoft/vscode` PR #325532, REST returns **37** runs
-including `copilot-pull-request-reviewer` and the rollup returns **36**, omitting it — **stably, across
-refetches**. That is a by-design asymmetry, **not motion**, so "sets differ → pending, refetch" spins
-forever. This repo ships `gauntlet:copilot-address-reviews`, so its users are exactly the affected ones.
+`dynamic`-event check suites BY DESIGN**: REST can legitimately return a check run — a
+`copilot-pull-request-reviewer` run is one — that the rollup **does not list at all**, and it stays that
+way **across refetches**. (Illustrative, and expected to drift: observed on 2026-07-13 on
+`microsoft/vscode` PR #325532, where the REST read held exactly that run and the rollup did not. The
+**CLAIM** is what is permanent, never the counts on either side.) That asymmetry is **by design, NOT
+motion**, so "sets differ → pending, refetch" spins forever — which is precisely why a **REST-only** row
+is **FINE**. This repo ships `gauntlet:copilot-address-reviews`, so its users are exactly the affected
+ones.
 
 #### DECIDE from the verified file's contents
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -38,15 +38,19 @@ A source you never queried reports nothing, and "nothing" parses as "nothing wro
 #     conclusion), so no check-run judgment is ever joined across two fetches. `id` is `details_url`, the
 #     CROSS-SOURCE identity the containment test below compares on — REST `.details_url` and rollup
 #     `.detailsUrl` are the SAME VALUE. REST status/conclusion are lowercase -> upcased.
+#     `sha` comes from GITHUB'S OWN `.head_sha` on each row — NEVER a literal we substitute in.
 gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/check-runs" \
-  --jq '.check_runs[] | {row:"checkrun", sha:"<head_sha>", name:.name, app_id:(.app.id|tostring),
+  --jq '.check_runs[] | {row:"checkrun", sha:.head_sha, name:.name, app_id:(.app.id|tostring),
                          status:(.status|ascii_upcase),
                          conclusion:((.conclusion // "-")|ascii_upcase),
                          id:(.details_url // "-")}'
 
 # (2) COMMIT STATUSES — the legacy family, which (1) CANNOT SEE.
+#     The response carries the commit ONCE, at the TOP LEVEL (`.sha`) — not on each status. Capture it
+#     first and stamp GITHUB'S value onto every row; again, NEVER a literal we substitute in.
 gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/status" \
-  --jq '.statuses[] | {row:"status", sha:"<head_sha>", context:.context, state:(.state|ascii_upcase)}'
+  --jq '.sha as $sha | .statuses[] |
+        {row:"status", sha:$sha, context:.context, state:(.state|ascii_upcase)}'
 
 # (3) ROLLUP — WITNESSES ONLY (identity, no verdict). Used ONLY for the containment test below.
 #     The rollup carries no app.id and no commit oid, so it can NEVER be read as a verdict.
@@ -67,6 +71,12 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
 - **Honest limit, not a proof:** `/check-runs` is capped at the **1000 most recent check suites**.
   `--paginate` defeats page-size truncation; it does **not** prove completeness at extreme scale. Say
   that, and never claim more.
+- **EVERY evidence row's `sha` MUST come from the RESPONSE, NEVER from a literal you interpolate.** Both
+  APIs return the commit themselves — `.head_sha` on each check run, `.sha` at the top level of the status
+  response — so take it from there. Stamping `sha:"<head_sha>"` into the `--jq` filter would copy the value
+  you *asked for* onto rows you have not checked, and the verify rule below would then compare that copy
+  against its own source: **it could never fail**. The rows must carry what **GitHub said**, so that
+  disagreeing with the ledger is *possible*.
 
 #### PROMOTE it atomically, STAMP it with the SHA it describes
 
@@ -74,6 +84,8 @@ Write to a temp file **inside `<rundir>`** (same filesystem ⇒ `mv` is an atomi
 
 ```sh
 tmp="<rundir>/.ci-<pr>.$$"      # INSIDE <rundir>, so the mv below cannot cross a filesystem
+# The header records the sha we REQUESTED — this is the ONE row whose sha is ours. Every EVIDENCE row's
+# sha comes from GitHub (above), which is what makes the verify rule able to fail at all.
 printf '{"row":"header","sha":"%s"}\n' "<head_sha>" > "$tmp"
 #   ... append the three fetches above ...
 mv "$tmp" "<rundir>/ci-<pr>-<head_sha>.txt"
@@ -84,12 +96,16 @@ is no comment line, no plain-text line, and nothing to special-case: read the fi
 each line as JSON. Four `row` types, distinguished by the `row` field — and **every EVIDENCE row
 (`checkrun`, `status`) carries the SHA it is about**:
 
-| `row` | Fields | Meaning |
-|---|---|---|
-| `header` | `sha` | The `head_sha` the whole file describes. Exactly one, first line. |
-| `checkrun` | `sha`, `name`, `app_id`, `status`, `conclusion`, `id` | Check-run **identity AND verdict**. `conclusion` is `"-"` when absent; `id` is `details_url` (`"-"` when absent). |
-| `status` | `sha`, `context`, `state` | Commit-status **verdict**. |
-| `witness` | `name`, `id` | Rollup **identity only** — **no `sha`, no verdict**. `id` is `detailsUrl`. |
+| `row` | Fields | Meaning | Whose SHA |
+|---|---|---|---|
+| `header` | `sha` | The `head_sha` we **REQUESTED** — what the file was fetched *for*. Exactly one, first line. | **OURS** (the ledger's) |
+| `checkrun` | `sha`, `name`, `app_id`, `status`, `conclusion`, `id` | Check-run **identity AND verdict**. `conclusion` is `"-"` when absent; `id` is `details_url` (`"-"` when absent). | **GITHUB'S** (`.head_sha`) |
+| `status` | `sha`, `context`, `state` | Commit-status **verdict**. | **GITHUB'S** (response `.sha`) |
+| `witness` | `name`, `id` | Rollup **identity only** — **no `sha`, no verdict**. `id` is `detailsUrl`. | — (none exists) |
+
+**The last column is the point of the whole artifact.** The `header` records what we **asked for**; every
+**evidence** row carries the SHA **GitHub itself** put on that row. They come from **two different
+sources**, which is the only reason comparing them can tell you anything.
 
 **WHY JSONL, and NOT a space-delimited row: CHECK-RUN NAMES AND STATUS CONTEXTS CONTAIN SPACES.** This
 repo's own two checks are named **`Lint scripts`** and **`Validate plugins`**. A positional parser handed
@@ -114,6 +130,17 @@ pending`, refetch — **NEVER** parse it, and **NEVER** promote it.
 
 #### VERIFY THE STAMP BEFORE PARSING
 
+**THE PRINCIPLE — A STAMP YOU WROTE YOURSELF IS NOT EVIDENCE.** Verification compares a value **the
+SOURCE produced** against the value **you expected**. Comparing your own literal to your own literal is a
+**tautology dressed as a check**: it passes unconditionally, including on a snapshot fetched for the
+**wrong commit**. That is precisely the *"assumption treated as observation"* failure this whole section
+exists to prevent — **NEVER** build the check out of your own input.
+
+So the check has force **only** because the `checkrun`/`status` rows carry **GitHub's OWN** SHA
+(`.head_sha` / the status response's top-level `.sha`) while the ledger's `head_sha` is **ours**: two
+independent sources, so they **CAN** disagree — and if the snapshot describes a superseded commit, they
+**WILL**.
+
 Parse the file **only** if the `header` row's `.sha`, **every `checkrun` and `status` row's `.sha`**,
 **and** the filename all equal the ledger's current `head_sha`. **`witness` rows are EXEMPT** — they carry
 **no `sha` field at all** and no verdict. Any mismatch means the snapshot describes a **superseded commit**
@@ -121,35 +148,53 @@ Parse the file **only** if the `header` row's `.sha`, **every `checkrun` and `st
 **does not parse as JSON** is a corrupt snapshot — treat it exactly like a failed fetch: `ci = pending`,
 refetch.
 
+The `header` and the filename are **ours**, so checking them catches only a *misfiled* artifact (a stale
+file left in `<rundir>`). The **evidence rows** are what catch a **wrong-commit fetch** — they are the
+part of this rule that can actually fail. **If you ever find yourself writing the ledger's `head_sha` onto
+an evidence row, you have deleted the verification**, not implemented it.
+
 **The ledger write is GATED ON the parsed contents.** A guard that runs *beside* the write is not a
 guard.
 
-#### CROSS-FETCH AGREEMENT — MULTISET containment on `.id`, NOT equality
+#### CROSS-FETCH AGREEMENT — containment on a USABLE `.id`, NOT equality
 
 The fetches are taken at different times, so they can disagree. But the correct test is **containment**,
-not equality — and it is compared on the **identity**, **counting occurrences**:
+not equality — compared on the **per-run identity**, and **only** when that identity can actually tell two
+runs apart:
 
-> **REST ⊇ rollup-witnesses, as MULTISETS over the `.id` field.** The identity of a check run is its
+> **FIRST, the identity must be USABLE — a NULL or DUPLICATED witness identity is UNVERIFIABLE, never
+> "fine".** If **any** `witness` row's `.id` is **null/absent** (`"-"`), **or** two `witness` rows share
+> the **SAME** `.id`, the containment test **CANNOT prove REST saw everything** → `ci = pending`,
+> refetch/escalate — **NEVER green off it**. Only when every witness `.id` is **non-null and unique** does
+> the test below mean anything.
+>
+> **THEN: REST ⊇ rollup-witnesses over the `.id` field.** The identity of a check run is its
 > **`details_url`**, carried as `.id` on **both** row types (REST `.details_url` ≡ rollup `.detailsUrl` —
-> the **same value**, carrying the Actions job id). For **every** identity, require
-> `count_checkrun(id) >= count_witness(id)`. If **any** `witness` row's `.id` appears **FEWER** times among
-> the `checkrun` rows than among the `witness` rows → the REST read is **missing evidence** → `ci =
-> pending`, refetch. A **REST-only** row is **FINE** — it can only *add* evidence and cannot hide a
-> failure, because the `checkrun` row carries **identity AND verdict in the same row**.
+> the **same value**, carrying the Actions job id). **Every** `witness` row's `.id` must appear among the
+> `checkrun` rows' `.id`s. If **any** does not → the REST read is **missing evidence** → `ci = pending`,
+> refetch. A **REST-only** row is **FINE** — it can only *add* evidence and cannot hide a failure, because
+> the `checkrun` row carries **identity AND verdict in the same row**.
 
-**NEVER compare on NAME, and NEVER compare as a SET — CHECK-RUN NAMES ARE NOT UNIQUE.** Matrix jobs and
-reusable workflows routinely emit many runs sharing one name: a live `Homebrew/homebrew-core` commit
-(`1f672559`) carries **16** check runs named `status-check`, **15** named `merge`, and **7** named
-`comment`. A set-of-names test **cannot see a missing duplicate**: if the rollup holds 7 rows named
-`comment` and the REST read returned only 1, `{comment} ⊆ {comment}` **PASSES** while REST is silently
-short **6** runs — **any of which could be the failing one**. That run then never reaches the DECIDE rules
-and the snapshot **greens on incomplete evidence** — the exact defect this whole section exists to
-prevent, reproduced inside the guard meant to catch it. **Counting is what closes it.**
+**WHY the guard fails CLOSED — an identity that cannot distinguish two runs cannot prove one of them was
+seen.** Counting occurrences is **not** a substitute for a usable identity: if two witnesses share id `A`,
+REST can return one row genuinely matching `A` plus a **different, REST-only** row that also carries `A`,
+and `count_checkrun(A) = 2 >= count_witness(A) = 2` **PASSES** while a witnessed run is in fact **MISSING**
+— the extra REST row silently *compensates* for it, and the compensation is invisible. So a degenerate
+identity is treated as **"cannot tell"**, never as **"agrees"**. In practice GitHub Actions gives each job
+a **unique** `details_url` (it carries the job id), so this rarely fires — but **"rarely" is not "never"**,
+and a containment test that silently degrades is **worse** than one that says it cannot tell.
 
-**Count occurrences — do NOT assume the identity is a key.** `details_url` is not *guaranteed* unique for
-non-Actions apps, which is **why** the rule compares multiplicities rather than treating the identity as a
-primary key. The multiset test is correct **either way**: if the identity is unique the counts are all 1
-and it degrades to the set test; if it is not, it still detects the missing duplicate.
+**NEVER compare on NAME — CHECK-RUN NAMES ARE NOT UNIQUE.** Matrix jobs and reusable workflows routinely
+emit **many** check runs sharing **one** name, so a name is **not an identity**. (Illustrative, and
+expected to drift: a live `Homebrew/homebrew-core` commit (`1f672559`) carried, when observed on
+2026-07-13, **dozens** of check runs named `status-check`, and dozens more sharing the names `merge` and
+`comment`. Those are **live counts on an active commit** — they change; the **CLAIM** is what is
+permanent, never the numbers.) A set-of-names test **cannot see a missing duplicate**: if the rollup holds
+*n* rows named `comment` and the REST read returned only **1**, `{comment} ⊆ {comment}` **PASSES** while
+REST is silently short *n−1* runs — **any of which could be the failing one**. That run then never reaches
+the DECIDE rules and the snapshot **greens on incomplete evidence** — the exact defect this whole section
+exists to prevent, reproduced inside the guard meant to catch it. **Comparing on the per-run identity is
+what closes it** — and the null/duplicate guard above is what keeps that identity meaningful.
 
 **NEVER require the two sets to be EQUAL — that never terminates.** GitHub's rollup **omits
 `dynamic`-event check suites BY DESIGN**: on `microsoft/vscode` PR #325532, REST returns **37** runs
@@ -193,12 +238,14 @@ rows. The `header` and `witness` rows hold **no verdict** and are never consulte
 **evidence rows** — `checkrun` + `status`; the `header` row does not count toward any of them.
 
 - **green** → the snapshot lists **≥1 evidence row**; **every** `checkrun` row has `.status` `COMPLETED`
-  and `.conclusion` `SUCCESS`; **every** `status` row has `.state` `SUCCESS`; and containment holds.
+  and `.conclusion` `SUCCESS`; **every** `status` row has `.state` `SUCCESS`; and containment holds **on a
+  usable identity** (every `witness` `.id` non-null and unique).
   **Zero evidence rows is NOT green** — it means nothing has registered yet. This bullet is subject to the
   **registration gap** above: it proves only that **what had registered** passed, **never** that the
   required set is complete.
 - **pending** → no usable snapshot (any fetch failed, the file is absent, a line does not parse as JSON, a
-  `.sha` does not match, or containment fails), zero evidence rows, or any `checkrun` row whose `.status`
+  `.sha` does not match, or containment **cannot be established** — it fails, **or** a `witness` `.id` is
+  null/duplicated so the test proves nothing), zero evidence rows, or any `checkrun` row whose `.status`
   is not yet `COMPLETED` / any `status` row whose `.state` is `PENDING` → leave `ci = pending` and, if the
   watch task has exited, **relaunch it in this same wake** — a pending PR must never sit unwatched waiting
   for the heartbeat.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -19,19 +19,21 @@ A source you never queried reports nothing, and "nothing" parses as "nothing wro
 
 ```sh
 # (1) CHECK RUNS — pinned to <head_sha> BY THE URL, and the only source of a check-run verdict.
-#     ONE row carries the commit, the IDENTITY (name + app.id) AND the RESULT (status + conclusion),
-#     so no check-run judgment is ever joined across two fetches. REST is lowercase -> upcased.
+#     ONE row carries the commit, the IDENTITY (name + app.id + details_url) AND the RESULT (status +
+#     conclusion), so no check-run judgment is ever joined across two fetches. `details_url` is the
+#     CROSS-SOURCE identity the containment test below compares on — REST `.details_url` and rollup
+#     `.detailsUrl` are the SAME VALUE. REST is lowercase -> upcased.
 gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/check-runs" \
-  --jq ".check_runs[] | \"checkrun <head_sha> \(.name) \(.app.id // \"-\") \(.status|ascii_upcase) \(.conclusion // \"-\"|ascii_upcase)\""
+  --jq ".check_runs[] | \"checkrun <head_sha> \(.name) \(.app.id // \"-\") \(.status|ascii_upcase) \(.conclusion // \"-\"|ascii_upcase) \(.details_url // \"-\")\""
 
 # (2) COMMIT STATUSES — the legacy family, which (1) CANNOT SEE.
 gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/status" \
   --jq ".statuses[] | \"status <head_sha> \(.context) \(.state|ascii_upcase)\""
 
-# (3) ROLLUP — WITNESSES ONLY (names, no verdict). Used ONLY for the containment test below.
+# (3) ROLLUP — WITNESSES ONLY (identity, no verdict). Used ONLY for the containment test below.
 #     The rollup carries no app.id and no commit oid, so it can NEVER be read as a verdict.
 gh pr view <pr> --json statusCheckRollup \
-  --jq '.statusCheckRollup[]? | select(.__typename=="CheckRun") | "witness \(.name)"'
+  --jq '.statusCheckRollup[]? | select(.__typename=="CheckRun") | "witness \(.name) \(.detailsUrl)"'
 ```
 
 - **`--paginate` is MANDATORY** — `/check-runs` pages at **30**; without it you parse page one and call
@@ -60,16 +62,20 @@ The artifact's row format — **every EVIDENCE row (`checkrun`, `status`) carrie
 
 ```
 # sha: <head_sha>
-checkrun <head_sha> <name> <app.id|-> <STATUS> <CONCLUSION|->
+checkrun <head_sha> <name> <app.id|-> <STATUS> <CONCLUSION|-> <details_url|->
 status   <head_sha> <context> <STATE>
-witness  <name>
+witness  <name> <detailsUrl>
 ```
 
 **`witness` rows are IDENTITY-ONLY, SHA-LESS, and NEVER a verdict.** They exist for **one** purpose: the
-REST ⊇ rollup-witnesses containment test below. **NEVER write a SHA onto a witness row** — the rollup
-**carries no commit oid at all**, so any SHA on that row would be one *we* invented, not one the API
-vouched for: **fabricated evidence**. Their SHA-lessness is exactly **WHY** they can never be read as
-evidence about a commit, and why they are exempt from the verify rule instead of being patched into it.
+containment test below. **NEVER write a SHA onto a witness row** — the rollup **carries no commit oid at
+all**, so any SHA on that row would be one *we* invented, not one the API vouched for: **fabricated
+evidence**. Their SHA-lessness is exactly **WHY** they can never be read as evidence about a commit, and
+why they are exempt from the verify rule instead of being patched into it.
+
+The `detailsUrl` on a witness row is **not** a SHA and not a verdict: it is the **cross-source identity**
+the containment test counts on. It is safe to carry precisely because it is inert — nothing reads a
+result off it.
 
 **If ANY fetch fails, the snapshot is NOT EVIDENCE.** `--paginate` leaves **partial output on disk** when
 it dies mid-run, and an error body lands in the redirect target. A failed or partial fetch → `ci =
@@ -85,15 +91,32 @@ pending`, refetch. **NEVER** green off it, and never "fix up" the mismatch.
 **The ledger write is GATED ON the parsed contents.** A guard that runs *beside* the write is not a
 guard.
 
-#### CROSS-FETCH AGREEMENT — containment, NOT equality
+#### CROSS-FETCH AGREEMENT — MULTISET containment on `details_url`, NOT equality
 
 The fetches are taken at different times, so they can disagree. But the correct test is **containment**,
-not equality:
+not equality — and it is compared on the **identity**, **counting occurrences**:
 
-> **REST ⊇ rollup-witnesses.** A `witness` name **absent** from the `checkrun` rows → the REST read is
-> missing something → `ci = pending`, refetch. A **REST-only** name is **FINE** — it can only *add*
+> **REST ⊇ rollup-witnesses, as MULTISETS over `details_url`.** The identity of a check run is its
+> **`details_url`** (REST `.details_url` ≡ rollup `.detailsUrl` — the **same value**, carrying the Actions
+> job id). For **every** identity, require `count_REST(identity) >= count_rollup(identity)`. If **any**
+> rollup identity appears **FEWER** times in the `checkrun` rows than in the `witness` rows → the REST read
+> is **missing evidence** → `ci = pending`, refetch. A **REST-only** row is **FINE** — it can only *add*
 > evidence and cannot hide a failure, because the REST row carries **identity AND verdict in the same
 > row**.
+
+**NEVER compare on NAME, and NEVER compare as a SET — CHECK-RUN NAMES ARE NOT UNIQUE.** Matrix jobs and
+reusable workflows routinely emit many runs sharing one name: a live `Homebrew/homebrew-core` commit
+(`1f672559`) carries **16** check runs named `status-check`, **15** named `merge`, and **7** named
+`comment`. A set-of-names test **cannot see a missing duplicate**: if the rollup holds 7 rows named
+`comment` and the REST read returned only 1, `{comment} ⊆ {comment}` **PASSES** while REST is silently
+short **6** runs — **any of which could be the failing one**. That run then never reaches the DECIDE rules
+and the snapshot **greens on incomplete evidence** — the exact defect this whole section exists to
+prevent, reproduced inside the guard meant to catch it. **Counting is what closes it.**
+
+**Count occurrences — do NOT assume the identity is a key.** `details_url` is not *guaranteed* unique for
+non-Actions apps, which is **why** the rule compares multiplicities rather than treating the identity as a
+primary key. The multiset test is correct **either way**: if the identity is unique the counts are all 1
+and it degrades to the set test; if it is not, it still detects the missing duplicate.
 
 **NEVER require the two sets to be EQUAL — that never terminates.** GitHub's rollup **omits
 `dynamic`-event check suites BY DESIGN**: on `microsoft/vscode` PR #325532, REST returns **37** runs

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -1,22 +1,116 @@
 ### 2b. CI (event-driven)
 
-Each PR has a background task that waits on `gh pr checks --watch`, then **re-polls** `gh pr checks
-<pr>` into `ci-<pr>.txt`. The watch only blocks; the re-polled snapshot is the source of truth. When
-the task completes, a wake reads the file and decides `ci` **from the file's contents — never from
-the watch exit code** — and writes the `ci`/`reviews_ok` result through `scripts/ledger.py … set --pr
-<N> --ci <state> [--reviews_ok 0]` **by field name** (`files-and-ledger.md`), never by hand-editing the
-row by column position:
+Each PR has a background task that waits on `gh pr checks --watch`. **The watch only BLOCKS — it is
+never evidence.** When the task completes, a wake **fetches a fresh snapshot pinned to the PR's current
+`head_sha`**, verifies it, and decides `ci` **from the snapshot's contents — NEVER from the watch's exit
+code** — then writes the `ci`/`reviews_ok` result through `scripts/ledger.py … set --pr <N> --ci <state>
+[--reviews_ok 0]` **by field name** (`files-and-ledger.md`), never by hand-editing the row by column
+position.
 
-- **green** → ONLY if the snapshot shows **zero failing lines AND zero pending lines** and the
-  expected checks are actually present. `gh pr checks --watch` can exit 0 while checks are still
-  pending or have not yet registered, so a clean exit is not evidence of green.
-- **pending** → any line still pending, or the expected checks haven't appeared yet → not green;
-  leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
+**NEVER derive CI from `gh pr checks`.** Its output **carries no SHA at all** (`--json headSha` →
+*Unknown JSON field*), so you can never prove which commit it describes — right after a push it can
+report the **previous** commit's passing checks, and the ledger records a **green for code the PR no
+longer contains**. This produced a false green on a live run in this repo, found by dogfooding rather
+than by review. Use `gh pr checks --watch` to **wait**; never to decide.
+
+#### FETCH — pinned to the SHA, paginated, and BOTH check families
+
+A source you never queried reports nothing, and "nothing" parses as "nothing wrong". Read **both**:
+
+```sh
+# (1) CHECK RUNS — pinned to <head_sha> BY THE URL, and the only source of a check-run verdict.
+#     ONE row carries the commit, the IDENTITY (name + app.id) AND the RESULT (status + conclusion),
+#     so no check-run judgment is ever joined across two fetches. REST is lowercase -> upcased.
+gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/check-runs" \
+  --jq ".check_runs[] | \"checkrun <head_sha> \(.name) \(.app.id // \"-\") \(.status|ascii_upcase) \(.conclusion // \"-\"|ascii_upcase)\""
+
+# (2) COMMIT STATUSES — the legacy family, which (1) CANNOT SEE.
+gh api --paginate "repos/<owner>/<repo>/commits/<head_sha>/status" \
+  --jq ".statuses[] | \"status <head_sha> \(.context) \(.state|ascii_upcase)\""
+
+# (3) ROLLUP — WITNESSES ONLY (names, no verdict). Used ONLY for the containment test below.
+#     The rollup carries no app.id and no commit oid, so it can NEVER be read as a verdict.
+gh pr view <pr> --json statusCheckRollup \
+  --jq '.statusCheckRollup[]? | select(.__typename=="CheckRun") | "witness \(.name)"'
+```
+
+- **`--paginate` is MANDATORY** — `/check-runs` pages at **30**; without it you parse page one and call
+  it the whole set.
+- **BOTH families are MANDATORY.** A failing Jenkins/CircleCI **commit status is genuinely invisible** to
+  `/check-runs`: a Kubernetes commit carrying **2 live statuses** reports `check_runs.total_count = 0`.
+- **NEVER read the combined status `.state` as a verdict.** It reports **`pending` at ZERO statuses**
+  (`repos/cli/cli/commits/trunk/status` → `{"state":"pending","total_count":0}`) — an absence, read as a
+  verdict, is a lie in both directions.
+- **Honest limit, not a proof:** `/check-runs` is capped at the **1000 most recent check suites**.
+  `--paginate` defeats page-size truncation; it does **not** prove completeness at extreme scale. Say
+  that, and never claim more.
+
+#### PROMOTE it atomically, STAMP it with the SHA it describes
+
+Write to a temp file **inside `<rundir>`** (same filesystem ⇒ `mv` is an atomic rename), then promote:
+
+```sh
+tmp="<rundir>/.ci-<pr>.$$"      # INSIDE <rundir>, so the mv below cannot cross a filesystem
+printf '# sha: %s\n' "<head_sha>" > "$tmp"
+#   ... append the three fetches above ...
+mv "$tmp" "<rundir>/ci-<pr>-<head_sha>.txt"
+```
+
+The artifact's row format — every row carries the SHA it is about:
+
+```
+# sha: <head_sha>
+checkrun <head_sha> <name> <app.id|-> <STATUS> <CONCLUSION|->
+status   <head_sha> <context> <STATE>
+witness  <name>
+```
+
+**If ANY fetch fails, the snapshot is NOT EVIDENCE.** `--paginate` leaves **partial output on disk** when
+it dies mid-run, and an error body lands in the redirect target. A failed or partial fetch → `ci =
+pending`, refetch — **NEVER** parse it, and **NEVER** promote it.
+
+#### VERIFY THE STAMP BEFORE PARSING
+
+Parse the file **only** if the `# sha:` header, **every** row's SHA, **and** the filename all equal the
+ledger's current `head_sha`. Any mismatch means the snapshot describes a **superseded commit** → discard
+it, `ci = pending`, refetch. **NEVER** green off it, and never "fix up" the mismatch.
+
+**The ledger write is GATED ON the parsed contents.** A guard that runs *beside* the write is not a
+guard.
+
+#### CROSS-FETCH AGREEMENT — containment, NOT equality
+
+The fetches are taken at different times, so they can disagree. But the correct test is **containment**,
+not equality:
+
+> **REST ⊇ rollup-witnesses.** A `witness` name **absent** from the `checkrun` rows → the REST read is
+> missing something → `ci = pending`, refetch. A **REST-only** name is **FINE** — it can only *add*
+> evidence and cannot hide a failure, because the REST row carries **identity AND verdict in the same
+> row**.
+
+**NEVER require the two sets to be EQUAL — that never terminates.** GitHub's rollup **omits
+`dynamic`-event check suites BY DESIGN**: on `microsoft/vscode` PR #325532, REST returns **37** runs
+including `copilot-pull-request-reviewer` and the rollup returns **36**, omitting it — **stably, across
+refetches**. That is a by-design asymmetry, **not motion**, so "sets differ → pending, refetch" spins
+forever. This repo ships `gauntlet:copilot-address-reviews`, so its users are exactly the affected ones.
+
+#### DECIDE from the verified file's contents
+
+- **green** → the snapshot lists **≥1 row**; **every** `checkrun` row is `COMPLETED` + `SUCCESS`; **every**
+  `status` row is `SUCCESS`; and containment holds. **Zero rows is NOT green** — it means nothing has
+  registered yet.
+- **pending** → no usable snapshot (any fetch failed, the file is absent, a SHA does not match, or
+  containment fails), zero rows, or any `checkrun` row not yet `COMPLETED` / any `status` row `PENDING`
+  → leave `ci = pending` and, if the watch task has exited, **relaunch it in this same wake** — a
   pending PR must never sit unwatched waiting for the heartbeat.
-- **red** → **if the PR is PARKED** (`status` = `awaiting-user` / `awaiting-api`), record `ci = red` and
+- **red** → any `checkrun` row whose conclusion is `FAILURE` / `TIMED_OUT` / `CANCELLED` /
+  `ACTION_REQUIRED`, or any `status` row whose state is `FAILURE` or `ERROR` (**`ERROR` is a failure** —
+  never shrug it off as a glitch).
+
+  **If the PR is PARKED** (`status` = `awaiting-user` / `awaiting-api`), record `ci = red` and
   **dispatch NO fix** — a parked PR dispatches nothing until the user answers (`loop-control.md` step 3).
   The **watch keeps running** either way: watching is observation, not work-dispatch, so a parked PR's CI
-  state stays fresh. Otherwise → any failing line → **stop any review pass in flight on that PR first** (Loop control
+  state stays fresh. Otherwise → any failing row → **stop any review pass in flight on that PR first** (Loop control
   step 3 — the fix will replace its SHA, so the verdict is already void; free the slot), then
   **CLASSIFY the failure** from the check logs ("Classify, then set the model" below) **before
   dispatching anything**, and dispatch a **scoped CI-fix subagent** into `<worktree>` — the PR row's
@@ -138,7 +232,8 @@ correctness (`stage-2-review-gate.md`). Say that plainly whenever the question c
 ---
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
-the watch's exit code alone — always confirm against the re-polled snapshot.
+the watch's exit code — always confirm against a **SHA-pinned, SHA-verified** snapshot of **both** check
+families.
 
 CI fixes serialize only within one PR/SHA. Different PRs with red CI may run scoped CI-fix subagents
 concurrently within the dispatcher cap.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -56,7 +56,7 @@ printf '# sha: %s\n' "<head_sha>" > "$tmp"
 mv "$tmp" "<rundir>/ci-<pr>-<head_sha>.txt"
 ```
 
-The artifact's row format — every row carries the SHA it is about:
+The artifact's row format — **every EVIDENCE row (`checkrun`, `status`) carries the SHA it is about**:
 
 ```
 # sha: <head_sha>
@@ -65,15 +65,22 @@ status   <head_sha> <context> <STATE>
 witness  <name>
 ```
 
+**`witness` rows are IDENTITY-ONLY, SHA-LESS, and NEVER a verdict.** They exist for **one** purpose: the
+REST ⊇ rollup-witnesses containment test below. **NEVER write a SHA onto a witness row** — the rollup
+**carries no commit oid at all**, so any SHA on that row would be one *we* invented, not one the API
+vouched for: **fabricated evidence**. Their SHA-lessness is exactly **WHY** they can never be read as
+evidence about a commit, and why they are exempt from the verify rule instead of being patched into it.
+
 **If ANY fetch fails, the snapshot is NOT EVIDENCE.** `--paginate` leaves **partial output on disk** when
 it dies mid-run, and an error body lands in the redirect target. A failed or partial fetch → `ci =
 pending`, refetch — **NEVER** parse it, and **NEVER** promote it.
 
 #### VERIFY THE STAMP BEFORE PARSING
 
-Parse the file **only** if the `# sha:` header, **every** row's SHA, **and** the filename all equal the
-ledger's current `head_sha`. Any mismatch means the snapshot describes a **superseded commit** → discard
-it, `ci = pending`, refetch. **NEVER** green off it, and never "fix up" the mismatch.
+Parse the file **only** if the `# sha:` header, **every `checkrun` and `status` row's SHA**, **and** the
+filename all equal the ledger's current `head_sha`. **`witness` rows are EXEMPT** — they carry no SHA and
+no verdict. Any mismatch means the snapshot describes a **superseded commit** → discard it, `ci =
+pending`, refetch. **NEVER** green off it, and never "fix up" the mismatch.
 
 **The ledger write is GATED ON the parsed contents.** A guard that runs *beside* the write is not a
 guard.
@@ -95,6 +102,14 @@ refetches**. That is a by-design asymmetry, **not motion**, so "sets differ → 
 forever. This repo ships `gauntlet:copilot-address-reviews`, so its users are exactly the affected ones.
 
 #### DECIDE from the verified file's contents
+
+**KNOWN GAP — these three bullets are NOT an exhaustive mapping.** The conclusion set below is **carried
+over unchanged from `main`** and is **known to be incomplete**: `SKIPPED`, `NEUTRAL`, `STARTUP_FAILURE`
+and `STALE` are real `CheckConclusionState` values (live `completed`/`skipped` runs exist on
+`nodejs/node`) and a `COMPLETED` check run holding one of them matches **none** of the three rules. This
+change replaces **where the evidence comes from**, not **what it means** — it deliberately neither
+regresses nor improves the classification. The total classification over the real enum lands in the
+**next PR in this series**. **NEVER read these bullets as complete.**
 
 - **green** → the snapshot lists **≥1 row**; **every** `checkrun` row is `COMPLETED` + `SUCCESS`; **every**
   `status` row is `SUCCESS`; and containment holds. **Zero rows is NOT green** — it means nothing has

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -7,6 +7,21 @@ code** — then writes the `ci`/`reviews_ok` result through `scripts/ledger.py �
 [--reviews_ok 0]` **by field name** (`files-and-ledger.md`), never by hand-editing the row by column
 position.
 
+#### WHO DOES WHAT — the background task ONLY WATCHES; the WAKE fetches. This section is the DEFINITION.
+
+**This split is normative, and every other file defers to it** (`pr-adoption.md`, `loop-control.md`):
+
+| Actor | Does | Does NOT |
+|---|---|---|
+| **The background task** | **BLOCKS on `gh pr checks <pr> --watch`, and NOTHING else.** Its **ONLY** job is to block, so that **its completion becomes a wake**. | It **NEVER** fetches, **NEVER** writes `ci-<pr>-<head_sha>.txt`, and **NEVER** produces evidence of any kind. |
+| **The wake** | **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci`. | — |
+
+**WHY the fetch cannot live in the background task:** the fetch must be pinned to the `head_sha` **the
+LEDGER currently holds**, and **only the wake knows that**. A background task that fetched at its own
+completion time would pin to whatever SHA *it* saw and could **promote an artifact for a SHA the ledger has
+already moved past** — the exact false-green this section exists to prevent, smuggled back in through the
+producer. **A watch completion yields a WAKE, never an artifact.**
+
 **NEVER derive CI from `gh pr checks`.** Its output **carries no SHA at all** (`--json headSha` →
 *Unknown JSON field*), so you can never prove which commit it describes — right after a push it can
 report the **previous** commit's passing checks, and the ledger records a **green for code the PR no
@@ -152,13 +167,36 @@ change replaces **where the evidence comes from**, not **what it means** — it 
 regresses nor improves the classification. The total classification over the real enum lands in the
 **next PR in this series**. **NEVER read these bullets as complete.**
 
+**KNOWN GAP — THE REGISTRATION GAP: `green` here does NOT mean the required set passed.** `main`'s green
+rule also demanded that "**the expected checks are actually present**". This change does **NOT** carry that
+requirement forward, and that omission is a **deliberate, disclosed** one — not an oversight, and **not** a
+claim that the risk is gone:
+
+- **Why it is dropped: `main`'s version was UNIMPLEMENTABLE.** `main` names **no mechanism** for knowing
+  what checks are *expected* — it demands a comparison against a set it never defines. The rule below is an
+  **honest restatement of what the evidence can actually deliver**, not a weakening dressed up as one.
+- **THE RISK IS REAL AND IT IS NAMED.** Where required checks exist but have **not registered yet** on the
+  `head_sha`, a snapshot holding **one** registered, successful check derives **green** — and campaign can
+  merge over a required check it **never saw**. `green` here means **ONLY**: *"every check that had
+  registered by the time we looked had passed."* It does **NOT** mean the required set passed, and it does
+  **NOT** mean the required set is complete.
+- **NEVER claim more than the registration gap allows when reporting a green.** Not in the ledger, not in
+  the report, not to the user. `green` is a statement about **what was observed**, never about what was
+  **expected**.
+- **The mechanism that closes it lands in the `required-set` PR later in this series** — it reads the base
+  branch's required checks from **branch protection + rulesets**, records `required_set` as
+  DECLARED / NONE DECLARED / CANNOT READ, and makes `green` require **every declared required check to be
+  present AND passing**. Until that lands, this gap is **open**.
+
 Read verdicts from the JSON fields: `.status` and `.conclusion` on `checkrun` rows, `.state` on `status`
 rows. The `header` and `witness` rows hold **no verdict** and are never consulted here. "Rows" below means
 **evidence rows** — `checkrun` + `status`; the `header` row does not count toward any of them.
 
 - **green** → the snapshot lists **≥1 evidence row**; **every** `checkrun` row has `.status` `COMPLETED`
   and `.conclusion` `SUCCESS`; **every** `status` row has `.state` `SUCCESS`; and containment holds.
-  **Zero evidence rows is NOT green** — it means nothing has registered yet.
+  **Zero evidence rows is NOT green** — it means nothing has registered yet. This bullet is subject to the
+  **registration gap** above: it proves only that **what had registered** passed, **never** that the
+  required set is complete.
 - **pending** → no usable snapshot (any fetch failed, the file is absent, a line does not parse as JSON, a
   `.sha` does not match, or containment fails), zero evidence rows, or any `checkrun` row whose `.status`
   is not yet `COMPLETED` / any `status` row whose `.state` is `PENDING` → leave `ci = pending` and, if the


### PR DESCRIPTION
First of the PRs replacing #26 (closed). **Evidence acquisition only** — where the CI evidence comes from and how we prove it is about the right commit. What the evidence *means* is deliberately left alone; see "Deliberately not in this PR" below.

## The bug

`gh pr checks` **carries no SHA at all** (`--json headSha` → *Unknown JSON field*), so you can never prove which commit its output describes. Right after a push it can report the **previous** commit's passing checks, and the ledger records a **green for code the PR no longer contains**. This produced a false green on a live run in this repo — found by dogfooding, not by review.

## The fix

- **Pin every fetch to `head_sha`** via `commits/<head_sha>/check-runs`, `--paginate`d (the endpoint pages at 30 — without it you parse page one and call it the whole set).
- **Read BOTH check families.** A failing Jenkins/CircleCI **commit status is genuinely invisible** to `/check-runs`: a Kubernetes commit with **2 live statuses** reports `check_runs.total_count = 0`. Reading one family is reading half the evidence.
- **Never read the combined status `.state` as a verdict** — it reports `pending` at **zero** statuses (`repos/cli/cli/commits/trunk/status` → `{"state":"pending","total_count":0}`).
- **Promote atomically and stamp the artifact with the SHA it describes; verify the stamp before parsing.** A partial `--paginate` leaves output on disk when it dies mid-run, so a failed fetch is not evidence.
- **Cross-fetch agreement is CONTAINMENT, not equality:** REST ⊇ rollup-witnesses. A REST-only name is fine — it can only *add* evidence and cannot hide a failure, because the REST row carries identity **and** verdict in the same row.
- Propagated to the **6 other sites** that named the unpinned snapshot as a derivation source.

## Why containment and not equality

#26 required the two sets to be **equal**. That **never terminates**: GitHub's rollup **omits `dynamic`-event check suites by design** — on `microsoft/vscode` PR #325532, REST returns 37 runs including `copilot-pull-request-reviewer` and the rollup returns 36, omitting it, **stably across refetches**. A by-design asymmetry is not motion, so "sets differ → pending, refetch" spins forever. This repo ships `gauntlet:copilot-address-reviews`, so its users are exactly the affected population.

## Deliberately NOT in this PR

- **Classification.** The green/red/pending rules are carried over **unchanged**, still expressed over the new rows. They are **still wrong** — `SKIPPED`/`NEUTRAL` match no rule, and `STARTUP_FAILURE`/`STALE` are failures absent from the red list. That is **PR C** (total function over the real 9-value enum). This PR does not regress it; it does not fix it either.
- **Liveness** (SETTLED + escalation), **required-set honesty** (deleting the false `.permissions.admin` probe), and the pre-existing `main` bugs are PRs D, E, F.

## Verification

Every command in the doc was executed and emits exactly the documented row format:

```
$ gh api --paginate "repos/lestrrat-ai/claude-code-plugins/commits/$SHA/check-runs" --jq ...
checkrun ca87663d… Lint scripts 15368 COMPLETED SUCCESS
checkrun ca87663d… Validate plugins 15368 COMPLETED SUCCESS
```

No version bump: per `CLAUDE.md`, this series is batched into a release PR after it lands. #28 establishes 0.1.3 as the trusted stage-0 that gates it.