### PR TITLE
add ledger table view for end-of-wake status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,12 @@ jobs:
       # hand-written matrix had sworn were covered, which is exactly why the matrix is now DERIVED here.
       - name: CI-snapshot mutation matrix (every rule pinned by a fixture)
         run: python3 plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
+
+      # The ledger's contract, executed — same reason, one file over. `escape_cell` is security-shaped: it
+      # is what stops a PR title from forging a column, a row, or a run-config line in the `table` view, and
+      # a sanitizer verified by eye is a sanitizer verified by NOTHING. The fixtures assert the escaping is
+      # INJECTIVE (two values that differ can never print as one cell) and re-parse the printed grid back to
+      # its declared columns and widths — mechanically, never by looking at it. Weaken any escape and one of
+      # them goes red.
+      - name: Ledger contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/ledger.py self-test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .tmp/
 .gauntlet/
 .worktrees/
+__pycache__/

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -204,8 +204,9 @@ Read stage refs only when that stage/action is due:
    PR, and — whenever any non-terminal work remains — a `ScheduleWakeup` heartbeat is actually
    scheduled. If any due launch or the heartbeat is missing, launch it and re-audit. NEVER sleep with
    due work un-launched or the heartbeat unscheduled.
-7. **Terminal -> carryover/report;** otherwise refresh lease and return (step 6 has already ensured the
-   heartbeat is scheduled).
+7. **Terminal -> carryover/report;** otherwise refresh lease, show the user where the run stands
+   (`ledger.py … table` output plus what each wait is on — `references/loop-control.md`, "Reschedule
+   or exit"), and return (step 6 has already ensured the heartbeat is scheduled).
 
 ## Critical Rules
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -221,15 +221,25 @@ to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decid
 logic, no derived values.
 
 **`table` is a PROJECTION — NEVER a source to read a value back out of.** Its output is *formatted for a
-human*, and the formatting is lossy in two ways:
+human*, and the formatting is lossy in three ways:
 
+- **It shows only SOME fields.** The default view is a **SUBSET** of the row fields listed above — as of
+  this writing `pr`, `slug`, `tier`, `reviews_ok`, `ci`, `attempts`, `status`, `head_sha`. Every other row
+  field (`branch`, `worktree`, `worktree_owned`, `branch_owned`, `started`, `api_approval`, `id`) is
+  **hidden unless you ask for it** with `--fields <f>,<f>,…`. So **a missing COLUMN is not a missing
+  VALUE** — the field is in the store, the default projection just does not print it. The list itself is
+  owned by `TABLE_DEFAULT_FIELDS` in `scripts/ledger.py` and printed **live** by `ledger.py table --help`
+  (it names the defaults); when this paragraph and that output disagree, **the script is right**.
 - **It shortens the SHA.** `table` prints `head_sha` truncated to its first **8 characters**. This is a
   **display-only** truncation and applies to **`table` alone** — nothing else in campaign ever shortens a
   SHA. The stored value, and the one every other subcommand returns, stays the full 40-char `headRefOid`:
   `ledger.py … get --pr N --field head_sha` prints all 40.
 - **It escapes cell values.** A value carrying a `|`, a newline, or a leading `#` would otherwise forge a
-  column, a row, or a header line, so `table` backslash-escapes those before printing. The escaped text is
-  what you see; the raw value is what is stored.
+  column, a row, or a run-config/marker line, so `table` backslash-escapes those before printing. The
+  escaped text is what you see; the raw value is what is stored. That escaping is also what reserves the
+  leading-`#` namespace for the table's own out-of-band lines — the `# <field>: …` run-config block and
+  the `# (no rows)` empty-ledger marker — so **no row can ever forge one**: an empty grid means the ledger
+  really is empty.
 
 So **read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.
 A SHA (or any value) recovered from `table`'s grid is a truncated, escaped rendering, and feeding one back

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -101,9 +101,15 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 
 ```
 {"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex"}
-{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review"}
-{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
+{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review"}
+{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review"}
 ```
+
+**`head_sha` is ALWAYS the full 40-char `headRefOid` — never an abbreviation.** The examples above spell
+it in full because they are what gets copied. A SHA in the ledger is compared for equality against `gh`'s
+live `headRefOid` and pasted into commands; an abbreviated one silently fails both. **NEVER write a
+shortened SHA into the store, and never reconstruct one from a display.** The ONLY place a SHA is ever
+shortened is `table`'s rendering (below) — that is display-only and does not exist on disk.
 
 Header-record fields: `run_id` (this run's identity — namespaces its dir/label/wakes; set once),
 `base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
@@ -211,8 +217,24 @@ ledger.py --file <state.jsonl> table [--fields <f>,<f>,…]         # print run 
 ```
 
 `table` is the user-facing status view: the end-of-wake report renders it whenever the run goes back
-to waiting (`loop-control.md`, "Reschedule or exit"). It is a pure projection of the ledger — raw field
-values only (`head_sha` shortened for display), no gate logic.
+to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decides nothing — no gate
+logic, no derived values.
+
+**`table` is a PROJECTION — NEVER a source to read a value back out of.** Its output is *formatted for a
+human*, and the formatting is lossy in two ways:
+
+- **It shortens the SHA.** `table` prints `head_sha` truncated to its first **8 characters**. This is a
+  **display-only** truncation and applies to **`table` alone** — nothing else in campaign ever shortens a
+  SHA. The stored value, and the one every other subcommand returns, stays the full 40-char `headRefOid`:
+  `ledger.py … get --pr N --field head_sha` prints all 40.
+- **It escapes cell values.** A value carrying a `|`, a newline, or a leading `#` would otherwise forge a
+  column, a row, or a header line, so `table` backslash-escapes those before printing. The escaped text is
+  what you see; the raw value is what is stored.
+
+So **read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.
+A SHA (or any value) recovered from `table`'s grid is a truncated, escaped rendering, and feeding one back
+into a command or writing it to the store is a bug: this repo has already had a fabricated 8-char SHA
+written into a real ledger, and a truncated SHA escape into a command.
 
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
 errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -234,11 +234,16 @@ human*, and the formatting is lossy in three ways:
   **display-only** truncation and applies to **`table` alone** — nothing else in campaign ever shortens a
   SHA. The stored value, and the one every other subcommand returns, stays the full 40-char `headRefOid`:
   `ledger.py … get --pr N --field head_sha` prints all 40.
-- **It escapes cell values.** A value carrying a `|`, a newline, or a leading `#` would otherwise forge a
-  column, a row, or a run-config/marker line, so `table` backslash-escapes those before printing. The
-  escaped text is what you see; the raw value is what is stored. That escaping is also what reserves the
-  leading-`#` namespace for the table's own out-of-band lines — the `# <field>: …` run-config block and
-  the `# (no rows)` empty-ledger marker — so **no row can ever forge one**: an empty grid means the ledger
+- **It escapes cell values.** Rendered raw, a value could forge the very layout it is printed into — an
+  extra column, an extra row, a run-config line, the empty-ledger marker — or, carrying whitespace at its
+  edges, be eaten by the column padding and come out looking like a DIFFERENT value. So `table`
+  backslash-escapes before printing: the escaped text is what you see, the raw value is what is stored.
+  **`escape_cell()` in `scripts/ledger.py` owns which characters are escaped and how, and its `self-test`
+  fixtures pin it** — that function is the definition, and this page deliberately does not restate it (a
+  list here goes stale the moment one is added). What you may rely on: the rendering is **injective** — two
+  different values NEVER print as the same cell, so one row can never be read as another — and it reserves
+  the leading-`#` namespace for the table's own out-of-band lines, the `# <field>: …` run-config block and
+  the `# (no rows)` empty-ledger marker, so **no row can ever forge one**: an empty grid means the ledger
   really is empty.
 
 So **read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -207,7 +207,12 @@ ledger.py --file <state.jsonl> add-row --pr N [--<field> <val> …] # register a
 ledger.py --file <state.jsonl> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
 ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
+ledger.py --file <state.jsonl> table [--fields <f>,<f>,…]         # print run header + all rows as an aligned table (read-only)
 ```
+
+`table` is the user-facing status view: the end-of-wake report renders it whenever the run goes back
+to waiting (`loop-control.md`, "Reschedule or exit"). It is a pure projection of the ledger — raw field
+values only (`head_sha` shortened for display), no gate logic.
 
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
 errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -275,7 +275,11 @@ blocks; each completion is its own wake.
      threshold: with no launch deadline pending, nothing can declare a review stalled before then, so a
      shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
      wake). ALWAYS schedule a heartbeat whenever non-terminal work remains — skipping it means a hung
-     or orphaned run wakes no one. Return.
+     or orphaned run wakes no one. Then **end the turn showing the user where the run stands**: run
+     `ledger.py --file <state.jsonl> table` and include its output verbatim, fenced, in the end-of-turn
+     message, followed by one line per remaining wait naming what it waits on (review in flight, CI
+     watch, parked on the user's answer). Render it after every ledger write of the wake — the ledger
+     was reconciled this wake, so the table is the state the next wake resumes from. Return.
    - All this run's PRs `merged` or `aborted` → **distill the run into the carryover ledger** (write
      this run's block to its own file `.gauntlet/history/<run-id>.md` — merged PRs, aborted
      PRs + why, and declined-API PRs; per-run files never

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -172,7 +172,7 @@ the tool and is shown only to document its shape. The fourth (`pass_identity`) i
 {"type":"progress","unit":"u01","status":"started"}
 {"type":"progress","unit":"u01","status":"done","evidence":"validate_idc.go:42 `canonicalizeValue`; edge case tested at validate_idc_test.go:88"}
 {"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
-{"type":"pass_identity","pr":"41","pass":"1","head_sha":"a3f29c1b","launch_attempt":"1","dispatched_at":"2026-07-06T00:00:00Z"}
+{"type":"pass_identity","pr":"41","pass":"1","head_sha":"a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c","launch_attempt":"1","dispatched_at":"2026-07-06T00:00:00Z"}
 ```
 
 **`pass_identity` is the pass's attempt id and its dispatch clock.** The orchestrator writes it as the

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -227,6 +227,52 @@ TABLE_DEFAULT_FIELDS = ("pr", "slug", "tier", "reviews_ok", "ci", "attempts", "s
 TABLE_SHA_WIDTH = 8
 
 
+def escape_cell(value: str) -> str:
+    """Make a value safe to render inside the grid — no value may forge the layout.
+
+    A field value is free text (`slug` is a PR title; `ci`-style reason fields hold
+    prose), so it can contain the very characters the table's layout is built from.
+    Rendered raw, a value carrying a `|` fabricates extra columns, a newline
+    fabricates extra ROWS, and a leading `# ` mimics the run-config header lines
+    printed above the grid. The table would then say something the ledger never did.
+
+    ESCAPING, not quoting: quoting every cell would widen every column by two chars
+    for the common (harmless) case and STILL need an escape for an embedded quote —
+    so it buys nothing. Backslash escapes leave every ordinary value byte-identical
+    and give the invariant outright: the returned string contains no `|`, no line
+    break, no control character, and never starts with `#`. Each escape is
+    unambiguous (a literal backslash is doubled), so the display stays reversible by
+    eye — but it is still a DISPLAY form. Read values back with `get --field`, never
+    by parsing this table.
+
+    Callers MUST escape BEFORE computing column widths, so the widths measure what is
+    actually printed. (Truncation of `head_sha` happens first, on the raw value, so a
+    cut can never land inside an escape sequence.)
+    """
+    out = []
+    for ch in value:
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == "|":
+            out.append("\\|")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append(f"\\x{ord(ch):02x}")  # any other control char
+        else:
+            out.append(ch)
+    text = "".join(out)
+    # Only a FIRST-column cell can open a line, but escape a leading '#' in every
+    # cell regardless: one value then has one rendering, whatever column it lands in.
+    if text.startswith("#"):
+        text = "\\" + text
+    return text
+
+
 def cmd_table(path: Path, args) -> int:
     header, rows = load(path)
     if args.fields is not None:  # an empty --fields is malformed, not "omitted"
@@ -235,16 +281,20 @@ def cmd_table(path: Path, args) -> int:
             check_field(f, ROW_FIELDS)
     else:
         fields = TABLE_DEFAULT_FIELDS
-    # '#' + blank line keep the run-config lines from reading as table columns
+    # '#' + blank line keep the run-config lines from reading as table columns.
+    # Header values are free text too, so they are escaped on the same terms: an
+    # un-escaped newline here would inject lines that read as part of the grid.
     for f in HEADER_FIELDS:
-        print(f"# {f}: {header[f]}")
+        print(f"# {f}: {escape_cell(header[f])}")
     print()
     cells = []
     for row in rows:
+        # truncate the RAW sha, then escape — so a cut never splits an escape
         cells.append(tuple(
-            row[f][:TABLE_SHA_WIDTH] if f == "head_sha" else row[f]
+            escape_cell(row[f][:TABLE_SHA_WIDTH] if f == "head_sha" else row[f])
             for f in fields
         ))
+    # widths measure the ESCAPED cells — i.e. exactly the text that gets printed
     widths = [max(len(f), *(len(c[i]) for c in cells)) if cells else len(f)
               for i, f in enumerate(fields)]
     print(" | ".join(f.ljust(w) for f, w in zip(fields, widths)).rstrip())

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -229,6 +229,17 @@ TABLE_DEFAULT_FIELDS = ("pr", "slug", "tier", "reviews_ok", "ci", "attempts", "s
 # value stays on disk and in `get`; the table is a projection, not a source.
 TABLE_SHA_WIDTH = 8
 
+# The empty-ledger marker, printed WHERE A ROW WOULD GO — so unlike every other piece of the layout it
+# sits in the one region a value also occupies, and position alone cannot tell them apart. It is therefore
+# made unforgeable BY CONSTRUCTION rather than by escaping it after the fact: it lives in the `#`
+# namespace, which `escape_cell()` already proves no cell can enter (a leading `#` is escaped, and a body
+# line always opens with its first cell — or with that cell's padding). A bare `(no rows)` was forgeable:
+# a row whose only shown field held that literal string rendered a body byte-identical to an empty
+# ledger's. That is the SAME CLASS as the header forgery `escape_cell()` exists to kill — an out-of-band
+# marker an in-band value can impersonate — so it gets the same answer: put the marker somewhere values
+# provably cannot reach.
+TABLE_EMPTY_MARKER = "# (no rows)"
+
 
 def escape_cell(value: str) -> str:
     r"""Make a value safe to render inside the grid — no value may forge the layout.
@@ -307,7 +318,7 @@ def cmd_table(path: Path, args) -> int:
     for c in cells:
         print(" | ".join(v.ljust(w) for v, w in zip(c, widths)).rstrip())
     if not cells:
-        print("(no rows)")
+        print(TABLE_EMPTY_MARKER)  # in the '#' namespace: no cell can render a line that impersonates it
     return 0
 
 
@@ -349,6 +360,9 @@ HOSTILE = {
     "row-forge": "x\n1 | pwned | | | | | |",
     "config-forge": "main\n# run_id: forged",
     "column-forge": "a | b | c",
+    "empty-marker": "(no rows)",              # forge the EMPTY-LEDGER marker (the old, un-namespaced one)
+    "empty-marker-hash": "# (no rows)",       # …and the marker as it is spelled TODAY
+    "rule-forge": "--------",                 # spelled like the rule line
     "empty": "",
     "spaces": "   ",
 }
@@ -398,7 +412,8 @@ def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], li
     Three properties, all checked here because all three are what a hostile value attacks:
 
       * the run config is EXACTLY len(HEADER_FIELDS) lines, each opening `# <field>: `, and NO grid line
-        opens with `#` — so no value can forge a config line;
+        opens with `#` — except the ONE line that is allowed to, `TABLE_EMPTY_MARKER`, and only as the
+        sole body row — so no value can forge a config line and no value can forge the empty marker;
       * every grid line splits into EXACTLY the number of columns the rule line declares, each at the
         declared width — so no value can forge a column;
       * the grid has exactly the lines it should — so no value can forge a row.
@@ -418,10 +433,13 @@ def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], li
         check(line.startswith(f"# {f}: "), f"run-config line for {f!r} is {line!r}")
     check(lines[0] == "", f"a blank line must separate the run config from the grid; got {lines[0]!r}")
     body = lines[1:]
-    for line in body:
-        check(not line.startswith("#"), f"a GRID line opens with '#' — it reads as a run-config line: {line!r}")
     check(len(body) >= 3, f"the grid needs a column-header line, a rule line and a body: {body!r}")
     colhead, rule, rows = body[0], body[1], body[2:]
+    # The ONLY line below the config block that may open with '#' is the empty marker, and only when it
+    # IS the body — a '#' anywhere else means a cell reached the namespace escape_cell() reserves.
+    empty = rows == [TABLE_EMPTY_MARKER]
+    for line in body if not empty else body[:2]:
+        check(not line.startswith("#"), f"a GRID line opens with '#' — it reads as out-of-band text: {line!r}")
 
     runs = rule.split("-+-")
     check(len(runs) == len(fields), f"the rule line declares {len(runs)} columns, not {len(fields)}: {rule!r}")
@@ -441,7 +459,7 @@ def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], li
 
     check(split(colhead) == [f.ljust(w) for f, w in zip(fields, widths)],
           f"the column-header line does not name the fields: {colhead!r}")
-    if rows == ["(no rows)"]:
+    if empty:
         return config, widths, []
     return config, widths, [split(r) for r in rows]
 
@@ -566,6 +584,19 @@ def t_grid_integrity(tmp: Path) -> None:
         check(code == 0, f"[{name}] table exited {code}: {err!r}")
         grid(out, ("slug", "pr"))
 
+    # …and once more in a ONE-COLUMN table — the narrowest grid there is, where the cell has the whole
+    # line to ITSELF and every other line of the table is something it could try to be. This is the shape
+    # the empty-marker forgery lived in, so every hostile value is run through it: the grid must still
+    # parse back to EXACTLY ONE row, never to an empty ledger and never to a fabricated second one.
+    for name, hostile in HOSTILE.items():
+        path = tmp / f"one-{name}.jsonl"
+        write_lines(path, header_line(), row_line(pr="1", slug=hostile))
+        code, out, err = run(["--file", str(path), "table", "--fields", "slug"])
+        check(code == 0, f"[{name}] table exited {code}: {err!r}")
+        _, widths, cells = grid(out, ("slug",))
+        check(cells == [[escape_cell(hostile).ljust(widths[0])]],
+              f"[{name}] a one-column grid did not print exactly the one escaped row: {cells!r}\n{out}")
+
 
 def t_widths_from_escaped(tmp: Path) -> None:
     """Column widths are computed from the ESCAPED text — i.e. from what is actually PRINTED.
@@ -645,7 +676,8 @@ def t_table_missing_file(tmp: Path) -> None:
     check(code == 0, f"table on a missing file exited {code}: {err!r}")
     config, _, cells = grid(out, TABLE_DEFAULT_FIELDS)
     check(cells == [], f"a missing file produced rows: {cells!r}")
-    check("(no rows)" in out, "a missing file must still say '(no rows)'")
+    check(out.rstrip().endswith(TABLE_EMPTY_MARKER),
+          f"a missing file must still say {TABLE_EMPTY_MARKER!r}: {out!r}")
     check(config[0] == "# run_id: -", f"a missing file must fall back to the defaults; got {config[0]!r}")
 
 
@@ -656,7 +688,56 @@ def t_table_no_rows(tmp: Path) -> None:
     check(code == 0, f"table exited {code}: {err!r}")
     _, _, cells = grid(out, TABLE_DEFAULT_FIELDS)
     check(cells == [], f"a header-only ledger produced rows: {cells!r}")
-    check(out.rstrip().endswith("(no rows)"), f"a header-only ledger must say '(no rows)': {out!r}")
+    check(out.rstrip().endswith(TABLE_EMPTY_MARKER),
+          f"a header-only ledger must say {TABLE_EMPTY_MARKER!r}: {out!r}")
+
+
+def t_empty_marker_not_forgeable(tmp: Path) -> None:
+    """A REAL row can NEVER render a body that reads as an EMPTY ledger.
+
+    The marker is the one piece of out-of-band text `table` prints WHERE A ROW WOULD GO, so position
+    cannot distinguish it from a value — only the `#` namespace can, and `escape_cell()` is what keeps
+    values out of it. The attack is a one-column table (`--fields <f>`, the narrowest grid there is,
+    where a cell has the whole line to itself) holding the marker's own text: with an un-namespaced
+    marker the body came out BYTE-IDENTICAL to an empty ledger's, and a reader — human or parser — was
+    told the run had no PRs at all while a PR sat right there in the store.
+
+    Pins TWO rules at once, and goes red if EITHER is weakened: the marker must live in the `#`
+    namespace (drop the `#` and the `(no rows)` case below forges it), and `escape_cell()` must escape a
+    leading `#` (drop that branch and the `# (no rows)` case forges it instead).
+    """
+    empty = write_lines(tmp / "empty.jsonl", header_line(run_id="r1"))
+    for name, forgery in (
+        ("old-marker", "(no rows)"),
+        ("marker", TABLE_EMPTY_MARKER),
+        ("marker-no-space", TABLE_EMPTY_MARKER.replace("# ", "#")),
+        ("marker-padded", TABLE_EMPTY_MARKER + "   "),
+    ):
+        for field in ("reviews_ok", "slug", "pr"):
+            path = write_lines(tmp / f"{name}-{field}.jsonl", header_line(run_id="r1"),
+                               row_line(**{"pr": "1", field: forgery}))
+            code, out, err = run(["--file", str(path), "table", "--fields", field])
+            check(code == 0, f"[{name}/{field}] table exited {code}: {err!r}")
+
+            code, blank, _ = run(["--file", str(empty), "table", "--fields", field])
+            check(code == 0, "table on a header-only ledger must succeed")
+            check(out != blank,
+                  f"[{name}/{field}] a row holding {forgery!r} renders EXACTLY what an EMPTY ledger "
+                  f"renders — the marker is forgeable:\n{out}")
+
+            # …and mechanically: the grid must parse back to ONE row, not to an empty ledger.
+            _, widths, cells = grid(out, (field,))
+            check(len(cells) == 1,
+                  f"[{name}/{field}] a row holding {forgery!r} parsed back as an EMPTY ledger "
+                  f"({len(cells)} rows) — the marker is forgeable:\n{out}")
+            check(cells[0] == [escape_cell(forgery).ljust(widths[0])],
+                  f"[{name}/{field}] the printed row is not the escaped row: {cells[0]!r}\n{out}")
+            # …and no LINE of a non-empty table IS the marker. (The escaped cell may well CONTAIN the
+            # marker's text — `\# (no rows)` does — but it can never BE that line: the `\` is in front of
+            # it, which is the whole point of the namespace.)
+            body = out.split("\n\n", 1)[1].split("\n")
+            check(TABLE_EMPTY_MARKER not in body,
+                  f"[{name}/{field}] a line of a NON-EMPTY table is the empty marker:\n{out}")
 
 
 def t_fields_rejected(tmp: Path) -> None:
@@ -781,8 +862,9 @@ CASES = [
     ("widths-from-escaped", "column widths measure the ESCAPED text — what is printed", t_widths_from_escaped),
     ("config-not-forgeable", "a hostile header value cannot inject a `# <field>:` line", t_config_cannot_be_forged),
     ("truncation-display-only", "table truncates head_sha; disk and `get` keep all 40 — and the cut precedes the escape", t_truncation_is_display_only),
-    ("table-missing-file", "a missing ledger is a fresh start: defaults, (no rows)", t_table_missing_file),
-    ("table-no-rows", "a header-only ledger says (no rows)", t_table_no_rows),
+    ("table-missing-file", "a missing ledger is a fresh start: defaults, `# (no rows)`", t_table_missing_file),
+    ("table-no-rows", "a header-only ledger says `# (no rows)`", t_table_no_rows),
+    ("empty-marker-safe", "no ROW can forge the empty-ledger marker — it lives where no cell can reach", t_empty_marker_not_forgeable),
     ("fields-rejected", "--fields is checked; an EMPTY --fields is malformed, not omitted", t_fields_rejected),
     ("fields-duplicate", "a field named twice prints twice, and the grid still parses", t_fields_duplicate),
     ("unknown-record-type", "an unrecognised record type is REJECTED, never skipped", t_unknown_record_type),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -220,6 +220,42 @@ def cmd_list(path: Path, args) -> int:
     return 0
 
 
+TABLE_DEFAULT_FIELDS = ("pr", "slug", "tier", "reviews_ok", "ci", "attempts", "status", "head_sha")
+
+# Display-only truncation: a 40-char SHA would dominate the table. The full
+# value stays on disk and in `get`; the table is a projection, not a source.
+TABLE_SHA_WIDTH = 8
+
+
+def cmd_table(path: Path, args) -> int:
+    header, rows = load(path)
+    if args.fields is not None:  # an empty --fields is malformed, not "omitted"
+        fields = tuple(f.strip() for f in args.fields.split(","))
+        for f in fields:
+            check_field(f, ROW_FIELDS)
+    else:
+        fields = TABLE_DEFAULT_FIELDS
+    # '#' + blank line keep the run-config lines from reading as table columns
+    for f in HEADER_FIELDS:
+        print(f"# {f}: {header[f]}")
+    print()
+    cells = []
+    for row in rows:
+        cells.append(tuple(
+            row[f][:TABLE_SHA_WIDTH] if f == "head_sha" else row[f]
+            for f in fields
+        ))
+    widths = [max(len(f), *(len(c[i]) for c in cells)) if cells else len(f)
+              for i, f in enumerate(fields)]
+    print(" | ".join(f.ljust(w) for f, w in zip(fields, widths)).rstrip())
+    print("-+-".join("-" * w for w in widths))
+    for c in cells:
+        print(" | ".join(v.ljust(w) for v, w in zip(c, widths)).rstrip())
+    if not cells:
+        print("(no rows)")
+    return 0
+
+
 # --- cli ----------------------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
@@ -258,6 +294,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     ls = sub.add_parser("list", help="print matching rows' pr numbers")
     ls.add_argument("--where", help="filter as <field>=<value>")
+
+    t = sub.add_parser("table", help="print the run header and all rows as an aligned table")
+    t.add_argument("--fields", help=f"comma-separated row fields to show (default: {','.join(TABLE_DEFAULT_FIELDS)})")
     return parser
 
 
@@ -266,7 +305,7 @@ def main(argv: list[str]) -> int:
     path = Path(args.file)
     handlers = {
         "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set,
-        "get": cmd_get, "list": cmd_list,
+        "get": cmd_get, "list": cmd_list, "table": cmd_table,
     }
     return handlers[args.cmd](path, args)
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -12,8 +12,11 @@ skill.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import sys
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
 
 DESCRIPTION = "Schema-owning accessor for the campaign ledger (state.jsonl)."
 from pathlib import Path
@@ -228,7 +231,7 @@ TABLE_SHA_WIDTH = 8
 
 
 def escape_cell(value: str) -> str:
-    """Make a value safe to render inside the grid — no value may forge the layout.
+    r"""Make a value safe to render inside the grid — no value may forge the layout.
 
     A field value is free text (`slug` is a PR title; `ci`-style reason fields hold
     prose), so it can contain the very characters the table's layout is built from.
@@ -239,8 +242,10 @@ def escape_cell(value: str) -> str:
     ESCAPING, not quoting: quoting every cell would widen every column by two chars
     for the common (harmless) case and STILL need an escape for an embedded quote —
     so it buys nothing. Backslash escapes leave every ordinary value byte-identical
-    and give the invariant outright: the returned string contains no `|`, no line
-    break, no control character, and never starts with `#`. Each escape is
+    and give the invariant outright: the returned string contains no BARE `|` (every
+    one is escaped to `\|`, and a `|` preceded by a backslash can never spell the
+    ` | ` column separator), no line break, no control character, and never starts
+    with `#`. Each escape is
     unambiguous (a literal backslash is doubled), so the display stays reversible by
     eye — but it is still a DISPLAY form. Read values back with `get --field`, never
     by parsing this table.
@@ -306,11 +311,524 @@ def cmd_table(path: Path, args) -> int:
     return 0
 
 
+# --- self-test: the fixtures ARE the contract ---------------------------------
+#
+# `escape_cell` is the one piece of this file that is SECURITY-SHAPED: it exists so that no field value
+# can make the table say something the ledger never did. A sanitizer verified by eye is a sanitizer
+# verified by nothing — it is exactly the class of gap that turned `stage-2-ci.md`'s prose contract into
+# `ci-snapshot.py`'s executable one, for exactly the same reason. So the rules are executed here, with
+# fixtures that FAIL when the rule they pin is removed, and CI runs them.
+#
+# EVERY FIXTURE MUST PIN A RULE — it must go red if its rule is deleted or weakened. A fixture that
+# would still pass with its rule gone tests nothing and manufactures false confidence. The `->` column
+# below names the rule each one stands on. (`ci-snapshot.py` has `mutate-ci-snapshot.py` to CHECK that
+# claim mechanically; this suite is small enough that the claim is checked by hand — see the PR.)
+#
+# The GRID checks are MECHANICAL, never by eye: `grid()` parses the printed table BACK and asserts the
+# declared column count and widths. Reading a table and going "looks fine" is how a forged column ships.
+
+# The adversarial values. Every one of them is a value the ledger can genuinely hold (`slug` is a PR
+# title; a branch name is free text), and every one is aimed at the grid's own syntax: the column
+# separator, the row separator, the run-config prefix — or at the ESCAPES THEMSELVES, which is the
+# attack the naive sanitizer misses (escape `|` but not `\`, and `a\|b` and `a|b` collide).
+HOSTILE = {
+    "pipe": "a|b",                          # forge a COLUMN
+    "escaped-pipe": "a\\|b",                # collides with the above unless `\` is doubled
+    "backslash": "\\",
+    "double-backslash": "\\\\",
+    "hex-lookalike": "\\x7c",               # spelled like the escape for U+007C ('|')
+    "newline-lookalike": "a\\nb",           # spelled like the escape for a newline
+    "newline": "a\nb",                      # forge a ROW
+    "crlf": "a\r\nb",
+    "tab": "a\tb",
+    "nul": "a\x00b",
+    "del": "a\x7fb",
+    "esc": "a\x1bb",                        # an ANSI escape: control chars never reach the terminal raw
+    "leading-hash": "#x",                   # forge a RUN-CONFIG line
+    "escaped-hash": "\\#x",                 # collides with the above unless `\` is doubled
+    "row-forge": "x\n1 | pwned | | | | | |",
+    "config-forge": "main\n# run_id: forged",
+    "column-forge": "a | b | c",
+    "empty": "",
+    "spaces": "   ",
+}
+
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SelfTestFailure(msg)
+
+
+def run(argv: list[str]) -> "tuple[int, str, str]":
+    """Drive the REAL CLI in-process and capture (exit code, stdout, stderr).
+
+    The subcommands are exercised through `main()` — never by calling their internals — so the argparse
+    wiring (the `--fields` rejection, the dash/underscore aliases, `fail()`'s exit 1) is under test too.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(argv)
+    except SystemExit as exc:  # fail() -> 1; argparse -> 2
+        code = exc.code if isinstance(exc.code, int) else 1
+    return code, out.getvalue(), err.getvalue()
+
+
+def write_lines(path: Path, *lines: str) -> Path:
+    """Write a ledger RAW — bypassing dump(), so a fixture can hold what dump() would never emit."""
+    path.write_text("".join(line + "\n" for line in lines))
+    return path
+
+
+def header_line(**over: str) -> str:
+    return json.dumps({"type": "header", **HEADER_DEFAULTS, **over})
+
+
+def row_line(**over: str) -> str:
+    return json.dumps({"type": "row", **ROW_DEFAULTS, **over})
+
+
+def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], list[list[str]]]":
+    """Parse the printed table BACK and assert its INTEGRITY. Returns (config lines, widths, cells).
+
+    Three properties, all checked here because all three are what a hostile value attacks:
+
+      * the run config is EXACTLY len(HEADER_FIELDS) lines, each opening `# <field>: `, and NO grid line
+        opens with `#` — so no value can forge a config line;
+      * every grid line splits into EXACTLY the number of columns the rule line declares, each at the
+        declared width — so no value can forge a column;
+      * the grid has exactly the lines it should — so no value can forge a row.
+
+    Lines are re-padded to the declared width before splitting, because `cmd_table` rstrips each line
+    (trailing padding is noise). Re-padding can only put SPACES back; it cannot invent a column
+    boundary. What it can NEVER repair is a raw `|` in a cell — that boundary is in the bytes, and the
+    split below then counts one column too many, which is precisely the failure this exists to catch.
+    """
+    lines = out.split("\n")
+    check(lines[-1] == "", "the table output must end in a newline")
+    lines = lines[:-1]
+    n = len(HEADER_FIELDS)
+    check(len(lines) >= n + 3, f"expected {n} run-config lines, a blank line and a grid; got {lines!r}")
+    config, lines = lines[:n], lines[n:]
+    for f, line in zip(HEADER_FIELDS, config):
+        check(line.startswith(f"# {f}: "), f"run-config line for {f!r} is {line!r}")
+    check(lines[0] == "", f"a blank line must separate the run config from the grid; got {lines[0]!r}")
+    body = lines[1:]
+    for line in body:
+        check(not line.startswith("#"), f"a GRID line opens with '#' — it reads as a run-config line: {line!r}")
+    check(len(body) >= 3, f"the grid needs a column-header line, a rule line and a body: {body!r}")
+    colhead, rule, rows = body[0], body[1], body[2:]
+
+    runs = rule.split("-+-")
+    check(len(runs) == len(fields), f"the rule line declares {len(runs)} columns, not {len(fields)}: {rule!r}")
+    for r in runs:
+        check(bool(r) and set(r) == {"-"}, f"malformed rule line: {rule!r}")
+    widths = [len(r) for r in runs]
+    full = sum(widths) + 3 * (len(widths) - 1)
+
+    def split(line: str) -> list[str]:
+        check(len(line) <= full, f"line is wider than the declared grid ({full}): {line!r}")
+        parts = line.ljust(full).split(" | ")
+        check(len(parts) == len(fields),
+              f"line splits into {len(parts)} columns, not the declared {len(fields)}: {line!r}")
+        for p, w in zip(parts, widths):
+            check(len(p) == w, f"a column is {len(p)} wide, not the declared {w}: {line!r}")
+        return parts
+
+    check(split(colhead) == [f.ljust(w) for f, w in zip(fields, widths)],
+          f"the column-header line does not name the fields: {colhead!r}")
+    if rows == ["(no rows)"]:
+        return config, widths, []
+    return config, widths, [split(r) for r in rows]
+
+
+# --- the fixtures -------------------------------------------------------------
+
+def t_escape_injective(tmp: Path) -> None:
+    """Two DIFFERENT values NEVER render as the same cell.
+
+    A non-injective escaping is a NEW LIE inside the code written to stop lies: `a|b` and `a\\|b` are
+    different values, and if both print as `a\\|b` the table has silently merged them. Doubling the
+    BACKSLASH is the whole reason this holds — remove that one branch and the two collide immediately.
+    """
+    values = sorted(set(
+        list(HOSTILE.values())
+        + [chr(c) for c in range(0x20)] + ["\x7f", "|", "#", "\\", "\\\\", "\\|", "\\n", "\\r", "\\t"]
+        + ["\\x00", "\\x1b", "\\#", "-", "a", "pr1"]
+    ))
+    seen: dict[str, str] = {}
+    for raw in values:
+        cell = escape_cell(raw)
+        if cell in seen:
+            raise SelfTestFailure(
+                f"escape_cell is NOT INJECTIVE: {seen[cell]!r} and {raw!r} both render as {cell!r} — "
+                f"the table cannot be telling the truth about both"
+            )
+        seen[cell] = raw
+
+
+def bare(cell: str) -> "list[str]":
+    """The characters in `cell` that are NOT part of an escape sequence and can forge the layout.
+
+    Walk the escaped text the way a reader does: a `\\` opens a two-character escape, so skip both. Every
+    OTHER character stands on its own — and a `|`, a line break or a control character standing on its
+    own is a grid metacharacter the sanitizer failed to defuse.
+
+    This is the check, and NOT `'|' not in cell`: the escaped form of a pipe IS `\\|`, which contains one.
+    What must never appear is a BARE one — and it is the bare one that can spell the ` | ` separator.
+    """
+    out, i = [], 0
+    while i < len(cell):
+        if cell[i] == "\\":
+            i += 2  # an escape sequence: its introducer plus the character it escapes
+            continue
+        if cell[i] == "|" or cell[i] == "\n" or cell[i] == "\r" or ord(cell[i]) < 0x20 or ord(cell[i]) == 0x7F:
+            out.append(cell[i])
+        i += 1
+    return out
+
+
+def t_escape_invariant(tmp: Path) -> None:
+    """The escaped cell holds NO BARE grid metacharacter: no unescaped `|`, no line break, no control
+    char — and it never opens with `#`. This is what makes the ` | ` separator and the `# ` config prefix
+    mean ONE thing wherever they appear."""
+    for raw in sorted(set(list(HOSTILE.values()) + [chr(c) for c in range(0x21)] + ["\x7f"])):
+        cell = escape_cell(raw)
+        check(not bare(cell),
+              f"escape_cell({raw!r}) = {cell!r} still carries a BARE {bare(cell)!r} — it can forge the layout")
+        check(" | " not in cell,
+              f"escape_cell({raw!r}) = {cell!r} spells the column separator — it can forge a COLUMN")
+        check("\n" not in cell and "\r" not in cell,
+              f"escape_cell({raw!r}) = {cell!r} still carries a line break — it can forge a ROW")
+        check(not any(ord(c) < 0x20 or ord(c) == 0x7F for c in cell),
+              f"escape_cell({raw!r}) = {cell!r} still carries a control character")
+        check(not cell.startswith("#"),
+              f"escape_cell({raw!r}) = {cell!r} opens with '#' — it can forge a RUN-CONFIG line")
+
+
+def t_escape_mapping(tmp: Path) -> None:
+    r"""The escape TABLE itself, character by character — and ordinary text left BYTE-IDENTICAL.
+
+    The invariant above is satisfied by more than one escaping (drop the `\n` branch and a newline still
+    gets defused, as `\x0a`, by the control-char catch-all — safe, but no longer what this file says it
+    prints). The DISPLAY FORM is a promise too: `escape_cell`'s docstring says the value stays readable,
+    and every rule that is real but unpinned is a rule that can be deleted with the suite still green.
+    That is exactly the gap `mutate-ci-snapshot.py` exists to find, and it found this one here.
+    """
+    for raw, want in {
+        "\\": "\\\\",         # doubled — the escape that makes every OTHER escape unambiguous
+        "|": "\\|",
+        "\n": "\\n",
+        "\r": "\\r",
+        "\t": "\\t",
+        "\x00": "\\x00",      # anything else that is a control char: \xNN, lowercase hex
+        "\x1b": "\\x1b",
+        "\x7f": "\\x7f",
+    }.items():
+        check(escape_cell(raw) == want, f"escape_cell({raw!r}) = {escape_cell(raw)!r}, not {want!r}")
+
+    check(escape_cell("#x") == "\\#x", f"a LEADING '#' must be escaped: {escape_cell('#x')!r}")
+    check(escape_cell("a#b") == "a#b", f"a '#' that is not leading needs no escape: {escape_cell('a#b')!r}")
+
+    # …and the whole reason this is escaping and not quoting: an ordinary value is untouched.
+    for plain in ("pr42", "fix/the-thing", "green", "-", "add a table view (#39)", "2026-07-13T10:00:00Z"):
+        check(escape_cell(plain) == plain, f"an ordinary value was mangled: {plain!r} -> {escape_cell(plain)!r}")
+
+
+def t_grid_integrity(tmp: Path) -> None:
+    """EVERY hostile value, in EVERY column, and the grid still parses back to the declared shape.
+
+    Checked MECHANICALLY (`grid()` re-parses the output). The `slug` column carries the hostile value
+    while `pr` sits FIRST — where a leading `#` would open a line — and a second row holds a benign
+    value, so a forged row/column has somewhere to be seen.
+    """
+    fields = ("slug", "pr", "ci")
+    for name, hostile in HOSTILE.items():
+        path = tmp / f"grid-{name}.jsonl"
+        write_lines(path, header_line(), row_line(pr="1", slug=hostile, ci="green"), row_line(pr="2"))
+        code, out, err = run(["--file", str(path), "table", "--fields", ",".join(fields)])
+        check(code == 0, f"[{name}] table exited {code}: {err!r}")
+        _, widths, cells = grid(out, fields)
+        check(len(cells) == 2, f"[{name}] the value forged a ROW: {len(cells)} rows printed, not 2\n{out}")
+        check(cells[0] == [escape_cell(v).ljust(w) for v, w in zip((hostile, "1", "green"), widths)],
+              f"[{name}] the printed row is not the escaped row: {cells[0]!r}\n{out}")
+
+    # …and again with the hostile value FIRST, which is the only position that can open a line — the
+    # leading-'#' rule is pinned HERE (`grid()` rejects a body line starting with '#').
+    for name, hostile in HOSTILE.items():
+        path = tmp / f"first-{name}.jsonl"
+        write_lines(path, header_line(), row_line(pr="1", slug=hostile))
+        code, out, err = run(["--file", str(path), "table", "--fields", "slug,pr"])
+        check(code == 0, f"[{name}] table exited {code}: {err!r}")
+        grid(out, ("slug", "pr"))
+
+
+def t_widths_from_escaped(tmp: Path) -> None:
+    """Column widths are computed from the ESCAPED text — i.e. from what is actually PRINTED.
+
+    Measure the RAW value and every escape makes its cell WIDER than the column reserved for it, so the
+    ` | ` separators stop lining up and the grid is ragged from the first hostile value on.
+    """
+    raw = "a|b|c|d"                 # 7 raw, 11 escaped: `a\|b\|c\|d`… wider than the field name
+    escaped = escape_cell(raw)
+    check(len(escaped) > len(raw) > len("slug"), "fixture is not measuring anything")
+    path = write_lines(tmp / "w.jsonl", header_line(), row_line(pr="1", slug=raw))
+    code, out, err = run(["--file", str(path), "table", "--fields", "slug,pr"])
+    check(code == 0, f"table exited {code}: {err!r}")
+    _, widths, cells = grid(out, ("slug", "pr"))
+    check(widths[0] == len(escaped),
+          f"the slug column is {widths[0]} wide but prints {len(escaped)} chars ({escaped!r}) — the width "
+          f"was measured on the RAW value ({len(raw)}), not the printed one")
+
+
+def t_config_cannot_be_forged(tmp: Path) -> None:
+    """A hostile header value cannot inject a line that READS AS a run-config line.
+
+    `base_branch` and `run_id` are free text too, and they are printed ABOVE the grid as `# <field>: …`.
+    An unescaped newline in one of them writes any line it likes into that block.
+    """
+    path = write_lines(
+        tmp / "cfg.jsonl",
+        header_line(run_id="real", base_branch="main\n# run_id: forged\n\npr | slug"),
+        row_line(pr="1"),
+    )
+    code, out, err = run(["--file", str(path), "table"])
+    check(code == 0, f"table exited {code}: {err!r}")
+    config, _, cells = grid(out, TABLE_DEFAULT_FIELDS)
+    check(len(cells) == 1, f"the header value forged a ROW: {out}")
+    forged = [line for line in out.split("\n") if line.startswith("# run_id:")]
+    check(forged == ["# run_id: real"],
+          f"a hostile base_branch forged a run-config line — lines opening '# run_id:': {forged!r}\n{out}")
+    check(config[0] == "# run_id: real", f"the real run_id line is {config[0]!r}")
+
+
+def t_truncation_is_display_only(tmp: Path) -> None:
+    """`table` shortens head_sha FOR DISPLAY. The ledger still holds all 40 chars — and `get` still says so.
+
+    A projection that quietly became the source of truth would hand every caller an 8-char prefix, and a
+    prefix is not a commit. Also pinned here: truncation happens BEFORE escaping, so a cut can never land
+    INSIDE an escape sequence and leave a dangling backslash behind.
+    """
+    sha = "abcdefg|" + "9" * 32  # the 8-char cut lands EXACTLY on a character that must be escaped
+    check(len(sha) == 40, "fixture sha is not 40 chars")
+    path = write_lines(tmp / "sha.jsonl", header_line(), row_line(pr="1", head_sha=sha))
+
+    code, out, err = run(["--file", str(path), "table"])
+    check(code == 0, f"table exited {code}: {err!r}")
+    _, widths, cells = grid(out, TABLE_DEFAULT_FIELDS)
+    col = TABLE_DEFAULT_FIELDS.index("head_sha")
+    cell = cells[0][col].rstrip()
+    # truncate(8) THEN escape -> `abcdefg\|` (9 chars). Escape THEN truncate(8) would cut the `\|` in
+    # half and print a DANGLING BACKSLASH — a cell that decodes to something the ledger never held.
+    check(cell == "abcdefg\\|",
+          f"head_sha renders as {cell!r}, not {'abcdefg\\|'!r} — escaping ran BEFORE truncation and the "
+          f"cut landed inside an escape sequence")
+    check((len(cell) - len(cell.rstrip("\\"))) % 2 == 0,
+          f"the rendered head_sha {cell!r} ends in a DANGLING escape — the cut split an escape sequence")
+    check(len(cell.rstrip()) < len(sha), "head_sha was not truncated for display at all")
+
+    # …and the FULL value is still what the ledger holds and what `get` returns.
+    code, out, _ = run(["--file", str(path), "get", "--pr", "1", "--field", "head_sha"])
+    check((code, out) == (0, sha + "\n"), f"get --field head_sha returned {out!r}, not the full 40 chars")
+    code, out, _ = run(["--file", str(path), "get", "--pr", "1"])
+    check(json.loads(out)["head_sha"] == sha, f"get returned a truncated head_sha: {out!r}")
+    check(sha in path.read_text(), "the ON-DISK row does not carry the full head_sha")
+
+
+def t_table_missing_file(tmp: Path) -> None:
+    """A ledger that does not exist yet is a FRESH START, not an error: defaults, and no rows."""
+    code, out, err = run(["--file", str(tmp / "nope.jsonl"), "table"])
+    check(code == 0, f"table on a missing file exited {code}: {err!r}")
+    config, _, cells = grid(out, TABLE_DEFAULT_FIELDS)
+    check(cells == [], f"a missing file produced rows: {cells!r}")
+    check("(no rows)" in out, "a missing file must still say '(no rows)'")
+    check(config[0] == "# run_id: -", f"a missing file must fall back to the defaults; got {config[0]!r}")
+
+
+def t_table_no_rows(tmp: Path) -> None:
+    """A header-only ledger prints the grid and says so — never an empty, wordless table."""
+    path = write_lines(tmp / "hdr.jsonl", header_line(run_id="r1"))
+    code, out, err = run(["--file", str(path), "table"])
+    check(code == 0, f"table exited {code}: {err!r}")
+    _, _, cells = grid(out, TABLE_DEFAULT_FIELDS)
+    check(cells == [], f"a header-only ledger produced rows: {cells!r}")
+    check(out.rstrip().endswith("(no rows)"), f"a header-only ledger must say '(no rows)': {out!r}")
+
+
+def t_fields_rejected(tmp: Path) -> None:
+    """`--fields` is CHECKED, and an EMPTY `--fields` is a malformed field list — never 'omitted'.
+
+    `args.fields is not None` is the rule: falsiness would read `--fields ''` as "the user asked for the
+    defaults" and print a table they did not ask for.
+    """
+    path = write_lines(tmp / "f.jsonl", header_line(), row_line(pr="1"))
+    for fields, needle in ((("--fields", ""), "unknown field ''"), (("--fields", "nope"), "unknown field 'nope'")):
+        code, out, err = run(["--file", str(path), "table", *fields])
+        check(code == 1, f"table {fields!r} exited {code}, not 1 — it was ACCEPTED:\n{out}")
+        check(needle in err, f"table {fields!r} failed with {err!r}, which does not mention {needle!r}")
+
+
+def t_fields_duplicate(tmp: Path) -> None:
+    """A field named TWICE prints TWICE — and the grid still declares the columns it actually has."""
+    path = write_lines(tmp / "d.jsonl", header_line(), row_line(pr="1", slug="s"))
+    code, out, err = run(["--file", str(path), "table", "--fields", "pr,pr"])
+    check(code == 0, f"table exited {code}: {err!r}")
+    _, _, cells = grid(out, ("pr", "pr"))
+    check([c.rstrip() for c in cells[0]] == ["1", "1"], f"a duplicated field did not print twice: {cells!r}")
+
+
+def t_unknown_record_type(tmp: Path) -> None:
+    """A record type we do not recognise is REJECTED, never skipped.
+
+    A skipped row is a row nothing reads — and if the campaign ever writes a type this accessor has not
+    learned, silently dropping it loses a PR's whole state without a word.
+    """
+    path = write_lines(tmp / "u.jsonl", header_line(), json.dumps({"type": "note", "pr": "1"}))
+    code, _, err = run(["--file", str(path), "list"])
+    check(code == 1, f"an unknown record type was ACCEPTED (exit {code})")
+    check("unknown record type" in err, f"failed for the wrong reason: {err!r}")
+
+
+def t_duplicate_row(tmp: Path) -> None:
+    """Two rows for one PR is a CORRUPT ledger — `find_row` would silently read the first and `set` would
+    update the first while the second stayed behind, disagreeing, forever."""
+    path = write_lines(tmp / "dup.jsonl", header_line(), row_line(pr="1"), row_line(pr="1"))
+    code, _, err = run(["--file", str(path), "list"])
+    check(code == 1, f"a duplicate row was ACCEPTED (exit {code})")
+    check("duplicate row for pr 1" in err, f"failed for the wrong reason: {err!r}")
+    # …and the duplicate is caught on the NORMALIZED key: a JSON number 1 and the string "1" are ONE pr.
+    path = write_lines(tmp / "dup2.jsonl", header_line(),
+                       json.dumps({"type": "row", "pr": 1}), row_line(pr="1"))
+    code, _, err = run(["--file", str(path), "list"])
+    check(code == 1, f"a duplicate row keyed 1 vs \"1\" was ACCEPTED (exit {code})")
+    check("duplicate row for pr 1" in err, f"failed for the wrong reason: {err!r}")
+
+
+def t_missing_header(tmp: Path) -> None:
+    """A ledger that EXISTS must carry a header. A missing FILE is a fresh start; a present-but-headerless
+    one is CORRUPT — resetting it to defaults would drop the run config and every row without a word."""
+    path = write_lines(tmp / "nohdr.jsonl", row_line(pr="1"))
+    code, _, err = run(["--file", str(path), "list"])
+    check(code == 1, f"a headerless ledger was ACCEPTED (exit {code})")
+    check("first record must be the header" in err, f"failed for the wrong reason: {err!r}")
+
+    empty = write_lines(tmp / "empty.jsonl", "", "   ")
+    code, _, err = run(["--file", str(empty), "list"])
+    check(code == 1, f"an all-blank ledger was ACCEPTED (exit {code})")
+    check("missing header record" in err, f"failed for the wrong reason: {err!r}")
+
+    two = write_lines(tmp / "two.jsonl", header_line(run_id="a"), row_line(pr="1"), header_line(run_id="b"))
+    code, _, err = run(["--file", str(two), "list"])
+    check(code == 1, f"a SECOND header was ACCEPTED (exit {code})")
+    check("second/out-of-order header" in err, f"failed for the wrong reason: {err!r}")
+
+
+def t_id_is_derived(tmp: Path) -> None:
+    """`id` is ALWAYS `pr<pr>` — recomputed on load, never trusted from the file and never caller-set."""
+    path = write_lines(tmp / "id.jsonl", header_line(), json.dumps({"type": "row", "pr": "7", "id": "pwned"}))
+    code, out, err = run(["--file", str(path), "get", "--pr", "7", "--field", "id"])
+    check((code, out) == (0, "pr7\n"), f"a forged on-disk id survived load(): {out!r} {err!r}")
+
+    fresh = tmp / "id2.jsonl"
+    code, out, err = run(["--file", str(fresh), "add-row", "--pr", "9"])
+    check(code == 0, f"add-row exited {code}: {err!r}")
+    check(json.loads(out)["id"] == "pr9", f"add-row did not derive id from pr: {out!r}")
+    code, out, _ = run(["--file", str(fresh), "get", "--pr", "9", "--field", "id"])
+    check(out == "pr9\n", f"the id did not survive the round trip: {out!r}")
+
+
+def t_defaults_backfill(tmp: Path) -> None:
+    """A row written BEFORE a field existed still reads back complete — every absent field takes its default.
+
+    This is what lets a field be ADDED to the schema without migrating the ledger: an old row is not a
+    broken row. Drop the back-fill and every accessor starts raising KeyError on real, existing state.
+    """
+    path = write_lines(tmp / "old.jsonl", header_line(), json.dumps({"type": "row", "pr": "3", "slug": "old"}))
+    code, out, err = run(["--file", str(path), "get", "--pr", "3"])
+    check(code == 0, f"get on a pre-schema row exited {code}: {err!r}")
+    row = json.loads(out)
+    check(set(row) == set(ROW_FIELDS), f"get did not project onto ROW_FIELDS: {sorted(row)}")
+    for f in ("tier", "status", "ci", "attempts"):
+        check(row[f] == ROW_DEFAULTS[f], f"{f} back-filled as {row[f]!r}, not the default {ROW_DEFAULTS[f]!r}")
+    check(row["slug"] == "old", "the field the row DID carry was overwritten by its default")
+    # A header written before a field existed back-fills the same way.
+    code, out, _ = run(["--file", str(path), "header", "get", "reviewer"])
+    check(out == HEADER_DEFAULTS["reviewer"] + "\n", f"header default did not back-fill: {out!r}")
+
+
+def t_values_are_strings(tmp: Path) -> None:
+    """Every ingested value is coerced to `str`, so the on-disk JSON's type cannot change a comparison."""
+    path = write_lines(tmp / "num.jsonl", header_line(),
+                       json.dumps({"type": "row", "pr": 11, "reviews_ok": 2, "worktree_owned": True}))
+    code, out, err = run(["--file", str(path), "get", "--pr", "11"])
+    check(code == 0, f"get exited {code}: {err!r}")
+    row = json.loads(out)
+    check(all(isinstance(v, str) for v in row.values()), f"a non-string value survived load(): {row!r}")
+    check(row["reviews_ok"] == "2" and row["worktree_owned"] == "True", f"bad coercion: {row!r}")
+    code, out, _ = run(["--file", str(path), "list", "--where", "reviews_ok=2"])
+    check(out == "11\n", f"--where could not match a value that was a JSON number on disk: {out!r}")
+
+
+CASES = [
+    ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
+    ("escape-invariant", "the escaped cell holds no bare |, newline, control char, or leading #", t_escape_invariant),
+    ("escape-mapping", "the escape table, char by char — and ordinary values left byte-identical", t_escape_mapping),
+    ("grid-integrity", "no hostile value forges a column, a row, or a config line", t_grid_integrity),
+    ("widths-from-escaped", "column widths measure the ESCAPED text — what is printed", t_widths_from_escaped),
+    ("config-not-forgeable", "a hostile header value cannot inject a `# <field>:` line", t_config_cannot_be_forged),
+    ("truncation-display-only", "table truncates head_sha; disk and `get` keep all 40 — and the cut precedes the escape", t_truncation_is_display_only),
+    ("table-missing-file", "a missing ledger is a fresh start: defaults, (no rows)", t_table_missing_file),
+    ("table-no-rows", "a header-only ledger says (no rows)", t_table_no_rows),
+    ("fields-rejected", "--fields is checked; an EMPTY --fields is malformed, not omitted", t_fields_rejected),
+    ("fields-duplicate", "a field named twice prints twice, and the grid still parses", t_fields_duplicate),
+    ("unknown-record-type", "an unrecognised record type is REJECTED, never skipped", t_unknown_record_type),
+    ("duplicate-row", "two rows for one pr is a corrupt ledger — on the NORMALIZED key", t_duplicate_row),
+    ("missing-header", "a present ledger must carry exactly one header, FIRST", t_missing_header),
+    ("id-derived", "id is always pr<pr> — never trusted from the file, never caller-set", t_id_is_derived),
+    ("defaults-backfill", "a row written before a field existed still reads back complete", t_defaults_backfill),
+    ("values-are-strings", "every ingested value is coerced to str", t_values_are_strings),
+]
+
+
+def self_test() -> int:
+    """Run every fixture. Exit 0 iff every rule this file claims to enforce actually holds."""
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for name, rule, fn in CASES:
+            work = Path(tmpdir) / name
+            work.mkdir()
+            try:
+                fn(work)
+            except SelfTestFailure as exc:
+                print(f"FAIL     {name:24} -> {rule}\n         {exc}")
+                failures += 1
+            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
+                # A crash is not a verdict. If the accessor raises where a fixture expected an answer,
+                # that fixture has FAILED — it must never be mistaken for a rule nothing tests.
+                print(f"FAIL     {name:24} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+                failures += 1
+            else:
+                print(f"ok       {name:24} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the ledger's contract is broken.")
+        return 1
+    print(f"all {len(CASES)} fixtures hold — the ledger's contract is intact.")
+    return 0
+
+
 # --- cli ----------------------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
-    parser.add_argument("--file", required=True, help="path to the ledger (state.jsonl)")
+    # NOT `required=True`: `self-test` reads no ledger at all. Every OTHER subcommand does, and main()
+    # enforces that through `parser.error` — the same message, usage line and exit 2 argparse itself
+    # would have produced, so a forgotten --file fails exactly as loudly as it always did.
+    parser.add_argument("--file", help="path to the ledger (state.jsonl)")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     h = sub.add_parser("header", help="get/set a run-config header field")
@@ -347,11 +865,18 @@ def build_parser() -> argparse.ArgumentParser:
 
     t = sub.add_parser("table", help="print the run header and all rows as an aligned table")
     t.add_argument("--fields", help=f"comma-separated row fields to show (default: {','.join(TABLE_DEFAULT_FIELDS)})")
+
+    sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
     return parser
 
 
 def main(argv: list[str]) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.cmd == "self-test":  # stdlib only, no ledger, no repo checkout, no network
+        return self_test()
+    if args.file is None:
+        parser.error("the following arguments are required: --file")
     path = Path(args.file)
     handlers = {
         "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set,

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -241,8 +241,14 @@ TABLE_SHA_WIDTH = 8
 TABLE_EMPTY_MARKER = "# (no rows)"
 
 
+def _hex_escape(ch: str) -> str:
+    """`\\xNN` for a byte-sized code point, `\\uNNNN` above it — the same spelling Python's own repr uses."""
+    return f"\\x{ord(ch):02x}" if ord(ch) < 0x100 else f"\\u{ord(ch):04x}"
+
+
 def escape_cell(value: str) -> str:
-    r"""Make a value safe to render inside the grid — no value may forge the layout.
+    r"""Make a value safe to render inside the grid — no value may forge the layout, and no two
+    values may render THE SAME.
 
     A field value is free text (`slug` is a PR title; `ci`-style reason fields hold
     prose), so it can contain the very characters the table's layout is built from.
@@ -261,12 +267,33 @@ def escape_cell(value: str) -> str:
     eye — but it is still a DISPLAY form. Read values back with `get --field`, never
     by parsing this table.
 
+    WHITESPACE IS ESCAPED AT THE EDGES, and that is not cosmetic — it is what makes the
+    escaping INJECTIVE ONCE PRINTED. The layout pads each cell with `ljust()` and then
+    `rstrip()`s the line, and BOTH of those EAT trailing whitespace: with it left raw,
+    `""` and `"   "` printed the same blank cell and `"a"` and `"a "` printed the same
+    `a`. The sanitizer was injective and the RENDERING was not — which is the same lie,
+    one layer down. So a leading or trailing whitespace run is escaped (`\x20` for a
+    space) and it survives display. INTERIOR spaces are left alone: escaping them would
+    turn every PR title into `add\x20a\x20table`, and nothing eats them.
+
+    Whitespace that is NOT a plain space is escaped WHEREVER it appears: it is invisible
+    or line-break-ish, `str.rstrip()` eats every bit of it (NBSP and NEL included, not
+    just ASCII), and nothing ordinary contains it. So the guarantee is flat: the escaped
+    text NEVER starts or ends with whitespace, and holds no whitespace but the plain
+    interior space — which is exactly what lets the printed cell be read back off the
+    line by stripping its padding (see `grid()` in the self-test).
+
     Callers MUST escape BEFORE computing column widths, so the widths measure what is
     actually printed. (Truncation of `head_sha` happens first, on the raw value, so a
     cut can never land inside an escape sequence.)
     """
+    # The RAW value's whitespace edges — `lstrip`/`rstrip` here use exactly the definition of
+    # whitespace that `cmd_table`'s `rstrip()` will apply to the printed line, so what is escaped is
+    # precisely what the layout would otherwise eat.
+    lead = len(value) - len(value.lstrip())
+    trail = len(value.rstrip())  # index where the trailing whitespace run starts
     out = []
-    for ch in value:
+    for i, ch in enumerate(value):
         if ch == "\\":
             out.append("\\\\")
         elif ch == "|":
@@ -279,11 +306,17 @@ def escape_cell(value: str) -> str:
             out.append("\\t")
         elif ord(ch) < 0x20 or ord(ch) == 0x7F:
             out.append(f"\\x{ord(ch):02x}")  # any other control char
+        elif ch.isspace() and ch != " ":
+            out.append(_hex_escape(ch))  # NBSP, NEL, U+2028, ideographic space…: invisible, and rstrip() eats it
+        elif ch == " " and (i < lead or i >= trail):
+            out.append("\\x20")  # a LEADING or TRAILING space: the padding would swallow it
         else:
             out.append(ch)
     text = "".join(out)
     # Only a FIRST-column cell can open a line, but escape a leading '#' in every
     # cell regardless: one value then has one rendering, whatever column it lands in.
+    # (A leading whitespace run is already escaped above, so a '#' here can only be the
+    # value's own first character.)
     if text.startswith("#"):
         text = "\\" + text
     return text
@@ -363,9 +396,31 @@ HOSTILE = {
     "empty-marker": "(no rows)",              # forge the EMPTY-LEDGER marker (the old, un-namespaced one)
     "empty-marker-hash": "# (no rows)",       # …and the marker as it is spelled TODAY
     "rule-forge": "--------",                 # spelled like the rule line
-    "empty": "",
-    "spaces": "   ",
 }
+
+# The WHITESPACE family — the attack on the LAYOUT rather than on the escapes. `ljust()` pads a cell with
+# spaces and `cmd_table` rstrips the printed line, so any whitespace at a value's EDGE is eaten by the
+# rendering and DISTINCT values print the same bytes. It is the quietest forgery of all: nothing is
+# fabricated, two rows simply become indistinguishable, and `""` reads as `"   "` reads as a cell that was
+# never there. `\xa0` and `\x85` are in here because `str.rstrip()` eats those too — "whitespace" is not
+# just the space bar.
+WHITESPACE = {
+    "empty": "",
+    "space": " ",
+    "spaces": "   ",
+    "plain": "a",
+    "trailing-space": "a ",
+    "trailing-spaces": "a  ",
+    "leading-space": " a",
+    "surrounded": " a ",
+    "interior-space": "a b",          # …and THIS one must stay byte-identical: it is an ordinary title
+    "nbsp": "a\xa0",                  # U+00A0 — invisible, and rstrip() eats it just the same
+    "nel": "a\x85",                   # U+0085 — a line break to str.splitlines(), whitespace to rstrip()
+    "ideographic-space": "a　",   # U+3000
+    "escaped-space": "a\\x20",        # spelled like the escape for a trailing space
+}
+
+HOSTILE.update(WHITESPACE)
 
 
 class SelfTestFailure(AssertionError):
@@ -406,6 +461,13 @@ def row_line(**over: str) -> str:
     return json.dumps({"type": "row", **ROW_DEFAULTS, **over})
 
 
+def body_lines(out: str) -> "list[str]":
+    """The table's printed ROW lines, EXACTLY as they came out — the bytes a reader actually sees."""
+    body = out.split("\n\n", 1)[1].split("\n")
+    check(body[-1] == "", "the table output must end in a newline")
+    return body[2:-1]  # drop the column-header line, the rule line, and the trailing ''
+
+
 def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], list[list[str]]]":
     """Parse the printed table BACK and assert its INTEGRITY. Returns (config lines, widths, cells).
 
@@ -414,14 +476,21 @@ def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], li
       * the run config is EXACTLY len(HEADER_FIELDS) lines, each opening `# <field>: `, and NO grid line
         opens with `#` — except the ONE line that is allowed to, `TABLE_EMPTY_MARKER`, and only as the
         sole body row — so no value can forge a config line and no value can forge the empty marker;
-      * every grid line splits into EXACTLY the number of columns the rule line declares, each at the
-        declared width — so no value can forge a column;
+      * every column boundary is EXACTLY where the rule line's widths declare it, and every BARE `|` in
+        the line IS one of those boundaries — so no value can forge a column;
       * the grid has exactly the lines it should — so no value can forge a row.
 
-    Lines are re-padded to the declared width before splitting, because `cmd_table` rstrips each line
-    (trailing padding is noise). Re-padding can only put SPACES back; it cannot invent a column
-    boundary. What it can NEVER repair is a raw `|` in a cell — that boundary is in the bytes, and the
-    split below then counts one column too many, which is precisely the failure this exists to catch.
+    THE CELLS IT RETURNS ARE THE PRINTED BYTES. `cmd_table` writes `content + padding` in each column and
+    then rstrips the line, so this oracle recovers the CONTENT by removing that padding — and that
+    recovery is EXACT, but only because `escape_cell()` guarantees an escaped cell never ends in
+    whitespace, so every trailing space in a printed column IS padding.
+
+    IT MUST NEVER RE-PAD. The oracle this replaced did: it `ljust`ed the printed line back out to the full
+    grid width and handed back PADDED columns, and every fixture then compared them against an equally
+    `ljust`ed expectation. Both sides were re-padded, so a collision CAUSED BY the padding could not
+    appear on either — and one did: `""` and `"   "` printed the same blank cell, `"a"` and `"a "` the
+    same `a`, and this suite stayed green through it. An oracle that normalizes away the thing under test
+    is not an oracle. What it hands back is what was PRINTED; nothing else.
     """
     lines = out.split("\n")
     check(lines[-1] == "", "the table output must end in a newline")
@@ -446,22 +515,42 @@ def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], li
     for r in runs:
         check(bool(r) and set(r) == {"-"}, f"malformed rule line: {rule!r}")
     widths = [len(r) for r in runs]
-    full = sum(widths) + 3 * (len(widths) - 1)
+    # Where each column STARTS, and where each separator's '|' sits — fixed by the declared widths alone.
+    starts = [sum(widths[:i]) + 3 * i for i in range(len(widths))]
+    full = starts[-1] + widths[-1]
+    pipes = {s - 2 for s in starts[1:]}
 
-    def split(line: str) -> list[str]:
+    def cut(line: str) -> list[str]:
         check(len(line) <= full, f"line is wider than the declared grid ({full}): {line!r}")
-        parts = line.ljust(full).split(" | ")
-        check(len(parts) == len(fields),
-              f"line splits into {len(parts)} columns, not the declared {len(fields)}: {line!r}")
-        for p, w in zip(parts, widths):
-            check(len(p) == w, f"a column is {len(p)} wide, not the declared {w}: {line!r}")
-        return parts
+        check(line == line.rstrip(), f"a printed line ends in whitespace — it was not rstripped: {line!r}")
+        # A BARE '|' anywhere but a declared separator is a forged column boundary. This is the check,
+        # not a column COUNT: it pins the boundary's POSITION, so a raw `|` smuggled into a cell cannot
+        # pass by landing where a separator would have been (a cell's bytes never reach that offset).
+        for j, ch in enumerate(line):
+            if ch == "|" and (j == 0 or line[j - 1] != "\\"):
+                check(j in pipes, f"a BARE '|' at offset {j} is not a declared column boundary: {line!r}")
+        cells = []
+        for i, (s, w) in enumerate(zip(starts, widths)):
+            if i:
+                check(line[s - 3:s - 1] == " |",
+                      f"the separator before column {i} is not where the widths declare it: {line!r}")
+                # rstrip() can reach the separator's TRAILING space — and only that — when every cell
+                # after it is empty. Nothing else of the separator is ever missing.
+                check(line[s - 1:s] in (" ", ""), f"malformed column separator before column {i}: {line!r}")
+            col = line[s:s + w]
+            # A column is printed at its declared width — UNLESS the line stops inside it, which is the
+            # one thing rstrip() can do: it eats the padding of the trailing columns (and, when they are
+            # all empty, the last separator's own trailing space with it). Anything shorter than that is
+            # a line that does not fit the grid it declares.
+            check(len(col) == w or len(line) <= s + w,
+                  f"column {i} is {len(col)} wide, not the declared {w}, and is not the stripped tail: {line!r}")
+            cells.append(col.rstrip())  # remove the PADDING — and only the padding: content never ends in ws
+        return cells
 
-    check(split(colhead) == [f.ljust(w) for f, w in zip(fields, widths)],
-          f"the column-header line does not name the fields: {colhead!r}")
+    check(cut(colhead) == list(fields), f"the column-header line does not name the fields: {colhead!r}")
     if empty:
         return config, widths, []
-    return config, widths, [split(r) for r in rows]
+    return config, widths, [cut(r) for r in rows]
 
 
 # --- the fixtures -------------------------------------------------------------
@@ -489,6 +578,47 @@ def t_escape_injective(tmp: Path) -> None:
         seen[cell] = raw
 
 
+def t_render_injective(tmp: Path) -> None:
+    """Two DIFFERENT values never render as the same PRINTED ROW. Asserted on the BYTES, not on cells.
+
+    `t_escape_injective` pins injectivity of the SANITIZER. That is not the property anyone relies on —
+    what a reader sees is the LINE, and between `escape_cell()` and the line sit `ljust()` and `rstrip()`,
+    both of which destroy trailing whitespace. So injectivity was pinned one layer above where it was
+    broken: the sanitizer was injective, the RENDERING was not, and this suite was green. This fixture
+    pins it where it is actually consumed — the printed row lines of a real table must be pairwise
+    DISTINCT — and the WHITESPACE family is what it is aimed at.
+
+    Three shapes, because the layout eats whitespace differently in each: a ONE-COLUMN table (the cell
+    owns the whole line, and `rstrip()` hits it directly), the value in the FIRST of two columns (where
+    `ljust()`'s padding swallows it instead), and the value in the LAST column (both at once). Only `slug`
+    varies; the other column is constant, so a difference between two lines can come from NOTHING but the
+    value.
+    """
+    values = sorted(set(HOSTILE.values()))
+    path = tmp / "inj.jsonl"
+    write_lines(path, header_line(),
+                *(row_line(pr=str(i + 1), slug=v, ci="green") for i, v in enumerate(values)))
+    for fields in (("slug",), ("slug", "ci"), ("ci", "slug")):
+        code, out, err = run(["--file", str(path), "table", "--fields", ",".join(fields)])
+        check(code == 0, f"table exited {code}: {err!r}")
+        lines = body_lines(out)
+        check(len(lines) == len(values),
+              f"{fields}: {len(lines)} row lines printed for {len(values)} rows:\n{out}")
+        seen: dict[str, str] = {}
+        for raw, line in zip(values, lines):
+            if line in seen:
+                raise SelfTestFailure(
+                    f"{fields}: the RENDERING is NOT INJECTIVE: {seen[line]!r} and {raw!r} both print as "
+                    f"the row line {line!r} — the table cannot be telling the truth about both"
+                )
+            seen[line] = raw
+        # …and each line really is that value's escaped cell, not merely something distinct.
+        _, _, cells = grid(out, fields)
+        for raw, row in zip(values, cells):
+            check(row[fields.index("slug")] == escape_cell(raw),
+                  f"{fields}: {raw!r} printed as {row[fields.index('slug')]!r}, not {escape_cell(raw)!r}")
+
+
 def bare(cell: str) -> "list[str]":
     """The characters in `cell` that are NOT part of an escape sequence and can forge the layout.
 
@@ -513,8 +643,15 @@ def bare(cell: str) -> "list[str]":
 def t_escape_invariant(tmp: Path) -> None:
     """The escaped cell holds NO BARE grid metacharacter: no unescaped `|`, no line break, no control
     char — and it never opens with `#`. This is what makes the ` | ` separator and the `# ` config prefix
-    mean ONE thing wherever they appear."""
-    for raw in sorted(set(list(HOSTILE.values()) + [chr(c) for c in range(0x21)] + ["\x7f"])):
+    mean ONE thing wherever they appear.
+
+    …and NO EDGE WHITESPACE, which is the layout's metacharacter rather than the syntax's: `ljust()` and
+    `rstrip()` eat it, so a cell that ends in whitespace is a cell whose printed bytes do not say what it
+    holds. That guarantee is also what lets `grid()` recover a cell by removing its padding — every
+    trailing space in a printed column IS padding, because content can no longer end in one.
+    """
+    for raw in sorted(set(list(HOSTILE.values()) + [chr(c) for c in range(0x21)]
+                          + ["\x7f", "\x85", "\xa0", " ", "　", " a ", "  ", "a\t"])):
         cell = escape_cell(raw)
         check(not bare(cell),
               f"escape_cell({raw!r}) = {cell!r} still carries a BARE {bare(cell)!r} — it can forge the layout")
@@ -526,6 +663,12 @@ def t_escape_invariant(tmp: Path) -> None:
               f"escape_cell({raw!r}) = {cell!r} still carries a control character")
         check(not cell.startswith("#"),
               f"escape_cell({raw!r}) = {cell!r} opens with '#' — it can forge a RUN-CONFIG line")
+        check(cell == cell.strip(),
+              f"escape_cell({raw!r}) = {cell!r} begins or ends with WHITESPACE — the padding eats it and "
+              f"the printed cell no longer says what the value is")
+        check(not any(c.isspace() and c != " " for c in cell),
+              f"escape_cell({raw!r}) = {cell!r} carries whitespace that is not a plain space — it is "
+              f"invisible, and rstrip() eats it")
 
 
 def t_escape_mapping(tmp: Path) -> None:
@@ -552,6 +695,23 @@ def t_escape_mapping(tmp: Path) -> None:
     check(escape_cell("#x") == "\\#x", f"a LEADING '#' must be escaped: {escape_cell('#x')!r}")
     check(escape_cell("a#b") == "a#b", f"a '#' that is not leading needs no escape: {escape_cell('a#b')!r}")
 
+    # Whitespace: escaped at the EDGES, where the layout eats it — and only there.
+    for raw, want in {
+        " ": "\\x20",
+        "   ": "\\x20\\x20\\x20",          # an all-whitespace value is ALL edge
+        "a ": "a\\x20",
+        " a": "\\x20a",
+        " a ": "\\x20a\\x20",
+        "a  b": "a  b",                    # INTERIOR spaces are untouched — a title is not a hex dump
+        "\xa0": "\\xa0",                   # not a plain space: escaped wherever it sits…
+        "a\xa0b": "a\\xa0b",               # …including the interior, where rstrip() would not reach it
+        "\x85": "\\x85",
+        "　": "\\u3000",                   # above 0xff, so \uNNNN
+        "#x ": "\\#x\\x20",                # the '#' escape and the whitespace escape compose
+        " #x": "\\x20#x",                  # …and a '#' behind an escaped space no longer opens the cell
+    }.items():
+        check(escape_cell(raw) == want, f"escape_cell({raw!r}) = {escape_cell(raw)!r}, not {want!r}")
+
     # …and the whole reason this is escaping and not quoting: an ordinary value is untouched.
     for plain in ("pr42", "fix/the-thing", "green", "-", "add a table view (#39)", "2026-07-13T10:00:00Z"):
         check(escape_cell(plain) == plain, f"an ordinary value was mangled: {plain!r} -> {escape_cell(plain)!r}")
@@ -570,9 +730,9 @@ def t_grid_integrity(tmp: Path) -> None:
         write_lines(path, header_line(), row_line(pr="1", slug=hostile, ci="green"), row_line(pr="2"))
         code, out, err = run(["--file", str(path), "table", "--fields", ",".join(fields)])
         check(code == 0, f"[{name}] table exited {code}: {err!r}")
-        _, widths, cells = grid(out, fields)
+        _, _, cells = grid(out, fields)
         check(len(cells) == 2, f"[{name}] the value forged a ROW: {len(cells)} rows printed, not 2\n{out}")
-        check(cells[0] == [escape_cell(v).ljust(w) for v, w in zip((hostile, "1", "green"), widths)],
+        check(cells[0] == [escape_cell(v) for v in (hostile, "1", "green")],
               f"[{name}] the printed row is not the escaped row: {cells[0]!r}\n{out}")
 
     # …and again with the hostile value FIRST, which is the only position that can open a line — the
@@ -593,8 +753,8 @@ def t_grid_integrity(tmp: Path) -> None:
         write_lines(path, header_line(), row_line(pr="1", slug=hostile))
         code, out, err = run(["--file", str(path), "table", "--fields", "slug"])
         check(code == 0, f"[{name}] table exited {code}: {err!r}")
-        _, widths, cells = grid(out, ("slug",))
-        check(cells == [[escape_cell(hostile).ljust(widths[0])]],
+        _, _, cells = grid(out, ("slug",))
+        check(cells == [[escape_cell(hostile)]],
               f"[{name}] a one-column grid did not print exactly the one escaped row: {cells!r}\n{out}")
 
 
@@ -650,9 +810,9 @@ def t_truncation_is_display_only(tmp: Path) -> None:
 
     code, out, err = run(["--file", str(path), "table"])
     check(code == 0, f"table exited {code}: {err!r}")
-    _, widths, cells = grid(out, TABLE_DEFAULT_FIELDS)
+    _, _, cells = grid(out, TABLE_DEFAULT_FIELDS)
     col = TABLE_DEFAULT_FIELDS.index("head_sha")
-    cell = cells[0][col].rstrip()
+    cell = cells[0][col]
     # truncate(8) THEN escape -> `abcdefg\|` (9 chars). Escape THEN truncate(8) would cut the `\|` in
     # half and print a DANGLING BACKSLASH — a cell that decodes to something the ledger never held.
     check(cell == "abcdefg\\|",
@@ -660,7 +820,7 @@ def t_truncation_is_display_only(tmp: Path) -> None:
           f"cut landed inside an escape sequence")
     check((len(cell) - len(cell.rstrip("\\"))) % 2 == 0,
           f"the rendered head_sha {cell!r} ends in a DANGLING escape — the cut split an escape sequence")
-    check(len(cell.rstrip()) < len(sha), "head_sha was not truncated for display at all")
+    check(len(cell) < len(sha), "head_sha was not truncated for display at all")
 
     # …and the FULL value is still what the ledger holds and what `get` returns.
     code, out, _ = run(["--file", str(path), "get", "--pr", "1", "--field", "head_sha"])
@@ -726,11 +886,11 @@ def t_empty_marker_not_forgeable(tmp: Path) -> None:
                   f"renders — the marker is forgeable:\n{out}")
 
             # …and mechanically: the grid must parse back to ONE row, not to an empty ledger.
-            _, widths, cells = grid(out, (field,))
+            _, _, cells = grid(out, (field,))
             check(len(cells) == 1,
                   f"[{name}/{field}] a row holding {forgery!r} parsed back as an EMPTY ledger "
                   f"({len(cells)} rows) — the marker is forgeable:\n{out}")
-            check(cells[0] == [escape_cell(forgery).ljust(widths[0])],
+            check(cells[0] == [escape_cell(forgery)],
                   f"[{name}/{field}] the printed row is not the escaped row: {cells[0]!r}\n{out}")
             # …and no LINE of a non-empty table IS the marker. (The escaped cell may well CONTAIN the
             # marker's text — `\# (no rows)` does — but it can never BE that line: the `\` is in front of
@@ -759,7 +919,7 @@ def t_fields_duplicate(tmp: Path) -> None:
     code, out, err = run(["--file", str(path), "table", "--fields", "pr,pr"])
     check(code == 0, f"table exited {code}: {err!r}")
     _, _, cells = grid(out, ("pr", "pr"))
-    check([c.rstrip() for c in cells[0]] == ["1", "1"], f"a duplicated field did not print twice: {cells!r}")
+    check(cells[0] == ["1", "1"], f"a duplicated field did not print twice: {cells!r}")
 
 
 def t_unknown_record_type(tmp: Path) -> None:
@@ -856,6 +1016,7 @@ def t_values_are_strings(tmp: Path) -> None:
 
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
+    ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
     ("escape-invariant", "the escaped cell holds no bare |, newline, control char, or leading #", t_escape_invariant),
     ("escape-mapping", "the escape table, char by char — and ordinary values left byte-identical", t_escape_mapping),
     ("grid-integrity", "no hostile value forges a column, a row, or a config line", t_grid_integrity),


### PR DESCRIPTION
- adds `ledger.py table` — an aligned view of the run's ledger for end-of-wake status
- cells are escaped so no value can forge the grid; the SHA is shortened for display only
- adds `ledger.py self-test` (19 fixtures) and runs it in CI
