### PR TITLE
de-shell the required-set base ref reads

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -902,6 +902,14 @@ and `unknown` can never go green: **`GET /repos/{o}/{r}/branches/{b}` needs `Con
 "Get rules for a branch"). **BOTH are mandatory** — neither can see what the other sees:
 
 ```sh
+# The base branch name is UNTRUSTED — a git ref may legally contain shell metacharacters ($(), backticks,
+# quotes), and it originates in a PR's `baseRefName`. Capture it ONCE into a shell variable — command
+# substitution OUTPUT is never re-parsed — and reference it double-quoted as "$base" inside the URL. NEVER
+# splice a raw <base> into the command string, where a branch named `main$(…)` would EXECUTE at parse time.
+# (`<owner>`/`<repo>` are this repo's OWN slug, not PR-supplied.) The jq filters below are unchanged, and
+# `ci-snapshot.py` still extracts them verbatim — only the URL's base ref moved out of shell reach.
+base=$(python3 <skill>/scripts/ledger.py --file <rundir>/state.jsonl header get base_branch)
+
 # (a) CLASSIC branch protection — AND the field that disambiguates its absence. Needs `Contents: read`
 #     (NOT Metadata — on a private repo a Metadata-only token 404s here and the required set reads
 #     `unknown`, which can never go green).
@@ -910,7 +918,7 @@ and `unknown` can never go green: **`GET /repos/{o}/{r}/branches/{b}` needs `Con
 #     is the same set WITHOUT it, and is deprecated — read `.checks[]`, never `.contexts`.
 #     `.app_id` is NULLABLE — the DEFAULT GOES BEFORE `tostring` (FETCH above owns that rule; get it
 #     backwards and every unbound required check binds to an app named "null" and can NEVER be matched).
-gh api "repos/<owner>/<repo>/branches/<base>" --jq '
+gh api "repos/<owner>/<repo>/branches/$base" --jq '
   {classic_enabled: (.protection.enabled // false),
    checks: [(.protection.required_status_checks.checks // [])[]
             | {context: .context, app: ((.app_id // "-") | tostring)}]}'
@@ -924,7 +932,7 @@ gh api "repos/<owner>/<repo>/branches/<base>" --jq '
 #     That is the exact false green this whole section exists to close, reintroduced by a missing flag.
 #     `--slurp` hands jq ONE array OF PAGES (and is mutually exclusive with gh's own `--jq`, hence the
 #     pipe) — so the filter flattens with `.[][]`: pages, then rules.
-gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/<base>" | jq -c '
+gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/$base" | jq -c '
   [.[][] | select(.type=="required_status_checks")
          | .parameters.required_status_checks[]
          | {context: .context, app: ((.integration_id // "-") | tostring)}]'

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -1149,9 +1149,12 @@ READS = {
     # bare `gh pr view <pr>` resolves the PR in the CURRENT CHECKOUT, so the command asks whichever repo the
     # reader is standing in — the only one of the five reads that could not say what it was about.
     "rollup": "gh pr view <pr> --repo <owner>/<repo> --json statusCheckRollup,headRefOid | jq -c '",
-    # The TWO required-set reads (WHAT WERE WE EXPECTING TO SEE?).
-    "classic": 'gh api "repos/<owner>/<repo>/branches/<base>" --jq \'',
-    "ruleset": 'gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/<base>" | jq -c \'',
+    # The TWO required-set reads (WHAT WERE WE EXPECTING TO SEE?). The base ref rides in as the shell var
+    # `$base` (captured in stage-2-ci.md, never spliced raw — a branch name is untrusted), so the opener
+    # ends `.../branches/$base" --jq '` verbatim; only the URL changed, the jq filter is still delimited by
+    # the trailing single quote exactly as before.
+    "classic": 'gh api "repos/<owner>/<repo>/branches/$base" --jq \'',
+    "ruleset": 'gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/$base" | jq -c \'',
 }
 
 # `gh api --paginate --slurp` hands jq ONE ARRAY OF PAGES. `jq -s` over N recorded page files builds exactly


### PR DESCRIPTION
- the required-set reads spliced an untrusted base branch name into a gh api shell command
- capture the base into a shell var and reference it double-quoted; a malicious name no longer executes
- update the two ci-snapshot.py extractor anchors; ci-snapshot self-test stays green
