### PR TITLE
require explicit version bump requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,9 @@ generalised; the author did not.** That is a defect in how the work was done, no
 
 ## Version is the plugin cache key
 
-`plugin.json`'s `version` decides whether an installed copy refreshes. Changing skill content **without**
-bumping it means installed copies stay stale at the old content while claiming to be current — this has
-already happened once across several releases. Bump the version in the same PR as any `plugins/**`
-content change, or in a release PR that batches several.
+`plugin.json`'s `version` decides whether an installed copy refreshes.
+
+**NEVER change a plugin version unless the user explicitly asks for that version bump.** Ordinary
+`plugins/**` changes leave both manifest versions unchanged. When the user does request a bump, update
+the Claude Code and Codex manifests together. A release PR may batch several plugin changes under one
+user-approved bump.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -43,4 +43,5 @@ Campaign's exact cross-agent command lines live in
 - `scripts/validate-plugins.sh` resolves every path a manifest declares (e.g. Codex `skills`) against
   its plugin root and rejects any that is missing or escapes the root, then proves both isolated
   installs yield identical skill content. Keep declared paths pointing at real in-tree directories.
-- Bump both plugin manifest versions after changing `plugins/**`.
+- NEVER change plugin manifest versions unless the user explicitly asks for a version bump. When asked,
+  update both host manifests together.


### PR DESCRIPTION
- require an explicit user request before changing plugin versions
- keep both plugin manifest versions paired when requested
