### PR TITLE
mark terminal review passes gone in status

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -840,6 +840,7 @@ class Tables:
         # NOT appear. `mtimes` maps a filename to the UTC time `os.utime` stamps on it.
         TORN = ident() + "\n" + started("u01") + "\n" + done("u01") + "\n" + \
             '{"type":"progress","unit":"u02","status":"star'   # a half-written append, NO trailing newline
+        UNREADABLE = "this is not valid json at all\n"   # a REAL corruption (has a newline; not a torn tail)
         PLAN3 = [unit("u01"), unit("u02", target="b.py", checks=["c"]),
                  unit("u03", target="c.py", checks=["c"]), unit("u04", target="d.py", checks=["c"])]
         NG1 = finding(writer="dev-time", purpose="-",
@@ -998,6 +999,52 @@ class Tables:
                 "why": "attempt 1 was RELAUNCHED — attempt 2 (`a2`) exists for the same (pr, pass) — so its "
                        "reviewer is gone: attempt 1 reads `gone`, never live, while the active attempt 2 "
                        "stays `working`",
+            },
+
+            # --- A TORN/CORRUPT progress file does not hide a pass's TERMINALITY (read from OTHER files) --
+            "unreadable-done": {
+                "files": {PROGRESS_FILE: UNREADABLE, PLAN_FILE: self.PLAN,
+                          "review-41-1.txt": "Report body.\nVERDICT: SATISFIED\n"},
+                "now": "2026-07-06T00:03:00Z",
+                "flags": ["--history"],   # `done` is terminal — --history reveals the row
+                "expect": {"41-1": {"units": "?", "health": "done", "verdict": "SAT"}},
+                "why": "the PROGRESS file is a real corruption, but its REPORT carries a VERDICT: the pass "
+                       "FINISHED. The verdict is scraped and `done` wins BEFORE the unreadable give-up, so "
+                       "the row reads `done`/`SAT`, never a live-looking `unreadable`",
+            },
+            "unreadable-done-hidden": {
+                "files": {PROGRESS_FILE: UNREADABLE, PLAN_FILE: self.PLAN,
+                          "review-41-1.txt": "Report body.\nVERDICT: SATISFIED\n"},
+                "now": "2026-07-06T00:03:00Z",
+                "absent": ["41-1"],
+                "footer": "1 terminal pass(es) hidden",
+                "why": "the SAME corrupt-but-finished pass in the DEFAULT view: `done` is terminal, so it is "
+                       "HIDDEN and the footer counts it — a torn progress file no longer forces a dead pass "
+                       "to show as in-flight",
+            },
+            "unreadable-superseded-gone": {
+                "files": {"review-41-1.progress.jsonl": UNREADABLE,
+                          "review-41-2.progress.jsonl": [ident(**{"pass": "2"}), started("u01")],
+                          PLAN_FILE: self.PLAN},
+                "now": "2026-07-06T00:03:00Z",
+                "flags": ["--history"],
+                "expect": {"41-1": {"health": "gone", "verdict": "-"},
+                           "41-2": {"health": "working"}},
+                "why": "pass 1's progress file is corrupt AND pass 2 exists, so pass 1 was SUPERSEDED — its "
+                       "reviewer is gone. `gone` is honoured before the unreadable give-up, so it reads "
+                       "`gone` (no verdict), never `unreadable`; the current pass 2 stays `working`",
+            },
+            "relaunched-footer": {
+                "files": {"review-7-1.progress.jsonl": [ident7(), started("u01")],
+                          "review-7-1.a2.progress.jsonl": [ident7(launch_attempt="2"), started("u01")],
+                          "review-7-1.plan.jsonl": self.PLAN},
+                "now": "2026-07-06T00:03:00Z",
+                "expect": {"7-1.a2": {"health": "working"}},
+                "absent": ["7-1"],
+                "footer": "1 terminal pass(es) hidden",
+                "why": "the DEFAULT view of a RELAUNCHED pass: the superseded attempt 1 (`gone`) is hidden AND "
+                       "COUNTED in the footer — it is a terminal launch attempt, not silently dropped, even "
+                       "though only the active attempt 2 renders",
             },
         }
 
@@ -1746,9 +1793,14 @@ def run_status_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> int:
         try:
             _cols, rows = status_parse(out)
         except SelfTestFailure as exc:
