### PR TITLE
repair a pr that stops converging, never loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,13 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py \
             plugins/gauntlet/skills/campaign/scripts/review-pass.py \
             plugins/gauntlet/skills/campaign/scripts/review-pass-test.py \
-            plugins/gauntlet/skills/campaign/scripts/emit-finding.py | tee pyright.json
+            plugins/gauntlet/skills/campaign/scripts/emit-finding.py \
+            plugins/gauntlet/skills/campaign/scripts/repair-pass.py \
+            plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "6" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 6 it was pointed at — it checked" \
+          if [ "${analyzed}" != "8" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 8 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -110,6 +112,15 @@ jobs:
       # them goes red.
       - name: Ledger contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/ledger.py self-test
+
+      # The REPAIR PASS's contract, executed — the mechanism that stops the review loop from running
+      # forever. Its fixtures REPLAY the two PRs that actually spiralled (21 and 14 adversarial rounds,
+      # 8.5 hours, neither converging) and assert the trigger fires where the design says AND stays silent
+      # while either PR is still finding genuine defects. A re-tuned cap that would have cut a real PR off
+      # mid-hunt fails here, saying so. The ledger's own self-test above runs the counter/cap fixtures;
+      # this one runs the decision enum, the ownership guardrail, and the repair cap.
+      - name: Repair-pass contract (the reassessment decision, the guardrail, the cap)
+        run: python3 plugins/gauntlet/skills/campaign/scripts/repair-pass.py self-test
 
       # The REVIEW PASS's contract, executed — the gate one layer up from CI. What a pass's plan,
       # pass_identity and progress files say decides whether a review COUNTS, and therefore whether a PR

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -53,11 +53,16 @@ PR's intent (a `## Purpose` line quoted verbatim, or the actor who can actually 
 finding that anchors to neither is **NON-GATING** — recorded as a follow-up, never a `NOT SATISFIED`, never
 a fix. `scripts/ledger.py` is the schema-owning accessor for
 `state.jsonl` — read/write the ledger header and per-PR rows **by field name** through it, never by column
-position (see `references/files-and-ledger.md`); pass its absolute path to subtasks the same way. Its
-`verdict` subcommand is the **only** sanctioned way to record a review verdict.
+position (see `references/files-and-ledger.md`); pass its absolute path to subtasks the same way. It also
+owns the **review loop's memory and its caps**: `ledger.py verdict` is the **only** sanctioned way to
+record a review verdict (it bumps `review_rounds`/`ns_streak`, applies the tally, and **at a cap holds the
+PR `repairing` and exits non-zero**), and `ledger.py dispatch-check` is the guard you run before **any**
+action that mutates a PR. `scripts/repair-pass.py` records the reassessment pass's decision for a PR that
+has stopped converging — the closed enum, the ownership guardrail, and the repair cap
+(`references/repair-pass.md`).
 
-Each script's fixtures live in a **sibling `*-test.py`** (`review-pass-test.py`, `ledger-test.py`); the
-`self-test` subcommand loads it and **fails loudly if it is missing**.
+Each script's fixtures live in a **sibling `*-test.py`** (`review-pass-test.py`, `ledger-test.py`,
+`repair-pass-test.py`); the `self-test` subcommand loads it and **fails loudly if it is missing**.
 
 **At run startup, record which version of these rules is actually running:** read `version` from the
 running plugin's `plugin.json` and write it to the ledger header —
@@ -77,6 +82,7 @@ a silent cost decision, taken by default, on every subagent this skill launches.
 | Fresh-subagent fallback review | **session model** | Same job as a review pass; counts toward the gate identically. |
 | Review-fix (after `NOT SATISFIED`) | **session model** | Authors code from scratch, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
 | Root-cause **mapper** | **session model** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
+| **Reassessment pass** (a PR at a review-loop cap) | **session model** | It reads a PR's ENTIRE history at once and decides the **acceptance path** — rescope, re-intent, demote, root-cause, or abort. It is gate machinery, and it is the one judgment no wake in the failed run was ever able to make. A weaker model here mis-diagnoses the loop and repairs the wrong thing (`repair-pass.md`). |
 | **CI-fix — formatting/lint failure** | **`sonnet`** (**`haiku`** only when trivially mechanical) | **Downgraded ON PURPOSE.** It does not author a fix: it runs a deterministic formatter, **READS the resulting diff**, verifies it, and **escalates** anything it cannot verify (`references/stage-2-ci.md`). |
 | **CI-fix — everything else**, and every **escalation** from the cheap tier | **session model** | Authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. |
 
@@ -154,6 +160,7 @@ Read stage refs only when that stage/action is due:
 | PR review gauntlet / progress ledger | `references/stage-2-review-gate.md` |
 | Dispatching ANY fix subagent (CI-fix or review-fix) | `references/fix-subagent-contract.md` |
 | Repeated sibling findings / shared root cause | `references/root-cause-pass.md` |
+| A PR at a review-loop cap (`status = repairing`) / a verdict that exits non-zero | `references/repair-pass.md` |
 | CI watch, check polling, CI fix | `references/stage-2-ci.md` |
 | Merge candidate / base refresh / cleanup | `references/stage-3-merge.md` |
 | Stuck task, abort, final report | `references/bailout-and-final-report.md` |
@@ -177,6 +184,14 @@ Read stage refs only when that stage/action is due:
 - **Remote branch cleanup isn't campaign's job:** campaign never passes `--delete-branch`; the repo's *Automatically delete head branches* setting governs the remote head branch. Local worktree/branch cleanup follows the per-PR `worktree_owned`/`branch_owned` flags.
 - **Review gate is tier-dependent:** `required(tier)` fresh, context-isolated `SATISFIED` verdicts on
   same live PR content + green CI — **1 if TRIVIAL, else 2** (any code/agent-doc/sensitive change is 2).
+- **The review loop has MEMORY, and it is capped:** record every verdict with `ledger.py verdict` (never
+  hand-set `reviews_ok` for one) — it bumps `review_rounds` (**NEVER reset**) and `ns_streak`. At a cap it
+  holds the PR `repairing` and **exits non-zero**: stop dispatching targeted fixes, hand the PR's **whole
+  history at once** to a context-isolated reassessment pass, and execute the ONE decision it returns —
+  **RESCOPE / REPAIR-INTENT / DEMOTE / ROOT-CAUSE / ABORT** — **without asking the user**. A cap is a
+  **mode switch, not a doorbell** (`references/repair-pass.md`). **Autonomous repair NEVER rewrites a PR
+  campaign does not own**: on `pr_origin = external` (the default) only DEMOTE / REPAIR-INTENT / ABORT are
+  permitted, and a second failed repair **aborts** rather than looping.
 - **Sequential same-PR reviews:** launch review 2 only after review 1 is `SATISFIED` (TRIVIAL needs
   only one).
 - **Progress ledger:** reviewer progress means planned unit `done` or accepted amendment, not vague
@@ -218,11 +233,13 @@ Read stage refs only when that stage/action is due:
   reviewers verify such comments, and a wrong claim is a finding. Refute a finding **once** — if the
   fresh reviewer re-raises it, that is a standoff → park `awaiting-user` for the USER to adjudicate
   (`references/stage-2-review-gate.md`).
-- **A parked PR is FROZEN — take no action that MUTATES it.** `status = awaiting-user` / `awaiting-api`
-  waits on a HUMAN. The test is "does this mutate the PR?", **not** "is it on a list": never review,
+- **A HELD PR is FROZEN — take no action that MUTATES it. `ledger.py … dispatch-check --pr <N>` exits
+  non-zero for one.** Two kinds: **parked** (`awaiting-user` / `awaiting-api` — waits on a HUMAN) and
+  **`repairing`** (at a review-loop cap; waits on the reassessment pass, **not** on a human). The test is
+  "does this mutate the PR?", **not** "is it on a list": never review,
   CI-fix, review-fix, merge, rebase, base-refresh, push to, or relabel it — nor anything else that
-  changes it (a park does NOT lower `reviews_ok`, so guard on `status` at every dispatch AND mutation
-  site). Sole exception: the park does not change the CI watch either way — observing is not mutating, so
+  changes it (being held does NOT lower `reviews_ok`, so guard on `status` at every dispatch AND mutation
+  site). `HELD_STATUSES` in `scripts/ledger.py` is the one enumeration — never retype it. Sole exception: the park does not change the CI watch either way — observing is not mutating, so
   the watch follows the normal policy (alive only while a check can still move). Keep driving the other
   PRs; unpark only on the user's answer — **recorded DURABLY, per park class** (`api_approval`; the
   standoff's audit record; `blocker_ruling` = `retry`/`abort` for a machine blocker, where `retry` clears
@@ -230,7 +247,7 @@ Read stage refs only when that stage/action is due:
   park entry and on consumption, so a previous park's answer can never unpark a later one;
   `references/stage-2-ci.md`, "THE RULING IS CONSUMED EXACTLY ONCE"). **Every park names the event that
   leaves it** (`references/loop-control.md`,
-  "parked-status guard" and "Only the user's answer unparks a PR").
+  "held-status guard" and "Only the user's answer unparks a PR").
 - **No green by watch exit:** derive CI from a **SHA-pinned** snapshot of **both** check families
   (`check-runs` **and** commit `status`), verified against `head_sha` before parsing. **NEVER from `gh pr
   checks`** — its output carries **no SHA** (`references/stage-2-ci.md`).
@@ -244,11 +261,13 @@ Read stage refs only when that stage/action is due:
    every PR carrying this run's `gauntlet-run-<run-id>` label from a batched snapshot. Treat `state.jsonl`
    as cache.
 3. **Fold completed review / CI / fix tasks** against the SHA each ran on.
-4. **Triage tier per PR, then launch due gate work up to caps — skipping PARKED PRs entirely** (`status`
-   `awaiting-user` / `awaiting-api`: FROZEN, no action that mutates the PR — no review, CI fix, review
-   fix, merge, rebase, base refresh, or relabel, and nothing else that changes it; the CI watch is
-   unaffected by the park and follows the normal policy).
-   Re-derive each non-parked PR's tier from its
+4. **Triage tier per PR, then launch due gate work up to caps — skipping HELD PRs** (`ledger.py …
+   dispatch-check --pr <N>` exits non-zero: FROZEN, no action that mutates the PR — no review, CI fix,
+   review fix, merge, rebase, base refresh, or relabel, and nothing else that changes it; the CI watch is
+   unaffected and follows the normal policy). **A `repairing` PR is the one held PR that still has machine
+   work due**: run its reassessment pass, then dispatch the decision it returns — and never a plain fix
+   (`references/repair-pass.md`).
+   Re-derive each non-held PR's tier from its
    `head_sha` (deterministic file-class triage), then launch reviews up to `required(tier)`, CI
    watches/fixes, precondition clearing (Copilot items / red CI / base conflict), and base refresh;
    stop in-flight reviews doomed by a content change.

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -3,12 +3,18 @@
 - **1-hour cap per task** — one hour of wall-clock since `started` without merging. The cap catches a
   *stuck* task, not a slow external system, and the ledger records no separately-metered work time — so
   key it off recorded row state, not a running subtraction of durations nothing stores: **do not fire
-  the cap on a wake where the row is in a BOUNDED wait.** There are exactly two kinds, and **neither is
+  the cap on a wake where the row is in a BOUNDED wait.** There are exactly three kinds, and **none is
   a `ci` value**:
   - **a PARK** — `status == awaiting-api` (parked for user approval) or `status == awaiting-user` (parked
     for the user to adjudicate a **review standoff** or a **machine blocker** — `files-and-ledger.md`,
     `status`). Its exit is **declared**: the user's answer (`approved`/`declined`, a standoff ruling, a
     `blocker_ruling` of `retry`/`abort`).
+  - **a REPAIR — `status == repairing`** (`repair-pass.md`). The PR has reached a review-loop cap and is
+    being reassessed and repaired. It is **bounded by `repair_count`/`REPAIR_CAP`**, and its exit is
+    **declared**: the reassessment's decision, and — at the cap — **ABORT**, which lands on this very
+    procedure. **Firing the 1-hour cap here would PRE-EMPT the repair the cap exists to reach**, aborting a
+    PR that the mechanism was in the middle of saving — the same mistake as firing it inside a live CI
+    liveness bound, for the same reason. A repairing PR always terminates: it repairs, or it aborts.
   - **a LIVE Stage 2 CI LIVENESS BOUND, still below its cap.** **Read the bounds from their owner —
     `stage-2-ci.md`, "THE LIVENESS COUNTERS", which is the ONE enumeration of the bounded CI waits and
     names each one's cap. NEVER re-list them here, and NEVER key this exemption on a `ci` value.** A bound
@@ -54,8 +60,9 @@
   bound is never aborted out from under it: the bound either resolves, or it reaches the human. This cap's
   job is the **agent-controlled** row — the task stuck in campaign's own work (a hung review, a red PR
   whose fix never lands), where nothing else is counting. Only a wake where
-  `started` is over an hour old *and* the row is agent-controlled (**NO** bound of the owner's set is live
-  for it — never a count of them, which rots the moment the set gains a member) trips it.
+  `started` is over an hour old *and* the row is agent-controlled — **it is in NONE of the three bounded
+  waits above**: not parked, not `repairing`, and **NO** bound of the CI owner's set live for it (never a
+  count of them, which rots the moment a set gains a member) — trips it.
   When it trips, abort cleanly and **retry once against the SAME adopted PR** (`attempts` += 1, reset
   `started`). The PR is user/externally owned — campaign never closes it and opens a replacement of
   its own. Instead, **rebuild the worktree from the PR's head branch** so the retry runs with fresh
@@ -74,12 +81,30 @@
   longer carries it and can no longer block terminal exit — an aborted row is terminal and lacks its
   `required(tier)` SATISFIED verdicts, so reconcile will never merge or keep driving it, and the
   un-labelled open PR is simply left for its owner.
