### PR TITLE
reproduce the failure before fixing working code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,30 @@ corrupt the very check meant to catch that bug — a branch that accidentally se
 would, used as its own gate, merge itself on a single verdict; a branch that weakened CI status
 derivation would feed itself a false `ci=green`. Keep a trusted stage-0.
 
+## Your OWN diagnosis is a claim too — reproduce the failure before you "fix" it
+
+The campaign gate already knows that **a reviewer's finding is a CLAIM, not a fact**, and must be audited
+CONFIRMED / ADJUSTED / REFUTED before any fix is dispatched (`critical-rules.md`). **That rule applies to
+your own diagnoses with exactly the same force, and it is the one place it kept getting skipped.**
+
+**If you cannot demonstrate the failure, you do not get to change the code.**
+
+Before you "fix" existing behavior, produce the reproduction: the command that fails, the input that
+breaks it, the line that cannot be reached. Walk the causal chain of the bug you *believe* is there and
+check every link. If you cannot make it fail, **it is not broken** — and what you are about to write is
+not a fix, it is a regression with good intentions.
+
+**Why this rule exists:** a PR in this repo changed `--state open` to `--state all` to fix terminal-PR
+reconciliation. The reconciliation was **never broken** — `main` already handled it via **absence** (with
+`--state open` a merged PR simply drops out of the snapshot, and the existing rule reads that absence as
+the signal). The "bug" was a misreading. The change then broke adoption (it resurrected merged PRs as
+active work), and the next three review rounds were spent patching the consequences of an invented
+problem — the exact death-spiral this repo has already suffered once. It took a human's call to stop it.
+
+The tell is unmistakable in hindsight, and it generalises: **when each fix creates the next finding, you
+are not converging on a bug — you are patching your own invention.** Stop and re-derive whether the
+original thing was ever broken.
+
 ## Version is the plugin cache key
 
 `plugin.json`'s `version` decides whether an installed copy refreshes. Changing skill content **without**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,12 +82,30 @@ breaks it, the line that cannot be reached. Walk the causal chain of the bug you
 check every link. If you cannot make it fail, **it is not broken** — and what you are about to write is
 not a fix, it is a regression with good intentions.
 