-            print(f"FAIL     [status] {name}: {exc}")
-            failures += 1
-            continue
+            # A view whose every pass is hidden prints a header + footer and NO table (no dash rule line).
+            # That is legitimate for an `absent`/`footer`-only case; only a case that expects rendered rows
+            # needs a table to parse.
+            if case.get("expect"):
+                print(f"FAIL     [status] {name}: {exc}")
+                failures += 1
+                continue
+            rows = {}
         ok = True
         for label, want in case.get("expect", {}).items():
             got = rows.get(label)
@@ -1764,6 +1816,17 @@ def run_status_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> int:
         for label in case.get("absent", []):
             if label in rows:
                 print(f"FAIL     [status] {name}: {label!r} must be suppressed but it rendered\n{out}")
+                ok = False
+        # `footer` pins the hidden-terminal count line (a `#` line status_parse skips as non-row): a
+        # substring that MUST appear verbatim in the printed output, or `""` to assert NO footer at all.
+        footer = case.get("footer")
+        if footer is not None:
+            has_footer = "terminal pass(es) hidden" in out
+            if footer == "" and has_footer:
+                print(f"FAIL     [status] {name}: expected NO hidden-count footer, but one printed\n{out}")
+                ok = False
+            elif footer and footer not in out:
+                print(f"FAIL     [status] {name}: hidden-count footer {footer!r} not in output\n{out}")
                 ok = False
         if ok:
             print(f"ok       [status] {name:24} {case['why'][:58]}")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -739,10 +739,10 @@ class Tables:
             "--purpose": [PURPOSE_GREEN], "--repro": ["a reply with no rows"], "--fix": ["refuse it"],
             # status's view flags. `--run .` drives the minimal invocation the door check executes; the
             # OPTIONAL flags are never in a minimal call, so their values are only here to satisfy the
-            # "every advertised flag has a supplied value" reconciliation. `--verify`/`--all-attempts` are
+            # "every advertised flag has a supplied value" reconciliation. `--verify`/`--history` are
             # store_true, so their value list is empty and never iterated.
             "--run": ["."], "--pr": ["41"], "--ledger": ["state.jsonl"], "--now": [TS],
-            "--verify": [], "--all-attempts": [],
+            "--verify": [], "--history": [],
         }
 
         # --- the DOMAINS -------------------------------------------------------------------------
@@ -896,9 +896,11 @@ class Tables:
                 "files": {PROGRESS_FILE: self.WORKED, PLAN_FILE: self.PLAN,
                           "review-41-1.txt": "Report body.\nVERDICT: NOT SATISFIED\n"},
                 "now": "2026-07-06T00:03:00Z",
+                "flags": ["--history"],   # `done` is TERMINAL, so the default hides it; --history shows it
                 "expect": {"41-1": {"units": "2/2", "health": "done", "verdict": "NOT-SAT"}},
