### PR TITLE
let a pass defer instead of forcing a verdict

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -251,7 +251,10 @@ Read stage refs only when that stage/action is due:
   same as one that blocks with nothing to point at. A finding cannot be blocking in the artifact and
   ignorable in the verdict. **The verdict is a REQUIRED input to `verify`** (`--verdict`, what the report's
   `VERDICT:` line says): a COMPLETE pass verified without one is `unusable`, because a guard whose input
-  can be ABSENT never fires.
+  can be ABSENT never fires. The line may instead read `VERDICT: DEFERRED` — the reviewer raised a separate
+  request (an amendment, or a broken-dispatch stop) rather than ruling; pass `--verdict deferred` (still
+  required, the third accepted value), which is not a verdict and routes on the progress file to
+  `amended`/`incomplete`/`unusable`, never a tally.
 - **Verdicts go through `ledger.py verdict` — NEVER set `reviews_ok` by hand.** It bumps `review_rounds`
   (**monotone, never reset — the loop's only memory across fresh-context wakes**), applies the tally, and
   moves `ns_streak`, atomically. `set` cannot RAISE the tally and no door can write the counters at all.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -251,7 +251,9 @@
     and so is a `satisfied` that recorded one. **`--verdict` is a REQUIRED input to `verify`**, so a
     COMPLETE pass verified without one is refused too: a rule whose input may be omitted is a rule the
     driver switches off by forgetting a flag, and this one is the only mechanical check on the reviewer's
-    own verdict.
+    own verdict. (`--verdict` takes a third value, `deferred`, when the reviewer raised a separate request
+    instead of ruling — it is not a verdict, routes on the progress file to `amended`/`incomplete`, and is
+    itself `unusable` if the pass is complete with nothing outstanding.)
   Every one of those rules holds at **both doors** — the same predicate refuses it on write (`emit`) and on
   read (`verify`), so it cannot be enforced at one and not the other. **Every identifier it handles has ONE
   legal form and NO door repairs one** (a unit id is `u01`-shaped; `pr`/`pass`/`launch_attempt` are decimal

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -166,6 +166,11 @@ blocks; each completion is its own wake.
    finding stands** — a verdict that blocks a PR
    must name what blocks it, and a finding that blocks a PR cannot be waved through by the verdict. Either
    way round is `unusable` (Stage 2a, "Does this pass COUNT?").
+   **A pass that raised a separate request instead of ruling passes `verify --verdict deferred`** (the
+   report's terminal line is `VERDICT: DEFERRED`, or the progress file holds an unruled
+   `plan_amendment_request`): `deferred` is not a verdict, so it is **never tallied** — the tool routes on
+   the progress file and returns `amended` (fold the amendment, re-run the pass) or `incomplete`
+   (relaunch), and only a binary `satisfied`/`not-satisfied` ever reaches the ledger below.
    **Then record the verdict with `scripts/ledger.py verdict --pr <N> --head-sha <sha> --verdict …`** — the
    ONLY sanctioned path, and the only thing that bumps `review_rounds` (Stage 2a, "Recording a verdict");
    never set `reviews_ok` by hand.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -102,7 +102,9 @@ control step 3).
 If the selected reviewer is external (e.g. `codex exec`) and a pass can't return a verdict
 (quota/rate-limit, auth, timeout, or other system error — see "The reviewer"), retry it once, then run
 that pass as a **fresh subagent** reviewing the whole `origin/<base>...HEAD` diff under the same output
-contract — a `RESIDUAL-RISK` line on SATISFIED immediately above exactly one final `VERDICT:` line. A
+contract — a `RESIDUAL-RISK` line on SATISFIED immediately above exactly one final `VERDICT:` line (that
+terminal line may instead read `VERDICT: DEFERRED — <reason>` when the pass raised a separate request
+rather than ruling; `RESIDUAL-RISK` is a SATISFIED-only line and never accompanies a DEFERRED one). A
 subagent fallback pass counts toward the review gate exactly like an external pass —
 it's another fresh, context-isolated re-roll in its own context. (When the reviewer is already Claude
 subagents, this *is* the normal path, not a fallback.)
