### PR TITLE
add intent preflight command

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -80,7 +80,9 @@ literal command line to paste.
 COUNT?", which
 validates every line of those files, including the one event the emit-only rule exempts from tool-writing
 (see `references/stage-2-review-gate.md`); never hand-parse one of those files, and never hand-write a
-line the tool writes.
+line the tool writes. Run `review-pass.py intent-check --file <rundir>/intent-<pr>.md` immediately after writing
+an intent artifact and before dispatching its first review; this uses the same parser every pass later
+loads, so a malformed intent fails before review work is spent.
 `scripts/emit-progress.py` is the reviewer's door into it — **its CLI is unchanged**, and it is the only
 sanctioned way to record a unit-progress event. **`scripts/emit-finding.py` is the reviewer's other door,
 and the only sanctioned way to report a FINDING**: every finding is a validated record that ANCHORS to the

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -219,6 +219,11 @@ For each `#PR` to adopt:
    **A block that fails that test is NOT a usable intent, and copying it is worse than authoring one** — the
    pass would be refused as `unusable` on the first `verify`, and the PR would sit there earning no verdicts.
 
+   **Validate the artifact immediately after writing it:** run
+   `review-pass.py intent-check --file <rundir>/intent-<pr>.md`. A non-zero exit refuses adoption for that
+   PR until the artifact is corrected. This is the same parser `verify` uses, moved before review dispatch;
+   never spend a review to learn that its intent could not be read.
+
    **A PR whose body already carries a usable intent block** (by the test above) → **COPY IT VERBATIM** into
    `intent-<pr>.md`. Record `intent = stated@<iso>`.
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -60,7 +60,7 @@ from collections import Counter
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Sequence
 
 from _gauntlet.mutation import (
     load_source_module,
@@ -754,7 +754,7 @@ class Tables:
         self.READ_ONLY_COMMANDS = frozenset({"intent-check", "verify", "self-test", "status"})
 
         # --- the DOORS ---------------------------------------------------------------------------
-        self.DOOR_SEEDS: "dict[str, tuple[str | None, list[str] | None]]" = {
+        self.DOOR_SEEDS: "dict[str, tuple[str | None, Sequence[str] | None]]" = {
             "emit": (PROGRESS_FILE, DISPATCHED),        # the reviewer's door: the identity is already there
             WRAPPER_DOOR: (PROGRESS_FILE, DISPATCHED),  # …and the same door, through the wrapper it runs
             "identity": (PROGRESS_FILE, None),          # it writes into a file that must hold NO BYTES

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -751,7 +751,7 @@ class Tables:
         # `status` writes NOTHING — it is an ADVISORY read-only view — so the round trip does not drive it
         # (there is no produced artifact to read back), and it is declared read-only here so the
         # command-coverage check is satisfied the day the subcommand is added.
-        self.READ_ONLY_COMMANDS = frozenset({"verify", "self-test", "status"})
+        self.READ_ONLY_COMMANDS = frozenset({"intent-check", "verify", "self-test", "status"})
 
         # --- the DOORS ---------------------------------------------------------------------------
         self.DOOR_SEEDS: "dict[str, tuple[str | None, list[str] | None]]" = {
@@ -761,6 +761,7 @@ class Tables:
             "plan-add": (PLAN_FILE, None),              # the first unit lands in a plan that does not exist
             "finding-add": (FINDINGS_FILE, None),       # …and the first finding in a findings file that does not
             FINDING_WRAPPER_DOOR: (FINDINGS_FILE, None),  # the reviewer's OTHER door, through its wrapper
+            "intent-check": (INTENT_FILE, INTENT.splitlines()),
             # a COMPLETE, sound pass — and the minimal invocation now CARRIES a `--verdict` (it is required),
             # so the door check drives the rule as well as the shape: `satisfied`, 0 gating findings, exit 0
             "verify": (PROGRESS_FILE, WORKED),
@@ -1727,6 +1728,29 @@ def check_commands_covered(R: types.ModuleType, T: Tables) -> "list[str]":
     return problems
 
 
+def check_intent_door(R: types.ModuleType, tmp: Path) -> int:
+    """Drive intent-check through its real CLI with one sound and one malformed artifact."""
+    cases = {
+        "usable": (INTENT, 0, "usable intent block"),
+        "missing-threat-model": (
+            "## Purpose\n- do the work\n\n## Non-goals\n",
+            1,
+            "missing ['## Threat model']",
+        ),
+    }
+    failures = 0
+    for name, (content, want, needle) in cases.items():
+        path = tmp / f"intent-door-{name}.md"
+        path.write_text(content, encoding="utf-8")
+        code, output = run_cli(R, ["intent-check", "--file", str(path)])
+        if code != want or needle not in output:
+            print(f"FAIL     [intent-check] {name}: exit {code}, expected {want}; output: {output.strip()}")
+            failures += 1
+        else:
+            print(f"ok       [intent-check] {name:24} exit {code}: {needle}")
+    return failures
+
+
 def status_parse(out: str) -> "tuple[list[str], dict[str, dict[str, str]]]":
     """Parse `status`'s printed table BACK: (column names, {pass label -> {column -> cell}}).
 
@@ -1868,6 +1892,8 @@ def run(R: types.ModuleType, tmp: Path) -> int:
     failures += check_boundaries(R, T)
     print()
     failures += check_docs(R)
+    print()
+    failures += check_intent_door(R, tmp)
     print()
     failures += run_status_cases(R, T, tmp)
     print()

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1728,6 +1728,18 @@ def cmd_verify(args) -> int:
     return 0 if verdict == OK else 1
 
 
+def cmd_intent_check(args) -> int:
+    """Refuse an intent artifact now, before a reviewer is launched against it."""
+    path = Path(args.file)
+    sections = load_intent(path)
+    print(
+        f"ok: {path} is a usable intent block "
+        f"({len(sections[PURPOSE_H])} purpose, {len(sections[NON_GOALS_H])} non-goal, "
+        f"{len(sections[THREAT_H])} threat-model bullet(s))"
+    )
+    return 0
+
+
 # --- the status view: an ADVISORY, READ-ONLY glance across a run ---------------------------------
 #
 # **`status` DECIDES NOTHING** (the active `AGENTS.md` or `CLAUDE.md`, "Dogfood the branch's behavior — but NEVER let it gate
@@ -2326,6 +2338,10 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     add_finding_args(sub.add_parser(
         "finding-add", help="record ONE finding, anchored to the PR's intent (what emit-finding.py calls)"))
 
+    intent = sub.add_parser(
+        "intent-check", help="refuse a missing or malformed intent block before review dispatch")
+    intent.add_argument("--file", required=True, help="the PR's intent-<pr>.md artifact")
+
     v = sub.add_parser("verify", help="DOES THIS PASS COUNT? (it never reads the reviewer's report)")
     v.add_argument("--file", required=True, help="the ACTIVE launch attempt's progress.jsonl")
     v.add_argument("--head-sha", required=True, help="the PR's LIVE head — the pass must have run on it")
@@ -2383,7 +2399,8 @@ def dispatch(args) -> int:
         return self_test()
     try:
         return {"emit": cmd_emit, "identity": cmd_identity, "plan-add": cmd_plan_add,
-                "finding-add": cmd_finding_add, "verify": cmd_verify, "status": cmd_status}[args.cmd](args)
+                "finding-add": cmd_finding_add, "intent-check": cmd_intent_check,
+                "verify": cmd_verify, "status": cmd_status}[args.cmd](args)
     except Defect as exc:
         fail(str(exc), 1)
     except OperatorError as exc:


### PR DESCRIPTION
- validate intent artifacts before review dispatch
- reuse the existing intent parser and add CLI coverage
