### PR TITLE
extract shared gauntlet table rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: |
           set -o pipefail
           npx --yes pyright@1.1.410 --outputjson \
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py \
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py \
             plugins/gauntlet/skills/campaign/scripts/ledger.py \
             plugins/gauntlet/skills/campaign/scripts/ledger-test.py \
             plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py \
@@ -91,8 +93,8 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/followups-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "10" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 10 it was pointed at — it checked" \
+          if [ "${analyzed}" != "12" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 12 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -122,12 +124,9 @@ jobs:
       - name: CI-status derivation contract (+ stage-2-ci.md agrees with the code)
         run: python3 plugins/gauntlet/skills/campaign/scripts/ci-status.py self-test
 
-      # The ledger's contract, executed — same reason, one file over. `escape_cell` is security-shaped: it
-      # is what stops a PR title from forging a column, a row, or a run-config line in the `table` view, and
-      # a sanitizer verified by eye is a sanitizer verified by NOTHING. The fixtures assert the escaping is
-      # INJECTIVE (two values that differ can never print as one cell) and re-parse the printed grid back to
-      # its declared columns and widths — mechanically, never by looking at it. Weaken any escape and one of
-      # them goes red.
+      # The ledger's contract, executed — including the shared table renderer it imports. `escape_cell` is
+      # security-shaped: it stops a PR title from forging a column, row, or run-config line. The fixtures
+      # assert injective escaping and re-parse the printed grid back to its declared columns and widths.
       - name: Ledger contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/ledger.py self-test
 
@@ -155,7 +154,7 @@ jobs:
       # elsewhere (a merged PR, an issue), never when work merely starts, or a PR that dies would take the
       # follow-up down with it; and the lock is what stops two concurrent runs from silently dropping an
       # entry that NOTHING can rebuild. Weaken any of them and a fixture goes red. It renders through the
-      # ledger's escaping and is checked by the ledger's own grid oracle, so a hostile PR title cannot
+      # shared table package and is checked by the ledger test's grid oracle, so a hostile PR title cannot
       # forge a column here either.
       #
       # The fixtures themselves live in the sibling `followups-test.py`, which `self-test` loads by path.

--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -504,10 +504,11 @@ human*, and the formatting is lossy in four ways:
   extra column, an extra row, a run-config line, the empty-ledger marker — or, carrying whitespace at its
   edges, be eaten by the column padding and come out looking like a DIFFERENT value. So `table`
   backslash-escapes before printing: the escaped text is what you see, the raw value is what is stored.
