### PR TITLE
prove the expected checks registered — probe the data, never the permissions

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -97,6 +97,12 @@ When the loop exits, summarize:
   least-certain area it named — `required(tier)` lines, so two for a STANDARD/HIGH PR and one for a
   TRIVIAL PR), and a flag when two accepting passes name the same area. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
+- **What the base branch REQUIRED** — the ledger's `required_set` (`stage-2-ci.md` owns its states). Report
+  **which state the run was in**, because it is what every `green` in this report rests on: `declared:…` —
+  name the checks that had to pass; `none` — the base branch required nothing, **read and confirmed**, not
+  merely unobserved. **NEVER report `unknown` as "no required checks"**: it means campaign **could not
+  read** them, nothing merged on it, and any PR that reached it **escalated** — say which read failed, so
+  the user can fix the access rather than wonder why the run stalled.
 - **Aborted** — PR number + slug, why, pointer to `abort-<id>.md`.
 - **Skipped (API-declined)** — any PR whose API-changing fix the user was asked about and declined,
   with the change each would have needed.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -340,10 +340,12 @@
   **never guessed into a bucket**. **The ORDER is `red` BEFORE the catch-all, on purpose:** a snapshot
   carrying **both** a `FAIL` and an unknown value is `red`, gets its CI fix, and **parks on the unknown
   value at the next derivation** once the failure clears — deferred, never dropped, and never merged
