### PR TITLE
give prs.json one schema and one command, and bound every gh pr list

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -51,9 +51,12 @@
 - Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.
-- Reconcile from ONE batched `gh pr list --label gauntlet-run-<run-id> --json …` snapshot per wake
-  (`<rundir>/prs.json`); per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth
-  stays the re-polled `gh pr checks` snapshot.
+- Reconcile from ONE batched `gh pr list` snapshot per wake (`<rundir>/prs.json`), written with the
+  **canonical `prs.json` command — the single owning definition is the `prs.json` row in
+  `files-and-ledger.md`** (**ONE path, ONE schema, ONE command**). Never spell a variant of it here or
+  anywhere else, and **NEVER drop `--state all --limit 1000`**: without `--state all` the snapshot omits
+  merged/closed PRs, and without `--limit` `gh pr list` silently caps at **30**. Per-PR `gh` calls only
+  where the snapshot falls short. Merge-gate CI truth stays the re-polled `gh pr checks` snapshot.
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs
   immediately, ask the user asynchronously, and fold the answer in as its own wake.
 - Public API surface/behavior changes need user confirmation by default (see Constraints). The

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -55,10 +55,10 @@
   **canonical `prs.json` command — the single owning definition is the block "The canonical `prs.json`
   command" in `files-and-ledger.md`**, which spells it in full, label and output path included (**ONE
   path, ONE schema, ONE command**). Never spell a variant of it here or anywhere else, and **NEVER drop
-  `--label gauntlet-run-<run-id>`, `--state all`, or `--limit 1000`**: without `--label` the snapshot
-  escapes the run's scope and reconcile would act on **other runs' PRs**, without `--state all` it omits
-  merged/closed PRs, and without `--limit` `gh pr list` silently caps at **30**. Per-PR `gh` calls only
-  where the snapshot falls short. Merge-gate CI truth stays the re-polled `gh pr checks` snapshot.
+  `--label gauntlet-run-<run-id>` or `--limit 1000`**: without `--label` the snapshot escapes the run's
+  scope and reconcile would act on **other runs' PRs**, and without `--limit` `gh pr list` silently caps
+  at **30**. Per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth stays the
+  re-polled `gh pr checks` snapshot.
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs
   immediately, ask the user asynchronously, and fold the answer in as its own wake.
 - Public API surface/behavior changes need user confirmation by default (see Constraints). The

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -52,9 +52,11 @@
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.
 - Reconcile from ONE batched `gh pr list` snapshot per wake (`<rundir>/prs.json`), written with the
-  **canonical `prs.json` command — the single owning definition is the `prs.json` row in
-  `files-and-ledger.md`** (**ONE path, ONE schema, ONE command**). Never spell a variant of it here or
-  anywhere else, and **NEVER drop `--state all --limit 1000`**: without `--state all` the snapshot omits
+  **canonical `prs.json` command — the single owning definition is the block "The canonical `prs.json`
+  command" in `files-and-ledger.md`**, which spells it in full, label and output path included (**ONE
+  path, ONE schema, ONE command**). Never spell a variant of it here or anywhere else, and **NEVER drop
+  `--label gauntlet-run-<run-id>`, `--state all`, or `--limit 1000`**: without `--label` the snapshot
+  escapes the run's scope and reconcile would act on **other runs' PRs**, without `--state all` it omits
   merged/closed PRs, and without `--limit` `gh pr list` silently caps at **30**. Per-PR `gh` calls only
   where the snapshot falls short. Merge-gate CI truth stays the re-polled `gh pr checks` snapshot.
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -29,7 +29,8 @@ gh pr list --label gauntlet-run-<run-id> --state open --limit 1000 \
   > <rundir>/prs.json
 ```
 
-`pr-adoption.md` (discovery) and `loop-control.md` step 2 (per-wake reconcile) each run this command
+`pr-adoption.md` (discovery) and `loop-control.md`'s per-wake PR scan (the `prs.json` block in step 1)
+each run this command
 inline, **identically** — same label, same flags, same `--json` field set, same path. That is intended:
 they are the same scan. What is forbidden is a **different** spelling anywhere.
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -24,7 +24,7 @@ a file that is scoped wrong or missing the fields it reads. Copy it whole, inclu
 filter and the output path:
 
 ```
-gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
+gh pr list --label gauntlet-run-<run-id> --state open --limit 1000 \
   --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
   > <rundir>/prs.json
 ```
@@ -39,9 +39,6 @@ Every part is load-bearing:
   **every PR in the repo** instead of this run's, and reconcile would then act on — adopt, relabel,
   even merge — **other runs' PRs**. That is a **run-isolation violation**, and run isolation is the
   property that lets concurrent runs coexist in one repo.
-- **Without `--state all`** (i.e. an `open`-only listing) merged and closed PRs vanish from the snapshot,
-  and their rows can never be reconciled to a terminal status — the PR that dropped out is **exactly**
-  the one whose row needed the update.
 - **Without `--limit`** `gh pr list` silently caps at **30** items, writing a truncated file that
   reconcile reads as the complete run snapshot.
 - **Without `--json <the field set above>`** the reader finds no `labels`/`mergeable`/`headRefOid` —

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -8,7 +8,7 @@ files from colliding — see "Run identity and concurrency".
 |------|----------|
 | `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
-| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**, written identically by `pr-adoption.md` and `loop-control.md` step 2: `--state all --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels`. **Two writers with different `--json` field sets would silently hand the reader a file missing the fields it reads** — adopt via one path and reconcile finds no `labels`/`mergeable` at all |
+| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**, written identically by `pr-adoption.md` and `loop-control.md` step 2: `--state all --limit 1000 --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels`. **Two writers with different `--json` field sets would silently hand the reader a file missing the fields it reads** — adopt via one path and reconcile finds no `labels`/`mergeable` at all. **`--limit` is mandatory, and it bounds rather than proves the snapshot** (see below) |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1) |
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
@@ -17,6 +17,15 @@ files from colliding — see "Run identity and concurrency".
 | `ci-<pr>.txt` | Latest `gh pr checks` snapshot for a PR (re-polled after the watch, not the watch stream) |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
+
+**`prs.json` is a BOUNDED snapshot, not a proof of completeness.** `gh pr list` fetches **30** items by
+default, so the canonical command passes `--limit 1000` — without it a run with more than 30 labelled PRs
+writes a silently truncated file that reconcile then reads as the complete run snapshot. That matters
+because **an absent PR is indistinguishable from a PR that was never adopted**: a dropped row does not
+error, it just quietly stops being reconciled. `--limit 1000` defeats the default-30 truncation; it does
+**not** make the snapshot provably complete — a run with more than 1000 labelled PRs would still
+truncate. Treat "every labelled PR is in `prs.json`" as an assumption bounded by that cap, never as a
+guarantee.
 
 Store ALL reviewer and `gh` output under `<rundir>` first, then Read/Grep it. NEVER `/tmp/`.
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -8,7 +8,7 @@ files from colliding — see "Run identity and concurrency".
 |------|----------|
 | `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
-| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input (Loop control) |
+| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**, written identically by `pr-adoption.md` and `loop-control.md` step 2: `--state all --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels`. **Two writers with different `--json` field sets would silently hand the reader a file missing the fields it reads** — adopt via one path and reconcile finds no `labels`/`mergeable` at all |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1) |
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -8,7 +8,7 @@ files from colliding — see "Run identity and concurrency".
 |------|----------|
 | `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
-| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**, written identically by `pr-adoption.md` and `loop-control.md` step 2: `--state all --limit 1000 --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels`. **Two writers with different `--json` field sets would silently hand the reader a file missing the fields it reads** — adopt via one path and reconcile finds no `labels`/`mergeable` at all. **`--limit` is mandatory, and it bounds rather than proves the snapshot** (see below) |
+| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**: the canonical command is spelled in full in **"The canonical `prs.json` command"**, the command block directly below this table, and that block is its ONLY definition |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1) |
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
@@ -18,14 +18,42 @@ files from colliding — see "Run identity and concurrency".
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
-**`prs.json` is a BOUNDED snapshot, not a proof of completeness.** `gh pr list` fetches **30** items by
-default, so the canonical command passes `--limit 1000` — without it a run with more than 30 labelled PRs
-writes a silently truncated file that reconcile then reads as the complete run snapshot. That matters
-because **an absent PR is indistinguishable from a PR that was never adopted**: a dropped row does not
-error, it just quietly stops being reconciled. `--limit 1000` defeats the default-30 truncation; it does
-**not** make the snapshot provably complete — a run with more than 1000 labelled PRs would still
-truncate. Treat "every labelled PR is in `prs.json`" as an assumption bounded by that cap, never as a
-guarantee.
+**The canonical `prs.json` command — this block is THE definition.** Every other site defers to it, and
+**NO site may spell a variant of it** — differing spellings are how a reader of `prs.json` ends up with
+a file that is scoped wrong or missing the fields it reads. Copy it whole, including the `--label`
+filter and the output path:
+
+```
+gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
+  --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
+  > <rundir>/prs.json
+```
+
+`pr-adoption.md` (discovery) and `loop-control.md` step 2 (per-wake reconcile) each run this command
+inline, **identically** — same label, same flags, same `--json` field set, same path. That is intended:
+they are the same scan. What is forbidden is a **different** spelling anywhere.
+
+Every part is load-bearing:
+
+- **Without `--label gauntlet-run-<run-id>`** the snapshot escapes the run's scope: the listing returns
+  **every PR in the repo** instead of this run's, and reconcile would then act on — adopt, relabel,
+  even merge — **other runs' PRs**. That is a **run-isolation violation**, and run isolation is the
+  property that lets concurrent runs coexist in one repo.
+- **Without `--state all`** (i.e. an `open`-only listing) merged and closed PRs vanish from the snapshot,
+  and their rows can never be reconciled to a terminal status — the PR that dropped out is **exactly**
+  the one whose row needed the update.
+- **Without `--limit`** `gh pr list` silently caps at **30** items, writing a truncated file that
+  reconcile reads as the complete run snapshot.
+- **Without `--json <the field set above>`** the reader finds no `labels`/`mergeable`/`headRefOid` —
+  two writers with different field sets silently hand the reader a file missing the fields it reads.
+- **Without `> <rundir>/prs.json`** the snapshot lands somewhere nobody reads, and reconcile reads a
+  file nobody wrote.
+
+**`prs.json` is a BOUNDED snapshot, not a proof of completeness.** `--limit 1000` defeats the default-30
+truncation; it does **not** make the snapshot provably complete — a run with more than 1000 labelled PRs
+would still truncate. That matters because **an absent PR is indistinguishable from a PR that was never
+adopted**: a dropped row does not error, it just quietly stops being reconciled. Treat "every labelled PR
+is in `prs.json`" as an assumption bounded by that cap, never as a guarantee.
 
 Store ALL reviewer and `gh` output under `<rundir>` first, then Read/Grep it. NEVER `/tmp/`.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -48,8 +48,16 @@ blocks; each completion is its own wake.
      diff unchanged does not reset the gate, so it keeps `gauntlet-accepted`.)
 
      Do the PR scan as
-     **one batched snapshot per wake** —
-     `gh pr list --label gauntlet-run-<run-id> --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels > <rundir>/prs.json`
+     **one batched snapshot per wake** — the **same canonical command** `pr-adoption.md` runs, writing the
+     **same path with the same schema** (they are the same scan; two spellings of it is how a reader of
+     `prs.json` ends up with fields that are not there):
+
+     ```
+     gh pr list --label gauntlet-run-<run-id> --state all \
+       --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
+       > <rundir>/prs.json
+     ```
+
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
      isn't enough (merge-gate CI truth stays the re-polled `gh pr checks` snapshot, Stage 2b). Wake
      turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read `run_id`, `base_branch`, `api_changes`, and `reviewer` from the ledger

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -53,7 +53,7 @@ blocks; each completion is its own wake.
      `prs.json` ends up with fields that are not there):
 
      ```
-     gh pr list --label gauntlet-run-<run-id> --state all \
+     gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
        --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
        > <rundir>/prs.json
      ```

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -70,6 +70,12 @@ blocks; each completion is its own wake.
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",
      "PR adoption"). Refresh
      the lease. This is the path every `--run` self-wake takes.