-  **`escape_cell()` in `scripts/ledger.py` owns which characters are escaped and how, and its `self-test`
-  fixtures pin it** — that function is the definition, and this page deliberately does not restate it (a
-  list here goes stale the moment one is added). What you may rely on: the rendering is **injective** — two
-  different values NEVER print as the same cell, so one row can never be read as another — and it reserves
+  **`escape_cell()` in `scripts/_gauntlet/table.py` owns which characters are escaped and how, and the
+  `ledger.py self-test` fixtures pin it** — that function is the definition, and this page deliberately
+  does not restate it (a list here goes stale the moment one is added). What you may rely on: the rendering
+  is **injective** — two different values NEVER print as the same cell, so one row can never be read as
+  another — and it reserves
   the leading-`#` namespace for **every** out-of-band line the table prints (the `# <field>: …` run-config
   block, the empty-grid markers, the hidden-count line), so **no row can ever forge one**. That is what
   makes the omission notice trustworthy, and it is why an empty grid always **says which empty it is** —

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
@@ -1,0 +1,1 @@
+"""Private shared implementation for Gauntlet campaign scripts."""

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
@@ -1,0 +1,114 @@
+"""Shared rendering for human-readable Gauntlet state tables."""
+
+from __future__ import annotations
+
+
+def _hex_escape(ch: str) -> str:
+    """``\\xNN`` for a byte-sized code point, ``\\uNNNN`` above it."""
+    return f"\\x{ord(ch):02x}" if ord(ch) < 0x100 else f"\\u{ord(ch):04x}"
+
+
+def escape_cell(value: str) -> str:
+    r"""Make a value safe to render inside the grid — no value may forge the layout, and no two
+    values may render THE SAME.
+
+    A field value is free text, so it can contain the very characters the table's layout is built from.
+    Rendered raw, a value carrying a ``|`` fabricates extra columns, a newline fabricates extra ROWS, and
+    a leading ``#`` mimics the out-of-band lines printed around the grid. The table would then say
+    something its store never did.
+
+    ESCAPING, not quoting: quoting every cell would widen every column by two chars for the common
+    (harmless) case and STILL need an escape for an embedded quote. Backslash escapes leave every ordinary
+    value byte-identical and give the invariant outright: the returned string contains no BARE ``|``, no
+    line break, no control character, and never starts with ``#``. Each escape is unambiguous because a
+    literal backslash is doubled. The display stays reversible by eye, but it is still a DISPLAY form;
+    callers read stored values through their schema-owning accessor, never by parsing the table.
+
+    WHITESPACE IS ESCAPED AT THE EDGES. The layout pads each cell with ``ljust()`` and then ``rstrip()``s
+    the line, and BOTH eat trailing whitespace: left raw, ``""`` and ``"   "`` print the same blank cell,
+    while ``"a"`` and ``"a "`` both print ``a``. A leading or trailing whitespace run is escaped and
+    survives display. Interior spaces stay unchanged so ordinary prose remains readable.
+
+    Whitespace that is NOT a plain space is escaped WHEREVER it appears: it is invisible or line-break-ish,
+    and ``str.rstrip()`` eats it. The escaped text therefore never starts or ends with whitespace and holds
+    no whitespace but a plain interior space. Callers MUST escape BEFORE computing column widths, so the
+    widths measure what is actually printed. Display-only truncation must happen on the raw value first.
+    """
+    # Use the same whitespace definition as the layout's `rstrip()`, so every character the layout would
+    # otherwise eat receives an escape spelling first.
+    lead = len(value) - len(value.lstrip())
+    trail = len(value.rstrip())
+    out = []
+    for i, ch in enumerate(value):
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == "|":
+            out.append("\\|")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append(f"\\x{ord(ch):02x}")  # any other control char
+        elif ch.isspace() and ch != " ":
+            out.append(_hex_escape(ch))  # NBSP, NEL, U+2028, ideographic space, and other invisible space
+        elif ch == " " and (i < lead or i >= trail):
+            out.append("\\x20")  # leading or trailing space: grid padding would swallow it
+        else:
+            out.append(ch)
+    text = "".join(out)
+    # One value has one rendering regardless of which column it occupies. Only a first-column cell can
+    # open a line, but escape a leading `#` in every cell rather than making position part of the encoding.
+    if text.startswith("#"):
+        text = "\\" + text
+    return text
+
+
+def hidden_notice(n: int, hidden: tuple[str, ...]) -> str:
+    """The line that makes a filtered table's omitted rows explicit.
+
+    A filtered view that does not say what it hid is a lie by omission. The count and the flag that reveals
+    every row are always present. The wording is derived from the caller's hidden-state set, so a store
+    cannot change that set while leaving a stale description beside it.
+    """
+    what = "/".join(hidden)
+    return f"# {n} {what} row{'' if n == 1 else 's'} hidden — pass --all to show every row"
+
+
+def config_lines(pairs: list[tuple[str, str]]) -> list[str]:
+    """The escaped ``# <name>: <value>`` block printed above a grid.
+
+    The ``#`` prefix and the blank line callers print after the block keep these lines from reading as
+    table columns. Values are free text, so they are escaped on the same terms as cells: an unescaped
+    newline here would inject lines that look like part of the grid.
+    """
+    return [f"# {name}: {escape_cell(value)}" for name, value in pairs]
+
+
+def grid_lines(fields: tuple[str, ...], rows: list[list[str]]) -> list[str]:
+    """Render raw values as an aligned grid: column header, rule, then one line per row.
+
+    The layout is owned here once for every table the campaign scripts print. A second copy of the
+    separator, width arithmetic, and ``rstrip()`` would be a second definition of the syntax
+    ``escape_cell()`` protects.
+
+    Cells arrive RAW and are escaped here, so a caller cannot render an unescaped value by forgetting to.
+    Widths are measured on the escaped text. Display-only truncation is the caller's job and must happen on
+    the raw value before it is handed over, so a cut cannot land inside an escape sequence.
+    """
+    cells = [tuple(escape_cell(value) for value in row) for row in rows]
+    widths = [
+        max(len(field), *(len(cell[i]) for cell in cells)) if cells else len(field)
+        for i, field in enumerate(fields)
+    ]
+    out = [
+        " | ".join(field.ljust(width) for field, width in zip(fields, widths)).rstrip(),
+        "-+-".join("-" * width for width in widths),
+    ]
+    out += [
+        " | ".join(value.ljust(width) for value, width in zip(cell, widths)).rstrip()
+        for cell in cells
+    ]
+    return out

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -8,9 +8,8 @@ EVERY FIXTURE MUST PIN A RULE — it must go red if its rule is deleted or weake
 still pass with its rule gone tests nothing and manufactures false confidence.
 
 The rendering fixtures lean on the LEDGER's oracle (`ledger-test.py`'s `grid`) and its hostile corpus on
