### PR TITLE
suggest a reporting style, don't impose one

### DIFF
--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -59,11 +59,8 @@ The plugin deliberately does **not** set how Claude talks to you. That is your e
 (`CLAUDE.md`, an output style), not a plugin's, and a skill that dictated tone would just fight whatever
 you had already configured.
 
-It is worth setting *something*, though, and a campaign is the case that makes it obvious. The run is
-unattended and long: it wakes on every review verdict, CI completion and fix, and each wake reports. Those
-summaries are the whole surface you experience the run through — you are reading updates, not watching
-tool calls. With no reporting contract you get dozens of them, and the one that says *this needs your
-decision* looks exactly like the twenty that say *still working*.
+Set something anyway. A campaign reports on every wake, for hours, and those updates are all you see of
+it. Without a contract, the update that needs your decision reads exactly like the twenty that don't.
 
 If you don't already have a style you like, [`docs/reporting-style.md`](docs/reporting-style.md) is a
 sample to copy into your `CLAUDE.md` and edit. The rule to steal even if you take nothing else: **end

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -64,9 +64,7 @@ you see of it. Without a contract, the update that needs your decision reads muc
 don't.
 
 If you don't already have a style you like, [`docs/reporting-style.md`](docs/reporting-style.md) is a
-sample to copy into your `CLAUDE.md` and edit. The rule to steal even if you take nothing else: **end
-every update with an explicit action item, or with "Nothing needed from you."** It makes "blocked on you"
-impossible to miss in a run you aren't watching.
+sample to copy into your `CLAUDE.md` and edit.
 
 ## Scratch files
 

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -59,8 +59,9 @@ The plugin deliberately does **not** set how Claude talks to you. That is your e
 (`CLAUDE.md`, an output style), not a plugin's, and a skill that dictated tone would just fight whatever
 you had already configured.
 
-Set something anyway. A campaign reports on every wake, for hours, and those updates are all you see of
-it. Without a contract, the update that needs your decision reads exactly like the twenty that don't.
+It's still worth setting something. A campaign reports on every wake, for hours, and those updates are all
+you see of it. Without a contract, the update that needs your decision reads much like the twenty that
+don't.
 
 If you don't already have a style you like, [`docs/reporting-style.md`](docs/reporting-style.md) is a
 sample to copy into your `CLAUDE.md` and edit. The rule to steal even if you take nothing else: **end

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -53,6 +53,23 @@ reviewer can't return a verdict because of a system problem (quota, auth, timeou
 retries once and then falls back to its own subagents, so an outage slows a run rather than stalling
 it.
 
+### Optional — tell it how to report to you
+
+The plugin deliberately does **not** set how Claude talks to you. That is your environment's business
+(`CLAUDE.md`, an output style), not a plugin's, and a skill that dictated tone would just fight whatever
+you had already configured.
+
+It is worth setting *something*, though, and a campaign is the case that makes it obvious. The run is
+unattended and long: it wakes on every review verdict, CI completion and fix, and each wake reports. Those
+summaries are the whole surface you experience the run through — you are reading updates, not watching
+tool calls. With no reporting contract you get dozens of them, and the one that says *this needs your
+decision* looks exactly like the twenty that say *still working*.
+
+If you don't already have a style you like, [`docs/reporting-style.md`](docs/reporting-style.md) is a
+sample to copy into your `CLAUDE.md` and edit. The rule to steal even if you take nothing else: **end
+every update with an explicit action item, or with "Nothing needed from you."** It makes "blocked on you"
+impossible to miss in a run you aren't watching.
+
 ## Scratch files
 
 Both skills keep working state under `.gauntlet/` at the repo root, which is git-ignored. Run scratch

--- a/plugins/gauntlet/docs/reporting-style.md
+++ b/plugins/gauntlet/docs/reporting-style.md
@@ -1,28 +1,12 @@
 # A sample reporting style
 
