### PR TITLE
share atomic store replacement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           set -o pipefail
           npx --yes pyright@1.1.410 --outputjson \
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py \
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py \
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py \
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py \
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py \
@@ -96,8 +97,8 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/followups-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "15" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 15 it was pointed at — it checked" \
+          if [ "${analyzed}" != "16" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 16 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
@@ -1,0 +1,44 @@
+"""Atomic text-file replacement shared by Gauntlet's local stores."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def replace_text(
+    path: Path,
+    text: str,
+    *,
+    temp_prefix: str,
+    encoding: str | None = None,
+    mode: int | None = None,
+) -> None:
+    """Durably replace ``path`` with ``text`` through a same-directory temp file.
+
+    The caller owns directory creation, serialization, locking, error conversion,
+    encoding choice, and the target's permission policy. This function owns only
+    the shared write, flush, fsync, rename, and failure-cleanup sequence.
+    """
+    fd, temp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=temp_prefix,
+        suffix=".tmp",
+    )
+    temp = Path(temp_name)
+    try:
+        if encoding is None:
+            stream = os.fdopen(fd, "w")
+        else:
+            stream = os.fdopen(fd, "w", encoding=encoding)
+        with stream:  # fdopen owns and closes the descriptor
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if mode is not None:
+            os.chmod(temp, mode)
+        os.replace(temp, path)
+    except BaseException:
+        temp.unlink(missing_ok=True)
+        raise

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -18,6 +18,7 @@ import argparse
 import importlib.util
 import io
 import json
+import os
 import re
 import sys
 import tempfile
@@ -1200,6 +1201,58 @@ def t_concurrent_writers_lose_nothing(tmp: Path) -> None:
     check(len(set(ids)) == len(ids), f"an id was handed out twice under concurrency: {ids!r}")
 
 
+def t_write_is_atomic_and_private(tmp: Path) -> None:
+    """A failed replacement leaves the old store intact; a successful one keeps the store private."""
+    path = write_lines(tmp / "atomic.jsonl", entry_line(id="fu1"))
+    path.chmod(0o644)
+    before = path.read_bytes()
+
+    fsyncs = 0
+    src: "Path | None" = None
+    dst: "Path | None" = None
+    real_fsync, real_replace = os.fsync, os.replace
+
+    def spy_fsync(fd: int) -> None:
+        nonlocal fsyncs
+        fsyncs += 1
+        real_fsync(fd)
+
+    def dying_replace(a: str, b: str) -> None:
+        nonlocal src, dst
+        src, dst = Path(a), Path(b)
+        raise OSError("the machine died between the write and the rename")
+
+    os.fsync, os.replace = spy_fsync, dying_replace
+    try:
+        code, _, err = run(["--file", str(path), "set", "--id", "fu1", "--title", "changed"])
+    finally:
+        os.fsync, os.replace = real_fsync, real_replace
+
+    check(code == 1, f"a failed replacement exited {code}, not the follow-up CLI's refusal code")
+    check("cannot write the store to" in err and "Nothing was touched." in err,
+          f"the replacement failure escaped the follow-up CLI's clean I/O error: {err!r}")
+    check(path.read_bytes() == before, "a failed replacement changed the follow-up store")
+    check(path.stat().st_mode & 0o777 == 0o644,
+          "a failed replacement changed the old store's permissions")
+    check(src is not None and src.parent == path.parent,
+          f"the replacement staged bytes outside the store directory: {src}")
+    check(dst == path, f"the replacement targeted {dst}, not {path}")
+    check(fsyncs >= 1, "the replacement reached rename without fsyncing its bytes")
+    temps = sorted(p.name for p in path.parent.glob(".followups-*.tmp"))
+    check(not temps, f"the failed replacement left temporary files behind: {temps}")
+
+    old_mask = os.umask(0o022)
+    try:
+        code, _, err = run(["--file", str(path), "set", "--id", "fu1", "--title", "changed"])
+    finally:
+        os.umask(old_mask)
+    check(code == 0, f"the unsabotaged follow-up write exited {code}: {err!r}")
+    check(path.stat().st_mode & 0o777 == 0o600,
+          f"the replacement made the follow-up store {path.stat().st_mode & 0o777:o}, not 600")
+    temps = sorted(p.name for p in path.parent.glob(".followups-*.tmp"))
+    check(not temps, f"the successful replacement left temporary files behind: {temps}")
+
+
 def t_table_hides_closed(tmp: Path) -> None:
     """The default view hides ONLY the CLOSED entries; everything still owed to someone stays visible.
 