-purpose: the store prints through the ledger's `escape_cell()`/`grid_lines()`, so it must be checked by the
-same parser that checks the ledger — a second, weaker copy of the oracle would be free to bless output the
-real one rejects.
+purpose: both stores print through the shared table renderer, so both must be checked by the same parser.
+A second, weaker copy of the oracle would be free to bless output the real one rejects.
 """
 
 from __future__ import annotations
@@ -27,14 +26,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import ledger  # noqa: E402
-from ledger import escape_cell, hidden_notice  # noqa: E402
+from _gauntlet.table import escape_cell, hidden_notice  # noqa: E402
 
 # The ledger's test ORACLE — `grid`, `notices`, `check`, `SelfTestFailure`, and the hostile corpus — lives
 # in the ledger's SIBLING suite, `ledger-test.py`, loaded BY PATH (its name is not a legal module name).
-# The follow-up store prints through the ledger's `escape_cell()`/`grid_lines()`, so its output MUST be
-# parsed back by the ledger's OWN oracle — not a friendlier copy, which would be free to bless what the
-# real one rejects. `grid` takes the store's own config-field names and markers; the ledger module is
-# handed in as `L` only for the fixed grid syntax it shares with every store.
+# The follow-up store and ledger print through the same renderer, so follow-up output MUST be parsed back
+# by the ledger test's oracle — not a friendlier copy. `grid` takes the store's config-field names and
+# markers; the ledger module is handed in as `L` for the compatibility exports used by that oracle.
 _ledger_test_path = Path(__file__).resolve().parent / "ledger-test.py"
 _spec = importlib.util.spec_from_file_location("ledger_test", _ledger_test_path)
 if _spec is None or _spec.loader is None:  # a broken install — never an input error
@@ -1283,7 +1281,7 @@ def t_table_grid_integrity(tmp: Path) -> None:
 
     A follow-up's `title` and `evidence` are free text written from a REVIEWER'S OUTPUT. Rendered raw, one
     carrying a `|` fabricates a column, a newline fabricates an entry, a leading `#` fabricates the rule
-    line or the omission notice. This store prints through the ledger's `escape_cell()`/`grid_lines()`, and
+    line or the omission notice. This store prints through the shared `escape_cell()`/`grid_lines()`, and
     it is checked by the LEDGER'S OWN ORACLE — the same parser, not a friendlier copy of it.
 
     A BLANK hostile (`''`, `'   '`) is put in NO column at all, and that is not a gap: no column of this

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -85,15 +85,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
-DESCRIPTION = "Schema-owning accessor for the follow-up ledger (.gauntlet/followups.jsonl)."
+# The grid is NOT reimplemented here. The private campaign package owns escaping, layout, and omission
+# notices; this file owns only the follow-up schema, lifecycle, and store lifetime.
+from _gauntlet.table import config_lines, grid_lines, hidden_notice
 
-# The grid is NOT reimplemented here. `escape_cell()` is what stops a value from forging a column, a row,
-# or an out-of-band line — and a second copy of it would be a second definition of the same guarantee,
-# free to rot away from the one the fixtures pin. So the escaping, the layout and the omission notice are
-# IMPORTED from the ledger, which owns them; this file owns only what is its own: the schema, the
-# lifecycle, and the store's lifetime.
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-from ledger import config_lines, grid_lines, hidden_notice  # noqa: E402
+DESCRIPTION = "Schema-owning accessor for the follow-up ledger (.gauntlet/followups.jsonl)."
 
 # --- the ACT conditions (owned here, once) ------------------------------------
 #

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -21,6 +21,12 @@ import tempfile
 from pathlib import Path
 from typing import NoReturn
 
+from _gauntlet.table import config_lines, escape_cell as _shared_escape_cell, grid_lines
+from _gauntlet.table import hidden_notice as _shared_hidden_notice
+
+# Compatibility export for existing test and script consumers. New consumers import `_gauntlet.table`.
+escape_cell = _shared_escape_cell
+
 DESCRIPTION = "Schema-owning accessor for the campaign ledger (state.jsonl)."
 
 HERE = Path(__file__).resolve().parent
@@ -727,137 +733,9 @@ TABLE_ALL_HIDDEN_MARKER = "# (no rows shown — the ledger is NOT empty; every r
 TABLE_HIDDEN_STATUSES = ("merged",)
 
 
-def _hex_escape(ch: str) -> str:
-    """`\\xNN` for a byte-sized code point, `\\uNNNN` above it — the same spelling Python's own repr uses."""
-    return f"\\x{ord(ch):02x}" if ord(ch) < 0x100 else f"\\u{ord(ch):04x}"
-
-
-def escape_cell(value: str) -> str:
-    r"""Make a value safe to render inside the grid — no value may forge the layout, and no two
-    values may render THE SAME.
-
-    A field value is free text (`slug` is a PR title; `ci`-style reason fields hold
-    prose), so it can contain the very characters the table's layout is built from.
-    Rendered raw, a value carrying a `|` fabricates extra columns, a newline
-    fabricates extra ROWS, and a leading `# ` mimics the run-config header lines
-    printed above the grid. The table would then say something the ledger never did.
-
-    ESCAPING, not quoting: quoting every cell would widen every column by two chars
-    for the common (harmless) case and STILL need an escape for an embedded quote —
-    so it buys nothing. Backslash escapes leave every ordinary value byte-identical
-    and give the invariant outright: the returned string contains no BARE `|` (every
-    one is escaped to `\|`, and a `|` preceded by a backslash can never spell the
-    ` | ` column separator), no line break, no control character, and never starts
-    with `#`. Each escape is
-    unambiguous (a literal backslash is doubled), so the display stays reversible by
-    eye — but it is still a DISPLAY form. Read values back with `get --field`, never
-    by parsing this table.
-
-    WHITESPACE IS ESCAPED AT THE EDGES, and that is not cosmetic — it is what makes the
-    escaping INJECTIVE ONCE PRINTED. The layout pads each cell with `ljust()` and then
-    `rstrip()`s the line, and BOTH of those EAT trailing whitespace: with it left raw,
-    `""` and `"   "` printed the same blank cell and `"a"` and `"a "` printed the same
-    `a`. The sanitizer was injective and the RENDERING was not — which is the same lie,
-    one layer down. So a leading or trailing whitespace run is escaped (`\x20` for a
-    space) and it survives display. INTERIOR spaces are left alone: escaping them would
-    turn every PR title into `add\x20a\x20table`, and nothing eats them.
-
-    Whitespace that is NOT a plain space is escaped WHEREVER it appears: it is invisible
-    or line-break-ish, `str.rstrip()` eats every bit of it (NBSP and NEL included, not
-    just ASCII), and nothing ordinary contains it. So the guarantee is flat: the escaped
-    text NEVER starts or ends with whitespace, and holds no whitespace but the plain
-    interior space — which is exactly what lets the printed cell be read back off the
-    line by stripping its padding (see `grid()` in the self-test).
-
-    Callers MUST escape BEFORE computing column widths, so the widths measure what is
-    actually printed. (Truncation of `head_sha` happens first, on the raw value, so a
-    cut can never land inside an escape sequence.)
-    """
-    # The RAW value's whitespace edges — `lstrip`/`rstrip` here use exactly the definition of
-    # whitespace that `cmd_table`'s `rstrip()` will apply to the printed line, so what is escaped is
-    # precisely what the layout would otherwise eat.
-    lead = len(value) - len(value.lstrip())
-    trail = len(value.rstrip())  # index where the trailing whitespace run starts
-    out = []
-    for i, ch in enumerate(value):
-        if ch == "\\":
-            out.append("\\\\")
-        elif ch == "|":
-            out.append("\\|")
-        elif ch == "\n":
-            out.append("\\n")
-        elif ch == "\r":
-            out.append("\\r")
-        elif ch == "\t":
-            out.append("\\t")
-        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
-            out.append(f"\\x{ord(ch):02x}")  # any other control char
-        elif ch.isspace() and ch != " ":
-            out.append(_hex_escape(ch))  # NBSP, NEL, U+2028, ideographic space…: invisible, and rstrip() eats it
-        elif ch == " " and (i < lead or i >= trail):
-            out.append("\\x20")  # a LEADING or TRAILING space: the padding would swallow it
-        else:
-            out.append(ch)
-    text = "".join(out)
-    # Only a FIRST-column cell can open a line, but escape a leading '#' in every
-    # cell regardless: one value then has one rendering, whatever column it lands in.
-    # (A leading whitespace run is already escaped above, so a '#' here can only be the
-    # value's own first character.)
-    if text.startswith("#"):
-        text = "\\" + text
-    return text
-
-
 def hidden_notice(n: int, hidden: "tuple[str, ...]" = TABLE_HIDDEN_STATUSES) -> str:
