### PR TITLE
add required-set command

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -119,6 +119,8 @@ PR's checks (SHA-pinned, both families), promotes the snapshot, verifies it (thr
 and decides **against the base branch's required set** (`--required-set`, from the ledger header —
 MANDATORY), printing the verdict and the ledger `ci` value as JSON
 (`references/stage-2-ci.md`, "THE DERIVATION IS A COMMAND", which owns the exact invocation).
+Run `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before derivation on every wake. It
+owns both GitHub reads and the atomic ledger write, retries only `unknown`, and reuses a settled value.
 **NEVER derive `ci` by reading a command's output and judging it by eye** — that is what once wrote
 `ci = green` for a PR whose checks had not registered at all.
 

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -443,6 +443,10 @@
 - Apply `reviewer.md`'s external-review retry budget, then take `runtime-adapter.md`'s owned transition.
   The gate is unchanged; record the selected route and resulting reviewer in the report. See "The
   reviewer".
+- **RUN `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before CI derivation on every
+  wake.** It owns both base-branch declaration reads, their strict parse and union, and the atomic ledger
+  write. A settled value is reused; only `unknown` is retried. See `stage-2-ci.md`, "WHAT WERE WE EXPECTING
+  TO SEE?".
 - **DERIVE `ci` BY RUNNING `scripts/ci-status.py derive --pr <N> --head-sha <the ledger's> --rundir
   <rundir> --required-set <the ledger header's>`, and by NOTHING ELSE.** It fetches, promotes, verifies and
   decides, and prints the verdict and the `ci` value as JSON (`stage-2-ci.md`, "THE DERIVATION IS A

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -153,6 +153,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
+
+   **Settle the base branch's required-check set before any CI derivation:** run `scripts/ci-status.py
+   required-set --ledger <rundir>/state.jsonl`. Run it every wake; the command reuses a settled value and
+   only retries `unknown`. `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?", owns its states and behavior.
 2. **Fold in completions.** For any background task that finished (CI watch → **a WAKE, not an artifact**:
    the watch **only blocks** and produces **nothing**, so **this wake** performs the SHA-pinned fetch of
    both check families, **promotes** it atomically to `ci-<pr>-<head_sha>.txt` and **verifies** its stamp

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -234,19 +234,17 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
 - **EVERY `//` DEFAULT GOES BEFORE THE CONVERSION, NEVER AFTER — `((.x // "-") | tostring)`, and
   NEVER `((.x | tostring) // "-")`.** In jq, `null | tostring` is the **STRING `"null"`**, which is
   **TRUTHY**, so a default placed after the conversion **NEVER FIRES** and the field carries the
-  four letters `null` where `-` was meant. This applies to **every nullable field read anywhere in
-  this file** — `.app.id` above (a check run need not come from an app) and the required-set reads'
-  `.app_id` / `.integration_id` below. **It is not cosmetic there: it is a WEDGE.** An unbound
+  four letters `null` where `-` was meant. This applies to `.app.id` above (a check run need not come
+  from an app). The required-set command applies the same rule in Python to `.app_id` and
+  `.integration_id`. **It is not cosmetic there: it is a WEDGE.** An unbound
   required check would come out bound to a producer named `"null"`, no evidence row could ever match
   it, and the PR would report `pending (required check absent)` **forever, for a reason nobody can
   see** — which is the failure this file's own SETTLED rule exists to prevent, arriving by the back
   door. `cli/cli`'s `trunk` returns `app_id: null` for **every** one of its required checks, so this
-  is the **common** configuration, not an exotic one. `ci-snapshot.py`'s `producer_test` **extracts
-  EVERY jq filter this file prescribes — all five reads, (1)(2)(3) here and (a)(b) below — and RUNS
-  them** against recorded API payloads that carry null bindings and span MULTIPLE PAGES: write the order
-  backwards in **any** of them, or drop a `--paginate`, and it goes red. **A filter this file prescribes
-  that no test EXECUTES is a filter that can rot** — (1)'s `.app.id` default was fixed once and pinned by
-  nothing, and could have been reverted forever without a single test noticing.
+  is the **common** configuration, not an exotic one. `ci-snapshot.py`'s `fetch_test` extracts and runs
+  the three snapshot filters against recorded, multi-page payloads. `ci-status.py self-test` drives the
+  required-set production functions against recorded classic and ruleset payloads with null bindings and
+  multiple pages. Drop pagination or mishandle a null binding in either path and its test goes red.
 - **BOTH families are MANDATORY, AND THE ARTIFACT MUST PROVE BOTH WERE READ.** A failing Jenkins/CircleCI
   **commit status is genuinely invisible** to `/check-runs`: a commit can carry **live commit statuses**
   while `/check-runs` reports `check_runs.total_count = 0` for that very commit. Read only one family and
@@ -611,14 +609,14 @@ ever worked.
 read the ENUMS is exactly where the drift got in.** Nothing parsed the `gh … | jq` block, so this file went
 on specifying `(.statusCheckRollup // [])` — which turns a **MISSING** rollup into an **EMPTY** one — while
 the tool **refused** that shape. The doc and the code disagreed about **what is refused**, in the one place
-nothing was looking. Two checks close that, and **neither is optional**:
+nothing was looking. Three checks close that, and **none is optional**:
 
-- **`ci-snapshot.py`'s `producer_test` RUNS the filters** (the `--paginate` bullet, above, is the same
-  point). It extracts **all five reads this file prescribes** — (1)(2)(3) here and (a)(b) below — **verbatim,
-  by their command line**, and executes them over recorded, **multi-page** API payloads, asserting **the
-  exact rows**. Drop a `--paginate`, drop `,headRefOid`, drop `--repo`, or write a `//` default on the wrong
-  side of a `tostring`, and it goes **RED**: the read it pins is the one an operator would copy out of this
-  file.
+- **`ci-snapshot.py`'s `fetch_test` RUNS the three snapshot filters** (the `--paginate` bullet, above, is
+  the same point). It extracts (1)(2)(3) verbatim by their command line and executes them over recorded,
+  multi-page API payloads, asserting the exact rows.
+- **`ci-status.py self-test` RUNS the required-set producer** over recorded classic-protection and paged
+  ruleset payloads. It asserts strict field handling, nullable app bindings, URL encoding, the complete
+  union, and the atomic ledger result.
 - **`ci-status.py doc-check` checks every `gh` INVOCATION in this file against the argv the code really
   issues** — *every copy of them*, not just the spec block (a recap that drops `,headRefOid` reconstructs a
   fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It sweeps
@@ -895,48 +893,29 @@ TOKEN's grants** — so a fine-grained token owned by an admin reads `admin: tru
 `Administration: read`. **A rule keyed on that probe declares "proven unprotected" on a branch it simply
 cannot see.**
 
-Two reads, and **they do NOT need the same permission** — name them per endpoint, because a token
-provisioned for only one of them fails the other on a **private** repo, the required set reads `unknown`,
-and `unknown` can never go green: **`GET /repos/{o}/{r}/branches/{b}` needs `Contents: read`**;
-**`GET /repos/{o}/{r}/rules/branches/{b}` needs `Metadata: read`** (GitHub REST docs, "Get a branch" /
-"Get rules for a branch"). **BOTH are mandatory** — neither can see what the other sees:
+Run the required-set command before CI derivation on every wake:
 
 ```sh
-# The base branch name is UNTRUSTED — a git ref may legally contain shell metacharacters ($(), backticks,
-# quotes), and it originates in a PR's `baseRefName`. Capture it ONCE into a shell variable — command
-# substitution OUTPUT is never re-parsed — and reference it double-quoted as "$base" inside the URL. NEVER
-# splice a raw <base> into the command string, where a branch named `main$(…)` would EXECUTE at parse time.
-# (`<owner>`/`<repo>` are this repo's OWN slug, not PR-supplied.) The jq filters below are unchanged, and
-# `ci-snapshot.py` still extracts them verbatim — only the URL's base ref moved out of shell reach.
-base=$(python3 <skill>/scripts/ledger.py --file <rundir>/state.jsonl header get base_branch)
-
-# (a) CLASSIC branch protection — AND the field that disambiguates its absence. Needs `Contents: read`
-#     (NOT Metadata — on a private repo a Metadata-only token 404s here and the required set reads
-#     `unknown`, which can never go green).
-#     `.protection.enabled` tells you whether classic protection EXISTS, so you never have to guess
-#     what a 404 from /branches/<b>/protection meant. `.checks[]` carries the app binding; `.contexts`
-#     is the same set WITHOUT it, and is deprecated — read `.checks[]`, never `.contexts`.
-#     `.app_id` is NULLABLE — the DEFAULT GOES BEFORE `tostring` (FETCH above owns that rule; get it
-#     backwards and every unbound required check binds to an app named "null" and can NEVER be matched).
-gh api "repos/<owner>/<repo>/branches/$base" --jq '
-  {classic_enabled: (.protection.enabled // false),
-   checks: [(.protection.required_status_checks.checks // [])[]
-            | {context: .context, app: ((.app_id // "-") | tostring)}]}'
-
-# (b) RULESETS — the rules actually in force on the branch. The CLASSIC endpoint CANNOT SEE THESE.
-#     Needs `Metadata: read`.
-#     `--paginate` IS MANDATORY HERE: this endpoint returns a PAGED LIST of rules (`page`/`per_page`,
-#     default 30 — GitHub REST docs, "Get rules for a branch"), and a repo can carry more rules than that.
-#     Read page one only and a `required_status_checks` rule sitting on page two is NEVER SEEN — the
-#     required set is recorded as if that check were not required, and a snapshot MISSING it goes GREEN.
-#     That is the exact false green this whole section exists to close, reintroduced by a missing flag.
-#     `--slurp` hands jq ONE array OF PAGES (and is mutually exclusive with gh's own `--jq`, hence the
-#     pipe) — so the filter flattens with `.[][]`: pages, then rules.
-gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/$base" | jq -c '
-  [.[][] | select(.type=="required_status_checks")
-         | .parameters.required_status_checks[]
-         | {context: .context, app: ((.integration_id // "-") | tostring)}]'
+python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl [--repo <owner>/<repo>]
 ```
+
+The command reads `base_branch` through `ledger.py`, URL-encodes it as an API path segment, scopes every
+GitHub call to one repository, reads both declaration sources, validates every response field, unions and
+sorts the declarations, validates the result through `ci-snapshot.py`'s strict parser, and writes the
+canonical value through `ledger.py`'s atomic store. It exits 0 for a settled `declared:…` or `none`, 1 for
+`unknown`, and 2 for a caller or ledger error. A settled value is returned without another GitHub read, so
+the same command is safe to run on every wake and retries only an `unknown` value.
+
+The command owns two mandatory reads. They do **not** need the same permission: **`GET
+/repos/{o}/{r}/branches/{b}` needs `Contents: read`**, while **`GET
+/repos/{o}/{r}/rules/branches/{b}` needs `Metadata: read`** (GitHub REST docs, "Get a branch" / "Get rules
+for a branch"). A token provisioned for only one endpoint leaves the complete set unknown.
+
+The classic branch read uses `.protection.enabled` to distinguish disabled classic protection, then reads
+`.protection.required_status_checks.checks`; `.contexts` drops app bindings and is not used. The ruleset
+read uses `--paginate --slurp` because the endpoint returns a paged list and a required-status-check rule
+may be on a later page. Nullable or absent app bindings become `"-"` before conversion; missing required
+response fields make the entire result `unknown`.
 
 **Read (a) is NOT paginated, and that is not an oversight** — `GET /repos/{o}/{r}/branches/{b}` returns a
 **single branch object**, not a list: it takes no `page`/`per_page`, and its
@@ -953,12 +932,8 @@ it is not optional.
 
 ##### THREE states, NEVER two — "I CANNOT SEE ANY" IS NOT "THERE ARE NONE"
 
-Persist the outcome in the ledger header as `required_set` — **a state you cannot persist is a state you do
-not have** (`files-and-ledger.md` owns the field; this block owns its meaning and its format):
-
-```sh
-ledger.py --file <state.jsonl> header set required_set '<declared:<json> | none | unknown>'
-```
+The command persists the outcome in the ledger header as `required_set` — **a state it cannot persist is a
+state it does not have** (`files-and-ledger.md` owns the field; this block owns its meaning and format).
 
 **WHEN: read it once per run, before the first CI derivation** — it is a property of `base_branch`, which is
 itself set once (`files-and-ledger.md`, "Base branch"), so one read serves every PR in the run. **And read

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -1017,7 +1017,6 @@ def self_test(fixtures: Path) -> int:
     failures += filename_test(fixtures)
     failures += required_test(fixtures)
     failures += fetch_test()
-    failures += producer_test(fixtures)
     failures += spec_test()
     print()
     if failures:
@@ -1025,7 +1024,6 @@ def self_test(fixtures: Path) -> int:
         return 1
     print(f"all {len(EXPECTED)} fixtures + {len(FILENAME_CASES)} filename cases + "
           f"{len(REQUIRED_CASES)} required-set cases + {len(FETCH_CASES)} fetch-read cases + "
-          f"{len(PRODUCER_CASES)} producer cases + "
           f"{len(SPEC_CASES)} spec cases hold — the contract is intact.")
     print("`mutate-ci-snapshot.py` is what proves each of them pins its OWN rule. Run it too.")
     return 0
@@ -1121,18 +1119,11 @@ def required_test(fixtures: Path) -> int:
 # but the OTHER failure, the one that files no report. And it was not exotic: `repos/cli/cli/branches/trunk`
 # returns `app_id: null` for EVERY required check it has.
 #
-# So the filters are NOT retyped here — they are EXTRACTED FROM stage-2-ci.md AND EXECUTED. A copy in this
-# file is exactly what could NOT have caught this: the bug was in the DOC, which is the only place these
-# reads live and the only place an operator reads them from. A test of a copy would have passed, forever.
-#
-# AND THE SAME ARGUMENT COVERS EVERY FILTER THE DOC PRESCRIBES, not only the required-set pair. It did not,
-# once: the `.app.id` fix in the FETCH read was pinned by NOTHING — a reviewer reverted it in the doc, ran
-# `self-test`, and the suite stayed GREEN, because this harness extracted only the two required-set reads
-# and the FETCH reads were merely eyeballed. A rule that is FIXED but PINNED BY NOTHING can be silently
-# reverted forever. So all FIVE reads are extracted here: the three FETCH reads and the two required-set
-# reads.
+# The three snapshot filters are NOT retyped here — they are EXTRACTED FROM stage-2-ci.md AND EXECUTED. A
+# copy in this file is exactly what could NOT have caught a bug in the DOC, which is where an operator reads
+# them. The required-set reads are now production Python in `ci-status.py required-set`; its sibling fixture
+# suite drives that code over the same recorded API responses instead of testing copied shell.
 DOC = Path(__file__).resolve().parents[1] / "references" / "stage-2-ci.md"
-PAYLOADS = Path(__file__).parent / "fixtures" / "required-set"  # payloads for the required-set reads
 FETCH_PAYLOADS = Path(__file__).parent / "fixtures" / "fetch"   # payloads for the evidence reads
 
 # Each read is identified by the COMMAND LINE that introduces it, VERBATIM — the pipeline included, so a
@@ -1147,20 +1138,13 @@ READS = {
     # prescribes a fetch that rule can never fire on. Pinned verbatim here, so dropping it goes RED.
     # `--repo` IS PART OF THE IDENTITY FOR THE SAME REASON, and it is the one this read shipped WITHOUT: a
     # bare `gh pr view <pr>` resolves the PR in the CURRENT CHECKOUT, so the command asks whichever repo the
-    # reader is standing in — the only one of the five reads that could not say what it was about.
+    # reader is standing in — the only one of the three reads that could not say what it was about.
     "rollup": "gh pr view <pr> --repo <owner>/<repo> --json statusCheckRollup,headRefOid | jq -c '",
-    # The TWO required-set reads (WHAT WERE WE EXPECTING TO SEE?). The base ref rides in as the shell var
-    # `$base` (captured in stage-2-ci.md, never spliced raw — a branch name is untrusted), so the opener
-    # ends `.../branches/$base" --jq '` verbatim; only the URL changed, the jq filter is still delimited by
-    # the trailing single quote exactly as before.
-    "classic": 'gh api "repos/<owner>/<repo>/branches/$base" --jq \'',
-    "ruleset": 'gh api --paginate --slurp "repos/<owner>/<repo>/rules/branches/$base" | jq -c \'',
 }
 
 # `gh api --paginate --slurp` hands jq ONE ARRAY OF PAGES. `jq -s` over N recorded page files builds exactly
 # that — so an N-page fetch is reproducible offline, and a filter that forgets to flatten the pages (or a
-# doc that drops the `--paginate`) goes RED here rather than in production, where it would silently record a
-# truncated required set and let a missing required check pass as green.
+# doc that drops the `--paginate`) goes RED here rather than silently producing a short snapshot.
 SLURPED = {which for which, opener in READS.items() if "--slurp" in opener}
 
 
@@ -1203,47 +1187,6 @@ def run_read(which: str, payloads: tuple[Path, ...]) -> list:
         raise DocDrift(f"the {which} read FAILED on {names}: {proc.stderr.strip()}")
     return [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
 
-
-def required_set_from(which: str, payloads: tuple[Path, ...]) -> list:
-    """Run the DOC's required-set read over recorded page(s) and return the declared checks it produces."""
-    emitted = run_read(which, payloads)
-    if len(emitted) != 1:
-        raise DocDrift(f"the {which} read must emit exactly ONE value, got {len(emitted)}")
-    out = emitted[0]
-    if which == "classic":
-        if not isinstance(out, dict) or not isinstance(out.get("checks"), list):
-            raise DocDrift(f"the classic read no longer produces a `checks` array: {out!r}")
-        out = out["checks"]
-    if not isinstance(out, list):
-        raise DocDrift(f"the {which} read did not produce an array: {out!r}")
-    return out
-
-
-# (payload pages, read, the checks the read MUST produce, snapshot, verdict, needle, why)
-PRODUCER_CASES = [
-    (("classic-protection.json",), "classic",
-     [("Lint scripts", "15368"), ("Validate plugins", ANY_APP)],
-     "green.jsonl", GREEN, "required set satisfied: Lint scripts, Validate plugins",
-     "CLASSIC PROTECTION carrying a NULL app binding — the shape cli/cli's trunk really returns. The unbound "
-     "check must read `-`, be satisfied by a row WHATEVER its producer, and go GREEN — while the BOUND check "
-     "keeps its id, because a default that fires when a binding IS there is the mirror bug"),
-    (("ruleset-null-app.json",), "ruleset", [("ci/jenkins", ANY_APP)],
-     "status-passing.jsonl", GREEN, "required set satisfied: ci/jenkins",
-     "a RULESET whose `integration_id` is explicitly NULL, satisfied by a COMMIT STATUS — a row with NO "
-     "producer field at all, which is precisely what an unbound declaration can be proven by"),
-    (("ruleset-no-app.json",), "ruleset", [("ci/jenkins", ANY_APP)],
-     "status-passing.jsonl", GREEN, "required set satisfied: ci/jenkins",
-     "the same ruleset with `integration_id` ABSENT rather than null — jq reads a missing field as null, and "
-     "this pins that the read defaults it the same way instead of emitting a key it never saw"),
-    (("ruleset-paged-p1.json", "ruleset-paged-p2.json"), "ruleset",
-     [("Lint scripts", "15368"), ("Validate plugins", ANY_APP)],
-     "green.jsonl", GREEN, "required set satisfied: Lint scripts, Validate plugins",
-     "THE PAGINATION CASE. /rules/branches is a PAGED LIST (per_page 30 by default) and the "
-     "`required_status_checks` rule is on PAGE 2. Without `--paginate --slurp` the doc's read sees page 1 "
-     "only, finds no required rule, and records the required set as `none` — `the base branch requires "
-     "nothing` — which is the FALSE GREEN this whole section exists to close, reintroduced by a missing "
-     "flag. The read must produce BOTH checks from BOTH pages"),
-]
 
 # (payload pages, read, the EXACT JSONL rows the read must emit, why)
 # The three FETCH reads, executed. These emit the snapshot's own rows, so the assertion is the rows
@@ -1311,43 +1254,6 @@ def fetch_test() -> int:
             failures += 1
             continue
         print(f"ok       {label:44} -> {len(got_rows)} rows ({why})")
-    return failures
-
-
-def producer_test(fixtures: Path) -> int:
-    """The doc's read -> the spec -> the parser -> a verdict. The whole chain, on payloads with a NULL app
-    binding, because the chain is where the wedge lived and no link of it could see the wedge alone."""
-    failures = 0
-    for pages, which, want_checks, snapshot, want, needle, why in PRODUCER_CASES:
-        label = f"{pages[0]}{f' +{len(pages) - 1}p' if len(pages) > 1 else ''} -> {which} read"
-        try:
-            produced = required_set_from(which, tuple(PAYLOADS / p for p in pages))
-        except DocDrift as exc:
-            print(f"FAIL     {label:44} -> {exc}")
-            failures += 1
-            continue
-        got_checks = [(c.get("context"), c.get("app")) for c in produced]
-        if got_checks != want_checks:
-            print(f"FAIL     {label:44} -> the read produced {got_checks}, expected {want_checks}")
-            failures += 1
-            continue
-        spec = DECLARED_PREFIX + json.dumps([{"context": c, "app": a} for c, a in got_checks])
-        try:
-            required = parse_required_set(spec)
-        except SpecError as exc:
-            # The read produced a required set ITS OWN PARSER refuses. Exactly what `app: "null"` does.
-            print(f"FAIL     {label:44} -> the read produced a spec the parser REJECTS: {exc}")
-            failures += 1
-            continue
-        got, reason = evaluate(
-            fixtures / snapshot, FIXTURE_SHA, required=required, expect_filename_sha=False
-        )
-        if got == want and needle in reason:
-            print(f"ok       {label:44} -> {got:8} ({why})")
-        else:
-            print(f"FAIL     {label:44} -> {got:8} expected {want} mentioning {needle!r}"
-                  f"\n         reason: {reason}")
-            failures += 1
     return failures
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -235,6 +235,95 @@ def check_seams(ci, tmp: Path) -> list[str]:
     return bad
 
 
+def required_set_cases(ci, tmp: Path) -> list[str]:
+    """Drive the required-set producer through recorded GitHub responses and the real ledger accessor."""
+    problems: list[str] = []
+    fixtures = ci.HERE / "fixtures" / "required-set"
+
+    def payload(name: str):
+        return json.loads((fixtures / name).read_text(encoding="utf-8"))
+
+    classic = ci.classic_required_set(payload("classic-protection.json"))
+    expected_classic = [("Lint scripts", "15368"), ("Validate plugins", ci.SNAP.ANY_APP)]
+    if classic != expected_classic:
+        problems.append(f"[required-set] classic protection produced {classic!r}, expected {expected_classic!r}")
+
+    for name in ("ruleset-null-app.json", "ruleset-no-app.json"):
+        got = ci.ruleset_required_set([payload(name)])
+        if got != [("ci/jenkins", ci.SNAP.ANY_APP)]:
+            problems.append(f"[required-set] {name} produced {got!r}, expected an unbound ci/jenkins")
+
+    pages = [payload("ruleset-paged-p1.json"), payload("ruleset-paged-p2.json")]
+    got_paged = ci.ruleset_required_set(pages)
+    if got_paged != expected_classic:
+        problems.append(f"[required-set] paged rules produced {got_paged!r}, expected {expected_classic!r}")
+
+    seen: list[tuple[str, list[str]]] = []
+
+    def recorded_fetch(source: str, argv: list[str]):
+        seen.append((source, argv))
+        return payload("classic-protection.json") if source.endswith("classic") else pages
+
+    spec, reason = ci.fetch_required_set(recorded_fetch, "o/r", "feature/x$(unsafe)")
+    expected_spec = ci.canonical_required_set(expected_classic)
+    if spec != expected_spec:
+        problems.append(f"[required-set] union produced {spec!r}, expected {expected_spec!r}: {reason}")
+    encoded = "feature%2Fx%24%28unsafe%29"
+    if len(seen) != 2 or any(encoded not in argv[-1] for _source, argv in seen):
+        problems.append(f"[required-set] base branch was not URL-encoded in both scoped reads: {seen!r}")
+
+    no_checks, _ = ci.fetch_required_set(
+        lambda source, _argv: {"protection": {"enabled": False}} if source.endswith("classic") else [[]],
+        "o/r", "main",
+    )
+    if no_checks != ci.SNAP.NONE_DECLARED:
+        problems.append(f"[required-set] two complete empty reads produced {no_checks!r}, expected `none`")
+
+    def failed_fetch(source: str, _argv: list[str]):
+        if source.endswith("ruleset"):
+            raise ci.FetchError("ruleset denied")
+        return {"protection": {"enabled": False}}
+
+    unknown, unknown_reason = ci.fetch_required_set(failed_fetch, "o/r", "main")
+    if unknown != ci.SNAP.CANNOT_READ or "denied" not in unknown_reason:
+        problems.append(f"[required-set] one failed source produced {unknown!r}: {unknown_reason}")
+
+    malformed, malformed_reason = ci.fetch_required_set(
+        lambda source, _argv: {} if source.endswith("classic") else [[]], "o/r", "main"
+    )
+    if malformed != ci.SNAP.CANNOT_READ or "ABSENT" not in malformed_reason:
+        problems.append(f"[required-set] an absent required field produced {malformed!r}: {malformed_reason}")
+
+    ledger = tmp / "required-set-state.jsonl"
+    header = dict(ci.LEDGER.HEADER_DEFAULTS)
+    header.update({"run_id": "test", "base_branch": "feature/x$(unsafe)"})
+    ci.LEDGER.dump(ledger, header, [])
+    settled = ci.refresh_required_set(recorded_fetch, ledger, "o/r")
+    persisted, _rows = ci.LEDGER.load(ledger)
+    if not settled["settled"] or persisted["required_set"] != expected_spec:
+        problems.append(f"[required-set] the canonical union was not settled atomically: {settled!r}")
+
+    def must_not_fetch(_source: str, _argv: list[str]):
+        raise AssertionError("a settled ledger was fetched again")
+
+    try:
+        reused = ci.refresh_required_set(must_not_fetch, ledger, "o/r")
+        if reused["required_set"] != expected_spec:
+            problems.append(f"[required-set] settled reuse changed the value: {reused!r}")
+    except Exception as exc:  # noqa: BLE001 - a fetch here is the behavior this case detects
+        problems.append(f"[required-set] settled ledger was not reused: {type(exc).__name__}: {exc}")
+
+    snapshot_fixtures = ci.SNAPSHOT_PY.parent / "fixtures" / "ci-snapshot"
+    required = ci.SNAP.parse_required_set(expected_spec)
+    verdict, verdict_reason = ci.SNAP.evaluate(
+        snapshot_fixtures / "green.jsonl", ci.FIXTURE_SHA, required=required, expect_filename_sha=False
+    )
+    if verdict != ci.SNAP.GREEN or "required set satisfied" not in verdict_reason:
+        problems.append(f"[required-set] producer-to-verifier chain returned {verdict}: {verdict_reason}")
+
+    return problems
+
+
 def run(ci, tmp: Path) -> int:
     """Every fixture, then the seams, then `doc-check`. Non-zero on any failure.
 
@@ -265,6 +354,13 @@ def run(ci, tmp: Path) -> int:
     if not problems:
         print(f"ok       {'the seams no fixture reaches':32} -> {len(SEAM_EXPECT)} cases: gh_fetch's own two "
               f"rules, the CLI's operator-error guards, and the repo-scoping refusal")
+
+    required_problems = required_set_cases(ci, tmp)
+    for problem in required_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not required_problems:
+        print(f"ok       {'required-set producer':32} -> 10 cases: both APIs, strict shapes, canonical ledger state")
 
     print()
     print(f"--- doc-check: {ci.DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -119,10 +119,11 @@ Drift is a RED BUILD, not a discovery.
 zero rules are extracted, `doc-check` FAILS. An extractor that silently matches nothing and reports success
 is the false green of this whole story, one level up, in the tool written to prevent it.
 
-(The doc's `gh … | jq` FETCH filters are EXECUTED — by `ci-snapshot.py`'s `producer_test`, which extracts
-all five reads the doc prescribes VERBATIM and runs them over recorded, multi-page API payloads. That is
-its job and it owns it; this file does not keep a second copy of that machinery.)
+(The doc's three `gh … | jq` snapshot filters are EXECUTED by `ci-snapshot.py` over recorded, multi-page
+API payloads. The required-set reads are production functions in this file and its sibling suite drives
+them over their recorded API payloads.)
 
+  required-set  read branch protection and rulesets, then persist their complete union in the ledger
   derive     fetch a PR's checks, promote the snapshot, verify it, and print the verdict as JSON
   doc-check  assert stage-2-ci.md's enums / CLASSIFY / DECIDE order agree with the code that runs
   self-test  run every fixture, assert its verdict AND the rule that produced it, then run doc-check
@@ -146,9 +147,11 @@ import sys
 import textwrap
 from pathlib import Path
 from typing import Callable, NamedTuple, NoReturn
+from urllib.parse import quote
 
 HERE = Path(__file__).resolve().parent
 SNAPSHOT_PY = HERE / "ci-snapshot.py"
+LEDGER_PY = HERE / "ledger.py"
 TEST_PY = HERE / "ci-status-test.py"     # the fixture suite — this tool's executable contract
 DOC = HERE.parent / "references" / "stage-2-ci.md"
 FIXTURES = HERE / "fixtures" / "ci-status"
@@ -179,6 +182,19 @@ def load_snapshot_module():
 
 
 SNAP = load_snapshot_module()
+
+
+def load_ledger_module():
+    """Import the schema-owning ledger accessor instead of copying its file format or write rules."""
+    spec = importlib.util.spec_from_file_location("campaign_ledger_for_ci", LEDGER_PY)
+    if spec is None or spec.loader is None:  # pragma: no cover - a broken checkout, not a verdict
+        fail(f"cannot load {LEDGER_PY} — required-set persistence belongs to that accessor")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+LEDGER = load_ledger_module()
 
 # `StatusState`, as the ROLLUP hands it to us — and it is NOT a fourth copy of those values, it is the UNION
 # OF THE THREE BUCKETS `ci-snapshot.py` CLASSIFIES WITH. That file owns the enum; this file only asks whether
@@ -340,6 +356,122 @@ def check_required_set(spec: str):
             f"guessing at it would say 'the base branch requires nothing' on the strength of a value we "
             f"failed to parse."
         )
+
+
+# --- REQUIRED SET -------------------------------------------------------------------------------
+
+def required_check(source: str, value: object, app_key: str) -> tuple[str, str]:
+    """Parse one GitHub required-check declaration without turning absence into an empty value."""
+    context = field(source, value, "context", str)
+    app = field(source, value, app_key, int, NULL, ABSENT)
+    if app is None:
+        app = SNAP.ANY_APP
+    else:
+        app = str(app)
+    return context, app
+
+
+def classic_required_set(payload: object) -> list[tuple[str, str]]:
+    """Read classic branch protection from the complete branch object."""
+    source = "required-set-classic"
+    protection = field(source, payload, "protection", dict)
+    enabled = field(source, protection, "enabled", bool)
+    if not enabled:
+        return []
+    status_checks = field(source, protection, "required_status_checks", dict)
+    checks = field(source, status_checks, "checks", list)
+    return [required_check(source, check, "app_id") for check in checks]
+
+
+def ruleset_required_set(payload: object) -> list[tuple[str, str]]:
+    """Read every page returned by `gh api --paginate --slurp` for rules on the base branch."""
+    source = "required-set-ruleset"
+    if not isinstance(payload, list):
+        raise FetchError(f"{source}: the paginated response is not a list of pages")
+    checks: list[tuple[str, str]] = []
+    for page in payload:
+        if not isinstance(page, list):
+            raise FetchError(f"{source}: a page is not a list of rules: {page!r}")
+        for rule in page:
+            rule_type = field(source, rule, "type", str)
+            if rule_type != "required_status_checks":
+                continue
+            parameters = field(source, rule, "parameters", dict)
+            declared = field(source, parameters, "required_status_checks", list)
+            checks.extend(required_check(source, check, "integration_id") for check in declared)
+    return checks
+
+
+def canonical_required_set(checks: list[tuple[str, str]]) -> str:
+    """Return the one ledger spelling for a complete union of both declaration sources."""
+    unique = sorted(set(checks))
+    if not unique:
+        return SNAP.NONE_DECLARED
+    payload = [{"context": context, "app": app} for context, app in unique]
+    spec = SNAP.DECLARED_PREFIX + json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    SNAP.parse_required_set(spec)  # the verifier's parser has the final word on what may be persisted
+    return spec
+
+
+def fetch_required_set(fetch: Fetch, repo: str, base_branch: str) -> tuple[str, str]:
+    """Fetch both mandatory declaration sources. Any incomplete read stays `unknown`."""
+    scoped = repo_scoped(fetch, repo)
+    encoded = quote(base_branch, safe="")
+    try:
+        classic = scoped(
+            "required-set-classic",
+            ["gh", "api", f"repos/{REPO_SLOT}/branches/{encoded}"],
+        )
+        rules = scoped(
+            "required-set-ruleset",
+            ["gh", "api", "--paginate", "--slurp", f"repos/{REPO_SLOT}/rules/branches/{encoded}"],
+        )
+        value = canonical_required_set(classic_required_set(classic) + ruleset_required_set(rules))
+        return value, "both required-check sources were read completely"
+    except (FetchError, SNAP.SpecError) as exc:
+        return SNAP.CANNOT_READ, str(exc)
+
+
+def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = None) -> dict:
+    """Settle the ledger header once, retrying only while its value is `unknown`."""
+    header, rows = LEDGER.load(ledger_path)
+    current_spec = header["required_set"]
+    try:
+        current = SNAP.parse_required_set(current_spec)
+    except SNAP.SpecError as exc:
+        fail(f"ledger required_set {current_spec!r} is malformed ({exc}); refusing to overwrite it")
+
+    if current.state != SNAP.CANNOT_READ:
+        return {
+            "base_branch": header["base_branch"],
+            "repo": repo,
+            "required_set": current_spec,
+            "state": current.state,
+            "settled": True,
+            "reason": "the ledger already holds a settled required set; no GitHub read was made",
+        }
+
+    base_branch = header["base_branch"]
+    if not base_branch or base_branch == "-":
+        fail("ledger base_branch is not set; required checks cannot be read without it")
+    if repo is None:
+        try:
+            repo = resolve_repo(fetch)
+        except FetchError as exc:
+            fail(f"cannot determine the repo ({exc}) — pass --repo owner/name")
+
+    value, reason = fetch_required_set(fetch, repo, base_branch)
+    header["required_set"] = value
+    LEDGER.dump(ledger_path, header, rows)
+    parsed = SNAP.parse_required_set(value)
+    return {
+        "base_branch": base_branch,
+        "repo": repo,
+        "required_set": value,
+        "state": parsed.state,
+        "settled": parsed.state != SNAP.CANNOT_READ,
+        "reason": reason,
+    }
 
 
 # --- FETCH ---------------------------------------------------------------------------------------
@@ -1553,6 +1685,31 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
     return problems, copies
 
 
+def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
+    """Every runnable required-set copy names the ledger whose header the command owns."""
+    problems, copies = [], []
+    for md in sorted((root or HERE.parent).rglob("*.md")):
+        text = md.read_text(encoding="utf-8")
+        for match in re.finditer(r"ci-status\.py required-set", text):
+            end = text.find("\n\n", match.start())
+            command = text[match.start(): end if end > 0 else len(text)]
+            if "--ledger" not in command:
+                continue  # prose that names the subcommand, not a runnable copy
+            line = text.count("\n", 0, match.start()) + 1
+            copies.append(f"{md.name}:{line}")
+            if "state.jsonl" not in command:
+                problems.append(
+                    f"{md.name}:{line} runs `ci-status.py required-set` without the run ledger's "
+                    f"`state.jsonl` — the command must persist the value it read before the value exists"
+                )
+    if not copies:
+        problems.append(
+            "ZERO runnable copies of `ci-status.py required-set` were found in the skill's docs — finding "
+            "nothing means this check has lost its subject"
+        )
+    return problems, copies
+
+
 def doc_check(doc: Path) -> int:
     """Assert the DOC, the CODE, and this tool's DECIDE_ORDER all say the same thing.
 
@@ -1566,11 +1723,10 @@ def doc_check(doc: Path) -> int:
          paragraphs. A value in a hole matches NO branch: not green, not red, not pending — the PR can never
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       4. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
-         every copy of the derive command, for `--required-set`.
+         every copy of the derive and required-set commands and their required ledger inputs.
 
-    (The doc's `jq` FILTERS are executed by `ci-snapshot.py`'s `producer_test`, which extracts all five
-    reads this doc prescribes VERBATIM and runs them over recorded, multi-page API payloads. That check owns
-    them; a second copy of it here would be a second owner, free to disagree.)
+    (The doc's three snapshot `jq` filters are executed by `ci-snapshot.py` over recorded, multi-page API
+    payloads. The required-set reads are production functions here, covered by `ci-status-test.py`.)
     """
     if not doc.exists():
         print(f"FAIL     the doc is not at {doc} — a check that cannot find its subject NEVER passes")
@@ -1648,6 +1804,11 @@ def doc_check(doc: Path) -> int:
     if not derive_problems:
         held.append(f"{'the derive invocations':32} {len(derive_copies)} copies across the skill's docs, "
                     f"every one of them passing --required-set")
+    required_problems, required_copies = check_required_set_copies()
+    problems += required_problems
+    if not required_problems:
+        held.append(f"{'the required-set invocations':32} {len(required_copies)} runnable copies, every one "
+                    f"persisting to state.jsonl")
     for line in held:
         print(f"ok       {line}")
     for problem in problems:
@@ -1751,6 +1912,13 @@ def main() -> int:
     d.add_argument("--required-set", required=True,
                    help="the ledger header's `required_set`: `declared:<json>` | `none` | `unknown`")
 
+    r = sub.add_parser(
+        "required-set",
+        help="read both required-check sources and persist their canonical union in the ledger",
+    )
+    r.add_argument("--ledger", required=True, type=Path, help="the run's state.jsonl")
+    r.add_argument("--repo", help="owner/name (default: the current checkout's, via `gh repo view`)")
+
     c = sub.add_parser("doc-check", help="assert stage-2-ci.md agrees with the code that runs — enums, "
                                          "CLASSIFY, DECIDE order, and every copy of every command")
     c.add_argument("--doc", type=Path, default=DOC)
@@ -1764,6 +1932,11 @@ def main() -> int:
 
     if args.cmd == "self-test":
         return self_test()
+
+    if args.cmd == "required-set":
+        out = refresh_required_set(gh_fetch, args.ledger, args.repo)
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+        return 0 if out["settled"] else 1
 
     # EVERY OPERATOR ERROR IS NAMED BEFORE THE FIRST FETCH. A caller's mistake surfacing later — as a crash
     # during promotion, or as a verdict about the PR — is a defect reported against the wrong thing.


### PR DESCRIPTION
- read and persist required checks through ci-status.py
- cover classic protection, paged rulesets, and strict failure states