-                "why": "the report `.txt` carries a VERDICT line, so health is `done` and the verdict is "
-                       "scraped as NOT-SAT (NOT SATISFIED is tested before SATISFIED, which it contains)",
+                "why": "the report `.txt` carries a VERDICT line, so health is `done` (terminal, hidden by "
+                       "default) and the verdict is scraped as NOT-SAT (NOT SATISFIED is tested before "
+                       "SATISFIED, which it contains)",
             },
             "find-gating-split": {
                 "files": {PROGRESS_FILE: self.WORKED, PLAN_FILE: self.PLAN,
@@ -950,11 +952,52 @@ class Tables:
                 "files": {PROGRESS_FILE: self.WORKED, PLAN_FILE: self.PLAN, INTENT_FILE: INTENT,
                           "review-41-1.txt": "VERDICT: SATISFIED\n"},
                 "now": "2026-07-06T00:03:00Z",
-                "flags": ["--verify"],
+                "flags": ["--verify", "--history"],   # `done` is terminal — --history reveals it
                 "expect": {"41-1": {"units": "2/2", "verdict": "SAT", "counts(--verify)": "ok"}},
                 "why": "the opt-in `--verify` column runs the AUTHORITATIVE `evaluate()` verdict verbatim "
                        "(complete, sound, SATISFIED, zero gating findings) — `ok`, distinct from the "
                        "advisory tally",
+            },
+
+            # --- TERMINAL vs LIVE: a pass whose reviewer is GONE must never render live-looking ---------
+            "superseded-gone": {
+                "files": {"review-41-1.progress.jsonl": [ident(), started("u01"), done("u01"),
+                                                         started("u02")],
+                          "review-41-2.progress.jsonl": [ident(**{"pass": "2"}), started("u01")],
+                          PLAN_FILE: self.PLAN},
+                "mtimes": {"review-41-1.progress.jsonl": "2026-07-06T00:00:00Z"},
+                "now": "2026-07-06T00:20:00Z",
+                "flags": ["--history"],
+                "expect": {"41-1": {"units": "1/2", "health": "gone", "verdict": "-"},
+                           "41-2": {"health": "working"}},
+                "why": "pass 1 has launch evidence AND a 20-min-stale mtime — but pass 2 exists, so pass 1 "
+                       "was SUPERSEDED and its reviewer is gone: `gone`, NEVER the `STALLED` this mtime "
+                       "alone would show. Only the current pass 2 stays live (`working`)",
+            },
+            "superseded-hidden-by-default": {
+                "files": {"review-41-1.progress.jsonl": [ident(), started("u01"), done("u01"),
+                                                         started("u02")],
+                          "review-41-2.progress.jsonl": [ident(**{"pass": "2"}), started("u01")],
+                          PLAN_FILE: self.PLAN},
+                "mtimes": {"review-41-1.progress.jsonl": "2026-07-06T00:00:00Z"},
+                "now": "2026-07-06T00:20:00Z",
+                "expect": {"41-2": {"health": "working"}},
+                "absent": ["41-1"],
+                "why": "the SAME run in the DEFAULT view: the superseded (gone) pass 1 is a terminal pass, "
+                       "so it is HIDDEN and the table shows only the in-flight pass 2. Nothing is dropped "
+                       "silently — a footer counts what was hidden and `--history` shows it",
+            },
+            "relaunched-attempt-gone": {
+                "files": {"review-7-1.progress.jsonl": [ident7(), started("u01")],
+                          "review-7-1.a2.progress.jsonl": [ident7(launch_attempt="2"), started("u01")],
+                          "review-7-1.plan.jsonl": self.PLAN},
+                "now": "2026-07-06T00:03:00Z",
+                "flags": ["--history"],
+                "expect": {"7-1": {"health": "gone"},
+                           "7-1.a2": {"health": "working"}},
+                "why": "attempt 1 was RELAUNCHED — attempt 2 (`a2`) exists for the same (pr, pass) — so its "
+                       "reviewer is gone: attempt 1 reads `gone`, never live, while the active attempt 2 "
+                       "stays `working`",
             },
         }
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1999,9 +1999,17 @@ def status_row(progress: Path, now: datetime, want_verify: bool,
     label = f"{pr}-{npass}" + (f".a{attempt}" if attempt != "1" else "")
     events = read_lenient(progress)
     if events is None:
-        # The progress file itself is unreadable (a real corruption, not a torn tail). Render a row that
-        # says so, and let the other passes print.
-        cells = [label, "?", "-", "-", "-", "unreadable", "-"]
+        # The progress file itself is unreadable (a real corruption, not a torn tail). But a corrupt
+        # PROGRESS file does not make the pass any less TERMINAL: its report may still carry a verdict (the
+        # pass FINISHED) and a later pass or launch attempt may still have superseded it (the reviewer is
+        # GONE) — both facts live in OTHER files. So scrape the verdict and honour `superseded` BEFORE
+        # giving up, reusing `health_of` so `done`-beats-`gone` has ONE owner. Only a pass that is neither
+        # finished nor superseded stays `unreadable`; without this a finished/dead pass rendered a
+        # live-looking `unreadable` that the default view then showed instead of hiding.
+        verdict = scrape_verdict(progress)
+        terminal = verdict != V_NONE or superseded
+        health = health_of([], verdict, None, 0.0, superseded) if terminal else "unreadable"
+        cells = [label, "?", "-", "-", "-", health, verdict]
         if want_verify:
             cells.append("unreadable")
         if ledger_rows is not None:
@@ -2085,10 +2093,12 @@ def cmd_status(args) -> int:
     latest_pass = latest_pass_per_pr(rundir)
     health_col = columns.index("health")
 
-    if args.history:
-        pairs = all_attempts(rundir)
-    else:
-        pairs = [(p, True) for p in active_attempts(rundir)]
+    # BOTH views enumerate EVERY attempt; the default view then hides terminal passes (and counts them in
+    # the footer), while `--history` shows them. Building the default set from `active_attempts` alone
+    # dropped every superseded launch attempt (a relaunched `.a1`) BEFORE the hidden counter ran, so the
+    # table hid it but the footer under-counted. `all_attempts` flags each attempt active/superseded, and the
+    # ONE terminal classification in the render loop below both hides and counts it — no separate count path.
+    pairs = all_attempts(rundir)
     if args.pr is not None:
         pairs = [(p, a) for (p, a) in pairs if parse_name(p)[0] == str(args.pr)]
     pairs.sort(key=lambda pa: tuple(int(x) for x in parse_name(pa[0])[:2]) + (int(parse_name(pa[0])[2]),))

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1720,10 +1720,18 @@ def cmd_verify(args) -> int:
 LAUNCH_DEADLINE_S = 5 * 60      # launch evidence must be present by ~5 min from dispatch
 PROGRESS_DEADLINE_S = 15 * 60   # meaningful progress (a planned-unit done / accepted amendment) by ~15 min
 
-# The six health states (§4 of the design). The three ATTENTION states are upper-cased so they stand out
-# in a column of lower-case `working`/`launching`.
+# The health states (§4 of the design). The three ATTENTION states are upper-cased so they stand out in a
+# column of lower-case `working`/`launching`.
+#
+# TWO of them are TERMINAL — the reviewer does not exist anymore — and the mtime-based liveness states
+# (`launching`/`working`/`STALLED`/`NO-LAUNCH!`) apply to NEITHER: only a genuinely-CURRENT pass can be
+# live. `done` is a finished pass (its report carries a `VERDICT:` line). `gone` is a pass whose reviewer
+# left with NO verdict — it was SUPERSEDED (a later pass number exists for its PR) or RELAUNCHED (a later
+# launch attempt exists). Without this split a completed or abandoned pass from hours ago rendered as
+# `STALLED`/`AMEND(n)`, so the table listed "reviewers" that were long gone (`health_of`).
 H_LAUNCHING, H_WORKING, H_DONE = "launching", "working", "done"
 H_STALLED, H_NO_LAUNCH = "STALLED", "NO-LAUNCH!"
+H_GONE = "gone"                 # TERMINAL, no verdict: superseded or relaunched — the reviewer is gone
 
 # The report scrape's three outcomes (advisory: the authoritative verdict for gating is the ledger's).
 V_SAT, V_NOT_SAT, V_NONE = "SAT", "NOT-SAT", "-"
@@ -1793,6 +1801,23 @@ def all_attempts(rundir: Path) -> "list[tuple[Path, bool]]":
             continue
         out.append((path, path in active))
     return out
+
+
+def latest_pass_per_pr(rundir: Path) -> "dict[str, int]":
+    """The highest pass NUMBER seen for each PR across the run. A pass whose number is below its PR's max
+    was SUPERSEDED — the PR moved on to a later review round — so its reviewer is gone. Computed over EVERY
+    progress file (not just the shown ones), the same glob+`parse_name` the attempt readers use, so there is
+    no second parser: a name `parse_name` refuses is not a progress artifact and is skipped."""
+    latest: dict[str, int] = {}
+    for path in sorted(rundir.glob("review-*-*" + PROGRESS_SUFFIX)):
+        try:
+            pr, npass, _attempt = parse_name(path)
+        except Defect:
+            continue
+        n = int(npass)
+        if n > latest.get(pr, 0):
+            latest[pr] = n
+    return latest
 
 
 def report_path(progress: Path) -> Path:
@@ -1896,14 +1921,23 @@ def pass_identity_of(events: "list[dict]") -> "dict | None":
 
 
 def health_of(events: "list[dict]", verdict: str, elapsed_s: "float | None",
-              mtime_age_s: float) -> str:
+              mtime_age_s: float, terminal: bool = False) -> str:
     """The liveness read (§4). First match wins; the ATTENTION states sort above the calm ones.
 
-    `done` is the report's VERDICT line; `AMEND(n)` is any raised `plan_amendment_request` (an amendment IS
-    launch evidence and is the more actionable fact, so it outranks liveness); then the launch-evidence
-    split (`NO-LAUNCH!`/`launching`); then the progress-file mtime split (`STALLED`/`working`)."""
+    **THE TWO TERMINAL STATES COME FIRST, AND LIVENESS APPLIES TO NEITHER.** `done` is the report's VERDICT
+    line — the pass FINISHED. `gone` is a pass whose reviewer left with NO verdict because it was SUPERSEDED
+    or RELAUNCHED (`terminal`) — the reviewer is gone, and a table that showed it `STALLED`/`AMEND(n)` would
+    claim a reviewer is stuck RIGHT NOW when none exists. So `gone` is decided BEFORE amendments and before
+    the mtime split: a terminal pass is never live, whatever its progress file's age or amendments say.
+
+    Only a genuinely-CURRENT pass (not terminal, no verdict) reaches the liveness reads: `AMEND(n)` for any
+    raised `plan_amendment_request` (an amendment IS launch evidence and the more actionable fact, so it
+    outranks liveness); then the launch-evidence split (`NO-LAUNCH!`/`launching`); then the progress-file
+    mtime split (`STALLED`/`working`). `STALLED`/`NO-LAUNCH!` therefore flag ONLY a genuinely-current pass."""
     if verdict != V_NONE:
         return H_DONE
+    if terminal:
+        return H_GONE
     amendments = sum(1 for r in events if r.get("type") == AMENDMENT)
     if amendments:
         return f"AMEND({amendments})"
@@ -1954,8 +1988,13 @@ def load_ledger_module() -> types.ModuleType:
 
 
 def status_row(progress: Path, now: datetime, want_verify: bool,
-               ledger_rows: "list[dict] | None") -> "list[str]":
-    """One pass's cells, rendered in isolation so ONE malformed pass cannot crash the whole table."""
+               ledger_rows: "list[dict] | None", superseded: bool = False) -> "list[str]":
+    """One pass's cells, rendered in isolation so ONE malformed pass cannot crash the whole table.
+
+    `superseded` is TRUE when a later pass number or a later launch attempt exists for this (pr, pass) — the
+    reviewer is gone. It reaches `health_of` as `terminal`, so a superseded pass with no verdict renders
+    `gone`, never a live-looking `STALLED`/`AMEND(n)`. A superseded pass that DID finish still reads `done`
+    (the verdict wins in `health_of`)."""
     pr, npass, attempt = parse_name(progress)
     label = f"{pr}-{npass}" + (f".a{attempt}" if attempt != "1" else "")
     events = read_lenient(progress)
