### PR TITLE
make the sweep rule find what grep cannot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,19 @@ every place that RESTATES it is correct.**
   that was rewritten three times, and no search for an old value would ever have reached it. An INTRODUCED
   rule is the same trap at its sharpest: there is no old string at all, and searching for the new rule's
   own WORDING or NAME matches only the sites you already fixed, so it reports success every time and is
-  wrong every time — *"it only sets `ci = pending`"* restates a brand-new counter-reset rule and shares not
-  one word with it. None of this is a licence to skip text search: searching for the **behavior identifiers
-  the rule governs** is HOW you execute the enumeration.
+  wrong every time. The shape of that miss (**INVENTED strings — they exist nowhere in this repo, see the
+  bullet below**): you add *"a re-queue must reset the freshness counters"*, and a line elsewhere already
+  reads *"it only bumps `retry_epoch`"* — a stale restatement of your brand-new rule that shares not one
+  word with it. None of this is a licence to skip text search: searching for the **behavior identifiers the
+  rule governs** (here, `retry_epoch` — which only the enumeration could have told you to look for) is HOW
+  you execute the enumeration.
+- **An illustration of a defect must never be a live string in the tree.** When you quote a bad line as an
+  example, quote one that exists **nowhere** — invent it, and say you invented it. Quote a real one and the
+  doc becomes a false-positive generator: the next sweeper searches for the example, lands on the live site,
+  and condemns correct text. If a real quotation is unavoidable, mark it HISTORICAL unmistakably — but
+  prefer the invented one: that marking has to say where the phrase is still live and why it is correct
+  there, which is a fact about the tree, and it rots. **An example a reader can act on by mistake is worse
+  than no example.**
 - **A pointer with a gloss is still a restatement.** A site that points at the owner and then "just
   briefly" restates it — *"reset the liveness counters (`settled_strikes`, `unusable_refetches`)"* — has
   copied the definition into the gloss. The pointer stays right while the gloss silently goes wrong, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,19 @@ every place that RESTATES it is correct.**
 - `grep` for the old value, the old spelling, the old command, the old number — not just the file you
   edited. Restatements hide in **summaries**, **quick-reference bullets**, **cross-references**, **table
   rows**, **worked examples**, and **other copies of the same command**.
