### PR TITLE
clear unused-variable hints in campaign scripts

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1356,8 +1356,8 @@ def t_no_verdict_for_a_held_row(L: ModuleType, tmp: Path) -> None:
     """No verdict may land on a HELD row — no review pass should have been running for it at all."""
     for status in L.HELD_STATUSES:
         path = capped_row(L, tmp, f"held-{status}.jsonl", status=status)
-        code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A,
-                               "--verdict", "not-satisfied"])
+        code, _, _ = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A,
+                             "--verdict", "not-satisfied"])
         check(code == 1, f"[{status}] a verdict on a held row was ACCEPTED (exit {code})")
         code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "review_rounds"])
         check(out == "0\n", f"[{status}] the REFUSED verdict bumped the counter anyway: {out!r}")
@@ -1382,7 +1382,7 @@ def t_dispatch_check_is_the_guard(L: ModuleType, tmp: Path) -> None:
 
     for status in ("in_review", "pending"):
         path = capped_row(L, tmp, f"live-{status}.jsonl", status=status)
-        code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+        code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
         check(code == 0, f"[{status}] a LIVE row was HELD (exit {code}) — the run would stall: {err!r}")
 
     # `--action repair`: refused with no decision recorded, and refused on a row that is not repairing.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -293,11 +293,13 @@ def grid(L: ModuleType, out: str, fields: "tuple[str, ...]",
 # --- the fixtures -------------------------------------------------------------
 #
 # Every fixture takes the ACCESSOR under test and its own scratch directory, handed to it by `run()`. A
-# fixture that asserts on a PURE function needs no file, so it names that argument `_tmp`: the signature is
-# fixed by the CASES table, and the leading underscore is how a parameter says it is deliberately unused
-# rather than forgotten.
+# fixture that asserts on a PURE function needs no file, so it names that argument `_`: the signature is
+# fixed by the CASES table (`run` calls `fn(L, work)` positionally, so the name is free), and a bare `_` is
+# how a parameter says it is deliberately unused rather than forgotten. It must be a BARE `_`, not a
+# descriptive `_tmp`: pyright's language server grays a named-underscore parameter as "not accessed", and
+# only a bare `_` is silent.
 
-def t_escape_injective(L: ModuleType, _tmp: Path) -> None:
+def t_escape_injective(L: ModuleType, _: Path) -> None:
     """Two DIFFERENT values NEVER render as the same cell.
 
     A non-injective escaping is a NEW LIE inside the code written to stop lies: `a|b` and `a\\|b` are
@@ -382,7 +384,7 @@ def bare(cell: str) -> "list[str]":
     return out
 
 
-def t_escape_invariant(L: ModuleType, _tmp: Path) -> None:
+def t_escape_invariant(L: ModuleType, _: Path) -> None:
     """The escaped cell holds NO BARE grid metacharacter: no unescaped `|`, no line break, no control
     char — and it never opens with `#`. This is what makes the ` | ` separator and the `# ` config prefix
     mean ONE thing wherever they appear.
@@ -413,7 +415,7 @@ def t_escape_invariant(L: ModuleType, _tmp: Path) -> None:
               f"invisible, and rstrip() eats it")
 
 
-def t_escape_mapping(L: ModuleType, _tmp: Path) -> None:
+def t_escape_mapping(L: ModuleType, _: Path) -> None:
     r"""The escape TABLE itself, character by character — and ordinary text left BYTE-IDENTICAL.
 
     The invariant above is satisfied by more than one escaping (drop the `\n` branch and a newline still

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -194,7 +194,7 @@ def t_a_decision_needs_a_record(tmp: Path) -> None:
     the context of an agent that has already exited is a decision the next wake — and the user — cannot
     audit, and it would be the one artifact of the mechanism that has no evidence behind it.
     """