@@ -128,7 +130,7 @@ review-pass.py finding-add --file <rundir>/<findings-file> --path <file> --line 
     --writer <enum> --purpose "<a ## Purpose line, VERBATIM, or ->" \
     --repro "<what makes it fail>" --fix "<the concrete fix>"   # what `emit-finding.py` runs
 review-pass.py verify --file <rundir>/<progress-file> --head-sha <the PR's LIVE head> \
-    --verdict satisfied|not-satisfied [--amendments-ruled N]    # DOES THIS PASS COUNT?
+    --verdict satisfied|not-satisfied|deferred [--amendments-ruled N]   # DOES THIS PASS COUNT? (deferred = reviewer raised a request, not a verdict)
 review-pass.py self-test                    # the fixtures, and the proof each rule is pinned by one
 ```
 
@@ -516,8 +518,9 @@ it attacks a declared non-goal. The proof machinery had become the thing under r
 measured against (checked for **every** pass — see below); a `NOT SATISFIED` pass records **no gating
 finding**; a `SATISFIED` pass records **one that stands**; **no verdict is given at all for a pass that is
 COMPLETE** (`--verdict` is REQUIRED — the rule below cannot be switched off by omitting its input); a
-required field is missing; `writer` is outside the enum; `purpose` is not a verbatim `## Purpose` line; or
-`writer` contradicts the repro. It still **cannot say `SATISFIED`** and still **cannot raise `reviews_ok`**
+`deferred` pass is **complete with no outstanding `plan_amendment_request`** (a deferral that points at
+nothing — it owes a binary verdict); a required field is missing; `writer` is outside the enum; `purpose`
+is not a verbatim `## Purpose` line; or `writer` contradicts the repro. It still **cannot say `SATISFIED`** and still **cannot raise `reviews_ok`**
 — it can only ever **subtract** a pass, never grant one.
 
 **THE VERDICT/FINDINGS RULE IS AN IF AND ONLY IF, AND BOTH HALVES ARE ENFORCED: `NOT SATISFIED` exactly
@@ -637,7 +640,8 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    It also refuses to append to a progress file that could not be read back — most often one holding no \
    pass_identity, which is written for you before you are launched. That refusal is about the FILE, not \
    your event: it means the pass was not dispatched properly, so do not retry and do not create the file \
-   yourself — say so in your report and stop. \
+   yourself — say so in your report and stop, and make your report's terminal line \
+   'VERDICT: DEFERRED — <one-line reason>' so the orchestrator has a matchable line to route on. \
    After every planned unit is done, do a brief UNSTRUCTURED ADVERSARIAL SWEEP: deliberately hunt for \
    defects no plan unit would naturally catch — cross-unit interactions, unstated assumptions, edge \
    cases, and whole categories the plan did not enumerate. This complements the plan, never replaces \
@@ -681,7 +685,12 @@ codex exec --sandbox workspace-write -c "sandbox_workspace_write.network_access=
    certainty relative to the rest. It is a calibration signal, NOT a finding, and does not weaken your \
    SATISFIED — do not manufacture a concern to fill it; if identifying it surfaces a real GATING defect, \
    record it with the tool and return NOT SATISFIED instead. End with exactly one line: \