+
+     **The snapshot is `--state all`, so branch on each PR's `state` — reconcile a terminal PR, NEVER
+     resurrect it** (`pr-adoption.md`, "Branch on `state` BEFORE any adoption work"). A PR whose `state`
+     is `MERGED` or `CLOSED` goes **terminal** in the ledger — `status` = `merged` / `aborted`, creating
+     the row if this wake found none — and then takes **no** further action: no gate reset, no relabel, no
+     worktree, no CI watch, and no dispatch in step 3. Only an **`OPEN`** PR is live work.
    - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no
      `#PR` args (a bare or non-`#PR` invocation that found no live run to resume — likewise `--new`

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -50,7 +50,9 @@ blocks; each completion is its own wake.
      Do the PR scan as
      **one batched snapshot per wake** — the **same canonical command** `pr-adoption.md` runs, writing the
      **same path with the same schema** (they are the same scan; two spellings of it is how a reader of
-     `prs.json` ends up with fields that are not there):
+     `prs.json` ends up with fields that are not there, or a snapshot scoped to the wrong PRs). Its owning
+     definition is the block **"The canonical `prs.json` command"** in `files-and-ledger.md`; copy it
+     whole, never a variant:
 
      ```
      gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -55,7 +55,7 @@ blocks; each completion is its own wake.
      whole, never a variant:
 
      ```
-     gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
+     gh pr list --label gauntlet-run-<run-id> --state open --limit 1000 \
        --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
        > <rundir>/prs.json
      ```
@@ -70,12 +70,6 @@ blocks; each completion is its own wake.
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",
      "PR adoption"). Refresh
      the lease. This is the path every `--run` self-wake takes.
-
-     **The snapshot is `--state all`, so branch on each PR's `state` — reconcile a terminal PR, NEVER
-     resurrect it** (`pr-adoption.md`, "Branch on `state` BEFORE any adoption work"). A PR whose `state`
-     is `MERGED` or `CLOSED` goes **terminal** in the ledger — `status` = `merged` / `aborted`, creating
-     the row if this wake found none — and then takes **no** further action: no gate reset, no relabel, no
-     worktree, no CI watch, and no dispatch in step 3. Only an **`OPEN`** PR is live work.
    - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no
      `#PR` args (a bare or non-`#PR` invocation that found no live run to resume — likewise `--new`

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -9,12 +9,20 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 - **no-arg discovery** (`/gauntlet:campaign`, resume) — reconcile the PRs already labelled for this run:
 
   ```
-  gh pr list --label gauntlet-run-<run-id> --state open --json number,headRefName,headRefOid,title,baseRefName > <rundir>/prs.json
+  # THE canonical run snapshot — the SAME command loop-control step 2 runs. ONE path, ONE schema.
+  gh pr list --label gauntlet-run-<run-id> --state all \
+    --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
+    > <rundir>/prs.json
   ```
 
-  Every open PR carrying this run's owner label is already ours — refresh its row from that snapshot.
+  Every PR carrying this run's owner label is already ours — refresh its row from that snapshot.
   A PR with the label but no row is a re-adoption after an amnesiac wake; a row whose PR is gone
   (merged/closed) reconciles to its terminal status.
+
+  **`--state all`, NOT `--state open`.** A merged or closed PR must still appear, or the sentence above
+  cannot be carried out: the PR that vanished from an `open`-only listing is **exactly** the one whose row
+  needs reconciling to a terminal status, and an absent row is indistinguishable from a PR that was never
+  adopted.
 
 `base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
 **must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -12,45 +12,17 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   # THE canonical run snapshot — the SAME command loop-control step 2 runs. ONE path, ONE schema.
   # Owning definition: "The canonical `prs.json` command" in files-and-ledger.md. Copy it whole;
   # never spell a variant.
-  gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
+  gh pr list --label gauntlet-run-<run-id> --state open --limit 1000 \
     --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
     > <rundir>/prs.json
   ```
 
