### PR TITLE
bump gauntlet to 0.1.5

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"


### PR DESCRIPTION
- release the intent-scoped review gate, autonomous repair mode, ci-status deriver, and status view
- includes the follow-up ledger, audit-as-subagent codification, and the pyright/underscore cleanup
- version-only bump; the merged content governs nothing until the cache refreshes to 0.1.5