-   'VERDICT: SATISFIED' or 'VERDICT: NOT SATISFIED'." < /dev/null   # run in background
+   'VERDICT: SATISFIED' or 'VERDICT: NOT SATISFIED'. \
+   The ONE exception is when you did NOT render a verdict because you raised a separate request the \
+   orchestrator must handle FIRST — you appended a plan_amendment_request naming a plan gap, or the \
+   dispatch was broken and you are stopping: then end with 'VERDICT: DEFERRED — <one-line reason>' and do \
+   NOT fabricate SATISFIED or NOT SATISFIED. A deferral is a REQUEST, not a verdict; the orchestrator \
+   routes it to the tool, which reads the progress file and decides what to do next." < /dev/null   # run in background
 ```
 
 **Redirect stdin from `/dev/null` (`< /dev/null`).** `codex exec` reads stdin and, when a prompt is
@@ -700,7 +709,7 @@ with a parser written fresh each wake. That is precisely how a driver read `gh p
 
 ```
 review-pass.py verify --file <rundir>/<active attempt's progress file> --head-sha <the PR's LIVE head> \
-    --verdict satisfied|not-satisfied
+    --verdict satisfied|not-satisfied|deferred
 ```
 
 **`--verdict` is what you READ in the report, TOLD to the tool** — the tool still never opens
@@ -708,6 +717,16 @@ review-pass.py verify --file <rundir>/<active attempt's progress file> --head-sh
 rule, and that rule is an **IF AND ONLY IF**: **`not-satisfied` exactly when at least one GATING finding
 stands.** A verdict that blocks a PR must name what blocks it — **and a finding that blocks a PR cannot be
 waved through by the verdict.** Both halves make a pass `unusable`; neither can grant one.
+
+**When the report's terminal line is `VERDICT: DEFERRED`** — the reviewer raised a separate request the
+orchestrator must handle first (it appended a `plan_amendment_request`, or the dispatch was broken and it
+stopped) instead of rendering a verdict — **OR** there is no binary verdict but the progress file holds an
+unruled `plan_amendment_request`, **pass `--verdict deferred`.** `deferred` is **not** a verdict and never
+reaches the coherence rule; it hands control to the progress file, and the tool answers with the same
+routing verdicts as any other pass — **`amended`** (fold the amendment and re-run), **`incomplete`**
+(the pass stopped early — relaunch), or **`unusable`** (a spurious deferral: nothing was outstanding, so
+it owes a binary verdict). **NEVER fabricate a binary `satisfied`/`not-satisfied` for the reviewer** — if
+it did not rule, you do not rule for it.
 
 **`--verdict` is REQUIRED, and a COMPLETE pass verified without it is `unusable` — never `ok`.** It used to
 be optional, and that made the only mechanical check on the reviewer's own verdict a guard a driver
@@ -726,7 +745,7 @@ pass is a trapdoor, not a disclosure:
 | `ok` | 0 | the artifacts are sound: a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt and **the live head SHA**; a **usable intent block** for this PR; every planned unit `done` **once**, with concrete evidence, after a `started` for it; every `done` for a unit that is **actually in the plan**; no unruled amendment; and the verdict you gave **coheres** with the findings | **tally the verdict you passed** |
 | `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
 | `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