-  (`red` cannot merge). One gap remains **open and disclosed** in `stage-2-ci.md`, and a
-  green claim must respect it: the **REGISTRATION GAP** — green proves only that *what had registered*
-  passed, **never** that the required set is complete. **NEVER claim more from a green than those rules
-  and that gap allow.**
+  (`red` cannot merge). And green is **not** a claim about the rows that happened to show up: it requires
+  that **the base branch's REQUIRED set is accounted for** — every declared required check **present and
+  passing**, or the set **read and empty** (`required_set`, `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO
+  SEE?"). **A required set campaign could not read is NEVER green** — it is a `pending` outcome that
+  escalates, because a check that never registered is **no row**, and no count of passing rows can rule it
+  out. **NEVER claim more from a green than those rules allow.**
 - The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -94,13 +94,14 @@ due from those, then refreshes this file. So a stale or half-written ledger is s
 act on it without reconciling against gh (and any existing worktree) first.
 
 The store is **JSONL** — one JSON object per line, `cat`/`grep`/`jq`-able. The first line is the
-run-config header record (`{"type": "header", …}` — `run_id`, `base_branch`, `api_changes`, `reviewer`,
-re-read every wake, see Constraints and "Run identity and concurrency"); each
+run-config header record (`{"type": "header", …}` — the run's config, **every field of it** re-read each
+wake, never from memory; the fields are the ones `ledger.py`'s `HEADER_FIELDS` declares and "Header-record
+fields" below defines, and no reader may keep its own copy of that list); each
 following line is one adopted PR's row record (`{"type": "row", …}`). Every record is **self-describing**
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:9f2c\u2026", "settled_strikes": "0", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:4a71\u2026", "settled_strikes": "1", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "required check absent: integration-tests", "blocker_ruling": "-"}
 ```
@@ -115,7 +116,16 @@ Header-record fields: `run_id` (this run's identity — namespaces its dir/label
 `base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
 once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
 `reviewer` (`default` (Claude subagents) | `codex` | `<other>` — the selected reviewer; set once, see
-"The reviewer").
+"The reviewer"), `required_set` (what `base_branch` **requires** — `stage-2-ci.md`, "What were we
+expecting to see?", owns the three states, the format, and the reads that produce them; re-read every
+wake while it is `unknown`).
+
+`required_set` is a property of the **base branch**, not of a PR, which is why it lives in the header. It
+defaults to **`unknown`**, and that default is **load-bearing, not a placeholder**: `unknown` **cannot go
+green** (`stage-2-ci.md`), so a run that never performed the read merges **nothing**. **"I have not
+looked" and "I looked and there are none" are different facts**, and the default is the one that claims
+nothing — a `none` that really meant "I could not see" is how a green gets recorded for a commit whose
+required check never registered.
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -72,9 +72,10 @@ blocks; each completion is its own wake.
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
      isn't enough (merge-gate CI truth stays the SHA-pinned, SHA-verified snapshot of **both** check
      families, Stage 2b). Wake
-     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, and `reviewer` from the ledger
-     header — they govern namespacing, the merge/diff target, API-change handling, and which reviewer runs
-     the review passes, and must be
+     turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read
+     **the ledger header's run config — EVERY field of it, whatever they are** (`files-and-ledger.md` owns
+     that set; do NOT keep a copy of it here, a list beside a property goes stale the wake a field is
+     added). It governs the run, and must be
      consulted fresh each wake, never from memory (a wake may be a fresh agent instance that just
      adopted the run, so an explicit/preferred reviewer would otherwise
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -46,7 +46,7 @@ the **slurped** pages — so a marker cannot exist for a fetch that did not run:
 #     returned ZERO rows has no oid to carry: its marker's sha is "-", and inventing one is forbidden.
 gh api --paginate --slurp "repos/<owner>/<repo>/commits/<head_sha>/check-runs" | jq -c '
   [.[].check_runs[]] as $r
-  | ($r[] | {row:"checkrun", sha:.head_sha, name:.name, app_id:(.app.id|tostring),
+  | ($r[] | {row:"checkrun", sha:.head_sha, name:.name, app_id:((.app.id // "-")|tostring),
              status:(.status|ascii_upcase),
              conclusion:((.conclusion // "-")|ascii_upcase),
              id:(.details_url // "-")}),
@@ -78,6 +78,19 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
   it the whole set. **`--slurp` collects every page into ONE array before `jq` runs**, which is what lets a
   single filter emit the rows *and* a marker whose `count` is the total **across pages** (per-page `--jq`
   cannot know it). `--slurp` and gh's own `--jq` are mutually exclusive, hence the pipe to `jq -c`.
+- **EVERY `//` DEFAULT GOES BEFORE THE CONVERSION, NEVER AFTER — `((.x // "-") | tostring)`, and
+  NEVER `((.x | tostring) // "-")`.** In jq, `null | tostring` is the **STRING `"null"`**, which is
+  **TRUTHY**, so a default placed after the conversion **NEVER FIRES** and the field carries the
+  four letters `null` where `-` was meant. This applies to **every nullable field read anywhere in
+  this file** — `.app.id` above (a check run need not come from an app) and the required-set reads'
+  `.app_id` / `.integration_id` below. **It is not cosmetic there: it is a WEDGE.** An unbound
+  required check would come out bound to a producer named `"null"`, no evidence row could ever match
+  it, and the PR would report `pending (required check absent)` **forever, for a reason nobody can
+  see** — which is the failure this file's own SETTLED rule exists to prevent, arriving by the back
+  door. `cli/cli`'s `trunk` returns `app_id: null` for **every** one of its required checks, so this
+  is the **common** configuration, not an exotic one. `ci-snapshot.py`'s `producer_test` **extracts
+  these filters from this file and runs them** against recorded payloads that carry null bindings —
+  write the order backwards and it goes red.
 - **BOTH families are MANDATORY, AND THE ARTIFACT MUST PROVE BOTH WERE READ.** A failing Jenkins/CircleCI
   **commit status is genuinely invisible** to `/check-runs`: a commit can carry **live commit statuses**
   while `/check-runs` reports `check_runs.total_count = 0` for that very commit. Read only one family and
@@ -138,7 +151,7 @@ each line as JSON. Five `row` types, distinguished by the `row` field — and **
 |---|---|---|---|
 | `header` | `sha` | The `head_sha` we **REQUESTED** — what the file was fetched *for*. Exactly one, first line. | **OURS** (the ledger's) |
 | `source` | `source`, `sha`, `count` | **COMPLETION MARKER — "this source WAS QUERIED".** Exactly **ONE** per mandatory source (`check-runs`, `status`, `rollup`), written **by that fetch's own `jq`**. `count` = the rows it returned. | **GITHUB'S**, or `"-"` where GitHub has none (below) |
-| `checkrun` | `sha`, `name`, `app_id`, `status`, `conclusion`, `id` | Check-run **identity AND verdict**. `conclusion` is `"-"` when absent; `id` is `details_url` (`"-"` when absent). | **GITHUB'S** (`.head_sha`) |
+| `checkrun` | `sha`, `name`, `app_id`, `status`, `conclusion`, `id` | Check-run **identity AND verdict**. `app_id` is `"-"` when the run has **no app**; `conclusion` is `"-"` when absent; `id` is `details_url` (`"-"` when absent). | **GITHUB'S** (`.head_sha`) |
 | `status` | `sha`, `context`, `state` | Commit-status **verdict**. | **GITHUB'S** (response `.sha`) |
 | `witness` | `name`, `id` | Rollup **identity only** — **no `sha`, no verdict**. `id` is `detailsUrl`. | — (none exists) |
 
@@ -574,16 +587,18 @@ Two reads, **both needing only Metadata**. **BOTH are mandatory** — neither ca
 #     `.protection.enabled` tells you whether classic protection EXISTS, so you never have to guess
 #     what a 404 from /branches/<b>/protection meant. `.checks[]` carries the app binding; `.contexts`
 #     is the same set WITHOUT it, and is deprecated — read `.checks[]`, never `.contexts`.
+#     `.app_id` is NULLABLE — the DEFAULT GOES BEFORE `tostring` (FETCH above owns that rule; get it
+#     backwards and every unbound required check binds to an app named "null" and can NEVER be matched).
 gh api "repos/<owner>/<repo>/branches/<base>" --jq '
   {classic_enabled: (.protection.enabled // false),
    checks: [(.protection.required_status_checks.checks // [])[]
-            | {context: .context, app: ((.app_id | tostring) // "-")}]}'
+            | {context: .context, app: ((.app_id // "-") | tostring)}]}'
 
 # (b) RULESETS — the rules actually in force on the branch. The CLASSIC endpoint CANNOT SEE THESE.
 gh api "repos/<owner>/<repo>/rules/branches/<base>" --jq '
   [.[] | select(.type=="required_status_checks")
        | .parameters.required_status_checks[]
-       | {context: .context, app: ((.integration_id | tostring) // "-")}]'
+       | {context: .context, app: ((.integration_id // "-") | tostring)}]'
 ```
 
 **A 404 from `/branches/<b>/protection` means THREE different things** — genuinely unprotected, *you may
@@ -628,8 +643,13 @@ non-empty set, you know **SOME** required checks — not that you know them **AL
 READ** (`unknown`). A **permissive** endpoint answering never vouches for a **restricted** one erroring.
 
 **`declared:` carries a JSON array, NOT a comma-separated list.** Each element is
-`{"context": "<name>", "app": "<app_id>" | "-"}`, and `"-"` means the declaration **binds no app** (any
-producer satisfies it). The payload is JSON because **a required check's name may CONTAIN A COMMA** — a
+`{"context": "<name>", "app": "<app_id>" | "-"}`, where `<app_id>` is the app id **as decimal digits** and
+`"-"` means the declaration **binds no app** (any producer satisfies it). **Those two are the ONLY shapes
+an `app` may take**: `ci-snapshot.py --required-set` rejects every other one **loudly** — above all the
+string `"null"`, which is what a `//` default written **after** a `tostring` yields from a null binding
+(FETCH above owns that rule). Bound to an app that **does not exist**, a check can never be matched by any
+row, so **accepting it would WEDGE the PR** — and **normalising it to `"-"` would be a GUESS** about a
+value we could not read. The payload is JSON because **a required check's name may CONTAIN A COMMA** — a
 matrix job's name is `job (a, b)`, and 40 of the 100 check runs on `vercel/next.js`'s default-branch head
 carried one when this was written (a dated illustration; the **claim** — commas are legal and common in
 check names — is the permanent point). A comma-separated list of those names is **ambiguous at the
@@ -641,8 +661,11 @@ required" would rebuild the exact false green this section removes.
 **MATCH ON PRODUCER, not just on name — a right-named check from the WRONG app is not the required one.**
 A declared check is **satisfied** only by an evidence row that carries its `context` **and** its producer:
 
-- a `checkrun` row whose `name` equals the context, and whose `app_id` equals the declared `app` (any
-  `app_id` satisfies a declaration whose `app` is `"-"`);
+- a `checkrun` row whose `name` equals the context, and whose `app_id` equals the declared `app`
+  (any `app_id` satisfies a declaration whose `app` is `"-"`). **`"-"` is a wildcard on the
+  DECLARATION and NOT on the ROW**: on a declaration it means *any producer may satisfy this*, while
+  on a row it means *this run came from no app* — so a producer-less row satisfies an **unbound**
+  declaration and **never** an app-bound one, for the same reason a `status` row cannot;
 - a `status` row whose `context` equals it — **and only where the declaration binds NO app.** The
   commit-status rows carry **no producer field at all** (FETCH above: the status response has none to
   give), so an app-bound declaration **cannot be proven** by one. It stays unsatisfied → `pending

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -439,26 +439,20 @@ block a merge, this is the line that was wrong.
 
 #### DECIDE — first match wins
 
-**KNOWN GAP — THE REGISTRATION GAP: `green` here does NOT mean the required set passed.** `main`'s green
-rule also demanded that "**the expected checks are actually present**". This change does **NOT** carry that
-requirement forward, and that omission is a **deliberate, disclosed** one — not an oversight, and **not** a
-claim that the risk is gone:
+**THE REGISTRATION GAP IS CLOSED — `green` means the required set passed.** It did not always. `green`
+once meant only *"every check that had REGISTERED by the time we looked had passed"*, which says nothing
+about whether a **required** check ever registered at all: a required check that has not registered is not
+a failing row, it is **NO ROW**, so the snapshot was nonempty, all-passing, and **not the truth about the
+commit** — a false green with a disclaimer printed beside it. **The disclaimer is gone because the hole is
+gone**, not because it was talked away:
 
-- **Why it is dropped: `main`'s version was UNIMPLEMENTABLE.** `main` names **no mechanism** for knowing
-  what checks are *expected* — it demands a comparison against a set it never defines. The rule below is an
-  **honest restatement of what the evidence can actually deliver**, not a weakening dressed up as one.
-- **THE RISK IS REAL AND IT IS NAMED.** Where required checks exist but have **not registered yet** on the
-  `head_sha`, a snapshot holding **one** registered, successful check derives **green** — and campaign can
-  merge over a required check it **never saw**. `green` here means **ONLY**: *"every check that had
-  registered by the time we looked had passed."* It does **NOT** mean the required set passed, and it does
-  **NOT** mean the required set is complete.
-- **NEVER claim more than the registration gap allows when reporting a green.** Not in the ledger, not in
-  the report, not to the user. `green` is a statement about **what was observed**, never about what was
-  **expected**.
-- **The mechanism that closes it lands in the `required-set` PR later in this series** — it reads the base
-  branch's required checks from **branch protection + rulesets**, records `required_set` as
-  DECLARED / NONE DECLARED / CANNOT READ, and makes `green` require **every declared required check to be
-  present AND passing**. Until that lands, this gap is **open**.
+- **The expected set is now READ, not assumed** — from branch protection **and** rulesets, into the ledger's
+  `required_set` ("WHAT WERE WE EXPECTING TO SEE?" below). That read is the mechanism the rule always
+  needed and never had.
+- **`green` now requires every declared required check to be PRESENT and PASSING**, matched on producer.
+- **The states that cannot support the claim do not make it.** A missing declared check and an unreadable
+  required set are **`pending` bullets below** — non-merging outcomes, each bounded and escalated — never a
+  green with a footnote. **A caveat attached to a green is not a caveat; it is a merge.**
 
 Evaluate the bullets **in this order — first match wins.**
 
@@ -533,11 +527,128 @@ ever re-ordered again.
   green** — it means nothing has registered yet. **Do NOT watch it**: there is no row that could move, so
   there is nothing to block on. If nothing ever registers, SETTLED below escalates it instead of letting it
   spin.
+- **pending (required set unreadable)** → `required_set` is **CANNOT READ** ("WHAT WERE WE EXPECTING TO
+  SEE?" below). We do not know what this commit was supposed to show, so **no snapshot of it can be
+  green** — not even an all-`PASS` one. **Do NOT watch it**: no row moving would answer the question that
+  is open. It is **bounded like every other `pending`**: nothing is RUNNING, so SETTLED below strikes it
+  and escalates at the STRIKE CAP, naming the read that failed. Re-attempt the read each wake while it is
+  `unknown` — a transient failure clears itself well inside that budget.
+- **pending (required check missing)** → `required_set` is **DECLARED** and a declared required check has
+  **no row** in the snapshot (matched on name **and** producer — below). **A check that has not registered
+  is not a failing row, it is NO ROW**, and a snapshot missing it is nonempty, all-`PASS`, and **not the
+  truth about this commit**. **NEVER green.** Bounded the same way: if it never registers, SETTLED
+  escalates with the check **named** (that is exactly the "which check never registered" ESCALATE already
+  promises). A declared check that IS present but still running is not this bullet — it is a `RUNNING` row,
+  so plain `pending` above already caught it, and it is watched, as it should be.
 - **green** → **all three `source` markers are present and hold** (VERIFY above — otherwise you do not know
-  what you did not read); **≥1 evidence row**; **every** evidence row classifies `PASS`; and containment
-  holds **on a usable identity** (every `witness` `.id` non-null and unique). This bullet is subject to the
-  **registration gap** above: it proves only that **what had registered** passed, **never** that the
-  required set is complete.
+  what you did not read); **≥1 evidence row**; **every** evidence row classifies `PASS`; containment
+  holds **on a usable identity** (every `witness` `.id` non-null and unique); **and the required set is
+  ACCOUNTED FOR** — `required_set` is **DECLARED** and every declared check is **present AND classified
+  `PASS`, proven from the SAME row, matched on producer**, or `required_set` is **NONE DECLARED**, which is
+  a **read fact, not an absence of one**: the base branch requires nothing, so nothing required can be
+  missing. **`green` now means the required set passed. It carries NO caveat, and it never did license
+  one** — the two states that could not support the claim (`CANNOT READ`, a missing declared check) are
+  **`pending` bullets above**, not footnotes under this one.
+
+#### WHAT WERE WE EXPECTING TO SEE? — the required-check set
+
+`green` above says *"every evidence row passes"*. That is only worth something if the rows are **the rows
+that were supposed to be there**. A required check that has **not registered yet** is not a failing row —
+it is **no row at all** — so a snapshot of the checks that *did* register can be nonempty, entirely
+passing, and **still not the truth about this commit**. This section is what makes `green` mean the
+required set passed. **It is not a disclosure of that hole; it is the closing of it.**
+
+So: **read what the base branch REQUIRES, and prove every required check is PRESENT and PASSING.**
+
+**PROBE THE DATA, NEVER THE PERMISSIONS.** Do **not** ask "may I read this?" and infer the answer —
+**ask for the thing, and see whether you got it.** A permissions probe is not evidence about a token:
+`GET /repos/{o}/{r}` needs only **Metadata**, and its `.permissions` reports **the USER's role, not the
+TOKEN's grants** — so a fine-grained token owned by an admin reads `admin: true` while lacking
+`Administration: read`. **A rule keyed on that probe declares "proven unprotected" on a branch it simply
+cannot see.**
+
+Two reads, **both needing only Metadata**. **BOTH are mandatory** — neither can see what the other sees:
+
+```sh
+# (a) CLASSIC branch protection — AND the field that disambiguates its absence.
+#     `.protection.enabled` tells you whether classic protection EXISTS, so you never have to guess
+#     what a 404 from /branches/<b>/protection meant. `.checks[]` carries the app binding; `.contexts`
+#     is the same set WITHOUT it, and is deprecated — read `.checks[]`, never `.contexts`.
+gh api "repos/<owner>/<repo>/branches/<base>" --jq '
+  {classic_enabled: (.protection.enabled // false),
+   checks: [(.protection.required_status_checks.checks // [])[]
+            | {context: .context, app: ((.app_id | tostring) // "-")}]}'
+
+# (b) RULESETS — the rules actually in force on the branch. The CLASSIC endpoint CANNOT SEE THESE.
+gh api "repos/<owner>/<repo>/rules/branches/<base>" --jq '
+  [.[] | select(.type=="required_status_checks")
+       | .parameters.required_status_checks[]
+       | {context: .context, app: ((.integration_id | tostring) // "-")}]'
+```
+
+**A 404 from `/branches/<b>/protection` means THREE different things** — genuinely unprotected, *you may
+not look*, **or protected by a RULESET the classic endpoint cannot see**. Reproduced on **this repo** (a
+dated illustration — the repo's settings are a live fact and will drift; the API behavior is the permanent
+point): `.permissions.admin` reads `true`, `.protection.enabled` reads `false`, and yet
+`branches/main.protected` reads `true`, because a **ruleset** protects it. **A classic 404, or a
+`classic_enabled: false`, NEVER establishes "nothing is required."** That is why read (b) exists and why
+it is not optional.
+
+##### THREE states, NEVER two — "I CANNOT SEE ANY" IS NOT "THERE ARE NONE"
+
+Persist the outcome in the ledger header as `required_set` — **a state you cannot persist is a state you do
+not have** (`files-and-ledger.md` owns the field; this block owns its meaning and its format):
+
+```sh
+ledger.py --file <state.jsonl> header set required_set '<declared:<json> | none | unknown>'
+```
+
+**WHEN: read it once per run, before the first CI derivation** — it is a property of `base_branch`, which is
+itself set once (`files-and-ledger.md`, "Base branch"), so one read serves every PR in the run. **And read
+it AGAIN, every wake, for as long as it is `unknown`** — that is the whole of its retry policy, and it is
+what keeps a transient failure (a network blip, a rate limit) from parking PRs that were never really
+blocked: a read that recovers before the STRIKE CAP costs the run nothing at all. **Once it is `declared:…`
+or `none`, it is SETTLED — do not re-read it**, and never overwrite a successful read with a later failure.
+
+| State | `required_set` | When | What `green` may claim |
+|---|---|---|---|
+| **DECLARED** | `declared:<json>` | **BOTH** reads succeeded **and** their union is non-empty | every declared check is **present AND passing** — the required set passed |
+| **NONE DECLARED** | `none` | **BOTH** reads succeeded **and** their union is empty | the base branch **requires nothing**, so nothing required can be missing — **the required set passed, vacuously and completely** |
+| **CANNOT READ** | `unknown` | **EITHER** read errored, **or** the field it needed was **absent** from the response | **NOTHING. `green` is UNREACHABLE** — the PR goes `pending (required set unreadable)` and escalates. |
+
+**`unknown` CANNOT GO GREEN, and that is the entire point of separating it from `none`.** A `green`
+printed next to *"…but a required check may exist, be missing, and campaign cannot tell"* is **not a
+disclosure, it is a trapdoor with a sign on it**: the merge still happens, and the sign is read by nobody.
+The three states are not three flavours of green — they are **two that can prove the claim and one that
+must not make it**. That is also what makes `unknown` the **safe default** (`ledger.py`): a run that never
+performed the read merges **nothing**, rather than merging everything with a footnote.
+
+**`DECLARED` requires that BOTH reads SUCCEEDED.** If one read was denied and the other returned a
+non-empty set, you know **SOME** required checks — not that you know them **ALL**. That is **CANNOT
+READ** (`unknown`). A **permissive** endpoint answering never vouches for a **restricted** one erroring.
+
+**`declared:` carries a JSON array, NOT a comma-separated list.** Each element is
+`{"context": "<name>", "app": "<app_id>" | "-"}`, and `"-"` means the declaration **binds no app** (any
+producer satisfies it). The payload is JSON because **a required check's name may CONTAIN A COMMA** — a
+matrix job's name is `job (a, b)`, and 40 of the 100 check runs on `vercel/next.js`'s default-branch head
+carried one when this was written (a dated illustration; the **claim** — commas are legal and common in
+check names — is the permanent point). A comma-separated list of those names is **ambiguous at the
+separator**, and a required set you cannot parse back is a required set you do not have.
+`ci-snapshot.py --required-set` is the **one parser**; it rejects anything malformed **loudly** and
+**NEVER degrades a value it cannot read into `none`** — quietly reading a broken spec as "nothing is
+required" would rebuild the exact false green this section removes.
+
+**MATCH ON PRODUCER, not just on name — a right-named check from the WRONG app is not the required one.**
+A declared check is **satisfied** only by an evidence row that carries its `context` **and** its producer:
+
+- a `checkrun` row whose `name` equals the context, and whose `app_id` equals the declared `app` (any
+  `app_id` satisfies a declaration whose `app` is `"-"`);
+- a `status` row whose `context` equals it — **and only where the declaration binds NO app.** The
+  commit-status rows carry **no producer field at all** (FETCH above: the status response has none to
+  give), so an app-bound declaration **cannot be proven** by one. It stays unsatisfied → `pending
+  (required check missing)` → SETTLED escalates it, naming the check. **That is fail-closed on purpose**:
+  the alternative is to accept a status from an app we never identified as proof of a check that named
+  one, which is the false green with an extra step.
 
 #### `pending` MUST NOT BE AN ABSORBING STATE — SETTLED, then ESCALATE
 
@@ -955,6 +1066,8 @@ The watch is warranted by **a row that can still move**, never by the `ci` value
 |---|---|
 | **pending** — an evidence row classifies `RUNNING` | **YES** — ensure a watch task is alive; relaunch it in this same wake if it has exited. **The watch is not the bound**: if that row never finishes, the watch blocks forever and RUNNING-STALL is what ends it, on the heartbeat. |
 | **pending (nothing registered)** — zero evidence rows | **NO.** Nothing to block on. SETTLED escalates it. |
+| **pending (required check missing)** — a declared check has no row | **NO.** Every row present is terminal (a running one would have matched plain `pending` above), so nothing can move. SETTLED escalates it, naming the check. |
+| **pending (required set unreadable)** — `required_set` is `unknown` | **NO.** The open question is what the base branch REQUIRES; no row finishing would answer it. Re-attempt the read each wake; SETTLED escalates it. |
 | **red** — but some row still `RUNNING` | **YES** — that row can still move; the CI fix runs regardless. |
 | **red** — every row terminal | **NO.** The CI fix moves it, not the watch. |
 | **UNKNOWN_VALUE** | **NO.** The park is the resolution. |
@@ -1093,7 +1206,8 @@ correctness (`stage-2-review-gate.md`). Say that plainly whenever the question c
 
 Every CI failure must be handled; never merge over a red or pending check, and never infer green from
 the watch's exit code — always confirm against a **SHA-pinned, SHA-verified** snapshot of **both** check
-families.
+families, **and against what the base branch REQUIRED** ("WHAT WERE WE EXPECTING TO SEE?"): the rows that
+showed up passing is not the same claim as the required set passing, and only the second one may merge.
 
 CI fixes serialize only within one PR/SHA. Different PRs with red CI may run scoped CI-fix subagents
 concurrently within the dispatcher cap.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -580,10 +580,16 @@ TOKEN's grants** — so a fine-grained token owned by an admin reads `admin: tru
 `Administration: read`. **A rule keyed on that probe declares "proven unprotected" on a branch it simply
 cannot see.**
 
-Two reads, **both needing only Metadata**. **BOTH are mandatory** — neither can see what the other sees:
+Two reads, and **they do NOT need the same permission** — name them per endpoint, because a token
+provisioned for only one of them fails the other on a **private** repo, the required set reads `unknown`,
+and `unknown` can never go green: **`GET /repos/{o}/{r}/branches/{b}` needs `Contents: read`**;
+**`GET /repos/{o}/{r}/rules/branches/{b}` needs `Metadata: read`** (GitHub REST docs, "Get a branch" /
+"Get rules for a branch"). **BOTH are mandatory** — neither can see what the other sees:
 
 ```sh
-# (a) CLASSIC branch protection — AND the field that disambiguates its absence.
+# (a) CLASSIC branch protection — AND the field that disambiguates its absence. Needs `Contents: read`
+#     (NOT Metadata — on a private repo a Metadata-only token 404s here and the required set reads
+#     `unknown`, which can never go green).
 #     `.protection.enabled` tells you whether classic protection EXISTS, so you never have to guess
 #     what a 404 from /branches/<b>/protection meant. `.checks[]` carries the app binding; `.contexts`
 #     is the same set WITHOUT it, and is deprecated — read `.checks[]`, never `.contexts`.
@@ -595,6 +601,7 @@ gh api "repos/<owner>/<repo>/branches/<base>" --jq '
             | {context: .context, app: ((.app_id // "-") | tostring)}]}'
 
 # (b) RULESETS — the rules actually in force on the branch. The CLASSIC endpoint CANNOT SEE THESE.
+#     Needs `Metadata: read`.
 gh api "repos/<owner>/<repo>/rules/branches/<base>" --jq '
   [.[] | select(.type=="required_status_checks")
        | .parameters.required_status_checks[]

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -89,8 +89,11 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
   see** — which is the failure this file's own SETTLED rule exists to prevent, arriving by the back
   door. `cli/cli`'s `trunk` returns `app_id: null` for **every** one of its required checks, so this
   is the **common** configuration, not an exotic one. `ci-snapshot.py`'s `producer_test` **extracts
-  these filters from this file and runs them** against recorded payloads that carry null bindings —
-  write the order backwards and it goes red.
+  EVERY jq filter this file prescribes — all five reads, (1)(2)(3) here and (a)(b) below — and RUNS
+  them** against recorded API payloads that carry null bindings and span MULTIPLE PAGES: write the order
+  backwards in **any** of them, or drop a `--paginate`, and it goes red. **A filter this file prescribes
+  that no test EXECUTES is a filter that can rot** — (1)'s `.app.id` default was fixed once and pinned by
+  nothing, and could have been reverted forever without a single test noticing.
 - **BOTH families are MANDATORY, AND THE ARTIFACT MUST PROVE BOTH WERE READ.** A failing Jenkins/CircleCI
   **commit status is genuinely invisible** to `/check-runs`: a commit can carry **live commit statuses**
   while `/check-runs` reports `check_runs.total_count = 0` for that very commit. Read only one family and
@@ -602,11 +605,23 @@ gh api "repos/<owner>/<repo>/branches/<base>" --jq '
 
 # (b) RULESETS — the rules actually in force on the branch. The CLASSIC endpoint CANNOT SEE THESE.
 #     Needs `Metadata: read`.
-gh api "repos/<owner>/<repo>/rules/branches/<base>" --jq '
-  [.[] | select(.type=="required_status_checks")
-       | .parameters.required_status_checks[]
-       | {context: .context, app: ((.integration_id // "-") | tostring)}]'
+#     `--paginate` IS MANDATORY HERE: this endpoint returns a PAGED LIST of rules (`page`/`per_page`,
+#     default 30 — GitHub REST docs, "Get rules for a branch"), and a repo can carry more rules than that.
+#     Read page one only and a `required_status_checks` rule sitting on page two is NEVER SEEN — the
+#     required set is recorded as if that check were not required, and a snapshot MISSING it goes GREEN.
+#     That is the exact false green this whole section exists to close, reintroduced by a missing flag.
+#     `--slurp` hands jq ONE array OF PAGES (and is mutually exclusive with gh's own `--jq`, hence the
+#     pipe) — so the filter flattens with `.[][]`: pages, then rules.
+gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/<base>" | jq -c '
+  [.[][] | select(.type=="required_status_checks")
+         | .parameters.required_status_checks[]
+         | {context: .context, app: ((.integration_id // "-") | tostring)}]'
 ```
+
+**Read (a) is NOT paginated, and that is not an oversight** — `GET /repos/{o}/{r}/branches/{b}` returns a
+**single branch object**, not a list: it takes no `page`/`per_page`, and its
+`.protection.required_status_checks.checks` array arrives whole. `--paginate` belongs on **every read that
+returns a LIST** and on no other; read (b) is one, read (a) is not.
 
 **A 404 from `/branches/<b>/protection` means THREE different things** — genuinely unprotected, *you may
 not look*, **or protected by a RULESET the classic endpoint cannot see**. Reproduced on **this repo** (a

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -114,6 +114,7 @@ import argparse
 import json
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 from collections import Counter
@@ -258,6 +259,22 @@ def parse_required_set(spec: str) -> RequiredSet:
         ctx, app = entry["context"], entry["app"]
         if not isinstance(ctx, str) or not isinstance(app, str) or not ctx:
             raise SpecError(f"`context` and `app` must be strings, and `context` non-empty: {entry!r}")
+        # AN APP BINDING IS A GITHUB APP ID — DECIMAL DIGITS — OR `ANY_APP`. THERE IS NO THIRD SHAPE, and
+        # the one that keeps trying to be one is the STRING "null": jq's `tostring` applied to a null
+        # binding BEFORE the `// "-"` default, which is exactly what the producer read shipped (stage-2-ci.md
+        # FETCH owns the rule; `cli/cli` returns `app_id: null` for every required check on `trunk`, so it is
+        # the COMMON case). Bound to an app that DOES NOT EXIST, the check can never be matched by any row:
+        # the PR reports `pending (required check absent)` FOREVER, for a reason nobody can see. That is a
+        # WEDGE, and a wedge is not the safe side of a false green — it is the other failure.
+        #
+        # So it is REJECTED, never NORMALISED. Reading "null" as ANY_APP would be a GUESS about a value we
+        # could not read — the same degradation this parser refuses everywhere else, and this time it would
+        # guess in the direction that makes an unmatched required check pass.
+        if app != ANY_APP and not (app.isascii() and app.isdigit()):
+            raise SpecError(
+                f"`app` is an app id in decimal digits, or {ANY_APP!r} when the declaration binds no app "
+                f"(the string 'null' is a `//` default that fired too late, never a producer): {entry!r}"
+            )
         checks.append((ctx, app))
     return RequiredSet(DECLARED, tuple(checks))
 
@@ -907,6 +924,7 @@ EXPECTED = {
     "expected-status.jsonl": (PENDING, "still running", "EXPECTED = a required status DECLARED BUT NOT POSTED YET — the one shape of not-yet-registered the evidence can express on its own; REQUIRED_CASES below covers the shape it cannot"),
     "status-passing.jsonl": (GREEN, "all passing", "a SUCCESS commit status and no check runs at all — the family /check-runs cannot see, green on its own; REQUIRED_CASES uses it to pin what a producer-less row can and cannot prove"),
     "skipped-is-pass.jsonl": (GREEN, "all passing", "SKIPPED is a PASS — GitHub rolls it up that way, and a rule set without it can NEVER go green on a repo with path filters"),
+    "unbound-checkrun.jsonl": (GREEN, "all passing", "a check run with NO PRODUCER — `.app` was null, so the read wrote `-`. Green on its own; REQUIRED_CASES pins what that row may and may not PROVE"),
     # THE CATCH-ALL, and it is now reachable ONLY by a value GitHub has ADDED SINCE — which is exactly what
     # it is for. Both values below are INVENTED: no CheckStatusState is `AWAITING_APPROVAL`, no
     # CheckConclusionState is `FLAKED_OUT`, and no StatusState is `BLOCKED`. That is the point — the real
@@ -998,14 +1016,15 @@ def self_test(fixtures: Path) -> int:
 
     failures += filename_test(fixtures)
     failures += required_test(fixtures)
+    failures += producer_test(fixtures)
     failures += spec_test()
     print()
     if failures:
         print(f"{failures} check(s) FAILED — the CI-snapshot contract is broken.")
         return 1
     print(f"all {len(EXPECTED)} fixtures + {len(FILENAME_CASES)} filename cases + "
-          f"{len(REQUIRED_CASES)} required-set cases + {len(SPEC_CASES)} spec cases hold — "
-          f"the contract is intact.")
+          f"{len(REQUIRED_CASES)} required-set cases + {len(PRODUCER_CASES)} producer cases + "
+          f"{len(SPEC_CASES)} spec cases hold — the contract is intact.")
     print("`mutate-ci-snapshot.py` is what proves each of them pins its OWN rule. Run it too.")
     return 0
 
@@ -1047,6 +1066,17 @@ REQUIRED_CASES = [
      GREEN, "required set satisfied: ci/jenkins",
      "an UNBOUND declaration IS satisfiable by a commit status — the producer rule must not wall off the "
      "legacy family it was never about"),
+    # `-` ON A ROW IS "NO PRODUCER", AND ON A DECLARATION IT IS "ANY PRODUCER". Both sides can now carry it
+    # — the check-run read defaults a null `.app` to `-` — and the two meanings must not blur into a
+    # wildcard that matches from either end.
+    ("unbound-checkrun.jsonl", f'{DECLARED_PREFIX}[{{"context": "Deploy", "app": "-"}}]',
+     GREEN, "required set satisfied: Deploy",
+     "an UNBOUND declaration satisfied by a check run that HAS NO PRODUCER — the pair the wedge made "
+     "unmatchable, and the configuration `cli/cli` actually runs: every required check on `trunk` is unbound"),
+    ("unbound-checkrun.jsonl", f'{DECLARED_PREFIX}[{{"context": "Deploy", "app": "15368"}}]',
+     PENDING, "required check absent: Deploy (app 15368)",
+     "THE MIRROR: a producer-less row cannot prove an APP-BOUND declaration. `-` on a ROW means 'no app', "
+     "NEVER 'any app' — read as a wildcard it would let an unidentified producer satisfy a check that named one"),
     # A declared check that is PRESENT but still RUNNING is NOT this rule's business: it is a RUNNING row,
     # so plain `pending` outranks and the PR gets WATCHED, as it must. Ordering, pinned.
     ("running-checkrun.jsonl", f'{DECLARED_PREFIX}[{{"context": "Validate plugins", "app": "-"}}]',
@@ -1076,6 +1106,129 @@ def required_test(fixtures: Path) -> int:
     return failures
 
 
+# --- THE PRODUCER, EXECUTED — the two reads in stage-2-ci.md, RUN over recorded API payloads -----------
+#
+# Every rule above takes the required set AS GIVEN. So a required set the DOC READS WRONG is a defect that
+# NOTHING above could see — and one shipped: both reads defaulted a null app binding AFTER converting it,
+# `((.x | tostring) // "-")` where `((.x // "-") | tostring)` was meant (the shape is written with a
+# placeholder on purpose: an illustration of a defect must not be a live string anyone can grep into).
+# In jq, `null | tostring` is the STRING "null", which is TRUTHY, so the default NEVER FIRED, and a
+# required check that binds NO app
+# came out bound to a producer named "null". No row can ever match that: the PR reports `pending (required
+# check absent)` FOREVER, for a reason nobody can see. That is a WEDGE — NOT the safe side of a false green,
+# but the OTHER failure, the one that files no report. And it was not exotic: `repos/cli/cli/branches/trunk`
+# returns `app_id: null` for EVERY required check it has.
+#
+# So the filters are NOT retyped here — they are EXTRACTED FROM stage-2-ci.md AND EXECUTED. A copy in this
+# file is exactly what could NOT have caught this: the bug was in the DOC, which is the only place these
+# reads live and the only place an operator reads them from. A test of a copy would have passed, forever.
+DOC = Path(__file__).resolve().parents[1] / "references" / "stage-2-ci.md"
+PAYLOADS = Path(__file__).parent / "fixtures" / "required-set"
+
+# Each read is identified by the `gh api` line that introduces it. A jq filter contains no single quote, so
+# the value is everything up to the next one.
+READS = {
+    "classic": 'gh api "repos/<owner>/<repo>/branches/<base>" --jq \'',
+    "ruleset": 'gh api "repos/<owner>/<repo>/rules/branches/<base>" --jq \'',
+}
+
+
+class DocDrift(Exception):
+    """The read this test executes is no longer in the doc, or no longer runs. NEVER a silent skip: a check
+    that cannot run must FAIL, or it reports health it did not measure."""
+
+
+def doc_read(which: str) -> str:
+    """The jq program stage-2-ci.md tells the operator to run. Extracted, never retyped."""
+    text = DOC.read_text(encoding="utf-8")
+    opener = READS[which]
+    start = text.find(opener)
+    if start < 0:
+        raise DocDrift(f"{DOC.name} no longer contains the {which} read — this test pins NOTHING until the "
+                       f"line `{opener[:46]}…` is found again")
+    start += len(opener)
+    end = text.find("'", start)
+    if end < 0:
+        raise DocDrift(f"the {which} read in {DOC.name} is never closed by a `'`")
+    return text[start:end]
+
+
+def required_set_from(which: str, payload: Path) -> list:
+    """Run the DOC's read over a recorded payload and return the declared checks it produces."""
+    jq = shutil.which("jq")
+    if jq is None:
+        raise DocDrift("`jq` is not installed, so the reads cannot be executed — and a check that SKIPS is "
+                       "a check that lies. Install jq (the campaign's own fetch needs it regardless)")
+    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [jq, "-c", doc_read(which), str(payload)], capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        raise DocDrift(f"the {which} read FAILED on {payload.name}: {proc.stderr.strip()}")
+    out = json.loads(proc.stdout)
+    if which == "classic":
+        if not isinstance(out, dict) or not isinstance(out.get("checks"), list):
+            raise DocDrift(f"the classic read no longer produces a `checks` array: {out!r}")
+        out = out["checks"]
+    if not isinstance(out, list):
+        raise DocDrift(f"the {which} read did not produce an array: {out!r}")
+    return out
+
+
+# (payload, read, the checks the read MUST produce, snapshot, verdict, needle, why)
+PRODUCER_CASES = [
+    ("classic-protection.json", "classic", [("Lint scripts", "15368"), ("Validate plugins", ANY_APP)],
+     "green.jsonl", GREEN, "required set satisfied: Lint scripts, Validate plugins",
+     "CLASSIC PROTECTION carrying a NULL app binding — the shape cli/cli's trunk really returns. The unbound "
+     "check must read `-`, be satisfied by a row WHATEVER its producer, and go GREEN — while the BOUND check "
+     "keeps its id, because a default that fires when a binding IS there is the mirror bug"),
+    ("ruleset-null-app.json", "ruleset", [("ci/jenkins", ANY_APP)],
+     "status-passing.jsonl", GREEN, "required set satisfied: ci/jenkins",
+     "a RULESET whose `integration_id` is explicitly NULL, satisfied by a COMMIT STATUS — a row with NO "
+     "producer field at all, which is precisely what an unbound declaration can be proven by"),
+    ("ruleset-no-app.json", "ruleset", [("ci/jenkins", ANY_APP)],
+     "status-passing.jsonl", GREEN, "required set satisfied: ci/jenkins",
+     "the same ruleset with `integration_id` ABSENT rather than null — jq reads a missing field as null, and "
+     "this pins that the read defaults it the same way instead of emitting a key it never saw"),
+]
+
+
+def producer_test(fixtures: Path) -> int:
+    """The doc's read -> the spec -> the parser -> a verdict. The whole chain, on payloads with a NULL app
+    binding, because the chain is where the wedge lived and no link of it could see the wedge alone."""
+    failures = 0
+    for payload, which, want_checks, snapshot, want, needle, why in PRODUCER_CASES:
+        label = f"{payload} -> {which} read"
+        try:
+            produced = required_set_from(which, PAYLOADS / payload)
+        except DocDrift as exc:
+            print(f"FAIL     {label:44} -> {exc}")
+            failures += 1
+            continue
+        got_checks = [(c.get("context"), c.get("app")) for c in produced]
+        if got_checks != want_checks:
+            print(f"FAIL     {label:44} -> the read produced {got_checks}, expected {want_checks}")
+            failures += 1
+            continue
+        spec = DECLARED_PREFIX + json.dumps([{"context": c, "app": a} for c, a in got_checks])
+        try:
+            required = parse_required_set(spec)
+        except SpecError as exc:
+            # The read produced a required set ITS OWN PARSER refuses. Exactly what `app: "null"` does.
+            print(f"FAIL     {label:44} -> the read produced a spec the parser REJECTS: {exc}")
+            failures += 1
+            continue
+        got, reason = evaluate(
+            fixtures / snapshot, FIXTURE_SHA, required=required, expect_filename_sha=False
+        )
+        if got == want and needle in reason:
+            print(f"ok       {label:44} -> {got:8} ({why})")
+        else:
+            print(f"FAIL     {label:44} -> {got:8} expected {want} mentioning {needle!r}"
+                  f"\n         reason: {reason}")
+            failures += 1
+    return failures
+
+
 # A SPEC WE CANNOT READ MUST NEVER BECOME `none`. That is the one degradation that would rebuild the false
 # green inside the parser — "the base branch requires nothing", asserted on the strength of a value we
 # failed to parse. Every case below must RAISE, and the CLI turns each into exit 2 with NO verdict.
@@ -1088,6 +1241,14 @@ SPEC_CASES = [
     ('declared:[{"context": "build"}]', "a declared check missing its `app` — half a declaration"),
     ('declared:[{"context": "build", "app": 15368}]', "a non-string `app` — a value we cannot compare"),
     ('declared:[{"context": "", "app": "-"}]', "an EMPTY context — it would match nothing, forever"),
+    ('declared:[{"context": "build", "app": "null"}]',
+     'THE WEDGE, ONE LAYER DOWN: the STRING "null" — a `// "-"` default written AFTER `tostring`, so it '
+     "never fired. It binds the check to an app that DOES NOT EXIST, no row can ever match it, and the PR "
+     "is `pending (required check absent)` FOREVER. Rejected, and never normalised back to `-`"),
+    ('declared:[{"context": "build", "app": "github-actions"}]',
+     "an app NAME where the id belongs — a producer that no `app_id` on any row can equal"),
+    ('declared:[{"context": "build", "app": ""}]',
+     "an EMPTY app — 'binds no app' is `-`, written explicitly; an empty string is a value we failed to write"),
     ("none-declared", "a near-miss of a state name, which is not one of the three"),
     ("NONE", "the right word, the wrong case — states are exact, never close enough"),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -1016,6 +1016,7 @@ def self_test(fixtures: Path) -> int:
 
     failures += filename_test(fixtures)
     failures += required_test(fixtures)
+    failures += fetch_test()
     failures += producer_test(fixtures)
     failures += spec_test()
     print()
@@ -1023,7 +1024,8 @@ def self_test(fixtures: Path) -> int:
         print(f"{failures} check(s) FAILED — the CI-snapshot contract is broken.")
         return 1
     print(f"all {len(EXPECTED)} fixtures + {len(FILENAME_CASES)} filename cases + "
-          f"{len(REQUIRED_CASES)} required-set cases + {len(PRODUCER_CASES)} producer cases + "
+          f"{len(REQUIRED_CASES)} required-set cases + {len(FETCH_CASES)} fetch-read cases + "
+          f"{len(PRODUCER_CASES)} producer cases + "
           f"{len(SPEC_CASES)} spec cases hold — the contract is intact.")
     print("`mutate-ci-snapshot.py` is what proves each of them pins its OWN rule. Run it too.")
     return 0
@@ -1106,7 +1108,7 @@ def required_test(fixtures: Path) -> int:
     return failures
 
 
-# --- THE PRODUCER, EXECUTED — the two reads in stage-2-ci.md, RUN over recorded API payloads -----------
+# --- THE PRODUCER, EXECUTED — the FIVE reads in stage-2-ci.md, RUN over recorded API payloads -----------
 #
 # Every rule above takes the required set AS GIVEN. So a required set the DOC READS WRONG is a defect that
 # NOTHING above could see — and one shipped: both reads defaulted a null app binding AFTER converting it,
@@ -1122,15 +1124,35 @@ def required_test(fixtures: Path) -> int:
 # So the filters are NOT retyped here — they are EXTRACTED FROM stage-2-ci.md AND EXECUTED. A copy in this
 # file is exactly what could NOT have caught this: the bug was in the DOC, which is the only place these
 # reads live and the only place an operator reads them from. A test of a copy would have passed, forever.
+#
+# AND THE SAME ARGUMENT COVERS EVERY FILTER THE DOC PRESCRIBES, not only the required-set pair. It did not,
+# once: the `.app.id` fix in the FETCH read was pinned by NOTHING — a reviewer reverted it in the doc, ran
+# `self-test`, and the suite stayed GREEN, because this harness extracted only the two required-set reads
+# and the FETCH reads were merely eyeballed. A rule that is FIXED but PINNED BY NOTHING can be silently
+# reverted forever. So all FIVE reads are extracted here: the three FETCH reads and the two required-set
+# reads.
 DOC = Path(__file__).resolve().parents[1] / "references" / "stage-2-ci.md"
-PAYLOADS = Path(__file__).parent / "fixtures" / "required-set"
+PAYLOADS = Path(__file__).parent / "fixtures" / "required-set"  # payloads for the required-set reads
+FETCH_PAYLOADS = Path(__file__).parent / "fixtures" / "fetch"   # payloads for the evidence reads
 
-# Each read is identified by the `gh api` line that introduces it. A jq filter contains no single quote, so
-# the value is everything up to the next one.
+# Each read is identified by the COMMAND LINE that introduces it, VERBATIM — the pipeline included, so a
+# `--paginate` silently dropped from the doc is a drift this harness NOTICES instead of quietly executing
+# the truncating form. A jq filter contains no single quote, so the filter is everything up to the next one.
 READS = {
+    # The THREE evidence fetches (FETCH).
+    "check-runs": 'gh api --paginate --slurp "repos/<owner>/<repo>/commits/<head_sha>/check-runs" | jq -c \'',
+    "status": 'gh api --paginate --slurp "repos/<owner>/<repo>/commits/<head_sha>/status" | jq -c \'',
+    "rollup": "gh pr view <pr> --json statusCheckRollup | jq -c '",
+    # The TWO required-set reads (WHAT WERE WE EXPECTING TO SEE?).
     "classic": 'gh api "repos/<owner>/<repo>/branches/<base>" --jq \'',
-    "ruleset": 'gh api "repos/<owner>/<repo>/rules/branches/<base>" --jq \'',
+    "ruleset": 'gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/<base>" | jq -c \'',
 }
+
+# `gh api --paginate --slurp` hands jq ONE ARRAY OF PAGES. `jq -s` over N recorded page files builds exactly
+# that — so an N-page fetch is reproducible offline, and a filter that forgets to flatten the pages (or a
+# doc that drops the `--paginate`) goes RED here rather than in production, where it would silently record a
+# truncated required set and let a missing required check pass as green.
+SLURPED = {which for which, opener in READS.items() if "--slurp" in opener}
 
 
 class DocDrift(Exception):
@@ -1153,18 +1175,32 @@ def doc_read(which: str) -> str:
     return text[start:end]
 
 
-def required_set_from(which: str, payload: Path) -> list:
-    """Run the DOC's read over a recorded payload and return the declared checks it produces."""
+def run_read(which: str, payloads: tuple[Path, ...]) -> list:
+    """Run the DOC's read over recorded API PAGE(S) and return the JSON values it emits, one per line.
+
+    The payloads are the pages the endpoint returned. For a `--slurp`ed read they are handed to `jq -s`,
+    which is precisely the array-of-pages `gh api --paginate --slurp` produces — so PAGINATION ITSELF is
+    under test, not assumed.
+    """
     jq = shutil.which("jq")
     if jq is None:
         raise DocDrift("`jq` is not installed, so the reads cannot be executed — and a check that SKIPS is "
                        "a check that lies. Install jq (the campaign's own fetch needs it regardless)")
-    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
-        [jq, "-c", doc_read(which), str(payload)], capture_output=True, text=True, check=False
-    )
+    argv = [jq, "-c"] + (["-s"] if which in SLURPED else []) + [doc_read(which)]
+    argv += [str(p) for p in payloads]
+    proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603 - fixed argv
     if proc.returncode != 0:
-        raise DocDrift(f"the {which} read FAILED on {payload.name}: {proc.stderr.strip()}")
-    out = json.loads(proc.stdout)
+        names = ", ".join(p.name for p in payloads)
+        raise DocDrift(f"the {which} read FAILED on {names}: {proc.stderr.strip()}")
+    return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def required_set_from(which: str, payloads: tuple[Path, ...]) -> list:
+    """Run the DOC's required-set read over recorded page(s) and return the declared checks it produces."""
+    emitted = run_read(which, payloads)
+    if len(emitted) != 1:
+        raise DocDrift(f"the {which} read must emit exactly ONE value, got {len(emitted)}")
+    out = emitted[0]
     if which == "classic":
         if not isinstance(out, dict) or not isinstance(out.get("checks"), list):
             raise DocDrift(f"the classic read no longer produces a `checks` array: {out!r}")
@@ -1174,32 +1210,109 @@ def required_set_from(which: str, payload: Path) -> list:
     return out
 
 
-# (payload, read, the checks the read MUST produce, snapshot, verdict, needle, why)
+# (payload pages, read, the checks the read MUST produce, snapshot, verdict, needle, why)
 PRODUCER_CASES = [
-    ("classic-protection.json", "classic", [("Lint scripts", "15368"), ("Validate plugins", ANY_APP)],
+    (("classic-protection.json",), "classic",
+     [("Lint scripts", "15368"), ("Validate plugins", ANY_APP)],
      "green.jsonl", GREEN, "required set satisfied: Lint scripts, Validate plugins",
      "CLASSIC PROTECTION carrying a NULL app binding — the shape cli/cli's trunk really returns. The unbound "
      "check must read `-`, be satisfied by a row WHATEVER its producer, and go GREEN — while the BOUND check "
      "keeps its id, because a default that fires when a binding IS there is the mirror bug"),
-    ("ruleset-null-app.json", "ruleset", [("ci/jenkins", ANY_APP)],
+    (("ruleset-null-app.json",), "ruleset", [("ci/jenkins", ANY_APP)],
      "status-passing.jsonl", GREEN, "required set satisfied: ci/jenkins",
      "a RULESET whose `integration_id` is explicitly NULL, satisfied by a COMMIT STATUS — a row with NO "
      "producer field at all, which is precisely what an unbound declaration can be proven by"),
-    ("ruleset-no-app.json", "ruleset", [("ci/jenkins", ANY_APP)],
+    (("ruleset-no-app.json",), "ruleset", [("ci/jenkins", ANY_APP)],
      "status-passing.jsonl", GREEN, "required set satisfied: ci/jenkins",
      "the same ruleset with `integration_id` ABSENT rather than null — jq reads a missing field as null, and "
      "this pins that the read defaults it the same way instead of emitting a key it never saw"),
+    (("ruleset-paged-p1.json", "ruleset-paged-p2.json"), "ruleset",
+     [("Lint scripts", "15368"), ("Validate plugins", ANY_APP)],
+     "green.jsonl", GREEN, "required set satisfied: Lint scripts, Validate plugins",
+     "THE PAGINATION CASE. /rules/branches is a PAGED LIST (per_page 30 by default) and the "
+     "`required_status_checks` rule is on PAGE 2. Without `--paginate --slurp` the doc's read sees page 1 "
+     "only, finds no required rule, and records the required set as `none` — `the base branch requires "
+     "nothing` — which is the FALSE GREEN this whole section exists to close, reintroduced by a missing "
+     "flag. The read must produce BOTH checks from BOTH pages"),
 ]
+
+# (payload pages, read, the EXACT JSONL rows the read must emit, why)
+# The three FETCH reads, executed. These emit the snapshot's own rows, so the assertion is the rows
+# THEMSELVES — no verdict to hide behind: a wrong `app_id` here is the WEDGE, and it was pinned by nothing.
+FETCH_CASES = [
+    (("check-runs-p1.json", "check-runs-p2.json"), "check-runs", [
+        {"row": "checkrun", "sha": FIXTURE_SHA, "name": "Lint scripts", "app_id": "15368",
+         "status": "COMPLETED", "conclusion": "SUCCESS",
+         "id": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842667"},
+        {"row": "checkrun", "sha": FIXTURE_SHA, "name": "Validate plugins", "app_id": ANY_APP,
+         "status": "COMPLETED", "conclusion": "SUCCESS",
+         "id": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842710"},
+        {"row": "checkrun", "sha": FIXTURE_SHA, "name": "Deploy", "app_id": ANY_APP,
+         "status": "IN_PROGRESS", "conclusion": ANY_APP,
+         "id": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842999"},
+        {"row": "source", "source": "check-runs", "sha": FIXTURE_SHA, "count": "3"},
+     ],
+     "THE `.app.id` DEFAULT, AT LAST EXECUTED. A check run need not come from an App, and `null|tostring` is "
+     'the TRUTHY string "null", so `((.app.id|tostring) // "-")` never fires its default and binds the row '
+     "to a producer named `null` that no declaration can match. Both unbound rows must read `-`, the bound "
+     "one must keep 15368, the running row's null conclusion must read `-` — and `count` must be 3, which "
+     "it can only be if BOTH PAGES were read"),
+    (("status-one.json",), "status", [
+        {"row": "status", "sha": FIXTURE_SHA, "context": "ci/jenkins", "state": "SUCCESS"},
+        {"row": "source", "source": "status", "sha": FIXTURE_SHA, "count": "1"},
+     ],
+     "the LEGACY family. The oid is carried ONCE at the top level, never on the status — so both the row's "
+     "sha and the marker's sha must come from THERE, and from GitHub, never from a literal we interpolate"),
+    (("status-none.json",), "status", [
+        {"row": "source", "source": "status", "sha": FIXTURE_SHA, "count": "0"},
+     ],
+     "a commit with ZERO statuses: NO rows, and a marker that still carries GitHub's sha and `count: 0`. "
+     "That marker is the entire reason `we asked, and there are none` is distinguishable from `we never "
+     "asked` — and the latter, read as the former, is an absence that parses as `nothing wrong`"),
+    (("rollup.json",), "rollup", [
+        {"row": "witness", "name": "Lint scripts",
+         "id": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842667"},
+        {"row": "source", "source": "rollup", "sha": ANY_APP, "count": "1"},
+     ],
+     "WITNESSES ONLY. The StatusContext entry must NOT become a witness (the `select` is what keeps the "
+     "containment test comparing like with like), and the rollup marker's sha must be `-`: the rollup "
+     "carries no oid, so any sha there would be one WE INVENTED"),
+]
+
+
+def fetch_test() -> int:
+    """The three FETCH reads in stage-2-ci.md, EXTRACTED AND RUN over recorded API pages.
+
+    Nothing else in this file could catch a bug in them: every rule above takes the SNAPSHOT as given, and
+    these reads are what PRODUCE it. The `.app.id` ordering fix lived here, fixed and pinned by nothing —
+    revert it in the doc and, until this test existed, the whole suite stayed green.
+    """
+    failures = 0
+    for pages, which, want_rows, why in FETCH_CASES:
+        label = f"{pages[0]}{f' +{len(pages) - 1}p' if len(pages) > 1 else ''} -> {which} read"
+        try:
+            got_rows = run_read(which, tuple(FETCH_PAYLOADS / p for p in pages))
+        except DocDrift as exc:
+            print(f"FAIL     {label:44} -> {exc}")
+            failures += 1
+            continue
+        if got_rows != want_rows:
+            print(f"FAIL     {label:44} -> the read emitted\n           {got_rows}\n         expected\n"
+                  f"           {want_rows}")
+            failures += 1
+            continue
+        print(f"ok       {label:44} -> {len(got_rows)} rows ({why})")
+    return failures
 
 
 def producer_test(fixtures: Path) -> int:
     """The doc's read -> the spec -> the parser -> a verdict. The whole chain, on payloads with a NULL app
     binding, because the chain is where the wedge lived and no link of it could see the wedge alone."""
     failures = 0
-    for payload, which, want_checks, snapshot, want, needle, why in PRODUCER_CASES:
-        label = f"{payload} -> {which} read"
+    for pages, which, want_checks, snapshot, want, needle, why in PRODUCER_CASES:
+        label = f"{pages[0]}{f' +{len(pages) - 1}p' if len(pages) > 1 else ''} -> {which} read"
         try:
-            produced = required_set_from(which, PAYLOADS / payload)
+            produced = required_set_from(which, tuple(PAYLOADS / p for p in pages))
         except DocDrift as exc:
             print(f"FAIL     {label:44} -> {exc}")
             failures += 1

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -58,8 +58,21 @@ but NOT COUNTED parses as "nothing wrong":
     founding principle, unenforced by its own artifact. `source` rows (below) are what make an ABSENCE
     say "we do not know" instead of "nothing wrong".
 
-The lesson is one lesson, not eight: check the EXACT shape. "The thing I need is in there somewhere" is
-not a check — it is the absence of one, and every defect above is that same absence wearing a new hat.
+  * and then ONE LEVEL ABOVE THE ARTIFACT ENTIRELY — the last one, and the only one no rule here could
+    ever have caught, because it is not a defect IN the file. THE REGISTRATION GAP: every rule above
+    quantifies over the rows that ARE in the snapshot, and a REQUIRED check that has not registered yet is
+    NOT A FAILING ROW — IT IS NO ROW. So a snapshot could be perfectly formed, every marker present, every
+    row PASSING, containment holding — and still be silent about a required check that never showed up.
+    `green` meant "everything that had registered by the time we looked had passed", which is a statement
+    about WHAT SHOWED UP, while every caller read it as a statement about WHAT WAS REQUIRED. It was known,
+    and it was DISCLOSED IN A COMMENT — which merges the PR just the same: a disclaimer printed beside a
+    green is not a disclosure, it is a trapdoor with a sign on it. The fix is the only one available: STOP
+    LOOKING ONLY AT THE FILE. Read what the base branch REQUIRES and pass it in (`--required-set`).
+
+The lesson is one lesson, not nine: check the EXACT shape, and against the EXPECTED set. "The thing I need
+is in there somewhere" is not a check — it is the absence of one — and neither is "everything in here looks
+fine", when nothing ever asked what was supposed to BE here. Every defect above is that same absence
+wearing a new hat.
 
 So this file is not a description of the rules. It is the rules, executed, with fixtures that FAIL
 when the rules are wrong. `self-test` is the handoff: give it to a reviewer or a fix subagent and
@@ -81,7 +94,9 @@ it — and `mutate-ci-snapshot.py` removes each one in turn, re-runs the fixture
 notices, and FAILS if none does. Both run in CI. "Which rules are unpinned?" is a question the SUITE
 answers, not one a reviewer has to discover. ADD A RULE, MARK IT, AND GIVE IT A FIXTURE.
 
-  verify    parse a snapshot, verify it against an expected head_sha, and print the verdict
+  verify    parse a snapshot, verify it against an expected head_sha AND the base branch's required set
+            (--required-set, MANDATORY — the file alone cannot tell you what was missing from it), and
+            print the verdict
   self-test run every fixture and assert its expected verdict (and its REASON — the reason is the only
             thing that says WHICH rule fired, and a fixture that fails for someone else's reason pins
             nothing)
@@ -103,7 +118,7 @@ import sys
 import tempfile
 from collections import Counter
 from pathlib import Path
-from typing import NoReturn
+from typing import NamedTuple, NoReturn
 
 # --- the contract (stage-2-ci.md) ---------------------------------------------------------------
 #
@@ -159,6 +174,121 @@ PENDING = "pending"
 UNUSABLE = "unusable"  # the evidence is defective; refetch
 UNVERIFIABLE = "unverifiable"  # containment cannot be decided; fail CLOSED
 UNCLASSIFIED = "unclassified"  # a value NO rule maps — escalate to a human; NEVER guess a bucket for it
+
+
+# --- WHAT WERE WE EXPECTING TO SEE? — the required-check set -------------------------------------
+#
+# EVERY RULE ABOVE QUANTIFIES OVER THE ROWS THAT ARE IN THE FILE. Not one of them can see a row that is
+# NOT — and a REQUIRED check that has not registered yet is exactly that: not a failing row, NO ROW. So a
+# snapshot can be nonempty, every row PASSING, containment holding, every marker present — and still not be
+# the truth about the commit. "Every check that had registered by the time we looked had passed" is a
+# statement about what SHOWED UP; `green` is supposed to be a statement about what was REQUIRED.
+#
+# That was the REGISTRATION GAP, and it is what this section closes: the expected set is READ from the base
+# branch (branch protection AND rulesets — stage-2-ci.md owns the two reads), carried in the ledger header's
+# `required_set`, and passed in here. `green` now requires every declared check to be PRESENT and PASSING.
+#
+# THREE STATES, NEVER TWO. "I could not see any" is NOT "there are none":
+DECLARED = "declared"  # both reads succeeded, the union is non-empty — these checks must be present+passing
+NONE_DECLARED = "none"  # both reads succeeded, the union is EMPTY — a read FACT: nothing is required
+CANNOT_READ = "unknown"  # a read FAILED. We do not know what was required — see below
+
+# `unknown` CANNOT GO GREEN, and that is the whole reason it is not folded into `none`. A green printed
+# beside "...but a required check may exist, be missing, and campaign cannot tell" is NOT a disclosure, it
+# is a TRAPDOOR WITH A SIGN ON IT: the merge still happens and nobody reads the sign. So `unknown` is a
+# PENDING outcome that escalates (stage-2-ci.md, SETTLED) — and it is `ledger.py`'s DEFAULT, which makes a
+# run that never performed the read merge NOTHING instead of merging everything with a footnote.
+
+# The spec, as it is written in the ledger header: `declared:<json>` | `none` | `unknown`.
+#
+# The `declared:` payload is a JSON ARRAY, not a comma-separated list, and that is not fussiness: A REQUIRED
+# CHECK'S NAME MAY CONTAIN A COMMA. A matrix job is named `job (a, b)` — 40 of the 100 check runs on
+# `vercel/next.js`'s default-branch head carried one when this was written (a dated illustration; that
+# commas are legal and common in check names is the permanent claim). `"build,test".split(",")` on that set
+# invents checks that do not exist and loses the ones that do, and a required set you cannot parse back is a
+# required set you DO NOT HAVE.
+DECLARED_PREFIX = "declared:"
+
+# The declaration binds no app — ANY producer satisfies it. Same "-" convention as NO_OID: an explicit
+# "there is nothing here", never a value we failed to write down.
+ANY_APP = "-"
+
+
+class RequiredSet(NamedTuple):
+    """What the base branch requires. `checks` is empty unless `state` is DECLARED."""
+
+    state: str
+    checks: tuple[tuple[str, str], ...] = ()  # (context, app_id | ANY_APP)
+
+
+class SpecError(Exception):
+    """The --required-set spec is not readable. An OPERATOR error, never a snapshot verdict."""
+
+
+def parse_required_set(spec: str) -> RequiredSet:
+    """Parse the ledger's `required_set` value. STRICT, and LOUD when it cannot.
+
+    THE ONE THING THIS MUST NEVER DO IS DEGRADE. A spec we cannot read quietly becoming `none` would say
+    "the base branch requires nothing" on the strength of a value we failed to parse — rebuilding the exact
+    false green this whole section removes, one layer further down. So: raise, and the caller exits 2 with
+    NO verdict. No verdict at all beats a verdict about the wrong question.
+    """
+    if spec == NONE_DECLARED:
+        return RequiredSet(NONE_DECLARED)
+    if spec == CANNOT_READ:
+        return RequiredSet(CANNOT_READ)
+    if not spec.startswith(DECLARED_PREFIX):
+        raise SpecError(
+            f"{spec!r} is not a required-set spec: expected {NONE_DECLARED!r}, {CANNOT_READ!r}, "
+            f"or {DECLARED_PREFIX}<json>"
+        )
+    try:
+        payload = json.loads(spec[len(DECLARED_PREFIX):])
+    except json.JSONDecodeError as exc:
+        raise SpecError(f"the {DECLARED_PREFIX} payload is not JSON: {exc}") from exc
+    if not isinstance(payload, list) or not payload:
+        raise SpecError(
+            f"the {DECLARED_PREFIX} payload must be a NON-EMPTY JSON array — an empty required set is "
+            f"{NONE_DECLARED!r}, which is a different fact and must be recorded as one"
+        )
+    checks: list[tuple[str, str]] = []
+    for entry in payload:
+        if not isinstance(entry, dict) or set(entry) != {"context", "app"}:
+            raise SpecError(f"each declared check is {{'context': …, 'app': …}}, not {entry!r}")
+        ctx, app = entry["context"], entry["app"]
+        if not isinstance(ctx, str) or not isinstance(app, str) or not ctx:
+            raise SpecError(f"`context` and `app` must be strings, and `context` non-empty: {entry!r}")
+        checks.append((ctx, app))
+    return RequiredSet(DECLARED, tuple(checks))
+
+
+def satisfied_by(rows: list[dict], context: str, app: str) -> bool:
+    """Is this declared required check PRESENT and PASSING in the evidence?
+
+    MATCHED ON PRODUCER, NOT JUST ON NAME — A RIGHT-NAMED CHECK FROM THE WRONG APP IS NOT THE REQUIRED ONE.
+    A declaration that binds an app (`app != ANY_APP`) is a statement about WHO must produce the check, and
+    a rule that compares only the name would let any app in the world satisfy it by naming a job the same.
+
+    A `status` row can satisfy only an UNBOUND declaration. The commit-status family carries NO producer
+    field at all (the response has none to give — see the FETCH block in stage-2-ci.md), so an app-bound
+    declaration CANNOT BE PROVEN by one. It stays unsatisfied, the PR goes `pending (required check
+    missing)`, and SETTLED escalates it with the check named. That is FAIL-CLOSED ON PURPOSE: the
+    alternative is to accept a status from an app we never identified as proof of a check that named one —
+    the false green with an extra step.
+
+    PASSING is tested here, not assumed from the caller's position. It is true that `decide` only reaches
+    this after every row has already classified PASS — but a rule that is correct only because of where it
+    sits is a rule that breaks silently the day the bullets are reordered.
+    """
+    for r in rows:
+        if r["row"] == "checkrun" and r.get("name") == context:
+            if app in (ANY_APP, r.get("app_id")) and r.get("status") == TERMINAL_STATUS \
+                    and r.get("conclusion") in PASS_CONCLUSIONS:
+                return True
+        if r["row"] == "status" and r.get("context") == context and app == ANY_APP:
+            if r.get("state") in STATUS_PASS:
+                return True
+    return False
 
 
 class SnapshotError(Exception):
@@ -587,8 +717,13 @@ class Unverifiable(Exception):
     """Containment cannot be decided. Fail closed; never green."""
 
 
-def decide(rows: list[dict]) -> tuple[str, str]:
-    """Decide from the verified file's contents — FIRST MATCH WINS. Returns (verdict, reason).
+def decide(rows: list[dict], required: RequiredSet) -> tuple[str, str]:
+    """Decide from the verified file's contents AND what the base branch REQUIRED — FIRST MATCH WINS.
+    Returns (verdict, reason).
+
+    `required` is the second half of the question, and the file alone cannot answer it: every rule that
+    reads `rows` quantifies over the rows that ARE there, and a required check that never registered is
+    NO ROW. See "WHAT WERE WE EXPECTING TO SEE?" above.
 
     THE ORDER IS PART OF THE RULE, and `red` OUTRANKS `UNCLASSIFIED` DELIBERATELY. A snapshot carrying BOTH
     a failing row and an unknown value is RED: the known failure is actionable NOW and blocks the merge
@@ -659,12 +794,49 @@ def decide(rows: list[dict]) -> tuple[str, str]:
         # MUTATE:zero-evidence:pass
         return PENDING, "zero evidence rows — nothing has registered yet (NOT green)"
 
-    # Every evidence row classified PASS. Nothing else can reach this line.
-    return GREEN, f"{len(evidence)} evidence rows, all passing, containment holds"
+    # ---------------------------------------------------------------------------------------------
+    # Every evidence row classified PASS. EVERY RULE ABOVE IS NOW SATISFIED — and that is exactly the
+    # state in which the registration gap used to hand back a false green. The remaining question is the
+    # one no row can answer: WERE THESE THE ROWS THAT WERE SUPPOSED TO BE HERE?
+    # ---------------------------------------------------------------------------------------------
+
+    # --- pending: we do not know what was required, so we cannot say this is green. INCOMPLETE EVIDENCE
+    # IS NOT GREEN, exactly as ZERO evidence is not. This is the branch that makes `unknown` — ledger.py's
+    # DEFAULT — fail CLOSED: a run that never read the base branch's required checks merges nothing.
+    if required.state == CANNOT_READ:
+        # MUTATE:required-set-unreadable:pass
+        return PENDING, (
+            "the base branch's required checks could NOT BE READ (required_set=unknown) — a required check "
+            "may exist, be missing, and this snapshot cannot tell. NOT green"
+        )
+
+    # --- pending: a DECLARED required check has no passing row. It has not registered — which is NO ROW,
+    # not a failing one, so every rule above passed straight over it.
+    for context, app in required.checks:
+        if not satisfied_by(rows, context, app):
+            # MUTATE:required-check-missing:pass
+            return PENDING, (
+                f"required check absent: {context}"
+                f"{'' if app == ANY_APP else f' (app {app})'} — declared by the base branch, and NOT "
+                f"present and passing in this snapshot. NOT green"
+            )
+
+    # Every evidence row passed AND the required set is accounted for. Nothing else can reach this line,
+    # and `green` here means the REQUIRED SET PASSED — not merely that whatever showed up did.
+    return GREEN, (
+        f"{len(evidence)} evidence rows, all passing, containment holds; required set "
+        f"{'satisfied: ' + ', '.join(c for c, _ in required.checks) if required.checks else 'is EMPTY (read, not assumed)'}"
+    )
 
 
-def evaluate(path: Path, expected_sha: str, *, expect_filename_sha: bool = True) -> tuple[str, str]:
-    """`expect_filename_sha` is OFF only for the fixtures, which are named by the PROPERTY they pin
+def evaluate(
+    path: Path, expected_sha: str, *, required: RequiredSet, expect_filename_sha: bool = True
+) -> tuple[str, str]:
+    """`required` is MANDATORY and keyword-only. There is deliberately NO default: a caller that forgot to
+    say what the base branch requires must not be silently given the permissive answer — that is the whole
+    class of bug this parameter exists to kill.
+
+    `expect_filename_sha` is OFF only for the fixtures, which are named by the PROPERTY they pin
     (`green.jsonl`, `wrong-sha.jsonl`, …) rather than by a SHA — their names are documentation. It is ON
     for every real artifact, and `self-test` proves the check still fires (FILENAME_CASES below).
     """
@@ -679,7 +851,7 @@ def evaluate(path: Path, expected_sha: str, *, expect_filename_sha: bool = True)
         return UNVERIFIABLE, str(exc)
     except SnapshotError as exc:
         return UNUSABLE, str(exc)
-    return decide(rows)
+    return decide(rows, required)
 
 
 # --- self-test: the fixtures ARE the evidence ---------------------------------------------------
@@ -732,7 +904,8 @@ EXPECTED = {
     "red-checkrun.jsonl": (RED, "concluded FAILURE", "a FAILED check run is RED — the rule that decides the whole point of the artifact"),
     "running-checkrun.jsonl": (PENDING, "still running", "a check run whose `.status` classifies RUNNING can still move — it is NOT a green (and the test is MEMBERSHIP in RUNNING_STATUSES, never `!= COMPLETED`)"),
     "pending-status.jsonl": (PENDING, "still running", "a PENDING commit status can still move — it is NOT a green"),
-    "expected-status.jsonl": (PENDING, "still running", "EXPECTED = a required status NOT POSTED YET — the registration gap, visible in the evidence for once"),
+    "expected-status.jsonl": (PENDING, "still running", "EXPECTED = a required status DECLARED BUT NOT POSTED YET — the one shape of not-yet-registered the evidence can express on its own; REQUIRED_CASES below covers the shape it cannot"),
+    "status-passing.jsonl": (GREEN, "all passing", "a SUCCESS commit status and no check runs at all — the family /check-runs cannot see, green on its own; REQUIRED_CASES uses it to pin what a producer-less row can and cannot prove"),
     "skipped-is-pass.jsonl": (GREEN, "all passing", "SKIPPED is a PASS — GitHub rolls it up that way, and a rule set without it can NEVER go green on a repo with path filters"),
     # THE CATCH-ALL, and it is now reachable ONLY by a value GitHub has ADDED SINCE — which is exactly what
     # it is for. Both values below are INVENTED: no CheckStatusState is `AWAITING_APPROVAL`, no
@@ -786,6 +959,13 @@ EXPECTED = {
 }
 
 
+# EVERY fixture in EXPECTED is evaluated against a base branch that requires NOTHING (`none`) — the state
+# in which the rules above are the ONLY thing deciding, which is exactly what those fixtures are for. The
+# required-set rule gets its own table, REQUIRED_CASES, because it is the one rule whose input is NOT in the
+# file: the same bytes are green or pending depending on what the BASE BRANCH declared.
+NO_REQUIRED = RequiredSet(NONE_DECLARED)
+
+
 def self_test(fixtures: Path) -> int:
     """Every fixture is evaluated against the SAME expected head_sha the ledger would hold.
 
@@ -802,7 +982,7 @@ def self_test(fixtures: Path) -> int:
             failures += 1
             continue
         # The fixtures are named by PROPERTY, not by SHA, so the filename rule is exercised separately.
-        got, reason = evaluate(path, FIXTURE_SHA, expect_filename_sha=False)
+        got, reason = evaluate(path, FIXTURE_SHA, required=NO_REQUIRED, expect_filename_sha=False)
         if got == want and needle in reason:
             print(f"ok       {name:28} -> {got:14} ({why})")
         elif got != want:
@@ -817,13 +997,113 @@ def self_test(fixtures: Path) -> int:
             failures += 1
 
     failures += filename_test(fixtures)
+    failures += required_test(fixtures)
+    failures += spec_test()
     print()
     if failures:
         print(f"{failures} check(s) FAILED — the CI-snapshot contract is broken.")
         return 1
-    print(f"all {len(EXPECTED)} fixtures + {len(FILENAME_CASES)} filename cases hold — the contract is intact.")
+    print(f"all {len(EXPECTED)} fixtures + {len(FILENAME_CASES)} filename cases + "
+          f"{len(REQUIRED_CASES)} required-set cases + {len(SPEC_CASES)} spec cases hold — "
+          f"the contract is intact.")
     print("`mutate-ci-snapshot.py` is what proves each of them pins its OWN rule. Run it too.")
     return 0
+
+
+# THE REGISTRATION GAP, PINNED. Every case below reuses fixture bytes that are ALREADY GREEN on their own —
+# so the ONLY thing under test is what the BASE BRANCH declared. That is the point: the gap was never
+# visible in the file, which is precisely why no rule that reads only the file could ever have closed it.
+#
+# Each case is (fixture, spec, verdict, needle, why).
+REQUIRED_CASES = [
+    # The two that would have been FALSE GREENS, and the reason this rule exists.
+    ("green.jsonl", CANNOT_READ, PENDING, "could NOT BE READ",
+     "THE ONE THAT MATTERS MOST: flawless all-passing evidence, and we never learned what was REQUIRED — "
+     "so it is NOT green. `unknown` is ledger.py's DEFAULT, which makes a run that never looked merge nothing"),
+    ("green.jsonl", f'{DECLARED_PREFIX}[{{"context": "integration-tests", "app": "-"}}]',
+     PENDING, "required check absent: integration-tests",
+     "THE REGISTRATION GAP ITSELF: a required check that NEVER REGISTERED is not a failing row, it is NO "
+     "ROW — the snapshot is nonempty, every row passes, and it is still not the truth about this commit"),
+    # PRODUCER. A right-named check from the WRONG app is not the required one.
+    ("green.jsonl", f'{DECLARED_PREFIX}[{{"context": "Lint scripts", "app": "99999"}}]',
+     PENDING, "required check absent: Lint scripts (app 99999)",
+     "the name matches and the APP DOES NOT — matching on name alone would let any app on earth satisfy a "
+     "declaration by naming a job the same"),
+    ("status-passing.jsonl", f'{DECLARED_PREFIX}[{{"context": "ci/jenkins", "app": "15368"}}]',
+     PENDING, "required check absent: ci/jenkins (app 15368)",
+     "an APP-BOUND declaration against a COMMIT STATUS, which carries no producer field at all — it cannot "
+     "be PROVEN, so it is not accepted. Fail-closed, and the doc says so"),
+    # The greens. A rule that cannot say YES is not a gate, it is a wall.
+    ("green.jsonl", NONE_DECLARED, GREEN, "required set is EMPTY (read, not assumed)",
+     "the base branch requires NOTHING — and that is a READ FACT, not an absence of one, so nothing "
+     "required can be missing and the green carries NO caveat"),
+    ("green.jsonl",
+     f'{DECLARED_PREFIX}[{{"context": "Lint scripts", "app": "15368"}}, '
+     f'{{"context": "Validate plugins", "app": "-"}}]',
+     GREEN, "required set satisfied: Lint scripts, Validate plugins",
+     "every declared check PRESENT and PASSING — one bound to its app, one unbound. THIS is what green is "
+     "now allowed to mean"),
+    ("status-passing.jsonl", f'{DECLARED_PREFIX}[{{"context": "ci/jenkins", "app": "-"}}]',
+     GREEN, "required set satisfied: ci/jenkins",
+     "an UNBOUND declaration IS satisfiable by a commit status — the producer rule must not wall off the "
+     "legacy family it was never about"),
+    # A declared check that is PRESENT but still RUNNING is NOT this rule's business: it is a RUNNING row,
+    # so plain `pending` outranks and the PR gets WATCHED, as it must. Ordering, pinned.
+    ("running-checkrun.jsonl", f'{DECLARED_PREFIX}[{{"context": "Validate plugins", "app": "-"}}]',
+     PENDING, "still running",
+     "a declared check that IS registered and still running is caught by the RUNNING bullet, NOT by "
+     "'required check missing' — it can still move, so it is watched"),
+]
+
+
+def required_test(fixtures: Path) -> int:
+    """The same bytes, different declarations. Nothing here is a property OF THE FILE."""
+    failures = 0
+    for name, spec, want, needle, why in REQUIRED_CASES:
+        got, reason = evaluate(
+            fixtures / name, FIXTURE_SHA, required=parse_required_set(spec), expect_filename_sha=False
+        )
+        label = f"{name} + {spec[:34]}"
+        if got == want and needle in reason:
+            print(f"ok       {label:70} -> {got:8} ({why})")
+        elif got != want:
+            print(f"FAIL     {label:70} -> {got:8} expected {want}\n         reason: {reason}")
+            failures += 1
+        else:
+            print(f"FAIL     {label:70} -> {got:8} but the reason does not mention {needle!r}"
+                  f"\n         reason: {reason}")
+            failures += 1
+    return failures
+
+
+# A SPEC WE CANNOT READ MUST NEVER BECOME `none`. That is the one degradation that would rebuild the false
+# green inside the parser — "the base branch requires nothing", asserted on the strength of a value we
+# failed to parse. Every case below must RAISE, and the CLI turns each into exit 2 with NO verdict.
+SPEC_CASES = [
+    ("", "an empty spec is not a state"),
+    ("declared:", "a `declared:` with no payload"),
+    ("declared:[]", "an EMPTY declared list — an empty required set is `none`, a DIFFERENT fact"),
+    ("declared:build,test", "THE OLD COMMA FORMAT: unparseable as JSON, and never silently read as `none`"),
+    ('declared:{"context": "build", "app": "-"}', "an object where an ARRAY is required"),
+    ('declared:[{"context": "build"}]', "a declared check missing its `app` — half a declaration"),
+    ('declared:[{"context": "build", "app": 15368}]', "a non-string `app` — a value we cannot compare"),
+    ('declared:[{"context": "", "app": "-"}]', "an EMPTY context — it would match nothing, forever"),
+    ("none-declared", "a near-miss of a state name, which is not one of the three"),
+    ("NONE", "the right word, the wrong case — states are exact, never close enough"),
+]
+
+
+def spec_test() -> int:
+    failures = 0
+    for spec, why in SPEC_CASES:
+        try:
+            got = parse_required_set(spec)
+        except SpecError:
+            print(f"ok       spec {spec[:30]!r:34} -> REJECTED ({why})")
+            continue
+        print(f"FAIL     spec {spec[:30]!r:34} -> PARSED as {got} — it must be REJECTED, never degraded")
+        failures += 1
+    return failures
 
 
 # The filename rule, every way. A check that cannot FAIL is not a check — `wrong-sha.jsonl` exists because
@@ -851,7 +1131,7 @@ def filename_test(fixtures: Path) -> int:
         for name, want, needle, why in FILENAME_CASES:
             path = Path(tmp) / name
             shutil.copyfile(fixtures / "green.jsonl", path)
-            got, reason = evaluate(path, FIXTURE_SHA, expect_filename_sha=True)
+            got, reason = evaluate(path, FIXTURE_SHA, required=NO_REQUIRED, expect_filename_sha=True)
             if got == want and needle in reason:
                 print(f"ok       {name:28} -> {got:14} ({why})")
             elif got != want:
@@ -876,6 +1156,17 @@ def main() -> int:
     v = sub.add_parser("verify", help="verify a snapshot against an expected head_sha")
     v.add_argument("--file", required=True, type=Path)
     v.add_argument("--head-sha", required=True)
+    v.add_argument(
+        "--required-set",
+        required=True,
+        help=(
+            "what the BASE BRANCH requires — the ledger header's `required_set`, VERBATIM: "
+            "`declared:<json>` | `none` | `unknown` (stage-2-ci.md, 'WHAT WERE WE EXPECTING TO SEE?'). "
+            "REQUIRED, with no default: a snapshot can be nonempty and all-passing while a REQUIRED check "
+            "has not registered at all — that is no row, not a failing one, and no rule that reads only "
+            "the file can see it. `unknown` NEVER goes green."
+        ),
+    )
     v.add_argument(
         "--expect-filename-sha",
         action=argparse.BooleanOptionalAction,
@@ -903,7 +1194,16 @@ def main() -> int:
         fail(f"--head-sha {args.head_sha!r} is not a git object id (40 LOWERCASE hex) — refusing to verify")
     if not args.file.exists():
         fail(f"no such snapshot: {args.file}")
-    verdict, reason = evaluate(args.file, args.head_sha, expect_filename_sha=args.expect_filename_sha)
+    # A required-set spec we cannot READ is an operator error too, and it gets the same treatment: exit 2,
+    # NO verdict. It must NEVER fall back to `none` — "the base branch requires nothing", asserted from a
+    # value we failed to parse, is the false green this flag exists to prevent, rebuilt inside the parser.
+    try:
+        required = parse_required_set(args.required_set)
+    except SpecError as exc:
+        fail(f"--required-set: {exc}")
+    verdict, reason = evaluate(
+        args.file, args.head_sha, required=required, expect_filename_sha=args.expect_filename_sha
+    )
     print(f"{verdict}: {reason}")
     # green is the ONLY exit-0 verdict. Everything else — including UNCLASSIFIED — is not a green.
     return 0 if verdict == GREEN else 1

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/ci-snapshot/status-passing.jsonl
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/ci-snapshot/status-passing.jsonl
@@ -1,0 +1,5 @@
+{"row":"header","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971"}
+{"row":"status","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971","context":"ci/jenkins","state":"SUCCESS"}
+{"row":"source","source":"check-runs","sha":"-","count":"0"}
+{"row":"source","source":"status","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971","count":"1"}
+{"row":"source","source":"rollup","sha":"-","count":"0"}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/ci-snapshot/unbound-checkrun.jsonl
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/ci-snapshot/unbound-checkrun.jsonl
@@ -1,0 +1,6 @@
+{"row":"header","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971"}
+{"row":"checkrun","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971","name":"Deploy","app_id":"-","status":"COMPLETED","conclusion":"SUCCESS","id":"https://ci.example.com/deploy/1"}
+{"row":"source","source":"check-runs","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971","count":"1"}
+{"row":"source","source":"status","sha":"1499c72bf1715e74abb0e28658b515eaa2c0c971","count":"0"}
+{"row":"witness","name":"Deploy","id":"https://ci.example.com/deploy/1"}
+{"row":"source","source":"rollup","sha":"-","count":"1"}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/check-runs-p1.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/check-runs-p1.json
@@ -1,0 +1,15 @@
+{
+  "_fixture": "PAGE 1 of GET /repos/{owner}/{repo}/commits/{sha}/check-runs. `/check-runs` pages at 30; the page boundary here is forced so that a fixture need not depend on a commit carrying 31 checks. Page 2 (`check-runs-p2.json`) carries the runs with a NULL `.app` — read page one only and `count` says 1 while the commit has 3.",
+  "total_count": 3,
+  "check_runs": [
+    {
+      "id": 86862842667,
+      "name": "Lint scripts",
+      "head_sha": "1499c72bf1715e74abb0e28658b515eaa2c0c971",
+      "status": "completed",
+      "conclusion": "success",
+      "details_url": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842667",
+      "app": { "id": 15368, "slug": "github-actions" }
+    }
+  ]
+}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/check-runs-p2.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/check-runs-p2.json
@@ -1,0 +1,24 @@
+{
+  "_fixture": "PAGE 2. `\"app\": null` is the shape the doc's `((.app.id // \"-\")|tostring)` exists for: a check run need NOT come from a GitHub App. Written `((.app.id|tostring) // \"-\")` the default never fires and `app_id` carries the four letters `null`. `\"conclusion\": null` on the still-running row is the same trap on the same line's neighbour.",
+  "total_count": 3,
+  "check_runs": [
+    {
+      "id": 86862842710,
+      "name": "Validate plugins",
+      "head_sha": "1499c72bf1715e74abb0e28658b515eaa2c0c971",
+      "status": "completed",
+      "conclusion": "success",
+      "details_url": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842710",
+      "app": null
+    },
+    {
+      "id": 86862842999,
+      "name": "Deploy",
+      "head_sha": "1499c72bf1715e74abb0e28658b515eaa2c0c971",
+      "status": "in_progress",
+      "conclusion": null,
+      "details_url": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842999",
+      "app": null
+    }
+  ]
+}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/rollup.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/rollup.json
@@ -1,0 +1,18 @@
+{
+  "_fixture": "`gh pr view <pr> --json statusCheckRollup`. WITNESSES ONLY: the rollup carries no app id and NO COMMIT OID, so it can never be read as a verdict — hence its marker's sha is `-`, ALWAYS, and a sha there would be one WE invented. The StatusContext entry is here to pin the `select(.__typename==\"CheckRun\")`: it must NOT become a witness, because the containment test compares check-run identities and a status has no `detailsUrl` to compare.",
+  "statusCheckRollup": [
+    {
+      "__typename": "CheckRun",
+      "name": "Lint scripts",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/86862842667"
+    },
+    {
+      "__typename": "StatusContext",
+      "context": "ci/jenkins",
+      "state": "SUCCESS",
+      "targetUrl": "https://jenkins.example.com/job/42"
+    }
+  ]
+}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/status-none.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/status-none.json
@@ -1,0 +1,7 @@
+{
+  "_fixture": "A commit with ZERO statuses. `state` reads `pending` with `total_count: 0` — an ABSENCE, which read as a verdict is a lie in both directions, and which is why the doc reads `.statuses[]`, never `.state`. The top-level `.sha` is present ANYWAY, and that is what lets the marker PROVE `we asked this commit, and it has none` — {\"source\":\"status\",\"sha\":\"<GitHub's>\",\"count\":\"0\"} — instead of leaving a silence that parses as `nothing wrong`.",
+  "state": "pending",
+  "sha": "1499c72bf1715e74abb0e28658b515eaa2c0c971",
+  "total_count": 0,
+  "statuses": []
+}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/status-one.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/fetch/status-one.json
@@ -1,0 +1,9 @@
+{
+  "_fixture": "GET /repos/{owner}/{repo}/commits/{sha}/status — the LEGACY family, invisible to /check-runs. The commit oid is carried ONCE, at the TOP LEVEL, never on the individual statuses; the rows and the marker must both take it from there. A status carries NO producer field at all, which is why an app-bound required check can never be proven by one.",
+  "state": "success",
+  "sha": "1499c72bf1715e74abb0e28658b515eaa2c0c971",
+  "total_count": 1,
+  "statuses": [
+    { "context": "ci/jenkins", "state": "success", "description": "build succeeded" }
+  ]
+}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/classic-protection.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/classic-protection.json
@@ -1,0 +1,16 @@
+{
+  "_fixture": "GET /repos/{owner}/{repo}/branches/{branch}, trimmed to what the read touches. `app_id: null` is NOT invented: repos/cli/cli/branches/trunk returns exactly that for every one of its required checks (read 2026-07-13). The contexts are this repo's, so the required set this payload produces can be run end-to-end against green.jsonl; the app-bound entry pins that a default must not swallow a binding that IS there.",
+  "name": "main",
+  "protected": true,
+  "protection": {
+    "enabled": true,
+    "required_status_checks": {
+      "enforcement_level": "everyone",
+      "checks": [
+        { "context": "Lint scripts", "app_id": 15368 },
+        { "context": "Validate plugins", "app_id": null }
+      ],
+      "contexts": ["Lint scripts", "Validate plugins"]
+    }
+  }
+}

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-no-app.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-no-app.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "required_status_checks",
+    "ruleset_source_type": "Repository",
+    "parameters": {
+      "strict_required_status_checks_policy": false,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [
+        { "context": "ci/jenkins" }
+      ]
+    }
+  }
+]

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-null-app.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-null-app.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "pull_request",
+    "parameters": { "required_approving_review_count": 1 }
+  },
+  {
+    "type": "required_status_checks",
+    "ruleset_source_type": "Repository",
+    "parameters": {
+      "strict_required_status_checks_policy": false,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [
+        { "context": "ci/jenkins", "integration_id": null }
+      ]
+    }
+  }
+]

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-paged-p1.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-paged-p1.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "deletion",
+    "ruleset_source_type": "Repository",
+    "ruleset_id": 1,
+    "parameters": {}
+  },
+  {
+    "type": "non_fast_forward",
+    "ruleset_source_type": "Repository",
+    "ruleset_id": 1,
+    "parameters": {}
+  }
+]

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-paged-p2.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/required-set/ruleset-paged-p2.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "required_status_checks",
+    "ruleset_source_type": "Repository",
+    "ruleset_id": 2,
+    "parameters": {
+      "strict_required_status_checks_policy": false,
+      "do_not_enforce_on_create": false,
+      "required_status_checks": [
+        { "context": "Lint scripts", "integration_id": 15368 },
+        { "context": "Validate plugins", "integration_id": null }
+      ]
+    }
+  }
+]

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -24,12 +24,25 @@ from typing import NoReturn
 
 # --- schema (owned here, once) ------------------------------------------------
 
-HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer")
+HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_set")
 HEADER_DEFAULTS = {
     "run_id": "-",
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
+    # What `base_branch` REQUIRES (stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?", which owns the three
+    # states and the format). A property of the BASE BRANCH, not of a PR, so it lives here, not on the rows.
+    #
+    #   declared:<json>  the required checks, READ. `ci-snapshot.py --required-set` is the one parser.
+    #   none             both reads succeeded and the set is EMPTY — a read FACT: nothing is required.
+    #   unknown          a read failed. We do not know what was required.
+    #
+    # The default is `unknown`, and it is LOAD-BEARING, not a placeholder: `unknown` CANNOT GO GREEN
+    # (stage-2-ci.md), so a run that never performed the read merges NOTHING. "I have not looked" and "I
+    # looked and there are none" are DIFFERENT facts, and the default is the one that claims nothing —
+    # a `none` that really meant "I could not see" is how a green is recorded for a commit whose required
+    # check never registered.
+    "required_set": "unknown",
 }
 
 ROW_FIELDS = (

--- a/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
@@ -159,8 +159,15 @@ def mutate(source: str, rule: str, weakening: str, stmt: ast.stmt) -> str:
     return "\n".join(lines[: stmt.lineno - 1] + body + lines[stmt.end_lineno :]) + "\n"
 
 
+def required_case_id(name: str, spec: str) -> str:
+    """Stable, readable key for a REQUIRED_CASES case. The spec is part of the identity: the SAME bytes are
+    green or pending depending on it, which is the entire point of that table."""
+    return f"[req] {name} + {spec[:40]}"
+
+
 def run_cases(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
-    """Every fixture + every filename case, against this (possibly mutated) module.
+    """Every fixture + every filename case + every required-set case, against this (possibly mutated)
+    module.
 
     A mutant that CRASHES has not returned a verdict, and "no verdict" is itself a deviation — so it is
     recorded, never swallowed.
@@ -168,7 +175,9 @@ def run_cases(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
     out: dict[str, tuple[str, str]] = {}
     for name in mod.EXPECTED:
         try:
-            out[name] = mod.evaluate(FIXTURES / name, mod.FIXTURE_SHA, expect_filename_sha=False)
+            out[name] = mod.evaluate(
+                FIXTURES / name, mod.FIXTURE_SHA, required=mod.NO_REQUIRED, expect_filename_sha=False
+            )
         except Exception as exc:  # noqa: BLE001 - a crash IS the result here
             out[name] = (f"crash:{type(exc).__name__}", str(exc))
     with tempfile.TemporaryDirectory() as tmp:
@@ -176,9 +185,22 @@ def run_cases(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
             path = Path(tmp) / name
             shutil.copyfile(FIXTURES / "green.jsonl", path)
             try:
-                out[f"[name] {name}"] = mod.evaluate(path, mod.FIXTURE_SHA, expect_filename_sha=True)
+                out[f"[name] {name}"] = mod.evaluate(
+                    path, mod.FIXTURE_SHA, required=mod.NO_REQUIRED, expect_filename_sha=True
+                )
             except Exception as exc:  # noqa: BLE001
                 out[f"[name] {name}"] = (f"crash:{type(exc).__name__}", str(exc))
+    # The required-set rule is the ONE rule whose input is not in the file. Its cases must run against the
+    # mutant too, or removing it would be pinned by nobody — the failure mode this harness exists for.
+    for name, spec, _want, _needle, _why in mod.REQUIRED_CASES:
+        case = required_case_id(name, spec)
+        try:
+            out[case] = mod.evaluate(
+                FIXTURES / name, mod.FIXTURE_SHA,
+                required=mod.parse_required_set(spec), expect_filename_sha=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            out[case] = (f"crash:{type(exc).__name__}", str(exc))
     return out
 
 
@@ -186,6 +208,10 @@ def expectations(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
     """case -> (expected verdict, needle the reason must contain)."""
     out = {name: (want, needle) for name, (want, needle, _why) in mod.EXPECTED.items()}
     out.update({f"[name] {n}": (want, needle) for n, want, needle, _why in mod.FILENAME_CASES})
+    out.update({
+        required_case_id(n, spec): (want, needle)
+        for n, spec, want, needle, _why in mod.REQUIRED_CASES
+    })
     return out
 
 


### PR DESCRIPTION
**Stacked on #31.** Fourth of the PRs replacing #26.

## The bug: an unimplementable rule

`stage-2-ci.md` on `main` says green requires that **"the expected checks are actually present"** — and then gives **no mechanism whatsoever** to know what is expected. The rule cannot be followed, so in practice it is not.

That matters because a required check that has **not registered yet** is not a failing row — it is **no row at all**. The snapshot of the checks that *did* register is nonempty, all-passing, and **not the truth about the commit**. That is a false green, and it is the one remaining false-green vector after #29/#30/#31.

## The fix: probe the DATA, never the PERMISSIONS

This is where #26 went wrong, and the trap is worth naming. #26 added a `.permissions.admin` probe to decide whether a 404 from classic branch protection meant "unprotected" or "you may not look."

**That probe is worthless**, and I reproduced it **on this repo**:

```
.permissions.admin              -> true
branches/main/protection        -> 404 "Branch not protected"
branches/main --jq .protected   -> true      # protected by a RULESET
rules/branches/main             -> [deletion, non_fast_forward]
```

`GET /repos/{o}/{r}` needs only **Metadata**, and `.permissions` reports **the USER's role, not the TOKEN's grants**. And a classic 404 has a **third** cause #26 never named: **protected by a ruleset**, which the classic endpoint cannot see. So the probe says `true`, the 404 gets read as "unprotected", and campaign declares **NONE DECLARED on a branch that is actively protected**.

So this PR never asks *"may I read this?"* It **asks for the thing and checks whether it got it**:

- `repos/{o}/{r}/branches/<base>` → `.protection.enabled` says whether classic protection **exists**, which disambiguates the 404 without any permissions probe, and `.protection.required_status_checks.checks[]` carries `app_id`.
- `repos/{o}/{r}/rules/branches/<base>` → the ruleset rules actually in force, with `integration_id`.

Both need only **Metadata**. If a read errors, or the field it needed is **absent**, that is **CANNOT READ** — never "none".

## Three states, never two

`required_set` (new ledger **header** field — it is a property of the base branch, not of a PR):

- **`declared:<ctx>,…`** — **both** reads succeeded, union non-empty. Green requires every required check **present AND passing**, matched on **producer** — a right-named check from the **wrong app** is not the required one. Missing → `pending`; if it never registers, #31's SETTLED rule escalates it with the check **named**, rather than spinning.
- **`none`** — **both** reads succeeded, union empty. Green means only *"every check that had registered by the time we looked had passed"* — the registration gap, now stated rather than papered over.
- **`unknown`** — either read errored or its field was absent. **Operationally like `none`, but never silently reported as it.** Disclosed at run start and in the final report.

**`declared` requires that BOTH reads succeeded.** If one is denied and the other returns a non-empty set, you know *some* required checks — not that you know them **all**. That is `unknown`. Verify the ones you do know; never claim you know the whole set.

## Verification

`ledger.py` exercised: `required_set` defaults to **`unknown`** — including when back-filling a **pre-existing header that lacks the field**, so an old ledger never reads as "no required checks" — and `header set`/`get` round-trips. The default is `unknown` on purpose: **"I have not looked" and "I looked and there are none" are different facts, and the default must be the one that claims nothing.**

The final report now states **what `green` was allowed to mean**. A gate that overstates what it verified is worse than one that verifies less and says so.