### PR TITLE
release on version bump, not by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+# Cuts a GitHub release when a version bump lands on main. The bump PR is the
+# trigger — no separate manual step. Notes are GitHub's auto-generated PR list,
+# prepended with the curated blurb in release-notes/<version>.md when present.
+on:
+  push:
+    branches: [main]
+    paths:
+      - plugins/gauntlet/.claude-plugin/plugin.json
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release, e.g. 0.1.6 (defaults to plugin.json)
+        required: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version, skip if already released
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ github.event.inputs.version }}"
+          if [ -z "$version" ]; then
+            version="$(jq -r '.version' plugins/gauntlet/.claude-plugin/plugin.json)"
+          fi
+          tag="gauntlet-v$version"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "release $tag already exists — nothing to do"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compose notes — curated blurb over GitHub's auto-generated list
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.gate.outputs.version }}"
+          tag="${{ steps.gate.outputs.tag }}"
+          prev="$(git tag -l 'gauntlet-v*' | sort -V | grep -vx "$tag" | tail -1 || true)"
+          if [ -n "$prev" ]; then
+            auto="$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$tag" -f target_commitish="$GITHUB_SHA" \
+              -f previous_tag_name="$prev" --jq '.body')"
+          else
+            auto="$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$tag" -f target_commitish="$GITHUB_SHA" --jq '.body')"
+          fi
+          summary="release-notes/$version.md"
+          if [ -f "$summary" ]; then
+            cat "$summary" > notes.md
+            printf '\n\n---\n\n' >> notes.md
+          else
+            echo "::warning::no release-notes/$version.md — shipping auto-generated notes only"
+            : > notes.md
+          fi
+          printf '%s\n' "$auto" >> notes.md
+
+      - name: Create tag and release
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "${{ steps.gate.outputs.tag }}" \
+            --target "$GITHUB_SHA" \
+            --title "gauntlet ${{ steps.gate.outputs.version }}" \
+            --notes-file notes.md \
+            --latest

--- a/release-notes/0.1.5.md
+++ b/release-notes/0.1.5.md
@@ -1,0 +1,5 @@
+## Highlights
+
+- **Autonomous repair mode** — when a review loop stops converging, the campaign re-assesses and repairs itself instead of stalling on a manual cap.
+- **CI status derived by tool, not by eye** — `ci-status.py derive` reads a SHA-pinned snapshot of both check families, closing the "green by watch exit" gap.
+- **Live review-pass status** — `review-pass.py status` shows in-flight passes and marks terminal ones gone, so a dead reviewer never looks live.

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,14 @@
+# Release notes
+
+`release.yml` cuts a GitHub release when a version bump lands on `main`. The
+release body is GitHub's auto-generated list of merged PRs. To highlight the
+top changes, add a short curated blurb here named for the version:
+
+    release-notes/<version>.md   e.g. release-notes/0.1.6.md
+
+Commit it in the same PR as the `plugin.json` version bump. The workflow
+prepends it above the auto-generated list, separated by a rule. If the file is
+absent the release still ships — with the auto-generated list only (and a
+warning in the run log).
+
+Keep it to a few bullets: what a user would care about, not every PR.


### PR DESCRIPTION
- `release.yml` tags + releases on a `plugin.json` version bump; idempotent on the tag
- notes = GitHub's auto PR list, prepended with `release-notes/<version>.md` if present
- uses the Action `GITHUB_TOKEN`, sidestepping the user-PAT `workflow`-scope block