-| `unusable` | 1 | the artifacts are **defective** — a short SHA or any other malformed identifier, a `done` for an unplanned unit, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape, an identity naming another commit or another attempt; **no usable intent block for the PR** (`pr-adoption.md` step 3a — checked for **every** pass, including one that found nothing); a **verdict that does not cohere with the findings** in *either* direction (**a `not-satisfied` that recorded no GATING finding**, or a **`satisfied` that recorded one that stands**); **NO verdict at all on a COMPLETE pass** (the coherence rule's input may not be omitted); a finding missing a field, a `writer` outside the enum, a `purpose` that is not a verbatim `## Purpose` line, or a `writer` its own repro contradicts | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict. **An `unusable` for a missing intent is NOT a reviewer failure** — it means the run skipped `pr-adoption.md` step 3a: write the intent, then re-dispatch the pass. **Neither is one for a missing verdict** — that is YOUR call being wrong, not the pass: read the report's `VERDICT:` line and pass it. (The CLI refuses that call outright — `--verdict` is required — so this verdict is reachable only by an in-process caller) |
+| `unusable` | 1 | the artifacts are **defective** — a short SHA or any other malformed identifier, a `done` for an unplanned unit, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done` for one unit, a hand-written line of the wrong shape, an identity naming another commit or another attempt; **no usable intent block for the PR** (`pr-adoption.md` step 3a — checked for **every** pass, including one that found nothing); a **verdict that does not cohere with the findings** in *either* direction (**a `not-satisfied` that recorded no GATING finding**, or a **`satisfied` that recorded one that stands**); **NO verdict at all on a COMPLETE pass** (the coherence rule's input may not be omitted); **a spurious `deferred`** (`--verdict deferred` on a pass that is complete with **no** outstanding `plan_amendment_request` — a deferral that points at nothing); a finding missing a field, a `writer` outside the enum, a `purpose` that is not a verbatim `## Purpose` line, or a `writer` its own repro contradicts | the pass **CANNOT count, whatever its report says.** Treat it as a reviewer system failure (retry / fresh-subagent fallback), never as a verdict. **An `unusable` for a missing intent is NOT a reviewer failure** — it means the run skipped `pr-adoption.md` step 3a: write the intent, then re-dispatch the pass. **Neither is one for a missing verdict** — that is YOUR call being wrong, not the pass: read the report's `VERDICT:` line and pass it. (The CLI refuses that call outright — `--verdict` is required — so the *absent*-verdict case is reachable only by an in-process caller; a spurious `deferred` reaches it from the CLI too, and means the reviewer owes a binary verdict or the request it meant to raise) |
 
 **`ok` IS NOT `SATISFIED`, and the tool will never say `SATISFIED`.** It does not open
 `review-<pr>-<n>.txt` and does not parse the reviewer's prose — the VERDICT is the reviewer's **judgment**

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -331,7 +331,7 @@ class Tables:
         # its citation, bound its writer, or ask what it DEFENDED — and therefore nothing could ever decline
         # one. Every finding became a fix; every fix added surface; the next reviewer hunted the surface.
         F = self.finding
-        NS, SAT = R.NOT_SATISFIED, R.SATISFIED
+        NS, SAT, DEF = R.NOT_SATISFIED, R.SATISFIED, R.DEFERRED
 
         # THE THREE REGRESSION FIXTURES, FROM THE REAL RECORD. They are the acceptance test for the gating
         # rule, and they are quoted from the actual review artifacts of the two PRs that never converged.
@@ -425,6 +425,31 @@ class Tables:
                 "check: a pass still WORKING has no verdict to state, and it is answered `incomplete` — not "
                 "refused for lacking one. `verify` is a door you come to with the report in hand; a pass in "
                 "flight is WATCHED, not verified"),
+
+            # --- `deferred` is NOT a verdict: it routes to the progress-file state --------------------
+            #
+            # A reviewer that raised a separate request the orchestrator must handle first — a
+            # `plan_amendment_request`, or a broken-dispatch stop — ends its report with `VERDICT: DEFERRED`
+            # and the orchestrator passes `--verdict deferred`. That value NEVER reaches the coherence rule;
+            # the progress file is authoritative, and `decide` answers amended / incomplete / unusable.
+            "deferred-with-amendment": (
+                PLAN, [ident(), started("u01"), done("u01"), amendment(), started("u02"), done("u02")],
+                [], INTENT, DEF, AMENDED, "not yet ruled on",
+                "**THE CASE THE MARKER EXISTS FOR.** The reviewer raised a `plan_amendment_request` and ended "
+                "`VERDICT: DEFERRED` instead of ruling. `deferred` is not weighed against anything — the "
+                "unruled amendment is found FIRST and returns `amended`, exactly as it would with no verdict "
+                "at all. The orchestrator folds the amendment and re-runs the pass"),
+            "deferred-nothing-outstanding": (
+                PLAN, WORKED, [], INTENT, DEF, UNUSABLE, "nothing to defer to",
+                "**THE SPURIOUS DEFERRAL.** Every planned unit is done and no `plan_amendment_request` is "
+                "outstanding, so a `deferred` here points at NOTHING — there is no request for the "
+                "orchestrator to handle first. A deferral must name what it defers to; this pass is FINISHED "
+                "and owes a binary verdict, so it is refused"),
+            "deferred-incomplete": (
+                PLAN, [ident(), started("u01")], [], INTENT, DEF, INCOMPLETE, "has not covered its plan",
+                "…and a `deferred` on a pass STILL WORKING is answered by the completeness check, not the "
+                "deferral rule: a broken-dispatch stop before the plan is covered reads as `incomplete`, "
+                "which relaunches. `deferred` changed nothing about which state the progress file is in"),
 
             # --- A PASS IS JUDGED AGAINST AN INTENT — WHATEVER IT FOUND, AND EVEN IF IT FOUND NOTHING ----
             #
