### PR TITLE
fix the class, not the instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,32 @@ The tell is unmistakable in hindsight, and it generalises: **when each fix creat
 are not converging on a bug — you are patching your own invention.** Stop and re-derive whether the
 original thing was ever broken.
 
+## Fix the CLASS, not the instance — a definition with one stale restatement is a definition that lies
+
+When you change a **definition** (a rule, a command, a schema, a format) or a **fact** (a count, a name,
+an API behavior), the change is not done when the thing you were looking at is correct. **It is done when
+every place that RESTATES it is correct.**
+
+**Sweep for restatements. Every time. Before you call it fixed.**
+
+- `grep` for the old value, the old spelling, the old command, the old number — not just the file you
+  edited. Restatements hide in **summaries**, **quick-reference bullets**, **cross-references**, **table
+  rows**, **worked examples**, and **other copies of the same command**.
+- A **summary that has drifted from its definition is worse than no summary**: it is the version people
+  actually read, and it will be believed. A one-line "green means zero failing and zero pending" outlived
+  three rewrites of the rule it summarised, and silently discarded both of that rule's disclosed caveats.
+- Prefer **one owner + pointers** over N copies. But then the owner must be **complete** — a pointer to a
+  partial definition is how a reader reconstructs a command with the run-scoping `--label` missing. And a
+  pointer must name the **block**, not the **step number**: numbers move.
+- Distinguish **volatile facts** from **stable constants**. A live count from a real repo (`16 runs named
+  X`) rots — cite the permanent **claim** and mark any number as a dated illustration. A documented API
+  constant (a page size of 30, a 1000-item cap) is the **point** — keep it exact, never hedge it.
+
+**Why this rule exists:** across one PR series, the review gate had to say *"you have two more"* about
+missed propagation sites, a fourth copy of a canonical command, a stale summary, and volatile counts in
+three separate places. Each time, the instance was fixed and the class survived. **The reviewer
+generalised; the author did not.** That is a defect in how the work was done, not in any one line.
+
 ## Version is the plugin cache key
 
 `plugin.json`'s `version` decides whether an installed copy refreshes. Changing skill content **without**

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -103,9 +103,14 @@ subagent spend. Running an **external reviewer** (e.g. `codex exec`, see `refere
 that cost off the subagent pool entirely — the quality argument (reviewer diversity) and the cost
 argument point the same way.
 
-**Scope every fix subagent.** Give it the worktree path and the specific issue list, and tell it **not**
-to re-derive the whole diff or re-read the repo beyond the named files. An unscoped fixer re-reads
-everything it was already told.
+**Every fix subagent — CI or review — is dispatched under one contract**, and
+`references/fix-subagent-contract.md` is its complete definition. Two halves, both mandatory:
+**SCOPE** the reading (worktree path + the specific issue list; **not** the whole diff, **not** the repo
+beyond the named files — an unscoped fixer re-reads everything it was already told), and **SWEEP** the
+writing (a fix that changes a definition or a fact is not done until every site that RESTATES it is
+correct — the contract's sweep-and-report block goes into the prompt **verbatim**). Read narrowly to
+UNDERSTAND, grep widely to FINISH. Read the contract before dispatching a fixer; do not reconstruct it
+from this summary.
 
 ## Load Discipline
 
@@ -127,6 +132,7 @@ Read stage refs only when that stage/action is due:
 | Selecting the reviewer; external-reviewer failure/fallback | `references/reviewer.md` |
 | Adopting PRs into a run (worktree/labels/ledger row) | `references/pr-adoption.md` |
 | PR review gauntlet / progress ledger | `references/stage-2-review-gate.md` |
+| Dispatching ANY fix subagent (CI-fix or review-fix) | `references/fix-subagent-contract.md` |
 | Repeated sibling findings / shared root cause | `references/root-cause-pass.md` |
 | CI watch, check polling, CI fix | `references/stage-2-ci.md` |
 | Merge candidate / base refresh / cleanup | `references/stage-3-merge.md` |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -260,10 +260,16 @@
   head resets the gate") — cheap CI-fix, session-model CI-fix, review-fix, or **refutation commit** alike. In the SAME step: reset
   `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, relaunch the CI
   watch, and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
-- Scope every fix subagent to its worktree + concrete issue list; tell it NOT to re-derive the whole diff.
-  **Scope by defect, not by guess — name every file the defect touches.** That, plus an **external
-  reviewer** taking review passes off the subagent pool (**the single biggest cost lever** — review passes
-  dominate campaign's spend), is where savings live.
+- **EVERY fix subagent — CI-fix (both tiers) and review-fix — is dispatched under the fix-subagent contract
+  (`fix-subagent-contract.md`, the complete DEFINITION; read it before dispatching, never reconstruct it
+  from a summary).** Both halves are mandatory: **SCOPE** the reading — worktree + concrete issue list, NOT
+  the whole diff, NOT beyond the named files; **scope by defect, not by guess — name every file the defect
+  touches**. **SWEEP** the writing — the contract's sweep-and-report block goes into the prompt **verbatim**:
+  a fix that changes a DEFINITION or a FACT is not done until every site that RESTATES it is correct, and
+  every site found is reported. Read narrowly to UNDERSTAND, grep widely to FINISH; neither half excuses
+  skipping the other. Scoping (not a cheaper model), plus an **external reviewer** taking review passes off
+  the subagent pool (**the single biggest cost lever** — review passes dominate campaign's spend), is where
+  savings live.
 - Default reviewer is Claude's own subagents; no external tool is required. Use the user's preferred
   reviewer when one is set (explicit invocation, or a preference in memory/`CLAUDE.md`/carryover). A
   different-model reviewer (e.g. Codex) is recommended for diversity but never required. See

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -1,0 +1,52 @@
+## The fix-subagent contract — SCOPE the reading, SWEEP the writing
+
+**This file is the DEFINITION, and it is COMPLETE.** Every fix subagent campaign dispatches — the cheap
+CI-fix, the session-model CI-fix, and the review-fix — is dispatched under it. `stage-2-ci.md` and
+`stage-2-review-gate.md` name the inputs their path hands over and the model it runs on; **neither
+restates the rules below, and neither may contradict them.** If you are dispatching a fixer, read this.
+
+The contract has two halves that pull in opposite directions **on purpose**. Ship both, or the fixer
+optimizes the one you gave it:
+
+- **SCOPE** bounds what it READS, so it does not re-derive a problem you already solved for it.
+- **SWEEP** bounds what it WRITES, so it does not leave the fix half-applied.
+
+**Read narrowly to UNDERSTAND; grep widely to FINISH.** They are not in conflict: the scope rule is
+about **not re-deriving the problem**, the sweep rule is about **not shipping half a fix**. Neither is
+licence to ignore the other. A fixer that greps the tree to find the sites its own change invalidated is
+**obeying** the scope rule, not breaking it — it is not re-deriving anything, it is finishing.
+
+### SCOPE — bounds the reading
+
+**Scope every fix subagent.** Hand it the worktree path and the **concrete issue list** (for a CI-fix:
+the failing check's logs and the specific failing file(s)), and tell it **NOT** to re-derive the whole
+diff or read the repo beyond what the named issues touch. An unscoped fixer re-reads everything it was
+already told, and that is where the cost is — **not** in the model tier.
+
+**Scope by defect, not by guess: name every file the defect actually touches**, or the fixer will
+faithfully leave the sites you forgot to list.
+
+### SWEEP — bounds the writing
+
+**Scoping the fix is NOT licence to fix only the INSTANCE.** Every fix subagent — CI or review — gets
+the block below in its prompt **verbatim**, because a scoped fixer is exactly the thing that will patch
+the one line it was pointed at and leave the class intact:
+
+> **When your fix changes a DEFINITION (a rule, a command, a schema, a format) or a FACT (a count, a
+> name, an API behavior), you are NOT done until every place that RESTATES it is also correct.** `grep`
+> for the old value, the old spelling, the old command, the old number — across the whole tree, not just
+> the file you were sent to. Restatements hide in **summaries**, **quick-reference bullets**,
+> **cross-references**, **table rows**, **worked examples**, and **other copies of the same command**. A
+> summary that has drifted from its definition is **worse than no summary** — it is the version people
+> actually read. **Report every site you found and its disposition, including the ones you deliberately
+> left alone and why.** If your fix is genuinely local and restates nothing, say so explicitly.
+>
+> This widening is **bounded by the change you are making**: grep for what your own fix invalidated. It
+> is **not** permission to re-derive the diff, re-review the PR, or fix defects nobody asked you to fix.
+
+This is a **report** requirement, not just a search requirement: a sweep nobody can audit did not happen.
+
+**Prefer ONE OWNER over another copy.** When the fixer finds a definition restated in N places, the best
+repair is usually to leave the definition in one place and make the others point at it — a fifth copy of
+a rule is a fifth thing that can go stale. A pointer is only valid if what it points at is **complete**;
+pointing at a partial definition is itself the defect.

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -1,9 +1,15 @@
 ## The fix-subagent contract — SCOPE the reading, SWEEP the writing
 
 **This file is the DEFINITION, and it is COMPLETE.** Every fix subagent campaign dispatches — the cheap
-CI-fix, the session-model CI-fix, and the review-fix — is dispatched under it. `stage-2-ci.md` and
-`stage-2-review-gate.md` name the inputs their path hands over and the model it runs on; **neither
-restates the rules below, and neither may contradict them.** If you are dispatching a fixer, read this.
+CI-fix, the session-model CI-fix, and the review-fix — is dispatched under it. If you are dispatching a
+fixer, read this.
+
+**Other files carry NON-AUTHORITATIVE summaries of the rules below** — `SKILL.md`, `critical-rules.md`,
+`stage-2-ci.md`, `stage-2-review-gate.md` — so each dispatch site reads on its own. Every one of them is
+a **pointer with a reminder attached, never a substitute**: **a summary may never be relied on, extended,
+or treated as complete, and if any of them disagrees with this file, THIS FILE WINS.** Never dispatch a
+fixer from a summary; never reconstruct the contract from one. Correcting this file means sweeping those
+sites too — a summary that has drifted from its definition is worse than no summary.
 
 The contract has two halves that pull in opposite directions **on purpose**. Ship both, or the fixer
 optimizes the one you gave it:

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -4,12 +4,26 @@
 CI-fix, the session-model CI-fix, and the review-fix — is dispatched under it. If you are dispatching a
 fixer, read this.
 
-**Other files carry NON-AUTHORITATIVE summaries of the rules below** — `SKILL.md`, `critical-rules.md`,
-`stage-2-ci.md`, `stage-2-review-gate.md` — so each dispatch site reads on its own. Every one of them is
-a **pointer with a reminder attached, never a substitute**: **a summary may never be relied on, extended,
-or treated as complete, and if any of them disagrees with this file, THIS FILE WINS.** Never dispatch a
-fixer from a summary; never reconstruct the contract from one. Correcting this file means sweeping those
-sites too — a summary that has drifted from its definition is worse than no summary.
+**Other files carry NON-AUTHORITATIVE summaries of the rules below**, so each dispatch site reads on its
+own. Every one of them is a **pointer with a reminder attached, never a substitute**: **a summary may
+never be relied on, extended, or treated as complete, and if any of them disagrees with this file, THIS
+FILE WINS.** Never dispatch a fixer from a summary; never reconstruct the contract from one. Correcting
+this file means sweeping those sites too — a summary that has drifted from its definition is worse than
+no summary.
+
+**When you correct this contract, GREP for the restatements — do NOT expect a list of them here.** There
+is deliberately none, and that is not an omission: **a list of restatement sites is ITSELF a restatement,
+and it rots exactly like every other one.** This file once enumerated four sites; six existed the day it
+was written — **the list went stale inside the commit that created it**, and a reader trusting it would
+have swept four and never looked for the rest. That is the whole reason you must grep instead. Search for
+the *shape* of the rules — a recipe does not go stale, a list of files does:
+
+- the **scope** rule — `SCOPE`, "scope … fix subagent", "re-derive", "whole diff", "beyond the named"
+- the **sweep** rule — `SWEEP`, "RESTATES", "sweep-and-report", "stale restatement", "fix only the instance"
+- **pointers at this file** — `fix-subagent-contract`
+
+Then read each hit and decide: it is a summary of this contract, or it is not. Do not stop when the count
+matches something you were told.
 
 The contract has two halves that pull in opposite directions **on purpose**. Ship both, or the fixer
 optimizes the one you gave it:

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -301,24 +301,13 @@ check logs FIRST; the class picks the model:
 | **Formatting / lint** — the fix is exactly what a standard formatter or autofixer produces | **`sonnet`** (**`haiku`** only when the failure is trivially mechanical) | It does NOT author a fix from scratch: it runs a deterministic tool, **READS the resulting diff**, verifies it, and **escalates** anything it cannot verify. Downgraded **on purpose**. |
 | **Everything else** — failing product test, compile error, flake, anything needing judgment — **and every escalation from the cheap subagent** | **session model** | It authors code that gets merged, and nothing downstream validates it. |
 
-**Scope every CI-fix subagent, both tiers:** give it the failing check's logs, the specific failing
-file(s), and the worktree path. Tell it **NOT** to re-derive the whole diff or read beyond what the
-failure touches.
-
-**But scoping the fix is NOT licence to fix only the INSTANCE.** Every fix subagent — CI or review —
-gets this instruction **verbatim**, because a scoped fixer is exactly the thing that will patch the one
-line it was pointed at and leave the class intact:
-
-> **When your fix changes a DEFINITION (a rule, a command, a schema, a format) or a FACT (a count, a
-> name, an API behavior), you are NOT done until every place that RESTATES it is also correct.** `grep`
-> for the old value, the old spelling, the old command, the old number — across the whole tree, not just
-> the file you were sent to. Restatements hide in **summaries**, **quick-reference bullets**,
-> **cross-references**, **table rows**, **worked examples**, and **other copies of the same command**. A
-> summary that has drifted from its definition is **worse than no summary** — it is the version people
-> actually read. **Report every site you found and its disposition, including the ones you deliberately
-> left alone and why.** If your fix is genuinely local and restates nothing, say so explicitly.
-
-This is a **report** requirement, not just a search requirement: a sweep nobody can audit did not happen.
+**Dispatch both tiers under the fix-subagent contract** (`fix-subagent-contract.md` — the DEFINITION for
+every fix subagent, CI or review; this file does not restate it). The CI-specific inputs it asks for are
+the failing check's logs, the specific failing file(s), and the worktree path — read narrowly: **NOT**
+the whole diff, **NOT** beyond what the failure touches. And because scoping the reading is not licence
+to fix only the **instance**, the contract's **sweep-and-report block goes into the prompt verbatim**: a
+fix that changes a definition or a fact is not done until every site that restates it is correct, and
+every site found is reported.
 
 #### The cheap CI-fix subagent — run the tool, READ the diff, ESCALATE
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -305,6 +305,21 @@ check logs FIRST; the class picks the model:
 file(s), and the worktree path. Tell it **NOT** to re-derive the whole diff or read beyond what the
 failure touches.
 
+**But scoping the fix is NOT licence to fix only the INSTANCE.** Every fix subagent — CI or review —
+gets this instruction **verbatim**, because a scoped fixer is exactly the thing that will patch the one
+line it was pointed at and leave the class intact:
+
+> **When your fix changes a DEFINITION (a rule, a command, a schema, a format) or a FACT (a count, a
+> name, an API behavior), you are NOT done until every place that RESTATES it is also correct.** `grep`
+> for the old value, the old spelling, the old command, the old number — across the whole tree, not just
+> the file you were sent to. Restatements hide in **summaries**, **quick-reference bullets**,
+> **cross-references**, **table rows**, **worked examples**, and **other copies of the same command**. A
+> summary that has drifted from its definition is **worse than no summary** — it is the version people
+> actually read. **Report every site you found and its disposition, including the ones you deliberately
+> left alone and why.** If your fix is genuinely local and restates nothing, say so explicitly.
+
+This is a **report** requirement, not just a search requirement: a sweep nobody can audit did not happen.
+
 #### The cheap CI-fix subagent — run the tool, READ the diff, ESCALATE
 
 The point of putting a model here is that **something LOOKS at what happened before it is committed**.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -301,13 +301,16 @@ check logs FIRST; the class picks the model:
 | **Formatting / lint** — the fix is exactly what a standard formatter or autofixer produces | **`sonnet`** (**`haiku`** only when the failure is trivially mechanical) | It does NOT author a fix from scratch: it runs a deterministic tool, **READS the resulting diff**, verifies it, and **escalates** anything it cannot verify. Downgraded **on purpose**. |
 | **Everything else** — failing product test, compile error, flake, anything needing judgment — **and every escalation from the cheap subagent** | **session model** | It authors code that gets merged, and nothing downstream validates it. |
 
-**Dispatch both tiers under the fix-subagent contract** (`fix-subagent-contract.md` — the DEFINITION for
-every fix subagent, CI or review; this file does not restate it). The CI-specific inputs it asks for are
-the failing check's logs, the specific failing file(s), and the worktree path — read narrowly: **NOT**
-the whole diff, **NOT** beyond what the failure touches. And because scoping the reading is not licence
-to fix only the **instance**, the contract's **sweep-and-report block goes into the prompt verbatim**: a
-fix that changes a definition or a fact is not done until every site that restates it is correct, and
-every site found is reported.
+**Dispatch both tiers under the fix-subagent contract** (`fix-subagent-contract.md` — the complete
+DEFINITION for every fix subagent, CI or review; **read it before dispatching**). The CI-specific inputs
+it asks for are the failing check's logs, the specific failing file(s), and the worktree path.
+
+*Non-authoritative summary of the contract — the contract is the definition and wins over this; never
+dispatch from this summary:* **SCOPE** the reading — read narrowly: **NOT** the whole diff, **NOT**
+beyond what the failure touches. And because scoping the reading is not licence to fix only the
+**instance**, **SWEEP** the writing — the contract's **sweep-and-report block goes into the prompt
+verbatim**: a fix that changes a definition or a fact is not done until every site that restates it is
+correct, and every site found is reported.
 
 #### The cheap CI-fix subagent — run the tool, READ the diff, ESCALATE
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -394,10 +394,13 @@ As each verdict lands, tally it for the SHA it ran on:
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
   and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half
   that pays. Worst case the pass misses it and the defect merges.
-  **Scope it** instead — hand it the worktree path and the concrete issue list, and tell it NOT to
-  re-derive the whole diff or read beyond the files those issues name; that is where the savings are,
-  not in the model tier. **Scope by defect, not by guess:** name every file the defect actually touches,
-  or the fixer will faithfully leave the sites you forgot to list.
+  **Dispatch it under the fix-subagent contract** (`fix-subagent-contract.md` — the DEFINITION for every
+  fix subagent, CI or review; this file does not restate it). **Scope it** — hand it the worktree path
+  and the concrete issue list (CONFIRMED + ADJUSTED only), and tell it NOT to re-derive the whole diff or
+  read beyond the files those issues name; that is where the savings are, not in the model tier. And put
+  the contract's **sweep-and-report block into the prompt verbatim** — a review defect whose fix changes
+  a definition or a fact is not done until every site that restates it is correct, and every site found
+  is reported. Scope bounds the READING; the sweep bounds the WRITING; the fixer owes you both.
 - **SATISFIED** → record it (bump `reviews_ok` via `ledger.py … set --pr <N> --reviews_ok <count>`, by
   field name). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -394,13 +394,16 @@ As each verdict lands, tally it for the SHA it ran on:
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
   and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half
   that pays. Worst case the pass misses it and the defect merges.
-  **Dispatch it under the fix-subagent contract** (`fix-subagent-contract.md` — the DEFINITION for every
-  fix subagent, CI or review; this file does not restate it). **Scope it** — hand it the worktree path
-  and the concrete issue list (CONFIRMED + ADJUSTED only), and tell it NOT to re-derive the whole diff or
-  read beyond the files those issues name; that is where the savings are, not in the model tier. And put
-  the contract's **sweep-and-report block into the prompt verbatim** — a review defect whose fix changes
-  a definition or a fact is not done until every site that restates it is correct, and every site found
-  is reported. Scope bounds the READING; the sweep bounds the WRITING; the fixer owes you both.
+  **Dispatch it under the fix-subagent contract** (`fix-subagent-contract.md` — the complete DEFINITION
+  for every fix subagent, CI or review; **read it before dispatching**). The review-specific inputs it
+  asks for are the worktree path and the concrete issue list (CONFIRMED + ADJUSTED only).
+
+  *Non-authoritative summary of the contract — the contract is the definition and wins over this; never
+  dispatch from this summary:* **SCOPE** it — tell it NOT to re-derive the whole diff or read beyond the
+  files those issues name; that is where the savings are, not in the model tier. And **SWEEP** — put the
+  contract's **sweep-and-report block into the prompt verbatim** — a review defect whose fix changes a
+  definition or a fact is not done until every site that restates it is correct, and every site found is
+  reported. Scope bounds the READING; the sweep bounds the WRITING; the fixer owes you both.
 - **SATISFIED** → record it (bump `reviews_ok` via `ledger.py … set --pr <N> --reviews_ok <count>`, by
   field name). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a

--- a/plugins/gauntlet/skills/review/README.md
+++ b/plugins/gauntlet/skills/review/README.md
@@ -75,7 +75,7 @@ a fix changes a definition or a fact, it greps the tree for every other place th
 corrects those too, in the same pull request, and tells you which sites it touched and which it left
 alone: a definition left with a stale restatement is a definition that lies. That's the same
 [fix-subagent contract](../campaign/references/fix-subagent-contract.md) campaign holds its own fixers
-to.
+to — that file is the definition and this paragraph is only a non-authoritative summary of it.
 
 So the usual progression is **review to find and confirm, then campaign to gate and merge** — but the
 review half never crosses into changing anything until you explicitly say yes.

--- a/plugins/gauntlet/skills/review/README.md
+++ b/plugins/gauntlet/skills/review/README.md
@@ -64,11 +64,18 @@ After it delivers the report, it asks once — and only once — whether to open
 confirmed fix and run them through the gauntlet.
 
 Say **no** (or say nothing) and it stops there: report-only, no side effects. Say **yes** and it
-implements each Confirmed or Adjusted fix — exactly the change the finding describes, nothing more —
+implements each Confirmed or Adjusted fix — the change that finding describes and no other defects —
 on its own branch, opens one pull request per finding, and hands those PRs to
 [`/gauntlet:campaign`](../campaign/README.md). Campaign takes it from there: it adopts the PRs, gates
 each one through the reviews its tier requires plus CI, and merges. Refuted and Uncertain findings
 are left alone.
+
+"No other defects" bounds *which problems* it fixes — not *how many places* one fix has to touch. When
+a fix changes a definition or a fact, it greps the tree for every other place that restates it and
+corrects those too, in the same pull request, and tells you which sites it touched and which it left
+alone: a definition left with a stale restatement is a definition that lies. That's the same
+[fix-subagent contract](../campaign/references/fix-subagent-contract.md) campaign holds its own fixers
+to.
 
 So the usual progression is **review to find and confirm, then campaign to gate and merge** — but the
 review half never crosses into changing anything until you explicitly say yes.

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -393,6 +393,13 @@ default branch or **ask the user** (never branch off an unresolved base). Then, 
 or **Adjusted** finding only (skip Refuted and Uncertain), in its own branch off that resolved base:
 
 1. Implement the fix — exactly the change in the finding's `Fix:`, nothing more; no drive-by edits.
+   **"Nothing more" bounds the DEFECTS you fix, not the SITES one fix touches.** If the change alters a
+   DEFINITION (a rule, a command, a schema, a format) or a FACT (a count, a name, an API behavior), then
+   `grep` the tree for every place that RESTATES it — summaries, quick-reference bullets, cross-references,
+   table rows, worked examples — and correct each one **in this same PR**: a definition left with a stale
+   restatement is a definition that lies, and that sweep is part of the fix, not a drive-by. Report every
+   site you found and its disposition, including any you deliberately left alone. (Same contract campaign
+   puts in every fix subagent's prompt: `${CLAUDE_PLUGIN_ROOT}/skills/campaign/references/fix-subagent-contract.md`.)
 2. `git commit` the fix, then `git push` the branch.
 3. `gh pr create` one PR for that finding. Title from the finding; body cites the finding ID,
    trigger, impact, and fix. Do **NOT** apply any `gauntlet-run-*` owner label — review does not know

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -398,8 +398,10 @@ or **Adjusted** finding only (skip Refuted and Uncertain), in its own branch off
    `grep` the tree for every place that RESTATES it — summaries, quick-reference bullets, cross-references,
    table rows, worked examples — and correct each one **in this same PR**: a definition left with a stale
    restatement is a definition that lies, and that sweep is part of the fix, not a drive-by. Report every
-   site you found and its disposition, including any you deliberately left alone. (Same contract campaign
-   puts in every fix subagent's prompt: `${CLAUDE_PLUGIN_ROOT}/skills/campaign/references/fix-subagent-contract.md`.)
+   site you found and its disposition, including any you deliberately left alone. (This paragraph is a
+   **non-authoritative summary** of the same contract campaign puts in every fix subagent's prompt —
+   `${CLAUDE_PLUGIN_ROOT}/skills/campaign/references/fix-subagent-contract.md` is the complete DEFINITION
+   and **wins over this** wherever they differ; read it, never reconstruct it from this summary.)
 2. `git commit` the fix, then `git push` the branch.
 3. `gh pr create` one PR for that finding. Title from the finding; body cites the finding ID,
    trigger, impact, and fix. Do **NOT** apply any `gauntlet-run-*` owner label — review does not know


### PR DESCRIPTION
- `references/fix-subagent-contract.md` — one owner for the fix-subagent scope+sweep rule
- both dispatch paths run under it; other sites carry fenced non-authoritative summaries
- `CLAUDE.md`: when you change a definition, grep for every site that restates it