-- **Converging-but-expensively → escalate to the root-cause pass.** The bailouts above catch a *stuck*
-  task; this catches one that's *progressing by whack-a-mole*. A targeted per-finding fix is right for
-  the **first** `NOT SATISFIED` on a PR, or for genuinely independent findings. But on the **second**
-  `NOT SATISFIED` on the same PR, **stop targeted patching and run the §2a-deep root-cause pass** — map
-  the whole space with a dedicated read-only mapper and fix at one chokepoint. This is a hard backstop:
-  even if the archetype wasn't obvious on finding 1, the 2nd sibling finding forces the pass no later.
+- **Not converging → the REASSESSMENT PASS takes over. `repair-pass.md` owns this, and it SUPERSEDES the
+  rule that used to live here.** The bailouts above catch a *stuck* task; this catches one that is
+  *progressing by whack-a-mole* — a loop that produces a real finding and a real fix every single round and
+  never finishes.
+
+  **The rule this replaces was "stop targeted patching on the 2nd `NOT SATISFIED` and run the root-cause
+  pass", and it NEVER FIRED — not once, across 35 review rounds on two PRs.** It was not skipped in bad
+  faith: it was **unevaluable**. Its trigger is a fact about *history* ("the second `NOT SATISFIED` on this
+  PR"), the ledger recorded no history, and every wake is a fresh agent instance holding exactly one
+  finding. It called itself a hard backstop; it was a hard backstop **with no sensor**. Do not restore it.
+
+  What replaces it is a **counter with a cap**, on disk, evaluated by the tool that records the verdict:
+  `ledger.py verdict` bumps `review_rounds` / `ns_streak`, and at a cap it sets `status = repairing` and
+  **exits non-zero**. The driver then hands the PR's **whole history at once** to a context-isolated
+  reassessment pass, which returns ONE decision — **RESCOPE / REPAIR-INTENT / DEMOTE / ROOT-CAUSE /
+  ABORT** — and the driver executes it **without asking the user**. **A cap is a MODE SWITCH, not a
+  doorbell.** The root-cause pass is still exactly the right answer when the findings share one cause —
+  it is now **one of five decisions an agent that can see all the rounds gets to choose between**, rather
+  than a rule nothing could trigger.
+
+  **ABORT is the only decision that ends the PR, and it lands on the procedure below** (leave the PR OPEN,
+  drop this run's labels, write `abort-<id>.md`) — reused, not reinvented. A **second failed repair**
+  aborts rather than looping (`repair_count`, capped): the mechanism that fixes non-convergence must not
+  itself fail to converge.
 
   **THIS BACKSTOP HAD NO SENSOR, AND THAT IS WHY IT NEVER FIRED.** Its trigger — *"the second `NOT
   SATISFIED` on the same PR"* — is a **fact about history**, and nothing recorded any history: `reviews_ok`
@@ -90,13 +115,18 @@
 
   The ledger now records that history — `ns_streak` (consecutive `NOT SATISFIED`, cleared only by a
   `SATISFIED`) and `review_rounds` (landed verdicts, **never** reset) — so the trigger is, for the first
-  time, a value a fresh wake can **read** (`files-and-ledger.md`). **This release adds the sensors and
-  nothing that consumes them**: no cap, no new escalation, and no change to when this pass fires. The
-  autonomous reassessment that acts on them lands separately. Adding the reader in the same change as the
-  counter is how a counter comes to be reset by the thing that reads it.
+  time, a value a fresh wake can **read** (`files-and-ledger.md`). **And it IS read: `ledger.py verdict`
+  evaluates the caps as it records the verdict, and at a cap it holds the PR `repairing` and exits
+  non-zero.** The reader lives in the one door that cannot be skipped, because a cap evaluated by a
+  *separate* command is a cap a driver can forget to run — which is the failure being cured, not a fresh
+  instance of it. The counters are never written backwards by it: the cap path writes `status` and nothing
+  else.
 
 Other stop conditions — escalate rather than loop: a worktree won't build, the reviewer keeps
-returning the same unactionable verdict, or CI fails identically after a fix attempt.
+returning the same unactionable verdict, or CI fails identically after a fix attempt. **Note what is NOT
+on that list: a reviewer that is RIGHT every time and still never lets the PR through.** Those conditions
+all describe a **broken** reviewer, and the reviewer that ran 21 rounds was **working perfectly** — that is
+exactly what made it lethal. That case is the reassessment pass's, above, and no rule here catches it.
 
 ---
 
@@ -130,6 +160,11 @@ When the loop exits, summarize:
   merely unobserved. **NEVER report `unknown` as "no required checks"**: it means campaign **could not
   read** them, nothing merged on it, and any PR that reached it **escalated** — say which read failed, so
   the user can fix the access rather than wonder why the run stalled.
+- **Repaired** — every PR that reached a review-loop cap: its `review_rounds`, the decision the
+  reassessment pass returned, and a pointer to `repair-<pr>-<k>.md` (`repair-pass.md`). **Report a DEMOTE's
+  demoted findings explicitly** — they are true findings that were deliberately **not fixed**, and burying
+  that is how a report becomes a false claim of cleanliness. This is the run telling the user, in the one
+  place they will read, that it stopped whacking moles and what it did instead.
 - **Aborted** — PR number + slug, why, pointer to `abort-<id>.md`.
 - **Skipped (API-declined)** — any PR whose API-changing fix the user was asked about and declined,
   with the change each would have needed.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -191,15 +191,19 @@
   `blocker_ruling` = `retry`/`abort` (`files-and-ledger.md`, `status`;
   `loop-control.md` step 3, "Only the user's answer unparks a PR"). **NEVER park into a state whose exit
   is undefined.**
-- **A PARKED PR IS FROZEN — TAKE NO ACTION THAT MUTATES IT.** `status = awaiting-user` (standoff) or
-  `awaiting-api` (API approval) means the PR waits on a **HUMAN**. The test is **"does this MUTATE the
+- **A HELD PR IS FROZEN — TAKE NO ACTION THAT MUTATES IT. ASK THE TOOL: `ledger.py … dispatch-check --pr
+  <N>` exits non-zero.** A PR is **HELD** when it is **parked on a HUMAN** (`status = awaiting-user`, a
+  standoff; `awaiting-api`, API approval) **or `repairing`** — it reached a review-loop cap, has stopped
+  converging, and is being reassessed and repaired (`repair-pass.md`; **that one waits on no human — do
+  NOT prompt the user**). `HELD_STATUSES` in `scripts/ledger.py` is the **one** enumeration; never retype
+  it. The test is **"does this MUTATE the
   PR?"** — **not** "is this action named in a list", because an enumeration will miss a site (it did:
   the guard once named four dispatch sites and missed `stage-3-merge.md` step 6's post-merge rebase).
   **NEVER** launch a review pass, a CI fix, a review fix, or a merge for it; **NEVER** rebase it,
   refresh its base, push to it, relabel it, or change its content in any other way — **and nothing
-  absent from that list either**. Skip it and keep driving the run's other PRs. The park does **not**
+  absent from that list either**. Skip it and keep driving the run's other PRs. Being held does **not**
   raise `reviews_ok`, so a dispatch or merge rule that reads only `reviews_ok`/`ci`/`mergeable` would
-  re-review a parked PR and let a `SATISFIED` verdict merge it **without the user's ruling** — and a
+  re-review a held PR and let a `SATISFIED` verdict merge it **without the user's ruling** — and a
   post-merge rebase would change the very content the user is adjudicating. The guard MUST be enforced
   at **every dispatch and mutation site** — `loop-control.md` step 3 (the canonical statement), the
   **merge** and the **post-merge reconcile** (`stage-3-merge.md`) — not merely recorded in the ledger.
@@ -273,8 +277,27 @@
 - One decision at N sites is the most common root cause. Trigger the §2a-deep root-cause pass on the
   **first** "missing/wrong at site X" finding (its shape, not a round count), map the whole space with
   a dedicated **read-only mapper** subagent — never one that also fixes, which under-maps toward what
-  it can reach — and fix at a **single chokepoint**. Hard backstop: a 2nd `NOT SATISFIED` on one PR
-  forces the pass (Bailout).
+  it can reach — and fix at a **single chokepoint**. **The old "2nd `NOT SATISFIED` forces the pass"
+  backstop is GONE — it triggered on history nothing recorded and NEVER FIRED, across 35 review rounds
+  on two PRs.** The backstop now is a **counter with a cap** (`repair-pass.md`), and the root-cause pass
+  is one of the five decisions it can reach.
+- **RECORD EVERY VERDICT WITH `ledger.py verdict` — NEVER hand-set `reviews_ok` for one.** It bumps the
+  loop's memory (`review_rounds`, **never** reset; `ns_streak`), applies the tally, and evaluates the
+  review-loop caps, **atomically**. Hand-setting the tally silently skips the counters and restores the
+  amnesia that let a PR run **21** review rounds while its row still read `reviews_ok=0`. (A gate **reset**
+  from a content change is still `set --reviews-ok 0` — `verdict` records what a reviewer *decided*, `set`
+  records what a commit *did*.)
+- **A PR THAT STOPS CONVERGING IS REPAIRED, NOT PROMPTED.** At a review-loop cap `ledger.py verdict` sets
+  `status = repairing` and **exits non-zero**: dispatch **no** further targeted fix and **no** further
+  review pass. Hand the PR's **whole history at once** to a context-isolated reassessment pass, which
+  returns ONE decision — **RESCOPE / REPAIR-INTENT / DEMOTE / ROOT-CAUSE / ABORT** — and execute it
+  **without asking the user** (`repair-pass.md`). **A cap is a MODE SWITCH, not a doorbell.**
+- **AUTONOMOUS REPAIR NEVER REWRITES A PR CAMPAIGN DOES NOT OWN.** On a PR with `pr_origin = external` —
+  the user's, a teammate's, any PR adopted by number, **and the DEFAULT** — the permitted decisions are
+  **only DEMOTE / REPAIR-INTENT / ABORT**. RESCOPE and ROOT-CAUSE reshape branch content wholesale, and
+  `repair-pass.py` refuses them outright. (Ordinary targeted fixes are unaffected — this is about the
+  wholesale rewrite.) **A second failed repair ABORTS rather than looping**: the mechanism that fixes
+  non-convergence must not itself fail to converge.
 - When a PR's tier requires two reviews they run **sequentially, never queued together**: launch the
   first, wait for its verdict, and launch the second **only if the first came back SATISFIED**. A
   NOT-SATISFIED first review means a fix lands and the SHA changes, so a concurrently-queued second

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -18,6 +18,7 @@ files from colliding — see "Run identity and concurrency".
 | `review-<pr>-<n>.a<k>.txt` / `.a<k>.progress.jsonl` / `.a<k>.findings.jsonl` | The same three per-attempt artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted (see `stage-2-review-gate.md`). The plan and the intent are **not** per-attempt: the plan is per-pass, the intent per-PR |
 | `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, fetched **BY THE WAKE** after the watch completes (**the watch never writes it**), promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Carries a **`source` completion marker per mandatory source**, so a source that was **never queried** is `unusable`, not a silent green (`stage-2-ci.md`). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
 | `audit-<pr>-<n>.md` | The orchestrator's audit of round `n`'s findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
+| `repair-<pr>-<k>.md` | The **reassessment pass**'s decision record for repair `k`: the whole round-by-round history it was handed, the ONE decision it returned, and why (`repair-pass.md`). Written **before** the decision is recorded — `repair-pass.py decide` refuses a `--record` that is missing or empty, because a wake is a fresh agent instance and a justification held only in a dead agent's context can never be audited |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
 **The canonical `prs.json` command — this block is THE definition.** Every other site defers to it, and
@@ -104,8 +105,8 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 
 ```
 {"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4"}
-{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:9f2c\u2026", "settled_strikes": "0", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-", "review_rounds": "3", "ns_streak": "0", "intent": "stated@2026-07-04T09:15:00Z"}
-{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:4a71\u2026", "settled_strikes": "1", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "required check absent: integration-tests", "blocker_ruling": "-", "review_rounds": "5", "ns_streak": "2", "intent": "authored@2026-07-04T09:20:00Z"}
+{"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": ".worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:9f2c\u2026", "settled_strikes": "0", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-", "review_rounds": "3", "ns_streak": "0", "intent": "stated@2026-07-04T09:15:00Z", "pr_origin": "gauntlet", "repair_count": "0", "repair_decision": "-"}
+{"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": ".worktrees/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:4a71\u2026", "settled_strikes": "1", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "required check absent: integration-tests", "blocker_ruling": "-", "review_rounds": "5", "ns_streak": "2", "intent": "authored@2026-07-04T09:20:00Z", "pr_origin": "external", "repair_count": "0", "repair_decision": "-"}
 ```
 
 Read those two rows together and the sensor's whole point is visible: **`pr41` and `pr52` both read
@@ -206,9 +207,14 @@ Header field notes (the header fields above; per-row fields follow):
 - `ns_streak` — consecutive NOT SATISFIED verdicts. Cleared **only** by a SATISFIED — never by a fix, a
   rebase or a content change. Same owner, same absent flag, same reason.
 
-  **Nothing in this release READS either counter** — there is no cap and no escalation here. They are
-  **sensors**; the autonomous reassessment that consumes them lands separately. A counter that is reset by
-  the thing that consumes it is not a counter.
+  **What READS these counters is `ledger.py verdict` itself, and at a cap it STOPS THE LOOP.** They are
+  sensors, and the reader is fused into the one door that cannot be skipped — deliberately: a cap
+  evaluated by a *separate* command is a cap a driver can forget to run, which is exactly how a "hard
+  backstop" sat unfired through 35 review rounds. The hazard that argues for keeping a reader out of a
+  sensor — that the reader comes to reset what it consumes — is structurally absent here: the cap path
+  writes `status` and **nothing else**, so `review_rounds` stays monotone whatever it decides. At a cap the
+  row goes **`repairing`** and the command **exits non-zero** (`repair-pass.md` owns the caps, the
+  reassessment, and the repair).
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it
@@ -218,6 +224,21 @@ Header field notes (the header fields above; per-row fields follow):
   The distinction is the honest one and the final report states it: an `authored` intent is **the driver's
   CLAIM about what the PR is for**, not the author's, and a wrong intent block silently **narrows** a
   review.
+- `pr_origin` — who authored this PR: `gauntlet` (this pipeline opened it — it carries the
+  `gauntlet-authored` label) | `external` (the user's, a teammate's, or any PR adopted by number). Set at
+  adoption (`pr-adoption.md`). It decides **which autonomous repairs are permitted**: an `external` PR may
+  never have its branch content rewritten by a repair (`repair-pass.md`, "The ownership guardrail").
+  **The default is `external` and it is LOAD-BEARING, not a placeholder** — a row whose origin was never
+  established can never have its owner's work reshaped. This is **separate from `worktree_owned` /
+  `branch_owned`**, which say whether campaign created the local checkout and branch for cleanup purposes;
+  a PR can have a campaign-created worktree and still belong to someone else.
+- `repair_count` — reassessment decisions taken for this PR (`repair-pass.md`). At **`REPAIR_CAP`** the
+  only permitted decision is **ABORT**: a second failed repair leaves the PR open for a human rather than
+  looping. The mechanism that fixes non-convergence must not itself fail to converge. Like `review_rounds`,
+  it has **no flag at any door** — a budget you can zero is not a bound.
+- `repair_decision` — `-`, or the last reassessment decision + when: `<decision>@<iso>`. Durable, because
+  the wake that dispatches the repair may be a different agent instance from the one that decided it — and
+  a repair may not be dispatched at all until this field is set (`ledger.py dispatch-check --action repair`).
 - `tier` — the adaptive review tier derived from `head_sha`: `TRIVIAL` | `STANDARD` | `HIGH`. Re-derived
   every wake and re-triaged on any content change; drives `required(tier)` and the review depth.
 - `ci` — `green` / `red` / `pending` for `head_sha`. (**There is no `none`.** It was documented but no
@@ -296,21 +317,37 @@ Header field notes (the header fields above; per-row fields follow):
   live position, so the two never contradict: `approved` pairs with the PR back in normal
   gate flow, `declined` with a terminal `aborted`. A one-off approval lands here only; it never flips
   the run-wide `api_changes` header.
-- `status` — `in_review` → `merged`, or `aborted`; plus two **user-parked** (non-terminal)
-  statuses. **BOTH parked statuses FREEZE that PR until the user answers**: while `status` is
-  `awaiting-api` or `awaiting-user`, take **no action that MUTATES the PR** — never launch a review
-  pass, a CI fix, a review fix, or a merge for it, and never rebase it, refresh its base, push to it, or
-  relabel it (`loop-control.md` step 3, "parked-status guard" — the property, of which those are only
-  examples; `stage-3-merge.md` binds both the merge and the post-merge reconcile). The park does
-  not raise `reviews_ok`, so the guard reads **`status`** — never `reviews_ok`/`ci`/`mergeable` alone,
-  which would re-review a parked PR and merge it without the ruling. **The park does not change the watch
-  policy either way** (observing is not mutating): the watch follows `stage-2-ci.md`, "WATCH ONLY WHAT CAN
-  MOVE" — alive while a row is still `RUNNING`, **not** relaunched once CI has settled. Parking never
-  stops a warranted watch, and never starts an unwarranted one. The other PRs keep being driven; the
-  user's answer unparks the PR **to the `status` that answer dictates** — a **RESUME** answer (`approved`,
-  a standoff ruling, `retry`) to `in_review`, with normal dispatch resuming on the next wake; a
-  **TERMINAL** answer (`declined`, `abort`) to `aborted`, which never resumes. Per class, below —
-  and `loop-control.md` step 3, "Only the user's answer unparks a PR", owns the mapping.
+- `status` — `in_review` → `merged`, or `aborted`; plus the **HELD** (non-terminal) statuses below.
+
+  **HELD is the PROPERTY the dispatch guard is keyed on: campaign takes NO action that MUTATES a held
+  PR.** Never launch a review pass, a CI fix, a review fix, or a merge for it, and never rebase it, refresh
+  its base, push to it, or relabel it (`loop-control.md` step 3, "held-status guard" — the property, of
+  which those are only examples; `stage-3-merge.md` binds both the merge and the post-merge reconcile).
+  Being held does not raise `reviews_ok`, so the guard reads **`status`** — never `reviews_ok`/`ci`/
+  `mergeable` alone, which would re-review a held PR and merge it without its question ever being answered.
+  **It is a command, not a memory exercise**: `ledger.py … dispatch-check --pr <N>` exits non-zero on
+  every held status, and the members are `HELD_STATUSES` in `scripts/ledger.py` — **the one place they are
+  enumerated. Never retype that list; ask the tool.** A status added to it is enforced everywhere with no
+  edit to any of the sites that consult it.
+
+  **Holding does not change the watch policy either way** (observing is not mutating): the watch follows
+  `stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE" — alive while a row is still `RUNNING`, **not** relaunched
+  once CI has settled. Nor does it stop **reconcile** from reading the PR and recording what it read. The
+  other PRs keep being driven: **a held PR never blocks the loop.**
+
+  Held statuses come in **two kinds, and they are cleared by DIFFERENT events — do not collapse them:**
+
+  1. **PARKED — waiting on a HUMAN** (`awaiting-api`, `awaiting-user`). No amount of machine work can
+     resolve it. The user's answer unparks the PR **to the `status` that answer dictates** — a **RESUME**
+     answer (`approved`, a standoff ruling, `retry`) to `in_review`, with normal dispatch resuming on the
+     next wake; a **TERMINAL** answer (`declined`, `abort`) to `aborted`, which never resumes. Per class,
+     below — and `loop-control.md` step 3, "Only the user's answer unparks a PR", owns the mapping.
+  2. **`repairing` — waiting on the REASSESSMENT PASS, not on a human.** The PR reached a review-loop cap
+     (`review_rounds` or `ns_streak`), so it has stopped converging and **must not take another targeted
+     fix or another review pass**. `ledger.py verdict` sets it, and it is **NOT a park**: campaign clears it
+     itself, by reassessing the PR and executing the one decision that comes back (`repair-pass.md` — the
+     owner). **A cap is a MODE SWITCH, not a doorbell**: the driver repairs the PR autonomously and asks the
+     user nothing. Only the ABORT decision involves a human at all, and it is the last resort of five.
   - `awaiting-api` — parked for the user to approve an API-changing fix. Resolves via `api_approval`:
     `approved` returns the PR to the normal flow, `declined` makes it `aborted` (terminal).
   - `awaiting-user` — parked for the user to adjudicate. **Two CLASSES, each with its OWN durable answer
@@ -391,7 +428,24 @@ ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfi
 ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
 ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only)
+ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfied|not-satisfied
+ledger.py --file <state.jsonl> dispatch-check --pr N [--action ordinary|repair]
 ```
+
+**`verdict` is the ONLY sanctioned way to record a review verdict**, and it is not a convenience: it bumps
+the loop's memory (`review_rounds`, `ns_streak`), applies the tally (`reviews_ok`), and evaluates the
+review-loop caps — **atomically**. Hand-setting `reviews_ok` for a verdict does the tally and silently
+skips the rest, which is exactly how a PR ran 21 review rounds while its row still read `reviews_ok=0`,
+indistinguishable from a PR on its first. At a cap it sets `status = repairing` and **exits non-zero**
+(`repair-pass.md`). **A gate RESET is not a verdict**: a content change still writes `reviews_ok = 0`
+through `set`, exactly as it always has — `verdict` records what a *reviewer decided*, `set` records what
+a *commit did*.
+
+**`dispatch-check` is the guard, and it is a COMMAND, not a rule to remember.** Run it before **any**
+action that MUTATES a PR; it exits non-zero when the row is HELD (`status`, above). `--action repair` is
+the one kind of work a `repairing` row accepts, and it is refused until the reassessment's decision is on
+the row — otherwise a driver could call its next targeted fix "the repair" and go on whacking moles under
+a new name.
 
 `table` is the user-facing status view: the end-of-wake report renders it whenever the run goes back
 to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decides nothing — no gate

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -239,6 +239,10 @@ Header field notes (the header fields above; per-row fields follow):
 - `repair_decision` — `-`, or the last reassessment decision + when: `<decision>@<iso>`. Durable, because
   the wake that dispatches the repair may be a different agent instance from the one that decided it — and
   a repair may not be dispatched at all until this field is set (`ledger.py dispatch-check --action repair`).
+  **DURABLE *and* SPENT EXACTLY ONCE per cap** — it is reset to `-` when the row **re-enters `repairing`**
+  (`ledger.py verdict` at a cap), so a decision answers exactly the cap it was recorded for and a PR that
+  reaches a cap **again** must earn a fresh `decide` (which spends `repair_count`, so the bound holds).
+  `abort@…` is terminal and is never cleared.
 - `tier` — the adaptive review tier derived from `head_sha`: `TRIVIAL` | `STANDARD` | `HIGH`. Re-derived
   every wake and re-triaged on any content change; drives `required(tier)` and the review depth.
 - `ci` — `green` / `red` / `pending` for `head_sha`. (**There is no `none`.** It was documented but no

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -176,12 +176,30 @@ blocks; each completion is its own wake.
    Launch only what is actually due *and not already in flight* (check ground truth first, never the
    ledger alone).
 
-   **PARKED-STATUS GUARD — a PROPERTY, not a list. Apply it BEFORE every bullet below, and before
-   every other action this skill takes on a PR.** While a PR's `status` is **`awaiting-user`** or
-   **`awaiting-api`** the PR is **FROZEN: take NO action that MUTATES it.** It is waiting on a
-   **HUMAN**, and no amount of machine work can resolve it. **Skip it and keep driving the run's other
-   PRs** — the run stays live and the park NEVER blocks the loop (`run-identity-and-lease.md`, "Never
-   hold the run hostage on a user prompt").
+   **HELD-STATUS GUARD — a PROPERTY, not a list, and now a COMMAND. Apply it BEFORE every bullet below,
+   and before every other action this skill takes on a PR.** While a PR's `status` is **HELD** the PR is
+   **FROZEN: take NO action that MUTATES it.** **Skip it and keep driving the run's other PRs** — the run
+   stays live and a held PR NEVER blocks the loop (`run-identity-and-lease.md`, "Never hold the run hostage
+   on a user prompt").
+
+   **Ask the tool, never a memorized list:**
+
+   ```
+   ledger.py --file <state.jsonl> dispatch-check --pr <N>     # non-zero => do NOT act on this PR
+   ```
+
+   `HELD_STATUSES` in `scripts/ledger.py` is the **one place** the members are enumerated, and
+   `files-and-ledger.md`, `status`, is their definition. **Never retype that list here or anywhere else** —
+   a status added to it must be enforced at every site with no edit to any of them. Today it holds two
+   kinds, held for **different reasons** and cleared by **different events**:
+
+   - **PARKED** (`awaiting-user`, `awaiting-api`) — waiting on a **HUMAN**. No amount of machine work can
+     resolve it; only the user's answer unparks it (below).
+   - **`repairing`** — the PR reached a **review-loop cap** and has stopped converging. It is **NOT waiting
+     on a human**: campaign clears it **itself**, by running the reassessment pass and executing the one
+     decision that comes back (`repair-pass.md`). **A cap is a mode switch, not a doorbell — do NOT prompt
+     the user.** Ordinary gate work is refused for it; the **decided repair** is the one thing that may be
+     dispatched, and only once the decision is recorded (`dispatch-check --action repair`).
 
    **The test is "does this MUTATE the PR?" — NOT "is this action named in a list?"** *Mutate* = change
    the PR or dispatch work that will: its content, its head commit, its base, its labels, its
@@ -190,9 +208,9 @@ blocks; each completion is its own wake.
    relabel, no gate reset, no content change of any kind — **and nothing absent from this list either.**
    The list is **illustrative; the property governs.** An enumeration of dispatch sites WILL miss one —
    it already did: this guard once listed four (review, CI fix, review fix, merge) and missed
-   `stage-3-merge.md` step 6, whose post-merge rebase of PRs that fell behind would have moved a parked
+   `stage-3-merge.md` step 6, whose post-merge rebase of PRs that fell behind would have moved a held
    PR's `head_sha`, reset its gate, and **changed the very PR content the user was parked to
-   adjudicate**. Any site the skill grows later is covered the moment it would mutate a parked PR, with
+   adjudicate**. Any site the skill grows later is covered the moment it would mutate a held PR, with
    no edit to this list. When unsure whether an action mutates, treat it as mutating and skip it.
    - **The ONE exception is the CI watch: OBSERVING a PR is not mutating it.** The park **does not change
      the watch either way** — it follows the normal policy, `stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE":
@@ -249,7 +267,22 @@ blocks; each completion is its own wake.
      park exists to close. **The park MUST be enforced wherever the PR is ACTED ON — every dispatch site
      and every mutation site — not merely recorded in the ledger.**
 
-   Then, for each **non-parked** PR:
+   **A `repairing` PR is the ONE held PR that still has machine work due — and it is NOT the work the
+   other bullets describe.** Do not skip it and do not prompt the user; drive its repair to completion:
+
+   - **no `repair_decision` yet** → dispatch the **reassessment pass** (`repair-pass.md`): a
+     context-isolated agent, on the **session model**, handed **every round's verdict and finding, the
+     diff-growth curve, the intent artifact, and the current diff — all at once**. No wake has ever had
+     that view; it is why 21 rounds passed unnoticed. It returns ONE decision from a closed enum, recorded
+     with `repair-pass.py decide` (which refuses a decision this PR may not take — see the ownership
+     guardrail).
+   - **a `repair_decision` is recorded** → `ledger.py dispatch-check --pr <N> --action repair`, then
+     execute **that** decision and no other work. When the repair has landed, return the row to the gate
+     (`ledger.py … set --pr <N> --status in_review`). `review_rounds` is **not** reset — it never is.
+   - **`repair_decision` is `abort@…`** → the row is already terminal (`aborted`): run the abort procedure
+     (`bailout-and-final-report.md`) — leave the PR **OPEN**, drop this run's labels, write `abort-<id>.md`.
+
+   Then, for each PR that is **not held at all**:
    - any newly-adopted PR whose ledger row lacks a `tier`, or any PR whose `head_sha` changed since it
      was last triaged → **re-triage its tier** (deterministic file-class classification of the changed
      files at that `head_sha`; agent-docs = code; default STANDARD on uncertainty — see the tiers
@@ -328,7 +361,7 @@ blocks; each completion is its own wake.
    and none is in flight (no-arg idle), do not spin: **PROMPT** "No PRs under a campaign. Run
    gauntlet:review to find issues, or pass PR numbers to gate."
 4. **Merge** queued PRs as a serialized drain: re-confirm one candidate against the live SHA **and
-   re-check it is not parked** (the parked-status guard binds the merge too — Stage 3), merge
+   re-check it is not parked** (the held-status guard binds the merge too — Stage 3), merge
    it, sync `<base>`, reconcile remaining candidates, and repeat while another PR is immediately
    mergeable (Stage 3).
 5. **Reschedule or exit.**

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -114,7 +114,21 @@ For each `#PR` to adopt:
      `tier` = triage per `head_sha` (Stage **2a-triage**); `attempts` = `0` (no attempt has run yet —
      `attempts` counts attempts **so far**, and seeding it at `1` silently spends half the retry-once
      budget before any work is dispatched); `started` = now;
-     `api_approval` = `-`; `blocker_ruling` = `-`; `status` = `in_review`.
+     `api_approval` = `-`; `blocker_ruling` = `-`; `status` = `in_review`;
+     `review_rounds` = `0`; `ns_streak` = `0`; `repair_count` = `0`; `repair_decision` = `-`.
+   - **`pr_origin` — WHO WROTE THIS PR. Read it from the PR's LABELS, and default to `external`.**
+     `gauntlet` **only** when the PR carries the **`gauntlet-authored`** label, which `gauntlet:review`'s
+     handoff applies to every PR it opens; **`external` for everything else** — the user's PR, a
+     teammate's, any PR adopted by number. The label is already in the adoption snapshot's `labels` field,
+     so this costs no extra call.
+
+     It decides **which autonomous repairs may ever run on this PR** (`repair-pass.md`, "The ownership
+     guardrail"): an `external` PR may be demoted, re-intented or aborted, but its **branch content is
+     never rewritten** by a repair. **The default is the SAFE one and that is load-bearing** — a PR whose
+     origin cannot be established must never be treated as campaign's own work to reshape. *"I do not know
+     who wrote this"* is not *"I wrote this"*. It is **NOT** `worktree_owned`/`branch_owned`: those say
+     whether campaign created the local checkout and branch, which is a **cleanup** question, and a PR can
+     have a campaign-created worktree and still belong entirely to someone else.
    - **On a REFRESH of an existing row, PRESERVE EVERY FIELD THIS STEP DOES NOT EXPLICITLY RECOMPUTE.**
      That is a **property, not a list** — and deliberately so, because the list that stood here was one:
      `ledger.py … set` writes only the fields it **NAMES**, so preservation is the **default**, and this

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -1,0 +1,160 @@
+## The reassessment pass — when a PR stops converging, REPAIR IT
+
+**This file owns the definition. `scripts/ledger.py` and `scripts/repair-pass.py` own the enforcement.**
+Everything below is a command that exits non-zero, not a rule an attentive agent has to remember — which
+is the entire point, and is explained by the section that ends this file.
+
+### Why this exists
+
+The review gate had **no memory and could not see its own non-convergence.** Every wake is a fresh agent
+instance; `reviews_ok` is zeroed on every `NOT SATISFIED`; and nothing counted rounds. So the ledger after
+21 review rounds was **indistinguishable from the ledger after 1**, and the skill's stopping rules — "run
+the root-cause pass on the 2nd `NOT SATISFIED`", the 1-hour cap — were rules with **no sensor**. They sat
+in the skill, unfired, for 8.5 hours.
+
+Two PRs ran **21** and **14** adversarial review rounds. Nearly every round produced a **true** finding, a
+fix was dispatched, the fix added code, and the next round found more — in the late rounds, more *in the
+guards the loop itself had just added*. Neither PR converged. A human stopped it, and could only do so by
+holding all 21 rounds in mind **at once**. That view is what no wake had, and it is what this pass restores.
+
+**The reviewer was not malfunctioning.** It was doing exactly what it was asked, and what it was asked has
+**no fixed point**: an open-ended adversarial mandate over a growing surface always has one more true thing
+to say. Do not look for a bug in the reviewer. The bug is that nothing could **count**.
+
+### The trigger — the loop's memory, and the caps on it
+
+`ledger.py` carries the memory. Two counters, and `ledger.py verdict` is the **ONLY** sanctioned way to
+record a verdict — it bumps them, applies the tally, and evaluates the caps **atomically**:
+
+```
+ledger.py --file <state.jsonl> verdict --pr <N> --head-sha <the live head> --verdict satisfied|not-satisfied
+```
+
+- **`review_rounds`** — landed verdicts. **NEVER reset** — not by a fix, a rebase, or a content change.
+  This is the loop's only memory. Reset it and every round looks like round 1 again, which is precisely how
+  21 of them passed unnoticed.
+- **`ns_streak`** — consecutive `NOT SATISFIED`. Reset **only** by a `SATISFIED`.
+
+**Hand-setting `reviews_ok` for a verdict is FORBIDDEN** — it applies the tally and silently skips the
+counters, restoring the amnesia. **But a gate RESET is not a verdict**: a content change (a fix commit, a
+CI fix, a conflict-resolving rebase, a bot push) still writes `reviews_ok = 0` through `ledger.py … set`,
+exactly as it always has. `verdict` records what a **reviewer decided**; `set` records what a **commit
+did**. Do not convert the reset sites into `verdict` calls.
+
+**When a cap is reached on a `NOT SATISFIED`, `ledger.py verdict` sets `status = repairing` and EXITS
+NON-ZERO.** The driver **MUST NOT** dispatch another targeted fix and **MUST NOT** launch another review
+pass for that PR. It runs the reassessment pass below.
+
+**The caps are evaluated ONLY on a `NOT SATISFIED`** — a `SATISFIED` is the gate *moving*, and a PR one
+corroborating pass from merging must never be torn up. (On the real record this is not hypothetical: PR
+#42's 10th landed verdict was a `SATISFIED`.)
+
+**The cap values live in `ledger.py` and are named, never numbered, anywhere else** — `ROUND_CAP`,
+`NS_STREAK_CAP`, `REPAIR_CAP`. A value retyped in prose is a value that goes stale the day it is tuned,
+and the prose is the copy people read. `ledger.py`'s comment defends each number against the real record,
+and `ledger-test.py` **replays that record** so a re-tuned cap states, in its own failure message, what the
+new number would have done to two PRs that really ran.
+
+### A cap is a MODE SWITCH, not a doorbell
+
+**It does not stop and ask the user.** The driver stops dispatching targeted fixes and **repairs the PR
+itself, autonomously.** Asking a human is one of the five outcomes, and it is the last resort — not the
+first.
+
+### The reassessment pass — give the loop the memory it never had
+
+Dispatch **one context-isolated agent** on the **session model** (it decides the acceptance path — never
+downgrade it; `SKILL.md`, "Subagent Dispatch"), and hand it **THE WHOLE HISTORY AT ONCE**. This is the
+crux: **no wake has ever had this view**, which is exactly why 21 rounds could pass unnoticed.
+
+It receives, in one prompt:
+
+- **every round's verdict and finding** — all of `<rundir>/review-<pr>-*.txt`, in order, with each one's
+  verdict. Not a summary: the findings themselves.
+- **the diff-growth curve** — what the PR's main files measured at each of this run's commits:
+  `git log --oneline origin/<base>..HEAD` and, per commit, `git show <sha>:<file> | wc -l`.
+- **the PR's intent artifact** — its Purpose / Non-goals / Threat model.
+- **the current diff** — `git diff origin/<base>...HEAD`.
+- **the permitted decisions** — from `repair-pass.py --file <state.jsonl> permitted --pr <N>`, which
+  derives them from the row. **Build the prompt from that output; never retype the enum**, or the prompt
+  will drift from the rule the tool enforces.
+
+It returns **exactly ONE decision from a CLOSED enum**, and the driver executes it **without asking the
+user**:
+
+| Decision | When | What the driver does |
+|---|---|---|
+| **RESCOPE** | the diff has **outgrown its stated purpose** — the findings may all be true, and most of the lines now defend the guards the loop itself added | dispatch a shrink back to intent, then re-gate |
+| **REPAIR-INTENT** | the intent artifact is **missing, vague or wrong**, so the reviewer has nothing to measure against and **nothing can be out of scope** | re-author it (Purpose / Non-goals / Threat model), then re-gate |
+| **DEMOTE** | the findings **anchor to no Purpose line and no Threat-model actor** — true, and not reasons to block this PR | record them as follow-ups, **do NOT fix them**, re-gate |
+| **ROOT-CAUSE** | the findings **share one cause** | run the root-cause pass — **`root-cause-pass.md` already defines it; REUSE it, do not reinvent it** — and fix at the chokepoint |
+| **ABORT** | unsalvageable | the **existing** bailout procedure (`bailout-and-final-report.md`): **leave the PR OPEN**, drop this run's labels, write `abort-<id>.md` |
+
+The decision is recorded through the tool, and **only** through the tool:
+
+```
+repair-pass.py --file <state.jsonl> decide --pr <N> --decision <one of the five> --record <rundir>/repair-<pr>-<k>.md
+```
+
+`--record` is **refused if it does not exist or is empty**. The reasoning — the history the pass saw, the
+decision, and why — must be **on disk**: every wake is a fresh agent instance, and a justification that
+lives only in the context of an agent that has already exited is one nobody can audit.
+
+### The repair is dispatched only after its decision is recorded
+
+While `status = repairing`, **ordinary gate work on that PR is refused** — no review pass, no review fix,
+no CI fix, no merge, no rebase, no relabel. The repair itself is the one thing that may run, and it is
+gated on the decision existing:
+
+```
+ledger.py --file <state.jsonl> dispatch-check --pr <N>                    # before ANY action that mutates the PR
+ledger.py --file <state.jsonl> dispatch-check --pr <N> --action repair    # before dispatching the decided repair
+```
+
+Without that second gate the guard would have a hole exactly where it matters: a driver could call its next
+targeted fix "the repair", dispatch it, and **go on whacking moles under a new name**. `--action repair`
+refuses until a decision is on the row, and prints **which** decision, so the work that follows is the work
+that was decided.
+
+When the repair has landed, return the row to the gate (`ledger.py … set --pr <N> --status in_review`) and
+let the review gauntlet run again from the top. **`review_rounds` is not reset** — it never is. A PR that
+comes back to a cap has spent another repair.
+
+### Bound the repair itself — it must not become the new spiral
+
+**`repair_count`, capped at `REPAIR_CAP`.** At the cap, the **only** permitted decision is **ABORT** —
+`repair-pass.py` refuses every other one, and `permitted` says so before the agent is even asked. **A
+second failed repair leaves the PR OPEN for a human rather than looping.** The irony would be fatal: a
+mechanism that fixes non-convergence must not itself fail to converge.
+
+### The ownership guardrail — autonomous repair NEVER rewrites a PR it does not own
+
+Campaign **adopts** PRs. They may be the user's, or a third party's. **RESCOPE** and **ROOT-CAUSE** reshape
+branch content wholesale, and doing that to someone else's work uninvited is not a repair — it is a hijack.
+
+`pr_origin` is the ledger's answer, set at adoption (`pr-adoption.md`):
+
+| `pr_origin` | Meaning | Permitted repairs |
+|---|---|---|
+| `gauntlet` | this pipeline opened the PR — it carries the `gauntlet-authored` label, applied by `gauntlet:review`'s handoff when it opens a PR | **all five** |
+| `external` | anything else: the user's PR, a teammate's, a PR adopted by number — **and the DEFAULT** | **DEMOTE / REPAIR-INTENT / ABORT only** |
+
+**The default is `external`, and it is load-bearing.** A row whose origin was never established can never
+have its owner's branch reshaped. *"I do not know who wrote this"* must never resolve to *"I wrote this"*.
+
+**This does NOT restrict targeted per-finding fixes.** Campaign has always pushed those to adopted PRs, and
+that is the workflow the user asked for. What is forbidden on an `external` PR is the **wholesale rewrite**,
+never the ordinary fix.
+
+### Why every part of this is a command and not a paragraph
+
+The rules that failed on 2026-07-14 did not fail by being ignored. **They failed by being unevaluable.**
+The 2nd-`NOT SATISFIED` backstop triggers on a fact about history that nothing recorded, read by a wake
+that remembers nothing. The 1-hour cap was never computed by anything, and its own word — *"stuck"* — did
+not describe a loop that produced a real finding and a real fix every single round. It **looked like
+progress**, one round at a time, all night.
+
+So: the counters are **on disk**, the caps are **evaluated by the tool that records the verdict**, the
+dispatch guard is **a command that exits non-zero**, and the decision enum is **closed and enforced**. A
+driver that ignores this mechanism has a **failed command in its transcript**, not a defensible judgment
+call. That is the only kind of rule that was ever going to work here.

--- a/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
@@ -16,8 +16,17 @@ decision applied independently at more than one site. Do **NOT** wait for the re
 sites 2..N over successive rounds — that is the reviewer mapping *your* space for you, one expensive
 review at a time. One such finding is enough to suspect the archetype and map the whole space now. (A
 string of `NOT SATISFIED` findings that are siblings in one structured space — same function/concept,
-different instance — is the same signal arriving late; treat it identically, and see the Bailout
-escalation rung, which forces this pass no later than the 2nd `NOT SATISFIED` on a PR.)
+different instance — is the same signal arriving late; treat it identically.)
+
+**The old "no later than the 2nd `NOT SATISFIED`" backstop is GONE — do not look for it, and do not
+restore it.** It triggered on a fact about history that nothing recorded, evaluated by a wake that
+remembers nothing, and it **never fired once** across 35 review rounds on two PRs
+(`bailout-and-final-report.md`). What backstops this pass now is a **counter with a cap**: at a review-loop
+cap the PR goes `repairing` and a reassessment pass sees **every round at once** and returns one decision —
+and **ROOT-CAUSE is one of the five** (`repair-pass.md`). So this pass is now reached by **two** doors: the
+shape trigger above, which is still the fast one and still the one you should be using, and the
+reassessment, which is the backstop that actually fires. **This file remains the definition of the pass
+itself; the reassessment REUSES it and never reimplements it.**
 
 **Enumeration is a SEPARATE read-only pass — NEVER folded into a fix.**
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -503,9 +503,12 @@ ever re-ordered again.
 - **red** → **any** evidence row classifies `FAIL`. Other rows still `RUNNING` does **not** change this —
   a failure is actionable now.
 
-  **If the PR is PARKED** (`status` = `awaiting-user` / `awaiting-api`), record `ci = red` and
-  **dispatch NO fix** — a parked PR dispatches nothing until the user answers (`loop-control.md` step 3).
-  **The park does not change the watch either way** — watching is observation, not work-dispatch, so the
+  **If the PR is HELD** (`ledger.py … dispatch-check --pr <N>` exits non-zero — it is parked on a human,
+  or `repairing` after a review-loop cap), record `ci = red` and
+  **dispatch NO fix** — a held PR dispatches nothing until its question is answered (`loop-control.md`
+  step 3, "held-status guard"). A CI fix on a PR whose diff the reassessment pass is about to rescope is
+  work thrown away twice over.
+  **Being held does not change the watch either way** — watching is observation, not work-dispatch, so the
   watch follows the normal policy below ("WATCH ONLY WHAT CAN MOVE"): alive while a row can still move,
   and **not** relaunched once nothing can. Parking never stops a warranted watch and never starts an
   unwarranted one. Otherwise → any failing row → **stop any review pass in flight on that PR first** (Loop control
@@ -845,7 +848,7 @@ missing. That, too, is a **property, not a fixed list of scans**: whichever rule
 one that says so. For a CI fix it is `loop-control.md` step 3's dispatch scan; for a rebase it is the rule
 that owns the rebase (Stage 2a's preconditions, `stage-2-review-gate.md`; the step-6 reconcile,
 `stage-3-merge.md`) finding the PR behind/conflicting on this wake. A PR **frozen by a park** has **no**
-machine action due — the parked-status guard forbids every one of them (`loop-control.md`), so nothing is
+machine action due — the held-status guard forbids every one of them (`loop-control.md`), so nothing is
 coming, which is why the park is the terminus and not another wait.
 
 **IT STILL TERMINATES — a liveness rule that can be suppressed forever is not a liveness rule.** The STOP

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -37,14 +37,17 @@ the row by column position). Default to **STANDARD** whenever you are unsure. `r
 
 ### 2a. The review gauntlet
 
-**A PARKED PR IS NOT REVIEWABLE — check `status` FIRST.** If `status` is `awaiting-user` or
-`awaiting-api` the PR is **FROZEN**: take no action that **MUTATES** it — no review pass, no
+**A HELD PR IS NOT REVIEWABLE — check `status` FIRST, and check it with the TOOL.** Run `ledger.py …
+dispatch-check --pr <N>`: it exits non-zero on every **HELD** status (`files-and-ledger.md`, `status` —
+the owner; `HELD_STATUSES` in `scripts/ledger.py` is the one place they are enumerated, so **never retype
+that list**). A held PR is **FROZEN**: take no action that **MUTATES** it — no review pass, no
 precondition fix (including the conflict rebase below), no CI fix, no review fix, no merge, and nothing
-else that changes it (`loop-control.md` step 3, "parked-status guard" — the governing property; these
-are only examples). The park leaves
+else that changes it (`loop-control.md` step 3, "held-status guard" — the governing property; these
+are only examples). Held leaves
 `reviews_ok < required(tier)`, so the review-launch rule MUST read `status` too — otherwise the next
-wake re-reviews a PR that is waiting on a HUMAN and a `SATISFIED` verdict merges it **without the
-user's ruling**. The park does **not** change its CI watch either way — observing is not mutating, so the
+wake re-reviews a PR that is **waiting on a HUMAN** (a park) and a `SATISFIED` verdict merges it **without
+the user's ruling**, or re-reviews a PR that has **stopped converging** (`repairing`) and spends round 22
+of a loop that has already been told to stop. The park does **not** change its CI watch either way — observing is not mutating, so the
 watch follows the normal policy (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE": alive while a row can still
 move, **not** relaunched once CI has SETTLED). Everything else waits for the user's answer.
 
@@ -758,9 +761,21 @@ unfired — the trigger is a fact about history, and nothing recorded any histor
 `reviews_ok=0 attempts=0`, exactly as it had after round one. `ns_streak` (consecutive `NOT SATISFIED`,
 cleared **only** by a `SATISFIED`) is the same sensor one derivative down.
 
-**This PR adds the counters and NOTHING that reads them** — no cap, no escalation. They are sensors; the
-autonomous reassessment that consumes them lands separately. A counter that is reset by the thing that
-consumes it is not a counter.
+**What READS these counters is `verdict` itself, and at a cap it STOPS THE LOOP.** They are sensors, and
+the reader is fused into the one door that cannot be skipped — deliberately. A cap evaluated by a
+*separate* command is a cap a driver can forget to run, and that is precisely how the "hard backstop" above
+sat unfired through 35 review rounds. The hazard that normally argues for keeping a reader out of a sensor
+— that the reader comes to reset what it consumes — is structurally absent here: **the cap path writes
+`status` and nothing else**, so `review_rounds` stays monotone whatever it decides.
+
+**At a review-loop cap, `verdict` sets `status = repairing` and EXITS NON-ZERO.** The PR has stopped
+converging: **do NOT dispatch a fix subagent and do NOT launch another review pass for it.** Hand its
+**whole history at once** to the **reassessment pass** and execute the one decision it returns —
+`repair-pass.md` owns the caps, the decision enum, and the repair. Ordinary work on that PR is refused by
+`ledger.py … dispatch-check --pr <N>` until the repair lands, so this is not a rule you have to remember.
+
+**A `SATISFIED` NEVER trips a cap.** The gate is moving, and a PR one corroborating pass from merging must
+never be torn up for a repair.
 
 Then, per verdict:
 
@@ -771,7 +786,8 @@ Then, per verdict:
   applies the moment the verdict lands, *before* any fix is written: a PR whose latest verdict says
   NOT SATISFIED must never still read `gauntlet-accepted` on GitHub. **Only GATING findings reach the fix
   path at all** — a non-gating finding is recorded as a follow-up and no fix is dispatched for it (the
-  gating rule, above; `verify` has already refused the pass if a `not-satisfied` recorded none). **Then AUDIT
+  gating rule, above; `verify` has already refused the pass if a `not-satisfied` recorded none). **Then —
+  unless `verdict` just held the PR for repair, in which case NO fix is dispatched at all — AUDIT
   the gating findings — see
   "Audit every finding before you fix it" below; NEVER dispatch a fix for an unaudited finding — and
   dispatch a scoped fix subagent** into `<worktree>` (the PR row's ledger `worktree` column value) with
@@ -803,7 +819,8 @@ Then, per verdict:
   reported. Scope bounds the READING; the sweep bounds the WRITING; the fixer owes you both.
 - **SATISFIED** → record it (`ledger.py … verdict --pr <N> --head-sha <sha> --verdict satisfied`, which
   bumps `reviews_ok` and `review_rounds` and clears `ns_streak` in one write — **never** `set
-  --reviews-ok`, which refuses to raise the tally). The gate is met once this SHA holds `required(tier)` SATISFIED verdicts
+  --reviews-ok`, which refuses to raise the tally). It **never** trips a review-loop cap. The gate is met
+  once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a
   `required==2` PR — the next wake launches the next (corroborating) review on the same SHA. When the
   tally **reaches** `required(tier)` on the same SHA, the review gate is met for this HEAD — swap the

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -7,11 +7,15 @@ equals the ledger `head_sha` AND `reviews_ok >= required(tier)` AND `ci == green
 against the live tip. (An adopted PR may have no local worktree checked out, so use the PR's own head
 via `gh`, never a local `git rev-parse HEAD`.)
 
-**The parked-status guard binds the merge (`loop-control.md` step 3).** A PR whose `status` is
-`awaiting-user` or `awaiting-api` is parked on a HUMAN: **NEVER merge it**, whatever `reviews_ok` /
-`ci` / `mergeable` say. Merge eligibility is **not** derived from the gate counters alone — a park does
-not lower `reviews_ok`, so a rule that reads only the counters would merge a PR whose disputed finding
-or API change the user has not yet ruled on. Only the user's answer unparks it, and **to the `status` that
+**The held-status guard binds the merge (`loop-control.md` step 3).** A **HELD** PR — `ledger.py …
+dispatch-check --pr <N>` exits non-zero for it — is **NEVER merged**, whatever `reviews_ok` / `ci` /
+`mergeable` say. That covers a PR **parked on a HUMAN** (`awaiting-user`, `awaiting-api`) and a PR that has
+stopped converging and is being **`repairing`**-ed (`repair-pass.md`); `HELD_STATUSES` in
+`scripts/ledger.py` is the one enumeration, so **do not retype it here**. Merge eligibility is **not**
+derived from the gate counters alone — being held does not lower `reviews_ok`, so a rule that reads only
+the counters would merge a PR whose disputed finding or API change the user has not yet ruled on, or one
+whose diff the reassessment pass is in the middle of rescoping. For a park, only the user's answer unparks
+it, and **to the `status` that
 answer dictates** — `in_review` for a **resume** answer; terminal `aborted` for a **terminal** one (a
 `declined` API change, a `blocker_ruling` of `abort`), which never returns to `in_review` and is never
 merged (`loop-control.md` step 3, "Only the user's answer unparks a PR", owns the mapping). Until the
@@ -164,9 +168,10 @@ subagent at a check that is merely **still running**.
    change below through `scripts/ledger.py … set --pr <N> --<field> <val>` by field name, never by
    hand-editing the row by column position).
 
-   **SKIP PARKED PRs FIRST — before any base refresh, rebase, or conflict handling.** A PR whose
-   `status` is `awaiting-user` or `awaiting-api` is **FROZEN** (`loop-control.md` step 3,
-   "parked-status guard"): this reconcile MUTATES a PR, so it is exactly what the guard forbids. A clean
+   **SKIP HELD PRs FIRST — before any base refresh, rebase, or conflict handling.** A **HELD** PR
+   (`ledger.py … dispatch-check --pr <N>` — parked on a human, or `repairing`) is **FROZEN**
+   (`loop-control.md` step 3,
+   "held-status guard"): this reconcile MUTATES a PR, so it is exactly what the guard forbids. A clean
    rebase would move its `head_sha`, set `ci = pending` and reset its liveness counters (`stage-2-ci.md`,
    "THE LIVENESS COUNTERS"); a conflict-resolving rebase would reset
    `reviews_ok`, relabel, and relaunch work — and would **change the PR's content**, which can invalidate

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1530,6 +1530,65 @@ def t_replay_the_real_record(L: ModuleType, tmp: Path) -> None:
                   f"it is the version people read")
 
 
+def t_stale_repair_decision_cleared_at_cap(L: ModuleType, tmp: Path) -> None:
+    """RE-ENTERING `repairing` at a cap CLEARS any stale reassessment decision — so the repair BUDGET binds.
+
+    `repair_decision` is durable and is written by exactly two things: `repair-pass.py decide` (which also
+    SPENDS `repair_count`) and this reset in `cmd_verdict`. A decision recorded for a PREVIOUS cap — left on
+    the row after that repair completed and the row returned to `in_review` — would otherwise still be there
+    when the loop hits a cap AGAIN, and `dispatch-check --action repair` accepts ANY non-`-` decision. A
+    driver would then dispatch a SECOND repair with no fresh `decide`, spending no budget, and `REPAIR_CAP`
+    would never bind: the mechanism that bounds non-convergence would itself fail to converge.
+
+    So a NOT SATISFIED that trips a cap must land the row `repairing` AND wipe the stale decision to `-`.
+    Delete that one write in `cmd_verdict` and this fixture goes red.
+    """
+    # The state a completed FIRST repair leaves behind: budget spent once, its decision still on the row,
+    # and the loop back in review. Written RAW — `repair-pass.py decide` is what produces it, and
+    # `repair_count`/`repair_decision` have NO `set` flag by design (t_the_repair_bound_has_no_door).
+    stale = "rescope@2026-07-14T00:00:00Z"
+    path = write_lines(tmp / "stale.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, status="in_review",
+                                pr_origin="gauntlet", repair_count="1", repair_decision=stale))
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "repair_decision"])
+    check(out.strip() == stale, f"fixture setup is wrong — the row does not carry the stale decision: {out!r}")
+
+    # Hit the cap AGAIN via an independent NS streak — the last verdict trips it and exits EXIT_STOP.
+    landed, code = verdicts(L, path, "N" * L.NS_STREAK_CAP)
+    check(code == L.EXIT_STOP, f"the cap did not fire ({landed} verdicts landed, exit {code})")
+
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    row = json.loads(out)
+    check(row["status"] == L.REPAIR_STATUS, f"the row is {row['status']!r}, not {L.REPAIR_STATUS!r}")
+    # THE PIN: the stale decision is GONE. Without the clear-on-entry write it would still read `stale`.
+    check(row["repair_decision"] == "-",
+          f"a STALE decision survived the re-entry: {row['repair_decision']!r}. `dispatch-check --action "
+          f"repair` accepts any non-`-` decision, so a second repair would dispatch with NO fresh `decide` "
+          f"and REPAIR_CAP would never bind")
+    # The budget was NOT spent by hitting the cap — only a fresh `decide` spends it, which is exactly what
+    # now holds the bound: one `decide` per cap, one `repair_count` per `decide`.
+    check(row["repair_count"] == "1",
+          f"re-entering the cap moved repair_count to {row['repair_count']!r} — the budget is spent by "
+          f"`decide`, never by reaching the cap")
+
+    # The consequence the pin buys: a repair is REFUSED until a fresh reassessment decides one.
+    code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == L.EXIT_STOP,
+          f"a repair was dispatchable at the SECOND cap with no fresh decision (exit {code}) — the stale "
+          f"decision was not cleared, so the repair budget can be bypassed")
+    check("NO REASSESSMENT DECISION" in err, f"refused for the wrong reason: {err!r}")
+
+    # …until a fresh decision is recorded (the state `repair-pass.py decide` writes: budget now at
+    # REPAIR_CAP). The refusal LIFTS — the guard blocks until a decision exists, not forever.
+    fresh = "rescope@2026-07-14T01:00:00Z"
+    write_lines(path, header_line(L),
+                row_line(L, pr="1", head_sha=SHA_A, status=L.REPAIR_STATUS,
+                         pr_origin="gauntlet", repair_count="2", repair_decision=fresh))
+    code, out, _ = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == 0, f"a repair with a FRESH decision recorded was refused (exit {code})")
+    check(fresh in out, f"dispatch-check must name the decision to dispatch: {out!r}")
+
+
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
     ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
@@ -1571,6 +1630,7 @@ CASES = [
     ("held-row-no-verdict", "no verdict may land on a held row", t_no_verdict_for_a_held_row),
     ("dispatch-check", "every HELD status refuses a mutating dispatch; a repair needs its decision first", t_dispatch_check_is_the_guard),
     ("repair-bound-no-door", "repair_count has NO flag — a budget you can zero is not a bound", t_the_repair_bound_has_no_door),
+    ("repair-decision-cleared", "re-entering a cap CLEARS the stale reassessment decision — the repair budget binds", t_stale_repair_decision_cleared_at_cap),
     ("pr-origin-default", "an unknown origin is `external` — the fail-safe direction", t_pr_origin_defaults_to_external),
     ("replay-the-record", "the REAL #42/#43 verdict sequences: it fires, never too early, and says what it costs", t_replay_the_real_record),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1259,6 +1259,277 @@ def t_skill_version_is_recorded(L: ModuleType, tmp: Path) -> None:
           f"the table's run-config block does not state which version governed the run: {config!r}")
 
 
+# --- the caps: what READS the counters, and stops the loop ---------------------
+
+def verdicts(L: ModuleType, path: Path, seq: str, pr: str = "1", move_head: bool = False) -> "tuple[int, int]":
+    """Drive a verdict sequence ('N'/'S') through the real CLI. Returns (verdicts landed, exit of the last).
+
+    `move_head` replays what really happens between rounds: a NOT SATISFIED sends a fix, the fix pushes,
+    the head moves. That is what makes this a test of "`review_rounds` survives a fix" and not a rehearsal
+    on static content.
+    """
+    sha = SHA_A
+    for i, v in enumerate(seq, start=1):
+        code, _, _ = cli(L, ["--file", str(path), "verdict", "--pr", pr, "--head-sha", sha,
+                             "--verdict", "satisfied" if v == "S" else "not-satisfied"])
+        if code != 0:
+            return i, code
+        if move_head and v == "N":
+            sha = f"{i:040x}"
+            cli(L, ["--file", str(path), "set", "--pr", pr, "--head-sha", sha])
+    return len(seq), 0
+
+
+def capped_row(L: ModuleType, tmp: Path, name: str, **over: str) -> Path:
+    fields = {"pr": "1", "head_sha": SHA_A, "status": "in_review", **over}
+    return write_lines(tmp / name, header_line(L), row_line(L, **fields))
+
+
+def t_round_cap_fires(L: ModuleType, tmp: Path) -> None:
+    """At ROUND_CAP, a NOT SATISFIED holds the row `repairing` and EXITS NON-ZERO.
+
+    Non-zero is the entire point. The skill's own "hard backstop" on the 2nd NOT SATISFIED sat unfired
+    through 35 review rounds because nothing COMPUTED it — it was prose, evaluated by a fresh-context wake
+    that could not see round 1 from round 21. A driver that dispatches a fix after this has a FAILED
+    COMMAND in its transcript, not a judgment call.
+    """
+    path = capped_row(L, tmp, "cap.jsonl")
+    # alternate so the NS streak never fires — this isolates the ROUND cap
+    landed, code = verdicts(L, path, "NS" * (L.ROUND_CAP // 2) + "N"[: L.ROUND_CAP % 2])
+    check(code == L.EXIT_STOP,
+          f"{landed} verdicts landed and the last exited {code}, not {L.EXIT_STOP} — the round cap did not "
+          f"fire, so the driver is free to dispatch fix number {L.ROUND_CAP + 1}")
+    check(landed == L.ROUND_CAP, f"the cap fired at verdict {landed}, not {L.ROUND_CAP}")
+
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    row = json.loads(out)
+    check(row["status"] == L.REPAIR_STATUS, f"the row is {row['status']!r}, not {L.REPAIR_STATUS!r}")
+    check(row["review_rounds"] == str(L.ROUND_CAP), "the verdict that tripped the cap must still be RECORDED")
+
+
+def t_ns_streak_cap_fires(L: ModuleType, tmp: Path) -> None:
+    """NS_STREAK_CAP is an INDEPENDENT sensor — it catches the PR that NEVER scores, well before ROUND_CAP.
+
+    A PR that has not once come back SATISFIED is failing in a way a round count is slow to see. (The cap
+    sits below ROUND_CAP on purpose; if the two were equal this fixture would pin nothing.)
+    """
+    check(L.NS_STREAK_CAP < L.ROUND_CAP, "the streak cap must bite before the round cap, or it is dead code")
+
+    path = capped_row(L, tmp, "streak.jsonl")
+    landed, code = verdicts(L, path, "N" * L.NS_STREAK_CAP)
+    check(code == L.EXIT_STOP, f"{L.NS_STREAK_CAP} consecutive NOT SATISFIEDs exited {code}")
+    check(landed == L.NS_STREAK_CAP, f"the streak cap fired at {landed}, not {L.NS_STREAK_CAP}")
+
+    # …and ONE SATISFIED breaks it: the sensor measures CONSECUTIVE failure and nothing else.
+    path = capped_row(L, tmp, "streak2.jsonl")
+    _, code = verdicts(L, path, "N" * (L.NS_STREAK_CAP - 1) + "S" + "N")
+    check(code == 0, "a SATISFIED did not clear the streak — the sensor is counting the wrong thing")
+
+
+def t_a_satisfied_never_fires_a_cap(L: ModuleType, tmp: Path) -> None:
+    """THE CAPS ARE NEVER EVALUATED ON A SATISFIED — a PR one pass from merging is never torn up.
+
+    Not an optimization: a correctness rule taken from the record. PR #42's TENTH landed verdict was a
+    SATISFIED, so a cap that fired on ANY verdict at 10 would have interrupted a PR whose very next pass
+    could have merged it. A PR is interrupted only when a verdict says its content is STILL WRONG *and*
+    the loop's history says it is no longer converging.
+    """
+    path = capped_row(L, tmp, "sat.jsonl")
+    landed, code = verdicts(L, path, "S" * (L.ROUND_CAP * 2))
+    check(code == 0, f"a SATISFIED exited {code} — a cap fired on a PASSING verdict")
+    check(landed == L.ROUND_CAP * 2, "the fixture never got past the cap")
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "status"])
+    check(out.strip() == "in_review", f"a run of SATISFIED verdicts held the row: {out!r}")
+
+
+def t_no_verdict_for_a_held_row(L: ModuleType, tmp: Path) -> None:
+    """No verdict may land on a HELD row — no review pass should have been running for it at all."""
+    for status in L.HELD_STATUSES:
+        path = capped_row(L, tmp, f"held-{status}.jsonl", status=status)
+        code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A,
+                               "--verdict", "not-satisfied"])
+        check(code == 1, f"[{status}] a verdict on a held row was ACCEPTED (exit {code})")
+        code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "review_rounds"])
+        check(out == "0\n", f"[{status}] the REFUSED verdict bumped the counter anyway: {out!r}")
+
+
+def t_dispatch_check_is_the_guard(L: ModuleType, tmp: Path) -> None:
+    """`dispatch-check` refuses a mutating dispatch on EVERY held status, and allows one on a live row.
+
+    The park was already a prose rule obeyed by attention; `repairing` is a new one. Both are now a command
+    that FAILS. The message must say what CLEARS the hold — a guard that only says "refused" teaches the
+    driver nothing and invites it to route around the guard.
+    """
+    for status in L.HELD_STATUSES:
+        path = capped_row(L, tmp, f"dc-{status}.jsonl", status=status)
+        code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+        check(code == L.EXIT_STOP, f"[{status}] dispatch-check exited {code}, not {L.EXIT_STOP}")
+        check(status in err and "MUTATES" in err, f"[{status}] the refusal does not state the rule: {err!r}")
+        check("watch" in err, f"[{status}] the refusal must keep the CI watch exempt — observing is not "
+                              f"mutating, and a stopped watch is how a PR goes unwatched forever: {err!r}")
+
+    check(L.REPAIR_STATUS in L.HELD_STATUSES, "the repairing status must be HELD, or NO guard covers it")
+
+    for status in ("in_review", "pending"):
+        path = capped_row(L, tmp, f"live-{status}.jsonl", status=status)
+        code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+        check(code == 0, f"[{status}] a LIVE row was HELD (exit {code}) — the run would stall: {err!r}")
+
+    # `--action repair`: refused with no decision recorded, and refused on a row that is not repairing.
+    path = capped_row(L, tmp, "rep.jsonl", status=L.REPAIR_STATUS)
+    code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == L.EXIT_STOP, f"a repair was dispatchable with NO decision recorded (exit {code})")
+    check("NO REASSESSMENT DECISION" in err, f"refused for the wrong reason: {err!r}")
+
+    path = capped_row(L, tmp, "live-rep.jsonl", status="in_review")
+    code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == L.EXIT_STOP, f"repair work was dispatchable on a PR that never hit a cap (exit {code})")
+
+
+def t_the_repair_bound_has_no_door(L: ModuleType, tmp: Path) -> None:
+    """`repair_count` CANNOT BE WRITTEN through `set`/`add-row` — the same mechanism as `review_rounds`.
+
+    A driver that could zero its own repair budget could repair forever. The bound on the repair is only a
+    bound if nothing but the tool that SPENDS it may write it. Enforced by the ABSENCE of a flag, which
+    argparse cannot be talked round.
+    """
+    path = capped_row(L, tmp, "ro.jsonl")
+    for field in L.REPAIR_OWNED:
+        for door in (["set", "--pr", "1"], ["add-row", "--pr", "77"]):
+            code, _, err = cli(L, ["--file", str(path), *door, f"--{field.replace('_', '-')}", "0"])
+            check(code == 2, f"`{door[0]} --{field}` was ACCEPTED (exit {code}) — a door that can write the "
+                             f"repair budget is a door that can RESET it, and the repair would never end")
+            check("unrecognized arguments" in err,
+                  f"`{door[0]} --{field}` failed, but not because the flag does not EXIST: {err!r}")
+
+
+def t_pr_origin_defaults_to_external(L: ModuleType, tmp: Path) -> None:
+    """A row whose origin was never established is `external` — the FAIL-SAFE direction.
+
+    `pr_origin` decides whether an autonomous repair may REWRITE this PR's branch. Guessing wrong in the
+    other direction lets the mechanism reshape a stranger's work because a field was never set. "I do not
+    know who wrote this" must never resolve to "I wrote this".
+    """
+    path = write_lines(tmp / "origin.jsonl", header_line(L),
+                       json.dumps({"type": "row", "pr": "3", "slug": "pre-schema"}))
+    code, out, err = cli(L, ["--file", str(path), "get", "--pr", "3"])
+    check(code == 0, f"get on a pre-schema row exited {code}: {err!r}")
+    row = json.loads(out)
+    check(row["pr_origin"] == "external",
+          f"pr_origin back-filled as {row['pr_origin']!r} — a row of UNKNOWN origin must never be treated "
+          f"as campaign's own work to rewrite")
+    check((row["repair_count"], row["repair_decision"]) == ("0", "-"), f"repair fields: {row!r}")
+
+
+# --- the acceptance test: REPLAY THE REAL RECORD -------------------------------
+
+# The verdict sequences PR #42 and PR #43 actually produced, in order, on the night of 2026-07-14 (run
+# g260714-0746-bc5e8e20), read off each pass's `VERDICT:` line. The passes that landed NO verdict (#42 r4,
+# r7; #43 r5, r16) are absent — a pass that lands no verdict is not a round. `S`/`N` = SATISFIED / NOT.
+#
+# `protect_through` and `preempts` are the two halves of the thresholds' DEFENCE, and they pull in OPPOSITE
+# directions — which is exactly why BOTH are asserted. A cap must land after the work and before the
+# spiral, and on this record those two windows very nearly touch.
+REAL_RECORD = {
+    "42": {
+        "verdicts": "NNSNNNSNNSNSNSNNNSNNN",
+        "passes": [1, 2, 3, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+        "fires_at": 13,
+        # The last finding a real END USER could reach: `accept --at -` exits 0 and writes a store that
+        # `list` then refuses to read. Squarely the PR's job — a ledger that corrupts itself.
+        "protect_through": 10,
+        # THE DISCLOSED COST, asserted so it can never be quietly forgotten. Pass r15 ("the load path
+        # accepts blank required fields") is PR-ORIGINAL and gating, and the trigger DOES cut it off. It is
+        # not lost: RESCOPE shrinks the PR back to its purpose and RE-GATES it from scratch, and this defect
+        # is in the PR's own validation — a fresh reviewer meets it again on the shrunk diff if it survived.
+        # What is bought for that risk is TEN ROUNDS: a human stopped this PR at r21; the cap stops it at r13.
+        "preempts": [15],
+    },
+    "43": {
+        "verdicts": "NNNNSNNNNNSNNN",
+        "passes": [1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        "fires_at": 13,
+        # THE HARD BAR. #43's four genuine false-green bugs — the exact thing that PR exists to prevent —
+        # landed at passes 1, 4, 7 and 11, and pass 12 is the SATISFIED that corroborated the last fix. The
+        # trigger must be silent through ALL of it, and it fires at 13: the FIRST spiral round, where the
+        # subject of review had become the AST scanner that the r11–r12 fixes themselves built.
+        "protect_through": 12,
+        "preempts": [],  # nothing genuine is cut off on #43
+    },
+}
+
+
+def replay(L: ModuleType, tmp: Path, pr: str, stop_after: "int | None" = None) -> "int | None":
+    """Drive one PR's REAL verdict sequence through the REAL CLI. Returns the pass the trigger fired at."""
+    rec = REAL_RECORD[pr]
+    seq, passes = rec["verdicts"], rec["passes"]
+    assert isinstance(seq, str) and isinstance(passes, list)
+    check(len(seq) == len(passes), f"[#{pr}] the fixture's own record is inconsistent")
+    path = write_lines(tmp / f"replay-{pr}-{stop_after}.jsonl", header_line(L),
+                       row_line(L, pr=pr, head_sha=SHA_A, status="in_review"))
+    sha = SHA_A
+    for i, (v, npass) in enumerate(zip(seq, passes), start=1):
+        if stop_after is not None and npass > stop_after:
+            return None
+        code, _, _ = cli(L, ["--file", str(path), "verdict", "--pr", pr, "--head-sha", sha,
+                             "--verdict", "satisfied" if v == "S" else "not-satisfied"])
+        if code == L.EXIT_STOP:
+            code, out, _ = cli(L, ["--file", str(path), "get", "--pr", pr, "--field", "status"])
+            check(out.strip() == L.REPAIR_STATUS, f"[#{pr}] the trigger left the row live")
+            return npass
+        check(code == 0, f"[#{pr}] verdict {i} (pass r{npass}) exited {code}")
+        if v == "N":  # a fix was dispatched and pushed: the head MOVED
+            sha = f"{i:040x}"
+            cli(L, ["--file", str(path), "set", "--pr", pr, "--head-sha", sha])
+    return None
+
+
+def t_replay_the_real_record(L: ModuleType, tmp: Path) -> None:
+    """THE ACCEPTANCE TEST. Drive the two PRs that ACTUALLY spiralled through the real CLI.
+
+    Three claims, and the last two are what make the thresholds *defended* rather than merely chosen:
+
+    1. **The trigger fires.** #42 at review pass r13 (it ran 23), #43 at r13 (it ran 16). The loop stops.
+    2. **It never fires before the genuine work is done.** #43's four false-green bugs landed at passes 1,
+       4, 7 and 11 and were corroborated at 12; the trigger is silent through all of it. A cap that aborted
+       #43 at pass 3 would have destroyed the entire point of that PR.
+    3. **What it DOES cut off is STATED, not hidden.** On #42 the trigger pre-empts the PR-original finding
+       at pass r15. That is a real cost, it is asserted here, and RESCOPE + a full re-gate is what recovers
+       it. A design whose costs live only in its author's head is a design nobody can review.
+
+    Re-tune a cap and this fixture tells you, in its own failure message, what the new number would have
+    done to two PRs that really ran.
+    """
+    for pr, rec in REAL_RECORD.items():
+        fires_at, protect, preempts = rec["fires_at"], rec["protect_through"], rec["preempts"]
+        assert isinstance(fires_at, int) and isinstance(protect, int) and isinstance(preempts, list)
+
+        fired_at = replay(L, tmp, pr)
+        check(fired_at is not None,
+              f"[#{pr}] the trigger NEVER FIRED across all {len(rec['verdicts'])} landed verdicts — this is "
+              f"the 8.5-hour spiral, exactly as it happened, and the mechanism did nothing about it")
+        check(fired_at == fires_at,
+              f"[#{pr}] the trigger fired at review pass r{fired_at}, not r{fires_at}. With "
+              f"ROUND_CAP={L.ROUND_CAP} / NS_STREAK_CAP={L.NS_STREAK_CAP} the loop stops at a different "
+              f"round than the one the thresholds were defended against — re-derive them against the "
+              f"record before changing this expectation")
+
+        # (2) THE WORK IS PROTECTED. Replayed independently, so it cannot be satisfied by the run above
+        # having already stopped: this asserts the trigger is SILENT through the last genuine finding.
+        check(replay(L, tmp, pr, stop_after=protect) is None,
+              f"[#{pr}] THE TRIGGER FIRED AT OR BEFORE PASS r{protect}, WHERE THE PR WAS STILL FINDING "
+              f"GENUINE, PURPOSE-SERVING DEFECTS. A cap this tight destroys real value — #43's four "
+              f"false-green bugs ARE the reason that PR exists. Raise ROUND_CAP (={L.ROUND_CAP}) / "
+              f"NS_STREAK_CAP (={L.NS_STREAK_CAP}); do NOT weaken this fixture")
+
+        # (3) THE COST IS DISCLOSED — a fact about the thresholds, so it is asserted like one.
+        for p in preempts:
+            check(fires_at < p,
+                  f"[#{pr}] the record claims the trigger pre-empts the gating finding at pass r{p}, but it "
+                  f"fires at r{fires_at} — the disclosure is now STALE, which is worse than no disclosure: "
+                  f"it is the version people read")
+
+
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
     ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
@@ -1294,6 +1565,14 @@ CASES = [
     ("counter-corrupt", "a counter field that is not a count is refused, never handed to int()", t_counter_refuses_a_corrupt_value),
     ("write-atomic", "a write that dies mid-way leaves the OLD ledger intact — temp + fsync + os.replace", t_write_is_atomic),
     ("skill-version", "the header records WHICH VERSION of the rules governed the run; default `unknown`", t_skill_version_is_recorded),
+    ("round-cap", "at ROUND_CAP a NOT SATISFIED holds the row `repairing` and exits non-zero", t_round_cap_fires),
+    ("ns-streak-cap", "NS_STREAK_CAP is an independent sensor; one SATISFIED clears the streak", t_ns_streak_cap_fires),
+    ("satisfied-never-fires", "a cap is NEVER evaluated on a SATISFIED — a passing PR is never torn up", t_a_satisfied_never_fires_a_cap),
+    ("held-row-no-verdict", "no verdict may land on a held row", t_no_verdict_for_a_held_row),
+    ("dispatch-check", "every HELD status refuses a mutating dispatch; a repair needs its decision first", t_dispatch_check_is_the_guard),
+    ("repair-bound-no-door", "repair_count has NO flag — a budget you can zero is not a bound", t_the_repair_bound_has_no_door),
+    ("pr-origin-default", "an unknown origin is `external` — the fail-safe direction", t_pr_origin_defaults_to_external),
+    ("replay-the-record", "the REAL #42/#43 verdict sequences: it fires, never too early, and says what it costs", t_replay_the_real_record),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -132,7 +132,10 @@ ROW_FIELDS = (
     # THE REPAIR'S OWN BOUND — the mechanism that fixes non-convergence must not itself fail to converge.
     "repair_count",     # reassessment decisions taken. At REPAIR_CAP the only decision left is ABORT.
     "repair_decision",  # - | <decision>@<iso> — durable, so the wake that DISPATCHES a repair can be a
-                        # different agent instance from the one that DECIDED it.
+                        # different agent instance from the one that DECIDED it. RESET to `-` when the row
+                        # RE-ENTERS `repairing` (`cmd_verdict` at a cap), scoping a decision to ONE cap: the
+                        # next repair must be earned by a fresh `decide` (which spends `repair_count`), so
+                        # the budget binds. `abort` is terminal and is never cleared.
 )
 ROW_DEFAULTS = {
     "id": "-", "slug": "-", "branch": "-", "worktree": "-", "worktree_owned": "-",
@@ -539,6 +542,14 @@ def cmd_verdict(path: Path, args) -> int:
     at_cap = args.verdict == NOT_SATISFIED and (rounds >= ROUND_CAP or streak >= NS_STREAK_CAP)
     if at_cap:
         row["status"] = REPAIR_STATUS
+        # Clear any STALE reassessment decision as the row RE-ENTERS `repairing`. `repair_decision` is
+        # written only by `repair-pass.py decide` (which also spends `repair_count`) and by this reset, so a
+        # decision left on the row from a PREVIOUS cap would otherwise satisfy `dispatch-check --action
+        # repair` at THIS cap with no fresh `decide` — dispatching a repair that spends no budget, and
+        # `REPAIR_CAP` would never bind. A verdict only reaches this branch from a non-held (so post-repair
+        # `in_review`) row, so the decision it clears is always a spent one. The next repair here MUST be
+        # earned by a fresh `decide`, which bumps `repair_count` — the bound the mechanism exists to hold.
+        row["repair_decision"] = "-"
     dump(path, header, rows)
     print(json.dumps(row))
     if not at_cap:

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -115,6 +115,24 @@ ROW_FIELDS = (
     # nothing the reviewer was measured against before — but a WRONG intent block silently NARROWS a
     # review, so which kind it is has to be visible rather than buried.
     "intent",
+    # WHO AUTHORED THIS PR — it decides which autonomous repairs are permitted (`repair-pass.md`, "The
+    # ownership guardrail"). `gauntlet` = this pipeline opened the PR (it carries the `gauntlet-authored`
+    # label, applied by gauntlet:review's handoff). `external` = anything else: the user's PR, a
+    # teammate's, a PR adopted by number.
+    #
+    # The default is `external` and it is LOAD-BEARING, not a placeholder: the repairs that REWRITE branch
+    # content (RESCOPE, ROOT-CAUSE) are refused on an `external` PR, so a row whose origin was never
+    # established can never have its owner's work reshaped. "I do not know who wrote this" and "I wrote
+    # this" are different facts, and the default is the one that claims nothing.
+    #
+    # NOT `worktree_owned`/`branch_owned`: those say whether campaign created the local checkout and
+    # branch, which is a CLEANUP question. A PR can have a campaign-created worktree and still belong
+    # entirely to someone else.
+    "pr_origin",
+    # THE REPAIR'S OWN BOUND — the mechanism that fixes non-convergence must not itself fail to converge.
+    "repair_count",     # reassessment decisions taken. At REPAIR_CAP the only decision left is ABORT.
+    "repair_decision",  # - | <decision>@<iso> — durable, so the wake that DISPATCHES a repair can be a
+                        # different agent instance from the one that DECIDED it.
 )
 ROW_DEFAULTS = {
     "id": "-", "slug": "-", "branch": "-", "worktree": "-", "worktree_owned": "-",
@@ -123,6 +141,7 @@ ROW_DEFAULTS = {
     "ci_fingerprint": "-", "settled_strikes": "0", "unusable_refetches": "0",
     "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-",
     "review_rounds": "0", "ns_streak": "0", "intent": "-",
+    "pr_origin": "external", "repair_count": "0", "repair_decision": "-",
 }
 
 # The two fields `verdict` OWNS — and the ONLY reason they are not settable through `set`/`add-row` is
@@ -135,8 +154,64 @@ ROW_DEFAULTS = {
 # must stay. What `set` may NOT do is RAISE it: see `check_tally`.)
 VERDICT_OWNED = ("review_rounds", "ns_streak")
 
+# The repair's own fields, owned by `repair-pass.py` and settable through NO flag — the same mechanism as
+# VERDICT_OWNED, for the same reason. `repair_count` is the bound on the repair itself: a door that can
+# write it is a door that can zero it, and a driver that could zero its own repair budget could repair
+# forever. The tool that decides a repair is the only thing that writes what it spent.
+REPAIR_OWNED = ("repair_count", "repair_decision")
+
 SATISFIED, NOT_SATISFIED = "satisfied", "not-satisfied"
 VERDICTS = (SATISFIED, NOT_SATISFIED)
+
+# --- the review loop's caps (this file is their ONE defining site) ------------
+#
+# Numbered here and NOWHERE ELSE. Every reference that needs one names the CAP, never its value — a value
+# retyped in prose goes stale the day it is tuned, and the prose is the copy people read.
+#
+# The numbers are DEFENDED AGAINST THE REAL RECORD (`repair-pass.md`, "The thresholds"), and
+# `ledger-test.py` REPLAYS that record so a re-tuned cap states, in its own failure message, what the new
+# number would have done to two PRs that really ran:
+#
+#   ROUND_CAP = 11    PR #43's last GENUINE defect (a false green reachable from a real GitHub response —
+#                     the exact thing that PR existed to prevent) landed on its 10th verdict and was
+#                     corroborated by its 11th. A cap of 11 is the smallest that lets a PR doing real work
+#                     finish it. It then fires on #43's 12th verdict — its FIRST spiral round — and on
+#                     #42's 11th of 21.
+#   NS_STREAK_CAP = 6 #43 ran FIVE consecutive NOT SATISFIEDs that were still producing genuine, purpose-
+#                     serving findings, so 5 must NOT trigger. 6 is the smallest number the record does not
+#                     refute. It catches the shape neither PR had — a PR that NEVER scores a SATISFIED —
+#                     several rounds before ROUND_CAP would.
+#   REPAIR_CAP = 2    A second failed repair aborts rather than looping.
+#
+# A wrong threshold is SURVIVABLE, and that is what licenses picking one at all: the trigger is a MODE
+# SWITCH, not a rejection. Firing early costs one reassessment pass and a re-gate; nothing is merged, and
+# nothing is closed. Firing late costs 8.5 hours.
+ROUND_CAP = 11
+NS_STREAK_CAP = 6
+REPAIR_CAP = 2
+
+# Where a PR goes when it reaches a cap. It is NOT a park: a park waits on a HUMAN and only the user's
+# answer leaves it, while this waits on the reassessment pass and the driver clears it itself.
+REPAIR_STATUS = "repairing"
+
+# HELD — the statuses in which campaign MUST NOT dispatch ordinary gate work on a PR (a review pass, a
+# review fix, a CI fix, a merge, a rebase, a relabel — anything that MUTATES it). THE ONE ENUMERATION;
+# `dispatch-check` is what makes it a command that can FAIL rather than a rule an attentive agent must
+# remember. The members are held for DIFFERENT reasons and cleared by DIFFERENT events — never collapse
+# them:
+#
+#   awaiting-api / awaiting-user   parked on a HUMAN. Only the user's answer unparks.
+#   repairing                      at a review-loop cap. The reassessment pass and the repair it decides
+#                                  clear it — no human is waited on.
+#
+# The ONE exception, for every member alike: OBSERVING a PR is not mutating it, so the CI watch follows
+# its normal policy, and reconcile still READS a held PR and records what it read.
+HELD_STATUSES = ("awaiting-api", "awaiting-user", REPAIR_STATUS)
+
+# `fail()` keeps 1 for "your input was rejected". A HELD/AT-CAP answer is NOT an input error — the command
+# did its job and the answer is STOP — so it gets its own code. A driver that proceeds anyway has a FAILED
+# COMMAND in its transcript, not a defensible judgment call.
+EXIT_STOP = 3
 
 # A git object id, as git writes one: 40 LOWERCASE hex — the same rule `review-pass.py` and
 # `ci-snapshot.py` hold a SHA to, and for the same reason. A verdict is recorded AGAINST a commit, so a
@@ -317,8 +392,10 @@ def settable(name: str) -> bool:
     `pr` is the row key (passed via --pr) and `id` is derived from it. `VERDICT_OWNED` is the new
     exclusion, and it is the mechanism behind "`review_rounds` is NEVER reset": a door that can write a
     counter is a door that can zero it, so those two fields simply have NO flag. `verdict` writes them.
+    `REPAIR_OWNED` is the same mechanism for the repair's bound: a driver that could zero `repair_count`
+    could repair forever, so only `repair-pass.py decide` writes what a PR has spent.
     """
-    return name not in ("pr", "id") and name not in VERDICT_OWNED
+    return name not in ("pr", "id") and name not in VERDICT_OWNED and name not in REPAIR_OWNED
 
 
 def _named_field_values(args) -> dict:
@@ -418,15 +495,31 @@ def cmd_verdict(path: Path, args) -> int:
     door, so a late verdict from a superseded attempt can never reach the tally through a driver that
     skipped the check.
 
-    **It sets no cap and escalates nothing.** These are SENSORS. What reads them is a separate concern,
-    and building the reader into the sensor is how a counter comes to be reset by the thing that consumes
-    it.
+    **The counters are SENSORS, and this door NEVER WRITES THEM BACKWARDS — but it does READ them, and at
+    a cap it STOPS THE LOOP.** The hazard in fusing a reader into a sensor is that the reader comes to
+    reset the counter it consumes; that hazard is structurally absent here, because the cap path writes
+    `status` and NOTHING ELSE — `review_rounds` stays monotone whatever it decides.
+
+    And the trigger MUST live here, because this is the one door that cannot be skipped. A cap evaluated
+    by a separate command is a cap a driver can forget to run — which is precisely the failure this whole
+    mechanism exists to end: the skill's "hard backstop" on the 2nd NOT SATISFIED never fired once in 35
+    review rounds, because nothing computed it. So at a cap this sets `status = repairing` and **exits
+    non-zero** (`EXIT_STOP`), and the driver that ignores it has a failed command in its transcript.
+
+    **The caps are evaluated ONLY on a NOT SATISFIED.** A SATISFIED is the gate MOVING — the PR may be one
+    corroborating pass from merging, and tearing it up for a repair would be the mechanism destroying the
+    very outcome it exists to protect. (On the real record: PR #42's TENTH landed verdict was a SATISFIED.)
+    A PR is interrupted only when a verdict says the content is STILL WRONG *and* the loop's own history
+    says it is no longer converging.
     """
     header, rows = load(path)
     pr = str(args.pr)
     row = find_row(rows, pr)
     if row is None:
         fail(f"no row for pr {pr}; use `add-row` to create it")
+    if row["status"] in HELD_STATUSES:
+        fail(f"pr {pr} is {row['status']} — no review pass should have been running for it, so this "
+             f"verdict describes work that was never due ({held_reason(row['status'])})")
     if not SHA_RE.match(args.head_sha):
         fail(f"--head-sha {args.head_sha!r} is not a git object id (40 LOWERCASE hex) — a verdict is "
              f"recorded AGAINST a commit, and a value that cannot be one makes every 'does this verdict "
@@ -442,9 +535,102 @@ def cmd_verdict(path: Path, args) -> int:
     else:
         tally, streak = 0, counter(row, "ns_streak") + 1
     row.update({"review_rounds": str(rounds), "reviews_ok": str(tally), "ns_streak": str(streak)})
+
+    at_cap = args.verdict == NOT_SATISFIED and (rounds >= ROUND_CAP or streak >= NS_STREAK_CAP)
+    if at_cap:
+        row["status"] = REPAIR_STATUS
     dump(path, header, rows)
     print(json.dumps(row))
-    return 0
+    if not at_cap:
+        return 0
+
+    which = []
+    if rounds >= ROUND_CAP:
+        which.append(f"review_rounds={rounds} (cap {ROUND_CAP})")
+    if streak >= NS_STREAK_CAP:
+        which.append(f"ns_streak={streak} (cap {NS_STREAK_CAP})")
+    spent = counter(row, "repair_count") >= REPAIR_CAP
+    print(
+        f"ledger: pr {pr} is NOT CONVERGING — {', '.join(which)}. The verdict IS recorded, and the row is "
+        f"now `{REPAIR_STATUS}`.\n"
+        f"ledger: DO NOT dispatch a fix subagent and DO NOT launch another review pass for it. Run the "
+        f"REASSESSMENT PASS (`repair-pass.md`): hand a context-isolated agent the WHOLE history at once — "
+        f"every round's verdict and finding, the diff-growth curve, the intent, the current diff — and "
+        f"record the ONE decision it returns with `repair-pass.py decide`.\n"
+        f"ledger: repair_count={counter(row, 'repair_count')} of {REPAIR_CAP}"
+        + (" — SPENT: this PR's repair budget is exhausted, so the only permitted decision is `abort`."
+           if spent else "."),
+        file=sys.stderr,
+    )
+    return EXIT_STOP
+
+
+def held_reason(status: str) -> str:
+    """Why a held row is held, and WHAT CLEARS IT — never merely that it is on a list.
+
+    A guard that says only "refused" teaches the driver nothing and invites it to route around the guard.
+    DERIVED from the status, so a new member of HELD_STATUSES cannot silently inherit a wrong explanation.
+    """
+    if status == REPAIR_STATUS:
+        return ("at a review-loop cap and awaiting its REASSESSMENT PASS — the reassessment's decision and "
+                "the repair it dispatches clear it (`repair-pass.md`); NO human is waited on")
+    if status == "awaiting-api":
+        return "parked for the user to approve an API-changing fix — only the user's answer unparks it"
+    if status == "awaiting-user":
+        return ("parked for the user to adjudicate a review standoff or a machine blocker — only the "
+                "user's answer unparks it")
+    return "held"
+
+
+def cmd_dispatch_check(path: Path, args) -> int:
+    """MAY campaign act on this PR? Run it BEFORE every action that MUTATES a PR — and obey a non-zero exit.
+
+    This is the mechanical form of a rule that already existed in prose and was already obeyed only by
+    attention: **a HELD PR is FROZEN**. The park has always said so; `repairing` says so too. A rule an
+    attentive agent must remember is exactly the kind that failed here.
+
+    The test is the PROPERTY — "does this MUTATE the PR?" — not membership of a list of actions. Review
+    pass, review fix, CI fix, copilot-address, precondition fix, merge, rebase, base refresh, push,
+    relabel: all mutate, all are `ordinary`, all must check. **OBSERVING is not mutating**: the CI watch
+    follows its normal policy, and reconcile still reads a held PR and records what it read.
+
+    **`--action repair` is the ONE kind of work a `repairing` row accepts** — and it is refused until a
+    reassessment DECISION is on the row. Without that second half the guard would have a hole exactly
+    where it matters: a driver could call its next fix "the repair", dispatch it, and go right on whacking
+    moles under a new name. The decision must exist first, and the tool prints WHICH one, so the work that
+    follows is the work that was decided.
+    """
+    _, rows = load(path)
+    pr = str(args.pr)
+    row = find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}")
+    status, decision = row["status"], row["repair_decision"]
+
+    if args.action == "repair":
+        if status != REPAIR_STATUS:
+            print(f"refused: pr {pr} is {status}, not {REPAIR_STATUS} — it is not at a review-loop cap, so "
+                  f"there is no repair to dispatch. Ordinary gate work is what this PR is owed.",
+                  file=sys.stderr)
+            return EXIT_STOP
+        if decision == "-":
+            print(f"refused: pr {pr} is {REPAIR_STATUS} but NO REASSESSMENT DECISION is recorded. Run the "
+                  f"reassessment pass and record its decision with `repair-pass.py decide` FIRST — a repair "
+                  f"dispatched without one is just the next targeted fix wearing a new name, which is the "
+                  f"loop this mechanism exists to stop.", file=sys.stderr)
+            return EXIT_STOP
+        print(f"ok: pr {pr} is {REPAIR_STATUS} with decision {decision} — dispatch THAT repair, and no "
+              f"other work")
+        return 0
+
+    if status not in HELD_STATUSES:
+        print(f"ok: pr {pr} is {status} — campaign may act on it")
+        return 0
+    print(f"held: pr {pr} is {status} — {held_reason(status)}", file=sys.stderr)
+    print(f"held: take NO action that MUTATES this PR (no review pass, review fix, CI fix, merge, rebase, "
+          f"push or relabel). Observing it is fine: the CI watch and reconcile are unaffected. Keep "
+          f"driving the run's OTHER PRs — a held PR never blocks the loop.", file=sys.stderr)
+    return EXIT_STOP
 
 
 def cmd_get(path: Path, args) -> int:
@@ -744,6 +930,14 @@ def build_parser() -> argparse.ArgumentParser:
     v.add_argument("--verdict", required=True, choices=VERDICTS,
                    help="the reviewer's VERDICT line, as the orchestrator read it")
 
+    d = sub.add_parser("dispatch-check", help="may campaign ACT on this PR? run before every action that "
+                                              f"MUTATES a PR; exits {EXIT_STOP} when the row is HELD")
+    d.add_argument("--pr", required=True, help="PR number (row key)")
+    d.add_argument("--action", choices=("ordinary", "repair"), default="ordinary",
+                   help="'ordinary' (default) = any action that mutates the PR — review, fix, merge, "
+                        "rebase, relabel. 'repair' = the reassessment's decided repair, the only work a "
+                        "`repairing` row accepts (and only once its decision is recorded)")
+
     g = sub.add_parser("get", help="print the row for --pr as JSON, or one field")
     g.add_argument("--pr", required=True, help="PR number (row key)")
     g.add_argument("--field", help="print only this field")
@@ -774,6 +968,7 @@ def main(argv: list[str]) -> int:
     handlers = {
         "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set, "verdict": cmd_verdict,
         "get": cmd_get, "list": cmd_list, "table": cmd_table,
+        "dispatch-check": cmd_dispatch_check,
     }
     return handlers[args.cmd](path, args)
 

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Fixtures for `repair-pass.py` — the reassessment decision, the ownership guardrail, and the repair cap.
+
+They live in a SIBLING file, and `repair-pass.py self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE MUST PIN A RULE — it must go red if its rule is deleted or weakened. Three of these guard
+things a well-meaning driver would otherwise do without noticing: reassess a PR that never hit a cap,
+rewrite a PR belonging to someone else, and repair forever.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+OWNER = Path(__file__).resolve().parent / "repair-pass.py"
+
+
+def _load_owner():
+    spec = importlib.util.spec_from_file_location("repair_pass_owner", OWNER)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load the repair pass at {OWNER}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+R = _load_owner()
+L = R.L  # the ledger — the ONE owner of the schema, the caps and the statuses
+
+SHA = "c" * 40
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise R.SelfTestFailure(msg)
+
+
+def ledger_cli(argv: "list[str]") -> "tuple[int, str, str]":
+    """Drive the LEDGER's real CLI in-process — the guard and the row reads live there, not here."""
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            code = L.main(argv)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    return code, out.getvalue(), err.getvalue()
+
+
+def setup(tmp: Path, name: str = "state.jsonl", **row) -> "tuple[Path, Path]":
+    """A ledger holding one PR at a cap, plus a written decision record.
+
+    Written RAW (never through `dump()`), because `repair_count` and `review_rounds` have no CLI door —
+    that is the point of them — so a fixture that needs a PR mid-budget must place it there directly.
+    """
+    path = tmp / name
+    fields = {**L.ROW_DEFAULTS, "pr": "1", "head_sha": SHA, "status": L.REPAIR_STATUS,
+              "review_rounds": str(L.ROUND_CAP), "ns_streak": "1", **row}
+    path.write_text(
+        json.dumps({"type": "header", **L.HEADER_DEFAULTS}) + "\n"
+        + json.dumps({"type": "row", **fields}) + "\n"
+    )
+    record = tmp / f"repair-{name}.md"
+    record.write_text("# reassessment\n\n21 rounds, the diff tripled, the findings left the purpose.\n")
+    return path, record
+
+
+def decide(path: Path, record: Path, decision: str, pr: str = "1") -> "tuple[int, str, str]":
+    return R.run(["--file", str(path), "decide", "--pr", pr, "--decision", decision, "--record", str(record)])
+
+
+def field(path: Path, name: str, pr: str = "1") -> str:
+    code, out, err = ledger_cli(["--file", str(path), "get", "--pr", pr, "--field", name])
+    check(code == 0, f"get --field {name} exited {code}: {err!r}")
+    return out.strip()
+
+
+# --- the guardrail: campaign NEVER rewrites a PR it does not own ---------------
+
+def t_external_pr_is_never_rewritten(tmp: Path) -> None:
+    """An `external` PR REFUSES every decision that rewrites branch content — RESCOPE and ROOT-CAUSE.
+
+    Campaign ADOPTS PRs. They may be the user's or a third party's, and reshaping someone else's work
+    uninvited is not a repair, it is a hijack. This is the fixture that stands between an autonomous
+    mechanism and a stranger's branch, so it checks BOTH directions: the rewrites are refused, and the
+    three that are safe still work — a guardrail that refused everything would just be a broken feature.
+    """
+    check(set(R.REWRITES_CONTENT) == {"rescope", "root-cause"},
+            f"the rewriting decisions are {R.REWRITES_CONTENT} — if a new decision rewrites branch content "
+            f"it MUST be refused on an external PR, and this fixture must know about it")
+
+    for decision in R.REWRITES_CONTENT:
+        path, record = setup(tmp, f"ext-{decision}.jsonl", pr_origin="external")
+        code, _, err = decide(path, record, decision)
+        check(code == 1, f"[{decision}] an EXTERNAL PR was rewritten by an autonomous repair (exit {code})")
+        check("did not open this PR" in err, f"[{decision}] refused for the wrong reason: {err!r}")
+        check(field(path, "repair_count") == "0", f"[{decision}] a REFUSED decision spent the budget")
+        check(field(path, "repair_decision") == "-", f"[{decision}] a REFUSED decision was recorded")
+
+    for decision in R.EXTERNAL_PERMITTED:
+        path, record = setup(tmp, f"ok-{decision}.jsonl", pr_origin="external")
+        code, _, err = decide(path, record, decision)
+        check(code == 0, f"[{decision}] a PERMITTED repair on an external PR was refused: {err!r}")
+        check(field(path, "repair_decision").startswith(decision), "the decision was not recorded")
+
+
+def t_gauntlet_pr_takes_every_repair(tmp: Path) -> None:
+    """A PR campaign itself opened may take ALL FIVE decisions — the guardrail is about OWNERSHIP, not fear."""
+    for decision in R.DECISIONS:
+        path, record = setup(tmp, f"own-{decision}.jsonl", pr_origin="gauntlet")
+        code, _, err = decide(path, record, decision)
+        check(code == 0, f"[{decision}] refused on a campaign-authored PR: {err!r}")
+        check(field(path, "repair_decision").startswith(decision), f"[{decision}] not recorded")
+
+
+def t_unknown_origin_is_treated_as_external(tmp: Path) -> None:
+    """A row whose origin was never established is EXTERNAL — the fail-safe direction, and the default.
+
+    Guessing wrong in the other direction lets an autonomous mechanism rewrite a stranger's branch because
+    a field was never set. "I do not know who wrote this" must never resolve to "I did".
+    """
+    path = tmp / "unset.jsonl"
+    path.write_text(
+        json.dumps({"type": "header", **L.HEADER_DEFAULTS}) + "\n"
+        # A row written BEFORE `pr_origin` existed — no such key at all. It must read back `external`.
+        + json.dumps({"type": "row", "pr": "1", "head_sha": SHA, "status": L.REPAIR_STATUS}) + "\n"
+    )
+    record = tmp / "r.md"
+    record.write_text("reassessment\n")
+    check(field(path, "pr_origin") == "external", "an unset pr_origin must read back as external")
+    code, _, err = decide(path, record, "rescope")
+    check(code == 1, f"a PR of UNKNOWN origin was rewritten (exit {code})")
+    check("did not open this PR" in err, f"refused for the wrong reason: {err!r}")
+
+
+# --- the repair's own bound ---------------------------------------------------
+
+def t_repair_budget_is_spent(tmp: Path) -> None:
+    """At REPAIR_CAP the ONLY decision left is ABORT — even for a PR campaign owns.
+
+    The mechanism that fixes non-convergence must not itself fail to converge; the irony would be fatal.
+    A second failed repair leaves the PR OPEN for a human rather than looping.
+    """
+    for decision in (d for d in R.DECISIONS if d != "abort"):
+        path, record = setup(tmp, f"spent-{decision}.jsonl", pr_origin="gauntlet",
+                             repair_count=str(L.REPAIR_CAP))
+        code, _, err = decide(path, record, decision)
+        check(code == 1, f"[{decision}] a THIRD repair was permitted (exit {code}) — the repair loops")
+        check("spent its repair budget" in err, f"[{decision}] refused for the wrong reason: {err!r}")
+
+    path, record = setup(tmp, "spent-abort.jsonl", pr_origin="gauntlet", repair_count=str(L.REPAIR_CAP))
+    code, _, err = decide(path, record, "abort")
+    check(code == 0, f"ABORT must always remain available: {err!r}")
+    check(field(path, "status") == "aborted", f"abort left the row {field(path, 'status')!r}")
+
+    # …and `permitted` says so BEFORE the agent is even asked — the prompt is built from this.
+    code, out, _ = R.run(["--file", str(path), "permitted", "--pr", "1"])
+    check(code == 0, "permitted exited non-zero")
+    check(json.loads(out)["permitted"] == ["abort"], f"permitted did not narrow to abort: {out!r}")
+
+
+def t_abort_is_terminal_and_leaves_the_pr_open(tmp: Path) -> None:
+    """ABORT goes terminal and TELLS THE DRIVER TO LEAVE THE PR OPEN.
+
+    Campaign never closes an adopted PR — it is the user's. The abort PROCEDURE is owned by
+    `bailout-and-final-report.md`; this decision routes into it and does not invent a second one.
+    """
+    path, record = setup(tmp, "abort.jsonl", pr_origin="gauntlet")
+    code, _, err = decide(path, record, "abort")
+    check(code == 0, f"abort exited {code}: {err!r}")
+    check(field(path, "status") == "aborted", "abort is terminal")
+    check("LEAVE THE PR OPEN" in err, f"the abort message must say the PR stays open: {err!r}")
+    check("bailout-and-final-report" in err, f"the abort must route into the EXISTING procedure: {err!r}")
+
+
+# --- the decision is real, recorded, and only for a PR that needs one ----------
+
+def t_only_a_capped_pr_may_be_reassessed(tmp: Path) -> None:
+    """A PR that never hit a cap CANNOT be reassessed. The repair is not a way around a review you dislike."""
+    for status in ("in_review", "pending", "awaiting-user"):
+        path, record = setup(tmp, f"live-{status}.jsonl", status=status, pr_origin="gauntlet")
+        code, _, err = decide(path, record, "demote")
+        check(code == 1, f"[{status}] a PR that is not repairing took a decision (exit {code})")
+        check("has NOT reached a review-loop cap" in err, f"[{status}] wrong reason: {err!r}")
+
+
+def t_a_decision_needs_a_record(tmp: Path) -> None:
+    """No decision without its REASONING ON DISK. Every wake is a fresh agent that remembers nothing.
+
+    The whole failure was a loop that could not see itself. A decision whose justification lives only in
+    the context of an agent that has already exited is a decision the next wake — and the user — cannot
+    audit, and it would be the one artifact of the mechanism that has no evidence behind it.
+    """
+    path, record = setup(tmp, "norec.jsonl", pr_origin="gauntlet")
+    missing = path.parent / "nope.md"
+    code, _, err = R.run(["--file", str(path), "decide", "--pr", "1", "--decision", "demote",
+                          "--record", str(missing)])
+    check(code == 1, f"a decision with NO record was accepted (exit {code})")
+    check("does not exist or is empty" in err, f"wrong reason: {err!r}")
+
+    empty = path.parent / "empty.md"
+    empty.write_text("   \n\n")
+    code, _, err = R.run(["--file", str(path), "decide", "--pr", "1", "--decision", "demote",
+                          "--record", str(empty)])
+    check(code == 1, f"a decision with an EMPTY record was accepted (exit {code})")
+    check(field(path, "repair_count") == "0", "a refused decision spent the budget anyway")
+
+
+def t_decision_enum_is_closed(tmp: Path) -> None:
+    """The enum is CLOSED — argparse refuses anything else, and the five have a definition each.
+
+    "Think about it and do something sensible" is precisely what a fresh-context driver holding one finding
+    already did, twenty-one times. A decision outside the enum is not a decision, it is improvisation.
+    """
+    path, record = setup(tmp, "enum.jsonl", pr_origin="gauntlet")
+    for bogus in ("fix", "retry", "RESCOPE", "rescope-and-merge", ""):
+        code, _, _ = decide(path, record, bogus)
+        check(code == 2, f"the decision {bogus!r} was not rejected by the parser (exit {code})")
+    check(set(R.DECISIONS) == {"rescope", "repair-intent", "demote", "root-cause", "abort"},
+            f"the enum changed: {sorted(R.DECISIONS)} — a new decision needs an ownership ruling "
+            f"(does it rewrite branch content?) before it can ship")
+    for name, why in R.DECISIONS.items():
+        check(len(why) > 80, f"the decision {name!r} has no real definition — the agent is told nothing")
+
+
+def t_the_repair_dispatch_gate(tmp: Path) -> None:
+    """A repair may be dispatched ONLY after its decision is recorded — and ordinary work never may.
+
+    This is the hole the guard would otherwise have: a driver could call its next targeted fix "the repair",
+    dispatch it, and go on whacking moles under a new name. The decision must exist first.
+    """
+    path, record = setup(tmp, "gate.jsonl", pr_origin="gauntlet")
+
+    code, _, err = ledger_cli(["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == L.EXIT_STOP, f"a repair was dispatchable with NO decision recorded (exit {code})")
+    check("NO REASSESSMENT DECISION" in err, f"wrong reason: {err!r}")
+
+    code, _, err = ledger_cli(["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == L.EXIT_STOP, f"ordinary work was dispatchable on a repairing PR (exit {code})")
+
+    decide(path, record, "rescope")
+
+    code, out, _ = ledger_cli(["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == 0, f"the DECIDED repair was refused (exit {code})")
+    check("rescope" in out, f"dispatch-check must name the decided repair, so the right work runs: {out!r}")
+
+    code, _, _ = ledger_cli(["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == L.EXIT_STOP, "ordinary work is STILL frozen while the repair is outstanding")
+
+    # …and once the repair has landed and the driver returns the row to the gate, everything is normal again.
+    ledger_cli(["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+    code, _, _ = ledger_cli(["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == 0, "the PR never returned to the gate after its repair")
+    code, _, _ = ledger_cli(["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == L.EXIT_STOP, "a repair was still dispatchable after the PR returned to the gate")
+
+
+CASES = [
+    ("external-not-rewritten", "an external PR refuses RESCOPE and ROOT-CAUSE, and takes the other three", t_external_pr_is_never_rewritten),
+    ("gauntlet-takes-all", "a campaign-authored PR may take every decision", t_gauntlet_pr_takes_every_repair),
+    ("unknown-is-external", "an unset origin is EXTERNAL — the fail-safe direction", t_unknown_origin_is_treated_as_external),
+    ("budget-spent", "at REPAIR_CAP the only decision left is abort", t_repair_budget_is_spent),
+    ("abort-leaves-it-open", "abort is terminal, leaves the PR OPEN, and reuses the existing procedure", t_abort_is_terminal_and_leaves_the_pr_open),
+    ("only-a-capped-pr", "a PR that never hit a cap cannot be reassessed", t_only_a_capped_pr_may_be_reassessed),
+    ("decision-needs-record", "no decision without its reasoning on disk", t_a_decision_needs_a_record),
+    ("enum-is-closed", "the decision enum is closed, and each member is defined", t_decision_enum_is_closed),
+    ("repair-dispatch-gate", "a repair needs a recorded decision; ordinary work stays frozen", t_the_repair_dispatch_gate),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""The REASSESSMENT PASS's door — the only sanctioned way to record what to do about a PR that has stopped
+converging.
+
+The campaign review gate had no memory. Every wake was a fresh agent instance, `reviews_ok` was zeroed on
+every NOT SATISFIED, and nothing counted rounds — so the ledger after 21 review rounds was indistinguishable
+from the ledger after 1, and every stopping rule in the skill was a rule with NO SENSOR. Two PRs ran 21 and
+14 adversarial rounds, produced a true finding almost every time, and never converged. A human stopped it at
+8.5 hours, and could only do so by holding all 21 rounds in mind at once.
+
+`ledger.py` now carries the memory (`review_rounds`, `ns_streak`) and the caps. When one is reached the row
+goes `repairing` and ordinary gate work is REFUSED for it. This file owns what happens next: a
+context-isolated agent is handed THE WHOLE HISTORY AT ONCE — every round's verdict and finding, the
+diff-growth curve, the PR's intent artifact, the current diff — and returns exactly ONE decision from a
+CLOSED enum. `references/repair-pass.md` is the definition; this is its enforcement.
+
+**A CAP IS A MODE SWITCH, NOT A DOORBELL.** It does not stop and ask the user. The driver stops dispatching
+targeted fixes and REPAIRS THE PR ITSELF — rescopes it back to its stated purpose, re-authors the intent the
+reviewer had nothing to measure against, demotes findings that anchor to no purpose and no writer, fixes at
+the chokepoint instead of playing whack-a-mole, or gives up and leaves the PR open for a human. Only the
+last of those involves the user at all, and it is the last resort, not the first.
+
+Three refusals this tool exists to make, all of them things a well-meaning driver would otherwise do:
+
+1. **A decision for a PR that is not at a cap.** The reassessment is not a tool for skipping a review you
+   dislike. Only a `repairing` row may take one.
+2. **A repair that REWRITES A PR CAMPAIGN DOES NOT OWN.** Campaign ADOPTS PRs — they may be the user's or a
+   third party's. RESCOPE and ROOT-CAUSE reshape branch content wholesale, and doing that to someone else's
+   work uninvited is not a repair, it is a hijack. On an `external` PR the permitted decisions are ONLY
+   DEMOTE / REPAIR-INTENT / ABORT, and this tool refuses the other two outright. (Targeted per-finding
+   fixes are NOT affected — campaign has always pushed those to adopted PRs, and that is the workflow the
+   user asked for. What is forbidden is the wholesale reshaping, not the ordinary fix.)
+3. **A THIRD repair.** The mechanism that fixes non-convergence must not itself fail to converge — the
+   irony would be fatal. At `REPAIR_CAP` the only decision left is ABORT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn
+
+DESCRIPTION = "Record the reassessment pass's decision for a PR that has stopped converging."
+
+OWNER = Path(__file__).resolve().parent / "ledger.py"
+
+
+def load_ledger():
+    """Load `ledger.py` BY PATH — it owns the schema, the caps and the statuses, and it owns them ONCE.
+
+    Not by import: the cwd is the driver's worktree while the skill's scripts live wherever the plugin is
+    installed. Re-declaring the field names or the caps here would be a second copy of the schema, which is
+    the exact defect `ledger.py` exists to prevent.
+    """
+    spec = importlib.util.spec_from_file_location("ledger", OWNER)
+    if spec is None or spec.loader is None:  # a broken install — never an input error
+        print(f"repair-pass: cannot load its schema owner at {OWNER}", file=sys.stderr)
+        raise SystemExit(1)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+L = load_ledger()
+
+# --- the closed enum ----------------------------------------------------------
+#
+# FIVE decisions, and the reassessment agent returns EXACTLY ONE. A closed enum is the point: "think about
+# it and do something sensible" is what a fresh-context driver holding one finding already does, twenty-one
+# times in a row. Each decision names a DIFFERENT diagnosis of why the loop stopped converging, and the
+# driver executes it without asking the user.
+DECISIONS = {
+    "rescope": (
+        "THE DIFF HAS OUTGROWN ITS STATED PURPOSE. The findings may all be true, and the PR is still no "
+        "longer the change it set out to be — most of its lines now defend the guards the loop itself "
+        "added. Dispatch a shrink back to intent, then re-gate. (This is what a human did to PR #42, at "
+        "round 21 rather than round 13: followups.py went 4,319 lines -> 939 and lost nothing real.)"
+    ),
+    "repair-intent": (
+        "THE INTENT ARTIFACT IS MISSING, VAGUE OR WRONG, so the reviewer has nothing to measure against "
+        "and NOTHING CAN BE OUT OF SCOPE. Re-author it — Purpose, Non-goals, Threat model — and re-gate. "
+        "This was the actual root cause of the 2026-07-14 spiral: an open-ended adversarial mandate over a "
+        "growing surface has no fixed point, because there is always one more true statement to make."
+    ),
+    "demote": (
+        "THE FINDINGS ANCHOR TO NO PURPOSE LINE AND NO THREAT-MODEL ACTOR. They are true and they are not "
+        "reasons to block this PR: a defect in a guard this same loop added, against an input nobody but a "
+        "developer with a text editor can write. RECORD THEM AS FOLLOW-UPS, DO NOT FIX THEM, and re-gate. "
+        "Fixing them adds review surface at the rate it removes it."
+    ),
+    "root-cause": (
+        "THE FINDINGS SHARE ONE CAUSE. Stop patching sites and fix at the chokepoint: run the root-cause "
+        "pass (`root-cause-pass.md` — it already exists; do NOT reinvent it), which maps the whole space "
+        "with a read-only mapper and fixes every cell at once, including the ones no reviewer has hit yet."
+    ),
+    "abort": (
+        "UNSALVAGEABLE. Leave the PR OPEN, drop this run's labels, write the abort note "
+        "(`bailout-and-final-report.md` owns the procedure — reuse it, do not invent a second one). "
+        "Campaign never closes an adopted PR: it is the user's, and it is left for them."
+    ),
+}
+
+# What an `external` PR may take. The two that are missing are the two that REWRITE BRANCH CONTENT.
+EXTERNAL_PERMITTED = ("demote", "repair-intent", "abort")
+
+# The repairs that reshape someone's branch wholesale — the ones the ownership guardrail exists for.
+REWRITES_CONTENT = tuple(d for d in DECISIONS if d not in EXTERNAL_PERMITTED)
+
+
+def fail(msg: str) -> NoReturn:
+    print(f"repair-pass: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def permitted_for(row: dict) -> "tuple[str, ...]":
+    """The decisions this row may actually take — DERIVED, never retyped.
+
+    Two independent narrowings, and the budget one wins:
+      * an `external` PR (the default!) may not have its content rewritten -> DEMOTE / REPAIR-INTENT / ABORT
+      * a PR whose repair budget is SPENT may only ABORT — whatever its origin
+    The reassessment agent is TOLD this set by `permitted`, so its prompt can never drift from the rule
+    the tool enforces. A closed enum restated in prose is a closed enum that goes stale.
+    """
+    if L.counter(row, "repair_count") >= L.REPAIR_CAP:
+        return ("abort",)
+    if row["pr_origin"] == "gauntlet":
+        return tuple(DECISIONS)
+    return EXTERNAL_PERMITTED
+
+
+def get_row(path: Path, pr: str) -> dict:
+    _, rows = L.load(path)
+    row = L.find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}")
+    return row
+
+
+def cmd_permitted(path: Path, args) -> int:
+    """Print the decisions this PR may take, and why — the reassessment prompt is BUILT from this."""
+    row = get_row(path, str(args.pr))
+    allowed = permitted_for(row)
+    spent = L.counter(row, "repair_count") >= L.REPAIR_CAP
+    print(json.dumps({
+        "pr": row["pr"],
+        "status": row["status"],
+        "pr_origin": row["pr_origin"],
+        "review_rounds": row["review_rounds"],
+        "ns_streak": row["ns_streak"],
+        "repair_count": row["repair_count"],
+        "repair_cap": str(L.REPAIR_CAP),
+        "permitted": list(allowed),
+        "why": (
+            f"the repair budget is SPENT ({row['repair_count']} of {L.REPAIR_CAP}) — a second failed repair "
+            f"aborts rather than looping, so ABORT is all that is left"
+            if spent else
+            "campaign opened this PR, so every repair is permitted" if row["pr_origin"] == "gauntlet" else
+            f"pr_origin={row['pr_origin']} — campaign did NOT open this PR, so it may never rewrite its "
+            f"content: {', '.join(REWRITES_CONTENT)} are refused. Record findings, re-author the intent, or "
+            f"leave it for its owner"
+        ),
+    }))
+    return 0
+
+
+def cmd_decide(path: Path, args) -> int:
+    """Record the reassessment's decision. The ONLY sanctioned way — and it REFUSES more than it accepts."""
+    pr = str(args.pr)
+    header, rows = L.load(path)
+    row = L.find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}")
+
+    if row["status"] != L.REPAIR_STATUS:
+        fail(f"pr {pr} is {row['status']}, not {L.REPAIR_STATUS} — it has NOT reached a review-loop cap, so "
+             f"there is nothing to reassess. The reassessment is not a way around a review you disagree "
+             f"with; it is what happens when the loop stops converging.")
+
+    # THE DECISION RECORD MUST EXIST BEFORE IT IS RECORDED. A decision whose reasoning is only in a dead
+    # agent's context is a decision nobody can audit — and every wake is a fresh agent instance.
+    record = Path(args.record)
+    if not record.exists() or not record.read_text().strip():
+        fail(f"--record {record} does not exist or is empty. Write the reassessment's reasoning — the "
+             f"round-by-round history it saw, the decision, and WHY — before recording the decision. A "
+             f"decision with no record on disk cannot be audited by the next wake, which remembers nothing.")
+
+    allowed = permitted_for(row)
+    if args.decision not in allowed:
+        spent = L.counter(row, "repair_count") >= L.REPAIR_CAP
+        if spent:
+            fail(f"pr {pr} has spent its repair budget ({row['repair_count']} of {L.REPAIR_CAP}) — the only "
+                 f"permitted decision is `abort`, not `{args.decision}`. A mechanism that fixes "
+                 f"non-convergence must not itself fail to converge.")
+        fail(f"`{args.decision}` REWRITES BRANCH CONTENT, and pr {pr} has pr_origin={row['pr_origin']} — "
+             f"campaign did not open this PR. It may be the user's or a third party's, and reshaping "
+             f"someone else's work uninvited is not a repair. Permitted here: {', '.join(allowed)}. "
+             f"(Targeted per-finding fixes are unaffected — this refusal is about the WHOLESALE rewrite.)")
+
+    row["repair_count"] = str(L.counter(row, "repair_count") + 1)
+    row["repair_decision"] = f"{args.decision}@{now()}"
+    if args.decision == "abort":
+        # Terminal. The driver still runs the abort PROCEDURE (leave the PR OPEN, drop this run's labels,
+        # write abort-<id>.md) — `bailout-and-final-report.md` owns it, and this does not replace it.
+        row["status"] = "aborted"
+    L.dump(path, header, rows)
+    print(json.dumps({f: row[f] for f in L.ROW_FIELDS}))
+
+    if args.decision == "abort":
+        print(f"repair-pass: pr {pr} -> ABORTED. Now run the abort procedure "
+              f"(`bailout-and-final-report.md`): LEAVE THE PR OPEN, remove this run's labels, write "
+              f"abort-<id>.md, and keep driving the other PRs.", file=sys.stderr)
+        return 0
+    print(f"repair-pass: pr {pr} -> {args.decision.upper()} (repair {row['repair_count']} of "
+          f"{L.REPAIR_CAP}). The row stays `{L.REPAIR_STATUS}`: dispatch THIS repair and no other work "
+          f"(`ledger.py dispatch-check --pr {pr} --action repair`). When the repair has landed, return the "
+          f"row to `in_review` and let the gate run again. If this PR reaches a cap AGAIN, its budget is "
+          f"{'SPENT — the next decision must be abort' if L.counter(row, 'repair_count') >= L.REPAIR_CAP else 'nearly spent'}.",
+          file=sys.stderr)
+    return 0
+
+
+# --- self-test: the fixtures live in the SIBLING, and a missing sibling is a HARD FAILURE ---------------
+
+SIBLING = Path(__file__).resolve().parent / "repair-pass-test.py"
+
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SelfTestFailure(msg)
+
+
+def run(argv: "list[str]") -> "tuple[int, str, str]":
+    """Drive the REAL CLI in-process and capture (exit code, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(argv)
+    except SystemExit as exc:  # fail() -> 1; argparse -> 2
+        code = exc.code if isinstance(exc.code, int) else 1
+    return code, out.getvalue(), err.getvalue()
+
+
+def sibling_cases() -> list:
+    """Load the sibling's fixtures — and FAIL LOUDLY if they are not there.
+
+    A self-test that passes because it found nothing to check is worse than no self-test: it reports health
+    while checking nothing. A reviewer proved exactly that on this repo's own follow-up ledger, where
+    `self_test()` went green with an empty case list. Missing, unloadable, or exporting no cases: all hard
+    errors, never an empty list quietly appended to nothing.
+    """
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
+            f"health. Every rule this file enforces is now unpinned."
+        )
+    spec = importlib.util.spec_from_file_location("repair_pass_test", SIBLING)
+    if spec is None or spec.loader is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["repair_pass_test"] = mod
+    spec.loader.exec_module(mod)
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':22} -> the fixtures in {SIBLING.name} must be RUNNABLE\n         {exc}")
+        print("\n1 check(s) FAILED — the repair pass's contract is broken.")
+        return 1
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for name, rule, fn in cases:
+            work = Path(tmpdir) / name
+            work.mkdir()
+            try:
+                fn(work)
+            except SelfTestFailure as exc:
+                print(f"FAIL     {name:22} -> {rule}\n         {exc}")
+                failures += 1
+            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
+                print(f"FAIL     {name:22} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+                failures += 1
+            else:
+                print(f"ok       {name:22} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the repair pass's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the repair pass's contract is intact.")
+    return 0
+
+
+# --- cli ----------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("--file", help="path to the ledger (state.jsonl)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("permitted", help="print the decisions this PR may take, and why (build the "
+                                         "reassessment prompt from this — never from a retyped list)")
+    p.add_argument("--pr", required=True, help="PR number (row key)")
+
+    d = sub.add_parser("decide", help="record the reassessment pass's ONE decision")
+    d.add_argument("--pr", required=True, help="PR number (row key)")
+    d.add_argument("--decision", required=True, choices=tuple(DECISIONS),
+                   help="; ".join(f"{k}: {v.split('.')[0]}" for k, v in DECISIONS.items()))
+    d.add_argument("--record", required=True,
+                   help="path to the decision record — the history the pass saw, the decision, and why. "
+                        "Refused if it does not exist or is empty")
+
+    sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
+    return parser
+
+
+def dispatch(args) -> int:
+    if args.cmd == "self-test":
+        return self_test()
+    if args.file is None:
+        build_parser().error("the following arguments are required: --file")
+    path = Path(args.file)
+    return {"permitted": cmd_permitted, "decide": cmd_decide}[args.cmd](path, args)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    return dispatch(build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -410,6 +410,15 @@ or **Adjusted** finding only (skip Refuted and Uncertain), in its own branch off
    run-owner label**; a neutral `gauntlet-reviewing` status label is fine but is not required. Create
    the status label with `gh label create` if you apply it and the repo lacks it.
 
+   **DO apply the `gauntlet-authored` label to every PR you open here** (`gh label create
+   gauntlet-authored --force`, then `gh pr create … --label gauntlet-authored`). It is not a status and it
+   is not an owner label: it is the durable record that **this pipeline wrote this PR**, and campaign reads
+   it at adoption into `pr_origin` (`campaign/references/pr-adoption.md`). It is what later permits
+   campaign to **rescope or restructure the PR autonomously** if the review loop stops converging on it —
+   a thing it must **never** do to a PR a human wrote (`campaign/references/repair-pass.md`, "The
+   ownership guardrail"). **Omitting it is safe** (the PR is then treated as someone else's and only its
+   findings are demoted or the PR abandoned); applying it to a PR you did **not** author is not.
+
 One finding = one PR. Never batch multiple findings into a single PR.
 
 Then invoke the campaign on exactly those PRs:


### PR DESCRIPTION
- `ledger.py verdict` caps the review loop: at a cap it holds the PR `repairing` and exits non-zero
- A reassessment pass sees every round at once and returns one decision, via `repair-pass.py`
- Repair never rewrites a PR campaign did not open; a second failed repair aborts