@@ -624,6 +649,11 @@ class Tables:
              "**THE NEW ONE, AT THE VERIFY DOOR:** a complete, perfectly sound pass that returns NOT SATISFIED and records nothing that may block. The artifacts are flawless and the pass still cannot count — a verdict that blocks a PR must name what blocks it"),
             (["verify", "--head-sha", SHA, "--verdict", "satisfied"], WORKED, 0, "0 gating finding(s)",
              "…and the same pass returning SATISFIED, which needs no finding at all"),
+            (["verify", "--head-sha", SHA, "--verdict", "deferred"], WORKED, 1, "nothing to defer to",
+             "**THE THIRD `--verdict` VALUE, AT THE DOOR.** argparse ACCEPTS `deferred` (it is a "
+             "`VERDICT_CHOICES` member, not an exit-2 rejection) and routes it to the progress file. On this "
+             "complete pass with no amendment there is nothing to defer to, so it comes back UNUSABLE — "
+             "proving the flag parses AND that `deferred` is never silently treated as a passing verdict"),
         ]
 
         # `plan-add` and `finding-add` get their own families: their flags do not fit the shape above (a

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -87,12 +87,15 @@ THE VERDICTS. Exactly one is printed, and there is no "counts, BUT…":
   unusable    the artifacts are defective — this pass CANNOT count, whatever its report says
 
 `--verdict` IS REQUIRED, and that is the whole of what "a gate must not depend on a caller remembering"
-means here. You come to `verify` WITH the report's `VERDICT:` line in hand; you do not come to it to find
-out whether the reviewer is done. A pass still in flight is WATCHED, not verified — its progress file is
-the liveness evidence (stage-2-review-gate.md, "Launch check"). While the flag could be left out, a
-complete pass verified without it returned `ok`, so the one machine-checked rule about the reviewer's own
-verdict was OFF for any driver that forgot a flag — and a driver that forgot it merged a PR whose reviewer
-had returned SATISFIED over a GATING finding it recorded itself.
+means here. It takes THREE values: `satisfied`/`not-satisfied` is the reviewer's binary verdict (the
+coherence rule below checks it); `deferred` is NOT a verdict — the reviewer raised a separate request
+instead (an amendment, or a broken-dispatch stop), so control routes to the progress file and the pass
+comes back amended/incomplete/unusable. You come to `verify` WITH the report's `VERDICT:` line in hand;
+you do not come to it to find out whether the reviewer is done. A pass still in flight is WATCHED, not
+verified — its progress file is the liveness evidence (stage-2-review-gate.md, "Launch check"). While the
+flag could be left out, a complete pass verified without it returned `ok`, so the one machine-checked rule
+about the reviewer's own verdict was OFF for any driver that forgot a flag — and a driver that forgot it
+merged a PR whose reviewer had returned SATISFIED over a GATING finding it recorded itself.
 
 `amended` is a VERDICT and not a footnote beside `ok` on purpose. A disclosure printed next to a pass is a
 trapdoor, not a disclosure: "this pass counts, but note that the reviewer says the plan is missing a
