### PR TITLE
share in-process CLI test capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py \
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py \
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py \
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py \
             plugins/gauntlet/skills/campaign/scripts/ledger.py \
             plugins/gauntlet/skills/campaign/scripts/ledger-test.py \
             plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py \
@@ -96,8 +97,8 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/followups-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "15" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 15 it was pointed at — it checked" \
+          if [ "${analyzed}" != "16" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 16 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -1,0 +1,22 @@
+"""Narrow helpers shared by Gauntlet's in-process CLI tests."""
+
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from typing import Callable
+
+
+def capture_cli(main: "Callable[[list[str]], int]", argv: "list[str]") -> "tuple[int, str, str]":
+    """Run ``main`` in-process and return its exit code, stdout, and stderr.
+
+    Integer ``SystemExit`` codes are preserved. Non-integer codes match command-line failure behavior by
+    becoming exit code 1.
+    """
+    out, err = StringIO(), StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(argv)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    return code, out.getvalue(), err.getvalue()

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -16,17 +16,16 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import io
 import json
 import re
 import sys
 import tempfile
-from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import ledger  # noqa: E402
 from _gauntlet.table import escape_cell, hidden_notice  # noqa: E402
+from _gauntlet.testing import capture_cli  # noqa: E402
 
 # The ledger's test ORACLE — `grid`, `notices`, `check`, `SelfTestFailure`, and the hostile corpus — lives
 # in the ledger's SIBLING suite, `ledger-test.py`, loaded BY PATH (its name is not a legal module name).
@@ -56,13 +55,7 @@ from followups import (  # noqa: E402
 
 def run(argv: "list[str]") -> "tuple[int, str, str]":
     """Drive the REAL CLI in-process and capture (exit code, stdout, stderr)."""
-    out, err = io.StringIO(), io.StringIO()
-    try:
-        with redirect_stdout(out), redirect_stderr(err):
-            code = followups.main(argv)
-    except SystemExit as exc:  # fail() -> 1; argparse -> 2
-        code = exc.code if isinstance(exc.code, int) else 1
-    return code, out.getvalue(), err.getvalue()
+    return capture_cli(followups.main, argv)
 
 
 def entry_line(**over: object) -> str:

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -36,14 +36,14 @@ What the fixtures are aimed at, in two families:
 from __future__ import annotations
 
 import importlib.util
-import io
 import json
 import os
 import sys
 import tempfile
-from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import ModuleType
+
+from _gauntlet.testing import capture_cli
 
 HERE = Path(__file__).resolve().parent
 LEDGER_PY = HERE / "ledger.py"
@@ -142,13 +142,7 @@ def cli(L: ModuleType, argv: "list[str]") -> "tuple[int, str, str]":
     wiring (the `--fields` rejection, the dash/underscore aliases, the ABSENCE of a `--review-rounds` flag,
     `fail()`'s exit 1) is under test too.
     """
-    out, err = io.StringIO(), io.StringIO()
-    try:
-        with redirect_stdout(out), redirect_stderr(err):
-            code = L.main(argv)
-    except SystemExit as exc:  # fail() -> 1; argparse -> 2
-        code = exc.code if isinstance(exc.code, int) else 1
-    return code, out.getvalue(), err.getvalue()
+    return capture_cli(L.main, argv)
 
 
 def write_lines(path: Path, *lines: str) -> Path:

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -10,13 +10,12 @@ rewrite a PR belonging to someone else, and repair forever.
 
 from __future__ import annotations
 
-import io
 import json
 import sys
-from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
 
 OWNER = Path(__file__).resolve().parent / "repair-pass.py"
 
@@ -41,13 +40,7 @@ def check(cond: bool, msg: str) -> None:
 
 def ledger_cli(argv: "list[str]") -> "tuple[int, str, str]":
     """Drive the LEDGER's real CLI in-process — the guard and the row reads live there, not here."""
-    out, err = io.StringIO(), io.StringIO()
-    try:
-        with redirect_stdout(out), redirect_stderr(err):
-            code = L.main(argv)
-    except SystemExit as exc:
-        code = exc.code if isinstance(exc.code, int) else 1
-    return code, out.getvalue(), err.getvalue()
+    return capture_cli(L.main, argv)
 
 
 def setup(tmp: Path, name: str = "state.jsonl", **row) -> "tuple[Path, Path]":

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -37,16 +37,15 @@ Three refusals this tool exists to make, all of them things a well-meaning drive
 from __future__ import annotations
 
 import argparse
-import io
 import json
 import sys
 import tempfile
-from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
 
 DESCRIPTION = "Record the reassessment pass's decision for a PR that has stopped converging."
 
@@ -245,13 +244,7 @@ def check(cond: bool, msg: str) -> None:
 
 def run(argv: "list[str]") -> "tuple[int, str, str]":
     """Drive the REAL CLI in-process and capture (exit code, stdout, stderr)."""
-    out, err = io.StringIO(), io.StringIO()
-    try:
-        with redirect_stdout(out), redirect_stderr(err):
-            code = main(argv)
-    except SystemExit as exc:  # fail() -> 1; argparse -> 2
-        code = exc.code if isinstance(exc.code, int) else 1
-    return code, out.getvalue(), err.getvalue()
+    return capture_cli(main, argv)
 
 
 def sibling_cases() -> list:


### PR DESCRIPTION
## Purpose

- Share CLI capture while keeping each existing local wrapper and its call sites unchanged.

## Non-goals

- Add commands, move unrelated helpers, change command behavior, or change plugin versions.

## Threat model

- Tests control helper inputs; each existing command still owns CLI validation and error paths.