+**Name the asymmetry, or you will misread this as contradicting the rule beside it.** `critical-rules.md`
+also says **"unsure → CONFIRMED, never REFUTED"**: for a *reviewer's* finding, uncertainty means **fix
+it**. Here, for your *own* diagnosis, inability to reproduce means **do NOT fix it**. Both are correct,
+because the **evidence differs** — that, not the verdict, is what to reason from:
+
+- A **reviewer's finding is INDEPENDENT EVIDENCE.** A separate, context-isolated observer looked at the
+  code and saw something. Being unsure about it means *you* have not yet understood what *they* saw — so
+  it stays **CONFIRMED** and gets fixed: wrongly refuting a real defect is far worse than wrongly fixing
+  a phantom one.
+- A **self-originated diagnosis has NO independent corroboration.** Nothing observed it but you. So it
+  needs a **demonstrated failure or a verified causal chain** before any fix is dispatched — otherwise a
+  fix subagent is dispatched at an **invented** bug and lands a regression that CI and the review gate
+  will happily pass, because nothing downstream knows the bug was never real.
+
+**Unsure that a REVIEWER is right → FIX. Unsure that YOU are right → STOP and reproduce it.** The two
+rules never conflict once that is named — and they always appear to, as long as it is not.
+
 **Why this rule exists:** a PR in this repo changed `--state open` to `--state all` to fix terminal-PR
 reconciliation. The reconciliation was **never broken** — `main` already handled it via **absence** (with
 `--state open` a merged PR simply drops out of the snapshot, and the existing rule reads that absence as
 the signal). The "bug" was a misreading. The change then broke adoption (it resurrected merged PRs as
-active work), and the next three review rounds were spent patching the consequences of an invented
-problem — the exact death-spiral this repo has already suffered once. It took a human's call to stop it.
+active work), and several subsequent review rounds were then spent patching the consequences of an
+invented problem, round after round — the exact death-spiral this repo has already suffered before. It
+took a human's call to stop it.
 
 The tell is unmistakable in hindsight, and it generalises: **when each fix creates the next finding, you
 are not converging on a bug — you are patching your own invention.** Stop and re-derive whether the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -83,6 +83,14 @@
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` (it only sets
   `ci = pending`). Per-wake label reconcile is the self-healing backstop, never the mechanism
   (`stage-2-review-gate.md`, "Status labels mirror the review gate").
+- **YOUR OWN diagnosis is a claim too — REPRODUCE the failure before you "fix" working code.** The rule
+  below audits a *reviewer's* finding. It binds **your own** with equal force, and that is where it keeps
+  getting skipped: campaign never writes fixes from scratch, but it *does* decide that existing behavior
+  is broken — and a fix subagent dispatched on an **invented** bug lands a regression that CI and the
+  review gate will happily pass, because nothing downstream knows the bug was never real. **If you cannot
+  make it fail, it is not broken.** Walk the causal chain and check every link, exactly as you would for a
+  reviewer's claim. **The tell that you have invented one: each fix creates the next finding.** When that
+  happens, stop patching and re-derive whether the original thing was ever broken.
 - **A reviewer's finding is a CLAIM, not a fact — AUDIT it before you fix it.** On every `NOT
   SATISFIED`, verdict each finding against the source *before* dispatching a fix — NEVER dispatch a fix
   for an unaudited finding: **CONFIRMED** (real, and its mechanism can occur → fix), **ADJUSTED** (a real

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -86,11 +86,18 @@
 - **YOUR OWN diagnosis is a claim too — REPRODUCE the failure before you "fix" working code.** The rule
   below audits a *reviewer's* finding. It binds **your own** with equal force, and that is where it keeps
   getting skipped: campaign never writes fixes from scratch, but it *does* decide that existing behavior
-  is broken — and a fix subagent dispatched on an **invented** bug lands a regression that CI and the
-  review gate will happily pass, because nothing downstream knows the bug was never real. **If you cannot
-  make it fail, it is not broken.** Walk the causal chain and check every link, exactly as you would for a
-  reviewer's claim. **The tell that you have invented one: each fix creates the next finding.** When that
-  happens, stop patching and re-derive whether the original thing was ever broken.
+  is broken. **The two resolve uncertainty in OPPOSITE directions, and the asymmetry is the point — it is
+  a difference in EVIDENCE, not a contradiction:** a **reviewer's finding is INDEPENDENT EVIDENCE** (a
+  separate, context-isolated observer looked at this code and saw something), so being unsure about it
+  means *you* have not yet understood what *they* saw → it stays **CONFIRMED** and gets fixed (rule
+  below). A **self-originated diagnosis has NO independent corroboration** — nothing observed it but you —
+  so it needs a **demonstrated failure or a verified causal chain** before any fix is dispatched:
+  otherwise a fix subagent is dispatched at an **invented** bug and lands a regression that CI and the
+  review gate will happily pass, because nothing downstream knows the bug was never real. **Unsure that a
+  REVIEWER is right → FIX. Unsure that YOU are right → STOP and reproduce it. If you cannot make it fail,
+  it is not broken.** Walk the causal chain and check every link, exactly as you would for a reviewer's
+  claim. **The tell that you have invented one: each fix creates the next finding.** When that happens,
+  stop patching and re-derive whether the original thing was ever broken.
 - **A reviewer's finding is a CLAIM, not a fact — AUDIT it before you fix it.** On every `NOT
   SATISFIED`, verdict each finding against the source *before* dispatching a fix — NEVER dispatch a fix
   for an unaudited finding: **CONFIRMED** (real, and its mechanism can occur → fix), **ADJUSTED** (a real
@@ -102,7 +109,9 @@
   it on ANY input campaign consumes — PR content, reviewer output, CI logs/snapshots, ledger and run
   state, the base branch, user preferences, the installed skill itself (illustrative, NEVER exhaustive).
   **Unsure → CONFIRMED, never REFUTED:** wrongly refuting a real defect is far worse than wrongly fixing
-  a phantom one. A guard was once built against a "hardlink escape" — refuted because git has **no
+  a phantom one. This default holds **only because a reviewer's finding is independent evidence** —
+  **your OWN diagnosis has none and gets the OPPOSITE default** (rule above: unsure → reproduce it, do
+  NOT fix). A guard was once built against a "hardlink escape" — refuted because git has **no
   hardlink mode** (verified empirically: hardlinked files stored as ordinary `100644` blobs, checkout
   recreates separate inodes), so the chain breaks at its first link; the guard was dead weight and a full
   round was wasted.


### PR DESCRIPTION
This repo already knows that **a reviewer's finding is a CLAIM, not a fact** — `critical-rules.md` requires every finding be audited CONFIRMED / ADJUSTED / REFUTED before any fix is dispatched, and forbids dispatching a fix for an unaudited finding.

**That rule was never turned on the orchestrator's own diagnoses.** It should have been obvious. It was not applied, and it cost four review rounds.

## What happened

A PR changed the run snapshot from `--state open` to `--state all` to "fix" terminal-PR reconciliation.

**The reconciliation was never broken.** `main` already handled it — via **absence**. With `--state open`, a merged PR simply **drops out of the snapshot**, and main's existing rule (*"a row whose PR is gone (merged/closed) reconciles to its terminal status"*) reads that absence as the signal. I read "gone" as "must appear with `state = MERGED`", concluded the rule was broken, and changed it.

The change then **created** a real bug (adoption resurrected merged PRs as active work), whose fix contradicted the liveness rule, whose fix contradicted the label reconcile — three straight rounds patching the consequences of a problem that never existed. It took a human's call to split it out and stop the spiral. **That is the same death-spiral this repo already suffered once, in the PR this whole series replaced.**

## The rule

> **If you cannot demonstrate the failure, you do not get to change the code.**

Before "fixing" existing behavior, produce the reproduction: the command that fails, the input that breaks it, the line that cannot be reached. Walk the causal chain of the bug you *believe* is there and check every link — exactly the reachability test the existing rule already demands for a reviewer's claim. If you cannot make it fail, **it is not broken**, and what you are about to write is not a fix — it is a regression with good intentions.

**And the tell, which generalises:** *when each fix creates the next finding, you are not converging on a bug — you are patching your own invention.* Stop and re-derive whether the original thing was ever broken.

## Why it needs to be written down at all

A fix subagent dispatched on an **invented** bug lands a regression that **CI and the review gate will happily pass** — because nothing downstream knows the bug was never real. The gate checks that the change is *correct and consistent*; it cannot check that the change was *necessary*. That is the orchestrator's job, and it is the one it skipped.

Added to `critical-rules.md` (beside the existing finding-audit rule it extends) and to `CLAUDE.md`.