@@ -1984,7 +2023,7 @@ def status_row(progress: Path, now: datetime, want_verify: bool,
         mtime_age_s = (now - mtime).total_seconds()
     except OSError:
         mtime_age_s = 0.0
-    health = health_of(events, verdict, elapsed_s, mtime_age_s)
+    health = health_of(events, verdict, elapsed_s, mtime_age_s, superseded)
     elapsed = fmt_elapsed(elapsed_s) if elapsed_s is not None else "-"
 
     cells = [label, f"{done}/{total}", now_unit, finding_counts(progress), elapsed, health, verdict]
@@ -2040,7 +2079,13 @@ def cmd_status(args) -> int:
     if ledger_rows is not None:
         columns.append("tally(--ledger)")
 
-    if args.all_attempts:
+    # SUPERSESSION is a fact about the WHOLE run: a pass is superseded when its PR has a later pass number.
+    # It is computed over every progress file, once, before any view filtering (a `--pr` filter or the
+    # default hide must not change whether a pass counts as superseded).
+    latest_pass = latest_pass_per_pr(rundir)
+    health_col = columns.index("health")
+
+    if args.history:
         pairs = all_attempts(rundir)
     else:
         pairs = [(p, True) for p in active_attempts(rundir)]
@@ -2048,20 +2093,31 @@ def cmd_status(args) -> int:
         pairs = [(p, a) for (p, a) in pairs if parse_name(p)[0] == str(args.pr)]
     pairs.sort(key=lambda pa: tuple(int(x) for x in parse_name(pa[0])[:2]) + (int(parse_name(pa[0])[2]),))
 
-    dim_dead = args.all_attempts and sys.stdout.isatty()
+    # A pass is TERMINAL when its rendered health is `done` (finished) or `gone` (superseded/relaunched, no
+    # verdict). The DEFAULT view hides terminal passes so the table shows only what is genuinely in flight;
+    # `--history` shows everything (terminal passes and superseded attempts, dimmed on a TTY). Nothing is
+    # ever silently dropped: the count of hidden passes is printed, and `--history` reveals them all.
+    dim_terminal = args.history and sys.stdout.isatty()
     rows: list[list[str]] = []
-    dead_flags: list[bool] = []
+    terminal_flags: list[bool] = []
+    hidden = 0
     for progress, is_active in pairs:
+        pr, npass, _attempt = parse_name(progress)
+        superseded = (not is_active) or (int(npass) < latest_pass.get(pr, 0))
         try:
-            rows.append(status_row(progress, now, args.verify, ledger_rows))
+            row = status_row(progress, now, args.verify, ledger_rows, superseded)
         except Exception as exc:  # noqa: BLE001 - one bad pass must never crash the whole table
             row = [progress.name, "?", "-", "-", "-", f"error:{type(exc).__name__}", "-"]
             while len(row) < len(columns):
                 row.append("-")
-            rows.append(row)
-        dead_flags.append(not is_active)
+        is_terminal = row[health_col] in (H_DONE, H_GONE)
+        if is_terminal and not args.history:
+            hidden += 1
+            continue
+        rows.append(row)
+        terminal_flags.append(is_terminal)
 
-    scope = ("all attempts" if args.all_attempts else "active attempts only")
+    scope = ("all passes (history)" if args.history else "in-flight passes only")
     segs = [f"run {rundir.name or str(rundir)}"]
     if reviewer:
         segs.append(f"reviewer={reviewer}")
@@ -2069,19 +2125,24 @@ def cmd_status(args) -> int:
     segs.append(f"as-of {now.strftime('%Y-%m-%dT%H:%M:%SZ')}")
     header = "# " + "   ".join(segs)
 
+    hidden_note = (f"# {hidden} terminal pass(es) hidden (done/gone) — --history to show them"
+                   if hidden else None)
+
     if not rows:
         sys.stdout.write(header + "\n\n")
-        sys.stdout.write(f"# (no review passes in {rundir})\n")
+        sys.stdout.write(hidden_note + "\n" if hidden_note else f"# (no review passes in {rundir})\n")
         return 0
 
     text = render_status(header, columns, rows)
-    if dim_dead and any(dead_flags):
+    if dim_terminal and any(terminal_flags):
         lines = text.split("\n")
         body_start = 4  # header, blank, column header, rule, then rows
-        for i, dead in enumerate(dead_flags):
-            if dead:
+        for i, terminal in enumerate(terminal_flags):
+            if terminal:
                 lines[body_start + i] = f"{DIM}{lines[body_start + i]}{RESET}"
         text = "\n".join(lines)
+    if hidden_note:
+        text += hidden_note + "\n"
     sys.stdout.write(text)
     return 0
 
@@ -2251,8 +2312,10 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     st.add_argument("--verify", action="store_true",
                     help="add evaluate()'s authoritative verdict column (ok/incomplete/amended/unusable)")
     st.add_argument("--ledger", help="a state.jsonl — adds a reviews_ok/required(tier) tally column")
-    st.add_argument("--all-attempts", dest="all_attempts", action="store_true",
-                    help="show superseded launch attempts too (dimmed on a TTY), not just the active one")
+    st.add_argument("--history", dest="history", action="store_true",
+                    help="show TERMINAL passes too — done (finished) and gone (superseded/relaunched) — plus "
+                         "superseded launch attempts, dimmed on a TTY. The default hides them and prints a "
+                         "count, so the table shows only what is genuinely in flight")
     st.add_argument("--now", help="UTC ISO-8601 render clock (or REVIEW_PASS_NOW) — a determinism seam")
 
     sub.add_parser("self-test", help="run every fixture, then DELETE each rule and prove a fixture notices")


### PR DESCRIPTION
- `status`: a superseded/relaunched pass with no verdict now renders `gone`, not a live-looking `STALLED`/`AMEND`
- default hides terminal (`done`/`gone`) passes with a count footer; `--history` (was `--all-attempts`) shows all
- add three `STATUS_CASES` fixtures for the gone/hide/relaunch cases