-**Nothing here is loaded, read, or enforced by the plugin.** This is a reference you can copy into your
-own `CLAUDE.md` (or an output style) and edit until it sounds like what you want to read. How Claude
-talks to *you* is yours to set, not a plugin's to decide — see [why this file exists](#why-this-file-exists)
-below.
+Nothing here is loaded or enforced by the plugin — see the
+[README](../README.md#optional--tell-it-how-to-report-to-you) for why it's a sample and not a setting.
 
-## Why a campaign makes reporting worth tuning
-
-`/gauntlet:campaign` runs unattended, often for hours. It wakes on every review verdict, CI completion
-and fix landing, and each wake produces an update. Over a long run that is dozens of updates you did not
-ask for individually, and they are the entire surface you experience the run through — you are not
-watching the tool calls, you are reading the summaries.
-
-So the cost of a vague default lands harder here than in a normal back-and-forth session. Ten wakes of
-"I'll now check the CI status" tells you nothing about a run that has been going for two hours. What you
-usually want to know at a glance is: **what changed, is it converging, and does it need me.** That third
-one especially — an unattended run is worth exactly nothing if you have to reconstruct whether it is
-blocked on you.
-
-The rules below are one set that works. They are opinionated on purpose. Take the parts you like.
+One set of rules that works. Opinionated on purpose. Copy it into your `CLAUDE.md` and edit until it
+sounds like what you want to read.
 
 ## The sample
-
-Copy from here down into your `CLAUDE.md`.
 
 ---
 
@@ -86,13 +70,3 @@ derivation. The explanation can follow — it just cannot come first.
 
 **"Never justify past work unasked."** An agent explaining why its earlier choice was defensible is
 spending your attention on its reputation instead of your problem.
-
-## Why this file exists
-
-Reporting style is an *environment* concern. It belongs to you and your `CLAUDE.md`, not to a plugin
-you installed — a skill that dictated tone would be overreaching into a preference it has no business
-holding, and it would fight whatever you had already set.
-
-But the campaign skill is unusual in how much it reports and in how long it runs without you, so leaving
-you to discover the problem after a four-hour run seemed worse than offering a starting point. Hence: a
-sample, not a setting.

--- a/plugins/gauntlet/docs/reporting-style.md
+++ b/plugins/gauntlet/docs/reporting-style.md
@@ -8,11 +8,10 @@ sounds like what you want to read.
 
 ## The sample
 
----
+````markdown
+# Reporting
 
-### Reporting
-
-#### Interim updates (after tool batches, subagent returns, phase boundaries)
+## Interim updates (after tool batches, subagent returns, phase boundaries)
 
 - State what was learned / what changed in plain language, then next step. NEVER narrate mechanics
   ("grepping now") or use labels/numbering invented mid-task.
@@ -28,12 +27,12 @@ sounds like what you want to read.
 - No meta-commentary about own reporting ("because they're real risks, not mechanics"). Report the work
   only.
 
-#### Final report
+## Final report
 
 - Summary of work + worktree name (`.worktrees/<branch>`) or directory.
 - Action items for user listed explicitly, or state none.
 
-#### Answering direct questions
+## Answering direct questions
 
 - First sentence = the answer. "Does X need action from me?" → "No." / "Yes: `<action>`." BEFORE any
   explanation.
@@ -41,8 +40,7 @@ sounds like what you want to read.
 - NEVER justify/defend past work unasked. Answer the question, don't litigate.
 - Side-findings/plans surfaced while answering → ≤1 sentence mention ("queuing a doc fix separately").
   Details on request.
-
----
+````
 
 ## What each rule is actually buying you
 

--- a/plugins/gauntlet/docs/reporting-style.md
+++ b/plugins/gauntlet/docs/reporting-style.md
@@ -47,8 +47,8 @@ sounds like what you want to read.
 Worth understanding before you adopt or drop any of them — several look like style nits and are not.
 
 **"End every update with an action item or 'Nothing needed from you.'"** The single highest-value rule
-for an unattended run. It makes *blocked-on-you* impossible to miss and impossible to fake. Without it,
-a run that needs your decision reads exactly like a run that is making progress.
+for an unattended run. It makes *blocked-on-you* impossible to miss and impossible to fake — the agent
+must commit to one or the other, every time, and cannot trail off ambiguously.
 
 **"No new info → no update."** Removes the heartbeat noise that trains you to stop reading. If every
 wake produces prose, none of it is a signal.

--- a/plugins/gauntlet/docs/reporting-style.md
+++ b/plugins/gauntlet/docs/reporting-style.md
@@ -1,0 +1,98 @@
+# A sample reporting style
+
+**Nothing here is loaded, read, or enforced by the plugin.** This is a reference you can copy into your
+own `CLAUDE.md` (or an output style) and edit until it sounds like what you want to read. How Claude
+talks to *you* is yours to set, not a plugin's to decide — see [why this file exists](#why-this-file-exists)
+below.
+
+## Why a campaign makes reporting worth tuning
+
+`/gauntlet:campaign` runs unattended, often for hours. It wakes on every review verdict, CI completion
+and fix landing, and each wake produces an update. Over a long run that is dozens of updates you did not
+ask for individually, and they are the entire surface you experience the run through — you are not
+watching the tool calls, you are reading the summaries.
+
+So the cost of a vague default lands harder here than in a normal back-and-forth session. Ten wakes of
+"I'll now check the CI status" tells you nothing about a run that has been going for two hours. What you
+usually want to know at a glance is: **what changed, is it converging, and does it need me.** That third
+one especially — an unattended run is worth exactly nothing if you have to reconstruct whether it is
+blocked on you.
+
+The rules below are one set that works. They are opinionated on purpose. Take the parts you like.
+
+## The sample
+
+Copy from here down into your `CLAUDE.md`.
+
+---
+
+### Reporting
+
+#### Interim updates (after tool batches, subagent returns, phase boundaries)
+
+- State what was learned / what changed in plain language, then next step. NEVER narrate mechanics
+  ("grepping now") or use labels/numbering invented mid-task.
+- End EVERY interim update with either explicit user action item(s) or "Nothing needed from you."
+- No new info → no update.
+- Budget: 1–4 complete sentences. Full sentences, no fragments/arrow chains.
+- One idea per sentence, ≤ ~20 words. NEVER semicolon-chain clauses or nest conditionals — split into
+  separate sentences.
+- Anchor identifiers on first mention per update: `#30 (retention rules)`, not bare `#30`. Applies to
+  PR/issue numbers, branches, agent names.
+- 2+ independent items → one short bullet per item, NOT packed prose. Sentence budget covers only the
+  non-bullet portion.
+- No meta-commentary about own reporting ("because they're real risks, not mechanics"). Report the work
+  only.
+
+#### Final report
+
+- Summary of work + worktree name (`.worktrees/<branch>`) or directory.
+- Action items for user listed explicitly, or state none.
+
+#### Answering direct questions
+
+- First sentence = the answer. "Does X need action from me?" → "No." / "Yes: `<action>`." BEFORE any
+  explanation.
+- Explanation budget: 1–3 sentences, only what the asker needs to act. No root-cause essays unless asked.
+- NEVER justify/defend past work unasked. Answer the question, don't litigate.
+- Side-findings/plans surfaced while answering → ≤1 sentence mention ("queuing a doc fix separately").
+  Details on request.
+
+---
+
+## What each rule is actually buying you
+
+Worth understanding before you adopt or drop any of them — several look like style nits and are not.
+
+**"End every update with an action item or 'Nothing needed from you.'"** The single highest-value rule
+for an unattended run. It makes *blocked-on-you* impossible to miss and impossible to fake. Without it,
+a run that needs your decision reads exactly like a run that is making progress.
+
+**"No new info → no update."** Removes the heartbeat noise that trains you to stop reading. If every
+wake produces prose, none of it is a signal.
+
+**"Never narrate mechanics."** "Grepping the tree now" is a fact about the agent, not about your code.
+Over a hundred updates it crowds out the ones that mean something.
+
+**"Anchor identifiers on first mention."** After two hours you will not remember what `#31` was. `#31
+(CI liveness)` costs three words and saves a lookup every single time.
+
+**"One idea per sentence, ≤20 words."** The rule people are most tempted to drop, and it is doing real
+work: it forbids the semicolon-chained mega-sentence that technically contains the news but buries it.
+Splitting forces the important clause to stand alone.
+
+**"First sentence = the answer."** When you ask a direct question mid-run, you want the answer, not the
+derivation. The explanation can follow — it just cannot come first.
+
+**"Never justify past work unasked."** An agent explaining why its earlier choice was defensible is
+spending your attention on its reputation instead of your problem.
+
+## Why this file exists
+
+Reporting style is an *environment* concern. It belongs to you and your `CLAUDE.md`, not to a plugin
+you installed — a skill that dictated tone would be overreaching into a preference it has no business
+holding, and it would fight whatever you had already set.
+
+But the campaign skill is unusual in how much it reports and in how long it runs without you, so leaving
+you to discover the problem after a four-hour run seemed worse than offering a starting point. Hence: a
+sample, not a setting.


### PR DESCRIPTION
- gauntlet README: new `Optional — tell it how to report to you` section; why an unattended campaign makes a reporting contract worth setting, and why the plugin won't set it for you
- new `plugins/gauntlet/docs/reporting-style.md`: a copy-pasteable sample style, plus what each rule buys you
- no behavior change; docs only