-  Every PR carrying this run's owner label is already ours — refresh its row from that snapshot.
-  A PR with the label but no row is a re-adoption after an amnesiac wake. A **merged or closed** PR —
-  **whether it has a row or not** — reconciles to its **terminal** status and is never re-adopted as
-  active work (the hard rule below governs both cases).
-
-  **`--state all`, NOT `--state open`.** A merged or closed PR must still appear, or the sentence above
-  cannot be carried out: the PR that vanished from an `open`-only listing is **exactly** the one whose row
-  needs reconciling to a terminal status, and an absent row is indistinguishable from a PR that was never
-  adopted.
+  Every open PR carrying this run's owner label is already ours — refresh its row from that snapshot.
+  A PR with the label but no row is a re-adoption after an amnesiac wake; a row whose PR is gone
+  (merged/closed) reconciles to its terminal status.
 
   **`--limit` is NOT optional** — `gh pr list` silently caps at **30** items without it, and a truncated
-  snapshot loses rows exactly as an `open`-only listing does (`files-and-ledger.md`, `prs.json`).
-
-**Branch on `state` BEFORE any adoption work — a terminal PR is RECONCILED, never RESURRECTED.**
-`--state all` exists so a merged or closed PR can be **reconciled to its terminal status**; it is **NOT**
-an instruction to bring a terminal PR back to life. The `state` field is in the canonical `--json` set
-(and in the `gh pr view` read of step 1 on the explicit-`#PR` path), so read it and dispatch on it:
-
-- **`OPEN`** → adopt / refresh normally: the whole procedure below, unchanged.
-- **`MERGED`** → the PR has landed. Record its row **terminal** — `status` = `merged` — creating the row
-  if it has none (the amnesiac-wake case: a labelled, merged PR with no row; that row is born
-  **terminal**, **NEVER** `in_review`), else refreshing the existing row in place. Then **STOP**: create
-  **no** worktree (step 5), launch **no** CI watch (step 6), dispatch **no** review, and do **NOT** apply
-  `gauntlet-reviewing` (step 4's status labels do not run — a landed PR is not under review).
-- **`CLOSED`** (closed without merging) → terminal as well. Record the row `status` = `aborted`, creating
-  it if absent, and **STOP** on exactly the same terms — no worktree, no CI watch, no review, no status
-  label.
-
-**Both** the missing-row case and the existing-row case go through this branch. The missing-row case is
-the one that must never re-enter the gate: initializing a new row `status = in_review` (step 3) for a PR
-that is already merged or closed would give it `ci = pending`, a worktree, a CI watch, and review passes
-for work that is over. The existing-row case is the reconcile the `--state all` snapshot was widened for:
-a row still reading `in_review` whose PR has since merged or closed goes terminal here, rather than
-staying live forever.
+  snapshot loses rows silently (`files-and-ledger.md`, `prs.json`).
 
 `base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
 **must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).
@@ -129,9 +101,7 @@ For each `#PR` to adopt:
      `pr` = `<N>`; `head_sha` = `headRefOid`.
    - **On a NEW row only, initialize:** `reviews_ok` = `0` (no verdicts yet); `ci` = `pending`;
      `tier` = triage per `head_sha` ("Adaptive review tiers"); `attempts` = `1`; `started` = now;
-     `api_approval` = `-`; `status` = `in_review` — **`in_review` only when `state` is `OPEN`**. A
-     `MERGED`/`CLOSED` PR's new row is born terminal (`merged`/`aborted`) per the `state` branch above,
-     and adoption stops at this step for it.
+     `api_approval` = `-`; `status` = `in_review`.
    - **On a REFRESH of an existing row, PRESERVE the durable/live fields** — `api_approval`, `attempts`,
      `started`, `status`, `reviews_ok`, and `tier` — do **NOT** reset them (that would violate the
      durable API-decision contract, `files-and-ledger.md` / `scope-and-constraints.md`, and could re-ask

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -10,6 +10,8 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 
   ```
   # THE canonical run snapshot — the SAME command loop-control step 2 runs. ONE path, ONE schema.
+  # Owning definition: "The canonical `prs.json` command" in files-and-ledger.md. Copy it whole;
+  # never spell a variant.
   gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
     --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
     > <rundir>/prs.json

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -10,7 +10,7 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 
   ```
   # THE canonical run snapshot — the SAME command loop-control step 2 runs. ONE path, ONE schema.
-  gh pr list --label gauntlet-run-<run-id> --state all \
+  gh pr list --label gauntlet-run-<run-id> --state all --limit 1000 \
     --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
     > <rundir>/prs.json
   ```
@@ -23,6 +23,9 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   cannot be carried out: the PR that vanished from an `open`-only listing is **exactly** the one whose row
   needs reconciling to a terminal status, and an absent row is indistinguishable from a PR that was never
   adopted.
+
+  **`--limit` is NOT optional** — `gh pr list` silently caps at **30** items without it, and a truncated
+  snapshot loses rows exactly as an `open`-only listing does (`files-and-ledger.md`, `prs.json`).
 
 `base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
 **must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -9,7 +9,8 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 - **no-arg discovery** (`/gauntlet:campaign`, resume) — reconcile the PRs already labelled for this run:
 
   ```
-  # THE canonical run snapshot — the SAME command loop-control step 2 runs. ONE path, ONE schema.
+  # THE canonical run snapshot — the SAME command loop-control's per-wake PR scan (the `prs.json`
+  # block in step 1) runs. ONE path, ONE schema.
   # Owning definition: "The canonical `prs.json` command" in files-and-ledger.md. Copy it whole;
   # never spell a variant.
   gh pr list --label gauntlet-run-<run-id> --state open --limit 1000 \

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -18,8 +18,9 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   ```
 
   Every PR carrying this run's owner label is already ours — refresh its row from that snapshot.
-  A PR with the label but no row is a re-adoption after an amnesiac wake; a row whose PR is gone
-  (merged/closed) reconciles to its terminal status.
+  A PR with the label but no row is a re-adoption after an amnesiac wake. A **merged or closed** PR —
+  **whether it has a row or not** — reconciles to its **terminal** status and is never re-adopted as
+  active work (the hard rule below governs both cases).
 
   **`--state all`, NOT `--state open`.** A merged or closed PR must still appear, or the sentence above
   cannot be carried out: the PR that vanished from an `open`-only listing is **exactly** the one whose row
@@ -28,6 +29,28 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 
   **`--limit` is NOT optional** — `gh pr list` silently caps at **30** items without it, and a truncated
   snapshot loses rows exactly as an `open`-only listing does (`files-and-ledger.md`, `prs.json`).
+
+**Branch on `state` BEFORE any adoption work — a terminal PR is RECONCILED, never RESURRECTED.**
+`--state all` exists so a merged or closed PR can be **reconciled to its terminal status**; it is **NOT**
+an instruction to bring a terminal PR back to life. The `state` field is in the canonical `--json` set
+(and in the `gh pr view` read of step 1 on the explicit-`#PR` path), so read it and dispatch on it:
+
+- **`OPEN`** → adopt / refresh normally: the whole procedure below, unchanged.
+- **`MERGED`** → the PR has landed. Record its row **terminal** — `status` = `merged` — creating the row
+  if it has none (the amnesiac-wake case: a labelled, merged PR with no row; that row is born
+  **terminal**, **NEVER** `in_review`), else refreshing the existing row in place. Then **STOP**: create
+  **no** worktree (step 5), launch **no** CI watch (step 6), dispatch **no** review, and do **NOT** apply
+  `gauntlet-reviewing` (step 4's status labels do not run — a landed PR is not under review).
+- **`CLOSED`** (closed without merging) → terminal as well. Record the row `status` = `aborted`, creating
+  it if absent, and **STOP** on exactly the same terms — no worktree, no CI watch, no review, no status
+  label.
+
+**Both** the missing-row case and the existing-row case go through this branch. The missing-row case is
+the one that must never re-enter the gate: initializing a new row `status = in_review` (step 3) for a PR
+that is already merged or closed would give it `ci = pending`, a worktree, a CI watch, and review passes
+for work that is over. The existing-row case is the reconcile the `--state all` snapshot was widened for:
+a row still reading `in_review` whose PR has since merged or closed goes terminal here, rather than
+staying live forever.
 
 `base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
 **must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).
@@ -106,7 +129,9 @@ For each `#PR` to adopt:
      `pr` = `<N>`; `head_sha` = `headRefOid`.
    - **On a NEW row only, initialize:** `reviews_ok` = `0` (no verdicts yet); `ci` = `pending`;
      `tier` = triage per `head_sha` ("Adaptive review tiers"); `attempts` = `1`; `started` = now;
-     `api_approval` = `-`; `status` = `in_review`.
+     `api_approval` = `-`; `status` = `in_review` — **`in_review` only when `state` is `OPEN`**. A
+     `MERGED`/`CLOSED` PR's new row is born terminal (`merged`/`aborted`) per the `state` branch above,
+     and adoption stops at this step for it.
    - **On a REFRESH of an existing row, PRESERVE the durable/live fields** — `api_approval`, `attempts`,
      `started`, `status`, `reviews_ok`, and `tier` — do **NOT** reset them (that would violate the
      durable API-decision contract, `files-and-ledger.md` / `scope-and-constraints.md`, and could re-ask

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -118,8 +118,11 @@ Each run has `<rundir>/lease.json`:
      `auth`) is not a scope any more — treat it like the no-arg idle case below and prompt.
    - **No arg at all** (`/gauntlet:campaign`) → resume-oriented: **discover runs** and bucket by lease —
      the distinct `gauntlet-run-*` ids present on open PRs — list PRs **with their labels** and extract
-     the ids, since no id is known yet to query by (`gh pr list --state open --json number,labels`, then
-     pick labels matching `gauntlet-run-*`) ∪ run-ids with a `<rundir>/` (its `state.jsonl` or
+     the ids, since no id is known yet to query by (`gh pr list --state open --limit 1000 --json
+     number,labels`, then pick labels matching `gauntlet-run-*`; **`--limit` is mandatory** — `gh pr list`
+     silently caps at **30** without it, and a run missed by the scan reads exactly like a run that does
+     not exist, so the driver would start a duplicate or fail to resume an orphan. Like `prs.json`, the
+     cap **bounds** the scan rather than proving it complete) ∪ run-ids with a `<rundir>/` (its `state.jsonl` or
      `lease.json`), each **actively-driven** (fresh lease),
      **orphaned** (non-terminal, lease absent/stale), or **finished** (terminal, no open PR):
      - exactly one **orphaned** → adopt and resume it ("pick up where the previous instance left off"),


### PR DESCRIPTION
A **pre-existing bug on `main`** — not introduced by #26, surfaced by its audit. Independent of the #29→#32 stack; branches from `main`.

## The bug

`<rundir>/prs.json` has **two writers with two incompatible schemas**, writing to the **same path**:

| Writer | Command |
|---|---|
| `pr-adoption.md:12` | `gh pr list … --state open --json number,headRefName,headRefOid,title,baseRefName` |
| `loop-control.md:52` | `gh pr list … --json number,headRefName,headRefOid,state,mergeable,mergeStateStatus,labels` |

They are **the same scan** — discover this run's labelled PRs — spelled two different ways.

**Enter the run via adoption, and reconcile reads a `prs.json` with no `labels` and no `mergeable`.** So no stale `gauntlet-accepted` label is ever swapped, and **no PR is ever checked for `MERGEABLE`/`CLEAN`** — the reader silently gets a file missing the fields it reads.

## And a second bug in the same command

Adoption filters `--state open`, then says in its very next sentence:

> "a row whose PR is gone (**merged/closed**) reconciles to its terminal status"

With `--state open` those PRs are **not in the file**, so that reconcile can never happen. The PR that vanished from an open-only listing is *exactly* the one whose row needs reconciling — and an absent row is indistinguishable from a PR that was never adopted.

## The fix

**One path, one schema, one command**, written identically at both sites and documented once in `files-and-ledger.md` (which now owns the schema):

```
gh pr list --label gauntlet-run-<run-id> --state all \
  --json number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels \
  > <rundir>/prs.json
```

`--state all`, not `--state open`, so a merged or closed PR still appears and its row can reach a terminal status.