### PR TITLE
narrow the AST node before reading its position

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Shellcheck
         run: |
           mapfile -t files < <(find . -name '*.sh' -not -path './.git/*')
@@ -51,6 +55,35 @@ jobs:
           mapfile -t files < <(find . -name '*.py' -not -path './.git/*')
           printf 'checking %s\n' "${files[@]}"
           python3 -m py_compile "${files[@]}"
+
+      # `py_compile` above proves the file PARSES. It says nothing about whether the code is TYPE-correct,
+      # and the gap between those two is where a real defect already hid: an accessor reached for `.lineno`
+      # through `ast.AST`, which does not declare it — code that compiles, runs, and is a lie about what the
+      # walk yields.
+      #
+      # DELIBERATELY FILE-SCOPED, not repo-wide. The other scripts here are not type-clean yet, and a
+      # repo-wide gate would fail builds for reasons that have nothing to do with the change under review —
+      # a gate that is red for everyone is a gate nobody can use. Add each file to this list as it is fixed;
+      # the list is the record of what is CLEAN, and nothing may fall back out of it.
+      #
+      # The `filesAnalyzed` assertion is the load-bearing half of this step, not a flourish. Pyright analyses
+      # ZERO files IN SILENCE when a path matches nothing it will look at — it prints "0 errors" and exits 0.
+      # A step that trusted the exit code alone would keep reporting success after a rename, while checking
+      # nothing whatsoever. So the count is asserted: this step can only pass by actually having looked.
+      - name: Pyright (the type-clean scripts)
+        run: |
+          set -o pipefail
+          npx --yes pyright@1.1.410 --outputjson \
+            plugins/gauntlet/skills/campaign/scripts/ledger.py \
+            plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py | tee pyright.json
+          analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
+          echo "filesAnalyzed=${analyzed}"
+          if [ "${analyzed}" != "2" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 2 it was pointed at — it checked" \
+                 "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
+            exit 1
+          fi
+          rm -f pyright.json
 
       # The CI-snapshot contract, executed. The rules it pins are prose in stage-2-ci.md, and prose
       # cannot be run — three defects shipped in that prose, each of which dies instantly against a

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -666,8 +666,13 @@ def grid(out: str, fields: "tuple[str, ...]") -> "tuple[list[str], list[int], li
 
 
 # --- the fixtures -------------------------------------------------------------
+#
+# Every fixture takes the same argument — its own scratch directory, handed to it by `self_test()`. A
+# fixture that asserts on a PURE function needs no file, so it names that argument `_tmp`: the signature is
+# fixed by the CASES table, and the leading underscore is how a parameter says it is deliberately unused
+# rather than forgotten.
 
-def t_escape_injective(tmp: Path) -> None:
+def t_escape_injective(_tmp: Path) -> None:
     """Two DIFFERENT values NEVER render as the same cell.
 
     A non-injective escaping is a NEW LIE inside the code written to stop lies: `a|b` and `a\\|b` are
@@ -752,7 +757,7 @@ def bare(cell: str) -> "list[str]":
     return out
 
 
-def t_escape_invariant(tmp: Path) -> None:
+def t_escape_invariant(_tmp: Path) -> None:
     """The escaped cell holds NO BARE grid metacharacter: no unescaped `|`, no line break, no control
     char — and it never opens with `#`. This is what makes the ` | ` separator and the `# ` config prefix
     mean ONE thing wherever they appear.
@@ -783,7 +788,7 @@ def t_escape_invariant(tmp: Path) -> None:
               f"invisible, and rstrip() eats it")
 
 
-def t_escape_mapping(tmp: Path) -> None:
+def t_escape_mapping(_tmp: Path) -> None:
     r"""The escape TABLE itself, character by character — and ordinary text left BYTE-IDENTICAL.
 
     The invariant above is satisfied by more than one escaping (drop the `\n` branch and a newline still
@@ -882,7 +887,7 @@ def t_widths_from_escaped(tmp: Path) -> None:
     path = write_lines(tmp / "w.jsonl", header_line(), row_line(pr="1", slug=raw))
     code, out, err = run(["--file", str(path), "table", "--fields", "slug,pr"])
     check(code == 0, f"table exited {code}: {err!r}")
-    _, widths, cells = grid(out, ("slug", "pr"))
+    _, widths, _ = grid(out, ("slug", "pr"))
     check(widths[0] == len(escaped),
           f"the slug column is {widths[0]} wide but prints {len(escaped)} chars ({escaped!r}) — the width "
           f"was measured on the RAW value ({len(raw)}), not the printed one")

--- a/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
@@ -123,6 +123,31 @@ def marked_statements(source: str) -> dict[str, tuple[str, ast.stmt]]:
     return out
 
 
+def bare_name(node: ast.expr | None) -> str | None:
+    """The identifier this expression IS, or None if it is not a bare name.
+
+    `ast.expr` declares no `id` — only `ast.Name` does. Asking for `.id` through the base class (or through
+    a `getattr`) reads as "any expression might be a name", which is false, and it silently answers None for
+    an expression whose shape was never considered. This asks the question the node type can actually
+    answer, and every caller below has to handle the None.
+    """
+    return node.id if isinstance(node, ast.Name) else None
+
+
+def is_enforcing_raise(node: ast.Raise) -> bool:
+    """`raise SnapshotError(...)` / `raise Unverifiable(...)` — a rule REJECTING the evidence."""
+    return isinstance(node.exc, ast.Call) and bare_name(node.exc.func) in ENFORCING_EXCEPTIONS
+
+
+def is_enforcing_return(node: ast.Return) -> bool:
+    """`return RED/PENDING/UNCLASSIFIED, ...` — a rule DECIDING a non-green verdict."""
+    return (
+        isinstance(node.value, ast.Tuple)
+        and bool(node.value.elts)
+        and bare_name(node.value.elts[0]) in ENFORCING_VERDICTS
+    )
+
+
 def check_coverage(source: str, marked: dict[str, tuple[str, ast.stmt]]) -> list[str]:
     """EVERY enforcement point in a rule function must sit under a marker.
 