@@ -145,6 +148,14 @@ STATUSES = (STARTED, DONE)
 # doors by the same driver in the same step, and two spellings of one verdict is a bug waiting for a wake.
 SATISFIED, NOT_SATISFIED = "satisfied", "not-satisfied"
 VERDICTS = (SATISFIED, NOT_SATISFIED)
+# `deferred` is NOT a verdict — it is the reviewer saying "I did not render a verdict, I raised a separate
+# request the orchestrator must handle first" (a `plan_amendment_request`, or the broken-dispatch "say so
+# and stop"). It is deliberately BLANKET: the reviewer does not self-classify why. It NEVER enters `VERDICTS`
+# (the binary coherence set) and is NEVER tallied by the ledger — `--verdict deferred` routes control to the
+# progress file, which `evaluate()` reads and answers with amended/incomplete/unusable. `VERDICT_CHOICES` is
+# what the CLI accepts, so the report marker `DEFERRED` and the flag `deferred` are isomorphic.
+DEFERRED = "deferred"
+VERDICT_CHOICES = (SATISFIED, NOT_SATISFIED, DEFERRED)
 
 # The EXACT key set each event carries — every key it requires, and NOT ONE MORE. "Every required key is
 # present" admits an event that ALSO carries a key nothing reads, and a key nothing reads is evidence that
@@ -1222,7 +1233,11 @@ def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int,
     function still does not open `review-<pr>-<n>.txt` and still cannot SAY `SATISFIED`. The orchestrator
     reads the reviewer's VERDICT line, exactly as before, and passes what it read (`--verdict`) so that ONE
     coherence rule can be checked mechanically. **THE RULE IS AN IF AND ONLY IF, AND IT IS ENFORCED IN BOTH
-    DIRECTIONS: NOT SATISFIED exactly when at least one GATING finding stands.**
+    DIRECTIONS: NOT SATISFIED exactly when at least one GATING finding stands.** The orchestrator may also
+    pass `deferred` — the report's terminal line was `VERDICT: DEFERRED`, meaning the reviewer raised a
+    separate request instead of ruling; that value is not a verdict and never reaches the coherence rule,
+    it just routes to the progress-file state (an unruled amendment returns `amended` above; a spurious
+    deferral with nothing outstanding is `unusable`).
 
     **AND ON A COMPLETE PASS THE VERDICT IS NOT OPTIONAL — an ABSENT one is `unusable`, never `ok`.** It
     was optional, and that made the coherence rule above a guard a caller could switch off by FORGETTING a
@@ -1272,6 +1287,20 @@ def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int,
     # there IS a report, and the ONE rule this tool can check mechanically has an input it may not be denied.
     # Ordered BELOW `incomplete` on purpose: a pass still in flight has no verdict to state, and asking it
     # for one would refuse a reviewer for being unfinished, which `incomplete` already says better.