-    """The line that makes the omission LOUD — printed whenever the default view drops a row.
-
-    A FILTERED VIEW THAT DOES NOT SAY WHAT IT HID IS A LIE BY OMISSION, and it is the same lie as a
-    truncated `gh pr list` reporting 30 of 200 PRs without a word: nothing is fabricated, the reader is
-    simply never told that what they are looking at is a SUBSET. So the count is stated, and so is the flag
-    that reveals the rest — a reader can always get from the filtered view to the whole ledger without
-    knowing this file exists.
-
-    The wording is DERIVED from the set of hidden states, never spelled beside it: change what the default
-    hides and this line follows by construction, instead of becoming a stale restatement of the rule it
-    is supposed to summarise. `hidden` defaults to this store's own `TABLE_HIDDEN_STATUSES`; the sibling
-    store (`followups.py`) passes ITS set and gets the same derivation, so neither can drift.
-    """
-    what = "/".join(hidden)
-    return f"# {n} {what} row{'' if n == 1 else 's'} hidden — pass --all to show every row"
-
-
-def config_lines(pairs: "list[tuple[str, str]]") -> "list[str]":
-    """The `# <name>: <value>` block printed ABOVE a grid.
-
-    The `#` prefix and the blank line after the block are what keep these lines from reading as table
-    columns — and the values are free text, so they are escaped on exactly the same terms as a cell: an
-    un-escaped newline here would inject lines that read as part of the grid. Shared with `followups.py`
-    so the reserved `#` namespace has ONE definition, not one per store.
-    """
-    return [f"# {name}: {escape_cell(value)}" for name, value in pairs]
-
-
-def grid_lines(fields: "tuple[str, ...]", rows: "list[list[str]]") -> "list[str]":
-    """Render RAW cell values as the aligned grid: column-header line, rule line, then one line per row.
-
-    THE LAYOUT IS OWNED HERE, ONCE, for every table the campaign's scripts print (`followups.py` renders
-    through this function too). A second copy of the ` | ` separator, the width arithmetic and the
-    `rstrip()` would be a second definition of the very syntax `escape_cell()` exists to protect — and the
-    day one copy changed, its store's escaping would still be defending the OTHER one's grid.
-
-    Cells arrive RAW and are escaped here (`escape_cell()` owns HOW), so a caller can never render an
-    unescaped value by forgetting to. Widths are measured on the ESCAPED text — i.e. on exactly the bytes
-    that get printed; measure the raw value and every escape makes its cell wider than the column reserved
-    for it. Any display-only truncation is the CALLER's job and must happen on the raw value BEFORE it is
-    handed over, so a cut can never land inside an escape sequence.
-    """
-    cells = [tuple(escape_cell(v) for v in row) for row in rows]
-    widths = [max(len(f), *(len(c[i]) for c in cells)) if cells else len(f)
-              for i, f in enumerate(fields)]
-    out = [" | ".join(f.ljust(w) for f, w in zip(fields, widths)).rstrip(),
-           "-+-".join("-" * w for w in widths)]
-    out += [" | ".join(v.ljust(w) for v, w in zip(c, widths)).rstrip() for c in cells]
-    return out
+    """Keep the ledger's default hidden set while delegating shared rendering."""
+    return _shared_hidden_notice(n, hidden)
 
 
 def cmd_table(path: Path, args) -> int:


### PR DESCRIPTION
- move campaign table rendering into the private `_gauntlet` package
- keep ledger compatibility exports and switch follow-ups to direct imports
- extend Pyright coverage and bump both plugin manifests to 0.1.7
