### PR TITLE
give a review pass an executable contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,11 @@ jobs:
       # them goes red.
       - name: Ledger contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/ledger.py self-test
+
+      # The REVIEW PASS's contract, executed — the gate one layer up from CI. What a pass's plan,
+      # pass_identity and progress files say decides whether a review COUNTS, and therefore whether a PR
+      # may merge; three of those four artifacts used to be hand-written and the tally hand-parsed. This
+      # runs every fixture AND (like the mutation matrix above, but built in) deletes each rule in turn and
+      # fails if no fixture notices — so "N rules pinned" is DERIVED here, never a claim in a report.
+      - name: Review-pass contract (every rule pinned by a fixture)
+        run: python3 plugins/gauntlet/skills/campaign/scripts/review-pass.py self-test

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -41,8 +41,10 @@ Bundled scripts live in `scripts/`, resolved relative to the directory holding t
 the current working directory) — installed as `${CLAUDE_PLUGIN_ROOT}/skills/campaign/scripts/`, or in
 the repo at `plugins/gauntlet/skills/campaign/scripts/`. Pass their absolute paths to subtasks.
 `scripts/review-pass.py` is the schema-owning accessor for a review pass's artifacts — the plan, the
-`pass_identity`, the progress events, and the READ that answers "does this pass COUNT?" (see
-`references/stage-2-review-gate.md`); never hand-write or hand-parse one of those files.
+`pass_identity`, the unit-progress events, and the READ that answers "does this pass COUNT?", which
+validates every line of those files, including the one event the emit-only rule exempts from tool-writing
+(see `references/stage-2-review-gate.md`); never hand-parse one of those files, and never hand-write a
+line the tool writes.
 `scripts/emit-progress.py` is the reviewer's door into it — **its CLI is unchanged**, and it is the only
 sanctioned way to record a unit-progress event. `scripts/ledger.py` is the schema-owning accessor for
 `state.jsonl` — read/write the ledger header and per-PR rows **by field name** through it, never by column

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -39,9 +39,12 @@ resumes and takes no `#PR`/`--new`; `#PR` args alone start/adopt into a run. Inv
 
 Bundled scripts live in `scripts/`, resolved relative to the directory holding this `SKILL.md` (not
 the current working directory) — installed as `${CLAUDE_PLUGIN_ROOT}/skills/campaign/scripts/`, or in
-the repo at `plugins/gauntlet/skills/campaign/scripts/`. Pass their absolute paths to subtasks. The
-review gauntlet's `scripts/emit-progress.py` (already present there) emits canonical reviewer progress
-events (see `references/stage-2-review-gate.md`). `scripts/ledger.py` is the schema-owning accessor for
+the repo at `plugins/gauntlet/skills/campaign/scripts/`. Pass their absolute paths to subtasks.
+`scripts/review-pass.py` is the schema-owning accessor for a review pass's artifacts — the plan, the
+`pass_identity`, the progress events, and the READ that answers "does this pass COUNT?" (see
+`references/stage-2-review-gate.md`); never hand-write or hand-parse one of those files.
+`scripts/emit-progress.py` is the reviewer's door into it — **its CLI is unchanged**, and it is the only
+sanctioned way to record a unit-progress event. `scripts/ledger.py` is the schema-owning accessor for
 `state.jsonl` — read/write the ledger header and per-PR rows **by field name** through it, never by column
 position (see `references/files-and-ledger.md`); pass its absolute path to subtasks the same way.
 

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -186,9 +186,11 @@
   hand-parse one** (Stage 2a). It owns the plan, the `pass_identity`, the progress events, and the read
   that answers **does this pass COUNT?** — `verify`. **A verdict from a pass that does not verify `ok` is
   NEVER tallied**: a short SHA, a `done` for a unit that was never planned, an evidence-free `done`, a
-  hand-written line of the wrong shape, or an identity naming another commit or attempt all make the pass
-  `unusable`, whatever its report says. `ok` is **not** `SATISFIED` — the tool never reads the report and
-  never says SATISFIED; it can only ever *refuse* a pass, never accept one.
+  `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape,
+  or an identity naming another commit or attempt all make the pass `unusable`, whatever its report says.
+  Every one of those rules holds at **both doors** — the same predicate refuses it on write (`emit`) and on
+  read (`verify`), so it cannot be enforced at one and not the other. `ok` is **not** `SATISFIED` — the
+  tool never reads the report and never says SATISFIED; it can only ever *refuse* a pass, never accept one.
 - Before each review, write an orchestrator-owned `review-<pr>-<n>.plan.jsonl` (per-pass — a relaunch
   reuses it; written through the tool above, never a heredoc); reviewers append progress events against planned units to the **active launch attempt's**
   progress file (`review-<pr>-<n>.progress.jsonl` for attempt 1, `review-<pr>-<n>.a<k>.progress.jsonl`

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -182,9 +182,10 @@
   stochastic reviewer to catch a missed defect — the two are NOT statistically independent (the same
   diff, task, and protocol correlate them; same-reviewer passes also share model/prompt), so the gate
   is a miss-catcher, not a proof of correctness.
-- **A review pass's artifacts have a TOOL — `scripts/review-pass.py`. NEVER hand-write one, NEVER
-  hand-parse one** (Stage 2a). It owns the plan, the `pass_identity`, the progress events, and the read
-  that answers **does this pass COUNT?** — `verify`. **A verdict from a pass that does not verify `ok` is
+- **A review pass's artifacts have a TOOL — `scripts/review-pass.py`. NEVER hand-parse one, NEVER
+  hand-write a line the tool writes** (Stage 2a). It owns the plan, the `pass_identity`, the unit-progress
+  events, and the read that answers **does this pass COUNT?** — `verify`, which validates EVERY line of the
+  file, including the one event the emit-only rule exempts from tool-writing (Stage 2a owns that rule). **A verdict from a pass that does not verify `ok` is
   NEVER tallied**: a short SHA or any other malformed identifier, a `done` for a unit that was never
   planned, an evidence-free `done`, a
   `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape,

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -182,8 +182,15 @@
   stochastic reviewer to catch a missed defect — the two are NOT statistically independent (the same
   diff, task, and protocol correlate them; same-reviewer passes also share model/prompt), so the gate
   is a miss-catcher, not a proof of correctness.
+- **A review pass's artifacts have a TOOL — `scripts/review-pass.py`. NEVER hand-write one, NEVER
+  hand-parse one** (Stage 2a). It owns the plan, the `pass_identity`, the progress events, and the read
+  that answers **does this pass COUNT?** — `verify`. **A verdict from a pass that does not verify `ok` is
+  NEVER tallied**: a short SHA, a `done` for a unit that was never planned, an evidence-free `done`, a
+  hand-written line of the wrong shape, or an identity naming another commit or attempt all make the pass
+  `unusable`, whatever its report says. `ok` is **not** `SATISFIED` — the tool never reads the report and
+  never says SATISFIED; it can only ever *refuse* a pass, never accept one.
 - Before each review, write an orchestrator-owned `review-<pr>-<n>.plan.jsonl` (per-pass — a relaunch
-  reuses it); reviewers append progress events against planned units to the **active launch attempt's**
+  reuses it; written through the tool above, never a heredoc); reviewers append progress events against planned units to the **active launch attempt's**
   progress file (`review-<pr>-<n>.progress.jsonl` for attempt 1, `review-<pr>-<n>.a<k>.progress.jsonl`
   for a relaunch — only the attempt named in the active `pass_identity` is read or counted). Meaningful
   progress = planned unit `done` or accepted plan amendment, not vague "still working" output. Two

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -185,11 +185,18 @@
 - **A review pass's artifacts have a TOOL — `scripts/review-pass.py`. NEVER hand-write one, NEVER
   hand-parse one** (Stage 2a). It owns the plan, the `pass_identity`, the progress events, and the read
   that answers **does this pass COUNT?** — `verify`. **A verdict from a pass that does not verify `ok` is
-  NEVER tallied**: a short SHA, a `done` for a unit that was never planned, an evidence-free `done`, a
+  NEVER tallied**: a short SHA or any other malformed identifier, a `done` for a unit that was never
+  planned, an evidence-free `done`, a
   `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape,
   or an identity naming another commit or attempt all make the pass `unusable`, whatever its report says.
   Every one of those rules holds at **both doors** — the same predicate refuses it on write (`emit`) and on
-  read (`verify`), so it cannot be enforced at one and not the other. And **anything the tool writes it can
+  read (`verify`), so it cannot be enforced at one and not the other. **Every identifier it handles has ONE
+  legal form and NO door repairs one** (a unit id is `u01`-shaped; `pr`/`pass`/`launch_attempt` are decimal
+  from 1 up; `head_sha` is 40 lowercase hex): the tool used to strip `emit`'s `--unit` while `plan-add`
+  took its `--id` verbatim, so a plan could hold ` u01 ` and `emit` would then call that unit NOT IN THE
+  PLAN — a planned unit whose progress could never be recorded, and a review that could never complete.
+  Trimming at both doors would leave two spellings of one id; a FORMAT leaves nothing to convert. And
+  **anything the tool writes it can
   read back**: a write is refused unless the file it would produce verifies, so the tool can never accept
   your work and then tell you the work does not count (it did — see Stage 2a). `ok` is **not** `SATISFIED` — the
   tool never reads the report and never says SATISFIED; it can only ever *refuse* a pass, never accept one.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -189,7 +189,9 @@
   `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape,
   or an identity naming another commit or attempt all make the pass `unusable`, whatever its report says.
   Every one of those rules holds at **both doors** — the same predicate refuses it on write (`emit`) and on
-  read (`verify`), so it cannot be enforced at one and not the other. `ok` is **not** `SATISFIED` — the
+  read (`verify`), so it cannot be enforced at one and not the other. And **anything the tool writes it can
+  read back**: a write is refused unless the file it would produce verifies, so the tool can never accept
+  your work and then tell you the work does not count (it did — see Stage 2a). `ok` is **not** `SATISFIED` — the
   tool never reads the report and never says SATISFIED; it can only ever *refuse* a pass, never accept one.
 - Before each review, write an orchestrator-owned `review-<pr>-<n>.plan.jsonl` (per-pass — a relaunch
   reuses it; written through the tool above, never a heredoc); reviewers append progress events against planned units to the **active launch attempt's**

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -11,8 +11,8 @@ files from colliding — see "Run identity and concurrency".
 | `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**: the canonical command is spelled in full in **"The canonical `prs.json` command"**, the command block directly below this table, and that block is its ONLY definition |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1) |
-| `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it) |
-| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1) |
+| `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it). Written through `scripts/review-pass.py plan-add`, never a heredoc |
+| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1), opened by the orchestrator's `pass_identity` line. Every line of it is written and read through `scripts/review-pass.py` — see "Review-pass artifacts" below |
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
 | `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, fetched **BY THE WAKE** after the watch completes (**the watch never writes it**), promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Carries a **`source` completion marker per mandatory source**, so a source that was **never queried** is `unusable`, not a silent green (`stage-2-ci.md`). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
@@ -294,6 +294,17 @@ Header field notes (the header fields above; per-row fields follow):
     keep being driven, and the answer folds in as its own wake (`loop-control.md` step 3, "Only the
     user's answer unparks a PR" — the owning definition of the record + unpark for **every** park class).
     NEVER park without surfacing the question, and NEVER park into a state whose exit is undefined.
+
+### Review-pass artifacts — use `scripts/review-pass.py`
+
+The plan, the `pass_identity`, the progress events and the read that decides **whether a pass counts** are
+one artifact set with one owner. `scripts/review-pass.py` writes and reads all of it; the reviewer's
+`emit-progress.py` (CLI unchanged) is a door into the same owner. **Never hand-write one of those files,
+and never hand-parse one** — the hand-written `pass_identity` is how a truncated SHA reached real state,
+and the hand-rolled tally is the same "read it by eye and write down the answer" that produced a false
+`ci = green`. `stage-2-review-gate.md` owns the rules, the subcommands, and the four verdicts `verify`
+returns; resolve the script at `<skill-dir>/scripts/review-pass.py` and pass that path to subtasks, exactly
+as with `ledger.py` below.
 
 ### Editing the ledger — use `scripts/ledger.py`
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -12,7 +12,7 @@ files from colliding — see "Run identity and concurrency".
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1) |
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it). Written through `scripts/review-pass.py plan-add`, never a heredoc |
-| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1), opened by the orchestrator's `pass_identity` line. Every line of it is written and read through `scripts/review-pass.py` — see "Review-pass artifacts" below |
+| `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1), opened by the orchestrator's `pass_identity` line. **Every line is READ and validated through `scripts/review-pass.py` — and not every line is WRITTEN by it.** The `pass_identity` (`review-pass.py identity`) and the unit-progress events (the reviewer's `emit-progress.py`) are; a `plan_amendment_request` the reviewer appends **directly** is not — it is the one event the emit-only rule exempts. `stage-2-review-gate.md` owns that rule; see "Review-pass artifacts" below |
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` | Same two artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`) |
 | `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, fetched **BY THE WAKE** after the watch completes (**the watch never writes it**), promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Carries a **`source` completion marker per mandatory source**, so a source that was **never queried** is `unusable`, not a silent green (`stage-2-ci.md`). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
@@ -298,11 +298,13 @@ Header field notes (the header fields above; per-row fields follow):
 ### Review-pass artifacts — use `scripts/review-pass.py`
 
 The plan, the `pass_identity`, the progress events and the read that decides **whether a pass counts** are
-one artifact set with one owner. `scripts/review-pass.py` writes and reads all of it; the reviewer's
-`emit-progress.py` (CLI unchanged) is a door into the same owner. **Never hand-write one of those files,
-and never hand-parse one** — the hand-written `pass_identity` is how a truncated SHA reached real state,
-and the hand-rolled tally is the same "read it by eye and write down the answer" that produced a false
-`ci = green`. `stage-2-review-gate.md` owns the rules, the subcommands, and the four verdicts `verify`
+one artifact set with one owner. `scripts/review-pass.py` READS every line of it — whatever wrote that
+line — and WRITES every line the emit-only rule does not exempt; the reviewer's `emit-progress.py` (CLI
+unchanged) is a door into the same owner. **Never hand-parse one of those files, and never hand-write a
+line the tool writes for you** — the hand-written `pass_identity` is how a truncated SHA reached real
+state, and the hand-rolled tally is the same "read it by eye and write down the answer" that produced a
+false `ci = green`. `stage-2-review-gate.md` owns the rules — including the emit-only rule and the ONE
+event it exempts — the subcommands, and the four verdicts `verify`
 returns; resolve the script at `<skill-dir>/scripts/review-pass.py` and pass that path to subtasks, exactly
 as with `ledger.py` below.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -155,8 +155,10 @@ blocks; each completion is its own wake.
    PARSING"); review →
    the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
    writes `review-<pr>-<n>.txt` / `.progress.jsonl`, a relaunch writes `review-<pr>-<n>.a<k>.*`, and
-   only the attempt named in the current `pass_identity` is read or counted (Stage 2a); CI/review fix),
-   record the result against the SHA it ran on and act per Stage 2.
+   only the attempt named in the current `pass_identity` is read or counted (Stage 2a). **Before a
+   review verdict is counted, the pass's artifacts must verify** — `scripts/review-pass.py verify`, never
+   an ad-hoc parse; anything but `ok` means the verdict is not tallied (Stage 2a, "Does this pass COUNT?");
+   CI/review fix), record the result against the SHA it ran on and act per Stage 2.
 3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,
    not just the PR/job that woke you. Launch every due action that fits a free slot before returning.
    Launch only what is actually due *and not already in flight* (check ground truth first, never the

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -104,9 +104,12 @@ subagent fallback pass counts toward the review gate exactly like an external pa
 it's another fresh, context-isolated re-roll in its own context. (When the reviewer is already Claude
 subagents, this *is* the normal path, not a fallback.)
 
-**A REVIEW PASS'S ARTIFACTS HAVE A TOOL — `scripts/review-pass.py`. NEVER hand-write one, and never
-hand-parse one.** The plan, the `pass_identity`, every progress event, and the read that decides whether a
-pass COUNTS all go through it. It is the schema owner for the review-pass artifact set exactly as
+**A REVIEW PASS'S ARTIFACTS HAVE A TOOL — `scripts/review-pass.py`. NEVER hand-parse one, and never
+hand-write a line the tool writes.** The plan, the `pass_identity`, every unit-progress event, and the read
+that decides whether a pass COUNTS all go through it — and so does every line it does NOT write: `verify`
+re-derives its rules from the bytes, whatever produced them. There is exactly ONE event the reviewer
+appends directly, and the emit-only rule below is what names it.
+It is the schema owner for the review-pass artifact set exactly as
 `ledger.py` is for `state.jsonl`, and it enforces every rule below at **both doors** — where the commands
 enter *and* where the data enters, because a rule enforced only on write is not enforced: the progress
 file is a plaintext file in a directory the reviewer can write to.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -104,8 +104,36 @@ subagent fallback pass counts toward the review gate exactly like an external pa
 it's another fresh, context-isolated re-roll in its own context. (When the reviewer is already Claude
 subagents, this *is* the normal path, not a fallback.)
 
+**A REVIEW PASS'S ARTIFACTS HAVE A TOOL — `scripts/review-pass.py`. NEVER hand-write one, and never
+hand-parse one.** The plan, the `pass_identity`, every progress event, and the read that decides whether a
+pass COUNTS all go through it. It is the schema owner for the review-pass artifact set exactly as
+`ledger.py` is for `state.jsonl`, and it enforces every rule below at **both doors** — where the commands
+enter *and* where the data enters, because a rule enforced only on write is not enforced: the progress
+file is a plaintext file in a directory the reviewer can write to.
+
+```
+review-pass.py plan-add --file <rundir>/review-<pr>-<n>.plan.jsonl \
+    --id u01 --kind file --target <concrete target> --check "<check>" [--check "<check>" …]  # one unit
+review-pass.py identity --file <rundir>/<progress-file> --head-sha $(git rev-parse HEAD) \
+    --dispatched-at <UTC ISO-8601>          # pr/pass/launch_attempt are read FROM THE FILENAME
+review-pass.py emit --file <rundir>/<progress-file> --unit <planned unit> --status started|done \
+    [--evidence "<citation>"]               # what the reviewer's `emit-progress.py` call runs
+review-pass.py verify --file <rundir>/<progress-file> --head-sha <the PR's LIVE head> \
+    [--amendments-ruled N]                  # DOES THIS PASS COUNT?
+review-pass.py self-test                    # the fixtures, and the proof each rule is pinned by one
+```
+
+The hand-written artifacts are what this replaces, and each had already failed: a `printf`-ed
+`pass_identity` put a **TRUNCATED SHA** into real state; the emit tool accepted a `done` for a unit that
+**was never planned** (the rule was prose, enforced by nobody); and the tally was re-derived by eye with
+an ad-hoc parser written fresh each wake — the same "read it by eye, write down the answer" that produced
+a false `ci = green`. `verify` refuses a short sha, an unplanned unit, an evidence-free `done`, a
+`pass_identity` that names another commit or another launch attempt, and any hand-written line that is not
+the exact shape below — **whether or not the write tool was used**.
+
 **Review work-plan ledger — orchestrator-owned, target-generic.** Before launching each review pass,
-write `<rundir>/review-<pr>-<n>.plan.jsonl`. The orchestrator owns the plan; the reviewer reports
+write `<rundir>/review-<pr>-<n>.plan.jsonl` (through `review-pass.py plan-add` — one unit per call, each
+validated as it lands; a shell heredoc has no schema and no validation). The orchestrator owns the plan; the reviewer reports
 progress against it but does NOT redefine it. The reviewer is nonetheless expected to critically
 evaluate the plan for completeness before executing it, and to flag any omitted dimension via the
 amendment mechanism below rather than silently accepting the supplied decomposition as exhaustive.
@@ -161,7 +189,11 @@ other event types for unit progress. Unit-progress events carry ONLY the exact r
 **Calling `emit-progress.py` is the ONLY sanctioned way to record a unit-progress event
 (`started`/`done`).** The reviewer MUST NOT ever write those unit-progress events into the progress
 file directly — no hand-written JSON, no `echo`/`printf`/redirection into it, no editor append. Every
-unit-progress event reaches the file through the tool and no other path. This emit-only rule applies
+unit-progress event reaches the file through the tool and no other path. **Its CLI is unchanged**
+(`--file --unit --status --evidence`); it now forwards to `review-pass.py emit`, which **REFUSES a unit
+that is not in the plan** and a `done` with no concrete evidence. And the emit-only rule is no longer
+enforced by good faith: `verify` re-derives every rule from the bytes, so a hand-written line that the
+tool would have refused is caught on **READ** — the pass goes `unusable` rather than counting. This emit-only rule applies
 ONLY to the `started`/`done` unit-progress events: the tool does not produce any other event type.
 `plan_amendment_request` events are NOT emitted by the tool — the reviewer raises them through the
 amendment mechanism above — and `pass_identity` is written by the orchestrator; both are EXEMPT from
@@ -180,9 +212,15 @@ the tool and is shown only to document its shape. The fourth (`pass_identity`) i
 {"type":"pass_identity","pr":"41","pass":"1","head_sha":"a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c","launch_attempt":"1","dispatched_at":"2026-07-06T00:00:00Z"}
 ```
 
-**`pass_identity` is the pass's attempt id and its dispatch clock.** The orchestrator writes it as the
+**`pass_identity` is the pass's attempt id and its dispatch clock.** The orchestrator writes it — with
+`review-pass.py identity`, **never** a `printf` — as the
 **first line** of the launch attempt's progress file **before** launching the reviewer process, so that
-file exists from dispatch onward. Three rules depend on it: a late verdict is ignored unless its attempt
+file exists from dispatch onward. `pr`, `pass` and `launch_attempt` are taken **from the progress file's
+own name**, so the identity and the file it sits in can never disagree; the only values passed in are the
+head SHA (refused unless it is 40 lowercase hex — **a short SHA has escaped into this repo's real state
+twice**, once through exactly this line) and `dispatched_at` (refused unless it is a UTC ISO-8601
+timestamp — it is the launch deadline's clock, and a deadline measured from a time nobody can parse never
+fires). Three rules depend on it: a late verdict is ignored unless its attempt
 id still matches the active pass; `dispatched_at` is the clock the launch check below measures against;
 and `launch_attempt` (`1`, then `2` on a relaunch) is how a *later wake* — possibly a fresh agent —
 knows whether this pass has already been relaunched once. A progress file holding **only** this line is
@@ -345,8 +383,12 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    --status started' when a planned unit begins, and the same command with \
    '--status done --evidence \"<concrete citation: a file:line, a backticked span, or a filename>\"' \
    when it finishes. The tool appends the canonical progress event; a non-zero exit means your inputs \
-   were rejected — fix them and re-run. progress counts only when it references a planned unit and its \
-   done event includes concrete evidence. \
+   were rejected — fix them and re-run. Progress counts only when it references a PLANNED unit and its \
+   done event includes concrete evidence, and the tool ENFORCES both: it REFUSES a unit that is not in \
+   the plan (raise a plan_amendment_request instead — never self-grant a unit) and a done with no \
+   evidence. Hand-writing the event to get around a refusal does not work and destroys the pass: it is \
+   read back under the same rules, and one line the tool would have rejected makes the whole pass \
+   unusable. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \
@@ -374,7 +416,35 @@ immediate EOF. Keep it on every review dispatch (omit only if you ever deliberat
 prompt). Also: NEVER pass destructive instructions (delete, force-push, reset) to `codex exec`, and
 NEVER use `--dangerously-bypass-approvals-and-sandbox` — always `--sandbox workspace-write`.
 
-As each verdict lands, tally it for the SHA it ran on:
+### Does this pass COUNT? — ASK THE TOOL, never the eye
+
+**Before a verdict is tallied at all, verify the pass's artifacts.** A verdict is only worth as much as
+the pass that produced it, and "was this pass real?" was, until now, decided by reading three files by eye
+with a parser written fresh each wake. That is precisely how a driver read `gh pr checks` by eye and wrote
+`ci = green` on zero evidence — the same hole, one layer up.
+
+```
+review-pass.py verify --file <rundir>/<active attempt's progress file> --head-sha <the PR's LIVE head>
+```
+
+It answers with exactly one verdict, and there is **no "counts, but…"** — a disclosure printed beside a
+pass is a trapdoor, not a disclosure:
+
+| verdict | exit | what it means | what to do |
+|---|---|---|---|
+| `ok` | 0 | the artifacts are sound: a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt and **the live head SHA**; every planned unit `done` with concrete evidence; every `done` for a unit that is **actually in the plan**; no unruled amendment | **now** read the report's `VERDICT:` line and tally it |
+| `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
+| `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
+| `unusable` | 1 | the artifacts are **defective** — a short SHA, a `done` for an unplanned unit, an evidence-free `done`, a hand-written line of the wrong shape, an identity naming another commit or another attempt | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict |
+
+**`ok` IS NOT `SATISFIED`, and the tool will never say `SATISFIED`.** It does not open
+`review-<pr>-<n>.txt` and does not parse the reviewer's prose — the VERDICT is the reviewer's **judgment**
+and stays theirs; `verify` only checks the pass's **mechanics**. That line is what keeps the tool from
+*becoming* the gate: it can only ever **subtract** a pass (refuse a defective one), never **add** a
+SATISFIED verdict, never raise `reviews_ok`, and never merge anything. A bug in a tool that can only
+refuse costs a re-review; a bug in a tool that could accept would merge a PR nobody reviewed.
+
+Once `verify` says `ok`, tally the report's verdict for the SHA it ran on:
 
 - **NOT SATISFIED** → the SHA's tally is void: set `reviews_ok = 0` **and, in the same step, restore
   `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** (`gh pr edit <pr> --remove-label

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -128,8 +128,10 @@ The hand-written artifacts are what this replaces, and each had already failed: 
 **was never planned** (the rule was prose, enforced by nobody); and the tally was re-derived by eye with
 an ad-hoc parser written fresh each wake — the same "read it by eye, write down the answer" that produced
 a false `ci = green`. `verify` refuses a short sha, an unplanned unit, an evidence-free `done`, a `done`
-that no `started` precedes, a `pass_identity` that names another commit or another launch attempt, and any
-hand-written line that is not the exact shape below — **whether or not the write tool was used**.
+that no `started` precedes, a SECOND `done` for a unit already finished, a `pass_identity` that names
+another commit or another launch attempt, and any hand-written line that is not the exact shape below —
+**whether or not the write tool was used**. **`emit` refuses every one of those it can see, by calling the
+SAME functions** — one implementation, both doors, so a rule cannot hold at one and not the other.
 
 **Review work-plan ledger — orchestrator-owned, target-generic.** Before launching each review pass,
 write `<rundir>/review-<pr>-<n>.plan.jsonl` (through `review-pass.py plan-add` — one unit per call, each
@@ -163,6 +165,10 @@ Rules:
   the same SHA (or clean base-only rebase, diff unchanged), copy pass 1's plan to
   `review-<pr>-2.plan.jsonl` instead of re-deriving. Re-derive only when PR content changed.
 - Each unit MUST name concrete `target` + concrete `checks`.
+- **The plan's filename is part of the contract: `review-<pr>-<n>.plan.jsonl`, and `plan-add` refuses any
+  other.** `verify` is never given the plan's path — it DERIVES it from the progress file's name — so a
+  plan written under a different name is a plan nothing will ever open, and the pass is then refused for a
+  MISSING plan while its units sit on disk one filename away.
 - For code, include at least one cross-cutting unit when behavior spans files or packages.
 - For non-code, include at least one cross-artifact/whole-piece unit when multiple artifacts/sections
   exist.
@@ -192,6 +198,13 @@ carrying a valid `pass_identity` and a `done` for every planned unit — and not
 review that demonstrably did not happen, and the tool exists to say so. `emit` refuses to write such a
 `done` and `verify` refuses to read one.
 
+**A unit is `done` exactly ONCE — a SECOND `done` for it makes the pass `unusable`, at both doors.** Two
+`done` events for one unit are two accounts of it, and nothing says which was read. If what you found
+changed, the pass is what re-runs, not the line. (This rule held on READ and *not* on write: `emit`
+appended the second `done` and exited 0, so the reviewer was told it had succeeded and the pass was
+thrown away later for a defect the tool had just helped it commit. The three unit-progress rules —
+planned unit, `done` follows `started`, no second `done` — are now ONE predicate that both doors call.)
+
 The `plan_amendment_request` event keeps its existing shape; its `ts` must be a real UTC ISO-8601
 timestamp (the same clock rule `pass_identity.dispatched_at` obeys) and its `reason` must be non-empty —
 an amendment holds a pass back, so it must say something the orchestrator can rule on.
@@ -201,7 +214,8 @@ an amendment holds a pass back, so it must say something the orchestrator can ru
 file directly — no hand-written JSON, no `echo`/`printf`/redirection into it, no editor append. Every
 unit-progress event reaches the file through the tool and no other path. **Its CLI is unchanged**
 (`--file --unit --status --evidence`); it now forwards to `review-pass.py emit`, which **REFUSES a unit
-that is not in the plan** and a `done` with no concrete evidence. And the emit-only rule is no longer
+that is not in the plan**, a `done` with no concrete evidence, a `done` that no `started` precedes, and a
+SECOND `done` for a unit already finished. And the emit-only rule is no longer
 enforced by good faith: `verify` re-derives every rule from the bytes, so a hand-written line that the
 tool would have refused is caught on **READ** — the pass goes `unusable` rather than counting. This emit-only rule applies
 ONLY to the `started`/`done` unit-progress events: the tool does not produce any other event type.
@@ -218,7 +232,7 @@ the tool and is shown only to document its shape. The fourth (`pass_identity`) i
 ```
 {"type":"progress","unit":"u01","status":"started"}
 {"type":"progress","unit":"u01","status":"done","evidence":"validate_idc.go:42 `canonicalizeValue`; edge case tested at validate_idc_test.go:88"}
-{"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
+{"type":"plan_amendment_request","ts":"2026-07-06T00:05:00Z","reason":"diff changes generated docs; add doc consistency unit","proposed_unit":{"type":"unit","id":"u99","kind":"docs","target":"docs/generated.md","checks":["sync with API behavior"]}}
 {"type":"pass_identity","pr":"41","pass":"1","head_sha":"a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c","launch_attempt":"1","dispatched_at":"2026-07-06T00:00:00Z"}
 ```
 
@@ -445,10 +459,10 @@ pass is a trapdoor, not a disclosure:
 
 | verdict | exit | what it means | what to do |
 |---|---|---|---|
-| `ok` | 0 | the artifacts are sound: a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt and **the live head SHA**; every planned unit `done` with concrete evidence; every `done` for a unit that is **actually in the plan**; no unruled amendment | **now** read the report's `VERDICT:` line and tally it |
+| `ok` | 0 | the artifacts are sound: a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt and **the live head SHA**; every planned unit `done` **once**, with concrete evidence, after a `started` for it; every `done` for a unit that is **actually in the plan**; no unruled amendment | **now** read the report's `VERDICT:` line and tally it |
 | `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
 | `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
-| `unusable` | 1 | the artifacts are **defective** — a short SHA, a `done` for an unplanned unit, an evidence-free `done`, a hand-written line of the wrong shape, an identity naming another commit or another attempt | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict |
+| `unusable` | 1 | the artifacts are **defective** — a short SHA, a `done` for an unplanned unit, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape, an identity naming another commit or another attempt | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict |
 
 **`ok` IS NOT `SATISFIED`, and the tool will never say `SATISFIED`.** It does not open
 `review-<pr>-<n>.txt` and does not parse the reviewer's prose — the VERDICT is the reviewer's **judgment**

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -127,9 +127,9 @@ The hand-written artifacts are what this replaces, and each had already failed: 
 `pass_identity` put a **TRUNCATED SHA** into real state; the emit tool accepted a `done` for a unit that
 **was never planned** (the rule was prose, enforced by nobody); and the tally was re-derived by eye with
 an ad-hoc parser written fresh each wake — the same "read it by eye, write down the answer" that produced
-a false `ci = green`. `verify` refuses a short sha, an unplanned unit, an evidence-free `done`, a
-`pass_identity` that names another commit or another launch attempt, and any hand-written line that is not
-the exact shape below — **whether or not the write tool was used**.
+a false `ci = green`. `verify` refuses a short sha, an unplanned unit, an evidence-free `done`, a `done`
+that no `started` precedes, a `pass_identity` that names another commit or another launch attempt, and any
+hand-written line that is not the exact shape below — **whether or not the write tool was used**.
 
 **Review work-plan ledger — orchestrator-owned, target-generic.** Before launching each review pass,
 write `<rundir>/review-<pr>-<n>.plan.jsonl` (through `review-pass.py plan-add` — one unit per call, each
@@ -183,8 +183,18 @@ always `progress`; the only allowed `status` values are `started` and `done`. Th
 `status="done"`) AND a required `evidence` field carrying a concrete citation (a `file:line`, a
 backticked span, or a filename). Do NOT rename to `unit_done`/`unit_id`/`id`/`no_findings` or invent
 other event types for unit progress. Unit-progress events carry ONLY the exact required keys above
-(no extra keys such as `ts`); each event's required keys must be present and named exactly. The
-`plan_amendment_request` event keeps its existing shape.
+(no extra keys such as `ts`); each event's required keys must be present and named exactly.
+
+**A `done` REQUIRES an earlier `started` for the same unit — enforced by ORDER, at both doors.** A unit
+that was never begun cannot have been finished, so a `done` standing alone, or standing *above* its
+`started` in this append-only file, makes the pass `unusable`. This is not bookkeeping: a progress file
+carrying a valid `pass_identity` and a `done` for every planned unit — and not one `started` — is a
+review that demonstrably did not happen, and the tool exists to say so. `emit` refuses to write such a
+`done` and `verify` refuses to read one.
+
+The `plan_amendment_request` event keeps its existing shape; its `ts` must be a real UTC ISO-8601
+timestamp (the same clock rule `pass_identity.dispatched_at` obeys) and its `reason` must be non-empty —
+an amendment holds a pass back, so it must say something the orchestrator can rule on.
 
 **Calling `emit-progress.py` is the ONLY sanctioned way to record a unit-progress event
 (`started`/`done`).** The reviewer MUST NOT ever write those unit-progress events into the progress
@@ -220,7 +230,9 @@ own name**, so the identity and the file it sits in can never disagree; the only
 head SHA (refused unless it is 40 lowercase hex — **a short SHA has escaped into this repo's real state
 twice**, once through exactly this line) and `dispatched_at` (refused unless it is a UTC ISO-8601
 timestamp — it is the launch deadline's clock, and a deadline measured from a time nobody can parse never
-fires). Three rules depend on it: a late verdict is ignored unless its attempt
+fires — **and unless it PARSES as a real moment**: `2026-99-99T99:99:99Z` has the exact right shape, and
+a month 99 is not a month; the deadline is arithmetic on this value, so a shape check alone cannot protect
+it). Three rules depend on it: a late verdict is ignored unless its attempt
 id still matches the active pass; `dispatched_at` is the clock the launch check below measures against;
 and `launch_attempt` (`1`, then `2` on a relaunch) is how a *later wake* — possibly a fresh agent —
 knows whether this pass has already been relaunched once. A progress file holding **only** this line is
@@ -383,12 +395,13 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    --status started' when a planned unit begins, and the same command with \
    '--status done --evidence \"<concrete citation: a file:line, a backticked span, or a filename>\"' \
    when it finishes. The tool appends the canonical progress event; a non-zero exit means your inputs \
-   were rejected — fix them and re-run. Progress counts only when it references a PLANNED unit and its \
-   done event includes concrete evidence, and the tool ENFORCES both: it REFUSES a unit that is not in \
-   the plan (raise a plan_amendment_request instead — never self-grant a unit) and a done with no \
-   evidence. Hand-writing the event to get around a refusal does not work and destroys the pass: it is \
-   read back under the same rules, and one line the tool would have rejected makes the whole pass \
-   unusable. \
+   were rejected — fix them and re-run. Progress counts only when it references a PLANNED unit, was \
+   ANNOUNCED with a started event before its done event, and its done event includes concrete evidence; \
+   the tool ENFORCES all three: it REFUSES a unit that is not in the plan (raise a plan_amendment_request \
+   instead — never self-grant a unit), a done for a unit you never marked started (emit started when the \
+   unit BEGINS — do not batch both at the end), and a done with no evidence. Hand-writing the event to \
+   get around a refusal does not work and destroys the pass: it is read back under the same rules, and \
+   one line the tool would have rejected makes the whole pass unusable. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -127,11 +127,23 @@ The hand-written artifacts are what this replaces, and each had already failed: 
 `pass_identity` put a **TRUNCATED SHA** into real state; the emit tool accepted a `done` for a unit that
 **was never planned** (the rule was prose, enforced by nobody); and the tally was re-derived by eye with
 an ad-hoc parser written fresh each wake — the same "read it by eye, write down the answer" that produced
-a false `ci = green`. `verify` refuses a short sha, an unplanned unit, an evidence-free `done`, a `done`
+a false `ci = green`. `verify` refuses a short sha, a malformed identifier of any kind, an unplanned unit,
+an evidence-free `done`, a `done`
 that no `started` precedes, a SECOND `done` for a unit already finished, a `pass_identity` that names
 another commit or another launch attempt, and any hand-written line that is not the exact shape below —
 **whether or not the write tool was used**. **`emit` refuses every one of those it can see, by calling the
 SAME functions** — one implementation, both doors, so a rule cannot hold at one and not the other.
+
+**EVERY IDENTIFIER HAS ONE LEGAL FORM, AND NO DOOR REPAIRS ONE.** A unit `id`/`unit` is lowercase letters
+then digits (`u01`); `pr`, `pass` and `launch_attempt` are decimal numbers from 1 up; `head_sha` is 40
+lowercase hex. A value outside its form is an ERROR, not a variant to be trimmed into shape — and that
+distinction is the point, not pedantry. The tool used to strip `emit`'s `--unit` while `plan-add` took its
+`--id` verbatim, so `plan-add --id ' u01 '` exited 0 and `emit --unit ' u01 '` then failed with NOT IN THE
+PLAN, printing `Planned: [' u01 ']`: two doors, two ideas of one id, and a planned unit no reviewer could
+ever record progress against. Trimming at *both* doors would have fixed that call and kept the disease —
+two spellings of one id, and every future door obliged to remember the conversion. A FORMAT leaves nothing
+to convert. It is also the only rule that could ever have caught the **truncated sha** that reached real
+state: `a3f29c1` is perfectly clean, and simply not a commit id.
 
 **ANYTHING THE TOOL WRITES, IT CAN READ BACK — a write is REFUSED unless the file it would produce
 verifies.** Every rule holding at both doors is not enough on its own, and that gap was real: `emit` on an
@@ -180,6 +192,16 @@ Rules:
   the same SHA (or clean base-only rebase, diff unchanged), copy pass 1's plan to
   `review-<pr>-2.plan.jsonl` instead of re-deriving. Re-derive only when PR content changed.
 - Each unit MUST name concrete `target` + concrete `checks`.
+- **A unit `id` has ONE legal form: lowercase letters then digits (`u01`, `u02`) — and anything else is an
+  ERROR, never a variant to be repaired.** `U01`, `u 01`, ` u01 ` are not other ways of spelling `u01`;
+  they are not ids, and `plan-add` refuses them. This is the id every progress event MATCHES the unit by,
+  so a second spelling of it is a unit the reviewer's `emit` cannot name: the tool once accepted
+  `plan-add --id ' u01 '` and then told the reviewer that ` u01 ` was NOT IN THE PLAN — while printing
+  `Planned: [' u01 ']` — because the emit door trimmed the value and the plan door had not. The plan held a
+  unit whose progress could never be recorded, and the pass could never complete. **No door trims,
+  normalizes or repairs an identifier**; each is refused where it enters, so the plan can never come to
+  hold an id the other doors cannot match. The same holds for every other identifier the tool touches
+  (`pr`, `pass`, `launch_attempt` — decimal, from 1 up; `head_sha` — 40 lowercase hex).
 - **The plan's filename is part of the contract: `review-<pr>-<n>.plan.jsonl`, and `plan-add` refuses any
   other.** `verify` is never given the plan's path — it DERIVES it from the progress file's name — so a
   plan written under a different name is a plan nothing will ever open, and the pass is then refused for a
@@ -229,7 +251,9 @@ an amendment holds a pass back, so it must say something the orchestrator can ru
 file directly — no hand-written JSON, no `echo`/`printf`/redirection into it, no editor append. Every
 unit-progress event reaches the file through the tool and no other path. **Its CLI is unchanged**
 (`--file --unit --status --evidence`); it now forwards to `review-pass.py emit`, which **REFUSES a unit
-that is not in the plan**, a `done` with no concrete evidence, a `done` that no `started` precedes, a
+that is not in the plan**, **a `--unit` that is not a well-formed unit id** (it is NOT trimmed — pass the
+id exactly as the plan spells it), a `done` with no concrete evidence, a `done` that no `started`
+precedes, a
 SECOND `done` for a unit already finished, and — the refusal that is not about the event at all — **a
 progress file `verify` could not read**, which most often means one carrying no `pass_identity` yet. And the emit-only rule is no longer
 enforced by good faith: `verify` re-derives every rule from the bytes, so a hand-written line that the
@@ -482,7 +506,7 @@ pass is a trapdoor, not a disclosure:
 | `ok` | 0 | the artifacts are sound: a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt and **the live head SHA**; every planned unit `done` **once**, with concrete evidence, after a `started` for it; every `done` for a unit that is **actually in the plan**; no unruled amendment | **now** read the report's `VERDICT:` line and tally it |
 | `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
 | `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
-| `unusable` | 1 | the artifacts are **defective** — a short SHA, a `done` for an unplanned unit, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape, an identity naming another commit or another attempt | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict |
+| `unusable` | 1 | the artifacts are **defective** — a short SHA or any other malformed identifier, a `done` for an unplanned unit, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape, an identity naming another commit or another attempt | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict |
 
 **`ok` IS NOT `SATISFIED`, and the tool will never say `SATISFIED`.** It does not open
 `review-<pr>-<n>.txt` and does not parse the reviewer's prose — the VERDICT is the reviewer's **judgment**

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -133,6 +133,21 @@ another commit or another launch attempt, and any hand-written line that is not 
 **whether or not the write tool was used**. **`emit` refuses every one of those it can see, by calling the
 SAME functions** — one implementation, both doors, so a rule cannot hold at one and not the other.
 
+**ANYTHING THE TOOL WRITES, IT CAN READ BACK — a write is REFUSED unless the file it would produce
+verifies.** Every rule holding at both doors is not enough on its own, and that gap was real: `emit` on an
+empty progress file exited 0 (it never checked that the identity was there) and `verify` then called that
+same file `unusable: NO pass_identity`; `identity` treated a whitespace-only file as fresh and `verify`
+then refused the artifact for the blank line. The tool accepted the work and then said the work did not
+count. So every write command now runs the READ side's whole-file check on the bytes it is about to
+produce — the file it writes INTO and the file it would LEAVE — and writes nothing if that check refuses.
+Two consequences you can see from the outside: **`emit` refuses a progress file with no valid
+`pass_identity`** (the orchestrator writes it before the reviewer is launched, so an empty one means the
+pass was never dispatched — never "start" it by emitting into it), and **`identity` refuses a file that
+holds ANY BYTES**, not merely any non-blank text. **EMPTY MEANS NO BYTES**: a file with a blank line in it
+is not empty, it is a file with a blank line, and `verify` refuses the pass for exactly that. The one
+read-side rule no write can enforce is the LIVE HEAD comparison — the tip can move after a sound file is
+written, which is the whole reason a tally is voided when PR content changes.
+
 **Review work-plan ledger — orchestrator-owned, target-generic.** Before launching each review pass,
 write `<rundir>/review-<pr>-<n>.plan.jsonl` (through `review-pass.py plan-add` — one unit per call, each
 validated as it lands; a shell heredoc has no schema and no validation). The orchestrator owns the plan; the reviewer reports
@@ -214,8 +229,9 @@ an amendment holds a pass back, so it must say something the orchestrator can ru
 file directly — no hand-written JSON, no `echo`/`printf`/redirection into it, no editor append. Every
 unit-progress event reaches the file through the tool and no other path. **Its CLI is unchanged**
 (`--file --unit --status --evidence`); it now forwards to `review-pass.py emit`, which **REFUSES a unit
-that is not in the plan**, a `done` with no concrete evidence, a `done` that no `started` precedes, and a
-SECOND `done` for a unit already finished. And the emit-only rule is no longer
+that is not in the plan**, a `done` with no concrete evidence, a `done` that no `started` precedes, a
+SECOND `done` for a unit already finished, and — the refusal that is not about the event at all — **a
+progress file `verify` could not read**, which most often means one carrying no `pass_identity` yet. And the emit-only rule is no longer
 enforced by good faith: `verify` re-derives every rule from the bytes, so a hand-written line that the
 tool would have refused is caught on **READ** — the pass goes `unusable` rather than counting. This emit-only rule applies
 ONLY to the `started`/`done` unit-progress events: the tool does not produce any other event type.
@@ -416,6 +432,10 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    unit BEGINS — do not batch both at the end), and a done with no evidence. Hand-writing the event to \
    get around a refusal does not work and destroys the pass: it is read back under the same rules, and \
    one line the tool would have rejected makes the whole pass unusable. \
+   It also refuses to append to a progress file that could not be read back — most often one holding no \
+   pass_identity, which is written for you before you are launched. That refusal is about the FILE, not \
+   your event: it means the pass was not dispatched properly, so do not retry and do not create the file \
+   yourself — say so in your report and stop. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -62,6 +62,13 @@ The help door and the parser door disagreed about what the command IS, which is 
 doors disagreeing about what an ID is, one layer up — and the help is the door a reviewer READS. It has
 its own parser now, built from the owner's own `add_emit_args` (so the flags still have ONE definition and
 cannot drift), and `review-pass.py self-test` EXECUTES the invocation this `--help` advertises.
+
+**AND IT DOES THAT FOR EVERY DOOR, NOT JUST THIS ONE — WHICH IS THE PART THE FIRST CURE MISSED.** That
+check looked at this wrapper and at nothing else, so the owner's own subcommands went on advertising
+whatever they liked: `review-pass.py plan-add --help` bracketed `[--check CHECK]` — argparse for OPTIONAL —
+while the write path refused that exact command for having no checks. The same defect, one door over,
+underneath the check written to stop it. `self-test` now runs EVERY door — every subcommand and this
+wrapper — in the shape its own `--help` advertises.
 """
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -17,6 +17,13 @@ The rule you are most likely to meet: **a unit that is NOT IN THE PLAN is refuse
 when it references a planned unit" was stated in prose and enforced by nobody — this tool used to accept a
 `done` for a unit that was never planned, and the read side never looked. It holds at both doors now. If
 the plan is genuinely missing a dimension, raise a `plan_amendment_request`; never self-grant a unit.
+
+The rule you are most likely to meet SECOND, and the one that CHANGES what this CLI accepts: **a `done`
+for a unit with no earlier `started` is refused.** Emit `--status started` when a unit BEGINS and
+`--status done` when it ends — do not batch both at the end, and never emit only the `done`. The flags are
+unchanged; what is no longer accepted is a `done` that no `started` precedes. That is deliberate: a
+progress file holding a `done` for every planned unit and NOT ONE `started` used to verify `ok`, which
+made the tool that exists to prove a review HAPPENED accept one that demonstrably did not.
 """
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -30,9 +30,21 @@ refused to READ one; this door WROTE it, exited 0, and the pass was thrown away 
 tool had just helped commit. A rule enforced at one door is not enforced. If what you found changed, the
 pass is what re-runs, not the line.
 
+The FOURTH is not about your event at all — it is about the FILE: **a progress file that `verify` cannot
+read is refused, and nothing is appended to it.** Most often that means the file does not yet carry the
+orchestrator's `pass_identity` (it is written before you are launched, so an EMPTY or absent file means
+the pass was never dispatched — do not try to start it yourself), or a line already in it was
+hand-written, or its last line has no newline. This one is NEW, and it exists because the tool used to do
+the opposite: `--status started` on an empty file exited 0, and `verify` then called that same file
+`unusable: NO pass_identity`. Your event landed and your pass could not count. **Anything this tool
+writes, it must be able to read back** — so if the file it would produce is one `verify` would throw away,
+it declines to write and says why, while there is still something you can do about it.
+
 A REFUSAL here is not a broken CLI. The flags are the contract and they have not moved; what a refusal
-says is that the event you asked for is one `verify` would refuse to read, and writing it would only lose
-the pass. Read the message, fix the call, re-run.
+says is that the event you asked for — or the file it would land in — is one `verify` would refuse to
+read, and writing it would only lose the pass. Read the message, fix the call, re-run. If the message is
+about the FILE and not your event, it is not yours to fix: report it, because the pass's dispatch is
+broken and no event you emit into that file will count.
 """
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -18,6 +18,14 @@ when it references a planned unit" was stated in prose and enforced by nobody �
 `done` for a unit that was never planned, and the read side never looked. It holds at both doors now. If
 the plan is genuinely missing a dimension, raise a `plan_amendment_request`; never self-grant a unit.
 
+**And `--unit` IS NOT TRIMMED — pass the id exactly as the plan spells it.** A unit id has ONE legal form
+(lowercase letters then digits: `u01`), and a `--unit` outside that form is refused for what it IS — not
+an id — rather than silently repaired. This CHANGES what the CLI accepts, and the flags have still not
+moved: ` u01 ` used to be quietly stripped to `u01` here while `plan-add` took its `--id` verbatim, so a
+plan could hold ` u01 ` and this tool would then tell you that unit was NOT IN THE PLAN — while printing
+`Planned: [' u01 ']`. Two doors, two ideas of what an id is, and a planned unit whose progress could never
+be recorded. Neither door repairs an identifier now, so there is only ever one string to pass.
+
 The rule you are most likely to meet SECOND, and the one that CHANGES what this CLI accepts: **a `done`
 for a unit with no earlier `started` is refused.** Emit `--status started` when a unit BEGINS and
 `--status done` when it ends — do not batch both at the end, and never emit only the `done`. The flags are

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -24,6 +24,15 @@ for a unit with no earlier `started` is refused.** Emit `--status started` when 
 unchanged; what is no longer accepted is a `done` that no `started` precedes. That is deliberate: a
 progress file holding a `done` for every planned unit and NOT ONE `started` used to verify `ok`, which
 made the tool that exists to prove a review HAPPENED accept one that demonstrably did not.
+
+And the THIRD: **a unit is `done` exactly once — a SECOND `done` for it is refused.** `verify` already
+refused to READ one; this door WROTE it, exited 0, and the pass was thrown away later for a defect this
+tool had just helped commit. A rule enforced at one door is not enforced. If what you found changed, the
+pass is what re-runs, not the line.
+
+A REFUSAL here is not a broken CLI. The flags are the contract and they have not moved; what a refusal
+says is that the event you asked for is one `verify` would refuse to read, and writing it would only lose
+the pass. Read the message, fix the call, re-run.
 """
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -1,70 +1,48 @@
 #!/usr/bin/env python3
+"""Append one canonical reviewer progress event — the reviewer's door into `review-pass.py`.
+
+**THIS FILE'S CLI IS A PUBLIC CONTRACT AND IT HAS NOT MOVED.** `--file --unit --status --evidence`: same
+flags, same meanings, same "a non-zero exit means your inputs were rejected — fix them and re-run". It is
+named in SKILL.md, in `stage-2-review-gate.md`, in `files-and-ledger.md`, and — the reason it can never be
+renamed on a whim — inside every review prompt the orchestrator dispatches. Those prompts are already
+running against INSTALLED copies of this skill: rename or remove this file and a live reviewer's emit call
+dies mid-pass.
+
+What has changed is what it ENFORCES. The whole review-pass artifact set now has ONE owner —
+`review-pass.py`, which also writes the plan and the `pass_identity`, and reads a pass back to answer
+"does this pass COUNT?". This file forwards to that owner instead of re-implementing half of it, so a
+progress event has exactly one definition and there is no second copy to drift.
+
+The rule you are most likely to meet: **a unit that is NOT IN THE PLAN is refused.** "Progress counts only
+when it references a planned unit" was stated in prose and enforced by nobody — this tool used to accept a
+`done` for a unit that was never planned, and the read side never looked. It holds at both doors now. If
+the plan is genuinely missing a dimension, raise a `plan_amendment_request`; never self-grant a unit.
+"""
 
 from __future__ import annotations
 
-import argparse
-import json
+import importlib.util
 import sys
 from pathlib import Path
-from typing import NoReturn
 
-STATUS_STARTED = "started"
-STATUS_DONE = "done"
-ALLOWED_STATUSES = (STATUS_STARTED, STATUS_DONE)
+OWNER = Path(__file__).resolve().parent / "review-pass.py"
 
 
-def fail(msg: str) -> NoReturn:
-    print(f"emit-progress: {msg}", file=sys.stderr)
-    raise SystemExit(1)
+def load_owner():
+    """Load `review-pass.py` BY PATH, from this script's own directory.
 
-
-def parse_args(argv: list[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Append one canonical reviewer progress event to a progress.jsonl file."
-    )
-    parser.add_argument("--file", required=True, help="path to the progress.jsonl to append to")
-    parser.add_argument("--unit", required=True, help="plan unit id this event is about")
-    parser.add_argument("--status", required=True, choices=ALLOWED_STATUSES, help="started or done")
-    parser.add_argument("--evidence", help="concrete citation; required for --status done")
-    return parser.parse_args(argv)
-
-
-def build_event(unit: str, status: str, evidence: "str | None") -> dict:
-    unit = unit.strip()
-    if not unit:
-        fail("--unit must be non-empty")
-
-    if status == STATUS_STARTED:
-        if evidence is not None:
-            fail("--evidence must NOT be provided when --status is started")
-        return {"type": "progress", "unit": unit, "status": STATUS_STARTED}
-
-    # status == STATUS_DONE
-    if evidence is None or not evidence.strip():
-        fail("--evidence is required and must be non-empty when --status is done")
-    return {
-        "type": "progress",
-        "unit": unit,
-        "status": STATUS_DONE,
-        "evidence": evidence,
-    }
-
-
-def append_event(path: Path, event: dict) -> str:
-    line = json.dumps(event, separators=(",", ":")) + "\n"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a") as outfile:
-        outfile.write(line)
-    return line
-
-
-def main(argv: list[str]) -> int:
-    args = parse_args(argv)
-    event = build_event(args.unit, args.status, args.evidence)
-    line = append_event(Path(args.file), event)
-    sys.stdout.write(line)
-    return 0
+    Not by import: `review-pass` is not a legal module name, and the cwd is the reviewer's WORKTREE while
+    the skill's scripts live wherever the plugin is installed. `__file__` is the only thing that knows
+    where its sibling is.
+    """
+    spec = importlib.util.spec_from_file_location("review_pass", OWNER)
+    if spec is None or spec.loader is None:  # a broken install — never an input error
+        print(f"emit-progress: cannot load its owner at {OWNER}", file=sys.stderr)
+        raise SystemExit(1)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    raise SystemExit(load_owner().main(["emit", *sys.argv[1:]]))

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -53,15 +53,26 @@ says is that the event you asked for — or the file it would land in — is one
 read, and writing it would only lose the pass. Read the message, fix the call, re-run. If the message is
 about the FILE and not your event, it is not yours to fix: report it, because the pass's dispatch is
 broken and no event you emit into that file will count.
+
+**AND `--help` NOW DESCRIBES THE COMMAND THIS TOOL ACCEPTS.** It did not. This file had no parser of its
+own — it prepended the owner's `emit` subcommand to `sys.argv` and let the OWNER's argparse render the
+help under THIS script's name — so `--help` printed `usage: emit-progress.py emit [-h] --file …` while
+running that exact command died with `unrecognized arguments: emit`: the wrapper supplies `emit` itself.
+The help door and the parser door disagreed about what the command IS, which is the same defect as two
+doors disagreeing about what an ID is, one layer up — and the help is the door a reviewer READS. It has
+its own parser now, built from the owner's own `add_emit_args` (so the flags still have ONE definition and
+cannot drift), and `review-pass.py self-test` EXECUTES the invocation this `--help` advertises.
 """
 
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import sys
 from pathlib import Path
 
 OWNER = Path(__file__).resolve().parent / "review-pass.py"
+PROG = Path(__file__).name
 
 
 def load_owner():
@@ -80,5 +91,21 @@ def load_owner():
     return mod
 
 
+def main(argv: "list[str] | None" = None) -> int:
+    """This door's OWN parser — so what `--help` SAYS is what the tool TAKES, verbatim.
+
+    The flags are NOT restated here: `add_emit_args` is the owner's one definition of the emit door, and
+    both doors call it. The subcommand is supplied by `set_defaults`, where the caller cannot type it and
+    no usage line can advertise it — the old wrapper prepended it to `argv` instead, which is precisely how
+    it came to advertise a command it then refused. And the parsed args go to the owner's `dispatch`, so
+    the refusal-to-exit-code mapping is the owner's too: a non-zero exit means your inputs were rejected.
+    """
+    owner = load_owner()
+    p = argparse.ArgumentParser(prog=PROG, description=(__doc__ or "").splitlines()[0])
+    owner.add_emit_args(p)
+    p.set_defaults(cmd="emit")
+    return owner.dispatch(p.parse_args(argv))
+
+
 if __name__ == "__main__":
-    raise SystemExit(load_owner().main(["emit", *sys.argv[1:]]))
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -138,24 +138,110 @@ EVENT_KEYS: "dict[tuple[str, str | None], set[str]]" = {
 # is not a string: it is a LIST of them, and it is what makes a unit auditable ("what did you actually
 # look for?"). An empty list is a unit with no checks, which is not a unit.
 UNIT_KEYS = {"type", "id", "kind", "target", "checks"}
-UNIT_STRINGS = ("id", "kind", "target")
+# The two DESCRIPTIVE strings. `id` is NOT one of them: it is the one field in either artifact that is
+# MATCHED — a progress event names a unit BY it — so it is an IDENTIFIER and is governed by `ID_FORMATS`
+# below. Stating a weaker rule for it here as well is how a value comes to have two definitions.
+UNIT_STRINGS = ("kind", "target")
 UNIT = "unit"
+
+
+# --- the IDENTIFIERS: ONE LEGAL STRING EACH, and NO CONVERSIONS ANYWHERE -------------------------
+#
+# **AN IDENTIFIER IS A VALUE TWO DOORS COMPARE.** A unit id is written by `plan-add` and matched by `emit`;
+# `pr`/`pass`/`launch_attempt` are read from the FILENAME and compared to the `pass_identity`; `head_sha` is
+# written by `identity` and compared to the PR's live head. Every one of them crosses the tool, and a value
+# that crosses the tool is a value two doors must agree about.
+#
+# **SO EACH HAS EXACTLY ONE LEGAL FORM, AND ANYTHING ELSE IS AN ERROR — NEVER A VARIANT TO REPAIR.** That
+# is the whole rule, and it is NOT the same as normalizing. This tool used to `.strip()` `--unit` at the
+# emit door while the plan door accepted the padding, so `plan-add --id ' u01 '` succeeded and `emit --unit
+# ' u01 '` then failed with NOT IN THE PLAN, printing `Planned: [' u01 ']` — a plan holding a unit the emit
+# door could never match, and a review that could never complete. Stripping at BOTH doors would have fixed
+# that one call and kept the disease: two spellings of one id, and every future door obliged to remember
+# the conversion. A FORMAT leaves nothing to convert — `' u01 '` is not another way of writing `u01`, it is
+# NOT AN ID — so there is nothing for two doors to disagree about.
+#
+# The `head_sha` row is the proof that this beats normalization outright: no amount of stripping catches a
+# TRUNCATED sha (`a3f29c1`, which is what a hand-written `pass_identity` once carried into real state). It
+# is perfectly "clean"; it is simply not a commit id. Only a FORMAT can say so.
+#
+# REJECT ON THE WAY IN, NEVER ON THE WAY OUT: every door that ACCEPTS one of these calls `check_id`, so a
+# plan can never come to hold an id no door can match. `check_id` is the ONE validator; these are the ONE
+# set of patterns; there is no second copy and no door-local rule.
+#
+# **EVERY PATTERN HERE ENDS `\Z`, NEVER `$`, AND THAT IS NOT A STYLE CHOICE.** In Python `$` also matches
+# just BEFORE a trailing newline, so `^[0-9a-f]{40}$` — which is what this file used to say — ACCEPTS a
+# 40-hex sha with a `\n` glued to the end. That is a second spelling of one commit id: exactly the disease
+# the whole table exists to kill, hiding inside the fence meant to stop it. `\Z` is the end of the STRING,
+# and an identifier is a whole string or it is not one. The format matrix (`ID_CASES`) is what found this,
+# by asking each identifier to refuse its own value with a newline on it — which is the point of writing a
+# format down: it has an exact boundary, so a test can stand on both sides of it.
+
+# A decimal count of something that starts at ONE: no sign, no leading zeros, no whitespace, and no `int()`
+# (which would take `" +2 "` and then CRASH on `"two"`). There is no PR 0, no pass 0 and no launch attempt
+# 0, so a value that names one is not a value we may go on to compare.
+COUNT = r"[1-9][0-9]*"
+
+# A unit id, and the one form of one: lowercase letters then digits — `u01`, `u02`. It is the id an
+# ORCHESTRATOR writes into the plan and a REVIEWER names in every progress event, so it is typed twice by
+# two different processes, and the whole point of pinning its shape is that those two typings cannot differ
+# by a space. Nothing about it is normalized: `U01`, `u 01`, ` u01 ` and `u01 ` are all simply not ids.
+UNIT_ID_RE = re.compile(r"^[a-z]+[0-9]+\Z")
 
 # A git object id, as git writes one: 40 LOWERCASE hex. **A SHORT SHA HAS ESCAPED INTO REAL STATE IN THIS
 # REPO TWICE**, once through a hand-written `pass_identity`. A prefix is not a commit: it does not identify
 # the content a pass reviewed, and every "did this verdict describe the live tip?" comparison made against
 # one is a comparison that cannot mean what it says.
-SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}\Z")
 
-# A decimal integer: no sign, no leading zeros, no whitespace, no `int()` (which would take `" +2 "` and
-# then CRASH on `"two"`). `pr`, `pass` and `launch_attempt` are compared to the values parsed out of the
-# FILENAME, and a value we cannot compare is not one whose comparison we may assume.
-NUM_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+# identifier -> (its ONE legal form, that form in words, and why a value outside it is not one to repair).
+# The key is the FIELD NAME as it is spelled in the artifacts, so a message names the thing the caller
+# typed. A field not in this table is not an identifier — it is prose (`kind`, `target`, `evidence`,
+# `reason`), and prose is checked for being a non-blank string and nothing more.
+ID_FORMATS: "dict[str, tuple[re.Pattern[str], str, str]]" = {
+    "id": (UNIT_ID_RE, "lowercase letters then digits, e.g. `u01`",
+           "a unit id is MATCHED, not read: the plan writes it and every progress event names the unit by "
+           "it. A second spelling of one id is a unit the other door cannot find — ` u01 ` is not `u01` "
+           "with a space, it is NOT AN ID. Nothing here is stripped or repaired, at any door"),
+    "unit": (UNIT_ID_RE, "lowercase letters then digits, e.g. `u01`",
+             "the unit this event is progress FOR, named exactly as the plan names it. The emit door does "
+             "NOT strip it — if it did, the plan and the progress file would hold two spellings of one id "
+             "and only one of them would ever match"),
+    "pr": (re.compile(rf"^{COUNT}\Z"), "a decimal number from 1 up",
+           "it is COMPARED to the number in the FILENAME, and a value we cannot compare proves nothing"),
+    "pass": (re.compile(rf"^{COUNT}\Z"), "a decimal number from 1 up",
+             "it is COMPARED to the number in the FILENAME, and a value we cannot compare proves nothing"),
+    "launch_attempt": (re.compile(rf"^{COUNT}\Z"), "a decimal number from 1 up",
+                       "it is COMPARED to the attempt in the FILENAME — it is how a later wake knows the "
+                       "pass was already relaunched — and a value we cannot compare proves nothing"),
+    "head_sha": (SHA_RE, "40 LOWERCASE hex — `git rev-parse HEAD`, NEVER an abbreviation",
+                 "A short sha has escaped into this repo's real state TWICE, once through a hand-written "
+                 "`pass_identity`. A prefix is not a commit: it names no content, so every 'did this "
+                 "verdict describe the live tip?' comparison made against it is unfalsifiable. This is the "
+                 "row no amount of trimming could ever have caught — a truncated sha is perfectly clean, "
+                 "and simply not a commit id"),
+}
+
+
+def check_id(name: str, value: object, where: str) -> None:
+    """THE validator for every identifier this tool reads or writes. One function, one table, every door.
+
+    It is called wherever an identifier ENTERS — `plan-add`'s `--id`, `emit`'s `--unit`, the `pass_identity`
+    the orchestrator writes, and each of those same fields again as `verify` re-derives them from the bytes.
+    No caller normalizes, compares or repairs an identifier itself; a caller that did would be the second
+    definition, and two definitions of one value is the defect this table exists to make impossible.
+    """
+    pattern, spec, why = ID_FORMATS[name]
+    if not isinstance(value, str) or not pattern.match(value):
+        # MUTATE:id-format:return
+        raise Defect(f"{where}: `{name}` is {value!r} — an identifier has ONE legal form ({spec}), and "
+                     f"anything else is an ERROR, never a variant to be repaired. {why}")
+
 
 # `dispatched_at` is the launch check's CLOCK — the ~5-minute first-event deadline is measured from it. A
 # value that cannot be parsed as a time silently DISABLES that deadline: the guard's input is absent, so
 # the guard never fires, and a reviewer that never started is waited on forever. UTC ISO-8601, `Z`.
-TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
 
 
 def real_utc(value: str) -> bool:
@@ -180,7 +266,13 @@ def real_utc(value: str) -> bool:
 # The name is not decoration — it is the ONLY thing that says which PASS and which LAUNCH ATTEMPT these
 # bytes belong to, and the docs already call substituting attempt-1 names into a relaunch a "silent
 # self-defeat". Silent no longer: the name is parsed, and the identity inside must AGREE with it.
-NAME_RE = re.compile(r"^review-(?P<pr>\d+)-(?P<pass>\d+)(?:\.a(?P<attempt>[2-9]\d*))?\.progress\.jsonl$")
+#
+# The `pr` and `pass` in a NAME are the SAME identifiers `ID_FORMATS` governs, so they are built from the
+# same `COUNT` — a name is an intake door too, and `review-041-1.progress.jsonl` is not another way of
+# writing PR 41. (The attempt suffix appears only for k >= 2: attempt 1 has no suffix, which is why its
+# form is spelled out here rather than reused.)
+NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-(?P<pass>{COUNT})(?:\.a(?P<attempt>[2-9][0-9]*))?"
+                     rf"\.progress\.jsonl\Z")
 
 # The plan is PER-PASS, not per-attempt: a relaunch reuses it unchanged (stage-2-review-gate.md). So it is
 # DERIVED from the progress path and never passed separately — one fewer door, and no way to point a pass
@@ -192,7 +284,7 @@ NAME_RE = re.compile(r"^review-(?P<pr>\d+)-(?P<pass>\d+)(?:\.a(?P<attempt>[2-9]\
 # refuse the pass for a MISSING plan while its units sat on disk a filename away. Enforced by construction
 # at one door and not at all at the other is the same asymmetry as any other; `PLAN_NAME_RE` closes it.
 PLAN_NAME = "review-{pr}-{pass}.plan.jsonl"
-PLAN_NAME_RE = re.compile(r"^review-\d+-\d+\.plan\.jsonl$")
+PLAN_NAME_RE = re.compile(rf"^review-{COUNT}-{COUNT}\.plan\.jsonl\Z")
 
 
 class Defect(Exception):
@@ -330,6 +422,10 @@ def check_unit(unit: object, where: str) -> None:
     if unit["type"] != UNIT:
         # MUTATE:plan-row-type:pass
         raise Defect(f"{where}: type is {unit['type']!r}, and a plan holds only {UNIT!r} records")
+    # The id is an IDENTIFIER — the value the progress events MATCH — so it is checked by `check_id` and by
+    # nothing else, here or at any other door. This is the intake: a unit whose id is not an id never
+    # reaches the plan, so the plan can never come to hold a unit `emit` is unable to name.
+    check_id("id", unit["id"], where)
     for field in UNIT_STRINGS:
         if not isinstance(unit[field], str) or not unit[field].strip():
             # MUTATE:unit-fields:continue
@@ -428,6 +524,12 @@ def check_event(rec: dict, where: str) -> None:
                 f"{where}: `{field}` is {rec[field]!r}, not a string — a value we cannot read is not one "
                 f"we may hand to a comparison and hope (it used to CRASH the tool)"
             )
+    if kind == PROGRESS:
+        # The unit this event names is the SAME identifier the plan's `id` is, checked by the SAME table —
+        # so the two artifacts cannot come to hold two spellings of one unit. It is checked HERE, on the
+        # event, and not only against the plan: "not in the plan" is the wrong thing to tell someone who
+        # typed ` u01 `, and it is what this tool used to say — after quietly stripping the value first.
+        check_id("unit", rec["unit"], where)
     if kind == AMENDMENT:
         # The amendment is the ONE event a reviewer really does hand-write (it is exempt from the
         # emit-only rule), so it is the one whose fields nothing upstream has already shaped. Its `ts` had
@@ -539,22 +641,12 @@ def check_identity_shape(ident: dict, where: str) -> None:
     the pass was already relaunched once. Every one of those is a COMPARISON, and a comparison against a
     malformed value is not one.
     """
-    if not SHA_RE.match(ident["head_sha"]):
-        # MUTATE:identity-sha:pass
-        raise Defect(
-            f"{where}: head_sha {ident['head_sha']!r} is not a git object id (40 LOWERCASE hex). A short "
-            f"sha has escaped into this repo's real state TWICE — once through a hand-written "
-            f"`pass_identity`. A prefix is not a commit: it names no content, so every 'did this verdict "
-            f"describe the live tip?' comparison made against it is unfalsifiable. Use `git rev-parse "
-            f"HEAD`, never an abbreviation"
-        )
-    for field in ("pr", "pass", "launch_attempt"):
-        if not NUM_RE.match(ident[field]):
-            # MUTATE:identity-numbers:continue
-            raise Defect(
-                f"{where}: `{field}` is {ident[field]!r}, not a decimal number — it is COMPARED to the "
-                f"value in the FILENAME, and a value we cannot compare proves nothing"
-            )
+    # FOUR IDENTIFIERS, ONE VALIDATOR. The sha rule and the number rules used to be written out here, and
+    # writing a rule out is how it comes to exist in two places: the sha is ALSO what `verify`'s caller
+    # passes, the numbers are ALSO what the filename carries. They are `ID_FORMATS` rows now, and every door
+    # that takes one runs this same statement over it.
+    for field in ("head_sha", "pr", "pass", "launch_attempt"):
+        check_id(field, ident[field], where)
     if not TS_RE.match(ident["dispatched_at"]):
         # MUTATE:identity-dispatched-at:pass
         raise Defect(
@@ -844,11 +936,19 @@ def cmd_emit(args) -> int:
     """
     path = Path(args.file)
     pr, npass, _attempt = parse_name(path)
-    # The RECORD IS THE FLAGS. `--status done` with no `--evidence` is an event with no `evidence` key, and
-    # `--status started --evidence x` is one carrying a key nothing reads — so the flags are judged by the
-    # same `check_event` that judges a hand-written line, and the evidence rule exists in ONE place. (A CLI
-    # blank `--unit` needs no rule of its own either: it is a unit no plan holds, which is what it is.)
-    rec: "dict[str, object]" = {"type": PROGRESS, "unit": args.unit.strip(), "status": args.status}
+    # The RECORD IS THE FLAGS — VERBATIM. `--status done` with no `--evidence` is an event with no
+    # `evidence` key, and `--status started --evidence x` is one carrying a key nothing reads, so the flags
+    # are judged by the same `check_event` that judges a hand-written line and the evidence rule exists in
+    # ONE place.
+    #
+    # **`--unit` IS NOT STRIPPED, AND THAT IS THE RULE, NOT AN OVERSIGHT.** It used to be, and that one
+    # `.strip()` was the whole defect: the plan door accepted ` u01 ` verbatim while this door quietly
+    # trimmed it, so `plan-add --id ' u01 '` exited 0 and `emit --unit ' u01 '` then said the unit was NOT
+    # IN THE PLAN — while printing `Planned: [' u01 ']`. The plan held a unit this door could never match,
+    # and the pass could never complete. An identifier now has ONE legal form and no door repairs it: the
+    # id is refused where it ENTERS (`check_id`, from `check_event` below), by the same statement the plan
+    # door refuses it with, and the value that reaches the file is the value the reviewer typed.
+    rec: "dict[str, object]" = {"type": PROGRESS, "unit": args.unit, "status": args.status}
     if args.evidence is not None:
         rec["evidence"] = args.evidence
     check_event(rec, "the event you asked to emit (--unit/--status/--evidence)")
@@ -925,6 +1025,10 @@ def cmd_plan_add(args) -> int:
 
 def cmd_verify(args) -> int:
     path = Path(args.file)
+    # The CALLER's sha, against the SAME pattern the artifact's own `head_sha` is held to (`ID_FORMATS`) —
+    # they are compared to each other, so a form either one may take and the other may not is a comparison
+    # waiting to be meaningless. Only the VERDICT differs: a malformed value here is the OPERATOR's mistake
+    # (exit 2), not the artifact's.
     if not SHA_RE.match(args.head_sha):
         # MUTATE:caller-sha:pass
         raise OperatorError(
@@ -1086,7 +1190,8 @@ CASES = {
                        "a second identity naming another commit — read by nothing, present in the bytes"),
     "wrong-head": (PLAN, [ident(head_sha=OTHER_SHA), done("u01"), done("u02")], UNUSABLE, "no longer there",
                    "the pass ran on a commit that is not the tip: its verdict describes content that has moved"),
-    "identity-bad-number": (PLAN, [ident(launch_attempt="one"), done("u01")], UNUSABLE, "not a decimal number",
+    "identity-bad-number": (PLAN, [ident(launch_attempt="one"), done("u01")], UNUSABLE,
+                            "a decimal number from 1 up",
                             "an attempt number that cannot be COMPARED to the one in the filename"),
     "identity-bad-ts": (PLAN, [ident(dispatched_at="just now"), done("u01")], UNUSABLE, "LAUNCH DEADLINE's clock",
                         "a dispatched_at nobody can parse — the ~5-min deadline measured from it NEVER FIRES"),
@@ -1111,6 +1216,15 @@ CASES = {
                                "a unit with no target"),
     "plan-line-not-object": (['["u01"]'], [ident(), done("u01")], UNUSABLE, "not a JSON object",
                              "a plan LINE that is a list — the strict reader refuses it at the plan door exactly as at the progress door"),
+
+    # THE IDENTIFIERS. One legal form each, at every door — and nothing is ever repaired into one.
+    "plan-unit-padded-id": ([unit(" u01 ")], [ident()], UNUSABLE, "NOT AN ID",
+                            "THE FINDING, AT THE PLAN DOOR: a unit id with surrounding whitespace. `plan-add --id ' u01 '` exited 0 and `emit --unit ' u01 '` then said NOT IN THE PLAN — while printing `Planned: [' u01 ']` — because the emit door STRIPPED the value and the plan door did not. The plan held a unit no door could match and the pass could never complete. It is not repaired now, at either door: ` u01 ` is not `u01` with a space, it is not an id"),
+    "progress-padded-unit": (PLAN, [ident(), started(" u01 ")], UNUSABLE, "The emit door does NOT strip it",
+                             "…and at the PROGRESS door, which is where the strip used to be. A hand-written event naming ` u01 ` is told its unit id is malformed — not told the unit is 'not in the plan', which is the wrong lesson and was the old message"),
+    "amendment-padded-unit-id": (PLAN, [ident(), amendment(proposed_unit=json.loads(unit(" u99 ")))], UNUSABLE,
+                                 "NOT AN ID",
+                                 "…and at the THIRD intake: an amendment's `proposed_unit` is what the orchestrator FOLDS INTO THE PLAN, so an id the plan door would refuse must be refused here too — or the plan acquires, one wake later, exactly the unmatchable unit this rule exists to keep out of it"),
     "amendment-unit-not-object": (PLAN, [ident(), amendment(proposed_unit="u99")], UNUSABLE, "not a JSON object",
                                   "the amendment's proposed_unit is a STRING. This is the one place a non-dict unit can reach `check_unit` — the plan's own lines are objects by the time it runs — and it used to be handed straight to `set()`"),
     "plan-missing": (None, WORKED, UNUSABLE, "no plan at",
@@ -1177,7 +1291,10 @@ CLI_CASES = [
     (["emit", "--unit", "u01", "--status", "done"], DISPATCHED, 1, "carries EXACTLY", "a done with no evidence — the SAME key rule a hand-written line meets, not a second CLI-shaped copy of it"),
     (["emit", "--unit", "u01", "--status", "done", "--evidence", "  "], BEGUN, 1, "CONCRETE evidence", "…and blank evidence, on a file where the `started` is not the problem"),
     (["emit", "--unit", "u01", "--status", "started", "--evidence", "x"], DISPATCHED, 1, "carries EXACTLY", "a started carrying evidence: the mirror of a done without it, and the same rule"),
-    (["emit", "--unit", "  ", "--status", "started"], DISPATCHED, 1, "NOT IN THE PLAN", "a blank unit id — a unit no plan holds, which is exactly what it is"),
+    (["emit", "--unit", "  ", "--status", "started"], DISPATCHED, 1, "The emit door does NOT strip it",
+     "a blank unit id. It is refused for what it IS — not an id — and not for what it is not: this door used to STRIP `--unit` and then report the trimmed value 'not in the plan', which named the wrong defect even when it fired"),
+    (["emit", "--unit", " u01 ", "--status", "started"], DISPATCHED, 1, "The emit door does NOT strip it",
+     "HEADLINE, WRITE DOOR: THE FINDING. `plan-add --id ' u01 '` used to exit 0 while this door silently STRIPPED the padding — so the plan held a unit whose progress could never be recorded, and the review could never complete. `emit` said NOT IN THE PLAN and printed `Planned: [' u01 ']` in the same breath. Neither door repairs an identifier now, and the plan door refuses that id in the first place"),
     (["emit", "--unit", "u02", "--status", "started"], [ident(), '{"type":"progress","unit_id":"u01","status":"done","evidence":"x"}'], 1, "carries EXACTLY",
      "the file it is APPENDING TO is evidence too: a hand-written line already in it makes the pass unusable, so `emit` refuses to add a good line to a file `verify` will throw away"),
     (["identity", "--head-sha", SHA, "--dispatched-at", TS], EMPTY, 0, '"launch_attempt":"1"',
@@ -1208,7 +1325,11 @@ PLAN_CLI_CASES = [
      0, '"checks":["a","b"]', "the plan stops being a shell heredoc"),
     (PLAN_FILE, ["--id", "u01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "duplicate unit id",
      "a duplicate id — a `done` for it would say nothing about which unit was checked. Refused by the SAME statement `load_plan` refuses it with: the plan as it WOULD be goes through the reader's own function"),
-    (PLAN_FILE, ["--id", "  ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "names nothing", "a blank id"),
+    (PLAN_FILE, ["--id", "  ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "NOT AN ID", "a blank id"),
+    (PLAN_FILE, ["--id", " u01 ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "NOT AN ID",
+     "HEADLINE, PLAN DOOR: THE FINDING. This exited 0, and the id it wrote was one `emit` could never match — because `emit` stripped its `--unit` and this door did not. The plan is the INTAKE: refuse the id here and no later door can be handed a unit it cannot name"),
+    (PLAN_FILE, ["--id", "U01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "NOT AN ID",
+     "…and an id that is merely a different SPELLING of a legal one. There is no such thing: an identifier has one form, so `U01` is not `u01` in capitals — it is not an id, and it is refused rather than folded"),
     (PLAN_FILE, ["--id", "u03", "--kind", "file", "--target", "x.py"], 1, "not a unit", "a unit with NO checks"),
     ("plan.jsonl", ["--id", "u03", "--kind", "file", "--target", "x.py", "--check", "a"], 1,
      "not a plan artifact's name",
@@ -1283,6 +1404,125 @@ WRITE_COMMANDS: "dict[str, tuple[str, list[str]]]" = {
 READ_ONLY_COMMANDS = frozenset({"verify", "self-test"})
 
 HOLDS, VIOLATED = "holds", "VIOLATED"
+
+
+# --- the CROSS-DOOR property: an id the PLAN door takes is an id the EMIT door can NAME -----------
+#
+# The round trip above asks "can the tool read back what it wrote?" — ONE artifact, one command. This asks
+# the question one artifact over, and it is the one the tool got wrong: **the plan door and the emit door
+# must agree about what a unit id IS.** They did not. `plan-add --id ' u01 '` exited 0; `emit --unit
+# ' u01 '` then failed with `NOT IN THE PLAN` and printed `Planned: [' u01 ']`, because the emit door
+# STRIPPED its `--unit` and the plan door had accepted the padding verbatim. The plan held a unit whose
+# progress could never be recorded — a review that could never complete, wedged by two doors disagreeing
+# about one value.
+#
+# No per-rule fixture could fail on that: every rule was right on its own side. The defect was in the
+# RELATION, exactly as with the two write-then-refuse-to-read findings — so, exactly as there, the relation
+# is stated once, as a property, and driven:
+#
+#   **THE PLAN DOOR REFUSES THE ID, OR THE EMIT DOOR CAN MATCH IT.** Never "planned, and unnameable".
+#
+# It is driven with the reviewer's own input (` u01 `) and with every other way a shell, a YAML block or an
+# agent hands over a value with something extra on it. Note what makes it hold now: not that both doors
+# strip, but that NEITHER does — an id has one legal form (`ID_FORMATS`), so there is nothing to disagree
+# about. A future door that "helpfully" normalizes its input fails this the day it is added.
+
+CROSS_DOOR_IDS = {
+    "plain": "u01",
+    "padded": " u01 ",              # THE FINDING, verbatim: the reviewer's exact input
+    "trailing-space": "u01 ",
+    "leading-tab": "\tu01",
+    "inner-space": "u 01",
+    "blank": "   ",
+    "uppercase": "U01",
+    "newline": "u01\n",
+}
+
+
+def cross_door(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
+    """`plan-add --id X`, then `emit --unit X` — the SAME string, through both doors, for each X.
+
+    `holds` = the plan door REFUSED the id (so no plan ever held it), or it accepted the id and the emit
+    door could then name the unit. `VIOLATED` = the plan door took an id the emit door cannot match: a
+    planned unit with no way to record progress against it, which is a pass that can never complete.
+    """
+    got: dict[str, tuple[str, str]] = {}
+    for name, uid in CROSS_DOOR_IDS.items():
+        d = tmp / f"xd-{name}"
+        d.mkdir(parents=True, exist_ok=True)
+        plan, progress = d / PLAN_FILE, d / PROGRESS_FILE
+        key = f"[cross-door] the id {uid!r}"
+        try:
+            code, text = run_cli(mod, ["plan-add", "--file", str(plan), "--id", uid,
+                                       "--kind", "file", "--target", "x.py", "--check", "a"])
+            if code != 0:
+                got[key] = (HOLDS, f"the PLAN door REFUSED it (exit {code}), so no plan can hold it: "
+                                   f"{text.strip()}")
+                continue
+            run_cli(mod, ["identity", "--file", str(progress), "--head-sha", SHA, "--dispatched-at", TS])
+            code, text = run_cli(mod, ["emit", "--file", str(progress), "--unit", uid, "--status", "started"])
+            got[key] = (
+                (HOLDS if code == 0 else VIOLATED),
+                f"the plan door PLANNED it, and the emit door exited {code}: {text.strip()}",
+            )
+        except Exception as exc:  # noqa: BLE001 - a crash at either door is a violation, not an error
+            got[key] = (f"crash:{type(exc).__name__}", str(exc))
+    return got
+
+
+# --- every IDENTIFIER's format, stated as a table of what it TAKES and what it REFUSES ------------
+#
+# `ID_FORMATS` is the tool's claim about what an identifier is. This is the check on that claim, and it is
+# the reason a strict format beats normalizing: a rule that says "trim it" cannot be tabulated — there is
+# no set of strings it refuses — while a rule that says "it looks like THIS" has an exact boundary, and an
+# exact boundary is a thing a test can stand on both sides of.
+#
+# The identifiers COVERED are reconciled against `ID_FORMATS` itself, so an identifier added to the table
+# with no cases here FAILS the suite. A format nobody has fenced is a format that will drift.
+ID_CASES = [
+    ("id", "u01", True), ("id", "u99", True), ("id", "unit01", True),
+    ("id", " u01 ", False), ("id", "u01 ", False), ("id", "\tu01", False), ("id", "u 01", False),
+    ("id", "u01\n", False), ("id", "U01", False), ("id", "u", False), ("id", "01", False),
+    ("id", "u01a", False), ("id", "u-01", False), ("id", "", False), ("id", "   ", False),
+    ("id", 1, False), ("id", None, False),
+    ("unit", "u01", True), ("unit", " u01 ", False), ("unit", "U01", False), ("unit", "", False),
+    ("pr", "41", True), ("pr", "1", True),
+    ("pr", "0", False), ("pr", "041", False), ("pr", " 41", False), ("pr", "41 ", False),
+    ("pr", "+41", False), ("pr", "-41", False), ("pr", "4_1", False), ("pr", "", False), ("pr", 41, False),
+    ("pass", "1", True), ("pass", "0", False), ("pass", "one", False), ("pass", "01", False),
+    ("launch_attempt", "1", True), ("launch_attempt", "2", True),
+    ("launch_attempt", "0", False), ("launch_attempt", " 2", False), ("launch_attempt", "two", False),
+    ("head_sha", SHA, True),
+    ("head_sha", SHA[:7], False),          # THE TRUNCATED SHA — it reached real state, and it is CLEAN:
+    ("head_sha", SHA.upper(), False),      # no trimming could ever have caught it. Only a FORMAT can.
+    ("head_sha", SHA + "0", False), ("head_sha", " " + SHA, False), ("head_sha", SHA + "\n", False),
+    ("head_sha", "", False), ("head_sha", None, False),
+]
+
+
+def check_id_formats() -> int:
+    """Every identifier's format, against what it must TAKE and what it must REFUSE. Returns the failures."""
+    failures = 0
+    for name, value, accepted in ID_CASES:
+        try:
+            check_id(name, value, "[id-format]")
+            got = True
+        except Defect:
+            got = False
+        if got == accepted:
+            verb = "accepts" if accepted else "REFUSES"
+            print(f"ok       [id] `{name}` {verb} {value!r}")
+        else:
+            print(f"FAIL     [id] `{name}` {'REFUSED' if accepted else 'ACCEPTED'} {value!r} — and an "
+                  f"identifier's format is the ONE thing both doors read it by")
+            failures += 1
+    covered = {name for name, _v, _a in ID_CASES}
+    if covered != set(ID_FORMATS):
+        print(f"FAIL     [id] identifiers with a format and NO cases: {sorted(set(ID_FORMATS) - covered)}; "
+              f"cases for an identifier that has no format: {sorted(covered - set(ID_FORMATS))}. A format "
+              f"nobody fenced is one that will drift")
+        failures += 1
+    return failures
 
 
 # --- the DOCS' examples, fed through the tool ----------------------------------------------------
@@ -1465,6 +1705,7 @@ def run_cases(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
         except Exception as exc:  # noqa: BLE001
             got[f"[plan] {pname} {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
     got.update(round_trip(mod, tmp))
+    got.update(cross_door(mod, tmp))
     return got
 
 
@@ -1491,6 +1732,13 @@ def expectations() -> "dict[str, tuple[str, str, str]]":
         HOLDS, "",
         f"`{cmd}` against a {state} target: it must FAIL, or the file it wrote must READ BACK")
         for cmd in WRITE_COMMANDS for state in FILE_STATES})
+    # …and the cross-door property, whose expectation is likewise the PROPERTY and not a particular rule:
+    # the plan door refuses the id, or the emit door can match it. There is nothing else it may do.
+    out.update({f"[cross-door] the id {uid!r}": (
+        HOLDS, "",
+        f"`plan-add --id {uid!r}` then `emit --unit {uid!r}`: the PLAN door must refuse the id, or the "
+        f"EMIT door must be able to name the unit it planned")
+        for uid in CROSS_DOOR_IDS.values()})
     return out
 
 
@@ -1503,7 +1751,7 @@ MARKER_RE = re.compile(r"^(?P<indent>[ ]*)# MUTATE:(?P<rule>[a-z0-9-]+):(?P<weak
 # The functions that ENFORCE the contract. Every enforcement point inside them must carry a marker.
 # `evaluate` is not one: it MAPS an exception to a verdict; it decides nothing.
 RULE_FUNCTIONS = (
-    "hook", "read_text", "parse_lines", "read_lines", "check_unit", "plan_units", "load_plan",
+    "hook", "read_text", "parse_lines", "read_lines", "check_id", "check_unit", "plan_units", "load_plan",
     "check_event", "check_progress", "walk_progress", "check_identity_shape", "check_identity",
     "check_head", "check_progress_file", "check_plan_file", "decide", "parse_name",
     "before_text", "write_line", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
@@ -1646,6 +1894,8 @@ def self_test() -> int:
             print(f"FAIL     {case[:44]:44} -> {outcome:11} but nothing mentions {needle!r}\n         got: {text}")
             failures += 1
     print()
+    failures += check_id_formats()
+    print()
     doc_failures = check_docs()
     failures += doc_failures
     print()
@@ -1656,7 +1906,9 @@ def self_test() -> int:
           f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases + "
           f"{len(WRITE_COMMANDS) * len(FILE_STATES)} round-trip cases ({len(WRITE_COMMANDS)} write "
           f"commands, derived from the parser, x {len(FILE_STATES)} pre-existing file states) + "
-          f"{len(doc_examples())} DOC examples hold.\n")
+          f"{len(CROSS_DOOR_IDS)} cross-door cases (the plan door refuses the id, or the emit door can "
+          f"match it) + {len(ID_CASES)} identifier-format cases ({len(ID_FORMATS)} identifiers, each with "
+          f"ONE legal form) + {len(doc_examples())} DOC examples hold.\n")
 
     # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
     marked = marked_statements(source)

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -51,9 +51,25 @@ at both. Those are two halves of one discipline, and each half has already faile
   * and a rule enforced at both doors by TWO implementations is a rule waiting to acquire two definitions.
 
 So there are no per-door copies. `check_event`, `check_unit`, `check_identity_shape`, `check_progress` and
-`plan_units` ARE the rules; `emit`, `identity` and `plan-add` call exactly the functions `verify` calls —
-`emit` even replays the file it is appending to through `walk_progress`, the same walk `verify` performs,
-so it can never append a line to a file `verify` would refuse to read.
+`plan_units` ARE the rules; `emit`, `identity` and `plan-add` call exactly the functions `verify` calls.
+
+**AND THE RULES ARE NOT ENOUGH — ANYTHING THIS TOOL CAN WRITE, IT MUST BE ABLE TO READ BACK.** That is a
+property of the doors TOGETHER, and every individual rule can be right at both doors while it fails. It
+did, twice, in one release: `emit --status started` on an EMPTY progress file exited 0 (nothing checked
+that the file had an identity yet), and `verify` then called that same file `unusable: NO pass_identity`.
+`identity` decided "empty" with `.strip()`, so a file holding one blank line counted as fresh, the
+identity went in below the blank line — and `verify` refused the artifact FOR THAT BLANK LINE. In both
+cases the tool ACCEPTED the reviewer's work and then told it the work did not count. A pass is re-runnable
+so nothing was lost but time; the same defect in a store with no second copy BRICKS it.
+
+So the property is structural, not remembered: EVERY write goes through `write_line`, which hands the
+bytes it is about to produce — `the file as it is` + `the line` — to the READ side's own whole-file
+function (`check_progress_file`, `check_plan_file`) and REFUSES TO WRITE unless they accept it. Not a
+write-shaped copy of the rules: the same functions `verify` runs. And "empty" means NO BYTES at every
+door, because a file with a blank line in it is not an empty file — it is a file with a blank line, and
+`verify` says so. The one read-door rule a write door cannot run is `check_head` (it compares the file to
+the PR's LIVE head — the world, not the bytes); nothing a write does can cause that defect, and no write
+door has a `--head-sha` to compare against. That gap is named there and nowhere else.
 
 THE VERDICTS. Exactly one is printed, and there is no "counts, BUT…":
 
@@ -80,6 +96,7 @@ import sys
 import tempfile
 import types
 from collections import Counter
+from collections.abc import Callable
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime
 from pathlib import Path
@@ -188,7 +205,7 @@ class OperatorError(Exception):
 
 # --- the strict JSONL reader (shared by both artifacts) -----------------------------------------
 
-def strict_object(path: Path, n: int):
+def strict_object(name: str, n: int):
     """`object_pairs_hook` rejecting a REPEATED member name, in ANY object on the line.
 
     `json.loads` keeps the LAST value of a repeated key and silently DISCARDS the earlier one, so the
@@ -201,7 +218,7 @@ def strict_object(path: Path, n: int):
         if dupes:
             # MUTATE:duplicate-key:pass
             raise Defect(
-                f"{path.name} line {n}: duplicate member name(s) {', '.join(dupes)} — the decoder keeps "
+                f"{name} line {n}: duplicate member name(s) {', '.join(dupes)} — the decoder keeps "
                 f"only ONE value for a repeated key and discards the other, so the discarded one is in the "
                 f"bytes and reaches no rule"
             )
@@ -210,11 +227,15 @@ def strict_object(path: Path, n: int):
     return hook
 
 
-def read_lines(path: Path, what: str) -> "list[dict]":
-    """Every line of a JSONL artifact, as a dict. No line is skipped — not a blank one, not a bad one.
+def read_text(path: Path, what: str) -> str:
+    """An artifact's BYTES, as text — the one place either door turns a file into something to read.
 
-    A line this reader cannot understand is a producer we cannot trust, and a producer we cannot trust is
-    not one whose output a PR may merge on.
+    Both doors call it, and that is the point: `verify` reads the file it JUDGES through this, and a write
+    command reads the file it is about to append INTO through this, so a file the read side cannot decode
+    is not one the write side will grow. It returns the raw text and not lines, because the write side
+    needs the BYTES: what it is about to produce is `read_text(...) + the line`, and a file whose last line
+    has no newline turns the next append into a CONCATENATION — two events fused into one unreadable line.
+    Only the bytes can show that; a list of parsed lines has already forgotten it.
     """
     if not path.exists():
         # MUTATE:file-missing:pass
@@ -224,43 +245,58 @@ def read_lines(path: Path, what: str) -> "list[dict]":
             f"starts, so this file exists from dispatch onward)"
         )
     try:
-        text = path.read_text(encoding="utf-8")
+        return path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
-        # MUTATE:unreadable:text = path.read_bytes().decode("utf-8", errors="replace")
+        # MUTATE:unreadable:return path.read_bytes().decode("utf-8", errors="replace")
         raise Defect(
             f"{path.name} cannot be read as UTF-8 text ({exc}) — bytes we cannot decode are not evidence, "
             f"and decoding them LENIENTLY rewrites what the file says"
         ) from exc
 
+
+def parse_lines(text: str, name: str) -> "list[dict]":
+    """Every line of a JSONL artifact's TEXT, as a dict. No line is skipped — not a blank one, not a bad one.
+
+    A line this reader cannot understand is a producer we cannot trust, and a producer we cannot trust is
+    not one whose output a PR may merge on.
+
+    It takes TEXT, not a path, for one reason: the write side must be able to ask it about a file that does
+    not exist yet — the file it is ABOUT TO PRODUCE. Same statements, same defects, one implementation.
+    """
     out = []
     for n, line in enumerate(text.splitlines(), start=1):
         if not line.strip():
             # MUTATE:blank-line:continue
             raise Defect(
-                f"{path.name} line {n} is blank — JSONL has no blank lines, and a producer that writes one "
+                f"{name} line {n} is blank — JSONL has no blank lines, and a producer that writes one "
                 f"is not one we can trust with the lines we DO read"
             )
         try:
-            rec = json.loads(line, object_pairs_hook=strict_object(path, n))
+            rec = json.loads(line, object_pairs_hook=strict_object(name, n))
         except json.JSONDecodeError as exc:
             # MUTATE:not-json:continue
             raise Defect(
-                f"{path.name} line {n} is not JSON ({exc}) — a corrupt line is a corrupt artifact, never a "
+                f"{name} line {n} is not JSON ({exc}) — a corrupt line is a corrupt artifact, never a "
                 f"line to skip past"
             ) from exc
         except RecursionError as exc:
             # MUTATE:too-deep:continue
             raise Defect(
-                f"{path.name} line {n} is nested too deeply for the decoder — it RAISED where a verdict "
+                f"{name} line {n} is nested too deeply for the decoder — it RAISED where a verdict "
                 f"was owed, and a crash is not a verdict"
             ) from exc
         if not isinstance(rec, dict):
             # MUTATE:not-object:continue
             raise Defect(
-                f"{path.name} line {n} is not a JSON object — every line of this artifact is one event"
+                f"{name} line {n} is not a JSON object — every line of this artifact is one event"
             )
         out.append(rec)
     return out
+
+
+def read_lines(path: Path, what: str) -> "list[dict]":
+    """The file on disk, as events — the two halves above, in the only order they compose."""
+    return parse_lines(read_text(path, what), path.name)
 
 
 # --- the plan ------------------------------------------------------------------------------------
@@ -339,9 +375,10 @@ def load_plan(path: Path) -> "dict[str, dict]":
 
     Emptiness is the ONE rule here that is deliberately read-only, and it is not one-sided: `plan-add` is
     how a plan STOPS being empty, so a write door that refused an empty plan could never write the first
-    unit. The rule is about a plan a pass is JUDGED against, and that is the read door's question.
+    unit. The rule is about a plan a pass is JUDGED against, and that is the read door's question. Every
+    other plan rule is `check_plan_file` — the same statement `plan-add` runs over the plan it produces.
     """
-    units = plan_units(read_lines(path, "plan"), path.name)
+    units = check_plan_file(read_text(path, "plan"), path)
     if not units:
         # MUTATE:plan-empty:pass
         raise Defect(
@@ -535,9 +572,16 @@ def check_identity_shape(ident: dict, where: str) -> None:
         )
 
 
-def check_identity(events: "list[dict]", pr: str, npass: str, attempt: str, head_sha: str) -> dict:
+def check_identity(events: "list[dict]", pr: str, npass: str, attempt: str) -> dict:
     """The `pass_identity` line: exactly one, FIRST, well-formed, and agreeing with the NAME it is filed
-    under and with the commit the caller says the PR is on."""
+    under. **Everything here is a property of the BYTES ALONE** — which is exactly why both doors run it.
+
+    The commit comparison is NOT here; it is `check_head`, and the split is the line between "is this file
+    readable back?" (this) and "does what it says still describe the world?" (that). A write door can
+    answer the first and cannot answer the second: `emit`'s CLI has no `--head-sha` and never will (its
+    flags are a public contract). So `emit` runs THIS, and it is the whole of what a progress file must
+    satisfy for `verify` to be able to read it at all.
+    """
     ids = [e for e in events if e["type"] == IDENTITY]
     if not ids:
         # MUTATE:identity-missing:ids = [dict(events[0])]
@@ -569,13 +613,25 @@ def check_identity(events: "list[dict]", pr: str, npass: str, attempt: str, head
             f"self-defeat the attempt-scoped artifacts exist to prevent: the live pass writes into the "
             f"DEAD attempt's file and reads as never launched"
         )
+    return ident
+
+
+def check_head(ident: dict, head_sha: str) -> None:
+    """The pass's commit against the PR's LIVE head — the ONE rule that is not about the file.
+
+    It compares the artifact to THE WORLD, and the world is not in the bytes: a file that reads back
+    perfectly becomes stale the moment someone pushes. So it is the one read-door rule no write door can
+    run, and it is the honest GAP in "a write is refused unless the result would verify" — a write can
+    guarantee the file it produces is READABLE, never that the tip will not move afterwards. Nothing a
+    write door does can cause this defect (`identity` is handed the sha it writes; `emit` appends events
+    that name no commit at all), so the gap costs nothing: it is a rule about time, not about bytes.
+    """
     if ident["head_sha"] != head_sha:
         # MUTATE:identity-head-mismatch:pass
         raise Defect(
             f"this pass ran on {ident['head_sha']} but the PR's head is {head_sha} — its verdict describes "
             f"content that is no longer there, and PR content changing is exactly what voids a tally"
         )
-    return ident
 
 
 # --- the verdict ---------------------------------------------------------------------------------
@@ -636,22 +692,90 @@ def parse_name(path: Path) -> "tuple[str, str, str]":
     return m.group("pr"), m.group("pass"), m.group("attempt") or "1"
 
 
+def plan_path(progress: Path) -> Path:
+    """The pass's plan, DERIVED from its progress file's name — never passed in, at either door.
+
+    One derivation, so `emit` cannot be judged against a plan `verify` will not open. (The plan is
+    per-PASS, not per-attempt: a relaunch reuses it unchanged, so the attempt is not in its name.)
+    """
+    pr, npass, _attempt = parse_name(progress)
+    return progress.parent / PLAN_NAME.format(pr=pr, **{"pass": npass})
+
+
 def evaluate(progress: Path, head_sha: str, ruled: int = 0) -> "tuple[str, str]":
     """The whole read side. Every exception a rule can raise lands here as a VERDICT — never as a crash."""
     try:
-        pr, npass, attempt = parse_name(progress)
-        events = read_lines(progress, "progress file")
-        check_events(events, progress)
-        check_identity(events, pr, npass, attempt, head_sha)
-        units = load_plan(progress.parent / PLAN_NAME.format(pr=pr, **{"pass": npass}))
+        plan = plan_path(progress)
+        events, units = check_progress_file(text=read_text(progress, "progress file"), path=progress,
+                                            plan=lambda: load_plan(plan), head_sha=head_sha)
         return decide(events, units, ruled)
     except Defect as exc:
         return UNUSABLE, str(exc)
 
 
-def check_events(events: "list[dict]", path: Path) -> None:
+def check_events(events: "list[dict]", name: str) -> None:
     for n, rec in enumerate(events, start=1):
-        check_event(rec, f"{path.name} line {n}")
+        check_event(rec, f"{name} line {n}")
+
+
+# --- what "READABLE BACK" means, for each artifact — ONE statement of it, called at BOTH doors ----
+#
+# **ANYTHING THIS TOOL CAN WRITE, IT MUST BE ABLE TO READ BACK.** These two functions are that property,
+# and they are the only definition of it. `verify` calls them to judge a pass; every write path calls them
+# on the bytes it is ABOUT TO PRODUCE and refuses to write unless they hold (`write_line`). A write door
+# that used its own notion of "well-formed" would be a second definition, and two definitions of one rule
+# is how a tool comes to write a file it then refuses to read — which it DID: `emit --status started` on an
+# EMPTY progress file exited 0, and `verify` then called that same file `unusable: NO pass_identity`. The
+# tool accepted the reviewer's work and then told it the work did not count.
+#
+# Both take TEXT, never a path, because the file a write door must judge DOES NOT EXIST YET.
+
+
+def check_progress_file(text: str, path: Path, plan: "Callable[[], dict[str, dict]]",
+                        head_sha: "str | None" = None) -> "tuple[list[dict], dict[str, dict]]":
+    """Every rule `verify` derives from a progress file's BYTES — the name it is filed under, its lines,
+    its events, its identity, and the ORDER of its unit progress. Returns (events, plan units).
+
+    ONE function, so the doors cannot compose the rules differently — and **the ORDER is part of the
+    contract**, not an implementation detail: a file whose identity names another PR must be told THAT, not
+    told its plan is missing (the plan's path is derived from the progress file's name, so a misfiled
+    identity takes the plan's name down with it). Hence `plan` is a THUNK: the plan is not needed until the
+    file's own events are replayed, so it is not loaded — and cannot fail — before the file has answered
+    for itself.
+
+    `head_sha` is optional for the one reason set out in `check_head`: it is the only rule here that
+    compares the file to THE WORLD, and a write door has no `--head-sha` to compare against. Passing it is
+    what makes this the WHOLE of `verify`'s read; omitting it makes this the whole of what a write door can
+    guarantee about the file it produces. Nothing else differs between the doors.
+    """
+    pr, npass, attempt = parse_name(path)
+    events = parse_lines(text, path.name)
+    check_events(events, path.name)
+    ident = check_identity(events, pr, npass, attempt)
+    if head_sha is not None:
+        check_head(ident, head_sha)
+    units = plan()
+    walk_progress(events, units)
+    return events, units
+
+
+def check_plan_file(text: str, path: Path) -> "dict[str, dict]":
+    """…and the same, one artifact over: every rule `load_plan` derives from a plan file's BYTES.
+
+    `load_plan`'s EMPTINESS rule is deliberately not here, and that is not an inconsistency — it is the
+    reason this function exists. "A plan with no units is not a plan" is a rule about a plan a pass is
+    JUDGED against; `plan-add` is how a plan stops being empty, so a write door that enforced it could
+    never write the first unit. Every OTHER plan rule holds at both doors, by this statement.
+    """
+    if not PLAN_NAME_RE.match(path.name):
+        # MUTATE:plan-name-shape:pass
+        raise Defect(
+            f"{path.name} is not a plan artifact's name — it is `review-<pr>-<n>.plan.jsonl`. `verify` "
+            f"never takes the plan's path: it DERIVES it from the progress file's name, so a plan written "
+            f"under any other name is a plan nothing will ever read. The pass would be refused for a "
+            f"MISSING plan while its units sat on disk one filename away"
+        )
+    return plan_units(parse_lines(text, path.name), path.name)
 
 
 def count_amendments(progress: Path) -> int:
@@ -665,10 +789,35 @@ def count_amendments(progress: Path) -> int:
 
 # --- the write side (the same rules, at the other door) ------------------------------------------
 
-def append(path: Path, rec: dict) -> str:
+def before_text(path: Path) -> str:
+    """The bytes the file ALREADY holds — "" when it does not exist yet, and NOTHING ELSE means empty.
+
+    **EMPTY MEANS NO BYTES.** It used to mean "no non-whitespace text" at one door and no bytes at the
+    other, and a file with a blank line in it fell in the crack: `identity` called it fresh and wrote into
+    it, `verify` then refused the artifact FOR THE BLANK LINE. A file with a blank line is not an empty
+    file; it is a file with a blank line, and this returns it as such so the rules can say so.
+    """
+    return read_text(path, "file") if path.exists() else ""
+
+
+def write_line(path: Path, before: str, rec: "dict[str, object]",
+               readable_back: "Callable[[str], object]") -> str:
+    """THE ONE WRITE. A record is appended ONLY IF the file it would PRODUCE reads back.
+
+    Every write path in this tool goes through here, and `readable_back` is always one of the READ side's
+    own whole-file functions — never a write-shaped restatement of them. So the property is structural
+    rather than a rule someone remembered to repeat: **the tool cannot write a file it would refuse to
+    read**, because the bytes are handed to the reader BEFORE they reach the disk.
+
+    That is also what catches the defect neither door's per-record checks can see: a file whose last line
+    has NO TRAILING NEWLINE. The append lands ON that line, fusing two events into one — and every
+    record-level check passes, because the RECORD was never the problem. Only `before + line` shows it.
+    """
     line = json.dumps(rec, separators=(",", ":")) + "\n"
+    # MUTATE:write-verifies-result:pass
+    readable_back(before + line)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a") as out:
+    with path.open("a", encoding="utf-8") as out:
         out.write(line)
     return line
 
@@ -676,11 +825,18 @@ def append(path: Path, rec: dict) -> str:
 def cmd_emit(args) -> int:
     """Append one unit-progress event — the ONLY sanctioned way a reviewer records one.
 
-    **It runs the READ side's functions, and no others.** The event it is about to append is checked by
-    `check_event` and `check_progress`; the file it is about to append TO is re-read from disk and put
-    through `check_events` and `walk_progress` — the very walk `verify` performs. So `emit` cannot write a
-    line `verify` would refuse, and there is no CLI-shaped second copy of any rule to drift away from the
-    one the verdict is computed with.
+    **It runs the READ side's functions, and no others**, over THREE things in this order: the EVENT it was
+    asked for (`check_event`, `check_progress` — so the message names the mistake the reviewer just made),
+    the file it is about to append INTO (`check_progress_file` — a file `verify` already refuses is not one
+    to add a good line to), and the file it would PRODUCE (`write_line`). The last is what makes the
+    property structural; the first two exist to say WHICH rule fired, and all three are the same
+    statements, so there is no CLI-shaped second copy of any rule to drift from the one the verdict is
+    computed with.
+
+    **The file it appends into must ALREADY carry a valid `pass_identity`.** The orchestrator writes it
+    before the reviewer is launched, so it is there — and this door used to not look: `emit --status
+    started` on an EMPTY progress file exited 0, and `verify` then refused that very file for holding NO
+    `pass_identity`. The tool wrote what it would not read, and told the reviewer it had succeeded.
 
     That is not symmetry for its own sake. Every rule this refuses at write, it refuses at the moment the
     reviewer makes the mistake — with a message it can act on — instead of the pass being thrown away
@@ -697,27 +853,39 @@ def cmd_emit(args) -> int:
         rec["evidence"] = args.evidence
     check_event(rec, "the event you asked to emit (--unit/--status/--evidence)")
 
-    units = load_plan(path.parent / PLAN_NAME.format(pr=pr, **{"pass": npass}))
-    events = read_lines(path, "progress file")
-    check_events(events, path)
+    plan = plan_path(path)
+    text = read_text(path, "progress file")
+    events, units = check_progress_file(text, path, lambda: load_plan(plan))
     announced, done = walk_progress(events, units)
     check_progress(rec, units, announced, done, "the event you asked to emit")
-    sys.stdout.write(append(path, rec))
+    # …and the file it would PRODUCE, through that same function. `units` is already loaded, so the thunk
+    # just hands it back; nothing is re-derived, and nothing is re-stated.
+    sys.stdout.write(write_line(path, text, rec, lambda after: check_progress_file(after, path, lambda: units)))
     return 0
 
 
 def cmd_identity(args) -> int:
-    """Write a pass's `pass_identity` — the line that used to be a `printf`, and once got a TRUNCATED SHA."""
+    """Write a pass's `pass_identity` — the line that used to be a `printf`, and once got a TRUNCATED SHA.
+
+    It writes into a file that must hold NO BYTES. It used to demand only that the file hold no non-blank
+    TEXT — so a whitespace-only file counted as fresh, the identity went in below the blank line, and
+    `verify` then refused the artifact FOR THAT BLANK LINE. Two doors, two definitions of "empty", and the
+    file in the crack was one this tool wrote and would not read.
+    """
     path = Path(args.file)
     pr, npass, attempt = parse_name(path)
-    if path.exists() and path.read_text(encoding="utf-8", errors="replace").strip():
+    text = before_text(path)
+    if text:
         # MUTATE:identity-write-first:pass
         raise Defect(
-            f"{path.name} already holds events — `pass_identity` is the FIRST line of a launch attempt's "
-            f"progress file, written before the reviewer starts. A relaunch gets its OWN file "
-            f"(`review-<pr>-<n>.a<k>.progress.jsonl`), never this one"
+            f"{path.name} is NOT EMPTY — it already holds {len(text)} byte(s), and `pass_identity` is the "
+            f"FIRST line of a launch attempt's progress file, written before the reviewer starts. A "
+            f"relaunch gets its OWN file (`review-<pr>-<n>.a<k>.progress.jsonl`), never this one. EMPTY "
+            f"means NO BYTES: a file holding only a blank line is not empty, it is a file with a blank "
+            f"line — `verify` refuses the pass for exactly that, so writing here would produce an artifact "
+            f"this tool would then refuse to read"
         )
-    rec = {
+    rec: "dict[str, object]" = {
         "type": IDENTITY, "pr": pr, "pass": npass, "head_sha": args.head_sha,
         "launch_attempt": attempt, "dispatched_at": args.dispatched_at,
     }
@@ -725,31 +893,33 @@ def cmd_identity(args) -> int:
     # can never call malformed, and the sha/clock rules exist in exactly one place.
     check_event(rec, "the pass_identity you asked to write")
     check_identity_shape(rec, "the pass_identity you asked to write")
-    sys.stdout.write(append(path, rec))
+    # …and then the file it would PRODUCE, through the read side's own whole-file function. The EMPTY plan
+    # is EXACT and not a shortcut: the guard above proved the file holds no bytes, so what this produces is
+    # ONE line — the identity — and no unit-progress event a plan could have anything to say about. It is
+    # also why `identity` does not require the plan to exist yet: the orchestrator writes both before
+    # dispatch, and this door has no business imposing an order between them. (If the guard above is ever
+    # weakened, this still refuses whatever was in the file: an event no plan names.)
+    sys.stdout.write(write_line(path, text, rec, lambda after: check_progress_file(after, path, dict)))
     return 0
 
 
 def cmd_plan_add(args) -> int:
     """Append one validated unit to a pass's plan — the artifact that used to be a shell heredoc."""
     path = Path(args.file)
-    if not PLAN_NAME_RE.match(path.name):
-        # MUTATE:plan-name-shape:pass
-        raise Defect(
-            f"{path.name} is not a plan artifact's name — it is `review-<pr>-<n>.plan.jsonl`. `verify` "
-            f"never takes the plan's path: it DERIVES it from the progress file's name, so a plan written "
-            f"under any other name is a plan nothing will ever read. The pass would be refused for a "
-            f"MISSING plan while its units sat on disk one filename away"
-        )
-    rec = {
+    rec: "dict[str, object]" = {
         "type": UNIT, "id": args.id, "kind": args.kind, "target": args.target,
         "checks": list(args.check),
     }
     check_unit(rec, "the unit you asked to add")
-    # The plan AS IT WOULD BE, run through the reader's own function: the duplicate-id rule fires from the
-    # one statement `verify` fires it from, never from a second copy that can drift away from it.
-    existing = read_lines(path, "plan") if path.exists() else []
-    plan_units([*existing, rec], path.name)
-    sys.stdout.write(append(path, rec))
+    # The plan AS IT WOULD BE, run through the reader's own function: the NAME rule and the duplicate-id
+    # rule fire from the one statement `load_plan` fires them from, never from a second copy that can drift
+    # away from it. `check_plan_file` sees the produced BYTES, so a plan whose last line carries no newline
+    # is refused rather than fused with the next unit into one line nothing can parse.
+    #
+    # The name is checked BEFORE the file is read, and by the same statement: a path that is not a plan's
+    # name is not a file this tool reads at all, so `before_text` is not asked about it.
+    text = before_text(path) if PLAN_NAME_RE.match(path.name) else ""
+    sys.stdout.write(write_line(path, text, rec, lambda after: check_plan_file(after, path)))
     return 0
 
 
@@ -779,22 +949,31 @@ def cmd_verify(args) -> int:
 # --- self-test: the fixtures ARE the contract ----------------------------------------------------
 #
 # Every rule above marks itself `# MUTATE:<id>:<weakening>` on the line ABOVE the statement that ENFORCES
-# it. `self-test` then does three things, in order, and the third is the one that matters:
+# it. `self-test` then does four things, and the last two are the ones that matter:
 #
 #   1. runs every fixture and asserts its verdict AND the needle its reason must contain (the reason is
 #      the only thing that says WHICH rule fired — a fixture that goes `unusable` for someone else's
 #      reason pins NOTHING);
-#   2. asserts that EVERY enforcement point in a rule function sits under a marker. A rule ADDED without
+#   2. drives the ROUND TRIP — every write command the PARSER has, against every pre-existing file state —
+#      and asserts the property no per-rule fixture can state: **either the command FAILS, or the file it
+#      produced VERIFIES**;
+#   3. asserts that EVERY enforcement point in a rule function sits under a marker. A rule ADDED without
 #      one is never mutated, so nothing could ever report it unpinned. An unmarked rule is an untested one;
-#   3. DELETES each rule in turn — splicing in its weakening — re-runs every fixture and every CLI case,
-#      and FAILS if no fixture notices.
+#   4. DELETES each rule in turn — splicing in its weakening — re-runs every fixture, every CLI case and
+#      the whole round trip, and FAILS if no fixture notices.
 #
-# Step 3 exists because step 1 CANNOT see the failure that matters most: a rule NOTHING tests. Delete such
+# Step 4 exists because step 1 CANNOT see the failure that matters most: a rule NOTHING tests. Delete such
 # a rule and the suite stays green while the tool has quietly stopped checking. A sibling PR in this repo
 # proved the danger is not theoretical: a hand-written "N rules pinned" matrix was TRUE and INSUFFICIENT —
 # 8 guards were not in the inventory at all, and 7 of those were pinned by nothing. THE COUNT IS A CLAIM.
 # So the count is DERIVED, here, on every CI run, and "which rules are unpinned?" is a question the SUITE
 # answers rather than one a reviewer has to discover.
+#
+# Step 2 exists for the failure step 1 cannot see EITHER, and it is a different one: a defect that is not
+# in any rule but in the RELATION between the doors. Every rule can hold on both sides while the tool still
+# writes a file it will not read — and a fixture that asserts one command's exit code cannot fail on that.
+# The fixture at the head of the CLI list used to ASSERT the bad write succeeded (`emit` on an EMPTY file,
+# expected exit 0); the test encoded the bug, and a green suite reported it as correct behavior.
 
 SHA = "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c"
 OTHER_SHA = "b" * 40
@@ -975,26 +1154,30 @@ NAME_CASES = [
 # The WRITE door. Same rules, other side. `(argv, the progress file it runs against, expected exit, needle
 # in stdout+stderr, why)`. `emit-progress.py`'s CLI is unchanged, so the `emit` argv here are exactly what
 # a live reviewer prompt already runs — the contract those prompts were written against is the contract
-# still under test. The default seed is an EMPTY progress file: what the orchestrator has in hand when it
-# writes `pass_identity`, and what `emit` appends to thereafter.
+# still under test. The seed for `emit` is the file the orchestrator leaves AT DISPATCH — a `pass_identity`
+# and nothing else — because that is the only file a reviewer's `emit` is ever run against. `identity`'s
+# seed is the EMPTY file, which is what it is for.
 EMPTY: "list[str]" = []
+DISPATCHED = [ident()]  # what the orchestrator leaves behind: `pass_identity`, written before the launch
 BEGUN = [ident(), started("u01")]  # the file a reviewer has in hand once it has ANNOUNCED u01
 FINISHED = [ident(), started("u01"), done("u01")]  # …and once it has already FINISHED u01
 CLI_CASES = [
-    (["emit", "--unit", "u01", "--status", "started"], EMPTY, 0, '"status":"started"', "the call every reviewer prompt makes"),
+    (["emit", "--unit", "u01", "--status", "started"], DISPATCHED, 0, '"status":"started"', "the call every reviewer prompt makes"),
     (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], BEGUN, 0, '"evidence":"f.py:1"',
      "…and its done form, on the file that HAS the matching `started` — the only file the done form was ever meant to be run against"),
+    (["emit", "--unit", "u01", "--status", "started"], EMPTY, 1, "NO `pass_identity`",
+     "HEADLINE, WRITE DOOR: THE FILE THIS TOOL WROTE AND WOULD NOT READ. `emit` on an EMPTY progress file exited 0 — it never looked for the identity — and `verify` then called that same file `unusable: NO pass_identity`. The reviewer was told its work landed, and the pass could not count. `emit` now runs the READ side's identity check on the file it appends into, so what it accepts is what `verify` can read"),
     (["emit", "--unit", "u01", "--status", "done", "--evidence", "somewhere else"], FINISHED, 1, "SECOND",
      "HEADLINE, WRITE DOOR: a SECOND `done` for a unit already finished. `verify` refused it on READ and this door WROTE it (exit 0) — the rule held at one door and not the other, so the reviewer was handed a success and the pass was thrown away later for a defect the tool had just helped it commit. Both doors now run the SAME predicate"),
     (["emit", "--unit", "u02", "--status", "done", "--evidence", "f.py:1"], BEGUN, 1, "no earlier 'started'",
      "HEADLINE, WRITE DOOR: a `done` for a unit that was never begun. The write door refuses it at the moment the reviewer makes the mistake, instead of the pass being thrown away by `verify` fifteen minutes later"),
-    (["emit", "--unit", "u99", "--status", "done", "--evidence", "f.py:1"], EMPTY, 1, "NOT IN THE PLAN",
+    (["emit", "--unit", "u99", "--status", "done", "--evidence", "f.py:1"], DISPATCHED, 1, "NOT IN THE PLAN",
      "HEADLINE, WRITE DOOR: the tool accepted a self-granted unit. It no longer does — and it says UNPLANNED, not 'no started': an unplanned unit's real defect is that nobody planned it"),
-    (["emit", "--unit", "u99", "--status", "started"], EMPTY, 1, "NOT IN THE PLAN", "…and refuses to START one"),
-    (["emit", "--unit", "u01", "--status", "done"], EMPTY, 1, "carries EXACTLY", "a done with no evidence — the SAME key rule a hand-written line meets, not a second CLI-shaped copy of it"),
+    (["emit", "--unit", "u99", "--status", "started"], DISPATCHED, 1, "NOT IN THE PLAN", "…and refuses to START one"),
+    (["emit", "--unit", "u01", "--status", "done"], DISPATCHED, 1, "carries EXACTLY", "a done with no evidence — the SAME key rule a hand-written line meets, not a second CLI-shaped copy of it"),
     (["emit", "--unit", "u01", "--status", "done", "--evidence", "  "], BEGUN, 1, "CONCRETE evidence", "…and blank evidence, on a file where the `started` is not the problem"),
-    (["emit", "--unit", "u01", "--status", "started", "--evidence", "x"], EMPTY, 1, "carries EXACTLY", "a started carrying evidence: the mirror of a done without it, and the same rule"),
-    (["emit", "--unit", "  ", "--status", "started"], EMPTY, 1, "NOT IN THE PLAN", "a blank unit id — a unit no plan holds, which is exactly what it is"),
+    (["emit", "--unit", "u01", "--status", "started", "--evidence", "x"], DISPATCHED, 1, "carries EXACTLY", "a started carrying evidence: the mirror of a done without it, and the same rule"),
+    (["emit", "--unit", "  ", "--status", "started"], DISPATCHED, 1, "NOT IN THE PLAN", "a blank unit id — a unit no plan holds, which is exactly what it is"),
     (["emit", "--unit", "u02", "--status", "started"], [ident(), '{"type":"progress","unit_id":"u01","status":"done","evidence":"x"}'], 1, "carries EXACTLY",
      "the file it is APPENDING TO is evidence too: a hand-written line already in it makes the pass unusable, so `emit` refuses to add a good line to a file `verify` will throw away"),
     (["identity", "--head-sha", SHA, "--dispatched-at", TS], EMPTY, 0, '"launch_attempt":"1"',
@@ -1007,8 +1190,10 @@ CLI_CASES = [
      "a dispatch clock the launch deadline cannot be measured from — the write door runs the READ side's shape rules, so it cannot write one `verify` would reject"),
     (["identity", "--head-sha", SHA, "--dispatched-at", "2026-99-99T99:99:99Z"], EMPTY, 1, "not a real UTC time",
      "…and the one the SHAPE rule cannot see: an impossible date in the right shape. Both doors parse it now, so neither can produce a `dispatched_at` no clock ever passes"),
-    (["identity", "--head-sha", OTHER_SHA, "--dispatched-at", TS], [ident()], 1, "already holds events",
+    (["identity", "--head-sha", OTHER_SHA, "--dispatched-at", TS], [ident()], 1, "NOT EMPTY",
      "a SECOND identity into a live pass's file. `pass_identity` is the FIRST line, written before dispatch — a relaunch gets its OWN file, and appending here is how one pass ends up describing two commits"),
+    (["identity", "--head-sha", SHA, "--dispatched-at", TS], [""], 1, "NOT EMPTY",
+     "HEADLINE, WRITE DOOR: a WHITESPACE-ONLY file. This door decided 'empty' with `.strip()`, so a file holding one blank line counted as fresh — it wrote the identity in below the blank line, exited 0, and `verify` then refused the artifact FOR THAT BLANK LINE. Two doors, two definitions of empty, and the file in the crack was one this tool wrote and would not read. EMPTY now means NO BYTES, at both"),
     (["verify", "--head-sha", SHA[:7]], EMPTY, 2, "No verdict beats a wrong one",
      "an OPERATOR error is not a snapshot verdict: exit 2, never a verdict computed from a comparison that could not have succeeded"),
     (["verify", "--head-sha", SHA, "--amendments-ruled", "1"], EMPTY, 2, "raised only 0",
@@ -1033,6 +1218,71 @@ PLAN_CLI_CASES = [
 
 class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
+
+
+# --- the ROUND TRIP: anything the tool can WRITE, it must be able to READ BACK --------------------
+#
+# The cases above pin RULES, one by one, and that is exactly why they could not see this: **both findings
+# it missed were about a file the tool WROTE and then REFUSED TO READ.** `emit --status started` on an
+# empty progress file exited 0 and `verify` called that file `unusable: NO pass_identity`; `identity` on a
+# whitespace-only file exited 0 and `verify` refused the artifact for the blank line. Every individual rule
+# was correct at both doors. What was broken was the RELATION between them — and a per-rule fixture cannot
+# fail on a relation nobody stated. (The fixture at the head of the CLI list even ASSERTED the bad write
+# succeeded: `emit` on an EMPTY file, expected exit 0. The test encoded the bug.)
+#
+# So the relation is stated here, ONCE, as a property, and every write path is driven against a range of
+# pre-existing file states:
+#
+#   **EITHER THE COMMAND FAILS, OR THE FILE IT PRODUCED VERIFIES.** Never "succeeds, then does not verify".
+#
+# "Verifies" means the READ side can READ it — not that the pass is `ok`. A pass whose plan is not yet
+# covered reads back `incomplete`, and that is a correct, readable artifact: `ok`/`incomplete`/`amended`
+# all say the bytes are sound. `unusable` — and a CRASH, which is worse — are what a write must never
+# produce. (`verify` can still refuse the pass LATER for a reason that is not about the file: the head SHA
+# moves when someone pushes. That is `check_head`, the one read-door rule no write door can run, and it is
+# the honest gap in this property — see `check_head`.)
+#
+# THE COMMAND LIST IS DERIVED FROM THE PARSER (`build_parser`), never hand-listed: a subcommand that no
+# entry below drives FAILS the self-test. A new write path is therefore covered on the day it is added —
+# by failing until someone covers it, which is the only kind of coverage that cannot rot.
+
+PROGRESS_FILE = "review-41-1.progress.jsonl"
+
+# The pre-existing states of the file a write lands in. They are applied to WHICHEVER artifact the command
+# writes, and deliberately not "realistic" per command: a plan file holding a progress event, or a progress
+# file holding a plan unit, is exactly the kind of state nobody predicted — and the property must hold on
+# every one of them, or it is not a property.
+FILE_STATES: "dict[str, bytes | None]" = {
+    "absent": None,
+    "empty": b"",
+    "whitespace-only": b"   \n",
+    "blank-line": b"\n",
+    "identified": (ident() + "\n").encode(),
+    "begun": (ident() + "\n" + started("u01") + "\n").encode(),
+    "planned": (unit("u01") + "\n").encode(),
+    # THE CONCATENATION. The last line has NO trailing newline, so the next append lands ON it and fuses
+    # two records into one line that is not JSON. Every record-level check passes — the record was never
+    # the problem — and only the bytes `before + line` can show it. This is the SAME class as the two
+    # findings, and nothing but the round trip would have caught it.
+    "no-trailing-newline": (ident()).encode(),
+    "plan-no-trailing-newline": (unit("u01")).encode(),
+    "corrupt": b"not json at all\n",
+    "not-utf8": b"\xff\n",
+}
+
+# How to drive each WRITE command, and which artifact it writes. The command LIST is derived; only the
+# flags are here, because no parser can know what a valid `--check` looks like.
+WRITE_COMMANDS: "dict[str, tuple[str, list[str]]]" = {
+    "emit": (PROGRESS_FILE, ["--unit", "u01", "--status", "started"]),
+    "identity": (PROGRESS_FILE, ["--head-sha", SHA, "--dispatched-at", TS]),
+    "plan-add": (PLAN_FILE, ["--id", "u09", "--kind", "file", "--target", "x.py", "--check", "a"]),
+}
+
+# The subcommands that write NOTHING. They are listed so that `build_parser`'s subcommands can be
+# ACCOUNTED FOR exhaustively — a new one falls into neither set and fails the suite.
+READ_ONLY_COMMANDS = frozenset({"verify", "self-test"})
+
+HOLDS, VIOLATED = "holds", "VIOLATED"
 
 
 # --- the DOCS' examples, fed through the tool ----------------------------------------------------
@@ -1123,8 +1373,65 @@ def run_cli(mod: types.ModuleType, argv: "list[str]") -> "tuple[int, str]":
     return code, out.getvalue() + err.getvalue()
 
 
+def reads_back(mod: types.ModuleType, artifact: str, path: Path) -> "tuple[bool, str]":
+    """The READ side's answer about a file a write just produced: CAN IT BE READ BACK?
+
+    It calls the (possibly mutated) module's OWN read side — never this one's — because the question is
+    always "would THIS tool read back what THIS tool wrote?", and a mutant is a tool with a rule removed.
+
+    An exception is the loudest failure of all: the read side owes a VERDICT on any bytes, and a crash is
+    not a verdict.
+    """
+    try:
+        if artifact == PLAN_FILE:
+            mod.load_plan(path)
+            return True, "the plan reads back"
+        verdict, reason = mod.evaluate(path, SHA)
+        return verdict != UNUSABLE, f"{verdict}: {reason}"
+    except Exception as exc:  # noqa: BLE001 - a crash on READ is a violation, not an error to propagate
+        return False, f"crash:{type(exc).__name__}: {exc}"
+
+
+def round_trip(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
+    """EVERY write command x EVERY pre-existing file state: does the property hold on each?
+
+    `holds` = the command REFUSED (any non-zero exit), or it wrote and the result READS BACK.
+    `VIOLATED` = it exited 0 and produced an artifact its own read side will not read. That is the bug
+    class both findings belong to, and the one this asserts out of existence.
+    """
+    got: dict[str, tuple[str, str]] = {}
+    for cmd, (artifact, argv) in WRITE_COMMANDS.items():
+        for state, content in FILE_STATES.items():
+            d = tmp / f"rt-{cmd}-{state}"
+            d.mkdir(parents=True, exist_ok=True)
+            # A sound plan sits beside every progress-file case, so that what `evaluate` says about the
+            # produced file is about the PROGRESS file and nothing else.
+            (d / PLAN_FILE).write_text("".join(line + "\n" for line in PLAN), encoding="utf-8")
+            target = d / artifact
+            if content is None:
+                target.unlink(missing_ok=True)
+            else:
+                target.write_bytes(content)
+            key = f"[round-trip] {cmd} on a {state} file"
+            try:
+                code, text = run_cli(mod, [cmd, "--file", str(target), *argv])
+            except Exception as exc:  # noqa: BLE001 - the CLI owes an exit code, and a crash is not one
+                got[key] = (f"crash:{type(exc).__name__}", str(exc))
+                continue
+            if code != 0:
+                got[key] = (HOLDS, f"REFUSED (exit {code}) — nothing was written: {text.strip()}")
+                continue
+            ok, why = reads_back(mod, artifact, target)
+            got[key] = (
+                (HOLDS if ok else VIOLATED),
+                f"exit 0, and the file it produced reads back as -> {why}",
+            )
+    return got
+
+
 def run_cases(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
-    """Every fixture, every name case and every CLI case, against this (possibly mutated) module.
+    """Every fixture, every name case, every CLI case and the round-trip property, against this (possibly
+    mutated) module.
 
     A mutant that CRASHES has not returned a verdict, and "no verdict" is itself a deviation — recorded,
     never swallowed."""
@@ -1147,9 +1454,9 @@ def run_cases(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
         path = build(tmp, f"cli-{i}", PLAN, seed)
         try:
             code, text = run_cli(mod, [argv[0], "--file", str(path), *argv[1:]])
-            got[f"[cli] {' '.join(argv)}"] = (f"exit{code}", text)
+            got[cli_key(i, argv)] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
-            got[f"[cli] {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
+            got[cli_key(i, argv)] = (f"crash:{type(exc).__name__}", str(exc))
     for i, (pname, argv, _want, _needle, _why) in enumerate(PLAN_CLI_CASES):
         plan = build(tmp, f"plan-cli-{i}", PLAN, []).parent / pname
         try:
@@ -1157,16 +1464,33 @@ def run_cases(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
             got[f"[plan] {pname} {' '.join(argv)}"] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
             got[f"[plan] {pname} {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
+    got.update(round_trip(mod, tmp))
     return got
+
+
+def cli_key(i: int, argv: "list[str]") -> str:
+    """The case's key. The INDEX is in it because the SEED is part of the case and the argv is not: `emit
+    --unit u01 --status started` is a different case against an empty file than against a dispatched one —
+    that is the whole of finding 1 — and two cases sharing a key would silently collapse into one."""
+    return f"[cli {i}] {' '.join(argv)}"
 
 
 def expectations() -> "dict[str, tuple[str, str, str]]":
     """case -> (expected outcome, needle its output must contain, why the case exists)."""
     out = {n: (w, needle, why) for n, (_p, _pr, w, needle, why) in CASES.items()}
     out.update({f"[name] {n}": (w, needle, why) for n, w, needle, why in NAME_CASES})
-    out.update({f"[cli] {' '.join(a)}": (f"exit{c}", needle, why) for a, _seed, c, needle, why in CLI_CASES})
+    out.update({cli_key(i, a): (f"exit{c}", needle, why)
+                for i, (a, _seed, c, needle, why) in enumerate(CLI_CASES)})
     out.update({f"[plan] {p} {' '.join(a)}": (f"exit{c}", needle, why)
                 for p, a, c, needle, why in PLAN_CLI_CASES})
+    # The round trip's expectation is the PROPERTY, and it is the same for every case: the write is
+    # refused, or what it wrote reads back. There is no needle — no particular rule has to fire, and
+    # demanding one would be demanding a specific defect where the case only demands a sound outcome. The
+    # OUTCOME is the whole assertion.
+    out.update({f"[round-trip] {cmd} on a {state} file": (
+        HOLDS, "",
+        f"`{cmd}` against a {state} target: it must FAIL, or the file it wrote must READ BACK")
+        for cmd in WRITE_COMMANDS for state in FILE_STATES})
     return out
 
 
@@ -1179,9 +1503,10 @@ MARKER_RE = re.compile(r"^(?P<indent>[ ]*)# MUTATE:(?P<rule>[a-z0-9-]+):(?P<weak
 # The functions that ENFORCE the contract. Every enforcement point inside them must carry a marker.
 # `evaluate` is not one: it MAPS an exception to a verdict; it decides nothing.
 RULE_FUNCTIONS = (
-    "hook", "read_lines", "check_unit", "plan_units", "load_plan", "check_event", "check_progress",
-    "walk_progress", "check_identity_shape", "check_identity", "decide", "parse_name",
-    "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
+    "hook", "read_text", "parse_lines", "read_lines", "check_unit", "plan_units", "load_plan",
+    "check_event", "check_progress", "walk_progress", "check_identity_shape", "check_identity",
+    "check_head", "check_progress_file", "check_plan_file", "decide", "parse_name",
+    "before_text", "write_line", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
 )
 ENFORCING_EXCEPTIONS = ("Defect", "OperatorError")
 # The NAMES as they are spelled in the source, because that is what the AST holds — `return UNUSABLE, …`
@@ -1274,10 +1599,37 @@ def load_module(source: str, name: str) -> types.ModuleType:
     return mod
 
 
+def check_commands_covered() -> "list[str]":
+    """Is EVERY subcommand the parser has either driven by the round trip or declared to write nothing?
+
+    This is what makes the round trip's coverage DERIVED rather than claimed. A new subcommand appears in
+    the parser and in neither set below — so the suite goes red the day it is added, and stays red until
+    someone says which it is. A hand-listed set of commands would have gone on passing, silently, about a
+    write path nothing had ever driven.
+    """
+    _parser, commands = build_parser()
+    problems = []
+    for cmd in commands:
+        if cmd not in WRITE_COMMANDS and cmd not in READ_ONLY_COMMANDS:
+            problems.append(
+                f"the parser has a subcommand `{cmd}` that the round trip does not drive. If it WRITES, "
+                f"add it to WRITE_COMMANDS (the property must hold for it); if it writes nothing, add it "
+                f"to READ_ONLY_COMMANDS. An undriven write path is one nothing has ever asked to read back"
+            )
+    for cmd in sorted(set(WRITE_COMMANDS) | set(READ_ONLY_COMMANDS)):
+        if cmd not in commands:
+            problems.append(f"`{cmd}` is driven by the round trip but the parser no longer has it")
+    return problems
+
+
 def self_test() -> int:
     source = Path(__file__).read_text(encoding="utf-8")
     expect = expectations()
     failures = 0
+
+    for problem in check_commands_covered():
+        print(f"COMMANDS {problem}")
+        failures += 1
 
     with tempfile.TemporaryDirectory() as tmpdir:
         got = run_cases(sys.modules[__name__], Path(tmpdir))
@@ -1301,7 +1653,10 @@ def self_test() -> int:
         print(f"{failures} check(s) FAILED — the review-pass contract is broken.")
         return 1
     print(f"all {len(CASES)} fixtures + {len(NAME_CASES)} name cases + "
-          f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases + {len(doc_examples())} DOC examples hold.\n")
+          f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases + "
+          f"{len(WRITE_COMMANDS) * len(FILE_STATES)} round-trip cases ({len(WRITE_COMMANDS)} write "
+          f"commands, derived from the parser, x {len(FILE_STATES)} pre-existing file states) + "
+          f"{len(doc_examples())} DOC examples hold.\n")
 
     # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
     marked = marked_statements(source)
@@ -1379,7 +1734,13 @@ def fail(msg: str, code: int) -> NoReturn:
     raise SystemExit(code)
 
 
-def main(argv: "list[str] | None" = None) -> int:
+def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
+    """The CLI, and the list of subcommands it actually has — DERIVED from the parser, never typed out.
+
+    The round-trip fixture drives every command this returns and FAILS on one it does not know how to
+    drive. So a subcommand added here is covered on the day it is added: there is no second list of
+    commands to forget to update, which is the only way a new write path could ever ship unpinned.
+    """
     p = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     sub = p.add_subparsers(dest="cmd", required=True)
 
@@ -1409,6 +1770,11 @@ def main(argv: "list[str] | None" = None) -> int:
 
     sub.add_parser("self-test", help="run every fixture, then DELETE each rule and prove a fixture notices")
 
+    return p, sorted(str(name) for name in (sub.choices or {}))
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p, _cmds = build_parser()
     args = p.parse_args(argv)
     if args.cmd == "self-test":
         return self_test()

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1,0 +1,1155 @@
+#!/usr/bin/env python3
+"""Executable contract for a REVIEW PASS's artifacts (stage-2-review-gate.md).
+
+A review pass produces four things, and until now exactly ONE of them had a tool:
+
+  * `review-<pr>-<n>.plan.jsonl`      the units the reviewer must check — written BY HAND, with a shell
+                                      heredoc. No schema, no validation, no owner.
+  * `review-<pr>-<n>.progress.jsonl`  what the reviewer did. Its `pass_identity` line was written BY HAND
+                                      with `printf` — which is how a TRUNCATED SHA got into one. Its
+                                      `progress` events came from `emit-progress.py`, the one tooled part.
+  * `review-<pr>-<n>.txt`             the reviewer's report, and its VERDICT line.
+  * the TALLY                         read BY HAND, with an ad-hoc parser written fresh each time.
+
+**This is gate machinery**: what these files say decides whether a review pass COUNTS, and therefore
+whether a PR may merge. The one component of the CI gate that was never mechanized is the one that
+produced a false green in production — a driver read `gh pr checks` by eye and wrote `ci = green` on zero
+evidence. Reading a progress file by eye is the same hole, one layer up.
+
+So this file is the review pass's artifacts, executed:
+
+  plan-add    append ONE validated unit to a pass's plan          (the plan stops being a heredoc)
+  identity    write a pass's `pass_identity` line                 (the SHA stops being a `printf`)
+  emit        append ONE progress event                           (what `emit-progress.py` calls)
+  verify      READ a pass and answer: DOES THIS PASS COUNT?       (the tally stops being by eye)
+  self-test   the fixtures, and the proof that every rule is pinned by one
+
+WHAT `verify` DOES NOT DO — AND THE LINE IS DELIBERATE. It never opens `review-<pr>-<n>.txt`, never
+parses the reviewer's prose, and CANNOT SAY `SATISFIED`. Its whole answer is about the pass's MECHANICS:
+is there an identity, does it name the commit the pass actually ran on, is every `done` for a unit that
+was really planned, does every `done` carry evidence, were amendments raised. The VERDICT is the
+reviewer's JUDGMENT and stays theirs.
+
+That line is what keeps this tool from BECOMING the gate. `verify` can only ever SUBTRACT a pass — refuse
+one that is defective. It can never ADD a SATISFIED verdict, never raise `reviews_ok`, and never merge
+anything. A bug in a tool that can only refuse costs a re-review; a bug in a tool that could accept would
+merge a PR nobody reviewed. **`ok` IS NOT `SATISFIED`.** It means the pass is well-formed enough for its
+verdict to be *read* — a NECESSARY condition for counting it, never a sufficient one.
+
+BOTH DOORS, ALWAYS. Every rule here holds where the COMMANDS enter (`emit`, `identity`, `plan-add`) AND
+where the DATA enters (`verify`). An invariant enforced only at the write door is not enforced: the
+progress file is a plaintext file in a directory the reviewer can write to, the emit-only rule is prose,
+and a hand-written line lands in it just fine. So `verify` re-derives EVERYTHING from the bytes and
+assumes nothing about how they got there — it never trusts that the write tool was used. The write side
+and the read side run the SAME functions, so there is no second implementation to drift.
+
+THE VERDICTS. Exactly one is printed, and there is no "counts, BUT…":
+
+  ok          the artifacts are sound; the pass's verdict may now be read from its report
+  incomplete  sound, but a planned unit has no `done` event — the pass did not cover its plan
+  amended     sound, but the reviewer raised a plan amendment nobody has ruled on yet
+  unusable    the artifacts are defective — this pass CANNOT count, whatever its report says
+
+`amended` is a VERDICT and not a footnote beside `ok` on purpose. A disclosure printed next to a pass is a
+trapdoor, not a disclosure: "this pass counts, but note that the reviewer says the plan is missing a
+dimension" gets read as "counts". The orchestrator rules on the amendment (fold it into the plan and
+restart the pass, or record why not — stage-2-review-gate.md), and passes `--amendments-ruled <n>` to say
+so. Absent that, the guard fires: the DEFAULT is that nothing has been ruled on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+import tempfile
+import types
+from collections import Counter
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from typing import NoReturn
+
+# --- the contract (stage-2-review-gate.md) ------------------------------------------------------
+
+# Verdicts. `ok` is the ONLY one that lets a pass be counted — and even then only after its REPORT is read.
+OK = "ok"
+INCOMPLETE = "incomplete"
+AMENDED = "amended"
+UNUSABLE = "unusable"
+
+# The three event types a progress file may hold. There is no fourth, and a line of a type we do not
+# recognise is NOT nothing — it is something we FAILED TO UNDERSTAND, and a row we failed to understand is
+# never grounds to read on. An ignored line is invisible to every rule below, so a bogus `done` hiding
+# under an unknown type would parse as "nothing wrong".
+IDENTITY = "pass_identity"
+PROGRESS = "progress"
+AMENDMENT = "plan_amendment_request"
+
+STARTED = "started"
+DONE = "done"
+STATUSES = (STARTED, DONE)
+
+# The EXACT key set each event carries — every key it requires, and NOT ONE MORE. "Every required key is
+# present" admits an event that ALSO carries a key nothing reads, and a key nothing reads is evidence that
+# is PRESENT AND NOT COUNTED: a `done` with a `ts` nobody parses, a `pass_identity` with a second sha. The
+# progress events are keyed by (type, status) because a `started` carrying `evidence` is exactly as wrong
+# as a `done` without it — the evidence rule and the no-evidence rule are ONE rule, stated once.
+EVENT_KEYS = {
+    (IDENTITY, None): {"type", "pr", "pass", "head_sha", "launch_attempt", "dispatched_at"},
+    (PROGRESS, STARTED): {"type", "unit", "status"},
+    (PROGRESS, DONE): {"type", "unit", "status", "evidence"},
+    (AMENDMENT, None): {"type", "ts", "reason", "proposed_unit"},
+}
+
+# A plan unit's EXACT key set — same rule, one file over. `checks` is the one field in either artifact that
+# is not a string: it is a LIST of them, and it is what makes a unit auditable ("what did you actually
+# look for?"). An empty list is a unit with no checks, which is not a unit.
+UNIT_KEYS = {"type", "id", "kind", "target", "checks"}
+UNIT_STRINGS = ("id", "kind", "target")
+UNIT = "unit"
+
+# A git object id, as git writes one: 40 LOWERCASE hex. **A SHORT SHA HAS ESCAPED INTO REAL STATE IN THIS
+# REPO TWICE**, once through a hand-written `pass_identity`. A prefix is not a commit: it does not identify
+# the content a pass reviewed, and every "did this verdict describe the live tip?" comparison made against
+# one is a comparison that cannot mean what it says.
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# A decimal integer: no sign, no leading zeros, no whitespace, no `int()` (which would take `" +2 "` and
+# then CRASH on `"two"`). `pr`, `pass` and `launch_attempt` are compared to the values parsed out of the
+# FILENAME, and a value we cannot compare is not one whose comparison we may assume.
+NUM_RE = re.compile(r"^(0|[1-9][0-9]*)$")
+
+# `dispatched_at` is the launch check's CLOCK — the ~5-minute first-event deadline is measured from it. A
+# value that cannot be parsed as a time silently DISABLES that deadline: the guard's input is absent, so
+# the guard never fires, and a reviewer that never started is waited on forever. UTC ISO-8601, `Z`.
+TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+# The artifact's EXACT name (`files-and-ledger.md`; the attempt table in stage-2-review-gate.md):
+# attempt 1 is `review-<pr>-<n>.progress.jsonl`, a relaunch is `review-<pr>-<n>.a<k>.progress.jsonl`.
+# The name is not decoration — it is the ONLY thing that says which PASS and which LAUNCH ATTEMPT these
+# bytes belong to, and the docs already call substituting attempt-1 names into a relaunch a "silent
+# self-defeat". Silent no longer: the name is parsed, and the identity inside must AGREE with it.
+NAME_RE = re.compile(r"^review-(?P<pr>\d+)-(?P<pass>\d+)(?:\.a(?P<attempt>[2-9]\d*))?\.progress\.jsonl$")
+
+# The plan is PER-PASS, not per-attempt: a relaunch reuses it unchanged (stage-2-review-gate.md). So it is
+# DERIVED from the progress path and never passed separately — one fewer door, and no way to point a pass
+# at somebody else's plan.
+PLAN_NAME = "review-{pr}-{pass}.plan.jsonl"
+
+
+class Defect(Exception):
+    """The artifacts are not evidence. -> `unusable`, at either door."""
+
+
+class OperatorError(Exception):
+    """The CALLER is wrong, not the artifacts. A verdict about the wrong question is worse than none."""
+
+
+# --- the strict JSONL reader (shared by both artifacts) -----------------------------------------
+
+def strict_object(path: Path, n: int):
+    """`object_pairs_hook` rejecting a REPEATED member name, in ANY object on the line.
+
+    `json.loads` keeps the LAST value of a repeated key and silently DISCARDS the earlier one, so the
+    discarded value is present in the bytes and reaches NO rule below. `{"head_sha":"<short>","head_sha":
+    "<40 hex>"}` would pass every check in this file with a truncated sha sitting in the artifact. A field
+    given two values does not say ONE thing, and a file that does not say one thing is not evidence.
+    """
+    def hook(pairs: "list[tuple[str, object]]") -> dict:
+        dupes = sorted({k for k, c in Counter(k for k, _ in pairs).items() if c > 1})
+        if dupes:
+            # MUTATE:duplicate-key:pass
+            raise Defect(
+                f"{path.name} line {n}: duplicate member name(s) {', '.join(dupes)} — the decoder keeps "
+                f"only ONE value for a repeated key and discards the other, so the discarded one is in the "
+                f"bytes and reaches no rule"
+            )
+        return dict(pairs)
+
+    return hook
+
+
+def read_lines(path: Path, what: str) -> "list[dict]":
+    """Every line of a JSONL artifact, as a dict. No line is skipped — not a blank one, not a bad one.
+
+    A line this reader cannot understand is a producer we cannot trust, and a producer we cannot trust is
+    not one whose output a PR may merge on.
+    """
+    if not path.exists():
+        # MUTATE:file-missing:pass
+        raise Defect(
+            f"no {what} at {path} — a review pass whose {what} is missing produced no evidence at all "
+            f"(the orchestrator writes the plan before dispatch and `pass_identity` before the reviewer "
+            f"starts, so this file exists from dispatch onward)"
+        )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        # MUTATE:unreadable:text = path.read_bytes().decode("utf-8", errors="replace")
+        raise Defect(
+            f"{path.name} cannot be read as UTF-8 text ({exc}) — bytes we cannot decode are not evidence, "
+            f"and decoding them LENIENTLY rewrites what the file says"
+        ) from exc
+
+    out = []
+    for n, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            # MUTATE:blank-line:continue
+            raise Defect(
+                f"{path.name} line {n} is blank — JSONL has no blank lines, and a producer that writes one "
+                f"is not one we can trust with the lines we DO read"
+            )
+        try:
+            rec = json.loads(line, object_pairs_hook=strict_object(path, n))
+        except json.JSONDecodeError as exc:
+            # MUTATE:not-json:continue
+            raise Defect(
+                f"{path.name} line {n} is not JSON ({exc}) — a corrupt line is a corrupt artifact, never a "
+                f"line to skip past"
+            ) from exc
+        except RecursionError as exc:
+            # MUTATE:too-deep:continue
+            raise Defect(
+                f"{path.name} line {n} is nested too deeply for the decoder — it RAISED where a verdict "
+                f"was owed, and a crash is not a verdict"
+            ) from exc
+        if not isinstance(rec, dict):
+            # MUTATE:not-object:continue
+            raise Defect(
+                f"{path.name} line {n} is not a JSON object — every line of this artifact is one event"
+            )
+        out.append(rec)
+    return out
+
+
+# --- the plan ------------------------------------------------------------------------------------
+
+def check_unit(unit: dict, where: str) -> None:
+    """A plan unit, whether it sits in the plan or inside a `plan_amendment_request`. ONE definition."""
+    if not isinstance(unit, dict):
+        # MUTATE:unit-not-object:return
+        raise Defect(f"{where}: the unit is not a JSON object")
+    if set(unit) != UNIT_KEYS:
+        missing = sorted(UNIT_KEYS - set(unit))
+        extra = sorted(set(unit) - UNIT_KEYS)
+        # MUTATE:unit-keys:pass
+        raise Defect(
+            f"{where}: a unit carries EXACTLY {sorted(UNIT_KEYS)}"
+            + (f"; missing {missing}" if missing else "")
+            + (f"; unexpected key(s) {extra} — nothing reads them, so whatever they assert is neither "
+               f"verified nor refuted" if extra else "")
+        )
+    if unit["type"] != UNIT:
+        # MUTATE:plan-row-type:pass
+        raise Defect(f"{where}: type is {unit['type']!r}, and a plan holds only {UNIT!r} records")
+    for field in UNIT_STRINGS:
+        if not isinstance(unit[field], str) or not unit[field].strip():
+            # MUTATE:unit-fields:continue
+            raise Defect(
+                f"{where}: `{field}` is {unit[field]!r} — a unit names a CONCRETE target and a concrete "
+                f"kind, and an empty or non-string one names nothing"
+            )
+    checks = unit["checks"]
+    if (not isinstance(checks, list) or not checks
+            or not all(isinstance(c, str) and c.strip() for c in checks)):
+        # MUTATE:unit-checks:pass
+        raise Defect(
+            f"{where}: `checks` is {checks!r} — a unit with no concrete checks is not a unit; it is a "
+            f"heading, and a reviewer cannot be shown to have done anything against it"
+        )
+
+
+def load_plan(path: Path) -> "dict[str, dict]":
+    """The plan's units, by id. A plan is what makes `done` MEAN something — so it is validated, not read.
+
+    An EMPTY plan is refused, and that rule carries the most weight of any here: "every planned unit is
+    done" is VACUOUSLY TRUE of a plan with no units, so a pass that reviewed NOTHING would verify `ok`.
+    A completeness check whose input can be empty is not a check.
+    """
+    units: dict[str, dict] = {}
+    for n, rec in enumerate(read_lines(path, "plan"), start=1):
+        check_unit(rec, f"{path.name} line {n}")
+        if rec["id"] in units:
+            # MUTATE:plan-duplicate-id:pass
+            raise Defect(
+                f"{path.name} line {n}: duplicate unit id {rec['id']!r} — a `done` naming it would be "
+                f"ambiguous about WHICH unit was checked"
+            )
+        units[rec["id"]] = rec
+    if not units:
+        # MUTATE:plan-empty:pass
+        raise Defect(
+            f"{path.name} holds no units — 'every planned unit is done' is VACUOUSLY TRUE of an empty "
+            f"plan, so a pass that reviewed nothing at all would verify {OK}"
+        )
+    return units
+
+
+# --- the progress events -------------------------------------------------------------------------
+
+def check_event(rec: dict, where: str) -> None:
+    """One progress-file event, checked to the EXACT shape. Run at BOTH doors, so there is one definition.
+
+    Order matters: the TYPE decides which key set applies, the KEYS decide which fields exist, and only
+    then may a field's VALUE be read. Reading a value before its shape is known is how a tool crashes
+    instead of returning a verdict — and a crash is not a verdict.
+    """
+    kind = rec.get("type")
+    status = rec.get("status") if kind == PROGRESS else None
+    if kind not in (IDENTITY, PROGRESS, AMENDMENT):
+        # MUTATE:unknown-event:return
+        raise Defect(
+            f"{where}: UNRECOGNISED event type {kind!r} — a line we cannot understand is not a line we may "
+            f"read past; it is invisible to every rule below"
+        )
+    if kind == PROGRESS and status not in STATUSES:
+        # MUTATE:bad-status:status = STARTED
+        raise Defect(
+            f"{where}: `status` is {status!r} — the only unit-progress statuses are {list(STATUSES)}"
+        )
+    keys = EVENT_KEYS[(kind, status)]
+    if set(rec) != keys:
+        missing = sorted(keys - set(rec))
+        extra = sorted(set(rec) - keys)
+        # MUTATE:event-keys:pass
+        raise Defect(
+            f"{where}: a {kind!r} event carries EXACTLY {sorted(keys)}"
+            + (f"; missing {missing}" if missing else "")
+            + (f"; unexpected key(s) {extra} — nothing reads them, so they are present and NOT COUNTED"
+               if extra else "")
+        )
+    for field in sorted(keys - {"proposed_unit"}):
+        if not isinstance(rec[field], str):
+            # MUTATE:non-string:continue
+            raise Defect(
+                f"{where}: `{field}` is {rec[field]!r}, not a string — a value we cannot read is not one "
+                f"we may hand to a comparison and hope (it used to CRASH the tool)"
+            )
+    if kind == AMENDMENT:
+        check_unit(rec["proposed_unit"], f"{where} proposed_unit")
+    if kind == PROGRESS and status == DONE and not rec["evidence"].strip():
+        # MUTATE:empty-evidence:pass
+        raise Defect(
+            f"{where}: a {DONE!r} event carries CONCRETE evidence (a file:line, a backticked span, a "
+            f"filename) — blank evidence is a claim that a unit was checked, with nothing behind it"
+        )
+
+
+def check_identity_shape(ident: dict, where: str) -> None:
+    """Every VALUE in a `pass_identity`, checked once — and therefore at BOTH doors, because `identity`
+    (write) and `check_identity` (read) both call this and there is no second implementation to drift.
+
+    The identity is the pass's attempt id and its dispatch clock, and three rules downstream depend on it:
+    a late verdict is ignored unless its attempt id still matches; the ~5-minute launch deadline is
+    measured from `dispatched_at`; `launch_attempt` is how a *later* wake — possibly a fresh agent — knows
+    the pass was already relaunched once. Every one of those is a COMPARISON, and a comparison against a
+    malformed value is not one.
+    """
+    if not SHA_RE.match(ident["head_sha"]):
+        # MUTATE:identity-sha:pass
+        raise Defect(
+            f"{where}: head_sha {ident['head_sha']!r} is not a git object id (40 LOWERCASE hex). A short "
+            f"sha has escaped into this repo's real state TWICE — once through a hand-written "
+            f"`pass_identity`. A prefix is not a commit: it names no content, so every 'did this verdict "
+            f"describe the live tip?' comparison made against it is unfalsifiable. Use `git rev-parse "
+            f"HEAD`, never an abbreviation"
+        )
+    for field in ("pr", "pass", "launch_attempt"):
+        if not NUM_RE.match(ident[field]):
+            # MUTATE:identity-numbers:continue
+            raise Defect(
+                f"{where}: `{field}` is {ident[field]!r}, not a decimal number — it is COMPARED to the "
+                f"value in the FILENAME, and a value we cannot compare proves nothing"
+            )
+    if not TS_RE.match(ident["dispatched_at"]):
+        # MUTATE:identity-dispatched-at:pass
+        raise Defect(
+            f"{where}: `dispatched_at` is {ident['dispatched_at']!r}, not a UTC ISO-8601 timestamp "
+            f"(YYYY-MM-DDThh:mm:ssZ) — it is the LAUNCH DEADLINE's clock, and a deadline measured from a "
+            f"time nobody can parse never fires"
+        )
+
+
+def check_identity(events: "list[dict]", pr: str, npass: str, attempt: str, head_sha: str) -> dict:
+    """The `pass_identity` line: exactly one, FIRST, well-formed, and agreeing with the NAME it is filed
+    under and with the commit the caller says the PR is on."""
+    ids = [e for e in events if e["type"] == IDENTITY]
+    if not ids:
+        # MUTATE:identity-missing:ids = [dict(events[0])]
+        raise Defect(
+            "the progress file holds NO `pass_identity` — nothing binds these events to a PR, a pass, an "
+            "attempt or a COMMIT, so they could describe any review of anything"
+        )
+    if len(ids) > 1:
+        # MUTATE:identity-duplicate:pass
+        raise Defect(
+            f"the progress file holds {len(ids)} `pass_identity` lines — if they disagreed the file would "
+            f"describe two passes, and only one of them would ever be read"
+        )
+    if events[0]["type"] != IDENTITY:
+        # MUTATE:identity-not-first:pass
+        raise Defect(
+            "`pass_identity` is not the FIRST line — the orchestrator writes it BEFORE the reviewer is "
+            "launched, so an event ahead of it was written by something that had not been dispatched yet"
+        )
+    ident = ids[0]
+    check_identity_shape(ident, "`pass_identity`")
+
+    named = (ident["pr"], ident["pass"], ident["launch_attempt"])
+    if named != (pr, npass, attempt):
+        # MUTATE:identity-path-mismatch:pass
+        raise Defect(
+            f"`pass_identity` names pr/pass/attempt {named} but the file it is IN is attempt {attempt} of "
+            f"pass {npass} for PR {pr} — substituting one attempt's paths into another is the silent "
+            f"self-defeat the attempt-scoped artifacts exist to prevent: the live pass writes into the "
+            f"DEAD attempt's file and reads as never launched"
+        )
+    if ident["head_sha"] != head_sha:
+        # MUTATE:identity-head-mismatch:pass
+        raise Defect(
+            f"this pass ran on {ident['head_sha']} but the PR's head is {head_sha} — its verdict describes "
+            f"content that is no longer there, and PR content changing is exactly what voids a tally"
+        )
+    return ident
+
+
+# --- the verdict ---------------------------------------------------------------------------------
+
+def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int) -> "tuple[str, str]":
+    """Given SOUND artifacts: does this pass COUNT? (Its report is still not read. That is the point.)"""
+    done: dict[str, str] = {}
+    for n, rec in enumerate(events, start=1):
+        if rec["type"] != PROGRESS:
+            continue
+        unit = rec["unit"]
+        if unit not in units:
+            # MUTATE:unplanned-unit:pass
+            raise Defect(
+                f"line {n}: progress for unit {unit!r}, which is NOT IN THE PLAN — the reviewer never "
+                f"rewrites the plan or self-grants units, and progress counts only when it references a "
+                f"PLANNED unit. Planned: {sorted(units)}"
+            )
+        if rec["status"] != DONE:
+            continue
+        if unit in done:
+            # MUTATE:duplicate-done:pass
+            raise Defect(
+                f"line {n}: a SECOND {DONE!r} for unit {unit!r} — the file now offers two accounts of one "
+                f"unit, and nothing says which was read"
+            )
+        done[unit] = rec["evidence"]
+
+    amendments = [e for e in events if e["type"] == AMENDMENT]
+    unruled = len(amendments) - ruled
+    if unruled > 0:
+        # MUTATE:amended:pass
+        return AMENDED, (
+            f"the reviewer raised {len(amendments)} plan amendment(s), {unruled} not yet ruled on: "
+            + "; ".join(f"{a['proposed_unit']['id']}: {a['reason']}" for a in amendments[ruled:])
+            + ". A plan the REVIEWER says is incomplete is not a plan this pass can be counted against. "
+              "Fold it into the plan and restart the pass, or record why not, then pass "
+              "--amendments-ruled to say so"
+        )
+
+    missing = sorted(set(units) - set(done))
+    if missing:
+        # MUTATE:incomplete:pass
+        return INCOMPLETE, (
+            f"{len(done)}/{len(units)} planned units are done; no `{DONE}` event for {missing} — the pass "
+            f"has not covered its plan"
+        )
+    return OK, (
+        f"all {len(units)} planned units are done with evidence, on {events[0]['head_sha']}, no unruled "
+        f"amendments. This says the ARTIFACTS are sound — NOT that the pass is SATISFIED. Read the "
+        f"VERDICT line in the report"
+    )
+
+
+def parse_name(path: Path) -> "tuple[str, str, str]":
+    """(pr, pass, launch_attempt) — from the FILENAME, which is the only thing that says which pass and
+    which launch attempt these bytes are."""
+    m = NAME_RE.match(path.name)
+    if not m:
+        # MUTATE:name-shape:return ("0", "0", "1")
+        raise Defect(
+            f"{path.name} is not a progress artifact's name — it is `review-<pr>-<n>.progress.jsonl`, or "
+            f"`review-<pr>-<n>.a<k>.progress.jsonl` for launch attempt k >= 2. The name is what binds "
+            f"these bytes to a pass and an ATTEMPT; a file wearing another name was written by something "
+            f"we do not know"
+        )
+    return m.group("pr"), m.group("pass"), m.group("attempt") or "1"
+
+
+def evaluate(progress: Path, head_sha: str, ruled: int = 0) -> "tuple[str, str]":
+    """The whole read side. Every exception a rule can raise lands here as a VERDICT — never as a crash."""
+    try:
+        pr, npass, attempt = parse_name(progress)
+        events = read_lines(progress, "progress file")
+        check_events(events, progress)
+        check_identity(events, pr, npass, attempt, head_sha)
+        units = load_plan(progress.parent / PLAN_NAME.format(pr=pr, **{"pass": npass}))
+        return decide(events, units, ruled)
+    except Defect as exc:
+        return UNUSABLE, str(exc)
+
+
+def check_events(events: "list[dict]", path: Path) -> None:
+    for n, rec in enumerate(events, start=1):
+        check_event(rec, f"{path.name} line {n}")
+
+
+def count_amendments(progress: Path) -> int:
+    """How many amendments the file holds — read WITHOUT judging it, so `--amendments-ruled` can be
+    checked against reality before any verdict is computed."""
+    try:
+        return sum(1 for e in read_lines(progress, "progress file") if e.get("type") == AMENDMENT)
+    except Defect:
+        return 0  # a file we cannot read has no countable amendments; `evaluate` will say so, loudly
+
+
+# --- the write side (the same rules, at the other door) ------------------------------------------
+
+def append(path: Path, rec: dict) -> str:
+    line = json.dumps(rec, separators=(",", ":")) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as out:
+        out.write(line)
+    return line
+
+
+def cmd_emit(args) -> int:
+    """Append one unit-progress event — the ONLY sanctioned way a reviewer records one.
+
+    It refuses an unplanned unit HERE TOO, and not only in `verify`: the reviewer gets a non-zero exit and
+    a message it can act on, at the moment it makes the mistake, instead of a pass silently thrown away
+    fifteen minutes later.
+    """
+    path = Path(args.file)
+    pr, npass, _attempt = parse_name(path)
+    unit = args.unit.strip()
+    if not unit:
+        # MUTATE:emit-empty-unit:pass
+        raise Defect("--unit must be non-empty")
+    if args.status == DONE and (args.evidence is None or not args.evidence.strip()):
+        # MUTATE:emit-done-evidence:pass
+        raise Defect(
+            "--evidence is required and must be non-empty when --status is done: a unit is not done "
+            "because you say so, it is done because you can CITE what you checked"
+        )
+    if args.status == STARTED and args.evidence is not None:
+        # MUTATE:emit-started-evidence:pass
+        raise Defect("--evidence must NOT be provided when --status is started")
+
+    rec = {"type": PROGRESS, "unit": unit, "status": args.status}
+    if args.status == DONE:
+        rec["evidence"] = args.evidence
+    check_event(rec, "the event you asked to emit")
+    units = load_plan(path.parent / PLAN_NAME.format(pr=pr, **{"pass": npass}))
+    if unit not in units:
+        # MUTATE:emit-unplanned:pass
+        raise Defect(
+            f"unit {unit!r} is NOT IN THE PLAN — you may not self-grant a unit. Planned: {sorted(units)}. "
+            f"If the plan is missing a dimension, raise a plan_amendment_request instead"
+        )
+    sys.stdout.write(append(path, rec))
+    return 0
+
+
+def cmd_identity(args) -> int:
+    """Write a pass's `pass_identity` — the line that used to be a `printf`, and once got a TRUNCATED SHA."""
+    path = Path(args.file)
+    pr, npass, attempt = parse_name(path)
+    if path.exists() and path.read_text(encoding="utf-8", errors="replace").strip():
+        # MUTATE:identity-write-first:pass
+        raise Defect(
+            f"{path.name} already holds events — `pass_identity` is the FIRST line of a launch attempt's "
+            f"progress file, written before the reviewer starts. A relaunch gets its OWN file "
+            f"(`review-<pr>-<n>.a<k>.progress.jsonl`), never this one"
+        )
+    rec = {
+        "type": IDENTITY, "pr": pr, "pass": npass, "head_sha": args.head_sha,
+        "launch_attempt": attempt, "dispatched_at": args.dispatched_at,
+    }
+    # The SAME two functions the read side runs — so a `pass_identity` this door writes is one `verify`
+    # can never call malformed, and the sha/clock rules exist in exactly one place.
+    check_event(rec, "the pass_identity you asked to write")
+    check_identity_shape(rec, "the pass_identity you asked to write")
+    sys.stdout.write(append(path, rec))
+    return 0
+
+
+def cmd_plan_add(args) -> int:
+    """Append one validated unit to a pass's plan — the artifact that used to be a shell heredoc."""
+    path = Path(args.file)
+    rec = {
+        "type": UNIT, "id": args.id, "kind": args.kind, "target": args.target,
+        "checks": list(args.check),
+    }
+    check_unit(rec, "the unit you asked to add")
+    if path.exists():
+        for existing in read_lines(path, "plan"):
+            check_unit(existing, f"{path.name}")
+            if existing["id"] == rec["id"]:
+                # MUTATE:plan-add-duplicate:break
+                raise Defect(f"the plan already holds a unit {rec['id']!r}")
+    sys.stdout.write(append(path, rec))
+    return 0
+
+
+def cmd_verify(args) -> int:
+    path = Path(args.file)
+    if not SHA_RE.match(args.head_sha):
+        # MUTATE:caller-sha:pass
+        raise OperatorError(
+            f"--head-sha {args.head_sha!r} is not a git object id (40 LOWERCASE hex) — refusing to verify. "
+            f"Every comparison below would be against a value that cannot be a commit, so the verdict "
+            f"would be about the wrong question. No verdict beats a wrong one"
+        )
+    raised = count_amendments(path)
+    if args.amendments_ruled > raised:
+        # MUTATE:caller-ruled:pass
+        raise OperatorError(
+            f"--amendments-ruled {args.amendments_ruled} but this pass raised only {raised} amendment(s) — "
+            f"a ruling can only ever answer an amendment that EXISTS, and an over-count would silently "
+            f"clear the next one the reviewer raises"
+        )
+    verdict, reason = evaluate(path, args.head_sha, args.amendments_ruled)
+    print(f"{verdict}: {reason}")
+    # `ok` is the ONLY exit-0 verdict — and it still is NOT `SATISFIED`.
+    return 0 if verdict == OK else 1
+
+
+# --- self-test: the fixtures ARE the contract ----------------------------------------------------
+#
+# Every rule above marks itself `# MUTATE:<id>:<weakening>` on the line ABOVE the statement that ENFORCES
+# it. `self-test` then does three things, in order, and the third is the one that matters:
+#
+#   1. runs every fixture and asserts its verdict AND the needle its reason must contain (the reason is
+#      the only thing that says WHICH rule fired — a fixture that goes `unusable` for someone else's
+#      reason pins NOTHING);
+#   2. asserts that EVERY enforcement point in a rule function sits under a marker. A rule ADDED without
+#      one is never mutated, so nothing could ever report it unpinned. An unmarked rule is an untested one;
+#   3. DELETES each rule in turn — splicing in its weakening — re-runs every fixture and every CLI case,
+#      and FAILS if no fixture notices.
+#
+# Step 3 exists because step 1 CANNOT see the failure that matters most: a rule NOTHING tests. Delete such
+# a rule and the suite stays green while the tool has quietly stopped checking. A sibling PR in this repo
+# proved the danger is not theoretical: a hand-written "N rules pinned" matrix was TRUE and INSUFFICIENT —
+# 8 guards were not in the inventory at all, and 7 of those were pinned by nothing. THE COUNT IS A CLAIM.
+# So the count is DERIVED, here, on every CI run, and "which rules are unpinned?" is a question the SUITE
+# answers rather than one a reviewer has to discover.
+
+SHA = "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c"
+OTHER_SHA = "b" * 40
+TS = "2026-07-06T00:00:00Z"
+
+
+def ident(**over) -> str:
+    rec = {"type": IDENTITY, "pr": "41", "pass": "1", "head_sha": SHA,
+           "launch_attempt": "1", "dispatched_at": TS}
+    rec.update(over)
+    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
+
+
+def unit(uid: str = "u01", **over) -> str:
+    rec = {"type": UNIT, "id": uid, "kind": "file", "target": "scripts/review-pass.py",
+           "checks": ["the read side refuses what the write side refuses"]}
+    rec.update(over)
+    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
+
+
+def started(uid: str = "u01", **over) -> str:
+    rec = {"type": PROGRESS, "unit": uid, "status": STARTED}
+    rec.update(over)
+    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
+
+
+def done(uid: str = "u01", evidence: str = "review-pass.py:42 `check_event`", **over) -> str:
+    rec = {"type": PROGRESS, "unit": uid, "status": DONE, "evidence": evidence}
+    rec.update(over)
+    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
+
+
+def amendment(**over) -> str:
+    rec = {"type": AMENDMENT, "ts": TS, "reason": "no unit covers the mutation harness",
+           "proposed_unit": json.loads(unit("u99"))}
+    rec.update(over)
+    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
+
+
+class _Drop:
+    """A sentinel that REMOVES a key from a fixture record — so a fixture can omit a REQUIRED field."""
+
+
+DROP = _Drop()
+
+PLAN = [unit("u01"), unit("u02", target="stage-2-review-gate.md", checks=["the docs match the tool"])]
+WORKED = [ident(), started("u01"), done("u01"), started("u02"), done("u02", evidence="stage-2:161")]
+
+# A progress file written as BYTES, not lines — a sound pass with one byte in it that is not UTF-8. Read
+# leniently, `\xff` becomes U+FFFD and the file quietly says something it does not say.
+RAW_BYTES = b'{"type":"progress","unit":"u01","status":"done","evidence":"\xff"}\n'
+
+# name -> (plan lines, progress lines, expected verdict, needle its reason must contain, why it exists).
+# EVERY fixture must FAIL WHEN ITS RULE IS DELETED — that is what step 3 above checks, one rule at a time.
+CASES = {
+    "worked": (PLAN, WORKED, OK, "ARTIFACTS are sound", "the shape of a pass that counts — and the tool STILL does not say SATISFIED"),
+
+    # THE HEADLINES.
+    "unplanned-done": (PLAN, [ident(), done("u99")], UNUSABLE, "NOT IN THE PLAN",
+                       "a `done` for a unit nobody planned. The rule was PROSE and enforced by NOBODY: the write tool accepted it and the read side never looked"),
+    "unplanned-started": (PLAN, [ident(), started("u99")], UNUSABLE, "NOT IN THE PLAN",
+                          "…and a `started` for one, which is what a reviewer inventing a unit does FIRST"),
+    "done-no-evidence": (PLAN, [ident(), done("u01", evidence=DROP)], UNUSABLE, "carries EXACTLY",
+                         "a `done` with no evidence key at all — a claim with nothing behind it"),
+    "done-blank-evidence": (PLAN, [ident(), done("u01", evidence="   ")], UNUSABLE, "CONCRETE evidence",
+                            "…and a `done` whose evidence is whitespace, which the key check cannot see"),
+    "short-sha": (PLAN, [ident(head_sha=SHA[:7]), done("u01"), done("u02")], UNUSABLE, "A prefix is not a commit",
+                  "a truncated sha in a hand-written pass_identity — this HAPPENED, in production"),
+    "handwritten-bogus": (PLAN, [ident(), '{"type":"progress","unit_id":"u01","status":"done","evidence":"x"}'],
+                          UNUSABLE, "carries EXACTLY",
+                          "the reviewer bypassed the emit tool and hand-wrote a line — with `unit_id`, the exact renaming stage-2 forbids. The READ side catches it: it never assumes the write tool was used"),
+
+    # The progress file's line-level shape.
+    "blank-line": (PLAN, [ident(), "", done("u01")], UNUSABLE, "is blank", "JSONL has no blank lines"),
+    "not-json": (PLAN, [ident(), "u01 done"], UNUSABLE, "is not JSON", "a corrupt line is a corrupt artifact, never one to skip"),
+    "not-object": (PLAN, [ident(), '"u01 done"'], UNUSABLE, "not a JSON object", "a bare string is not an event"),
+    "duplicate-key": (PLAN, [ident(), '{"type":"progress","unit":"u99","unit":"u01","status":"started"}'],
+                      UNUSABLE, "duplicate member name", "the decoder DISCARDS the first value, so the unplanned `u99` in the bytes reaches no rule at all"),
+    "too-deep": (PLAN, [ident(), '{"type":"progress","unit":' + "[" * 20000 + "]" * 20000 + ',"status":"started"}'],
+                 UNUSABLE, "nested too deeply", "the decoder RAISED where a verdict was owed, and a crash is not a verdict"),
+    "unknown-event": (PLAN, [ident(), '{"type":"unit_done","unit":"u01"}'], UNUSABLE, "UNRECOGNISED event type",
+                      "the exact renaming stage-2 forbids (`unit_done`) — skipping it makes the pass read as incomplete-but-clean"),
+    "bad-status": (PLAN, [ident(), started("u01", status="finished")], UNUSABLE, "the only unit-progress statuses",
+                   "a status the tool never emits — it can only have been hand-written"),
+    "extra-key": (PLAN, [ident(), done("u01", ts=TS)], UNUSABLE, "present and NOT COUNTED",
+                  "a `done` carrying a `ts` nothing reads (stage-2 forbids extra keys by name)"),
+    "non-string": (PLAN, [ident(), done("u01", evidence=["file.py:1"])], UNUSABLE, "not a string",
+                   "evidence as a LIST — it used to be handed straight to `.strip()`"),
+    "started-with-evidence": (PLAN, [ident(), started("u01", evidence="x")], UNUSABLE, "carries EXACTLY",
+                              "a `started` carrying evidence: the mirror of a `done` without it"),
+
+    # pass_identity — the binding to a PR, a pass, an ATTEMPT and a COMMIT.
+    "no-identity": (PLAN, [done("u01"), done("u02")], UNUSABLE, "NO `pass_identity`",
+                    "two done units and nothing saying WHAT they reviewed"),
+    "identity-not-first": (PLAN, [started("u01"), ident(), done("u01")], UNUSABLE, "not the FIRST line",
+                           "an event written BEFORE the reviewer was dispatched"),
+    "identity-twice": (PLAN, [ident(), ident(head_sha=OTHER_SHA), done("u01")], UNUSABLE, "2 `pass_identity`",
+                       "a second identity naming another commit — read by nothing, present in the bytes"),
+    "wrong-head": (PLAN, [ident(head_sha=OTHER_SHA), done("u01"), done("u02")], UNUSABLE, "no longer there",
+                   "the pass ran on a commit that is not the tip: its verdict describes content that has moved"),
+    "identity-bad-number": (PLAN, [ident(launch_attempt="one"), done("u01")], UNUSABLE, "not a decimal number",
+                            "an attempt number that cannot be COMPARED to the one in the filename"),
+    "identity-bad-ts": (PLAN, [ident(dispatched_at="just now"), done("u01")], UNUSABLE, "LAUNCH DEADLINE's clock",
+                        "a dispatched_at nobody can parse — the ~5-min deadline measured from it NEVER FIRES"),
+    "identity-missing-key": (PLAN, [ident(dispatched_at=DROP), done("u01")], UNUSABLE, "carries EXACTLY",
+                             "a pass_identity with no dispatch clock at all"),
+
+    # The plan.
+    "plan-empty": ([], WORKED, UNUSABLE, "VACUOUSLY TRUE",
+                   "an EMPTY plan: 'every planned unit is done' is true of it, so a pass that reviewed NOTHING would verify ok"),
+    "plan-duplicate-id": ([unit("u01"), unit("u01", target="other.py")], [ident(), done("u01")], UNUSABLE,
+                          "duplicate unit id", "two units with one id — a `done` for it says nothing about WHICH was checked"),
+    "plan-unknown-type": ([unit("u01"), unit("u02", type="note")], WORKED, UNUSABLE, "only 'unit'",
+                          "a plan line of a type nothing reads — perfectly unit-SHAPED, and still not a unit"),
+    "plan-unit-extra-key": ([unit("u01", owner="me")], [ident(), done("u01")], UNUSABLE, "unexpected key",
+                            "a unit carrying a field nothing reads"),
+    "plan-unit-no-checks": ([unit("u01", checks=[])], [ident(), done("u01")], UNUSABLE, "not a unit",
+                            "a unit with an EMPTY checks list — a heading, not a unit: nothing can be shown to have been done against it"),
+    "plan-unit-blank-target": ([unit("u01", target="  ")], [ident(), done("u01")], UNUSABLE, "names nothing",
+                               "a unit with no target"),
+    "plan-line-not-object": (['["u01"]'], [ident(), done("u01")], UNUSABLE, "not a JSON object",
+                             "a plan LINE that is a list — the strict reader refuses it at the plan door exactly as at the progress door"),
+    "amendment-unit-not-object": (PLAN, [ident(), amendment(proposed_unit="u99")], UNUSABLE, "not a JSON object",
+                                  "the amendment's proposed_unit is a STRING. This is the one place a non-dict unit can reach `check_unit` — the plan's own lines are objects by the time it runs — and it used to be handed straight to `set()`"),
+    "plan-missing": (None, WORKED, UNUSABLE, "no plan at",
+                     "NO PLAN FILE AT ALL. A guard whose input can be ABSENT never fires — so absence is refused, never skipped"),
+    "not-utf8": (PLAN, RAW_BYTES, UNUSABLE, "UTF-8",
+                 "bytes we cannot decode are not evidence — and decoding them LENIENTLY rewrites what the file says"),
+
+    # Amendments, completeness, and the verdicts that are not refusals.
+    "amendment-unruled": (PLAN, [ident(), done("u01"), amendment(), done("u02")], AMENDED, "not yet ruled on",
+                          "the reviewer says the plan is missing a dimension. It is a VERDICT, never a footnote printed beside `ok`"),
+    "amendment-bad-unit": (PLAN, [ident(), amendment(proposed_unit={"id": "u99"})], UNUSABLE, "carries EXACTLY",
+                           "a hand-written amendment (they are EXEMPT from the emit-only rule, so this is the one event a reviewer really does write) whose proposed unit is malformed"),
+    "incomplete": (PLAN, [ident(), started("u01"), done("u01"), started("u02")], INCOMPLETE, "has not covered its plan",
+                   "u02 was started and never finished — `started` is liveness, NEVER completion"),
+    "duplicate-done": (PLAN, [ident(), done("u01"), done("u01", evidence="somewhere else"), done("u02")],
+                       UNUSABLE, "SECOND", "two accounts of one unit, and nothing says which was read"),
+    "identity-only": (PLAN, [ident()], INCOMPLETE, "0/2",
+                      "the file the orchestrator leaves at dispatch: the reviewer has produced NOTHING, and this is not an error — it is a pass that has not covered its plan yet"),
+}
+
+# The NAME cases. Same sound pass every time — only the FILENAME differs, so the name is the only thing
+# under test. It is the one thing that says which PASS and which ATTEMPT these bytes are, and the docs
+# already name substituting attempt-1 paths into a relaunch a "silent self-defeat".
+NAME_CASES = [
+    ("review-41-1.progress.jsonl", OK, "ARTIFACTS are sound", "attempt 1's name — the real artifact's shape"),
+    ("review-41-1.a2.progress.jsonl", UNUSABLE, "silent self-defeat",
+     "THE ONE THAT MATTERS: a RELAUNCH's file holding attempt 1's identity. The live pass would be writing into the dead attempt's file, and the launch check would read it as never launched"),
+    ("review-42-1.progress.jsonl", UNUSABLE, "silent self-defeat", "another PR's pass, filed under this one"),
+    ("review-41-2.progress.jsonl", UNUSABLE, "silent self-defeat", "pass 2's file holding pass 1's identity"),
+    ("progress.jsonl", UNUSABLE, "not a progress artifact's name", "a name that binds these bytes to nothing at all"),
+    ("review-41-1.progress.json", UNUSABLE, "not a progress artifact's name", "one character off is not the artifact"),
+]
+
+# The WRITE door. Same rules, other side. `(argv, the progress file it runs against, expected exit, needle
+# in stdout+stderr, why)`. `emit-progress.py`'s CLI is unchanged, so the `emit` argv here are exactly what
+# a live reviewer prompt already runs — the contract those prompts were written against is the contract
+# still under test. The default seed is an EMPTY progress file: what the orchestrator has in hand when it
+# writes `pass_identity`, and what `emit` appends to thereafter.
+EMPTY: "list[str]" = []
+CLI_CASES = [
+    (["emit", "--unit", "u01", "--status", "started"], EMPTY, 0, '"status":"started"', "the call every reviewer prompt makes"),
+    (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], EMPTY, 0, '"evidence":"f.py:1"', "…and its done form"),
+    (["emit", "--unit", "u99", "--status", "done", "--evidence", "f.py:1"], EMPTY, 1, "NOT IN THE PLAN",
+     "HEADLINE, WRITE DOOR: the tool accepted a self-granted unit. It no longer does"),
+    (["emit", "--unit", "u99", "--status", "started"], EMPTY, 1, "NOT IN THE PLAN", "…and refuses to START one"),
+    (["emit", "--unit", "u01", "--status", "done"], EMPTY, 1, "--evidence is required", "a done with no evidence"),
+    (["emit", "--unit", "u01", "--status", "done", "--evidence", "  "], EMPTY, 1, "--evidence is required", "…or blank evidence"),
+    (["emit", "--unit", "u01", "--status", "started", "--evidence", "x"], EMPTY, 1, "must NOT be provided", "a started carrying evidence"),
+    (["emit", "--unit", "  ", "--status", "started"], EMPTY, 1, "--unit must be non-empty", "an empty unit id"),
+    (["identity", "--head-sha", SHA, "--dispatched-at", TS], EMPTY, 0, '"launch_attempt":"1"',
+     "the line that was a `printf` — pr/pass/attempt now come from the FILENAME, so they cannot disagree with it"),
+    (["identity", "--head-sha", SHA[:7], "--dispatched-at", TS], EMPTY, 1, "escaped into this repo's real state",
+     "HEADLINE, WRITE DOOR: the truncated sha that got written into a real pass_identity"),
+    (["identity", "--head-sha", SHA.upper(), "--dispatched-at", TS], EMPTY, 1, "LOWERCASE",
+     "an UPPERCASE sha: no producer of ours emits one, so it did not come from `git rev-parse`"),
+    (["identity", "--head-sha", SHA, "--dispatched-at", "just now"], EMPTY, 1, "LAUNCH DEADLINE's clock",
+     "a dispatch clock the launch deadline cannot be measured from — the write door runs the READ side's shape rules, so it cannot write one `verify` would reject"),
+    (["identity", "--head-sha", OTHER_SHA, "--dispatched-at", TS], [ident()], 1, "already holds events",
+     "a SECOND identity into a live pass's file. `pass_identity` is the FIRST line, written before dispatch — a relaunch gets its OWN file, and appending here is how one pass ends up describing two commits"),
+    (["verify", "--head-sha", SHA[:7]], EMPTY, 2, "No verdict beats a wrong one",
+     "an OPERATOR error is not a snapshot verdict: exit 2, never a verdict computed from a comparison that could not have succeeded"),
+    (["verify", "--head-sha", SHA, "--amendments-ruled", "1"], EMPTY, 2, "raised only 0",
+     "a ruling for an amendment that does not exist would silently clear the NEXT one raised"),
+]
+
+# `plan-add` gets its own family: its `--check` is repeatable, so its argv do not fit the shape above.
+PLAN_CLI_CASES = [
+    (["--id", "u03", "--kind", "cross-cutting", "--target", "both doors", "--check", "a", "--check", "b"],
+     0, '"checks":["a","b"]', "the plan stops being a shell heredoc"),
+    (["--id", "u01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "already holds a unit",
+     "a duplicate id — a `done` for it would say nothing about which unit was checked"),
+    (["--id", "  ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "names nothing", "a blank id"),
+    (["--id", "u03", "--kind", "file", "--target", "x.py"], 1, "not a unit", "a unit with NO checks"),
+]
+
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def build(tmp: Path, name: str, plan: "list[str] | None", progress: "list[str] | bytes") -> Path:
+    """Write a fixture pass to disk RAW — bypassing every write-side check, because half these fixtures
+    hold exactly what the write side would have refused. That is the point: the READ side must catch them
+    without being told how they got there. (`progress` as BYTES is how a fixture holds what is not text.)"""
+    d = tmp / name
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "review-41-1.progress.jsonl"
+    if isinstance(progress, bytes):
+        path.write_bytes(progress)
+    else:
+        path.write_text("".join(line + "\n" for line in progress), encoding="utf-8")
+    if plan is not None:
+        (d / "review-41-1.plan.jsonl").write_text("".join(line + "\n" for line in plan), encoding="utf-8")
+    return path
+
+
+def run_cli(mod: types.ModuleType, argv: "list[str]") -> "tuple[int, str]":
+    """Drive the REAL CLI in-process: (exit code, stdout+stderr). Never the internals — so argparse, the
+    `Defect`/`OperatorError` -> exit-code mapping, and `main()`'s wiring are all under test too."""
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            code = mod.main(argv)
+    except SystemExit as exc:  # argparse -> 2
+        code = exc.code if isinstance(exc.code, int) else 1
+    return code, out.getvalue() + err.getvalue()
+
+
+def run_cases(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
+    """Every fixture, every name case and every CLI case, against this (possibly mutated) module.
+
+    A mutant that CRASHES has not returned a verdict, and "no verdict" is itself a deviation — recorded,
+    never swallowed."""
+    got: dict[str, tuple[str, str]] = {}
+    for name, (plan, progress, _want, _needle, _why) in CASES.items():
+        path = build(tmp, f"case-{name}", plan, progress)
+        try:
+            got[name] = mod.evaluate(path, SHA)
+        except Exception as exc:  # noqa: BLE001 - a crash IS the result here
+            got[name] = (f"crash:{type(exc).__name__}", str(exc))
+    for i, (name, _want, _needle, _why) in enumerate(NAME_CASES):
+        d = build(tmp, f"name-{i}", PLAN, WORKED).parent
+        path = d / name
+        path.write_text("".join(line + "\n" for line in WORKED), encoding="utf-8")
+        try:
+            got[f"[name] {name}"] = mod.evaluate(path, SHA)
+        except Exception as exc:  # noqa: BLE001
+            got[f"[name] {name}"] = (f"crash:{type(exc).__name__}", str(exc))
+    for i, (argv, seed, _want, _needle, _why) in enumerate(CLI_CASES):
+        path = build(tmp, f"cli-{i}", PLAN, seed)
+        try:
+            code, text = run_cli(mod, [argv[0], "--file", str(path), *argv[1:]])
+            got[f"[cli] {' '.join(argv)}"] = (f"exit{code}", text)
+        except Exception as exc:  # noqa: BLE001
+            got[f"[cli] {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
+    for i, (argv, _want, _needle, _why) in enumerate(PLAN_CLI_CASES):
+        plan = build(tmp, f"plan-cli-{i}", PLAN, []).parent / "review-41-1.plan.jsonl"
+        try:
+            code, text = run_cli(mod, ["plan-add", "--file", str(plan), *argv])
+            got[f"[plan] {' '.join(argv)}"] = (f"exit{code}", text)
+        except Exception as exc:  # noqa: BLE001
+            got[f"[plan] {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
+    return got
+
+
+def expectations() -> "dict[str, tuple[str, str, str]]":
+    """case -> (expected outcome, needle its output must contain, why the case exists)."""
+    out = {n: (w, needle, why) for n, (_p, _pr, w, needle, why) in CASES.items()}
+    out.update({f"[name] {n}": (w, needle, why) for n, w, needle, why in NAME_CASES})
+    out.update({f"[cli] {' '.join(a)}": (f"exit{c}", needle, why) for a, _seed, c, needle, why in CLI_CASES})
+    out.update({f"[plan] {' '.join(a)}": (f"exit{c}", needle, why) for a, c, needle, why in PLAN_CLI_CASES})
+    return out
+
+
+# The outcomes that mean "this passed": a mutant that turns a failing case into one of these has produced
+# the loudest possible failure — the weakened tool says "ship it" about artifacts that are defective.
+PASSING = (OK, "exit0")
+
+MARKER_RE = re.compile(r"^(?P<indent>[ ]*)# MUTATE:(?P<rule>[a-z0-9-]+):(?P<weakening>.+?)\s*$")
+
+# The functions that ENFORCE the contract. Every enforcement point inside them must carry a marker.
+# `evaluate` is not one: it MAPS an exception to a verdict; it decides nothing.
+RULE_FUNCTIONS = (
+    "hook", "read_lines", "check_unit", "load_plan", "check_event", "check_identity_shape",
+    "check_identity", "decide", "parse_name", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
+)
+ENFORCING_EXCEPTIONS = ("Defect", "OperatorError")
+ENFORCING_VERDICTS = (INCOMPLETE, AMENDED, UNUSABLE)  # `return OK` is the ABSENCE of a rule
+
+FALSE_PASS, VERDICT_KILL, MESSAGE_KILL, CRASH_KILL = "FALSE-PASS", "VERDICT", "MESSAGE", "CRASH"
+
+
+def markers(source: str) -> "list[tuple[str, str, int]]":
+    out = []
+    for n, line in enumerate(source.splitlines(), 1):
+        m = MARKER_RE.match(line)
+        if m:
+            out.append((m.group("rule"), m.group("weakening"), n))
+    return out
+
+
+def marked_statements(source: str) -> "dict[str, tuple[str, object]]":
+    """rule id -> (weakening, the statement the marker sits directly above)."""
+    import ast
+
+    tree = ast.parse(source)
+    stmts = {node.lineno: node for node in ast.walk(tree) if isinstance(node, ast.stmt)}
+    out: dict = {}
+    for rule, weakening, line in markers(source):
+        stmt = stmts.get(line + 1)
+        if stmt is None:
+            raise SelfTestFailure(f"# MUTATE:{rule} on line {line} sits above no statement")
+        if rule in out:
+            raise SelfTestFailure(f"duplicate rule id {rule!r} — every rule is marked exactly once")
+        out[rule] = (weakening, stmt)
+    if not out:
+        raise SelfTestFailure("no MUTATE markers — the rules cannot mark themselves absent")
+    return out
+
+
+def unmarked(source: str, marked: dict) -> "list[str]":
+    """EVERY refusal and every non-OK return in a rule function must sit under a marker.
+
+    This is the half of the question fixtures can NEVER answer. A rule added without a marker is never
+    mutated, so nothing ever asks whether a fixture would notice its absence — it is reported "pinned" by
+    nobody having looked. THE COUNT IS A CLAIM, and this is what makes the claim checkable: the inventory
+    is DERIVED from the source, never typed into a report.
+    """
+    import ast
+
+    lines = {stmt.lineno for _w, stmt in marked.values()}
+    problems = []
+    for fn in ast.walk(ast.parse(source)):
+        if not isinstance(fn, ast.FunctionDef) or fn.name not in RULE_FUNCTIONS:
+            continue
+        for node in ast.walk(fn):
+            enforcing = False
+            if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+                enforcing = getattr(node.exc.func, "id", None) in ENFORCING_EXCEPTIONS
+            elif isinstance(node, ast.Return) and isinstance(node.value, ast.Tuple) and node.value.elts:
+                first = node.value.elts[0]
+                enforcing = isinstance(first, ast.Name) and first.id in (
+                    "INCOMPLETE", "AMENDED", "UNUSABLE")
+            if enforcing and node.lineno not in lines:
+                what = "raise" if isinstance(node, ast.Raise) else "return"
+                problems.append(
+                    f"review-pass.py:{node.lineno}: {fn.name}() enforces a rule ({what}) with NO "
+                    f"# MUTATE marker — an unmarked rule is never mutated, so nothing can report it unpinned"
+                )
+    return problems
+
+
+def mutate(source: str, rule: str, weakening: str, stmt) -> str:
+    lines = source.splitlines()
+    body = [f"{' ' * stmt.col_offset}{weakening}  # MUTANT:{rule}"]
+    return "\n".join(lines[: stmt.lineno - 1] + body + lines[stmt.end_lineno:]) + "\n"
+
+
+def load_module(source: str, name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.__file__ = __file__
+    exec(compile(source, f"<{name}>", "exec"), mod.__dict__)  # noqa: S102 - the whole job
+    return mod
+
+
+def self_test() -> int:
+    source = Path(__file__).read_text(encoding="utf-8")
+    expect = expectations()
+    failures = 0
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        got = run_cases(sys.modules[__name__], Path(tmpdir))
+    for case, (want, needle, why) in expect.items():
+        outcome, text = got[case]
+        if outcome == want and needle in text:
+            print(f"ok       {case[:44]:44} -> {outcome:11} ({why})")
+        elif outcome != want:
+            print(f"FAIL     {case[:44]:44} -> {outcome:11} expected {want}\n         got: {text}")
+            failures += 1
+        else:
+            # Right outcome, WRONG RULE. The message is the only thing that says which rule fired, and a
+            # fixture that goes `unusable` for someone else's reason pins nothing.
+            print(f"FAIL     {case[:44]:44} -> {outcome:11} but nothing mentions {needle!r}\n         got: {text}")
+            failures += 1
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the review-pass contract is broken.")
+        return 1
+    print(f"all {len(CASES)} fixtures + {len(NAME_CASES)} name cases + "
+          f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases hold.\n")
+
+    # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
+    marked = marked_statements(source)
+    gaps = unmarked(source, marked)
+    for gap in gaps:
+        print(f"UNMARKED {gap}")
+    if gaps:
+        print(f"\n{len(gaps)} enforcement point(s) carry NO marker.")
+        return 1
+
+    print(f"{'rule':24} {'weakened to':42} {'killed by':32} {'outcome':11} kill")
+    print(f"{'-' * 24} {'-' * 42} {'-' * 32} {'-' * 11} ----")
+    unpinned, broken, tally = [], [], Counter()
+    for rule, (weakening, stmt) in marked.items():
+        try:
+            mod = load_module(mutate(source, rule, weakening, stmt), f"rp_mutant_{rule.replace('-', '_')}")
+        except SyntaxError as exc:
+            broken.append(f"{rule}: the weakening {weakening!r} does not compile ({exc})")
+            continue
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mutant = run_cases(mod, Path(tmpdir))
+        # A mutation only ever REMOVES a rule, so it can never turn a PASSING case into a failing one.
+        # If it does, the mutation is bogus — a harness bug, never a pinned rule.
+        wrong = [f"{c} expected {w} but the mutant returned {mutant[c][0]}"
+                 for c, (w, _n, _y) in expect.items() if w in PASSING and mutant[c][0] != w]
+        if wrong:
+            broken.append(f"{rule}: BOGUS MUTATION — {'; '.join(wrong)}")
+            continue
+        killers = []
+        for case, (want, needle, _why) in expect.items():
+            if want in PASSING:
+                continue  # a case that PASSES cannot kill a rule; it is a canary (checked above)
+            outcome, text = mutant[case]
+            if outcome in PASSING:
+                strength = FALSE_PASS
+            elif outcome.startswith("crash:"):
+                strength = CRASH_KILL
+            elif outcome != want:
+                strength = VERDICT_KILL
+            elif needle not in text:
+                strength = MESSAGE_KILL
+            else:
+                continue
+            killers.append((strength, case, outcome))
+        order = {FALSE_PASS: 0, VERDICT_KILL: 1, CRASH_KILL: 2, MESSAGE_KILL: 3}
+        killers.sort(key=lambda k: (order[k[0]], k[1]))
+        if not killers:
+            print(f"{rule:24} {weakening[:42]:42} {'NOTHING':32} {'—':11} UNPINNED")
+            unpinned.append(rule)
+            continue
+        strength, case, outcome = killers[0]
+        extra = f" (+{len(killers) - 1} more)" if len(killers) > 1 else ""
+        tally[strength] += 1
+        print(f"{rule:24} {weakening[:42]:42} {case[:32]:32} {outcome:11} {strength}{extra}")
+
+    print()
+    for b in broken:
+        print(f"HARNESS BROKEN: {b}")
+    if unpinned:
+        print(f"{len(unpinned)} RULE(S) PINNED BY NO FIXTURE: {', '.join(unpinned)}\n"
+              f"Delete any one of them and the fixtures still pass — the suite would report total health "
+              f"while the tool had stopped checking. Write a fixture that FAILS when the rule is gone.")
+    if unpinned or broken:
+        return 1
+    print(f"all {len(marked)} rules are pinned: {tally[FALSE_PASS]} by a FALSE PASS, "
+          f"{tally[VERDICT_KILL]} by a verdict change, {tally[CRASH_KILL]} by a crash, "
+          f"{tally[MESSAGE_KILL]} by its message. Remove any rule and a fixture fails.")
+    return 0
+
+
+# --- CLI -----------------------------------------------------------------------------------------
+
+def fail(msg: str, code: int) -> NoReturn:
+    print(f"review-pass: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("emit", help="append one unit-progress event (what emit-progress.py calls)")
+    e.add_argument("--file", required=True, help="the launch attempt's progress.jsonl")
+    e.add_argument("--unit", required=True, help="a PLANNED unit's id — an unplanned one is refused")
+    e.add_argument("--status", required=True, choices=STATUSES)
+    e.add_argument("--evidence", help="concrete citation; REQUIRED for --status done")
+
+    i = sub.add_parser("identity", help="write a pass's pass_identity line (pr/pass/attempt come from --file)")
+    i.add_argument("--file", required=True, help="the launch attempt's progress.jsonl — it must not exist yet")
+    i.add_argument("--head-sha", required=True, help="`git rev-parse HEAD` — 40 hex, NEVER an abbreviation")
+    i.add_argument("--dispatched-at", required=True, help="UTC ISO-8601, e.g. 2026-07-06T00:00:00Z")
+
+    a = sub.add_parser("plan-add", help="append one validated unit to a pass's plan")
+    a.add_argument("--file", required=True, help="the pass's plan.jsonl")
+    a.add_argument("--id", required=True)
+    a.add_argument("--kind", required=True, help="file | cross-cutting | docs | …")
+    a.add_argument("--target", required=True, help="the CONCRETE thing reviewed")
+    a.add_argument("--check", action="append", default=[], help="a concrete check; repeat (at least one)")
+
+    v = sub.add_parser("verify", help="DOES THIS PASS COUNT? (it never reads the reviewer's report)")
+    v.add_argument("--file", required=True, help="the ACTIVE launch attempt's progress.jsonl")
+    v.add_argument("--head-sha", required=True, help="the PR's LIVE head — the pass must have run on it")
+    v.add_argument("--amendments-ruled", type=int, default=0, metavar="N",
+                   help="how many of this pass's plan amendments you have already ruled on (default 0)")
+
+    sub.add_parser("self-test", help="run every fixture, then DELETE each rule and prove a fixture notices")
+
+    args = p.parse_args(argv)
+    if args.cmd == "self-test":
+        return self_test()
+    try:
+        return {"emit": cmd_emit, "identity": cmd_identity,
+                "plan-add": cmd_plan_add, "verify": cmd_verify}[args.cmd](args)
+    except Defect as exc:
+        fail(str(exc), 1)
+    except OperatorError as exc:
+        fail(str(exc), 2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -60,6 +60,7 @@ so. Absent that, the guard fires: the DEFAULT is that nothing has been ruled on.
 from __future__ import annotations
 
 import argparse
+import ast
 import io
 import json
 import re
@@ -96,7 +97,7 @@ STATUSES = (STARTED, DONE)
 # is PRESENT AND NOT COUNTED: a `done` with a `ts` nobody parses, a `pass_identity` with a second sha. The
 # progress events are keyed by (type, status) because a `started` carrying `evidence` is exactly as wrong
 # as a `done` without it — the evidence rule and the no-evidence rule are ONE rule, stated once.
-EVENT_KEYS = {
+EVENT_KEYS: "dict[tuple[str, str | None], set[str]]" = {
     (IDENTITY, None): {"type", "pr", "pass", "head_sha", "launch_attempt", "dispatched_at"},
     (PROGRESS, STARTED): {"type", "unit", "status"},
     (PROGRESS, DONE): {"type", "unit", "status", "evidence"},
@@ -226,8 +227,19 @@ def read_lines(path: Path, what: str) -> "list[dict]":
 
 # --- the plan ------------------------------------------------------------------------------------
 
-def check_unit(unit: dict, where: str) -> None:
-    """A plan unit, whether it sits in the plan or inside a `plan_amendment_request`. ONE definition."""
+def check_unit(unit: object, where: str) -> None:
+    """A plan unit, whether it sits in the plan or inside a `plan_amendment_request`. ONE definition.
+
+    **`unit: object` — NOT `dict` — and that is load-bearing, not pedantry.** This is handed values
+    straight out of `json.loads`, and a JSON value is whatever the file says it is: an amendment's
+    `proposed_unit` can arrive as a STRING (`"proposed_unit": "u99"`), and a reviewer hand-writes that
+    event — it is the one event type the emit-only rule exempts. Annotating the parameter `dict` would be
+    a promise no caller can keep, and a type checker reading that promise concludes the `isinstance` guard
+    below can never fire and the `raise` is UNREACHABLE. It is not: it fires, on that exact input, and the
+    fixture `amendment-unit-not-object` drives it. Believe the annotation and delete the "dead" guard, and
+    a string reaches `set(unit)` — which CRASHES, and a crash is not a verdict. Say what the caller can
+    actually promise, and the guard the tool needs is the guard the type checker asks for.
+    """
     if not isinstance(unit, dict):
         # MUTATE:unit-not-object:return
         raise Defect(f"{where}: the unit is not a JSON object")
@@ -646,44 +658,50 @@ OTHER_SHA = "b" * 40
 TS = "2026-07-06T00:00:00Z"
 
 
-def ident(**over) -> str:
-    rec = {"type": IDENTITY, "pr": "41", "pass": "1", "head_sha": SHA,
-           "launch_attempt": "1", "dispatched_at": TS}
-    rec.update(over)
-    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
-
-
-def unit(uid: str = "u01", **over) -> str:
-    rec = {"type": UNIT, "id": uid, "kind": "file", "target": "scripts/review-pass.py",
-           "checks": ["the read side refuses what the write side refuses"]}
-    rec.update(over)
-    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
-
-
-def started(uid: str = "u01", **over) -> str:
-    rec = {"type": PROGRESS, "unit": uid, "status": STARTED}
-    rec.update(over)
-    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
-
-
-def done(uid: str = "u01", evidence: str = "review-pass.py:42 `check_event`", **over) -> str:
-    rec = {"type": PROGRESS, "unit": uid, "status": DONE, "evidence": evidence}
-    rec.update(over)
-    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
-
-
-def amendment(**over) -> str:
-    rec = {"type": AMENDMENT, "ts": TS, "reason": "no unit covers the mutation harness",
-           "proposed_unit": json.loads(unit("u99"))}
-    rec.update(over)
-    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
-
-
 class _Drop:
-    """A sentinel that REMOVES a key from a fixture record — so a fixture can omit a REQUIRED field."""
+    """The sentinel that REMOVES a key from a fixture record, so a fixture can OMIT a required field.
+
+    It is not `None`: `null` is a legal JSON value, so a fixture must stay free to write
+    `"evidence": null` and watch the tool refuse it. "Absent" and "present and null" are different bytes
+    and different defects — collapse them onto one sentinel and one of the two becomes untestable.
+    """
 
 
 DROP = _Drop()
+
+# A fixture record's values are typed `object`, and that IS the type: these builders exist to write what
+# the schema FORBIDS — an `evidence` that is a list, a `proposed_unit` that is a string, a key that is not
+# there at all. Declaring them `str` would be a promise the fixtures are written to break, and a type
+# checker believing it would reject the very cases the read side must catch.
+Value = object
+
+
+def _rec(fields: "dict[str, Value]", over: "dict[str, Value]") -> str:
+    rec = {**fields, **over}
+    return json.dumps({k: v for k, v in rec.items() if v is not DROP})
+
+
+def ident(**over: Value) -> str:
+    return _rec({"type": IDENTITY, "pr": "41", "pass": "1", "head_sha": SHA,
+                 "launch_attempt": "1", "dispatched_at": TS}, over)
+
+
+def unit(uid: str = "u01", **over: Value) -> str:
+    return _rec({"type": UNIT, "id": uid, "kind": "file", "target": "scripts/review-pass.py",
+                 "checks": ["the read side refuses what the write side refuses"]}, over)
+
+
+def started(uid: str = "u01", **over: Value) -> str:
+    return _rec({"type": PROGRESS, "unit": uid, "status": STARTED}, over)
+
+
+def done(uid: str = "u01", evidence: Value = "review-pass.py:42 `check_event`", **over: Value) -> str:
+    return _rec({"type": PROGRESS, "unit": uid, "status": DONE, "evidence": evidence}, over)
+
+
+def amendment(**over: Value) -> str:
+    return _rec({"type": AMENDMENT, "ts": TS, "reason": "no unit covers the mutation harness",
+                 "proposed_unit": json.loads(unit("u99"))}, over)
 
 PLAN = [unit("u01"), unit("u02", target="stage-2-review-gate.md", checks=["the docs match the tool"])]
 WORKED = [ident(), started("u01"), done("u01"), started("u02"), done("u02", evidence="stage-2:161")]
@@ -929,7 +947,10 @@ RULE_FUNCTIONS = (
     "check_identity", "decide", "parse_name", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
 )
 ENFORCING_EXCEPTIONS = ("Defect", "OperatorError")
-ENFORCING_VERDICTS = (INCOMPLETE, AMENDED, UNUSABLE)  # `return OK` is the ABSENCE of a rule
+# The NAMES as they are spelled in the source, because that is what the AST holds — `return UNUSABLE, …`
+# parses to an `ast.Name` whose `id` is "UNUSABLE", never to the string "unusable" it evaluates to.
+# `return OK` is the ABSENCE of a rule, so it is not here.
+ENFORCING_VERDICT_NAMES = ("INCOMPLETE", "AMENDED", "UNUSABLE")
 
 FALSE_PASS, VERDICT_KILL, MESSAGE_KILL, CRASH_KILL = "FALSE-PASS", "VERDICT", "MESSAGE", "CRASH"
 
@@ -943,13 +964,15 @@ def markers(source: str) -> "list[tuple[str, str, int]]":
     return out
 
 
-def marked_statements(source: str) -> "dict[str, tuple[str, object]]":
-    """rule id -> (weakening, the statement the marker sits directly above)."""
-    import ast
+def marked_statements(source: str) -> "dict[str, tuple[str, ast.stmt]]":
+    """rule id -> (weakening, the statement the marker sits directly above).
 
+    `ast.stmt`, never `ast.AST`: only a statement has a `lineno`/`end_lineno`, and those two are the whole
+    reason this is collected — they are the span `mutate()` replaces.
+    """
     tree = ast.parse(source)
     stmts = {node.lineno: node for node in ast.walk(tree) if isinstance(node, ast.stmt)}
-    out: dict = {}
+    out: dict[str, tuple[str, ast.stmt]] = {}
     for rule, weakening, line in markers(source):
         stmt = stmts.get(line + 1)
         if stmt is None:
@@ -962,31 +985,38 @@ def marked_statements(source: str) -> "dict[str, tuple[str, object]]":
     return out
 
 
-def unmarked(source: str, marked: dict) -> "list[str]":
+def unmarked(source: str, marked: "dict[str, tuple[str, ast.stmt]]") -> "list[str]":
     """EVERY refusal and every non-OK return in a rule function must sit under a marker.
 
     This is the half of the question fixtures can NEVER answer. A rule added without a marker is never
     mutated, so nothing ever asks whether a fixture would notice its absence — it is reported "pinned" by
     nobody having looked. THE COUNT IS A CLAIM, and this is what makes the claim checkable: the inventory
     is DERIVED from the source, never typed into a report.
-    """
-    import ast
 
+    Every node is NARROWED to the concrete statement type before its `lineno` is read. `ast.AST` does not
+    declare one — reaching through the base class for it is how this walk would silently start reading the
+    line number of something that has none.
+    """
     lines = {stmt.lineno for _w, stmt in marked.values()}
-    problems = []
+    problems: list[str] = []
     for fn in ast.walk(ast.parse(source)):
         if not isinstance(fn, ast.FunctionDef) or fn.name not in RULE_FUNCTIONS:
             continue
         for node in ast.walk(fn):
-            enforcing = False
-            if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
-                enforcing = getattr(node.exc.func, "id", None) in ENFORCING_EXCEPTIONS
-            elif isinstance(node, ast.Return) and isinstance(node.value, ast.Tuple) and node.value.elts:
-                first = node.value.elts[0]
-                enforcing = isinstance(first, ast.Name) and first.id in (
-                    "INCOMPLETE", "AMENDED", "UNUSABLE")
+            if isinstance(node, ast.Raise):
+                exc = node.exc
+                enforcing = (isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name)
+                             and exc.func.id in ENFORCING_EXCEPTIONS)
+                what = "raise"
+            elif isinstance(node, ast.Return):
+                val = node.value
+                enforcing = (isinstance(val, ast.Tuple) and bool(val.elts)
+                             and isinstance(val.elts[0], ast.Name)
+                             and val.elts[0].id in ENFORCING_VERDICT_NAMES)
+                what = "return"
+            else:
+                continue  # `node` is now an ast.stmt, so `lineno` below is one it really has
             if enforcing and node.lineno not in lines:
-                what = "raise" if isinstance(node, ast.Raise) else "return"
                 problems.append(
                     f"review-pass.py:{node.lineno}: {fn.name}() enforces a rule ({what}) with NO "
                     f"# MUTATE marker — an unmarked rule is never mutated, so nothing can report it unpinned"
@@ -994,7 +1024,7 @@ def unmarked(source: str, marked: dict) -> "list[str]":
     return problems
 
 
-def mutate(source: str, rule: str, weakening: str, stmt) -> str:
+def mutate(source: str, rule: str, weakening: str, stmt: ast.stmt) -> str:
     lines = source.splitlines()
     body = [f"{' ' * stmt.col_offset}{weakening}  # MUTANT:{rule}"]
     return "\n".join(lines[: stmt.lineno - 1] + body + lines[stmt.end_lineno:]) + "\n"

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -26,8 +26,10 @@ So this file is the review pass's artifacts, executed:
   identity    write a pass's `pass_identity` line                 (the SHA stops being a `printf`)
   emit        append ONE progress event                           (what `emit-progress.py` calls)
   verify      READ a pass and answer: DOES THIS PASS COUNT?       (the tally stops being by eye)
-  self-test   the fixtures, the proof that every rule is pinned by one, and every JSON example in the
-              docs fed THROUGH the tool (a documented example the tool refuses is a trap, not a typo)
+  self-test   the fixtures, the proof that every rule is pinned by one, every JSON example in the docs fed
+              THROUGH the tool (a documented example the tool refuses is a trap, not a typo), and EVERY
+              DOOR run in the shape its own `--help` advertises (a command the help promises and the tool
+              refuses is the same trap, one layer up — `plan-add` shipped one)
 
 WHAT `verify` DOES NOT DO — AND THE LINE IS DELIBERATE. It never opens `review-<pr>-<n>.txt`, never
 parses the reviewer's prose, and CANNOT SAY `SATISFIED`. Its whole answer is about the pass's MECHANICS:
@@ -95,6 +97,7 @@ import argparse
 import ast
 import io
 import json
+import os
 import re
 import subprocess
 import sys
@@ -1112,7 +1115,10 @@ def cmd_verify(args) -> int:
 #   3. asserts that EVERY enforcement point in a rule function sits under a marker. A rule ADDED without
 #      one is never mutated, so nothing could ever report it unpinned. An unmarked rule is an untested one;
 #   4. DELETES each rule in turn — splicing in its weakening — re-runs every fixture, every CLI case and
-#      the whole round trip, and FAILS if no fixture notices.
+#      the whole round trip, and FAILS if no fixture notices;
+#   5. EXECUTES EVERY DOOR — every subcommand the parser has, and the `emit-progress.py` wrapper — in the
+#      exact shape that door's OWN `--help` advertises, and fails when the tool refuses it (`check_doors`).
+#      A door is free to lie about what it takes until something RUNS what it says.
 #
 # Step 4 exists because step 1 CANNOT see the failure that matters most: a rule NOTHING tests. Delete such
 # a rule and the suite stays green while the tool has quietly stopped checking. A sibling PR in this repo
@@ -1385,7 +1391,19 @@ PLAN_CLI_CASES = [
      "HEADLINE, PLAN DOOR: THE FINDING. This exited 0, and the id it wrote was one `emit` could never match — because `emit` stripped its `--unit` and this door did not. The plan is the INTAKE: refuse the id here and no later door can be handed a unit it cannot name"),
     (PLAN_FILE, ["--id", "U01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "NOT AN ID",
      "…and an id that is merely a different SPELLING of a legal one. There is no such thing: an identifier has one form, so `U01` is not `u01` in capitals — it is not an id, and it is refused rather than folded"),
-    (PLAN_FILE, ["--id", "u03", "--kind", "file", "--target", "x.py"], 1, "not a unit", "a unit with NO checks"),
+    (PLAN_FILE, ["--id", "u03", "--kind", "file", "--target", "x.py"], 2,
+     "the following arguments are required: --check",
+     "HEADLINE, THE HELP DOOR: **THIS IS THE COMMAND `plan-add --help` ADVERTISED.** `--check` was OPTIONAL "
+     "to argparse — the usage line BRACKETED it, `[--check CHECK]` — and the write path then refused the "
+     "call with `checks is []`. So the exact invocation the tool's own help tells you to run exited 1 — and "
+     "the mechanical check written to stop precisely this had only ever executed the `emit-progress.py` "
+     "wrapper's help, never this script's own doors, so it could not fire on the case that mattered. It is "
+     "`required=True` now, so the refusal comes from ARGPARSE and NAMES THE FLAG "
+     "(exit 2 — the CALLER's mistake) instead of from a rule about the unit that was built without it"),
+    (PLAN_FILE, ["--id", "u03", "--kind", "file", "--target", "x.py", "--check", "  "], 1, "not a unit",
+     "…and the check that argparse CANNOT make: a `--check` that is present and BLANK. `required=True` says "
+     "a unit has checks; only `check_unit` can say a blank string is not one, and it is the same statement "
+     "the read door refuses an empty `checks` list with"),
     ("plan.jsonl", ["--id", "u03", "--kind", "file", "--target", "x.py", "--check", "a"], 1,
      "not a plan artifact's name",
      "the plan's name was enforced at the READ door BY CONSTRUCTION (`verify` derives it and takes no plan path) and at the write door NOT AT ALL: this wrote a perfectly valid plan to a name nothing will ever open, and the pass would then be refused for a MISSING plan with its units on disk one filename away"),
@@ -1748,28 +1766,79 @@ def check_docs() -> int:
     return failures
 
 
-# --- the WRAPPER's HELP: what it SAYS must be what the tool TAKES --------------------------------
+# --- EVERY DOOR'S HELP: what it SAYS must be what the tool TAKES ---------------------------------
 #
 # `emit-progress.py --help` printed `usage: emit-progress.py emit [-h] --file …`, and running that exact
 # command failed with `unrecognized arguments: emit` — the wrapper prepends `emit` itself, so its own help
 # advertised a command shape it REFUSES. Two doors disagreeing about what the COMMAND is, which is the same
 # defect as two doors disagreeing about what an ID is — and the help is the door a reviewer READS.
 #
-# An exhortation to "keep the help and the parser in sync" cannot fail. This can: the usage block is parsed
-# for the invocation it advertises, and **that invocation is EXECUTED** — as a subprocess, against a real
-# dispatched pass, exactly as a reviewer would run it. Advertise a command the tool refuses and the suite
-# goes red. The FLAGS are checked the same way, against the emit door's own `add_emit_args`: the help may
-# not name a flag the tool does not take, nor omit one it requires.
+# **AND THE CURE FOR THAT HAD THE DISEASE IT WAS CURING.** The check written for it was real — it ran
+# `--help`, parsed the invocation and EXECUTED it — and it did that for the WRAPPER AND NOTHING ELSE. This
+# script has five doors of its own and not one of them was ever looked at, so the very next help/parser lie
+# shipped straight underneath the check meant to stop it: `plan-add --help` printed `[--check CHECK]` —
+# argparse's brackets mean OPTIONAL — while the write path refused that exact advertised command with
+# `checks is [] — a unit with no concrete checks is not a unit`. The command the tool's own help tells you
+# to run exited 1. **A check that cannot fire on the case that matters is not a check; it is a claim.**
+#
+# So every door is driven, and the DOOR LIST IS DERIVED from `build_parser()` — never hand-written — so a
+# subcommand added tomorrow is covered the day it is added, by failing until someone says how to drive it.
+# For each door:
+#
+#   1. its `--help` runs;
+#   2. the usage block is parsed for the COMMAND WORDS it advertises, its REQUIRED flags (argparse leaves
+#      them bare) and its OPTIONAL ones (argparse BRACKETS them) — and that split must be the one the
+#      door's own parser declares;
+#   3. **the advertised MINIMAL invocation is EXECUTED** — the required flags and NOTHING ELSE — as a
+#      subprocess, against a realistic seed, exactly as a reviewer would run it. It must SUCCEED. This is
+#      the direction the wrapper's cure never asked about and the one `plan-add` lied in: **a flag the help
+#      calls OPTIONAL must really be OMITTABLE**, in the WRITE path and not merely in argparse;
+#   4. …and every REQUIRED flag is dropped in turn, and the door must REFUSE the call: **a flag the help
+#      calls REQUIRED must really be refused when absent.** Same lie, other direction.
 
-WRAPPER = Path(__file__).resolve().parent / "emit-progress.py"
+OWNER = Path(__file__).resolve()
+WRAPPER = OWNER.parent / "emit-progress.py"
+WRAPPER_DOOR = "emit-progress.py"
+
+# The `self-test` door is a door like any other, and EXECUTING it is what this check does to every door —
+# so probing it means self-test runs self-test. This is what stops that being infinite: the nested run sees
+# the variable and skips THIS check (only this one — everything else runs in full), so the door is really
+# executed, by the real parser, all the way through its real body.
+DOOR_PROBE_ENV = "REVIEW_PASS_DOOR_PROBE"
+
+# Each door's `--file` artifact, and the bytes that file realistically holds when a caller runs that door —
+# the state the ORCHESTRATOR has left at that point of a real pass. `None` bytes = the file does not exist
+# yet (`identity` writes the first line of a progress file; `plan-add` the first unit of a plan). `None`
+# artifact = the door takes no `--file`.
+DOOR_SEEDS: "dict[str, tuple[str | None, list[str] | None]]" = {
+    "emit": (PROGRESS_FILE, DISPATCHED),       # the reviewer's door: the identity is already in the file
+    WRAPPER_DOOR: (PROGRESS_FILE, DISPATCHED),  # …and the same door, through the wrapper a reviewer runs
+    "identity": (PROGRESS_FILE, None),         # it writes into a file that must hold NO BYTES
+    "plan-add": (PLAN_FILE, None),             # the first unit lands in a plan that does not exist yet
+    "verify": (PROGRESS_FILE, WORKED),         # a COMPLETE, sound pass — it verifies `ok`, so exit 0
+    "self-test": (None, None),                 # no --file, no flags at all
+}
+
+# A realistic value for every flag any door advertises (`--file` is the seed's, above). A door that grows a
+# flag with no value here FAILS the suite: a flag nothing can supply is a door nothing can drive.
+FLAG_VALUES: "dict[str, list[str]]" = {
+    "--unit": ["u01"], "--status": [STARTED], "--evidence": ["f.py:1"],
+    "--head-sha": [SHA], "--dispatched-at": [TS],
+    "--id": ["u09"], "--kind": ["file"], "--target": ["x.py"], "--check": ["a"],
+    "--amendments-ruled": ["0"],
+}
 
 
-def advertised(help_text: str) -> "tuple[list[str], set[str]]":
-    """(the COMMAND WORDS `--help` advertises, the OPTIONS it advertises) — read out of its usage block.
+def advertised(help_text: str) -> "tuple[list[str], set[str], set[str]]":
+    """(the COMMAND WORDS a `--help` advertises, its REQUIRED flags, its OPTIONAL flags) — from the usage.
 
     The usage block is the first `usage:` line plus argparse's indented continuation lines. The command
-    words are everything before the first flag or bracket (`emit-progress.py`, and any subcommand it
-    claims); the options are every `-x`/`--xyz` in it.
+    words are everything before the first flag or bracket (the script, and any subcommand it claims).
+
+    **The BRACKETS are the claim under test.** argparse writes a required option bare (`--file FILE`) and
+    an optional one in brackets (`[--check CHECK]`), so the usage line does not merely list the flags — it
+    says which ones you may LEAVE OUT. That promise is what `plan-add` broke, and it is only a promise a
+    test can stand on because it has an exact shape.
     """
     block: list[str] = []
     for line in help_text.splitlines():
@@ -1785,44 +1854,162 @@ def advertised(help_text: str) -> "tuple[list[str], set[str]]":
         if word.startswith(("-", "[")):
             break
         words.append(word)
-    return words, set(re.findall(r"--?[a-z][a-z-]*", usage))
+    every = set(re.findall(r"--[a-z][a-z-]*", usage))
+    optional = {flag for group in re.findall(r"\[[^\[\]]*\]", usage)
+                for flag in re.findall(r"--[a-z][a-z-]*", group)}
+    return words, every - optional, optional
 
 
-def check_wrapper_help(tmp: Path) -> int:
-    """Run `emit-progress.py --help`, take the command it advertises, and RUN THAT. Returns the failures."""
-    failures = 0
-    help_run = subprocess.run([sys.executable, str(WRAPPER), "--help"],  # noqa: S603 - our own sibling
+def door_parsers() -> "dict[str, argparse.ArgumentParser]":
+    """Every door the tool has, and the parser behind it — DERIVED from `build_parser`, never listed.
+
+    That is what makes the coverage below un-rottable: a subcommand appears here the moment it is added to
+    the parser, and a door with no entry in `DOOR_SEEDS` fails the suite by name. The wrapper is the one
+    door that is a separate SCRIPT, so its parser is rebuilt here from `add_emit_args` — the same single
+    definition the wrapper itself calls; what is actually EXECUTED for it is the real script, as a
+    subprocess, so the replica cannot hide a wrapper that has drifted from it.
+    """
+    p, _cmds = build_parser()
+    doors: dict[str, argparse.ArgumentParser] = {}
+    for action in p._actions:  # noqa: SLF001 - the subparser map is where the doors are
+        choices = getattr(action, "choices", None)
+        if isinstance(choices, dict):
+            doors.update({str(name): sub for name, sub in choices.items()})
+    wrapper = argparse.ArgumentParser(prog=WRAPPER_DOOR)
+    add_emit_args(wrapper)
+    doors[WRAPPER_DOOR] = wrapper
+    return doors
+
+
+def declared(p: argparse.ArgumentParser) -> "tuple[set[str], set[str]]":
+    """(the flags a parser REQUIRES, the flags it accepts and does not require) — from the parser itself."""
+    required: set[str] = set()
+    optional: set[str] = set()
+    for action in p._actions:  # noqa: SLF001 - the flags are the actions; there is no public view of them
+        longs = {opt for opt in action.option_strings if opt.startswith("--")} - {"--help"}
+        (required if action.required else optional).update(longs)
+    return required, optional
+
+
+def seed_door(tmp: Path, door: str, case: str) -> "list[str]":
+    """A FRESH realistic pre-existing state for one probe of one door, and the `--file` argv naming it.
+
+    Fresh per probe, never shared: the minimal invocation of `emit` APPENDS to the file it is given, and a
+    later probe run against that mutated file would be probing something nobody declared.
+    """
+    artifact, lines = DOOR_SEEDS[door]
+    if artifact is None:
+        return []
+    d = tmp / f"door-{door}-{case}"
+    d.mkdir(parents=True, exist_ok=True)
+    if artifact != PLAN_FILE:  # a sound plan sits beside every progress-file door, as in a real rundir
+        (d / PLAN_FILE).write_text("".join(line + "\n" for line in PLAN), encoding="utf-8")
+    target = d / artifact
+    if lines is not None:
+        target.write_text("".join(line + "\n" for line in lines), encoding="utf-8")
+    return ["--file", str(target)]
+
+
+def run_door(door: str, words: "list[str]", argv: "list[str]") -> "tuple[int, str]":
+    """Run a door AS A CALLER DOES — a subprocess, with the command words its OWN help advertised.
+
+    `words[1:]` is the load-bearing part: it is the subcommand the usage line CLAIMS, not the one we know
+    it to be. `emit-progress.py --help` used to advertise `emit-progress.py emit …`, and running THAT is
+    the only thing that could have caught it.
+    """
+    script = WRAPPER if door == WRAPPER_DOOR else OWNER
+    run = subprocess.run([sys.executable, str(script), *words[1:], *argv],  # noqa: S603 - our own scripts
+                         capture_output=True, text=True, check=False,
+                         env={**os.environ, DOOR_PROBE_ENV: "1"})
+    return run.returncode, (run.stdout + run.stderr).strip()
+
+
+def check_door(door: str, parser: argparse.ArgumentParser, tmp: Path) -> int:
+    """One door: what its `--help` says, against what it TAKES. Returns the failures."""
+    script = WRAPPER if door == WRAPPER_DOOR else OWNER
+    ask = [] if door == WRAPPER_DOOR else [door]
+    help_run = subprocess.run([sys.executable, str(script), *ask, "--help"],  # noqa: S603 - our own scripts
                               capture_output=True, text=True, check=False)
     if help_run.returncode != 0:
-        print(f"FAIL     [help] `{WRAPPER.name} --help` exited {help_run.returncode}: {help_run.stderr}")
+        print(f"FAIL     [door] `{door} --help` exited {help_run.returncode}: {help_run.stderr.strip()}")
         return 1
-    words, options = advertised(help_run.stdout)
+    words, required, optional = advertised(help_run.stdout)
+    failures = 0
 
-    probe = argparse.ArgumentParser()
-    add_emit_args(probe)  # the door that ACCEPTS — its flags, not a list typed out here
-    accepted = {opt for action in probe._actions for opt in action.option_strings  # noqa: SLF001
-                if opt.startswith("--")} - {"--help"}
-    long_flags = {opt for opt in options if opt.startswith("--")}
-    if long_flags != accepted:
-        print(f"FAIL     [help] it advertises {sorted(long_flags)} and the tool accepts {sorted(accepted)} "
-              f"— a flag in one and not the other is a flag someone will type and be refused for")
+    declared_required, declared_optional = declared(parser)
+    if (required, optional) != (declared_required, declared_optional):
+        print(f"FAIL     [door] `{door}` ADVERTISES required {sorted(required)} / optional "
+              f"{sorted(optional)}, and its parser DECLARES required {sorted(declared_required)} / optional "
+              f"{sorted(declared_optional)} — the help is the door a reviewer READS, and a flag that is one "
+              f"thing there and another in the parser is a command someone will type and be refused for")
         failures += 1
     else:
-        print(f"ok       [help] the flags it advertises are the flags the emit door takes: {sorted(accepted)}")
+        print(f"ok       [door] `{door}` advertises exactly what its parser takes: required "
+              f"{sorted(required)}, optional {sorted(optional)}")
 
-    # …and now the whole point: EXECUTE what it advertises, on a pass that is really dispatched.
-    progress = build(tmp, "wrapper-help", PLAN, [ident()])
-    invocation = [sys.executable, str(WRAPPER), *words[1:],
-                  "--file", str(progress), "--unit", "u01", "--status", STARTED]
-    run = subprocess.run(invocation, capture_output=True, text=True, check=False)  # noqa: S603
-    shown = " ".join([WRAPPER.name, *words[1:], "--file <progress> --unit u01 --status started"])
-    if run.returncode != 0:
-        print(f"FAIL     [help] the tool REFUSES the command its own --help advertises — `{shown}` exited "
-              f"{run.returncode}: {(run.stdout + run.stderr).strip()}. The help door and the parser door "
-              f"disagree about what the command IS, and the help is the one a reviewer reads")
+    unsupplied = sorted((required | optional) - set(FLAG_VALUES) - {"--file"})
+    if unsupplied:
+        print(f"FAIL     [door] `{door}` advertises {unsupplied}, and `FLAG_VALUES` declares no value for "
+              f"it — a flag nothing can supply is a door nothing can drive, and an undriven door is exactly "
+              f"how `plan-add` came to refuse the command its own help advertised")
+        return failures + 1
+
+    def invoke(flags: "set[str]", case: str) -> "tuple[int, str]":
+        argv: list[str] = []
+        for flag in sorted(flags):
+            if flag == "--file":
+                argv += seed_door(tmp, door, case)
+            else:
+                argv += [arg for value in FLAG_VALUES[flag] for arg in (flag, value)]
+        return run_door(door, words, argv)
+
+    # THE WHOLE POINT: the MINIMAL command the help advertises — every flag it brackets left OUT — EXECUTED.
+    shown = " ".join([Path(script).name, *words[1:], *(f"{flag} …" for flag in sorted(required))]) or door
+    code, text = invoke(required, "minimal")
+    if code != 0:
+        print(f"FAIL     [door] the tool REFUSES the command its own `--help` advertises — `{shown}` exited "
+              f"{code}: {text}\n         Every flag left out is one the help BRACKETS as optional. This is "
+              f"the help door and the WRITE door disagreeing about what the command IS: `plan-add` "
+              f"advertised `[--check CHECK]` and then refused the call for having no checks")
         failures += 1
     else:
-        print(f"ok       [help] the advertised invocation RUNS: `{shown}` -> exit 0")
+        print(f"ok       [door] the advertised MINIMAL invocation RUNS: `{shown}` -> exit 0")
+
+    # …and the other direction: a flag the help calls REQUIRED must really be refused when it is absent.
+    for flag in sorted(required):
+        code, text = invoke(required - {flag}, f"no{flag}")
+        if code == 0:
+            print(f"FAIL     [door] `{door}` advertises {flag} as REQUIRED and then ACCEPTED the call "
+                  f"WITHOUT it (exit 0) — the same lie as an optional flag it refuses, with its sign "
+                  f"flipped: the help promises a shape, and the shape is not what the tool takes")
+            failures += 1
+    if required:
+        print(f"ok       [door] `{door}` REFUSES the call with any of {sorted(required)} absent")
+    return failures
+
+
+def check_doors(tmp: Path) -> int:
+    """EVERY door — the subcommands `build_parser` has AND the wrapper. Returns the failures.
+
+    The reconciliation is the mechanical part, and it is why this cannot rot back into the wrapper-only
+    check it replaces: the door list comes from the PARSER, so a door with no seed is REPORTED, by name,
+    the day it is added — and a seed for a door that no longer exists is reported too.
+    """
+    failures = 0
+    parsers = door_parsers()
+    for door in sorted(set(parsers) | set(DOOR_SEEDS)):
+        if door not in parsers:
+            print(f"FAIL     [door] `{door}` has a seed in `DOOR_SEEDS` but the tool has no such door — a "
+                  f"door that was renamed or removed leaves a check that probes NOTHING and passes")
+            failures += 1
+        elif door not in DOOR_SEEDS:
+            print(f"FAIL     [door] the parser has a door `{door}` that NOTHING drives — declare in "
+                  f"`DOOR_SEEDS` what its `--file` names and the bytes that file realistically holds, so "
+                  f"its `--help` can be executed against it. A door nothing drives is one that is free to "
+                  f"advertise a command it refuses")
+            failures += 1
+        else:
+            failures += check_door(door, parsers[door], tmp)
     return failures
 
 
@@ -2120,9 +2307,18 @@ def self_test() -> int:
         print(f"COMMANDS {problem}")
         failures += 1
 
+    # The `self-test` door is EXECUTED like every other door — which means self-test runs self-test. The
+    # nested run is the real door, doing its real work; it skips ONLY this check, which is the sole thing
+    # that recurses. Everything else in it runs in full.
+    probe = bool(os.environ.get(DOOR_PROBE_ENV))
     with tempfile.TemporaryDirectory() as tmpdir:
         got = run_cases(sys.modules[__name__], Path(tmpdir))
-        help_failures = check_wrapper_help(Path(tmpdir))
+        if probe:
+            door_failures = 0
+            print("skip     [door] the door checks do not run inside the `self-test` door's own probe — "
+                  "this process IS that probe, and re-running them here would recurse forever")
+        else:
+            door_failures = check_doors(Path(tmpdir))
     print()
     for case, (want, needle, why) in expect.items():
         outcome, text = got[case]
@@ -2137,7 +2333,7 @@ def self_test() -> int:
             print(f"FAIL     {case[:44]:44} -> {outcome:11} but nothing mentions {needle!r}\n         got: {text}")
             failures += 1
     print()
-    failures += help_failures
+    failures += door_failures
     failures += check_boundaries()
     print()
     doc_failures = check_docs()
@@ -2146,6 +2342,9 @@ def self_test() -> int:
     if failures:
         print(f"{failures} check(s) FAILED — the review-pass contract is broken.")
         return 1
+    doors = (f"the door checks were SKIPPED (this run is the `self-test` door's own probe)" if probe else
+             f"every one of the {len(DOOR_SEEDS)} doors ({', '.join(sorted(DOOR_SEEDS))}) had the MINIMAL "
+             f"invocation its OWN `--help` advertises EXECUTED, and it runs")
     print(f"all {len(CASES)} fixtures + {len(NAME_CASES)} name cases + "
           f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases + "
           f"{len(WRITE_COMMANDS) * len(FILE_STATES)} round-trip cases ({len(WRITE_COMMANDS)} write "
@@ -2153,8 +2352,7 @@ def self_test() -> int:
           f"{len(CROSS_DOOR_IDS)} cross-door cases (the plan door refuses the id, or the emit door can "
           f"match it) + {len(BOUNDARY_CASES)} boundary cases ({len(DOMAINS)} bounded values, each probed "
           f"JUST INSIDE and JUST OUTSIDE its declared domain) + {len(doc_examples())} DOC examples hold — "
-          f"and the invocation "
-          f"`{WRAPPER.name} --help` advertises was EXECUTED, and runs.\n")
+          f"and {doors}.\n")
 
     # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
     marked = marked_statements(source)
@@ -2250,9 +2448,11 @@ def add_emit_args(p: argparse.ArgumentParser) -> None:
 def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     """The CLI, and the list of subcommands it actually has — DERIVED from the parser, never typed out.
 
-    The round-trip fixture drives every command this returns and FAILS on one it does not know how to
-    drive. So a subcommand added here is covered on the day it is added: there is no second list of
-    commands to forget to update, which is the only way a new write path could ever ship unpinned.
+    TWO checks stand on this, and both FAIL on a subcommand they do not know how to drive: the ROUND TRIP
+    (does what this command writes read back?) and the DOOR check (does the command its own `--help`
+    advertises actually RUN?). So a subcommand added here is covered on the day it is added — there is no
+    second list of commands to forget to update, which is the only way a new door could ever ship
+    advertising a shape it refuses.
     """
     p = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -2269,7 +2469,16 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     a.add_argument("--id", required=True)
     a.add_argument("--kind", required=True, help="file | cross-cutting | docs | …")
     a.add_argument("--target", required=True, help="the CONCRETE thing reviewed")
-    a.add_argument("--check", action="append", default=[], help="a concrete check; repeat (at least one)")
+    # REQUIRED, and the `required=` is the whole of what this line had to say and did not. `--check` was
+    # OPTIONAL to argparse — so `--help` bracketed it, `[--check CHECK]` — while `check_unit` refuses a unit
+    # whose `checks` is empty. The command this tool's own help advertised (`plan-add --file … --id … --kind
+    # … --target …`) therefore exited 1: `checks is [] — a unit with no concrete checks is not a unit`. The
+    # help door and the WRITE door disagreed about what the command IS, which is the same defect as two
+    # doors disagreeing about what an ID is. It is `required=True` now, so the shape the help advertises is
+    # the shape the write path takes, and a missing `--check` is refused by ARGPARSE — at the door, naming
+    # the flag — instead of by a rule about the unit that was built from it.
+    a.add_argument("--check", action="append", default=[], required=True,
+                   help="a concrete check; REQUIRED, and repeatable — a unit with no checks is not a unit")
 
     v = sub.add_parser("verify", help="DOES THIS PASS COUNT? (it never reads the reviewer's report)")
     v.add_argument("--file", required=True, help="the ACTIVE launch attempt's progress.jsonl")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -92,6 +92,7 @@ import ast
 import io
 import json
 import re
+import subprocess
 import sys
 import tempfile
 import types
@@ -1585,6 +1586,84 @@ def check_docs() -> int:
     return failures
 
 
+# --- the WRAPPER's HELP: what it SAYS must be what the tool TAKES --------------------------------
+#
+# `emit-progress.py --help` printed `usage: emit-progress.py emit [-h] --file …`, and running that exact
+# command failed with `unrecognized arguments: emit` — the wrapper prepends `emit` itself, so its own help
+# advertised a command shape it REFUSES. Two doors disagreeing about what the COMMAND is, which is the same
+# defect as two doors disagreeing about what an ID is — and the help is the door a reviewer READS.
+#
+# An exhortation to "keep the help and the parser in sync" cannot fail. This can: the usage block is parsed
+# for the invocation it advertises, and **that invocation is EXECUTED** — as a subprocess, against a real
+# dispatched pass, exactly as a reviewer would run it. Advertise a command the tool refuses and the suite
+# goes red. The FLAGS are checked the same way, against the emit door's own `add_emit_args`: the help may
+# not name a flag the tool does not take, nor omit one it requires.
+
+WRAPPER = Path(__file__).resolve().parent / "emit-progress.py"
+
+
+def advertised(help_text: str) -> "tuple[list[str], set[str]]":
+    """(the COMMAND WORDS `--help` advertises, the OPTIONS it advertises) — read out of its usage block.
+
+    The usage block is the first `usage:` line plus argparse's indented continuation lines. The command
+    words are everything before the first flag or bracket (`emit-progress.py`, and any subcommand it
+    claims); the options are every `-x`/`--xyz` in it.
+    """
+    block: list[str] = []
+    for line in help_text.splitlines():
+        if line.startswith("usage:"):
+            block.append(line)
+        elif block and line.startswith(" ") and line.strip():
+            block.append(line)
+        elif block:
+            break
+    usage = " ".join(block).partition("usage:")[2]
+    words: list[str] = []
+    for word in usage.split():
+        if word.startswith(("-", "[")):
+            break
+        words.append(word)
+    return words, set(re.findall(r"--?[a-z][a-z-]*", usage))
+
+
+def check_wrapper_help(tmp: Path) -> int:
+    """Run `emit-progress.py --help`, take the command it advertises, and RUN THAT. Returns the failures."""
+    failures = 0
+    help_run = subprocess.run([sys.executable, str(WRAPPER), "--help"],  # noqa: S603 - our own sibling
+                              capture_output=True, text=True, check=False)
+    if help_run.returncode != 0:
+        print(f"FAIL     [help] `{WRAPPER.name} --help` exited {help_run.returncode}: {help_run.stderr}")
+        return 1
+    words, options = advertised(help_run.stdout)
+
+    probe = argparse.ArgumentParser()
+    add_emit_args(probe)  # the door that ACCEPTS — its flags, not a list typed out here
+    accepted = {opt for action in probe._actions for opt in action.option_strings  # noqa: SLF001
+                if opt.startswith("--")} - {"--help"}
+    long_flags = {opt for opt in options if opt.startswith("--")}
+    if long_flags != accepted:
+        print(f"FAIL     [help] it advertises {sorted(long_flags)} and the tool accepts {sorted(accepted)} "
+              f"— a flag in one and not the other is a flag someone will type and be refused for")
+        failures += 1
+    else:
+        print(f"ok       [help] the flags it advertises are the flags the emit door takes: {sorted(accepted)}")
+
+    # …and now the whole point: EXECUTE what it advertises, on a pass that is really dispatched.
+    progress = build(tmp, "wrapper-help", PLAN, [ident()])
+    invocation = [sys.executable, str(WRAPPER), *words[1:],
+                  "--file", str(progress), "--unit", "u01", "--status", STARTED]
+    run = subprocess.run(invocation, capture_output=True, text=True, check=False)  # noqa: S603
+    shown = " ".join([WRAPPER.name, *words[1:], "--file <progress> --unit u01 --status started"])
+    if run.returncode != 0:
+        print(f"FAIL     [help] the tool REFUSES the command its own --help advertises — `{shown}` exited "
+              f"{run.returncode}: {(run.stdout + run.stderr).strip()}. The help door and the parser door "
+              f"disagree about what the command IS, and the help is the one a reviewer reads")
+        failures += 1
+    else:
+        print(f"ok       [help] the advertised invocation RUNS: `{shown}` -> exit 0")
+    return failures
+
+
 def build(tmp: Path, name: str, plan: "list[str] | None", progress: "list[str] | bytes") -> Path:
     """Write a fixture pass to disk RAW — bypassing every write-side check, because half these fixtures
     hold exactly what the write side would have refused. That is the point: the READ side must catch them
@@ -1881,6 +1960,8 @@ def self_test() -> int:
 
     with tempfile.TemporaryDirectory() as tmpdir:
         got = run_cases(sys.modules[__name__], Path(tmpdir))
+        help_failures = check_wrapper_help(Path(tmpdir))
+    print()
     for case, (want, needle, why) in expect.items():
         outcome, text = got[case]
         if outcome == want and needle in text:
@@ -1894,6 +1975,7 @@ def self_test() -> int:
             print(f"FAIL     {case[:44]:44} -> {outcome:11} but nothing mentions {needle!r}\n         got: {text}")
             failures += 1
     print()
+    failures += help_failures
     failures += check_id_formats()
     print()
     doc_failures = check_docs()
@@ -1908,7 +1990,8 @@ def self_test() -> int:
           f"commands, derived from the parser, x {len(FILE_STATES)} pre-existing file states) + "
           f"{len(CROSS_DOOR_IDS)} cross-door cases (the plan door refuses the id, or the emit door can "
           f"match it) + {len(ID_CASES)} identifier-format cases ({len(ID_FORMATS)} identifiers, each with "
-          f"ONE legal form) + {len(doc_examples())} DOC examples hold.\n")
+          f"ONE legal form) + {len(doc_examples())} DOC examples hold — and the invocation "
+          f"`{WRAPPER.name} --help` advertises was EXECUTED, and runs.\n")
 
     # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
     marked = marked_statements(source)
@@ -1986,6 +2069,21 @@ def fail(msg: str, code: int) -> NoReturn:
     raise SystemExit(code)
 
 
+def add_emit_args(p: argparse.ArgumentParser) -> None:
+    """The emit door's flags — `--file --unit --status --evidence` — defined in exactly ONE place.
+
+    This is a PUBLIC CONTRACT: it is what every review prompt already dispatched against an INSTALLED copy
+    of this skill runs. `build_parser`'s `emit` subcommand and `emit-progress.py`'s own top-level parser
+    both call this, so the reviewer's door and the owner's door cannot come to accept — or ADVERTISE —
+    different flags. `emit-progress.py` used to have no parser of its own at all, and rendered the OWNER's
+    help instead: `--help` printed a command (`emit-progress.py emit …`) that the wrapper itself refuses.
+    """
+    p.add_argument("--file", required=True, help="the launch attempt's progress.jsonl")
+    p.add_argument("--unit", required=True, help="a PLANNED unit's id — an unplanned one is refused")
+    p.add_argument("--status", required=True, choices=STATUSES)
+    p.add_argument("--evidence", help="concrete citation; REQUIRED for --status done")
+
+
 def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     """The CLI, and the list of subcommands it actually has — DERIVED from the parser, never typed out.
 
@@ -1996,11 +2094,7 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     p = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    e = sub.add_parser("emit", help="append one unit-progress event (what emit-progress.py calls)")
-    e.add_argument("--file", required=True, help="the launch attempt's progress.jsonl")
-    e.add_argument("--unit", required=True, help="a PLANNED unit's id — an unplanned one is refused")
-    e.add_argument("--status", required=True, choices=STATUSES)
-    e.add_argument("--evidence", help="concrete citation; REQUIRED for --status done")
+    add_emit_args(sub.add_parser("emit", help="append one unit-progress event (what emit-progress.py calls)"))
 
     i = sub.add_parser("identity", help="write a pass's pass_identity line (pr/pass/attempt come from --file)")
     i.add_argument("--file", required=True, help="the launch attempt's progress.jsonl — it must not exist yet")
@@ -2025,9 +2119,14 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     return p, sorted(str(name) for name in (sub.choices or {}))
 
 
-def main(argv: "list[str] | None" = None) -> int:
-    p, _cmds = build_parser()
-    args = p.parse_args(argv)
+def dispatch(args) -> int:
+    """Run one PARSED command — and the ONE place a refusal becomes an exit code.
+
+    `emit-progress.py` hands its own parser's `args` straight to this (with `cmd` fixed to `emit` by
+    `set_defaults`, where no caller can type it and no help text can advertise it). So the wrapper reaches
+    the same function through the same refusal-to-exit-code mapping: exit 1 = your inputs were rejected,
+    exit 2 = the caller asked the wrong question. There is no second mapping to drift.
+    """
     if args.cmd == "self-test":
         return self_test()
     try:
@@ -2037,6 +2136,11 @@ def main(argv: "list[str] | None" = None) -> int:
         fail(str(exc), 1)
     except OperatorError as exc:
         fail(str(exc), 2)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p, _cmds = build_parser()
+    return dispatch(p.parse_args(argv))
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -22,7 +22,8 @@ So this file is the review pass's artifacts, executed:
   identity    write a pass's `pass_identity` line                 (the SHA stops being a `printf`)
   emit        append ONE progress event                           (what `emit-progress.py` calls)
   verify      READ a pass and answer: DOES THIS PASS COUNT?       (the tally stops being by eye)
-  self-test   the fixtures, and the proof that every rule is pinned by one
+  self-test   the fixtures, the proof that every rule is pinned by one, and every JSON example in the
+              docs fed THROUGH the tool (a documented example the tool refuses is a trap, not a typo)
 
 WHAT `verify` DOES NOT DO — AND THE LINE IS DELIBERATE. It never opens `review-<pr>-<n>.txt`, never
 parses the reviewer's prose, and CANNOT SAY `SATISFIED`. Its whole answer is about the pass's MECHANICS:
@@ -36,12 +37,23 @@ anything. A bug in a tool that can only refuse costs a re-review; a bug in a too
 merge a PR nobody reviewed. **`ok` IS NOT `SATISFIED`.** It means the pass is well-formed enough for its
 verdict to be *read* — a NECESSARY condition for counting it, never a sufficient one.
 
-BOTH DOORS, ALWAYS. Every rule here holds where the COMMANDS enter (`emit`, `identity`, `plan-add`) AND
-where the DATA enters (`verify`). An invariant enforced only at the write door is not enforced: the
-progress file is a plaintext file in a directory the reviewer can write to, the emit-only rule is prose,
-and a hand-written line lands in it just fine. So `verify` re-derives EVERYTHING from the bytes and
-assumes nothing about how they got there — it never trusts that the write tool was used. The write side
-and the read side run the SAME functions, so there is no second implementation to drift.
+BOTH DOORS, ALWAYS — AND ONE IMPLEMENTATION, NEVER TWO. Every rule here holds where the COMMANDS enter
+(`emit`, `identity`, `plan-add`) AND where the DATA enters (`verify`), and it holds by the SAME statement
+at both. Those are two halves of one discipline, and each half has already failed on its own:
+
+  * a rule enforced only at the WRITE door is not enforced. The progress file is a plaintext file in a
+    directory the reviewer can write to, the emit-only rule is prose, and a hand-written line lands in it
+    just fine. So `verify` re-derives EVERYTHING from the bytes and assumes nothing about how they got
+    there — it never trusts that the write tool was used.
+  * a rule enforced only at the READ door is a trap. The SECOND `done` was refused by `verify` and WRITTEN
+    by `emit`: exit 0, and the pass thrown away fifteen minutes later for a defect the tool had just
+    helped the reviewer commit. The reviewer was told it had succeeded.
+  * and a rule enforced at both doors by TWO implementations is a rule waiting to acquire two definitions.
+
+So there are no per-door copies. `check_event`, `check_unit`, `check_identity_shape`, `check_progress` and
+`plan_units` ARE the rules; `emit`, `identity` and `plan-add` call exactly the functions `verify` calls —
+`emit` even replays the file it is appending to through `walk_progress`, the same walk `verify` performs,
+so it can never append a line to a file `verify` would refuse to read.
 
 THE VERDICTS. Exactly one is printed, and there is no "counts, BUT…":
 
@@ -156,7 +168,14 @@ NAME_RE = re.compile(r"^review-(?P<pr>\d+)-(?P<pass>\d+)(?:\.a(?P<attempt>[2-9]\
 # The plan is PER-PASS, not per-attempt: a relaunch reuses it unchanged (stage-2-review-gate.md). So it is
 # DERIVED from the progress path and never passed separately — one fewer door, and no way to point a pass
 # at somebody else's plan.
+#
+# Deriving it means the READ side enforces the plan's name BY CONSTRUCTION: the only plan `verify` can ever
+# open is the one at this name. The WRITE side took a `--file` and wrote wherever it was pointed — so
+# `plan-add --file plan.jsonl` succeeded, and produced a plan NOTHING WILL EVER READ. `verify` would then
+# refuse the pass for a MISSING plan while its units sat on disk a filename away. Enforced by construction
+# at one door and not at all at the other is the same asymmetry as any other; `PLAN_NAME_RE` closes it.
 PLAN_NAME = "review-{pr}-{pass}.plan.jsonl"
+PLAN_NAME_RE = re.compile(r"^review-\d+-\d+\.plan\.jsonl$")
 
 
 class Defect(Exception):
@@ -292,23 +311,37 @@ def check_unit(unit: object, where: str) -> None:
         )
 
 
+def plan_units(records: "list[dict]", name: str) -> "dict[str, dict]":
+    """These plan records' units, by id — each validated, and a REPEATED id refused. ONE implementation,
+    and therefore the same rule at both doors: `load_plan` runs it over the file the reviewer is judged
+    against, and `cmd_plan_add` runs it over that file PLUS the unit it is about to append, so the write
+    door refuses a duplicate id by the SAME statement the read door refuses it with.
+    """
+    units: dict[str, dict] = {}
+    for n, rec in enumerate(records, start=1):
+        check_unit(rec, f"{name} line {n}")
+        if rec["id"] in units:
+            # MUTATE:plan-duplicate-id:pass
+            raise Defect(
+                f"{name} line {n}: duplicate unit id {rec['id']!r} — a `done` naming it would be "
+                f"ambiguous about WHICH unit was checked"
+            )
+        units[rec["id"]] = rec
+    return units
+
+
 def load_plan(path: Path) -> "dict[str, dict]":
     """The plan's units, by id. A plan is what makes `done` MEAN something — so it is validated, not read.
 
     An EMPTY plan is refused, and that rule carries the most weight of any here: "every planned unit is
     done" is VACUOUSLY TRUE of a plan with no units, so a pass that reviewed NOTHING would verify `ok`.
     A completeness check whose input can be empty is not a check.
+
+    Emptiness is the ONE rule here that is deliberately read-only, and it is not one-sided: `plan-add` is
+    how a plan STOPS being empty, so a write door that refused an empty plan could never write the first
+    unit. The rule is about a plan a pass is JUDGED against, and that is the read door's question.
     """
-    units: dict[str, dict] = {}
-    for n, rec in enumerate(read_lines(path, "plan"), start=1):
-        check_unit(rec, f"{path.name} line {n}")
-        if rec["id"] in units:
-            # MUTATE:plan-duplicate-id:pass
-            raise Defect(
-                f"{path.name} line {n}: duplicate unit id {rec['id']!r} — a `done` naming it would be "
-                f"ambiguous about WHICH unit was checked"
-            )
-        units[rec["id"]] = rec
+    units = plan_units(read_lines(path, "plan"), path.name)
     if not units:
         # MUTATE:plan-empty:pass
         raise Defect(
@@ -385,6 +418,78 @@ def check_event(rec: dict, where: str) -> None:
             f"{where}: a {DONE!r} event carries CONCRETE evidence (a file:line, a backticked span, a "
             f"filename) — blank evidence is a claim that a unit was checked, with nothing behind it"
         )
+
+
+def check_progress(rec: dict, units: "dict[str, dict]", announced: "set[str]", done: "dict[str, str]",
+                   where: str) -> None:
+    """ONE unit-progress event, judged against the PLAN and against everything the file ALREADY says.
+
+    **This is the single implementation of the three rules that govern a `started`/`done`, and BOTH doors
+    call it**: `cmd_emit` before it appends, and `walk_progress` — which is what `verify` re-derives from
+    the bytes — as it replays the file. It is one function and not three checks written twice, because the
+    two failures are the same failure: a rule enforced at ONE door is not enforced, and a rule enforced at
+    both doors by TWO implementations is a rule waiting to acquire two definitions.
+
+    The SECOND `done` proved both halves at once. `verify` refused it and `emit` WROTE it — the reviewer
+    got exit 0, the file grew two accounts of one unit, and the pass was thrown away fifteen minutes later
+    for a defect the tool had just helped it commit.
+
+    ORDER IS PART OF THE RULE. Unplanned first: a reviewer self-granting a unit must be told the unit is
+    not in the plan — telling it "no earlier `started`" would be true, and the wrong lesson.
+    """
+    unit = rec["unit"]
+    if unit not in units:
+        # MUTATE:unplanned-unit:pass
+        raise Defect(
+            f"{where}: progress for unit {unit!r}, which is NOT IN THE PLAN — the reviewer never rewrites "
+            f"the plan or self-grants units, and progress counts only when it references a PLANNED unit. "
+            f"Planned: {sorted(units)}. If the plan is missing a dimension, raise a plan_amendment_request "
+            f"instead"
+        )
+    if rec["status"] != DONE:
+        return
+    if unit not in announced:
+        # MUTATE:done-without-started:pass
+        raise Defect(
+            f"{where}: {DONE!r} for unit {unit!r} with no earlier {STARTED!r} for it — a unit that was "
+            f"never begun cannot have been finished. The reviewer emits {STARTED!r} when a unit BEGINS and "
+            f"{DONE!r} when it ends, so a `{DONE}` standing alone (or standing ABOVE its `{STARTED}` in "
+            f"this append-only file) is not the record of a review that happened; it is a file with the "
+            f"right lines in it"
+        )
+    if unit in done:
+        # MUTATE:duplicate-done:pass
+        raise Defect(
+            f"{where}: a SECOND {DONE!r} for unit {unit!r} — the file would offer two accounts of one "
+            f"unit, and nothing says which was read. A unit is finished ONCE; if what you found changed, "
+            f"the pass is what re-runs, not the line"
+        )
+
+
+def walk_progress(events: "list[dict]", units: "dict[str, dict]") -> "tuple[set[str], dict[str, str]]":
+    """Replay a progress file's unit events IN ORDER under `check_progress`, and return what it says: the
+    units ANNOUNCED, and the units DONE with their evidence.
+
+    BY ORDER, never by presence: `announced` only ever holds units a line ALREADY READ announced, so a
+    `started` that appears BELOW its `done` cannot satisfy it. The file is APPEND-ONLY, so its order IS
+    the order the events happened in, and a forger who must fabricate the `started` FIRST has to fabricate
+    the whole sequence — which is precisely the thing the file is evidence of.
+
+    The WRITE door replays this same walk over the bytes already on disk, because it has nothing else to
+    ask: a reviewer is many `emit` invocations, each a fresh process, and the only thing that survives
+    between them is the file. The file is the memory, and this is how `emit` knows what it already says.
+    """
+    announced: set[str] = set()
+    done: dict[str, str] = {}
+    for n, rec in enumerate(events, start=1):
+        if rec["type"] != PROGRESS:
+            continue
+        check_progress(rec, units, announced, done, f"line {n}")
+        if rec["status"] == DONE:
+            done[rec["unit"]] = rec["evidence"]
+        else:
+            announced.add(rec["unit"])
+    return announced, done
 
 
 def check_identity_shape(ident: dict, where: str) -> None:
@@ -478,52 +583,17 @@ def check_identity(events: "list[dict]", pr: str, npass: str, attempt: str, head
 def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int) -> "tuple[str, str]":
     """Given SOUND artifacts: does this pass COUNT? (Its report is still not read. That is the point.)
 
-    A `done` REQUIRES an earlier `started` for the same unit, and this walk enforces it BY ORDER, not by
-    presence: `announced` only ever holds units a line ALREADY READ announced, so a `started` that appears
-    BELOW its `done` cannot satisfy it. Presence alone would be the weaker rule and the wrong one — the
-    file is APPEND-ONLY, so its order IS the order the events happened in, and a forger who has to also
-    fabricate the `started` FIRST has to fabricate the whole sequence, which is precisely the thing the
-    file is evidence of. "u01 finished, then u01 began" is not a review; it is a file with the right lines
-    in it.
+    The per-event rules — planned unit, `done` follows `started`, no SECOND `done` — are `check_progress`,
+    replayed here by `walk_progress`. They are not restated: they are the SAME statements `emit` runs, so
+    what this door refuses to read is exactly what that door refuses to write.
 
-    **This is the rule that was PROSE and enforced by NOBODY, and it is the one the tool most needed.** A
+    **The `started` rule was PROSE and enforced by NOBODY, and it is the one the tool most needed.** A
     progress file with a valid identity and a `done` for EVERY planned unit — and NOT ONE `started` —
     verified `ok`: the tool that exists to prove a review HAPPENED accepted a review that demonstrably did
     not. Skip straight to "done" for every unit and the gate was satisfied on zero evidence of work. A
     `done` with no `started` is not progress, exactly as an empty plan is not a plan.
     """
-    announced: set[str] = set()
-    done: dict[str, str] = {}
-    for n, rec in enumerate(events, start=1):
-        if rec["type"] != PROGRESS:
-            continue
-        unit = rec["unit"]
-        if unit not in units:
-            # MUTATE:unplanned-unit:pass
-            raise Defect(
-                f"line {n}: progress for unit {unit!r}, which is NOT IN THE PLAN — the reviewer never "
-                f"rewrites the plan or self-grants units, and progress counts only when it references a "
-                f"PLANNED unit. Planned: {sorted(units)}"
-            )
-        if rec["status"] != DONE:
-            announced.add(unit)
-            continue
-        if unit not in announced:
-            # MUTATE:done-without-started:pass
-            raise Defect(
-                f"line {n}: {DONE!r} for unit {unit!r} with no earlier {STARTED!r} for it — a unit that "
-                f"was never begun cannot have been finished. The reviewer emits {STARTED!r} when a unit "
-                f"BEGINS and {DONE!r} when it ends, so a `{DONE}` standing alone (or standing ABOVE its "
-                f"`{STARTED}` in this append-only file) is not the record of a review that happened; it is "
-                f"a file with the right lines in it"
-            )
-        if unit in done:
-            # MUTATE:duplicate-done:pass
-            raise Defect(
-                f"line {n}: a SECOND {DONE!r} for unit {unit!r} — the file now offers two accounts of one "
-                f"unit, and nothing says which was read"
-            )
-        done[unit] = rec["evidence"]
+    _announced, done = walk_progress(events, units)
 
     amendments = [e for e in events if e["type"] == AMENDMENT]
     unruled = len(amendments) - ruled
@@ -603,64 +673,35 @@ def append(path: Path, rec: dict) -> str:
     return line
 
 
-def announced_units(path: Path) -> "set[str]":
-    """The units this progress file has ALREADY announced a `started` for — read from the BYTES on disk.
-
-    The write door cannot ask its own process what it emitted: a reviewer is many `emit` invocations, each
-    a fresh process, and the only thing that survives between them is the file. So the file is the memory,
-    and reading it is how `emit` knows whether the `done` it was just handed follows a `started`.
-    """
-    out: set[str] = set()
-    for e in read_lines(path, "progress file"):
-        if e.get("type") == PROGRESS and e.get("status") == STARTED and isinstance(e.get("unit"), str):
-            out.add(e["unit"])
-    return out
-
-
 def cmd_emit(args) -> int:
     """Append one unit-progress event — the ONLY sanctioned way a reviewer records one.
 
-    It refuses an unplanned unit HERE TOO, and not only in `verify`: the reviewer gets a non-zero exit and
-    a message it can act on, at the moment it makes the mistake, instead of a pass silently thrown away
-    fifteen minutes later. Same for a `done` that no `started` precedes.
+    **It runs the READ side's functions, and no others.** The event it is about to append is checked by
+    `check_event` and `check_progress`; the file it is about to append TO is re-read from disk and put
+    through `check_events` and `walk_progress` — the very walk `verify` performs. So `emit` cannot write a
+    line `verify` would refuse, and there is no CLI-shaped second copy of any rule to drift away from the
+    one the verdict is computed with.
+
+    That is not symmetry for its own sake. Every rule this refuses at write, it refuses at the moment the
+    reviewer makes the mistake — with a message it can act on — instead of the pass being thrown away
+    fifteen minutes later by a `verify` the reviewer never sees.
     """
     path = Path(args.file)
     pr, npass, _attempt = parse_name(path)
-    unit = args.unit.strip()
-    if not unit:
-        # MUTATE:emit-empty-unit:pass
-        raise Defect("--unit must be non-empty")
-    if args.status == DONE and (args.evidence is None or not args.evidence.strip()):
-        # MUTATE:emit-done-evidence:pass
-        raise Defect(
-            "--evidence is required and must be non-empty when --status is done: a unit is not done "
-            "because you say so, it is done because you can CITE what you checked"
-        )
-    if args.status == STARTED and args.evidence is not None:
-        # MUTATE:emit-started-evidence:pass
-        raise Defect("--evidence must NOT be provided when --status is started")
-
-    rec = {"type": PROGRESS, "unit": unit, "status": args.status}
-    if args.status == DONE:
+    # The RECORD IS THE FLAGS. `--status done` with no `--evidence` is an event with no `evidence` key, and
+    # `--status started --evidence x` is one carrying a key nothing reads — so the flags are judged by the
+    # same `check_event` that judges a hand-written line, and the evidence rule exists in ONE place. (A CLI
+    # blank `--unit` needs no rule of its own either: it is a unit no plan holds, which is what it is.)
+    rec: "dict[str, object]" = {"type": PROGRESS, "unit": args.unit.strip(), "status": args.status}
+    if args.evidence is not None:
         rec["evidence"] = args.evidence
-    check_event(rec, "the event you asked to emit")
+    check_event(rec, "the event you asked to emit (--unit/--status/--evidence)")
+
     units = load_plan(path.parent / PLAN_NAME.format(pr=pr, **{"pass": npass}))
-    if unit not in units:
-        # MUTATE:emit-unplanned:pass
-        raise Defect(
-            f"unit {unit!r} is NOT IN THE PLAN — you may not self-grant a unit. Planned: {sorted(units)}. "
-            f"If the plan is missing a dimension, raise a plan_amendment_request instead"
-        )
-    # LAST, deliberately: an unplanned `done` must still be refused as UNPLANNED. Were this check first, a
-    # reviewer self-granting a unit would be told "no earlier started" — true, and the wrong lesson.
-    if args.status == DONE and unit not in announced_units(path):
-        # MUTATE:emit-done-without-started:pass
-        raise Defect(
-            f"unit {unit!r} has no earlier `{STARTED}` event in {path.name} — emit `--status {STARTED}` "
-            f"when the unit BEGINS, and `--status {DONE}` when it ends. A unit that was never begun cannot "
-            f"be finished, and `verify` reads this back under the same rule: a `{DONE}` with no `{STARTED}` "
-            f"makes the whole pass unusable, so writing one here would only lose the pass later"
-        )
+    events = read_lines(path, "progress file")
+    check_events(events, path)
+    announced, done = walk_progress(events, units)
+    check_progress(rec, units, announced, done, "the event you asked to emit")
     sys.stdout.write(append(path, rec))
     return 0
 
@@ -691,17 +732,23 @@ def cmd_identity(args) -> int:
 def cmd_plan_add(args) -> int:
     """Append one validated unit to a pass's plan — the artifact that used to be a shell heredoc."""
     path = Path(args.file)
+    if not PLAN_NAME_RE.match(path.name):
+        # MUTATE:plan-name-shape:pass
+        raise Defect(
+            f"{path.name} is not a plan artifact's name — it is `review-<pr>-<n>.plan.jsonl`. `verify` "
+            f"never takes the plan's path: it DERIVES it from the progress file's name, so a plan written "
+            f"under any other name is a plan nothing will ever read. The pass would be refused for a "
+            f"MISSING plan while its units sat on disk one filename away"
+        )
     rec = {
         "type": UNIT, "id": args.id, "kind": args.kind, "target": args.target,
         "checks": list(args.check),
     }
     check_unit(rec, "the unit you asked to add")
-    if path.exists():
-        for existing in read_lines(path, "plan"):
-            check_unit(existing, f"{path.name}")
-            if existing["id"] == rec["id"]:
-                # MUTATE:plan-add-duplicate:break
-                raise Defect(f"the plan already holds a unit {rec['id']!r}")
+    # The plan AS IT WOULD BE, run through the reader's own function: the duplicate-id rule fires from the
+    # one statement `verify` fires it from, never from a second copy that can drift away from it.
+    existing = read_lines(path, "plan") if path.exists() else []
+    plan_units([*existing, rec], path.name)
     sys.stdout.write(append(path, rec))
     return 0
 
@@ -932,19 +979,24 @@ NAME_CASES = [
 # writes `pass_identity`, and what `emit` appends to thereafter.
 EMPTY: "list[str]" = []
 BEGUN = [ident(), started("u01")]  # the file a reviewer has in hand once it has ANNOUNCED u01
+FINISHED = [ident(), started("u01"), done("u01")]  # …and once it has already FINISHED u01
 CLI_CASES = [
     (["emit", "--unit", "u01", "--status", "started"], EMPTY, 0, '"status":"started"', "the call every reviewer prompt makes"),
     (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], BEGUN, 0, '"evidence":"f.py:1"',
      "…and its done form, on the file that HAS the matching `started` — the only file the done form was ever meant to be run against"),
-    (["emit", "--unit", "u02", "--status", "done", "--evidence", "f.py:1"], BEGUN, 1, "no earlier `started`",
+    (["emit", "--unit", "u01", "--status", "done", "--evidence", "somewhere else"], FINISHED, 1, "SECOND",
+     "HEADLINE, WRITE DOOR: a SECOND `done` for a unit already finished. `verify` refused it on READ and this door WROTE it (exit 0) — the rule held at one door and not the other, so the reviewer was handed a success and the pass was thrown away later for a defect the tool had just helped it commit. Both doors now run the SAME predicate"),
+    (["emit", "--unit", "u02", "--status", "done", "--evidence", "f.py:1"], BEGUN, 1, "no earlier 'started'",
      "HEADLINE, WRITE DOOR: a `done` for a unit that was never begun. The write door refuses it at the moment the reviewer makes the mistake, instead of the pass being thrown away by `verify` fifteen minutes later"),
     (["emit", "--unit", "u99", "--status", "done", "--evidence", "f.py:1"], EMPTY, 1, "NOT IN THE PLAN",
      "HEADLINE, WRITE DOOR: the tool accepted a self-granted unit. It no longer does — and it says UNPLANNED, not 'no started': an unplanned unit's real defect is that nobody planned it"),
     (["emit", "--unit", "u99", "--status", "started"], EMPTY, 1, "NOT IN THE PLAN", "…and refuses to START one"),
-    (["emit", "--unit", "u01", "--status", "done"], EMPTY, 1, "--evidence is required", "a done with no evidence"),
-    (["emit", "--unit", "u01", "--status", "done", "--evidence", "  "], EMPTY, 1, "--evidence is required", "…or blank evidence"),
-    (["emit", "--unit", "u01", "--status", "started", "--evidence", "x"], EMPTY, 1, "must NOT be provided", "a started carrying evidence"),
-    (["emit", "--unit", "  ", "--status", "started"], EMPTY, 1, "--unit must be non-empty", "an empty unit id"),
+    (["emit", "--unit", "u01", "--status", "done"], EMPTY, 1, "carries EXACTLY", "a done with no evidence — the SAME key rule a hand-written line meets, not a second CLI-shaped copy of it"),
+    (["emit", "--unit", "u01", "--status", "done", "--evidence", "  "], BEGUN, 1, "CONCRETE evidence", "…and blank evidence, on a file where the `started` is not the problem"),
+    (["emit", "--unit", "u01", "--status", "started", "--evidence", "x"], EMPTY, 1, "carries EXACTLY", "a started carrying evidence: the mirror of a done without it, and the same rule"),
+    (["emit", "--unit", "  ", "--status", "started"], EMPTY, 1, "NOT IN THE PLAN", "a blank unit id — a unit no plan holds, which is exactly what it is"),
+    (["emit", "--unit", "u02", "--status", "started"], [ident(), '{"type":"progress","unit_id":"u01","status":"done","evidence":"x"}'], 1, "carries EXACTLY",
+     "the file it is APPENDING TO is evidence too: a hand-written line already in it makes the pass unusable, so `emit` refuses to add a good line to a file `verify` will throw away"),
     (["identity", "--head-sha", SHA, "--dispatched-at", TS], EMPTY, 0, '"launch_attempt":"1"',
      "the line that was a `printf` — pr/pass/attempt now come from the FILENAME, so they cannot disagree with it"),
     (["identity", "--head-sha", SHA[:7], "--dispatched-at", TS], EMPTY, 1, "escaped into this repo's real state",
@@ -963,19 +1015,84 @@ CLI_CASES = [
      "a ruling for an amendment that does not exist would silently clear the NEXT one raised"),
 ]
 
-# `plan-add` gets its own family: its `--check` is repeatable, so its argv do not fit the shape above.
+# `plan-add` gets its own family: its `--check` is repeatable, so its argv do not fit the shape above, and
+# the plan file's NAME is under test too — `(the plan file's name, argv, expected exit, needle, why)`.
+PLAN_FILE = "review-41-1.plan.jsonl"
 PLAN_CLI_CASES = [
-    (["--id", "u03", "--kind", "cross-cutting", "--target", "both doors", "--check", "a", "--check", "b"],
+    (PLAN_FILE, ["--id", "u03", "--kind", "cross-cutting", "--target", "both doors", "--check", "a", "--check", "b"],
      0, '"checks":["a","b"]', "the plan stops being a shell heredoc"),
-    (["--id", "u01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "already holds a unit",
-     "a duplicate id — a `done` for it would say nothing about which unit was checked"),
-    (["--id", "  ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "names nothing", "a blank id"),
-    (["--id", "u03", "--kind", "file", "--target", "x.py"], 1, "not a unit", "a unit with NO checks"),
+    (PLAN_FILE, ["--id", "u01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "duplicate unit id",
+     "a duplicate id — a `done` for it would say nothing about which unit was checked. Refused by the SAME statement `load_plan` refuses it with: the plan as it WOULD be goes through the reader's own function"),
+    (PLAN_FILE, ["--id", "  ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "names nothing", "a blank id"),
+    (PLAN_FILE, ["--id", "u03", "--kind", "file", "--target", "x.py"], 1, "not a unit", "a unit with NO checks"),
+    ("plan.jsonl", ["--id", "u03", "--kind", "file", "--target", "x.py", "--check", "a"], 1,
+     "not a plan artifact's name",
+     "the plan's name was enforced at the READ door BY CONSTRUCTION (`verify` derives it and takes no plan path) and at the write door NOT AT ALL: this wrote a perfectly valid plan to a name nothing will ever open, and the pass would then be refused for a MISSING plan with its units on disk one filename away"),
 ]
 
 
 class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
+
+
+# --- the DOCS' examples, fed through the tool ----------------------------------------------------
+#
+# The doc is what a reviewer actually follows. **A documented example the tool REFUSES is not a typo — it
+# is a trap that makes correct behavior impossible**: the `plan_amendment_request` example omitted
+# `"type":"unit"` from its `proposed_unit`, the verifier REQUIRES that key, so a reviewer who copied the
+# documented shape produced a pass the tool then called `unusable`, with nothing telling it why.
+#
+# Eyeballing them is what let that ship. So they are EXECUTED: every JSON example in the campaign skill's
+# docs that claims one of THIS tool's types is parsed out and put through the very functions `verify` runs,
+# and a doc example this tool would reject FAILS THE BUILD. (Routing is by `type`, so the ledger's own
+# examples one file over are not this schema's business. The cost is that an example with a MISSPELLED
+# type would be skipped rather than caught — which is why the type set found is asserted below: a scan
+# that matched nothing, or lost a type, is a check that has quietly stopped checking.)
+
+DOCS = Path(__file__).resolve().parent.parent  # the campaign skill: SKILL.md and references/
+DOC_TYPES = {UNIT, PROGRESS, AMENDMENT, IDENTITY}
+
+
+def doc_examples() -> "list[tuple[str, int, dict]]":
+    """(file, line, record) for every JSON example in the docs that claims one of this tool's types."""
+    found: list[tuple[str, int, dict]] = []
+    for md in sorted(DOCS.rglob("*.md")):
+        for n, line in enumerate(md.read_text(encoding="utf-8").splitlines(), start=1):
+            text = line.strip()
+            if not text.startswith("{") or not text.endswith("}"):
+                continue
+            try:
+                rec = json.loads(text)
+            except json.JSONDecodeError:
+                continue  # a JSON-SHAPED line that is not JSON is some other doc's prose, not an example
+            if isinstance(rec, dict) and rec.get("type") in DOC_TYPES:
+                found.append((str(md.relative_to(DOCS)), n, rec))
+    return found
+
+
+def check_docs() -> int:
+    """Every documented example, through the tool. Returns the number that the tool would REFUSE."""
+    examples = doc_examples()
+    failures = 0
+    for where, n, rec in examples:
+        try:
+            if rec["type"] == UNIT:
+                check_unit(rec, f"{where}:{n}")
+            else:
+                check_event(rec, f"{where}:{n}")
+                if rec["type"] == IDENTITY:
+                    check_identity_shape(rec, f"{where}:{n}")
+            print(f"ok       {where}:{n:<4} {rec['type']:22} the tool accepts its own documented example")
+        except Defect as exc:
+            print(f"FAIL     {where}:{n:<4} the tool REFUSES its own documented example: {exc}")
+            failures += 1
+    seen = {rec["type"] for _w, _n, rec in examples}
+    if seen != DOC_TYPES:
+        print(f"FAIL     the docs no longer show an example of every event type — missing "
+              f"{sorted(DOC_TYPES - seen)}. A scan that matches nothing passes every time and checks "
+              f"nothing; these examples ARE the contract, so their absence is the failure")
+        failures += 1
+    return failures
 
 
 def build(tmp: Path, name: str, plan: "list[str] | None", progress: "list[str] | bytes") -> Path:
@@ -1033,13 +1150,13 @@ def run_cases(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]":
             got[f"[cli] {' '.join(argv)}"] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
             got[f"[cli] {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
-    for i, (argv, _want, _needle, _why) in enumerate(PLAN_CLI_CASES):
-        plan = build(tmp, f"plan-cli-{i}", PLAN, []).parent / "review-41-1.plan.jsonl"
+    for i, (pname, argv, _want, _needle, _why) in enumerate(PLAN_CLI_CASES):
+        plan = build(tmp, f"plan-cli-{i}", PLAN, []).parent / pname
         try:
             code, text = run_cli(mod, ["plan-add", "--file", str(plan), *argv])
-            got[f"[plan] {' '.join(argv)}"] = (f"exit{code}", text)
+            got[f"[plan] {pname} {' '.join(argv)}"] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
-            got[f"[plan] {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
+            got[f"[plan] {pname} {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
     return got
 
 
@@ -1048,7 +1165,8 @@ def expectations() -> "dict[str, tuple[str, str, str]]":
     out = {n: (w, needle, why) for n, (_p, _pr, w, needle, why) in CASES.items()}
     out.update({f"[name] {n}": (w, needle, why) for n, w, needle, why in NAME_CASES})
     out.update({f"[cli] {' '.join(a)}": (f"exit{c}", needle, why) for a, _seed, c, needle, why in CLI_CASES})
-    out.update({f"[plan] {' '.join(a)}": (f"exit{c}", needle, why) for a, c, needle, why in PLAN_CLI_CASES})
+    out.update({f"[plan] {p} {' '.join(a)}": (f"exit{c}", needle, why)
+                for p, a, c, needle, why in PLAN_CLI_CASES})
     return out
 
 
@@ -1061,8 +1179,9 @@ MARKER_RE = re.compile(r"^(?P<indent>[ ]*)# MUTATE:(?P<rule>[a-z0-9-]+):(?P<weak
 # The functions that ENFORCE the contract. Every enforcement point inside them must carry a marker.
 # `evaluate` is not one: it MAPS an exception to a verdict; it decides nothing.
 RULE_FUNCTIONS = (
-    "hook", "read_lines", "check_unit", "load_plan", "check_event", "check_identity_shape",
-    "check_identity", "decide", "parse_name", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
+    "hook", "read_lines", "check_unit", "plan_units", "load_plan", "check_event", "check_progress",
+    "walk_progress", "check_identity_shape", "check_identity", "decide", "parse_name",
+    "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
 )
 ENFORCING_EXCEPTIONS = ("Defect", "OperatorError")
 # The NAMES as they are spelled in the source, because that is what the AST holds — `return UNUSABLE, …`
@@ -1175,11 +1294,14 @@ def self_test() -> int:
             print(f"FAIL     {case[:44]:44} -> {outcome:11} but nothing mentions {needle!r}\n         got: {text}")
             failures += 1
     print()
+    doc_failures = check_docs()
+    failures += doc_failures
+    print()
     if failures:
         print(f"{failures} check(s) FAILED — the review-pass contract is broken.")
         return 1
     print(f"all {len(CASES)} fixtures + {len(NAME_CASES)} name cases + "
-          f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases hold.\n")
+          f"{len(CLI_CASES) + len(PLAN_CLI_CASES)} CLI cases + {len(doc_examples())} DOC examples hold.\n")
 
     # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
     marked = marked_statements(source)

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# THE EXEC BIT: mode 100644 is DELIBERATE, and TWO separate reviews have now proposed `chmod +x` here. The
+# answer is the same both times: nothing invokes this as `./review-pass.py`. Every caller runs it as
+# `python3 <path>` — CI does (`.github/workflows/ci.yml`), and so does the reviewer's emit call — so the
+# shebang is a courtesy and the mode carries nothing. Leave it.
 """Executable contract for a REVIEW PASS's artifacts (stage-2-review-gate.md).
 
 A review pass produces four things, and until now exactly ONE of them had a tool:
@@ -183,6 +187,20 @@ UNIT = "unit"
 # 0, so a value that names one is not a value we may go on to compare.
 COUNT = r"[1-9][0-9]*"
 
+# The LAUNCH ATTEMPT, as a FILENAME wears it: the `a<k>` suffix, which exists only for k >= 2 (attempt 1
+# has no suffix). Its domain is every decimal integer from 2 up, no leading zeros — a strict subset of
+# `COUNT`, because the attempt in the NAME is compared to the `launch_attempt` in the `pass_identity` and
+# the two must be the same kind of value.
+#
+# **IT WAS `[2-9][0-9]*`, WHICH READS LIKE "2 UPWARD" AND IS NOT.** That pattern accepts `a2`…`a9` and
+# `a20`, and REFUSES `a10` THROUGH `a19`: a tenth launch attempt could not name its own file, while this
+# tool's own error message and every doc say `k >= 2`. The regex and the definition disagreed about what an
+# attempt number IS — the same disease as ` u01 ` being two spellings of one id, one door over. A domain
+# with a hole in the middle of it is not a domain, and no fixture stood on that boundary.
+#
+# `[2-9]` is the one-digit case; `[1-9][0-9]+` is every longer one (so `10` is in and `02` is out).
+ATTEMPT = r"(?:[2-9]|[1-9][0-9]+)"
+
 # A unit id, and the one form of one: lowercase letters then digits — `u01`, `u02`. It is the id an
 # ORCHESTRATOR writes into the plan and a REVIEWER names in every progress event, so it is typed twice by
 # two different processes, and the whole point of pinning its shape is that those two typings cannot differ
@@ -270,9 +288,9 @@ def real_utc(value: str) -> bool:
 #
 # The `pr` and `pass` in a NAME are the SAME identifiers `ID_FORMATS` governs, so they are built from the
 # same `COUNT` — a name is an intake door too, and `review-041-1.progress.jsonl` is not another way of
-# writing PR 41. (The attempt suffix appears only for k >= 2: attempt 1 has no suffix, which is why its
-# form is spelled out here rather than reused.)
-NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-(?P<pass>{COUNT})(?:\.a(?P<attempt>[2-9][0-9]*))?"
+# writing PR 41. The attempt suffix is `ATTEMPT`, and it is a NAMED constant for the reason every other
+# value here is: written out inline it was `[2-9][0-9]*`, which silently refused `a10`-`a19`.
+NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-(?P<pass>{COUNT})(?:\.a(?P<attempt>{ATTEMPT}))?"
                      rf"\.progress\.jsonl\Z")
 
 # The plan is PER-PASS, not per-attempt: a relaunch reuses it unchanged (stage-2-review-gate.md). So it is
@@ -871,6 +889,30 @@ def check_plan_file(text: str, path: Path) -> "dict[str, dict]":
     return plan_units(parse_lines(text, path.name), path.name)
 
 
+def check_ruled(ruled: int) -> None:
+    """`--amendments-ruled` is a CARDINALITY — how many amendments the orchestrator has ruled on — so its
+    domain starts at ZERO, and this is the floor. The CEILING is the pass's own amendment count, and
+    `cmd_verify` enforces it one statement later; together they are the whole domain, bounded on both sides.
+
+    **A NEGATIVE VALUE WEDGES A PASS THAT WAS LEGITIMATELY EARNED.** `decide` computes `raised - ruled`, so
+    `--amendments-ruled -1` on a sound, COMPLETE pass with no amendments at all gives `0 - (-1) = 1` unruled
+    — and the pass comes back `amended`: "0 amendment(s), 1 not yet ruled on". There is no amendment to
+    rule on, so there is no way to clear it: the verdict names a thing that does not exist. It fails SAFE
+    (this tool can only ever SUBTRACT a pass, never grant one), and a pass withheld forever is still a pass
+    withheld — the over-count rule below already refuses a ruling for an amendment that does not exist, and
+    a NEGATIVE ruling is that same mistake with its sign flipped.
+    """
+    if ruled < 0:
+        # MUTATE:caller-ruled-negative:pass
+        raise OperatorError(
+            f"--amendments-ruled {ruled} is negative — it is a CARDINALITY (how many amendments you have "
+            f"already ruled on), so the smallest legal value is 0. A negative one is SUBTRACTED from the "
+            f"amendments the pass raised, so a complete, sound pass with none at all would come back "
+            f"{AMENDED!r} — '0 amendment(s), 1 not yet ruled on' — and no ruling could ever clear an "
+            f"amendment that was never raised"
+        )
+
+
 def count_amendments(progress: Path) -> int:
     """How many amendments the file holds — read WITHOUT judging it, so `--amendments-ruled` can be
     checked against reality before any verdict is computed."""
@@ -1037,6 +1079,11 @@ def cmd_verify(args) -> int:
             f"Every comparison below would be against a value that cannot be a commit, so the verdict "
             f"would be about the wrong question. No verdict beats a wrong one"
         )
+    # The ruling's DOMAIN, bounded on both sides and BEFORE `decide` ever sees the value: `check_ruled` is
+    # the floor (a cardinality starts at 0), the over-count rule below is the ceiling (you cannot rule on an
+    # amendment that was never raised). Neither is a fact about the artifacts — both are the CALLER's
+    # mistake, hence `OperatorError` and exit 2, not a verdict about the pass.
+    check_ruled(args.amendments_ruled)
     raised = count_amendments(path)
     if args.amendments_ruled > raised:
         # MUTATE:caller-ruled:pass
@@ -1316,6 +1363,13 @@ CLI_CASES = [
      "an OPERATOR error is not a snapshot verdict: exit 2, never a verdict computed from a comparison that could not have succeeded"),
     (["verify", "--head-sha", SHA, "--amendments-ruled", "1"], EMPTY, 2, "raised only 0",
      "a ruling for an amendment that does not exist would silently clear the NEXT one raised"),
+    (["verify", "--head-sha", SHA, "--amendments-ruled", "-1"], WORKED, 2, "smallest legal value is 0",
+     "HEADLINE: A NEGATIVE RULING WEDGES A PASS THAT WAS EARNED. The seed is a COMPLETE, sound pass — it "
+     "verifies `ok` with no flag at all — and `--amendments-ruled -1` used to turn it into `amended`: "
+     "`decide` subtracts the ruling, so `0 - (-1) = 1` amendment 'not yet ruled on' that the reviewer "
+     "never raised and no ruling can ever clear. It failed SAFE (this tool can only SUBTRACT a pass), and "
+     "a pass withheld forever is still withheld. The over-count rule bounded the value ABOVE and NOTHING "
+     "bounded it below: a cardinality's domain starts at 0, and now the floor is checked before `decide`"),
 ]
 
 # `plan-add` gets its own family: its `--check` is repeatable, so its argv do not fit the shape above, and
@@ -1471,16 +1525,78 @@ def cross_door(mod: types.ModuleType, tmp: Path) -> "dict[str, tuple[str, str]]"
     return got
 
 
-# --- every IDENTIFIER's format, stated as a table of what it TAKES and what it REFUSES ------------
+# --- EVERY BOUNDED VALUE, probed JUST INSIDE and JUST OUTSIDE its declared domain -----------------
 #
-# `ID_FORMATS` is the tool's claim about what an identifier is. This is the check on that claim, and it is
-# the reason a strict format beats normalizing: a rule that says "trim it" cannot be tabulated — there is
-# no set of strings it refuses — while a rule that says "it looks like THIS" has an exact boundary, and an
-# exact boundary is a thing a test can stand on both sides of.
+# A bounded value is one this tool ACCEPTS or REJECTS against a domain it has declared: every identifier
+# (`ID_FORMATS`), every number the FILENAME carries, and every numeric flag. The declaration is the tool's
+# CLAIM about what the value may be; this is the check on that claim, and it is the reason a strict format
+# beats normalizing — a rule that says "trim it" cannot be tabulated (there is no set of strings it
+# refuses), while a rule that says "it looks like THIS" has an exact boundary, and **an exact boundary is a
+# thing a test can stand on BOTH SIDES OF.**
 #
-# The identifiers COVERED are reconciled against `ID_FORMATS` itself, so an identifier added to the table
-# with no cases here FAILS the suite. A format nobody has fenced is a format that will drift.
-ID_CASES = [
+# **THE TOOL'S TWO WORST BUGS WERE BOTH A BOUNDARY NO FIXTURE STOOD ON**, and neither was a missing rule:
+#
+#   * the attempt suffix was `[2-9][0-9]*` — it took `a2`…`a9` and `a20` and REFUSED `a10` through `a19`,
+#     while the tool's own error message said `k >= 2`. A domain with a HOLE in the middle of it.
+#   * `--amendments-ruled` took `-1`, which `decide` then SUBTRACTED: a complete, sound pass with no
+#     amendments came back `amended`, "0 amendment(s), 1 not yet ruled on", and nothing could clear it.
+#
+# Every rule was present; every rule was right in the middle of its range. So the fence is not another rule
+# — it is COVERAGE, made mechanical. The values COVERED here are reconciled against `DOMAINS`, and a domain
+# with no cases, **or with cases on only ONE side of its boundary**, FAILS the suite. "We tested carefully"
+# cannot fail. "Every declared domain has a case just inside and just outside it, and here they are" can.
+
+Probe = Callable[[object], None]
+
+
+def probe_id(name: str) -> Probe:
+    """An identifier, through `check_id` — the ONE validator every real door calls."""
+    return lambda value: check_id(name, value, "[domain]")
+
+
+# The three numbers a progress file's NAME carries. They are probed through `parse_name` — the REAL door,
+# not a copy of its regex — by building the name that wears the value. `pr` and `pass` are the same `COUNT`
+# the identifiers use (the name is compared to the `pass_identity`, so they must be the same kind of value);
+# the attempt is `ATTEMPT`, from 2 up, and it is the one that was wrong.
+NAME_TEMPLATES = {"pr": "review-{v}-1.progress.jsonl",
+                  "pass": "review-41-{v}.progress.jsonl",
+                  "attempt": "review-41-1.a{v}.progress.jsonl"}
+
+
+def probe_name(field: str) -> Probe:
+    # A `def`, not a lambda: `parse_name` RETURNS the three numbers it parsed, and a probe answers only
+    # "was it refused?". The result is dropped here rather than leaked into a `Probe` that claims `None`.
+    def probe(value: object) -> None:
+        parse_name(Path(NAME_TEMPLATES[field].format(v=value)))
+
+    return probe
+
+
+def probe_ruled(value: object) -> None:
+    """`--amendments-ruled`, through the same `check_ruled` that `verify` runs — never a second copy of it.
+
+    The parser's `type=int` is what guarantees an int ever reaches that function, so this narrows the same
+    way: a non-integer is refused by argparse at the CLI door, one layer before the domain is consulted.
+    """
+    if not isinstance(value, int):
+        raise OperatorError(f"[domain] --amendments-ruled {value!r} is not an integer — the parser's "
+                            f"`type=int` refuses it before the domain is ever reached")
+    check_ruled(value)
+
+
+# The tool's every bounded value: name -> (the REAL door it enters by, its domain in words).
+DOMAINS: "dict[str, tuple[Probe, str]]" = {
+    **{name: (probe_id(name), spec) for name, (_re, spec, _why) in ID_FORMATS.items()},
+    "filename pr": (probe_name("pr"), "a decimal number from 1 up, as the progress file's NAME carries it"),
+    "filename pass": (probe_name("pass"), "a decimal number from 1 up, as the NAME carries it"),
+    "filename attempt": (probe_name("attempt"),
+                         "the `a<k>` suffix: a decimal integer from 2 UP, no leading zeros (attempt 1 "
+                         "wears no suffix at all)"),
+    "--amendments-ruled": (probe_ruled,
+                           "a CARDINALITY: an integer from 0 up, and never more than the pass raised"),
+}
+
+BOUNDARY_CASES: "list[tuple[str, object, bool]]" = [
     ("id", "u01", True), ("id", "u99", True), ("id", "unit01", True),
     ("id", " u01 ", False), ("id", "u01 ", False), ("id", "\tu01", False), ("id", "u 01", False),
     ("id", "u01\n", False), ("id", "U01", False), ("id", "u", False), ("id", "01", False),
@@ -1491,37 +1607,83 @@ ID_CASES = [
     ("pr", "0", False), ("pr", "041", False), ("pr", " 41", False), ("pr", "41 ", False),
     ("pr", "+41", False), ("pr", "-41", False), ("pr", "4_1", False), ("pr", "", False), ("pr", 41, False),
     ("pass", "1", True), ("pass", "0", False), ("pass", "one", False), ("pass", "01", False),
-    ("launch_attempt", "1", True), ("launch_attempt", "2", True),
+    ("launch_attempt", "1", True), ("launch_attempt", "2", True), ("launch_attempt", "10", True),
     ("launch_attempt", "0", False), ("launch_attempt", " 2", False), ("launch_attempt", "two", False),
     ("head_sha", SHA, True),
     ("head_sha", SHA[:7], False),          # THE TRUNCATED SHA — it reached real state, and it is CLEAN:
     ("head_sha", SHA.upper(), False),      # no trimming could ever have caught it. Only a FORMAT can.
-    ("head_sha", SHA + "0", False), ("head_sha", " " + SHA, False), ("head_sha", SHA + "\n", False),
+    ("head_sha", SHA + "0", False), ("head_sha", SHA[:39], False),
+    ("head_sha", " " + SHA, False), ("head_sha", SHA + "\n", False),
     ("head_sha", "", False), ("head_sha", None, False),
+
+    # The FILENAME's numbers — the same domains, at the door that reads the NAME rather than the bytes.
+    ("filename pr", "1", True), ("filename pr", "41", True), ("filename pr", "10", True),
+    ("filename pr", "0", False), ("filename pr", "041", False), ("filename pr", "", False),
+    ("filename pr", "-1", False), ("filename pr", "1 ", False),
+    ("filename pass", "1", True), ("filename pass", "2", True), ("filename pass", "10", True),
+    ("filename pass", "0", False), ("filename pass", "01", False), ("filename pass", "", False),
+
+    # **THE ATTEMPT SUFFIX — THE BOUNDARY NOBODY STOOD ON.** `a2`…`a9` and `a20` were accepted and
+    # `a10`…`a19` were REFUSED, so both edges of the hole are pinned here (9/10 and 19/20), along with the
+    # bottom edge (1 is out, 2 is in — attempt 1 wears no suffix) and the leading zero.
+    ("filename attempt", "2", True), ("filename attempt", "3", True), ("filename attempt", "9", True),
+    ("filename attempt", "10", True), ("filename attempt", "11", True), ("filename attempt", "19", True),
+    ("filename attempt", "20", True), ("filename attempt", "99", True), ("filename attempt", "100", True),
+    ("filename attempt", "1", False), ("filename attempt", "0", False),
+    ("filename attempt", "02", False), ("filename attempt", "010", False),
+    ("filename attempt", "", False), ("filename attempt", "-2", False), ("filename attempt", "+2", False),
+    ("filename attempt", "2 ", False), ("filename attempt", " 2", False), ("filename attempt", "2a", False),
+
+    # **`--amendments-ruled` — A CARDINALITY, and 0 is INSIDE it.** `-1` is the wedge: subtracted from the
+    # amendments the pass raised, it invents one that nobody can ever rule on.
+    ("--amendments-ruled", 0, True), ("--amendments-ruled", 1, True), ("--amendments-ruled", 7, True),
+    ("--amendments-ruled", -1, False), ("--amendments-ruled", -2, False),
 ]
 
 
-def check_id_formats() -> int:
-    """Every identifier's format, against what it must TAKE and what it must REFUSE. Returns the failures."""
+def check_boundaries() -> int:
+    """Every bounded value, JUST INSIDE and JUST OUTSIDE its domain — and every domain probed on BOTH sides.
+
+    Returns the failures. The second loop is the mechanical part: it is what a bug like `a10` has to get
+    past, and it cannot — a domain nobody fenced on both sides is reported as unfenced, by name.
+    """
     failures = 0
-    for name, value, accepted in ID_CASES:
+    sides: dict[str, set[bool]] = {}
+    for name, value, accepted in BOUNDARY_CASES:
+        # Recorded BEFORE the lookup, so a case naming a value with no declared domain is REPORTED (below)
+        # rather than skipped into silence — the `stray` check is how this table cannot quietly test a
+        # domain the tool does not actually declare.
+        sides.setdefault(name, set()).add(accepted)
+        if name not in DOMAINS:
+            continue
+        probe, spec = DOMAINS[name]
         try:
-            check_id(name, value, "[id-format]")
+            probe(value)
             got = True
-        except Defect:
+        except (Defect, OperatorError):
             got = False
         if got == accepted:
-            verb = "accepts" if accepted else "REFUSES"
-            print(f"ok       [id] `{name}` {verb} {value!r}")
+            print(f"ok       [domain] `{name}` {'accepts' if accepted else 'REFUSES'} {value!r}")
         else:
-            print(f"FAIL     [id] `{name}` {'REFUSED' if accepted else 'ACCEPTED'} {value!r} — and an "
-                  f"identifier's format is the ONE thing both doors read it by")
+            print(f"FAIL     [domain] `{name}` {'REFUSED' if accepted else 'ACCEPTED'} {value!r} — its "
+                  f"domain is {spec}, and the BOUNDARY is where two doors come to disagree about what a "
+                  f"value IS. `a10` was refused by a pattern whose own error message said `k >= 2`")
             failures += 1
-    covered = {name for name, _v, _a in ID_CASES}
-    if covered != set(ID_FORMATS):
-        print(f"FAIL     [id] identifiers with a format and NO cases: {sorted(set(ID_FORMATS) - covered)}; "
-              f"cases for an identifier that has no format: {sorted(covered - set(ID_FORMATS))}. A format "
-              f"nobody fenced is one that will drift")
+
+    for name, (_probe, spec) in DOMAINS.items():
+        probed = sides.get(name, set())
+        if probed == {True, False}:
+            continue
+        gap = ("NO CASES AT ALL" if not probed else
+               "no case INSIDE it" if True not in probed else "no case OUTSIDE it")
+        print(f"FAIL     [domain] `{name}` ({spec}) has {gap} — a domain is fenced only when the suite "
+              f"stands on BOTH sides of its boundary. An unprobed side is what `a10` and `-1` cost")
+        failures += 1
+
+    stray = sorted(set(sides) - set(DOMAINS))
+    if stray:
+        print(f"FAIL     [domain] cases for a value with no declared domain: {stray} — a domain is "
+              f"DECLARED in `DOMAINS` or it is not a domain at all")
         failures += 1
     return failures
 
@@ -1832,7 +1994,7 @@ MARKER_RE = re.compile(r"^(?P<indent>[ ]*)# MUTATE:(?P<rule>[a-z0-9-]+):(?P<weak
 RULE_FUNCTIONS = (
     "hook", "read_text", "parse_lines", "read_lines", "check_id", "check_unit", "plan_units", "load_plan",
     "check_event", "check_progress", "walk_progress", "check_identity_shape", "check_identity",
-    "check_head", "check_progress_file", "check_plan_file", "decide", "parse_name",
+    "check_head", "check_progress_file", "check_plan_file", "decide", "parse_name", "check_ruled",
     "before_text", "write_line", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_verify",
 )
 ENFORCING_EXCEPTIONS = ("Defect", "OperatorError")
@@ -1976,7 +2138,7 @@ def self_test() -> int:
             failures += 1
     print()
     failures += help_failures
-    failures += check_id_formats()
+    failures += check_boundaries()
     print()
     doc_failures = check_docs()
     failures += doc_failures
@@ -1989,8 +2151,9 @@ def self_test() -> int:
           f"{len(WRITE_COMMANDS) * len(FILE_STATES)} round-trip cases ({len(WRITE_COMMANDS)} write "
           f"commands, derived from the parser, x {len(FILE_STATES)} pre-existing file states) + "
           f"{len(CROSS_DOOR_IDS)} cross-door cases (the plan door refuses the id, or the emit door can "
-          f"match it) + {len(ID_CASES)} identifier-format cases ({len(ID_FORMATS)} identifiers, each with "
-          f"ONE legal form) + {len(doc_examples())} DOC examples hold — and the invocation "
+          f"match it) + {len(BOUNDARY_CASES)} boundary cases ({len(DOMAINS)} bounded values, each probed "
+          f"JUST INSIDE and JUST OUTSIDE its declared domain) + {len(doc_examples())} DOC examples hold — "
+          f"and the invocation "
           f"`{WRAPPER.name} --help` advertises was EXECUTED, and runs.\n")
 
     # …and now the question the block above CANNOT answer: is any rule pinned by NO fixture?
@@ -2112,7 +2275,8 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     v.add_argument("--file", required=True, help="the ACTIVE launch attempt's progress.jsonl")
     v.add_argument("--head-sha", required=True, help="the PR's LIVE head — the pass must have run on it")
     v.add_argument("--amendments-ruled", type=int, default=0, metavar="N",
-                   help="how many of this pass's plan amendments you have already ruled on (default 0)")
+                   help="how many of this pass's plan amendments you have already ruled on — a count, so "
+                        "N >= 0, and never more than the pass actually raised (default 0)")
 
     sub.add_parser("self-test", help="run every fixture, then DELETE each rule and prove a fixture notices")
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -27,8 +27,8 @@ So this file is the review pass's artifacts, executed:
 WHAT `verify` DOES NOT DO — AND THE LINE IS DELIBERATE. It never opens `review-<pr>-<n>.txt`, never
 parses the reviewer's prose, and CANNOT SAY `SATISFIED`. Its whole answer is about the pass's MECHANICS:
 is there an identity, does it name the commit the pass actually ran on, is every `done` for a unit that
-was really planned, does every `done` carry evidence, were amendments raised. The VERDICT is the
-reviewer's JUDGMENT and stays theirs.
+was really planned, did every `done` FOLLOW a `started` for that same unit, does every `done` carry
+evidence, were amendments raised. The VERDICT is the reviewer's JUDGMENT and stays theirs.
 
 That line is what keeps this tool from BECOMING the gate. `verify` can only ever SUBTRACT a pass — refuse
 one that is defective. It can never ADD a SATISFIED verdict, never raise `reviews_ok`, and never merge
@@ -69,6 +69,7 @@ import tempfile
 import types
 from collections import Counter
 from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime
 from pathlib import Path
 from typing import NoReturn
 
@@ -126,6 +127,24 @@ NUM_RE = re.compile(r"^(0|[1-9][0-9]*)$")
 # value that cannot be parsed as a time silently DISABLES that deadline: the guard's input is absent, so
 # the guard never fires, and a reviewer that never started is waited on forever. UTC ISO-8601, `Z`.
 TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def real_utc(value: str) -> bool:
+    """Does this timestamp name a MOMENT — not merely look like one?
+
+    `TS_RE` is a SHAPE check, and shape is not meaning: `2026-99-99T99:99:99Z` matches it exactly, and a
+    month-99 date is not a date. A regex that accepts month 99 is a guard that CANNOT FIRE on the case
+    that matters — the deadline measured from an impossible time is a deadline whose arithmetic cannot be
+    done, which is the very failure the shape check was written to stop. So after the shape holds, the
+    value is PARSED, and what does not parse is refused: `strptime` is the arbiter of what a date is, not
+    ten digits in the right places. (`%Y-%m-%dT%H:%M:%SZ` — the `Z` is a literal, so this is UTC by
+    construction; a value carrying any other offset never reaches here, `TS_RE` having refused it.)
+    """
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return False
+    return True
 
 # The artifact's EXACT name (`files-and-ledger.md`; the attempt table in stage-2-review-gate.md):
 # attempt 1 is `review-<pr>-<n>.progress.jsonl`, a relaunch is `review-<pr>-<n>.a<k>.progress.jsonl`.
@@ -340,6 +359,25 @@ def check_event(rec: dict, where: str) -> None:
                 f"we may hand to a comparison and hope (it used to CRASH the tool)"
             )
     if kind == AMENDMENT:
+        # The amendment is the ONE event a reviewer really does hand-write (it is exempt from the
+        # emit-only rule), so it is the one whose fields nothing upstream has already shaped. Its `ts` had
+        # NO check at all beyond "is a string" — the identity's clock was guarded and this one, the same
+        # kind of value, was not. It is what says WHEN the reviewer said the plan was wrong, and the
+        # orchestrator rules on amendments in order; a `ts` that is not a time cannot be ordered.
+        if not TS_RE.match(rec["ts"]) or not real_utc(rec["ts"]):
+            # MUTATE:amendment-ts:pass
+            raise Defect(
+                f"{where}: `ts` is {rec['ts']!r}, not a real UTC ISO-8601 time (YYYY-MM-DDThh:mm:ssZ) — "
+                f"the same clock rule the `pass_identity` obeys, and for the same reason: a value that is "
+                f"not a moment cannot be compared to one"
+            )
+        if not rec["reason"].strip():
+            # MUTATE:amendment-blank-reason:pass
+            raise Defect(
+                f"{where}: `reason` is blank — an amendment is a CLAIM that the plan misses a dimension, "
+                f"and the orchestrator must RULE on it. A ruling needs something to rule on; blank `reason` "
+                f"is the evidence-free `done` of the amendment world"
+            )
         check_unit(rec["proposed_unit"], f"{where} proposed_unit")
     if kind == PROGRESS and status == DONE and not rec["evidence"].strip():
         # MUTATE:empty-evidence:pass
@@ -381,6 +419,14 @@ def check_identity_shape(ident: dict, where: str) -> None:
             f"{where}: `dispatched_at` is {ident['dispatched_at']!r}, not a UTC ISO-8601 timestamp "
             f"(YYYY-MM-DDThh:mm:ssZ) — it is the LAUNCH DEADLINE's clock, and a deadline measured from a "
             f"time nobody can parse never fires"
+        )
+    if not real_utc(ident["dispatched_at"]):
+        # MUTATE:identity-dispatched-at-real:pass
+        raise Defect(
+            f"{where}: `dispatched_at` is {ident['dispatched_at']!r} — the right SHAPE, and not a real UTC "
+            f"time. A month 99 is not a month. The shape check alone could not fire on this, and the "
+            f"deadline it exists to protect is measured by ARITHMETIC on this value: a moment that does "
+            f"not exist is one no clock ever passes"
         )
 
 
@@ -430,7 +476,23 @@ def check_identity(events: "list[dict]", pr: str, npass: str, attempt: str, head
 # --- the verdict ---------------------------------------------------------------------------------
 
 def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int) -> "tuple[str, str]":
-    """Given SOUND artifacts: does this pass COUNT? (Its report is still not read. That is the point.)"""
+    """Given SOUND artifacts: does this pass COUNT? (Its report is still not read. That is the point.)
+
+    A `done` REQUIRES an earlier `started` for the same unit, and this walk enforces it BY ORDER, not by
+    presence: `announced` only ever holds units a line ALREADY READ announced, so a `started` that appears
+    BELOW its `done` cannot satisfy it. Presence alone would be the weaker rule and the wrong one — the
+    file is APPEND-ONLY, so its order IS the order the events happened in, and a forger who has to also
+    fabricate the `started` FIRST has to fabricate the whole sequence, which is precisely the thing the
+    file is evidence of. "u01 finished, then u01 began" is not a review; it is a file with the right lines
+    in it.
+
+    **This is the rule that was PROSE and enforced by NOBODY, and it is the one the tool most needed.** A
+    progress file with a valid identity and a `done` for EVERY planned unit — and NOT ONE `started` —
+    verified `ok`: the tool that exists to prove a review HAPPENED accepted a review that demonstrably did
+    not. Skip straight to "done" for every unit and the gate was satisfied on zero evidence of work. A
+    `done` with no `started` is not progress, exactly as an empty plan is not a plan.
+    """
+    announced: set[str] = set()
     done: dict[str, str] = {}
     for n, rec in enumerate(events, start=1):
         if rec["type"] != PROGRESS:
@@ -444,7 +506,17 @@ def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int) -> "tuple
                 f"PLANNED unit. Planned: {sorted(units)}"
             )
         if rec["status"] != DONE:
+            announced.add(unit)
             continue
+        if unit not in announced:
+            # MUTATE:done-without-started:pass
+            raise Defect(
+                f"line {n}: {DONE!r} for unit {unit!r} with no earlier {STARTED!r} for it — a unit that "
+                f"was never begun cannot have been finished. The reviewer emits {STARTED!r} when a unit "
+                f"BEGINS and {DONE!r} when it ends, so a `{DONE}` standing alone (or standing ABOVE its "
+                f"`{STARTED}` in this append-only file) is not the record of a review that happened; it is "
+                f"a file with the right lines in it"
+            )
         if unit in done:
             # MUTATE:duplicate-done:pass
             raise Defect(
@@ -531,12 +603,26 @@ def append(path: Path, rec: dict) -> str:
     return line
 
 
+def announced_units(path: Path) -> "set[str]":
+    """The units this progress file has ALREADY announced a `started` for — read from the BYTES on disk.
+
+    The write door cannot ask its own process what it emitted: a reviewer is many `emit` invocations, each
+    a fresh process, and the only thing that survives between them is the file. So the file is the memory,
+    and reading it is how `emit` knows whether the `done` it was just handed follows a `started`.
+    """
+    out: set[str] = set()
+    for e in read_lines(path, "progress file"):
+        if e.get("type") == PROGRESS and e.get("status") == STARTED and isinstance(e.get("unit"), str):
+            out.add(e["unit"])
+    return out
+
+
 def cmd_emit(args) -> int:
     """Append one unit-progress event — the ONLY sanctioned way a reviewer records one.
 
     It refuses an unplanned unit HERE TOO, and not only in `verify`: the reviewer gets a non-zero exit and
     a message it can act on, at the moment it makes the mistake, instead of a pass silently thrown away
-    fifteen minutes later.
+    fifteen minutes later. Same for a `done` that no `started` precedes.
     """
     path = Path(args.file)
     pr, npass, _attempt = parse_name(path)
@@ -564,6 +650,16 @@ def cmd_emit(args) -> int:
         raise Defect(
             f"unit {unit!r} is NOT IN THE PLAN — you may not self-grant a unit. Planned: {sorted(units)}. "
             f"If the plan is missing a dimension, raise a plan_amendment_request instead"
+        )
+    # LAST, deliberately: an unplanned `done` must still be refused as UNPLANNED. Were this check first, a
+    # reviewer self-granting a unit would be told "no earlier started" — true, and the wrong lesson.
+    if args.status == DONE and unit not in announced_units(path):
+        # MUTATE:emit-done-without-started:pass
+        raise Defect(
+            f"unit {unit!r} has no earlier `{STARTED}` event in {path.name} — emit `--status {STARTED}` "
+            f"when the unit BEGINS, and `--status {DONE}` when it ends. A unit that was never begun cannot "
+            f"be finished, and `verify` reads this back under the same rule: a `{DONE}` with no `{STARTED}` "
+            f"makes the whole pass unusable, so writing one here would only lose the pass later"
         )
     sys.stdout.write(append(path, rec))
     return 0
@@ -720,6 +816,12 @@ CASES = {
                        "a `done` for a unit nobody planned. The rule was PROSE and enforced by NOBODY: the write tool accepted it and the read side never looked"),
     "unplanned-started": (PLAN, [ident(), started("u99")], UNUSABLE, "NOT IN THE PLAN",
                           "…and a `started` for one, which is what a reviewer inventing a unit does FIRST"),
+    "done-without-started": (PLAN, [ident(), done("u01"), done("u02", evidence="stage-2:161")], UNUSABLE,
+                             "no earlier 'started'",
+                             "THE FORGED PASS: a valid identity and a `done` for EVERY planned unit, with NOT ONE `started`. It verified `ok` — the tool that exists to prove a review HAPPENED accepted one that demonstrably did not, on zero evidence of any work"),
+    "done-before-started": (PLAN, [ident(), done("u01"), started("u01"), started("u02"), done("u02")], UNUSABLE,
+                            "no earlier 'started'",
+                            "…and the ORDER of it: every `started` a real pass would have, but one lands BELOW its `done`. The file is append-only, so its order IS the sequence; 'u01 finished, then u01 began' is not a review"),
     "done-no-evidence": (PLAN, [ident(), done("u01", evidence=DROP)], UNUSABLE, "carries EXACTLY",
                          "a `done` with no evidence key at all — a claim with nothing behind it"),
     "done-blank-evidence": (PLAN, [ident(), done("u01", evidence="   ")], UNUSABLE, "CONCRETE evidence",
@@ -762,6 +864,9 @@ CASES = {
                             "an attempt number that cannot be COMPARED to the one in the filename"),
     "identity-bad-ts": (PLAN, [ident(dispatched_at="just now"), done("u01")], UNUSABLE, "LAUNCH DEADLINE's clock",
                         "a dispatched_at nobody can parse — the ~5-min deadline measured from it NEVER FIRES"),
+    "identity-impossible-ts": (PLAN, [ident(dispatched_at="2026-99-99T99:99:99Z"), started("u01"), done("u01"),
+                                      started("u02"), done("u02")], UNUSABLE, "not a real UTC time",
+                               "A DATE THAT CANNOT EXIST, in the right SHAPE. The regex matched it and the whole pass verified `ok` — month 99, hour 99. The shape check could not fire on the one input that defeats the deadline it protects"),
     "identity-missing-key": (PLAN, [ident(dispatched_at=DROP), done("u01")], UNUSABLE, "carries EXACTLY",
                              "a pass_identity with no dispatch clock at all"),
 
@@ -788,13 +893,20 @@ CASES = {
                  "bytes we cannot decode are not evidence — and decoding them LENIENTLY rewrites what the file says"),
 
     # Amendments, completeness, and the verdicts that are not refusals.
-    "amendment-unruled": (PLAN, [ident(), done("u01"), amendment(), done("u02")], AMENDED, "not yet ruled on",
+    "amendment-unruled": (PLAN, [ident(), started("u01"), done("u01"), amendment(), started("u02"), done("u02")],
+                          AMENDED, "not yet ruled on",
                           "the reviewer says the plan is missing a dimension. It is a VERDICT, never a footnote printed beside `ok`"),
     "amendment-bad-unit": (PLAN, [ident(), amendment(proposed_unit={"id": "u99"})], UNUSABLE, "carries EXACTLY",
                            "a hand-written amendment (they are EXEMPT from the emit-only rule, so this is the one event a reviewer really does write) whose proposed unit is malformed"),
+    "amendment-impossible-ts": (PLAN, [ident(), amendment(ts="2026-99-99T99:99:99Z")], UNUSABLE,
+                                "not a real UTC ISO-8601 time",
+                                "the amendment's `ts` had NO check at all beyond 'is a string' — the identity's clock was guarded and this one, the same kind of value, was not. The orchestrator rules on amendments; a `ts` that is not a moment cannot be ordered against one"),
+    "amendment-blank-reason": (PLAN, [ident(), amendment(reason="   ")], UNUSABLE, "an amendment is a CLAIM",
+                               "an amendment with a blank reason: it FORCES the `amended` verdict — a pass held back — while saying nothing the orchestrator can rule on. The evidence-free `done` of the amendment world"),
     "incomplete": (PLAN, [ident(), started("u01"), done("u01"), started("u02")], INCOMPLETE, "has not covered its plan",
                    "u02 was started and never finished — `started` is liveness, NEVER completion"),
-    "duplicate-done": (PLAN, [ident(), done("u01"), done("u01", evidence="somewhere else"), done("u02")],
+    "duplicate-done": (PLAN, [ident(), started("u01"), done("u01"), done("u01", evidence="somewhere else"),
+                              started("u02"), done("u02")],
                        UNUSABLE, "SECOND", "two accounts of one unit, and nothing says which was read"),
     "identity-only": (PLAN, [ident()], INCOMPLETE, "0/2",
                       "the file the orchestrator leaves at dispatch: the reviewer has produced NOTHING, and this is not an error — it is a pass that has not covered its plan yet"),
@@ -819,11 +931,15 @@ NAME_CASES = [
 # still under test. The default seed is an EMPTY progress file: what the orchestrator has in hand when it
 # writes `pass_identity`, and what `emit` appends to thereafter.
 EMPTY: "list[str]" = []
+BEGUN = [ident(), started("u01")]  # the file a reviewer has in hand once it has ANNOUNCED u01
 CLI_CASES = [
     (["emit", "--unit", "u01", "--status", "started"], EMPTY, 0, '"status":"started"', "the call every reviewer prompt makes"),
-    (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], EMPTY, 0, '"evidence":"f.py:1"', "…and its done form"),
+    (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], BEGUN, 0, '"evidence":"f.py:1"',
+     "…and its done form, on the file that HAS the matching `started` — the only file the done form was ever meant to be run against"),
+    (["emit", "--unit", "u02", "--status", "done", "--evidence", "f.py:1"], BEGUN, 1, "no earlier `started`",
+     "HEADLINE, WRITE DOOR: a `done` for a unit that was never begun. The write door refuses it at the moment the reviewer makes the mistake, instead of the pass being thrown away by `verify` fifteen minutes later"),
     (["emit", "--unit", "u99", "--status", "done", "--evidence", "f.py:1"], EMPTY, 1, "NOT IN THE PLAN",
-     "HEADLINE, WRITE DOOR: the tool accepted a self-granted unit. It no longer does"),
+     "HEADLINE, WRITE DOOR: the tool accepted a self-granted unit. It no longer does — and it says UNPLANNED, not 'no started': an unplanned unit's real defect is that nobody planned it"),
     (["emit", "--unit", "u99", "--status", "started"], EMPTY, 1, "NOT IN THE PLAN", "…and refuses to START one"),
     (["emit", "--unit", "u01", "--status", "done"], EMPTY, 1, "--evidence is required", "a done with no evidence"),
     (["emit", "--unit", "u01", "--status", "done", "--evidence", "  "], EMPTY, 1, "--evidence is required", "…or blank evidence"),
@@ -837,6 +953,8 @@ CLI_CASES = [
      "an UPPERCASE sha: no producer of ours emits one, so it did not come from `git rev-parse`"),
     (["identity", "--head-sha", SHA, "--dispatched-at", "just now"], EMPTY, 1, "LAUNCH DEADLINE's clock",
      "a dispatch clock the launch deadline cannot be measured from — the write door runs the READ side's shape rules, so it cannot write one `verify` would reject"),
+    (["identity", "--head-sha", SHA, "--dispatched-at", "2026-99-99T99:99:99Z"], EMPTY, 1, "not a real UTC time",
+     "…and the one the SHAPE rule cannot see: an impossible date in the right shape. Both doors parse it now, so neither can produce a `dispatched_at` no clock ever passes"),
     (["identity", "--head-sha", OTHER_SHA, "--dispatched-at", TS], [ident()], 1, "already holds events",
      "a SECOND identity into a live pass's file. `pass_identity` is the FIRST line, written before dispatch — a relaunch gets its OWN file, and appending here is how one pass ends up describing two commits"),
     (["verify", "--head-sha", SHA[:7]], EMPTY, 2, "No verdict beats a wrong one",


### PR DESCRIPTION
- add `scripts/review-pass.py`: one owner for a pass's plan, `pass_identity`, progress, and tally
- refuses an unplanned `done`, evidence-free `done`, truncated SHA — at the READ door too
- never reads the report, never says SATISFIED: it can refuse a pass, never accept one
- `emit-progress.py` CLI unchanged; CI self-test deletes each of 40 rules, fails if unpinned