+
+    # `deferred` says "I did not render a verdict — I raised a separate request first." But the two clauses
+    # that HOST a real request are already behind us: an unruled amendment returned `amended` above, and a
+    # pass that stopped early returned `incomplete`. Reaching HERE means the pass is COMPLETE with NO unruled
+    # amendment — so a `deferred` here points at nothing. It is spurious, and refusing it is the honest answer.
+    if verdict == DEFERRED:
+        # MUTATE:deferred-with-nothing-outstanding:pass
+        return UNUSABLE, (
+            f"this pass returned DEFERRED, but every planned unit is done and no `{AMENDMENT}` is "
+            f"outstanding — there is nothing to defer to. A deferral must point at a request the "
+            f"orchestrator handles first: an amendment to fold, or a stop before the plan was covered. This "
+            f"pass raised neither, so it is FINISHED and owes a binary verdict. Give one ({VERDICTS}), or "
+            f"raise the request you meant to"
+        )
     if verdict is None:
         # MUTATE:verdict-missing-on-complete:pass
         return UNUSABLE, (
@@ -1828,7 +1857,8 @@ def report_path(progress: Path) -> Path:
 
 
 def scrape_verdict(progress: Path) -> str:
-    """The report's last `VERDICT:` line, mapped to SAT / NOT-SAT / - . Advisory only."""
+    """The report's last `VERDICT:` line, mapped to SAT / NOT-SAT / - . Advisory only. A `VERDICT: DEFERRED`
+    line reads as "no binary verdict" (V_NONE): the reviewer raised a separate request instead of ruling."""
     path = report_path(progress)
     if not path.exists():
         return V_NONE
@@ -1840,8 +1870,12 @@ def scrape_verdict(progress: Path) -> str:
     for line in text.splitlines():
         if "VERDICT:" in line.upper():
             rest = line.upper().split("VERDICT:", 1)[1]
-            # NOT SATISFIED contains SATISFIED, so test the negative spelling first.
-            if "NOT" in rest and "SATISF" in rest:
+            # DEFERRED is not a binary verdict — test it FIRST, before the SATISF spelling tests. Its reason
+            # text (`DEFERRED — <reason>`) can itself contain "satisf…", which would otherwise mis-scrape as
+            # SATISFIED; and NOT SATISFIED contains SATISFIED, so the negative spelling comes before SATISF.
+            if "DEFER" in rest:
+                verdict = V_NONE
+            elif "NOT" in rest and "SATISF" in rest:
                 verdict = V_NOT_SAT
             elif "SATISF" in rest:
                 verdict = V_SAT
@@ -2306,13 +2340,17 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     # the report in hand; a pass still in flight is not verified, it is WATCHED (its progress file is the
     # liveness evidence — `stage-2-review-gate.md`, "Launch check"), and `decide` refuses an absent verdict
     # only once the pass is COMPLETE, so an in-process caller still gets `incomplete` rather than a scolding.
-    v.add_argument("--verdict", choices=VERDICTS, required=True,
-                   help="REQUIRED: the VERDICT line you read in the reviewer's report. It buys ONE "
-                        "machine-checked rule, an IF AND ONLY IF: the pass is UNUSABLE if `not-satisfied` "
-                        "recorded NO gating finding (a verdict that blocks a PR must name what blocks it), "
-                        "and equally UNUSABLE if `satisfied` recorded ONE (a finding that gates cannot be "
-                        "waved through in the verdict). A pass verified without it is UNUSABLE too — a rule "
-                        "a caller can switch off by omitting a flag is not a gate")
+    v.add_argument("--verdict", choices=VERDICT_CHOICES, required=True,
+                   help="REQUIRED: the VERDICT line you read in the reviewer's report. `satisfied` / "
+                        "`not-satisfied` is the reviewer's BINARY verdict, and it buys ONE machine-checked "
+                        "rule, an IF AND ONLY IF: the pass is UNUSABLE if `not-satisfied` recorded NO gating "
+                        "finding (a verdict that blocks a PR must name what blocks it), and equally UNUSABLE "
+                        "if `satisfied` recorded ONE (a finding that gates cannot be waved through in the "
+                        "verdict). `deferred` when the report's terminal line is `VERDICT: DEFERRED` — the "
+                        "reviewer raised a separate request (an amendment, or a broken-dispatch stop) INSTEAD "
+                        "of a verdict; the tool then reads the progress file and returns amended / incomplete "
+                        "/ unusable. A pass verified without any of these is UNUSABLE too — a rule a caller "
+                        "can switch off by omitting a flag is not a gate")
 
     # status is ADVISORY and READ-ONLY: it renders live progress and DECIDES NOTHING. Its flags are all
     # about the VIEW, never about a verdict — there is no `--head-sha`, no `--verdict`, and it writes no file.


### PR DESCRIPTION
- a pass that raised a request (amendment / broken-dispatch stop) ends `VERDICT: DEFERRED`, not a forced binary verdict
- `verify` takes a third `--verdict deferred` (still required); routes on the progress file, never tallied
- ledger verdict stays binary; bump 0.1.5 → 0.1.6