@@ -1356,6 +1409,7 @@ CASES = [
     ("defaults-backfill", "an entry written before a field existed reads back complete — as a CANDIDATE", t_defaults_backfill),
     ("values-are-strings", "every value in a follow-up is a STRING — a `null` or a number is refused, never coerced", t_every_value_is_a_string),
     ("concurrent-writers", "concurrent runs lose NOTHING — the read-modify-write is locked", t_concurrent_writers_lose_nothing),
+    ("write-atomic-private", "replacement failure preserves the old store; successful writes stay mode 0600", t_write_is_atomic_and_private),
     ("table-hides-closed", "the default view hides only CLOSED entries; a candidate always shows", t_table_hides_closed),
     ("table-omission-loud", "the omission is never silent, and an all-closed store never reads as empty", t_table_omission_is_never_silent),
     ("table-grid-integrity", "no hostile title/evidence forges a column, an entry, or an out-of-band line", t_table_grid_integrity),

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -75,10 +75,8 @@ import argparse
 import fcntl
 import importlib.util
 import json
-import os
 import re
 import sys
-import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -87,6 +85,7 @@ from typing import NoReturn
 
 # The grid is NOT reimplemented here. The private campaign package owns escaping, layout, and omission
 # notices; this file owns only the follow-up schema, lifecycle, and store lifetime.
+from _gauntlet.atomic import replace_text
 from _gauntlet.jsonl import JsonlError, object_lines
 from _gauntlet.table import config_lines, grid_lines, hidden_notice
 
@@ -579,16 +578,7 @@ def dump(path: Path, entries: "list[dict]", high: int) -> None:
     body += "".join(json.dumps({"type": ENTRY_TYPE, **record}) + "\n" for record in records)
     with clean_io("write the store to", path):
         path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".followups-", suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as fh:
-                fh.write(body)
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(tmp, path)
-        except BaseException:
-            Path(tmp).unlink(missing_ok=True)
-            raise
+        replace_text(path, body, temp_prefix=".followups-")
 
 
 @contextmanager

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1289,9 +1289,16 @@ def t_write_is_atomic(L: ModuleType, tmp: Path) -> None:
                     f"the next reader can mistake for one")
 
     # …and with nothing sabotaged, the same write LANDS: the point is atomicity, not refusal.
-    code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1",
-                           "--head-sha", SHA_A, "--verdict", "satisfied"])
+    old_mask = os.umask(0o022)
+    try:
+        code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1",
+                               "--head-sha", SHA_A, "--verdict", "satisfied"])
+    finally:
+        os.umask(old_mask)
     check(code == 0, f"the unsabotaged verdict exited {code}: {err!r}")
+    check(path.stat().st_mode & 0o777 == 0o644,
+          f"the replacement changed the ledger's create mode to {path.stat().st_mode & 0o777:o}, not 644 "
+          "under umask 022")
     code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "review_rounds"])
     check((code, out) == (0, "1\n"), f"the verdict did not land: review_rounds is {out!r}")
     left = sorted(p.name for p in path.parent.iterdir() if p != path)

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -21,6 +21,7 @@ import tempfile
 from pathlib import Path
 from typing import NoReturn
 
+from _gauntlet.atomic import replace_text
 from _gauntlet.jsonl import JsonlError, object_lines
 from _gauntlet.table import config_lines, escape_cell as _shared_escape_cell, grid_lines
 from _gauntlet.table import hidden_notice as _shared_hidden_notice
@@ -360,20 +361,13 @@ def dump(path: Path, header: dict, rows: list[dict]) -> None:
     # on the same breath.
     mask = os.umask(0)
     os.umask(mask)
-    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
-    tmp = Path(tmp_name)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:  # fdopen OWNS the descriptor: `with` closes it
-            fh.write("\n".join(out) + "\n")
-            fh.flush()
-            os.fsync(fh.fileno())  # the bytes are DURABLE before the rename makes them the ledger
-        os.chmod(tmp, 0o644 & ~mask)
-        os.replace(tmp, path)      # atomic within the filesystem: the swap is all-or-nothing
-    except BaseException:
-        # Nothing was replaced, so the ledger on disk is still the last COMPLETE one. Do not leave the
-        # half-written temp behind to be mistaken for a store.
-        tmp.unlink(missing_ok=True)
-        raise
+    replace_text(
+        path,
+        "\n".join(out) + "\n",
+        temp_prefix=f".{path.name}.",
+        encoding="utf-8",
+        mode=0o644 & ~mask,
+    )
 
 
 def find_row(rows: list[dict], pr: str) -> "dict | None":


### PR DESCRIPTION
## Purpose
- share durable text replacement while preserving each store's locking, errors, encoding, and permissions

## Non-goals
- change serialization, schemas, CLI behavior, or `ci-status.py`

## Threat model
- local operators choose paths while campaign tools produce contents; network users have no direct write path