+- **`grep` finds a CHANGED definition. It cannot find a NEW one.** A rule you just INTRODUCED has no old
+  string to hunt, and a stale restatement of it shares no keyword with it — *"it only sets `ci =
+  pending`"* restates a counter-reset rule and contains not one word of it. Searching for the new rule's
+  NAME finds only the sites you already fixed: it reports success every time and is wrong every time. So
+  sweep **semantically** — enumerate every site that **does the thing the rule governs** (writes the
+  field, enters the state, performs the reset, states the cap) and check each one.
+- **A pointer with a gloss is still a restatement.** A site that points at the owner and then "just
+  briefly" restates it — *"reset the liveness counters (`settled_strikes`, `unusable_refetches`)"* — has
+  copied the definition into the gloss. The pointer stays right while the gloss silently goes wrong, and
+  the gloss is the part people read. **Name the set; do not unpack it.** This survives every sweep that
+  asks "does this site point at the owner?", because it does.
+- **Prefer a mechanical check to an exhortation.** "Sweep thoroughly" cannot fail. "`rg -Un '<value>'`
+  returns exactly one hit, and here is every hit accounted for" can — reconcile the output out loud.
 - A **summary that has drifted from its definition is worse than no summary**: it is the version people
   actually read, and it will be believed. A one-line "green means zero failing and zero pending" outlived
   three rewrites of the rule it summarised, and silently discarded both of that rule's disclosed caveats.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,12 +122,13 @@ every place that RESTATES it is correct.**
 - `grep` for the old value, the old spelling, the old command, the old number — not just the file you
   edited. Restatements hide in **summaries**, **quick-reference bullets**, **cross-references**, **table
   rows**, **worked examples**, and **other copies of the same command**.
-- **`grep` finds a CHANGED definition. It cannot find a NEW one.** A rule you just INTRODUCED has no old
-  string to hunt, and a stale restatement of it shares no keyword with it — *"it only sets `ci =
-  pending`"* restates a counter-reset rule and contains not one word of it. Searching for the new rule's
-  NAME finds only the sites you already fixed: it reports success every time and is wrong every time. So
-  sweep **semantically** — enumerate every site that **does the thing the rule governs** (writes the
-  field, enters the state, performs the reset, states the cap) and check each one.
+- **`grep` cannot tell you WHAT to search for.** A rule you just INTRODUCED has no old string to hunt, and
+  searching for the new rule's own WORDING or NAME matches only the sites you already fixed: it reports
+  success every time and is wrong every time — *"it only sets `ci = pending`"* restates a brand-new
+  counter-reset rule and shares not one word with it. This is **not** a licence to skip text search:
+  searching for the **behavior identifiers the rule governs** (the field, the state, the command, the cap)
+  still works and is HOW you sweep. So **enumerate semantically first** — every site that **does the thing
+  the rule governs** — **then search for the identifiers that enumeration names**, and check every hit.
 - **A pointer with a gloss is still a restatement.** A site that points at the owner and then "just
   briefly" restates it — *"reset the liveness counters (`settled_strikes`, `unusable_refetches`)"* — has
   copied the definition into the gloss. The pointer stays right while the gloss silently goes wrong, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,16 +119,22 @@ every place that RESTATES it is correct.**
 
 **Sweep for restatements. Every time. Before you call it fixed.**
 
-- `grep` for the old value, the old spelling, the old command, the old number — not just the file you
-  edited. Restatements hide in **summaries**, **quick-reference bullets**, **cross-references**, **table
-  rows**, **worked examples**, and **other copies of the same command**.
-- **`grep` cannot tell you WHAT to search for.** A rule you just INTRODUCED has no old string to hunt, and
-  searching for the new rule's own WORDING or NAME matches only the sites you already fixed: it reports
-  success every time and is wrong every time — *"it only sets `ci = pending`"* restates a brand-new
-  counter-reset rule and shares not one word with it. This is **not** a licence to skip text search:
-  searching for the **behavior identifiers the rule governs** (the field, the state, the command, the cap)
-  still works and is HOW you sweep. So **enumerate semantically first** — every site that **does the thing
-  the rule governs** — **then search for the identifiers that enumeration names**, and check every hit.
+- **Enumerate SEMANTICALLY first, then search for the identifiers that enumeration names.** That is the
+  method for **every** definition or fact change — one you EDITED and one you just INTRODUCED alike. List
+  every site that **does or states the thing the rule governs**, search for those behavior identifiers (the
+  field, the state, the command, the cap), and check every hit. Restatements hide in **summaries**,
+  **quick-reference bullets**, **cross-references**, **table rows**, **worked examples**, and **other
+  copies of the same command** — not just the file you edited.
+- **`grep` for the old value, the old spelling, the old command, the old number is ONE INPUT to that
+  sweep, never the sweep itself** — `grep` cannot tell you WHAT to search for. A restatement is greppable
+  only if it COPIED the old value; one that **PARAPHRASES** the rule contains no old string, and an EDIT
+  has just as many paraphrases as an introduction — the drifted "green" summary below paraphrased a rule
+  that was rewritten three times, and no search for an old value would ever have reached it. An INTRODUCED
+  rule is the same trap at its sharpest: there is no old string at all, and searching for the new rule's
+  own WORDING or NAME matches only the sites you already fixed, so it reports success every time and is
+  wrong every time — *"it only sets `ci = pending`"* restates a brand-new counter-reset rule and shares not
+  one word with it. None of this is a licence to skip text search: searching for the **behavior identifiers
+  the rule governs** is HOW you execute the enumeration.
 - **A pointer with a gloss is still a restatement.** A site that points at the owner and then "just
   briefly" restates it — *"reset the liveness counters (`settled_strikes`, `unusable_refetches`)"* — has
   copied the definition into the gloss. The pointer stays right while the gloss silently goes wrong, and

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -109,8 +109,9 @@ argument point the same way.
 beyond the named files — an unscoped fixer re-reads everything it was already told), and **SWEEP** the
 writing (a fix that changes a definition or a fact is not done until every site that RESTATES it is
 correct — the contract's sweep-and-report block goes into the prompt **verbatim**). Read narrowly to
-UNDERSTAND, grep widely to FINISH. Read the contract before dispatching a fixer; do not reconstruct it
-from this summary.
+UNDERSTAND, sweep widely to FINISH — and the contract, not this line, defines how to sweep: `grep` alone
+does not find them all. Read the contract before dispatching a fixer; do not reconstruct it from this
+summary.
 
 ## Load Discipline
 

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -109,9 +109,8 @@ argument point the same way.
 beyond the named files — an unscoped fixer re-reads everything it was already told), and **SWEEP** the
 writing (a fix that changes a definition or a fact is not done until every site that RESTATES it is
 correct — the contract's sweep-and-report block goes into the prompt **verbatim**). Read narrowly to
-UNDERSTAND, sweep widely to FINISH — and the contract, not this line, defines how to sweep: `grep` alone
-does not find them all. Read the contract before dispatching a fixer; do not reconstruct it from this
-summary.
+UNDERSTAND, sweep widely to FINISH — and the contract, not this line, defines how to sweep. Read the
+contract before dispatching a fixer; do not reconstruct it from this summary.
 
 ## Load Discipline
 

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -266,7 +266,8 @@
   the whole diff, NOT beyond the named files; **scope by defect, not by guess — name every file the defect
   touches**. **SWEEP** the writing — the contract's sweep-and-report block goes into the prompt **verbatim**:
   a fix that changes a DEFINITION or a FACT is not done until every site that RESTATES it is correct, and
-  every site found is reported. Read narrowly to UNDERSTAND, grep widely to FINISH; neither half excuses
+  every site found is reported. Read narrowly to UNDERSTAND, sweep widely to FINISH — the contract, not
+  this bullet, defines how to sweep (`grep` alone does not find them all); neither half excuses
   skipping the other. Scoping (not a cheaper model), plus an **external reviewer** taking review passes off
   the subagent pool (**the single biggest cost lever** — review passes dominate campaign's spend), is where
   savings live.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -267,8 +267,7 @@
   touches**. **SWEEP** the writing — the contract's sweep-and-report block goes into the prompt **verbatim**:
   a fix that changes a DEFINITION or a FACT is not done until every site that RESTATES it is correct, and
   every site found is reported. Read narrowly to UNDERSTAND, sweep widely to FINISH — the contract, not
-  this bullet, defines how to sweep (`grep` alone does not find them all); neither half excuses
-  skipping the other. Scoping (not a cheaper model), plus an **external reviewer** taking review passes off
+  this bullet, defines how to sweep; neither half excuses skipping the other. Scoping (not a cheaper model), plus an **external reviewer** taking review passes off
   the subagent pool (**the single biggest cost lever** — review passes dominate campaign's spend), is where
   savings live.
 - Default reviewer is Claude's own subagents; no external tool is required. Use the user's preferred

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -23,8 +23,9 @@ for the *shape* of the rules — a recipe does not go stale, a list of files doe
 - **pointers at this file** — `fix-subagent-contract`
 
 Then read each hit and decide: it is a summary of this contract, or it is not. Do not stop when the count
-matches something you were told. And if you ADD a rule here rather than change one, **no text search can
-find its stale restatements** — sweep SEMANTICALLY instead, exactly as the SWEEP block below requires.
+matches something you were told. And if you ADD a rule here rather than change one, **searching for the
+new rule's own wording finds only the sites you already fixed** — enumerate SEMANTICALLY first and then
+search for the identifiers that enumeration names, exactly as the SWEEP block below requires.
 
 The contract has two halves that pull in opposite directions **on purpose**. Ship both, or the fixer
 optimizes the one you gave it:
@@ -65,16 +66,26 @@ the one line it was pointed at and leave the class intact:
 > This widening is **bounded by the change you are making**: grep for what your own fix invalidated. It
 > is **not** permission to re-derive the diff, re-review the PR, or fix defects nobody asked you to fix.
 >
-> **GREP FINDS A CHANGED DEFINITION. IT CANNOT FIND A NEW ONE.** When you EDIT an existing rule you have
-> an old string to hunt — the old value, the old spelling, the old number. When you INTRODUCE a rule,
-> **there is nothing to grep for**: a stale restatement of a brand-new rule shares no keyword with it. A
-> sentence reading "it only sets `ci = pending`" is a stale restatement of a counter-reset rule and
-> contains not one word of it. Searching for your new rule's NAME finds only the places you already
-> fixed — it will report success every time, and it will be wrong every time.
+> **GREP CANNOT TELL YOU WHAT TO SEARCH FOR.** When you EDIT an existing rule you have an old string to
+> hunt — the old value, the old spelling, the old number. When you INTRODUCE a rule there is no such
+> string, and **searching for the new rule's own WORDING or NAME is a trap: it matches only the sites you
+> already fixed, so it reports success every time and is wrong every time.** A sentence reading "it only
+> sets `ci = pending`" is a stale restatement of a brand-new counter-reset rule and shares not one word
+> with it.
 >
-> So for a NEW rule, sweep **SEMANTICALLY**: enumerate every site that **DOES THE THING THE RULE
-> GOVERNS** — every site that writes the field, enters the state, performs the reset, states the cap —
-> and check each one against the definition. Enumerate the BEHAVIOR, not the words. Report the site list.
+> **This does NOT mean text search is useless** — believing that swaps one incomplete method for another,
+> and makes you skip a search that would have worked. Searching for the **BEHAVIOR IDENTIFIERS the rule
+> governs** — the field, the state, the command, the cap's name — is legitimate and necessary; it is HOW
+> you execute the sweep. The site that survived five sweeps on one PR read *"the bailout is disabled while
+> `ci == pending`"*: `ci`, `pending` and `bailout` are all greppable, and a search WOULD have found it —
+> **but only once you knew to look for sites that describe what the bailout keys off.** Nothing in the new
+> rule's wording tells you that.
+>
+> So: **enumerate SEMANTICALLY first, then search for the identifiers the enumeration names.** List every
+> site that **DOES THE THING THE RULE GOVERNS** — writes the field, enters the state, performs the reset,
+> states the cap — search for each of those identifiers, and check every hit against the definition.
+> **The enumeration tells you WHAT to search for; the search is how you execute it, never a substitute
+> for it.** Enumerate the BEHAVIOR, not the words. Report the site list.
 >
 > **A POINTER WITH A GLOSS IS STILL A RESTATEMENT.** A site that correctly points at the owner and then
 > "just briefly" restates what it points at — *"reset the liveness counters (`settled_strikes`,

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -11,19 +11,20 @@ FILE WINS.** Never dispatch a fixer from a summary; never reconstruct the contra
 this file means sweeping those sites too — a summary that has drifted from its definition is worse than
 no summary.
 
-**When you correct this contract, GREP for the restatements — do NOT expect a list of them here.** There
+**When you correct this contract, SWEEP for the restatements — do NOT expect a list of them here.** There
 is deliberately none, and that is not an omission: **a list of restatement sites is ITSELF a restatement,
 and it rots exactly like every other one.** This file once enumerated four sites; six existed the day it
 was written — **the list went stale inside the commit that created it**, and a reader trusting it would
-have swept four and never looked for the rest. That is the whole reason you must grep instead. Search for
-the *shape* of the rules — a recipe does not go stale, a list of files does:
+have swept four and never looked for the rest. That is the whole reason you must search instead. Search
+for the *shape* of the rules — a recipe does not go stale, a list of files does:
 
 - the **scope** rule — `SCOPE`, "scope … fix subagent", "re-derive", "whole diff", "beyond the named"
 - the **sweep** rule — `SWEEP`, "RESTATES", "sweep-and-report", "stale restatement", "fix only the instance"
 - **pointers at this file** — `fix-subagent-contract`
 
 Then read each hit and decide: it is a summary of this contract, or it is not. Do not stop when the count
-matches something you were told.
+matches something you were told. And if you ADD a rule here rather than change one, **no text search can
+find its stale restatements** — sweep SEMANTICALLY instead, exactly as the SWEEP block below requires.
 
 The contract has two halves that pull in opposite directions **on purpose**. Ship both, or the fixer
 optimizes the one you gave it:
@@ -31,9 +32,9 @@ optimizes the one you gave it:
 - **SCOPE** bounds what it READS, so it does not re-derive a problem you already solved for it.
 - **SWEEP** bounds what it WRITES, so it does not leave the fix half-applied.
 
-**Read narrowly to UNDERSTAND; grep widely to FINISH.** They are not in conflict: the scope rule is
+**Read narrowly to UNDERSTAND; sweep widely to FINISH.** They are not in conflict: the scope rule is
 about **not re-deriving the problem**, the sweep rule is about **not shipping half a fix**. Neither is
-licence to ignore the other. A fixer that greps the tree to find the sites its own change invalidated is
+licence to ignore the other. A fixer that sweeps the tree to find the sites its own change invalidated is
 **obeying** the scope rule, not breaking it — it is not re-deriving anything, it is finishing.
 
 ### SCOPE — bounds the reading
@@ -63,10 +64,44 @@ the one line it was pointed at and leave the class intact:
 >
 > This widening is **bounded by the change you are making**: grep for what your own fix invalidated. It
 > is **not** permission to re-derive the diff, re-review the PR, or fix defects nobody asked you to fix.
+>
+> **GREP FINDS A CHANGED DEFINITION. IT CANNOT FIND A NEW ONE.** When you EDIT an existing rule you have
+> an old string to hunt — the old value, the old spelling, the old number. When you INTRODUCE a rule,
+> **there is nothing to grep for**: a stale restatement of a brand-new rule shares no keyword with it. A
+> sentence reading "it only sets `ci = pending`" is a stale restatement of a counter-reset rule and
+> contains not one word of it. Searching for your new rule's NAME finds only the places you already
+> fixed — it will report success every time, and it will be wrong every time.
+>
+> So for a NEW rule, sweep **SEMANTICALLY**: enumerate every site that **DOES THE THING THE RULE
+> GOVERNS** — every site that writes the field, enters the state, performs the reset, states the cap —
+> and check each one against the definition. Enumerate the BEHAVIOR, not the words. Report the site list.
+>
+> **A POINTER WITH A GLOSS IS STILL A RESTATEMENT.** A site that correctly points at the owner and then
+> "just briefly" restates what it points at — *"reset the liveness counters (`settled_strikes`,
+> `unusable_refetches`)"* — has **copied the definition into the gloss**. When the owner gains a member,
+> the pointer stays right and **the gloss silently goes wrong**, and the gloss is the part people read.
+> This shape survives every sweep that asks "does this site point at the owner?", because it does.
+> **Name the set. Do not unpack it.** If a gloss is genuinely needed, it must be COMPLETE — and then it
+> is a copy, and you own the cost of keeping it true.
+>
+> **MAKE THE CHECK MECHANICAL WHEREVER YOU CAN.** "Did you sweep thoroughly?" is not a check — it cannot
+> fail. "`rg -Un '<the value>'` returns exactly one hit, and here is every hit accounted for" is a check.
+> Prefer a command whose output you must reconcile out loud over a promise that you looked.
 
 This is a **report** requirement, not just a search requirement: a sweep nobody can audit did not happen.
 
 **Prefer ONE OWNER over another copy.** When the fixer finds a definition restated in N places, the best
 repair is usually to leave the definition in one place and make the others point at it — a fifth copy of
 a rule is a fifth thing that can go stale. A pointer is only valid if what it points at is **complete**;
-pointing at a partial definition is itself the defect.
+pointing at a partial definition is itself the defect. And a pointer is only a pointer while it stays a
+pointer: the moment it unpacks what it points at, it is a copy wearing a pointer's clothes.
+
+**A value that appears twice has two sources of truth.** Give every constant (a cap, a limit, a count)
+exactly ONE defining site that carries the literal; everywhere else names it. Then the sweep for it is a
+command, not a judgment call.
+
+**But an EXTERNAL constant that happens to equal yours is NOT a duplicate of it.** GitHub's documented 6h
+per-job execution limit is not your 6h stall cap — they are two independent facts that currently agree.
+"Unifying" them destroys a true external fact and couples you to a coincidence: change your cap to 4h and
+GitHub's limit still reads 6 hours. Keep the external constant EXACT, and mark it as theirs, so the next
+sweeper does not helpfully collapse it into yours.

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -76,16 +76,27 @@ the one line it was pointed at and leave the class intact:
 >
 > An INTRODUCED rule is the same trap at its sharpest: there is no old string to hunt at all, and
 > **searching for the new rule's own WORDING or NAME matches only the sites you already fixed, so it
-> reports success every time and is wrong every time.** A sentence reading "it only sets `ci = pending`" is
-> a stale restatement of a brand-new counter-reset rule and shares not one word with it.
+> reports success every time and is wrong every time.** The shape of that miss — **INVENTED strings, they
+> exist nowhere in this repo, see the rule below**: you add *"a re-queue must reset the freshness
+> counters"*, and somewhere else a line already reads *"it only bumps `retry_epoch`"*. That line is now a
+> stale restatement of your brand-new rule, and it shares **not one word** with it — no search for the
+> rule's wording, its name, or any old value will ever reach it.
 >
 > **This does NOT mean text search is useless** — believing that swaps one incomplete method for another,
 > and makes you skip a search that would have worked. Searching for the **BEHAVIOR IDENTIFIERS the rule
 > governs** — the field, the state, the command, the cap's name — is legitimate and necessary; it is HOW
-> you execute the sweep. The site that survived five sweeps on one PR read *"the bailout is disabled while
-> `ci == pending`"*: `ci`, `pending` and `bailout` are all greppable, and a search WOULD have found it —
-> **but only once you knew to look for sites that describe what the bailout keys off.** Nothing in the new
-> rule's wording tells you that.
+> you execute the sweep. Continue the invented example: *"it only bumps `retry_epoch`"* names a field, and
+> a search for `retry_epoch` WOULD have found it — **but only once you enumerated the sites that state what
+> a re-queue does.** Nothing in the new rule's own wording ("reset the freshness counters") tells you to go
+> looking for `retry_epoch`. That is the whole gap the enumeration closes.
+>
+> **AN ILLUSTRATION OF A DEFECT MUST NEVER BE A LIVE STRING IN THE TREE.** When you quote a bad line as an
+> example — here or in any doc you fix — quote one that exists **nowhere**, invent it, and say you invented
+> it. Quote a real one and the doc becomes a false-positive generator: the next sweeper searches for the
+> example, lands on the live site, and condemns text that is correct. If a real quotation is truly
+> unavoidable, mark it HISTORICAL unmistakably — but prefer the invented one, because that marking has to
+> say **where** the phrase is still live and **why** it is correct there, which is a fact about the tree,
+> and it rots. **An example a reader can act on by mistake is worse than no example.**
 >
 > So, for EVERY definition or fact change alike: **enumerate SEMANTICALLY first, then search for the
 > identifiers the enumeration names.** List every site that **DOES OR STATES THE THING THE RULE GOVERNS** —

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -23,9 +23,10 @@ for the *shape* of the rules — a recipe does not go stale, a list of files doe
 - **pointers at this file** — `fix-subagent-contract`
 
 Then read each hit and decide: it is a summary of this contract, or it is not. Do not stop when the count
-matches something you were told. And if you ADD a rule here rather than change one, **searching for the
-new rule's own wording finds only the sites you already fixed** — enumerate SEMANTICALLY first and then
-search for the identifiers that enumeration names, exactly as the SWEEP block below requires.
+matches something you were told. Whether you CHANGE a rule here or ADD one, **enumerate SEMANTICALLY first
+and then search for the identifiers that enumeration names**, exactly as the SWEEP block below requires:
+searching for the rule's own wording finds only the sites you already fixed, and searching for an old value
+misses every site that paraphrased it.
 
 The contract has two halves that pull in opposite directions **on purpose**. Ship both, or the fixer
 optimizes the one you gave it:
@@ -55,23 +56,28 @@ the block below in its prompt **verbatim**, because a scoped fixer is exactly th
 the one line it was pointed at and leave the class intact:
 
 > **When your fix changes a DEFINITION (a rule, a command, a schema, a format) or a FACT (a count, a
-> name, an API behavior), you are NOT done until every place that RESTATES it is also correct.** `grep`
-> for the old value, the old spelling, the old command, the old number — across the whole tree, not just
-> the file you were sent to. Restatements hide in **summaries**, **quick-reference bullets**,
-> **cross-references**, **table rows**, **worked examples**, and **other copies of the same command**. A
-> summary that has drifted from its definition is **worse than no summary** — it is the version people
-> actually read. **Report every site you found and its disposition, including the ones you deliberately
-> left alone and why.** If your fix is genuinely local and restates nothing, say so explicitly.
+> name, an API behavior), you are NOT done until every place that RESTATES it is also correct.** Sweep
+> the whole tree, not just the file you were sent to. Restatements hide in **summaries**, **quick-reference
+> bullets**, **cross-references**, **table rows**, **worked examples**, and **other copies of the same
+> command**. A summary that has drifted from its definition is **worse than no summary** — it is the
+> version people actually read. **Report every site you found and its disposition, including the ones you
+> deliberately left alone and why.** If your fix is genuinely local and restates nothing, say so explicitly.
 >
-> This widening is **bounded by the change you are making**: grep for what your own fix invalidated. It
+> This widening is **bounded by the change you are making**: sweep for what your own fix invalidated. It
 > is **not** permission to re-derive the diff, re-review the PR, or fix defects nobody asked you to fix.
 >
-> **GREP CANNOT TELL YOU WHAT TO SEARCH FOR.** When you EDIT an existing rule you have an old string to
-> hunt — the old value, the old spelling, the old number. When you INTRODUCE a rule there is no such
-> string, and **searching for the new rule's own WORDING or NAME is a trap: it matches only the sites you
-> already fixed, so it reports success every time and is wrong every time.** A sentence reading "it only
-> sets `ci = pending`" is a stale restatement of a brand-new counter-reset rule and shares not one word
-> with it.
+> **GREP CANNOT TELL YOU WHAT TO SEARCH FOR — whether you EDIT a rule or INTRODUCE one.** A restatement is
+> greppable only if it COPIED the old value, the old spelling, the old number. One that **PARAPHRASES** the
+> rule contains no old string, and an EDIT has just as many paraphrases as an introduction: the one-line
+> summary *"green means zero failing and zero pending"* outlived THREE rewrites of the rule it summarised
+> and silently dropped both of that rule's disclosed caveats — that rule was EDITED, and no search for an
+> old value would ever have reached that sentence. So **searching for the old value/spelling/command/number
+> is ONE INPUT to the sweep, never the sweep itself.**
+>
+> An INTRODUCED rule is the same trap at its sharpest: there is no old string to hunt at all, and
+> **searching for the new rule's own WORDING or NAME matches only the sites you already fixed, so it
+> reports success every time and is wrong every time.** A sentence reading "it only sets `ci = pending`" is
+> a stale restatement of a brand-new counter-reset rule and shares not one word with it.
 >
 > **This does NOT mean text search is useless** — believing that swaps one incomplete method for another,
 > and makes you skip a search that would have worked. Searching for the **BEHAVIOR IDENTIFIERS the rule
@@ -81,9 +87,10 @@ the one line it was pointed at and leave the class intact:
 > **but only once you knew to look for sites that describe what the bailout keys off.** Nothing in the new
 > rule's wording tells you that.
 >
-> So: **enumerate SEMANTICALLY first, then search for the identifiers the enumeration names.** List every
-> site that **DOES THE THING THE RULE GOVERNS** — writes the field, enters the state, performs the reset,
-> states the cap — search for each of those identifiers, and check every hit against the definition.
+> So, for EVERY definition or fact change alike: **enumerate SEMANTICALLY first, then search for the
+> identifiers the enumeration names.** List every site that **DOES OR STATES THE THING THE RULE GOVERNS** —
+> writes the field, enters the state, performs the reset, states the cap — search for each of those
+> identifiers, and check every hit against the definition.
 > **The enumeration tells you WHAT to search for; the search is how you execute it, never a substitute
 > for it.** Enumerate the BEHAVIOR, not the words. Report the site list.
 >

--- a/plugins/gauntlet/skills/review/README.md
+++ b/plugins/gauntlet/skills/review/README.md
@@ -71,7 +71,7 @@ each one through the reviews its tier requires plus CI, and merges. Refuted and 
 are left alone.
 
 "No other defects" bounds *which problems* it fixes — not *how many places* one fix has to touch. When
-a fix changes a definition or a fact, it greps the tree for every other place that restates it and
+a fix changes a definition or a fact, it sweeps the tree for every other place that restates it and
 corrects those too, in the same pull request, and tells you which sites it touched and which it left
 alone: a definition left with a stale restatement is a definition that lies. That's the same
 [fix-subagent contract](../campaign/references/fix-subagent-contract.md) campaign holds its own fixers

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -395,10 +395,11 @@ or **Adjusted** finding only (skip Refuted and Uncertain), in its own branch off
 1. Implement the fix — exactly the change in the finding's `Fix:`, nothing more; no drive-by edits.
    **"Nothing more" bounds the DEFECTS you fix, not the SITES one fix touches.** If the change alters a
    DEFINITION (a rule, a command, a schema, a format) or a FACT (a count, a name, an API behavior), then
-   `grep` the tree for every place that RESTATES it — summaries, quick-reference bullets, cross-references,
-   table rows, worked examples — and correct each one **in this same PR**: a definition left with a stale
-   restatement is a definition that lies, and that sweep is part of the fix, not a drive-by. Report every
-   site you found and its disposition, including any you deliberately left alone. (This paragraph is a
+   SWEEP the tree for every place that RESTATES it and correct each one **in this same PR**: a definition
+   left with a stale restatement is a definition that lies, and that sweep is part of the fix, not a
+   drive-by. Report every site you found and its disposition, including any you deliberately left alone.
+   **Sweep the way the contract says** — `grep` alone finds only what a *changed* definition invalidated;
+   it cannot find a stale restatement of a rule you just INTRODUCED. (This paragraph is a
    **non-authoritative summary** of the same contract campaign puts in every fix subagent's prompt —
    `${CLAUDE_PLUGIN_ROOT}/skills/campaign/references/fix-subagent-contract.md` is the complete DEFINITION
    and **wins over this** wherever they differ; read it, never reconstruct it from this summary.)

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -398,8 +398,7 @@ or **Adjusted** finding only (skip Refuted and Uncertain), in its own branch off
    SWEEP the tree for every place that RESTATES it and correct each one **in this same PR**: a definition
    left with a stale restatement is a definition that lies, and that sweep is part of the fix, not a
    drive-by. Report every site you found and its disposition, including any you deliberately left alone.
-   **Sweep the way the contract says** — `grep` alone finds only what a *changed* definition invalidated;
-   it cannot find a stale restatement of a rule you just INTRODUCED. (This paragraph is a
+   **Sweep the way the contract says** — it defines the method; this paragraph does not. (This paragraph is a
    **non-authoritative summary** of the same contract campaign puts in every fix subagent's prompt —
    `${CLAUDE_PLUGIN_ROOT}/skills/campaign/references/fix-subagent-contract.md` is the complete DEFINITION
    and **wins over this** wherever they differ; read it, never reconstruct it from this summary.)


### PR DESCRIPTION
- the sweep rule said "grep for the old value"; it missed paraphrased restatements six rounds running
- replaces it: enumerate the behavior first, then search for the identifiers that enumeration names
- forbids a pointer with a gloss — the gloss rots while the pointer stays right
