### PR TITLE
bump gauntlet to 0.2.0

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- bump both gauntlet manifests (.claude-plugin + .codex-plugin) 0.1.6 -> 0.2.0
- release cuts in Codex dual-host support (#58) plus the campaign fixes #61/#62/#63/#64
- refreshes the installed plugin cache so the merged content takes effect
