### PR TITLE
add gauntlet ledger and follow-up skills

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",
@@ -21,7 +21,9 @@
     "defaultPrompt": [
       "Review this change with Gauntlet.",
       "Gate these pull requests through review and CI.",
-      "Address Copilot review comments on this pull request."
+      "Address Copilot review comments on this pull request.",
+      "Show the current Gauntlet campaign ledger.",
+      "Show the durable Gauntlet follow-up queue."
     ]
   }
 }

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -44,6 +44,8 @@ Start a new Codex session after installation.
 | [`gauntlet:campaign`](skills/campaign/README.md) | The PR-gating pipeline. Adopts existing pull requests and drives each through review + CI to merge. |
 | [`gauntlet:review`](skills/review/README.md) | A standalone two-pass hostile review: pass 1 surfaces everything, pass 2 neutrally confirms or refutes each finding. Reports only by default; can opt-in to open PRs and hand them to a campaign. |
 | [`gauntlet:copilot-address-reviews`](skills/copilot-address-reviews/README.md) | Verify and address GitHub Copilot's PR review comments, one at a time. |
+| [`gauntlet:ledger`](skills/ledger/SKILL.md) | Show one campaign run's ledger as the script-owned read-only table. |
+| [`gauntlet:followups`](skills/followups/SKILL.md) | Show the durable follow-up queue as the script-owned read-only table. |
 
 ## Requirements
 
@@ -86,7 +88,7 @@ sample to copy into your `AGENTS.md` or `CLAUDE.md` and edit.
 
 ## Scratch files
 
-Both skills keep working state under `.gauntlet/` at the repo root, which is git-ignored. Run scratch
+Gauntlet keeps working state under `.gauntlet/` at the repo root, which is git-ignored. Run scratch
 lives in `.gauntlet/tmp/` and is mostly safe to delete — a just-finished run's dir is kept so campaign
 can still offer to gate more PRs, but deleting it only loses that prompt, not your history.
 Everything else under `.gauntlet/` is durable, so don't remove `.gauntlet/` wholesale: `history/` holds

--- a/plugins/gauntlet/skills/followups/SKILL.md
+++ b/plugins/gauntlet/skills/followups/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: followups
+description: Show Gauntlet's durable follow-up queue through its existing read-only table command. Use when the user asks to list or inspect Gauntlet follow-ups, deferred work candidates, or hidden and rejected follow-up entries.
+---
+
+# Follow-ups
+
+Invocation: Claude Code `/gauntlet:followups`; Codex `$gauntlet:followups`.
+
+1. Resolve repository root to an absolute path from the user-supplied checkout or current repository.
+2. Resolve `../campaign/scripts/followups.py` from this active `SKILL.md` to an absolute path. NEVER use a
+   plugin-root environment variable.
+3. Select `<repo>/.gauntlet/followups.jsonl`. Do not create it; the script handles a missing store.
+4. Run this argument vector with absolute paths:
+
+   ```text
+   ["python3", "<absolute-followups.py>", "--file", "<absolute-followups.jsonl>", "table"]
+   ```
+
+5. Append `"--all"` only when user asks for hidden, rejected, closed, or all entries.
+6. Print script stdout as-is. On failure, relay stderr as-is and stop.
+
+Read-only. NEVER create, edit, parse, summarize, or reformat follow-up data or table output.

--- a/plugins/gauntlet/skills/followups/agents/openai.yaml
+++ b/plugins/gauntlet/skills/followups/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gauntlet Follow-ups"
+  short_description: "Show the durable follow-up queue"
+  default_prompt: "Use $gauntlet:followups to show the current follow-up queue."

--- a/plugins/gauntlet/skills/ledger/SKILL.md
+++ b/plugins/gauntlet/skills/ledger/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: ledger
+description: Show a Gauntlet campaign ledger through its existing read-only table command. Use when the user asks for campaign status, a campaign ledger, PR state for a named or current campaign run, or hidden and merged campaign entries.
+---
+
+# Ledger
+
+Invocation: Claude Code `/gauntlet:ledger`; Codex `$gauntlet:ledger`.
+
+1. Resolve repository root to an absolute path from the user-supplied checkout or current repository.
+2. Resolve `../campaign/scripts/ledger.py` from this active `SKILL.md` to an absolute path. NEVER use a
+   plugin-root environment variable.
+3. Select state file:
+   - User named a run, or current campaign context supplies one → use that run's
+     `<repo>/.gauntlet/tmp/<run-id>/state.jsonl`.
+   - No run is known → enumerate `<repo>/.gauntlet/tmp/*/state.jsonl` without reading the files.
+   - Exactly one match → use it.
+   - No matches → report that no campaign ledger exists.
+   - Multiple matches → list run directory names and ask user to choose. NEVER guess by age or contents.
+4. Run this argument vector with absolute paths:
+
+   ```text
+   ["python3", "<absolute-ledger.py>", "--file", "<absolute-state.jsonl>", "table"]
+   ```
+
+5. Append `"--all"` only when user asks for hidden, merged, closed, or all entries.
+6. Print script stdout as-is. On failure, relay stderr as-is and stop.
+
+Read-only. NEVER create, edit, parse, summarize, or reformat ledger data or table output.

--- a/plugins/gauntlet/skills/ledger/agents/openai.yaml
+++ b/plugins/gauntlet/skills/ledger/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gauntlet Ledger"
+  short_description: "Show a campaign ledger table"
+  default_prompt: "Use $gauntlet:ledger to show the current campaign ledger."


### PR DESCRIPTION
- add read-only skills for campaign ledger and follow-up tables
- delegate all rendering to the existing campaign scripts
- expose both skills in Gauntlet plugin metadata and docs