@@ -137,13 +162,17 @@ def check_coverage(source: str, marked: dict[str, tuple[str, ast.stmt]]) -> list
         if not isinstance(fn, ast.FunctionDef) or fn.name not in RULE_FUNCTIONS:
             continue
         for node in ast.walk(fn):
-            enforcing = False
-            if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
-                enforcing = getattr(node.exc.func, "id", None) in ENFORCING_EXCEPTIONS
-            elif isinstance(node, ast.Return) and isinstance(node.value, ast.Tuple) and node.value.elts:
-                enforcing = getattr(node.value.elts[0], "id", None) in ENFORCING_VERDICTS
+            # `ast.walk` yields `ast.AST`, and `AST` carries NO position — `lineno` lives on the concrete
+            # node types. So the enforcement point is narrowed to the two node types it can actually BE,
+            # and the line number is read off THOSE. That narrowing is the whole point: it is what makes
+            # `what` follow from the node's type instead of being re-derived from it afterwards.
+            if isinstance(node, ast.Raise):
+                what, enforcing = "raise", is_enforcing_raise(node)
+            elif isinstance(node, ast.Return):
+                what, enforcing = "return", is_enforcing_return(node)
+            else:
+                continue
             if enforcing and node.lineno not in marked_lines:
-                what = "raise" if isinstance(node, ast.Raise) else "return"
                 problems.append(
                     f"{SCRIPT.name}:{node.lineno}: {fn.name}() enforces a rule ({what}) with NO "
                     f"# MUTATE marker — an unmarked rule is never mutated, so nothing can report it unpinned"
@@ -181,7 +210,9 @@ def run_cases(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
         except Exception as exc:  # noqa: BLE001 - a crash IS the result here
             out[name] = (f"crash:{type(exc).__name__}", str(exc))
     with tempfile.TemporaryDirectory() as tmp:
-        for name, _want, _needle, _why in mod.FILENAME_CASES:
+        # Only the NAME is an input here — the verdict a case expects is what `expectations()` reads, and it
+        # unpacks the row in full, so the row's shape stays pinned there.
+        for name, *_ in mod.FILENAME_CASES:
             path = Path(tmp) / name
             shutil.copyfile(FIXTURES / "green.jsonl", path)
             try:
@@ -192,7 +223,7 @@ def run_cases(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
                 out[f"[name] {name}"] = (f"crash:{type(exc).__name__}", str(exc))
     # The required-set rule is the ONE rule whose input is not in the file. Its cases must run against the
     # mutant too, or removing it would be pinned by nobody — the failure mode this harness exists for.
-    for name, spec, _want, _needle, _why in mod.REQUIRED_CASES:
+    for name, spec, *_ in mod.REQUIRED_CASES:
         case = required_case_id(name, spec)
         try:
             out[case] = mod.evaluate(
@@ -206,11 +237,11 @@ def run_cases(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
 
 def expectations(mod: types.ModuleType) -> dict[str, tuple[str, str]]:
     """case -> (expected verdict, needle the reason must contain)."""
-    out = {name: (want, needle) for name, (want, needle, _why) in mod.EXPECTED.items()}
-    out.update({f"[name] {n}": (want, needle) for n, want, needle, _why in mod.FILENAME_CASES})
+    out = {name: (want, needle) for name, (want, needle, _) in mod.EXPECTED.items()}
+    out.update({f"[name] {n}": (want, needle) for n, want, needle, _ in mod.FILENAME_CASES})
     out.update({
         required_case_id(n, spec): (want, needle)
-        for n, spec, want, needle, _why in mod.REQUIRED_CASES
+        for n, spec, want, needle, _ in mod.REQUIRED_CASES
     })
     return out
 
@@ -247,7 +278,7 @@ def bogus(expect: dict[str, tuple[str, str]], got: dict[str, tuple[str, str]], g
     """Removing a rule can never make a GREEN fixture stop being green. If it did, the mutation is wrong."""
     return [
         f"{case} expected {green} but the mutant returned {got[case][0]}"
-        for case, (want, _needle) in expect.items()
+        for case, (want, _) in expect.items()
         if want == green and got[case][0] != green
     ]
 


### PR DESCRIPTION
- `check_coverage` read `.lineno` off `ast.AST`, which declares no position — narrow to `Raise`/`Return`
- drop the dead bindings (`cells`, the unused fixture `tmp` params, `_want`/`_needle`/`_why`)
- add a Pyright CI step, scoped to these two files, asserting `filesAnalyzed` is not silently 0