-    path, record = setup(tmp, "norec.jsonl", pr_origin="gauntlet")
+    path, _ = setup(tmp, "norec.jsonl", pr_origin="gauntlet")
     missing = path.parent / "nope.md"
     code, _, err = R.run(["--file", str(path), "decide", "--pr", "1", "--decision", "demote",
                           "--record", str(missing)])

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -765,7 +765,7 @@ class Tables:
             R.check_ruled(value)
 
         self.DOMAINS: "dict[str, tuple[Callable[[object], None], str]]" = {
-            **{name: (probe_id(name), spec) for name, (_re, spec, _why) in R.ID_FORMATS.items()},
+            **{name: (probe_id(name), spec) for name, (_, spec, _) in R.ID_FORMATS.items()},  # drops regex, why
             "filename pr": (probe_name("pr"), "a decimal number from 1 up, as the progress file's NAME carries it"),
             "filename pass": (probe_name("pass"), "a decimal number from 1 up, as the NAME carries it"),
             "filename attempt": (probe_name("attempt"),
@@ -1263,19 +1263,19 @@ def run_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[s
     # must supply one or it would be asserting the wrong refusal. These cases carry no findings file, so
     # `satisfied` is the verdict that coheres; the cases that ARE about the verdict live in `FINDING_CASES`,
     # which passes its own — including `None`.
-    for name, (plan, progress, _want, _needle, _why) in T.CASES.items():
+    for name, (plan, progress, _, _, _) in T.CASES.items():  # drops want, needle, why
         path = build(tmp, f"case-{name}", plan, progress)
         try:
             got[name] = mod.evaluate(path, SHA, 0, mod.SATISFIED)
         except Exception as exc:  # noqa: BLE001 - a crash IS the result here
             got[name] = (f"crash:{type(exc).__name__}", str(exc))
-    for name, (plan, progress, findings, intent, verdict, _w, _n, _why) in T.FINDING_CASES.items():
+    for name, (plan, progress, findings, intent, verdict, _, _, _) in T.FINDING_CASES.items():  # drops want, needle, why
         path = build(tmp, f"find-{name}", plan, progress, findings, intent)
         try:
             got[f"[finding] {name}"] = mod.evaluate(path, SHA, 0, verdict)
         except Exception as exc:  # noqa: BLE001
             got[f"[finding] {name}"] = (f"crash:{type(exc).__name__}", str(exc))
-    for i, (name, _want, _needle, _why) in enumerate(T.NAME_CASES):
+    for i, (name, _, _, _) in enumerate(T.NAME_CASES):  # drops want, needle, why
         d = build(tmp, f"name-{i}", T.PLAN, T.WORKED).parent
         path = d / name
         path.write_text("".join(line + "\n" for line in T.WORKED), encoding="utf-8")
@@ -1285,21 +1285,21 @@ def run_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[s
             got[f"[name] {name}"] = mod.evaluate(path, SHA, 0, mod.SATISFIED)
         except Exception as exc:  # noqa: BLE001
             got[f"[name] {name}"] = (f"crash:{type(exc).__name__}", str(exc))
-    for i, (argv, seed, _want, _needle, _why) in enumerate(T.CLI_CASES):
+    for i, (argv, seed, _, _, _) in enumerate(T.CLI_CASES):  # drops want, needle, why
         path = build(tmp, f"cli-{i}", T.PLAN, seed)
         try:
             code, text = run_cli(mod, [argv[0], "--file", str(path), *argv[1:]])
             got[cli_key(i, argv)] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
             got[cli_key(i, argv)] = (f"crash:{type(exc).__name__}", str(exc))
-    for i, (pname, argv, _want, _needle, _why) in enumerate(T.PLAN_CLI_CASES):
+    for i, (pname, argv, _, _, _) in enumerate(T.PLAN_CLI_CASES):  # drops want, needle, why
         plan = build(tmp, f"plan-cli-{i}", T.PLAN, []).parent / pname
         try:
             code, text = run_cli(mod, ["plan-add", "--file", str(plan), *argv])
             got[f"[plan] {pname} {' '.join(argv)}"] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
             got[f"[plan] {pname} {' '.join(argv)}"] = (f"crash:{type(exc).__name__}", str(exc))
-    for i, (fname, argv, _want, _needle, _why) in enumerate(T.FINDING_CLI_CASES):
+    for i, (fname, argv, _, _, _) in enumerate(T.FINDING_CLI_CASES):  # drops want, needle, why
         d = build(tmp, f"find-cli-{i}", T.PLAN, T.DISPATCHED, None, INTENT).parent
         try:
             code, text = run_cli(mod, ["finding-add", "--file", str(d / fname), *argv])
@@ -1313,16 +1313,16 @@ def run_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[s
 
 def expectations(T: Tables) -> "dict[str, tuple[str, str, str]]":
     """case -> (expected outcome, needle its output must contain, why the case exists)."""
-    out = {n: (w, needle, why) for n, (_p, _pr, w, needle, why) in T.CASES.items()}
+    out = {n: (w, needle, why) for n, (_, _, w, needle, why) in T.CASES.items()}  # drops plan, progress
     out.update({f"[finding] {n}": (w, needle, why)
-                for n, (_p, _pr, _f, _i, _v, w, needle, why) in T.FINDING_CASES.items()})
+                for n, (_, _, _, _, _, w, needle, why) in T.FINDING_CASES.items()})  # drops plan, progress, findings, intent, verdict
     out.update({f"[name] {n}": (w, needle, why) for n, w, needle, why in T.NAME_CASES})
     out.update({cli_key(i, a): (f"exit{c}", needle, why)
-                for i, (a, _seed, c, needle, why) in enumerate(T.CLI_CASES)})
+                for i, (a, _, c, needle, why) in enumerate(T.CLI_CASES)})  # drops seed
     out.update({f"[plan] {p} {' '.join(a)}": (f"exit{c}", needle, why)
                 for p, a, c, needle, why in T.PLAN_CLI_CASES})
     out.update({find_key(i, p): (f"exit{c}", needle, why)
-                for i, (p, _a, c, needle, why) in enumerate(T.FINDING_CLI_CASES)})
+                for i, (p, _, c, needle, why) in enumerate(T.FINDING_CLI_CASES)})  # drops argv
     # The two PROPERTIES. Their expectation IS the property and not a particular rule — demanding a needle
     # would be demanding a specific defect where the case only demands a sound outcome.
     out.update({f"[round-trip] {cmd} on a {state} file": (
@@ -1364,7 +1364,7 @@ def check_boundaries(R: types.ModuleType, T: Tables) -> int:
                   f"value IS. `a10` was refused by a pattern whose own error message said `k >= 2`")
             failures += 1
 
-    for name, (_probe, spec) in T.DOMAINS.items():
+    for name, (_, spec) in T.DOMAINS.items():  # drops the probe callable
         probed = sides.get(name, set())
         if probed == {True, False}:
             continue
@@ -1433,7 +1433,7 @@ def check_docs(R: types.ModuleType) -> int:
         except R.Defect as exc:
             print(f"FAIL     {where}:{n:<4} the tool REFUSES its own documented example: {exc}")
             failures += 1
-    seen = {rec["type"] for _w, _n, rec in examples}
+    seen = {rec["type"] for _, _, rec in examples}  # drops want, needle
     if seen != want:
         print(f"FAIL     the docs no longer show an example of every record type — missing "
               f"{sorted(want - seen)}. A scan that matches nothing passes every time and checks nothing; "
@@ -1488,7 +1488,7 @@ def door_parsers(R: types.ModuleType) -> "dict[str, argparse.ArgumentParser]":
     actually EXECUTED for them is the real script, as a subprocess, so a replica cannot hide a wrapper that
     has drifted from it.
     """
-    p, _cmds = R.build_parser()
+    p, _ = R.build_parser()  # drops the commands map
     doors: dict[str, argparse.ArgumentParser] = {}
     for action in p._actions:  # noqa: SLF001 - the subparser map is where the doors are
         choices = getattr(action, "choices", None)
@@ -1676,7 +1676,7 @@ def unmarked(source: str, marked: "dict[str, tuple[str, ast.stmt]]") -> "list[st
     mutated, so nothing ever asks whether a fixture would notice its absence — it is reported "pinned" by
     nobody having looked. THE COUNT IS A CLAIM, and this is what makes the claim checkable.
     """
-    lines = {stmt.lineno for _w, stmt in marked.values()}
+    lines = {stmt.lineno for _, stmt in marked.values()}  # drops the weakening
     problems: list[str] = []
     for fn in ast.walk(ast.parse(source)):
         if not isinstance(fn, ast.FunctionDef) or fn.name not in RULE_FUNCTIONS:
@@ -1723,7 +1723,7 @@ def check_commands_covered(R: types.ModuleType, T: Tables) -> "list[str]":
     the parser and in neither set below — so the suite goes red the day it is added, and stays red until
     someone says which it is.
     """
-    _parser, commands = R.build_parser()
+    _, commands = R.build_parser()  # drops the parser
     problems = []
     for cmd in commands:
         if cmd not in T.WRITE_COMMANDS and cmd not in T.READ_ONLY_COMMANDS:
@@ -1791,7 +1791,7 @@ def run_status_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> int:
             failures += 1
             continue
         try:
-            _cols, rows = status_parse(out)
+            _, rows = status_parse(out)  # drops the header cols
         except SelfTestFailure as exc:
             # A view whose every pass is hidden prints a header + footer and NO table (no dash rule line).
             # That is legitimate for an `absent`/`footer`-only case; only a case that expects rendered rows
@@ -1920,12 +1920,12 @@ def run(R: types.ModuleType, tmp: Path) -> int:
         # A mutation only ever REMOVES a rule, so it can never turn a PASSING case into a failing one.
         # If it does, the mutation is bogus — a harness bug, never a pinned rule.
         wrong = [f"{c} expected {w} but the mutant returned {mutant[c][0]}"
-                 for c, (w, _n, _y) in expect.items() if w in PASSING and mutant[c][0] != w]
+                 for c, (w, _, _) in expect.items() if w in PASSING and mutant[c][0] != w]  # drops needle, why
         if wrong:
             broken.append(f"{rule}: BOGUS MUTATION — {'; '.join(wrong)}")
             continue
         killers = []
-        for case, (want, needle, _why) in expect.items():
+        for case, (want, needle, _) in expect.items():  # drops why
             if want in PASSING:
                 continue  # a case that PASSES cannot kill a rule; it is a canary (checked above)
             outcome, text = mutant[case]

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1246,7 +1246,7 @@ def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int,
     a NOT SATISFIED into a pass, raise `reviews_ok`, or merge anything; a tool that could accept would merge
     a PR nobody reviewed, and a bug in one that can only refuse costs a re-review.
     """
-    _announced, done = walk_progress(events, units)
+    _, done = walk_progress(events, units)  # drops the announced set
 
     amendments = [e for e in events if e["type"] == AMENDMENT]
     unruled = len(amendments) - ruled
@@ -1335,7 +1335,7 @@ def plan_path(progress: Path) -> Path:
     One derivation, so `emit` cannot be judged against a plan `verify` will not open. (The plan is
     per-PASS, not per-attempt: a relaunch reuses it unchanged, so the attempt is not in its name.)
     """
-    pr, npass, _attempt = parse_name(progress)
+    pr, npass, _ = parse_name(progress)  # drops the attempt
     return progress.parent / PLAN_NAME.format(pr=pr, **{"pass": npass})
 
 
@@ -1361,7 +1361,7 @@ def evaluate(progress: Path, head_sha: str, ruled: int = 0,
     """
     try:
         plan = plan_path(progress)
-        pr, _npass, _attempt = parse_name(progress)
+        pr, _, _ = parse_name(progress)  # drops npass, attempt
         events, units = check_progress_file(text=read_text(progress, "progress file"), path=progress,
                                             plan=lambda: load_plan(plan), head_sha=head_sha)
         # MUTATE:intent-required:pass
@@ -1525,7 +1525,7 @@ def cmd_emit(args) -> int:
     fifteen minutes later by a `verify` the reviewer never sees.
     """
     path = Path(args.file)
-    _pr, _npass, _attempt = parse_name(path)
+    parse_name(path)  # validates the filename; return discarded
     # The RECORD IS THE FLAGS — VERBATIM. `--status done` with no `--evidence` is an event with no
     # `evidence` key, and `--status started --evidence x` is one carrying a key nothing reads, so the flags
     # are judged by the same `check_event` that judges a hand-written line and the evidence rule exists in
@@ -1787,7 +1787,7 @@ def active_attempts(rundir: Path) -> "list[Path]":
         k = int(attempt)
         if key not in best or k > best[key][0]:
             best[key] = (k, path)
-    return [path for _k, path in best.values()]
+    return [path for _, path in best.values()]  # drops the attempt key
 
 
 def all_attempts(rundir: Path) -> "list[tuple[Path, bool]]":
@@ -1811,7 +1811,7 @@ def latest_pass_per_pr(rundir: Path) -> "dict[str, int]":
     latest: dict[str, int] = {}
     for path in sorted(rundir.glob("review-*-*" + PROGRESS_SUFFIX)):
         try:
-            pr, npass, _attempt = parse_name(path)
+            pr, npass, _ = parse_name(path)  # drops the attempt
         except Defect:
             continue
         n = int(npass)
@@ -1823,7 +1823,7 @@ def latest_pass_per_pr(rundir: Path) -> "dict[str, int]":
 def report_path(progress: Path) -> Path:
     """The reviewer's report (`review-<pr>-<n>.txt`) — per PASS, beside the progress file. `status` scrapes
     its `VERDICT:` tail for a convenience read; `verify` never opens it and neither does the gate."""
-    pr, npass, _attempt = parse_name(progress)
+    pr, npass, _ = parse_name(progress)  # drops the attempt
     return progress.parent / f"review-{pr}-{npass}.txt"
 
 
@@ -2112,7 +2112,7 @@ def cmd_status(args) -> int:
     terminal_flags: list[bool] = []
     hidden = 0
     for progress, is_active in pairs:
-        pr, npass, _attempt = parse_name(progress)
+        pr, npass, _ = parse_name(progress)  # drops the attempt
         superseded = (not is_active) or (int(npass) < latest_pass.get(pr, 0))
         try:
             row = status_row(progress, now, args.verify, ledger_rows, superseded)
@@ -2353,7 +2353,7 @@ def dispatch(args) -> int:
 
 
 def main(argv: "list[str] | None" = None) -> int:
-    p, _cmds = build_parser()
+    p, _ = build_parser()  # drops the commands map
     return dispatch(p.parse_args(argv))
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1525,7 +1525,7 @@ def cmd_emit(args) -> int:
     fifteen minutes later by a `verify` the reviewer never sees.
     """
     path = Path(args.file)
-    pr, npass, _attempt = parse_name(path)
+    _pr, _npass, _attempt = parse_name(path)
     # The RECORD IS THE FLAGS — VERBATIM. `--status done` with no `--evidence` is an event with no
     # `evidence` key, and `--status started --evidence x` is one carrying a key nothing reads, so the flags
     # are judged by the same `check_event` that judges a hand-written line and the evidence rule exists in

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "reportUnusedImport": "error",
+  "reportUnusedVariable": "error"
+}


### PR DESCRIPTION
- discard unused unpack/local targets so pyright stops graying them out for end-users
- add root `pyrightconfig.json` making unused variables/imports a CI error
