### PR TITLE
add run lease accessor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,13 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/nudge.py \
             plugins/gauntlet/skills/campaign/scripts/nudge-test.py \
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py \
-            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py | tee pyright.json
+            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py \
+            plugins/gauntlet/skills/campaign/scripts/lease.py \
+            plugins/gauntlet/skills/campaign/scripts/lease-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "22" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 22 it was pointed at — it checked" \
+          if [ "${analyzed}" != "24" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 24 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -192,3 +194,18 @@ jobs:
       # this step is that `py_compile` parses these files and runs neither.
       - name: Reviewer liveness probe contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py self-test
+
+      # The run lease's check-and-set, executed. The lease is what stops two agents driving one run, and
+      # until now it was the only durable store with no schema owner: four reference docs and an `echo`.
+      # The rules worth the most here are the ones the PROSE never defined, because nobody was watching
+      # them — an unparseable lease read as "absent" (which ADOPTS A LIVE RUN), a `release` that deletes
+      # someone else's lease, a skewed clock manufacturing an adoption. Each is a two-driver bug and each
+      # was reachable from the instructions as written. The suite also drives two REAL racing processes
+      # through the real lock.
+      #
+      # This step exists because `py_compile` above parses these files and executes neither. A triage
+      # suite shipped in this repo with no CI step at all, so a semantic regression passed CI while the
+      # focused suite failed; that is follow-up fu18. The sibling `lease-test.py` is loaded by path and a
+      # MISSING sibling fails loudly, so this can never report an all-clear over a suite it did not run.
+      - name: Run lease contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/lease.py self-test

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -104,8 +104,11 @@ when. Same rules: by field name, never hand-edited.
 has stopped converging — the closed enum, the ownership guardrail, and the repair cap
 (`references/repair-pass.md`).
 
-Each script's fixtures live in a **sibling `*-test.py`** (`review-pass-test.py`, `ledger-test.py`,
-`followups-test.py`, `repair-pass-test.py`); the `self-test` subcommand loads it and **fails loudly if it is missing**.
+Each script's fixtures live in a **sibling `*-test.py`** — the accessor's own filename with `-test`
+appended, in the same directory; the `self-test` subcommand loads it by path and **fails loudly if it is
+missing**. That is the rule, and it is deliberately **not** an enumeration: a list of the suites that exist
+today is a restatement, and it goes stale the next time one is added — by an author who never reads this
+line.
 `scripts/transport-contract-test.py` is the standalone exception: the plugin validator runs it directly
 to pin the runtime adapter's typed review/adoption boundary; it owns no run state and has no accessor
 `self-test` subcommand.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -104,14 +104,16 @@ when. Same rules: by field name, never hand-edited.
 has stopped converging — the closed enum, the ownership guardrail, and the repair cap
 (`references/repair-pass.md`).
 
-Each script's fixtures live in a **sibling `*-test.py`** — the accessor's own filename with `-test`
-appended, in the same directory; the `self-test` subcommand loads it by path and **fails loudly if it is
-missing**. That is the rule, and it is deliberately **not** an enumeration: a list of the suites that exist
-today is a restatement, and it goes stale the next time one is added — by an author who never reads this
-line.
-`scripts/transport-contract-test.py` is the standalone exception: the plugin validator runs it directly
-to pin the runtime adapter's typed review/adoption boundary; it owns no run state and has no accessor
-`self-test` subcommand.
+Each schema-owning accessor that carries a sibling suite keeps its fixtures in a **sibling `*-test.py`** —
+the accessor's own filename with `-test` appended, in the same directory; its `self-test` subcommand loads
+that file by path and **fails loudly if it is missing**. That is the rule, and it is deliberately **not** an
+enumeration: a list of the suites that exist today is a restatement, and it goes stale the next time one is
+added — by an author who never reads this line.
+Not every script follows it, so do not assume a sibling for one you have not checked: `ci-snapshot.py` has
+a `self-test` whose fixtures are in-file plus golden files under `scripts/fixtures/`, not a sibling module;
+and `scripts/transport-contract-test.py` is the standalone case the plugin validator runs directly to pin
+the runtime adapter's typed review/adoption boundary — it owns no run state and has no accessor `self-test`
+subcommand.
 
 **At run startup, record which version of these rules is actually running:** read `version` from the
 running plugin's `plugin.json` and write it to the ledger header —

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -414,10 +414,9 @@ may block the PR — the subcommands, and the four verdicts `verify`
 returns; resolve the script at `<skill-dir>/scripts/review-pass.py` and pass that path to subtasks, exactly
 as with `ledger.py` below.
 
-**Each script's fixtures are a SIBLING `*-test.py`** (`review-pass-test.py`, `ledger-test.py`), loaded by
-`self-test` from a `__file__`-relative path. **`self-test` FAILS LOUDLY when the sibling is missing** — a
-self-test that passes because it found no tests is a green derived from zero evidence, which is the exact
-class of bug these suites exist to catch.
+`review-pass.py`'s `self-test` loads a sibling fixture suite, following the **sibling-suite convention that
+`SKILL.md` owns** — that page defines the rule and names which scripts do and do not follow it. This page
+deliberately does not restate or enumerate it; a list here goes stale the moment a suite is added.
 
 ### Editing the ledger — use `scripts/ledger.py`
 

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -198,6 +198,29 @@ def t_future_updated_is_fresh_not_stale(work: Path) -> None:
             "a FUTURE `updated` must read FRESH — a skewed clock must not hand us someone's live run")
 
 
+def t_exact_boundary_is_not_stale(work: Path) -> None:
+    """A lease at age EXACTLY LEASE_STALE_AFTER is NOT stale — the boundary is `>`, never `>=`.
+
+    `>` and `>=` differ ONLY at exact equality, which wall-clock timing can never hit deterministically, so
+    a frozen clock is the only way to pin it. `is_stale`'s docstring says "never widen `>` to `>=`"; this
+    makes that regression go red. At the boundary the owner is BUSY, not dead, so a different token must be
+    superseded — widening to `>=` would adopt a live run.
+    """
+    frozen = 2_000_000_000
+    put(work, {"agent": "other", "heartbeat": "w0", "updated": frozen - L.LEASE_STALE_AFTER})
+    p = lease_path(work)
+    before = p.read_bytes()
+    original = L.now
+    setattr(L, "now", lambda: frozen)  # freeze the clock so age is EXACTLY the window
+    try:
+        code, out, _err = acquire(work, token="mine", heartbeat="w1")
+    finally:
+        setattr(L, "now", original)
+    L.check(code != 0 and verdict_of(out) == "superseded",
+            "age == LEASE_STALE_AFTER is a BUSY owner, not a dead one — `>=` would flip it to `adopted`")
+    L.check(p.read_bytes() == before, "a superseded acquire at the boundary must leave the lease unchanged")
+
+
 # --- corrupt is not absent ----------------------------------------------------
 
 def t_malformed_is_corrupt_never_adopted(work: Path) -> None:
@@ -234,6 +257,32 @@ def t_read_reports_corrupt_without_deciding(work: Path) -> None:
     L.check(code != 0 and verdict_of(out) == "corrupt", "`read` reports corruption rather than guessing")
 
 
+def t_duplicate_json_key_is_corrupt(work: Path) -> None:
+    """A lease that repeats a key reads two ways across parsers — reject it, never guess.
+
+    `json.loads` keeps the LAST duplicate, so `{"agent":"other","agent":"mine"}` resolves to `mine`; a
+    driver whose parser keeps the FIRST reads `other`. That cross-parser disagreement over WHO is driving
+    is a two-driver seam, so a duplicate key is `corrupt`, the same fail-closed direction as every other
+    unreadable lease. If this regresses (the hook dropped), the last-wins `agent` matches and the lease is
+    silently adopted / released.
+    """
+    for name, raw in (
+        ("dup-agent", '{"agent": "other", "agent": "mine", "heartbeat": "w0", "updated": 1}'),
+        ("dup-updated", '{"agent": "t1", "updated": 1, "updated": 2}'),
+    ):
+        p = put(work, None, raw=raw)
+        before = p.read_bytes()
+        code, _out, err = acquire(work, token="mine", heartbeat="w1")
+        L.check(code != 0, f"a {name} lease must REFUSE — a duplicate key is corrupt, not a value to guess")
+        L.check(p.read_bytes() == before, f"a {name} lease must not be overwritten")
+        L.check("cannot" in err.lower() or "two" in err.lower(),
+                f"the {name} refusal must explain why we will not guess who is driving")
+        rcode, rout, _ = L.run(["--file", str(p), "read"])
+        L.check(rcode != 0 and verdict_of(rout) == "corrupt", f"`read` must report a {name} lease corrupt")
+        dcode, _dout, _derr = L.run(["--file", str(p), "release", "--token", "mine"])
+        L.check(dcode != 0 and p.exists(), f"release must not delete a {name} lease it cannot trust")
+
+
 # --- release: the token check the prose forgot --------------------------------
 
 def t_release_refuses_someone_elses_lease(work: Path) -> None:
@@ -258,6 +307,23 @@ def t_release_of_a_corrupt_lease_refuses(work: Path) -> None:
     code, _out, _err = L.run(["--file", str(p), "release", "--token", "mine"])
     L.check(code != 0, "refuse to delete a lease we cannot read — it may belong to a live driver")
     L.check(p.exists(), "the unreadable lease must survive for a human to inspect")
+
+
+def t_release_of_an_absent_lease_refuses(work: Path) -> None:
+    """Release fails CLOSED on an absent lease — symmetric with refresh and the Purpose line.
+
+    A release proves ownership by matching the token in the lease. With no lease present there is nothing
+    to match, so it cannot confirm this caller ever owned the run: it must refuse, not exit 0. (This
+    reverses an earlier idempotency choice.)
+    """
+    p = lease_path(work)
+    L.check(not p.exists(), "fixture precondition: no lease")
+    code, out, err = L.run(["--file", str(p), "release", "--token", "mine"])
+    L.check(code != 0, "an absent lease must REFUSE release — there is no token to match against")
+    L.check(verdict_of(out) == "absent", "the verdict still names the absent state")
+    L.check(not p.exists(), "a refused release must conjure nothing")
+    L.check("no lease" in err.lower() and "match" in err.lower(),
+            "the refusal must say there is no lease to match the token against")
 
 
 # --- refresh ------------------------------------------------------------------
@@ -332,27 +398,62 @@ def t_the_lock_is_released_on_the_refusal_paths(work: Path) -> None:
 
 
 def t_only_one_of_two_racing_claimers_wins(work: Path) -> None:
-    """Real processes, real lock. The property the whole file exists for."""
+    """Real processes, real lock. The property the whole file exists for.
+
+    TEETH: this must FAIL if the critical section is unlocked, not merely if nobody wins. Several racers
+    are released together against an ABSENT lease by a shared barrier file. Under a real lock they
+    SERIALIZE: exactly one reads absent and adopts (owning the run AS ITSELF, exit 0); every other reads
+    that fresh lease and stands down (`superseded`/`lost-race`). Unlock the read/decide/write (e.g. move
+    `claim_lock`'s rmdir before the yield) and two or more racers read absent before anyone writes, each
+    commits its OWN token and reads it back — TWO self-believed owners of one run. The check below counts
+    self-owners and demands exactly one, so that regression goes red; several rounds make the interleave
+    reliable to catch.
+    """
     p = lease_path(work)
+    barrier = work / "go"
     prog = (
-        "import sys;"
+        "import sys, os, time;"
         f"sys.path.insert(0, {str(OWNER.parent)!r});"
         "from _gauntlet.modules import load_module_from_path;"
         f"m = load_module_from_path('lease_race', {str(OWNER)!r});"
+        f"b = {str(barrier)!r};"
+        "\nwhile not os.path.exists(b): time.sleep(0.002)\n"
         f"raise SystemExit(m.main(['--file', {str(p)!r}, 'acquire', '--token', sys.argv[1],"
         " '--heartbeat-id', 'w']))"
     )
-    procs = [subprocess.Popen([sys.executable, "-c", prog, tok],
-                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-             for tok in ("racer-a", "racer-b")]
-    codes = [p_.wait() for p_ in procs]
-    L.check(p.exists(), "one of the racers must have taken the lease")
-    winner = json.loads(p.read_text())["agent"]
-    L.check(winner in ("racer-a", "racer-b"), f"the lease must name a real racer, got {winner!r}")
-    L.check(not (work / L.LOCK_NAME).exists(), "neither racer may leak the lock")
-    # Both may legitimately exit 0: the loser can arrive after the winner's lease went in and read it as a
-    # normal `superseded`/adopt-by-stale... but it must NEVER be that BOTH think they own it as themselves.
-    L.check(codes.count(0) >= 1, "at least one racer must succeed")
+    tokens = [f"racer-{i}" for i in range(5)]
+    for _round in range(4):
+        if p.exists():
+            p.unlink()
+        if barrier.exists():
+            barrier.unlink()
+        procs = [subprocess.Popen([sys.executable, "-c", prog, tok],
+                                  stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+                 for tok in tokens]
+        time.sleep(0.15)          # let every racer reach its spin loop before...
+        barrier.touch()           # ...releasing them as simultaneously as the OS allows
+        outs = [(tok, pr.communicate()[0].decode()) for tok, pr in zip(tokens, procs)]
+
+        L.check(p.exists(), "one of the racers must have taken the lease")
+        winner = json.loads(p.read_text())["agent"]
+        L.check(winner in tokens, f"the lease must name a real racer, got {winner!r}")
+        L.check(not (work / L.LOCK_NAME).exists(), "neither racer may leak the lock")
+
+        self_owners = []
+        for tok, out in outs:
+            try:
+                rec = json.loads(out)
+            except json.JSONDecodeError:
+                continue
+            # "I own this run AS MYSELF" = a fresh acquire that wrote and read back my own token.
+            if rec.get("verdict") in ("owned", "adopted") and rec.get("token") == tok:
+                self_owners.append(tok)
+        L.check(len(self_owners) == 1,
+                f"EXACTLY ONE racer may own the run as itself; got {self_owners!r}. Two or more means the "
+                f"read/decide/write was NOT serialized — the lock is broken and both drivers believe they "
+                f"own the run.")
+        L.check(self_owners == [winner],
+                f"the self-believed owner {self_owners!r} must be the token actually in the lease {winner!r}")
 
 
 CASES = [
@@ -376,14 +477,20 @@ CASES = [
     ("stale-adopted", "a lease past the window has a dead driver", t_stale_is_adopted),
     ("inside-window-busy", "a lease inside the window is BUSY, not dead", t_just_inside_the_window_is_not_stale),
     ("future-is-fresh", "clock skew must not manufacture an adoption", t_future_updated_is_fresh_not_stale),
+    ("exact-boundary-fresh", "age == LEASE_STALE_AFTER is NOT stale — the boundary is `>`, not `>=`",
+     t_exact_boundary_is_not_stale),
     ("corrupt-not-absent", "an unreadable lease is CORRUPT — adopting it would double-drive a live run",
      t_malformed_is_corrupt_never_adopted),
     ("read-reports-corrupt", "`read` reports corruption rather than guessing",
      t_read_reports_corrupt_without_deciding),
+    ("duplicate-key-corrupt", "a duplicate JSON key reads two ways — corrupt, never guessed",
+     t_duplicate_json_key_is_corrupt),
     ("release-refuses-theirs", "release refuses a lease we do not own — the prose's missing check",
      t_release_refuses_someone_elses_lease),
     ("release-mine", "release with the right token releases", t_release_deletes_my_own),
     ("release-corrupt", "refuse to delete a lease we cannot read", t_release_of_a_corrupt_lease_refuses),
+    ("release-absent", "release fails closed on an absent lease — no token to match",
+     t_release_of_an_absent_lease_refuses),
     ("refresh-bumps", "refresh bumps, preserves the proof, and keeps unknown fields",
      t_refresh_bumps_and_preserves),
     ("refresh-superseded", "refresh refuses once superseded", t_refresh_refuses_when_superseded),

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import subprocess
 import sys
 import time
@@ -283,6 +284,115 @@ def t_duplicate_json_key_is_corrupt(work: Path) -> None:
         L.check(dcode != 0 and p.exists(), f"release must not delete a {name} lease it cannot trust")
 
 
+# --- corrupt at the DECODE/PARSE boundary, not just per-field -----------------
+
+def t_invalid_utf8_is_corrupt(work: Path) -> None:
+    """Undecodable bytes must FAIL CLOSED, not crash with a traceback.
+
+    `read_text` raises `UnicodeDecodeError`, a `ValueError` subclass and NOT an `OSError`, so before the
+    decode-boundary catch it escaped `except OSError` and `read` printed a raw traceback while `acquire`
+    skipped its Corrupt refusal entirely. A lease we cannot even decode is corrupt, never absent.
+    """
+    p = lease_path(work)
+    p.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    before = p.read_bytes()
+    code, _out, err = acquire(work, token="mine", heartbeat="w1")
+    L.check(code != 0, "a lease with invalid UTF-8 must REFUSE — undecodable bytes are corrupt, not absent")
+    L.check(p.read_bytes() == before, "an undecodable lease must not be overwritten")
+    L.check(err.startswith("lease: REFUSED"),
+            "acquire must emit its own REFUSED message, not let a raw UnicodeDecodeError escape")
+    L.check("Traceback" not in err and "UnicodeDecodeError" not in err,
+            "the tool must fail closed on undecodable bytes, never crash with a traceback")
+    rcode, rout, _ = L.run(["--file", str(p), "read"])
+    L.check(rcode != 0 and verdict_of(rout) == "corrupt", "`read` must report undecodable bytes as corrupt")
+
+
+def t_non_finite_is_corrupt(work: Path) -> None:
+    """`json.loads` accepts NaN/Infinity/-Infinity by default; the parse boundary must reject them.
+
+    The per-field checks only catch a non-finite `agent`/`updated`. Anywhere else — a preserved unknown
+    field, `heartbeat`, a nested object — a non-finite value slips past, reads `held`/acquires `owned`, and
+    round-trips to disk as INVALID strict JSON. Each `agent`/`updated` here is well-formed, so ONLY the
+    `parse_constant` reject makes these corrupt; without it acquire would adopt the stale lease (exit 0).
+    """
+    cases = [
+        ("heartbeat-nan", '{"agent": "t1", "heartbeat": NaN, "updated": 1}'),
+        ("unknown-infinity", '{"agent": "t1", "updated": 1, "extra": Infinity}'),
+        ("nested-neg-infinity", '{"agent": "t1", "updated": 1, "meta": {"drift": -Infinity}}'),
+    ]
+    for name, raw in cases:
+        p = put(work, None, raw=raw)
+        before = p.read_bytes()
+        code, _out, _err = acquire(work, token="mine", heartbeat="w1")
+        L.check(code != 0,
+                f"a {name} lease must REFUSE — a non-finite JSON constant is not strict JSON, so corrupt")
+        L.check(p.read_bytes() == before, f"a {name} lease must not be overwritten")
+        rcode, rout, _ = L.run(["--file", str(p), "read"])
+        L.check(rcode != 0 and verdict_of(rout) == "corrupt", f"`read` must report a {name} lease corrupt")
+
+
+def t_write_lease_never_writes_non_finite(work: Path) -> None:
+    """What we write must be STRICT JSON, and `write_lease` must refuse to serialize a non-finite value.
+
+    `allow_nan=False` is the guard that stops the tool putting on disk exactly what `read_lease` now
+    refuses to read back — a lease that would strand the run behind a corruption of our own making.
+    """
+    code, _out, _err = acquire(work, token="t1", heartbeat="w1")
+    L.check(code == 0, "precondition: a normal acquire succeeds")
+    content = lease_path(work).read_text()
+
+    def _boom(v):
+        raise AssertionError(f"the lease on disk holds a non-finite constant {v!r} — not strict JSON")
+
+    json.loads(content, parse_constant=_boom)  # raises if disk holds NaN/Infinity/-Infinity
+    L.check("NaN" not in content and "Infinity" not in content,
+            "the lease written to disk must be strict JSON — no NaN/Infinity tokens")
+
+    raised = False
+    try:
+        L.write_lease(lease_path(work),
+                      {"agent": "t1", "heartbeat": "w1", "updated": L.now(), "drift": float("inf")})
+    except ValueError:
+        raised = True
+    L.check(raised, "write_lease must REFUSE to serialize a non-finite number (allow_nan=False) — the tool "
+                    "must never itself put NaN/Infinity on disk")
+
+
+# --- mode: refresh/acquire must not narrow the lease's permissions ------------
+
+def t_refresh_preserves_file_mode(work: Path) -> None:
+    """`replace_text` writes through a 0600 mkstemp temp, so a rewrite would NARROW 0664 -> 0600.
+
+    write_lease preserves an existing lease's prior mode. Without it, every refresh silently tightens the
+    lease's permissions away from what the run dir was set up with.
+    """
+    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now() - 100})
+    os.chmod(p, 0o664)
+    code, _out, _err = L.run(["--file", str(p), "refresh", "--token", "t1"])
+    L.check(code == 0, "refreshing my own lease succeeds")
+    mode = stat.S_IMODE(p.stat().st_mode)
+    L.check(mode == 0o664,
+            f"refresh must PRESERVE the lease's prior mode (0664), got {oct(mode)} — a rewrite must not "
+            f"narrow it to mkstemp's private 0600")
+
+
+def t_new_lease_uses_umask_permissions(work: Path) -> None:
+    """A brand-new lease gets umask-adjusted create perms, NOT mkstemp's private 0600.
+
+    umask is pinned for the duration so the expected mode is deterministic regardless of the environment.
+    """
+    old = os.umask(0o022)
+    try:
+        code, _out, _err = acquire(work, token="t1", heartbeat="w1")
+    finally:
+        os.umask(old)
+    L.check(code == 0, "an absent lease is adoptable")
+    mode = stat.S_IMODE(lease_path(work).stat().st_mode)
+    L.check(mode == 0o644,
+            f"a NEW lease must get umask-adjusted create perms (0644 under umask 022), got {oct(mode)} — "
+            f"not mkstemp's private 0600")
+
+
 # --- release: the token check the prose forgot --------------------------------
 
 def t_release_refuses_someone_elses_lease(work: Path) -> None:
@@ -525,6 +635,15 @@ CASES = [
      t_read_reports_corrupt_without_deciding),
     ("duplicate-key-corrupt", "a duplicate JSON key reads two ways — corrupt, never guessed",
      t_duplicate_json_key_is_corrupt),
+    ("invalid-utf8-corrupt", "undecodable bytes fail closed to corrupt, never crash", t_invalid_utf8_is_corrupt),
+    ("non-finite-corrupt", "NaN/Infinity anywhere is corrupt, not a value to round-trip",
+     t_non_finite_is_corrupt),
+    ("strict-json-on-disk", "write_lease writes strict JSON and refuses a non-finite value",
+     t_write_lease_never_writes_non_finite),
+    ("refresh-preserves-mode", "refresh preserves the lease's prior mode, never narrows to 0600",
+     t_refresh_preserves_file_mode),
+    ("new-lease-umask-mode", "a new lease gets umask-adjusted perms, not mkstemp's 0600",
+     t_new_lease_uses_umask_permissions),
     ("release-refuses-theirs", "release refuses a lease we do not own — the prose's missing check",
      t_release_refuses_someone_elses_lease),
     ("release-mine", "release with the right token releases", t_release_deletes_my_own),

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -297,6 +297,20 @@ def t_a_held_lock_blocks(work: Path) -> None:
     L.check("held" in err, "the refusal must say the lock is held")
 
 
+def t_claim_lock_sweep_stays_on_the_lease_scale(work: Path) -> None:
+    """A short sweep timeout re-opens the clock-skew mutual-exclusion hole.
+
+    The claim.lock is a bare `mkdir` with no PID, so mtime is the ONLY cross-driver signal and the sweep
+    threshold is the only lever against a forward clock jump sweeping a LIVE sub-second claim. If a future
+    edit lowers it back toward the critical-section scale (the old `5 * 60`), a modest forward jump could
+    sweep a live lock and let a second driver in — two owners of one run. Pin it to the lease-staleness
+    scale so that regression goes RED here.
+    """
+    L.check(L.CLAIM_LOCK_STALE_AFTER >= L.LEASE_STALE_AFTER,
+            f"CLAIM_LOCK_STALE_AFTER ({L.CLAIM_LOCK_STALE_AFTER}s) must be >= LEASE_STALE_AFTER "
+            f"({L.LEASE_STALE_AFTER}s): a shorter claim-lock sweep re-opens the clock-skew two-driver hole")
+
+
 def t_a_stale_lock_is_swept(work: Path) -> None:
     lock = work / L.LOCK_NAME
     lock.mkdir()
@@ -375,6 +389,8 @@ CASES = [
     ("refresh-superseded", "refresh refuses once superseded", t_refresh_refuses_when_superseded),
     ("refresh-absent", "refresh does not conjure a lease", t_refresh_of_an_absent_lease_does_not_recreate_it),
     ("lock-blocks", "a held claim.lock blocks the check-and-set", t_a_held_lock_blocks),
+    ("lock-sweep-scale", "a short claim-lock sweep re-opens the clock-skew mutual-exclusion hole",
+     t_claim_lock_sweep_stays_on_the_lease_scale),
     ("lock-swept", "a lock from a crashed claim is swept", t_a_stale_lock_is_swept),
     ("lock-released", "the lock is released on the refusal paths", t_the_lock_is_released_on_the_refusal_paths),
     ("race", "two real racing claimers, one lease", t_only_one_of_two_racing_claimers_wins),

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Fixtures for `lease.py` — the check-and-set, the heartbeat precondition, and the refusals.
+
+They live in a SIBLING file, and `lease.py self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE MUST PIN A RULE — it must go red if its rule is deleted or weakened. The rules worth the
+most here are the ones the PROSE never defined, because nobody was watching them: a malformed lease read
+as "absent" (which ADOPTS A LIVE RUN), a `release` that deletes someone else's lease, and clock skew
+manufacturing an adoption. Each of those is a two-driver bug, and each was reachable from the instructions
+as written.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+OWNER = Path(__file__).resolve().parent / "lease.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("lease_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the lease accessor at {OWNER}")
+    return mod
+
+
+L = _load_owner()
+
+
+# --- helpers ------------------------------------------------------------------
+
+def lease_path(work: Path) -> Path:
+    return work / "lease.json"
+
+
+def put(work: Path, rec, *, raw: "str | None" = None) -> Path:
+    p = lease_path(work)
+    p.write_text(raw if raw is not None else json.dumps(rec) + "\n", encoding="utf-8")
+    return p
+
+
+def acquire(work: Path, **kw):
+    argv = ["--file", str(lease_path(work)), "acquire"]
+    for flag, val in (("--token", kw.get("token")), ("--heartbeat-id", kw.get("heartbeat"))):
+        if val is not None:
+            argv += [flag, val]
+    if kw.get("takeover"):
+        argv.append("--allow-takeover")
+    return L.run(argv)
+
+
+def verdict_of(out: str) -> str:
+    return json.loads(out)["verdict"]
+
+
+# --- the heartbeat precondition -----------------------------------------------
+
+def t_no_heartbeat_refuses(work: Path) -> None:
+    """The whole point: no proof of arming, no lease."""
+    code, _out, err = acquire(work, token="t1")
+    L.check(code != 0, "acquire with NO --heartbeat-id must REFUSE — that is the entire mechanism")
+    L.check(not lease_path(work).exists(), "a refused acquire must write NOTHING")
+    L.check("--heartbeat-id" in err and "ALREADY armed" in err,
+            "the refusal must say the proof names something ALREADY armed, not something intended")
+    L.check("IN THIS ORDER" in err, "the refusal must teach the order (arm, THEN acquire) — an "
+                                    "instruction, not a diagnosis")
+    L.check("runtime-adapter" in err, "the refusal must point at the doc that owns the host mapping")
+    for host_specific in ("ScheduleWakeup", "CronCreate", "bounded wait"):
+        L.check(host_specific not in err,
+                f"the refusal must name NO host mechanism ({host_specific!r} leaked) — that is the "
+                f"cross-host violation AGENTS.md forbids")
+
+
+def t_no_heartbeat_refuses_on_an_absent_lease(work: Path) -> None:
+    """The easy way to reintroduce the bug: check the proof only on the `owned` path.
+
+    A fresh run is the case with NO wake yet — exactly the one that must not sail through.
+    """
+    L.check(not lease_path(work).exists(), "fixture precondition: no lease yet")
+    code, _out, _err = acquire(work, token="t1")
+    L.check(code != 0, "an ABSENT lease must refuse without a proof too — a fresh run is the case with no "
+                       "wake armed yet, so checking only the `owned` path defeats the whole door")
+
+
+def t_empty_heartbeat_is_not_a_proof(work: Path) -> None:
+    """Not trimmed into existence — same identifier discipline as review-pass.py."""
+    for blank in ("", "   ", "\t\n"):
+        code, _out, _err = acquire(work, token="t1", heartbeat=blank)
+        L.check(code != 0, f"a whitespace-only proof ({blank!r}) must REFUSE, never be trimmed into a value")
+        L.check(not lease_path(work).exists(), "a refused acquire must write NOTHING")
+
+
+def t_argparse_must_not_steal_the_refusal(work: Path) -> None:
+    """The message IS the mechanism, so argparse must not answer first.
+
+    If --heartbeat-id were argparse-`required`, the caller would get "the following arguments are required"
+    — the right exit code and NONE of the instruction. The mechanism would be gone while the tests that
+    only assert `code != 0` stayed green.
+    """
+    _code, _out, err = acquire(work, token="t1")
+    L.check("the following arguments are required" not in err,
+            "argparse must NOT own this refusal — the instruction is the mechanism, not the exit code")
+    L.check(err.startswith("lease: REFUSED"), "the refusal must be OUR message")
+
+
+def t_no_token_refuses_and_never_mints(work: Path) -> None:
+    """A caller with no token never armed a wake that identifies it: its proof cannot be real."""
+    code, _out, err = acquire(work, heartbeat="wake-1")
+    L.check(code != 0, "acquire with NO --token must REFUSE")
+    L.check(not lease_path(work).exists(), "a refused acquire must write NOTHING — and must NOT mint a "
+                                           "token to make itself succeed")
+    L.check("mint" in err, "the refusal must point at `mint` as step one")
+
+
+# --- the proof is recorded, never interpreted ---------------------------------
+
+def t_proof_is_stored_verbatim(work: Path) -> None:
+    """The tool never parses, normalizes, or validates the proof's content."""
+    hostile = "  wake id/with spaces --and-dashes é中 $(echo no) `echo no`  "
+    code, out, _err = acquire(work, token="t1", heartbeat=hostile)
+    L.check(code == 0, "a proof with odd bytes is still a proof — the tool does not inspect it")
+    L.check(json.loads(out)["heartbeat"] == hostile, "the proof must round-trip VERBATIM")
+    L.check(json.loads(lease_path(work).read_text())["heartbeat"] == hostile,
+            "the proof must be stored VERBATIM on disk")
+
+
+def t_a_new_proof_is_not_a_generation_mismatch(work: Path) -> None:
+    """Pins the REJECTED design out: `heartbeat` is a record, not a generation to match.
+
+    An earlier draft compared the presented proof to the stored one and stood down on a mismatch. It could
+    never have worked: a wake has two things to say ("I am H1" / "I armed H2") and one flag to say them in.
+    """
+    acquire(work, token="t1", heartbeat="wake-1")
+    code, out, _err = acquire(work, token="t1", heartbeat="wake-2")
+    L.check(code == 0, "re-acquiring with a DIFFERENT proof is normal — each wake arms its own successor")
+    L.check(verdict_of(out) == "owned", "same token on a fresh lease is `owned`, whatever the proof says")
+    L.check(json.loads(lease_path(work).read_text())["heartbeat"] == "wake-2",
+            "the lease records the LATEST proof")
+
+
+# --- ownership: the decision table --------------------------------------------
+
+def t_absent_is_adopted(work: Path) -> None:
+    code, out, _err = acquire(work, token="t1", heartbeat="w1")
+    L.check(code == 0 and verdict_of(out) == "adopted", "an absent lease is adoptable")
+    L.check(json.loads(lease_path(work).read_text())["agent"] == "t1", "the token must land in the lease")
+
+
+def t_fresh_and_mine_is_owned(work: Path) -> None:
+    put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+    code, out, _err = acquire(work, token="t1", heartbeat="w1")
+    L.check(code == 0 and verdict_of(out) == "owned", "my own fresh lease is `owned`, and refreshes")
+
+
+def t_fresh_and_theirs_is_superseded(work: Path) -> None:
+    rec = {"agent": "other", "heartbeat": "w0", "updated": L.now()}
+    p = put(work, rec)
+    before = p.read_bytes()
+    code, out, err = acquire(work, token="mine", heartbeat="w1")
+    L.check(code != 0 and verdict_of(out) == "superseded", "a live lease held by ANOTHER agent refuses")
+    L.check(p.read_bytes() == before, "a superseded acquire must leave the lease BYTE-UNCHANGED")
+    L.check("not the driver" in err, "the refusal must tell the loser to stand down")
+
+
+def t_takeover_is_explicit(work: Path) -> None:
+    put(work, {"agent": "other", "heartbeat": "w0", "updated": L.now()})
+    code, out, _err = acquire(work, token="mine", heartbeat="w1", takeover=True)
+    L.check(code == 0 and verdict_of(out) == "adopted", "--allow-takeover adopts a live run")
+    L.check(json.loads(lease_path(work).read_text())["agent"] == "mine", "takeover writes the new token")
+
+
+def t_stale_is_adopted(work: Path) -> None:
+    put(work, {"agent": "dead", "heartbeat": "w0", "updated": L.now() - L.LEASE_STALE_AFTER - 1})
+    code, out, _err = acquire(work, token="mine", heartbeat="w1")
+    L.check(code == 0 and verdict_of(out) == "adopted", "a lease past LEASE_STALE_AFTER has a dead driver")
+
+
+def t_just_inside_the_window_is_not_stale(work: Path) -> None:
+    put(work, {"agent": "busy", "heartbeat": "w0", "updated": L.now() - L.LEASE_STALE_AFTER + 5})
+    code, out, _err = acquire(work, token="mine", heartbeat="w1")
+    L.check(code != 0 and verdict_of(out) == "superseded",
+            "a lease INSIDE the window is a BUSY driver, not a dead one — staleness must not be off by a "
+            "boundary and steal a live run")
+
+
+def t_future_updated_is_fresh_not_stale(work: Path) -> None:
+    """Clock skew must never manufacture an adoption — that is the two-driver bug."""
+    put(work, {"agent": "other", "heartbeat": "w0", "updated": L.now() + 10_000})
+    code, out, _err = acquire(work, token="mine", heartbeat="w1")
+    L.check(code != 0 and verdict_of(out) == "superseded",
+            "a FUTURE `updated` must read FRESH — a skewed clock must not hand us someone's live run")
+
+
+# --- corrupt is not absent ----------------------------------------------------
+
+def t_malformed_is_corrupt_never_adopted(work: Path) -> None:
+    """The prose said "absent or stale". It never said what an unparseable lease is.
+
+    A reader that lets "cannot parse" fall through to "absent" ADOPTS A LIVE RUN.
+    """
+    bad = [
+        ("empty", ""),
+        ("blank", "   \n"),
+        ("truncated", '{"agent": "t1", "upda'),
+        ("array", '["agent", "t1"]'),
+        ("string", '"just a string"'),
+        ("no-agent", '{"heartbeat": "w0", "updated": 1}'),
+        ("blank-agent", '{"agent": "   ", "updated": 1}'),
+        ("agent-not-string", '{"agent": 7, "updated": 1}'),
+        ("updated-string", '{"agent": "t1", "updated": "recently"}'),
+        ("updated-bool", '{"agent": "t1", "updated": true}'),
+        ("no-updated", '{"agent": "t1", "heartbeat": "w0"}'),
+    ]
+    for name, raw in bad:
+        p = put(work, None, raw=raw)
+        before = p.read_bytes()
+        code, _out, err = acquire(work, token="mine", heartbeat="w1")
+        L.check(code != 0, f"a {name} lease must REFUSE — it is CORRUPT, and corrupt is not absent")
+        L.check(p.read_bytes() == before, f"a {name} lease must not be overwritten")
+        L.check("two agents" in err or "cannot" in err.lower(),
+                f"the {name} refusal must explain why we will not guess")
+
+
+def t_read_reports_corrupt_without_deciding(work: Path) -> None:
+    put(work, None, raw="{oops")
+    code, out, _err = L.run(["--file", str(lease_path(work)), "read"])
+    L.check(code != 0 and verdict_of(out) == "corrupt", "`read` reports corruption rather than guessing")
+
+
+# --- release: the token check the prose forgot --------------------------------
+
+def t_release_refuses_someone_elses_lease(work: Path) -> None:
+    """"Delete lease.json on normal exit", followed literally by a superseded driver, hands away a live run."""
+    p = put(work, {"agent": "other", "heartbeat": "w0", "updated": L.now()})
+    before = p.read_bytes()
+    code, out, err = L.run(["--file", str(p), "release", "--token", "mine"])
+    L.check(code != 0 and verdict_of(out) == "superseded", "release must refuse a lease we do not own")
+    L.check(p.exists() and p.read_bytes() == before, "a refused release must leave the lease INTACT")
+    L.check("DIFFERENT agent" in err, "the refusal must say whose lease it is")
+
+
+def t_release_deletes_my_own(work: Path) -> None:
+    p = put(work, {"agent": "mine", "heartbeat": "w0", "updated": L.now()})
+    code, out, _err = L.run(["--file", str(p), "release", "--token", "mine"])
+    L.check(code == 0 and verdict_of(out) == "released", "release with the right token releases")
+    L.check(not p.exists(), "a released lease is gone, so the finished run shows no driver")
+
+
+def t_release_of_a_corrupt_lease_refuses(work: Path) -> None:
+    p = put(work, None, raw="{oops")
+    code, _out, _err = L.run(["--file", str(p), "release", "--token", "mine"])
+    L.check(code != 0, "refuse to delete a lease we cannot read — it may belong to a live driver")
+    L.check(p.exists(), "the unreadable lease must survive for a human to inspect")
+
+
+# --- refresh ------------------------------------------------------------------
+
+def t_refresh_bumps_and_preserves(work: Path) -> None:
+    old = L.now() - 100
+    put(work, {"agent": "t1", "heartbeat": "w0", "updated": old, "note": "unknown-field"})
+    code, _out, _err = L.run(["--file", str(lease_path(work)), "refresh", "--token", "t1"])
+    L.check(code == 0, "refreshing my own lease succeeds")
+    rec = json.loads(lease_path(work).read_text())
+    L.check(rec["updated"] > old, "refresh must bump `updated` — it is the liveness proof")
+    L.check(rec["heartbeat"] == "w0", "refresh does NOT re-arm, so it must preserve the proof")
+    L.check(rec["note"] == "unknown-field", "a field this version does not know must survive the write")
+
+
+def t_refresh_refuses_when_superseded(work: Path) -> None:
+    """The case that matters: the owner changed while this driver was slow."""
+    put(work, {"agent": "other", "heartbeat": "w0", "updated": L.now()})
+    code, out, err = L.run(["--file", str(lease_path(work)), "refresh", "--token", "mine"])
+    L.check(code != 0 and verdict_of(out) == "superseded", "refresh must refuse once superseded")
+    L.check("Stand down" in err, "a superseded driver must be told to stop")
+
+
+def t_refresh_of_an_absent_lease_does_not_recreate_it(work: Path) -> None:
+    code, _out, err = L.run(["--file", str(lease_path(work)), "refresh", "--token", "t1"])
+    L.check(code != 0, "refreshing a GONE lease must refuse, not silently re-create it")
+    L.check(not lease_path(work).exists(), "refresh must not conjure a lease")
+    L.check("GONE" in err, "the refusal must say the lease vanished, which is a bug worth seeing")
+
+
+# --- the lock -----------------------------------------------------------------
+
+def t_a_held_lock_blocks(work: Path) -> None:
+    (work / L.LOCK_NAME).mkdir()
+    code, _out, err = acquire(work, token="t1", heartbeat="w1")
+    L.check(code != 0, "a held claim.lock must block the check-and-set")
+    L.check("held" in err, "the refusal must say the lock is held")
+
+
+def t_a_stale_lock_is_swept(work: Path) -> None:
+    lock = work / L.LOCK_NAME
+    lock.mkdir()
+    old = time.time() - L.CLAIM_LOCK_STALE_AFTER - 60
+    os.utime(lock, (old, old))
+    code, _out, _err = acquire(work, token="t1", heartbeat="w1")
+    L.check(code == 0, "a claim.lock left by a process that died mid-claim must be swept, or the run "
+                       "wedges forever")
+
+
+def t_the_lock_is_released_on_the_refusal_paths(work: Path) -> None:
+    """A lock leaked on an error path wedges the run as surely as never sweeping it."""
+    put(work, None, raw="{oops")
+    acquire(work, token="t1", heartbeat="w1")  # refuses: corrupt
+    L.check(not (work / L.LOCK_NAME).exists(), "the lock must be released after a CORRUPT refusal")
+    put(work, {"agent": "other", "heartbeat": "w0", "updated": L.now()})
+    acquire(work, token="mine", heartbeat="w1")  # refuses: superseded
+    L.check(not (work / L.LOCK_NAME).exists(), "the lock must be released after a SUPERSEDED refusal")
+
+
+def t_only_one_of_two_racing_claimers_wins(work: Path) -> None:
+    """Real processes, real lock. The property the whole file exists for."""
+    p = lease_path(work)
+    prog = (
+        "import sys;"
+        f"sys.path.insert(0, {str(OWNER.parent)!r});"
+        "from _gauntlet.modules import load_module_from_path;"
+        f"m = load_module_from_path('lease_race', {str(OWNER)!r});"
+        f"raise SystemExit(m.main(['--file', {str(p)!r}, 'acquire', '--token', sys.argv[1],"
+        " '--heartbeat-id', 'w']))"
+    )
+    procs = [subprocess.Popen([sys.executable, "-c", prog, tok],
+                              stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+             for tok in ("racer-a", "racer-b")]
+    codes = [p_.wait() for p_ in procs]
+    L.check(p.exists(), "one of the racers must have taken the lease")
+    winner = json.loads(p.read_text())["agent"]
+    L.check(winner in ("racer-a", "racer-b"), f"the lease must name a real racer, got {winner!r}")
+    L.check(not (work / L.LOCK_NAME).exists(), "neither racer may leak the lock")
+    # Both may legitimately exit 0: the loser can arrive after the winner's lease went in and read it as a
+    # normal `superseded`/adopt-by-stale... but it must NEVER be that BOTH think they own it as themselves.
+    L.check(codes.count(0) >= 1, "at least one racer must succeed")
+
+
+CASES = [
+    ("no-heartbeat", "no proof of arming, no lease — the entire mechanism", t_no_heartbeat_refuses),
+    ("no-heartbeat-absent", "an ABSENT lease refuses too — a fresh run has no wake yet",
+     t_no_heartbeat_refuses_on_an_absent_lease),
+    ("blank-heartbeat", "a whitespace proof is refused, never trimmed into a value",
+     t_empty_heartbeat_is_not_a_proof),
+    ("refusal-is-ours", "argparse must not steal the refusal — the instruction IS the mechanism",
+     t_argparse_must_not_steal_the_refusal),
+    ("no-token", "no token, no lease — and acquire never mints one to save itself",
+     t_no_token_refuses_and_never_mints),
+    ("proof-verbatim", "the proof is recorded, never parsed or normalized", t_proof_is_stored_verbatim),
+    ("proof-not-a-generation", "a new proof is a record, not a generation mismatch",
+     t_a_new_proof_is_not_a_generation_mismatch),
+    ("absent-adopted", "an absent lease is adoptable", t_absent_is_adopted),
+    ("fresh-mine-owned", "my own fresh lease is owned", t_fresh_and_mine_is_owned),
+    ("fresh-theirs-refused", "a live lease held by another agent refuses, byte-unchanged",
+     t_fresh_and_theirs_is_superseded),
+    ("takeover-explicit", "--allow-takeover adopts a live run, and only then", t_takeover_is_explicit),
+    ("stale-adopted", "a lease past the window has a dead driver", t_stale_is_adopted),
+    ("inside-window-busy", "a lease inside the window is BUSY, not dead", t_just_inside_the_window_is_not_stale),
+    ("future-is-fresh", "clock skew must not manufacture an adoption", t_future_updated_is_fresh_not_stale),
+    ("corrupt-not-absent", "an unreadable lease is CORRUPT — adopting it would double-drive a live run",
+     t_malformed_is_corrupt_never_adopted),
+    ("read-reports-corrupt", "`read` reports corruption rather than guessing",
+     t_read_reports_corrupt_without_deciding),
+    ("release-refuses-theirs", "release refuses a lease we do not own — the prose's missing check",
+     t_release_refuses_someone_elses_lease),
+    ("release-mine", "release with the right token releases", t_release_deletes_my_own),
+    ("release-corrupt", "refuse to delete a lease we cannot read", t_release_of_a_corrupt_lease_refuses),
+    ("refresh-bumps", "refresh bumps, preserves the proof, and keeps unknown fields",
+     t_refresh_bumps_and_preserves),
+    ("refresh-superseded", "refresh refuses once superseded", t_refresh_refuses_when_superseded),
+    ("refresh-absent", "refresh does not conjure a lease", t_refresh_of_an_absent_lease_does_not_recreate_it),
+    ("lock-blocks", "a held claim.lock blocks the check-and-set", t_a_held_lock_blocks),
+    ("lock-swept", "a lock from a crashed claim is swept", t_a_stale_lock_is_swept),
+    ("lock-released", "the lock is released on the refusal paths", t_the_lock_is_released_on_the_refusal_paths),
+    ("race", "two real racing claimers, one lease", t_only_one_of_two_racing_claimers_wins),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -261,23 +261,30 @@ def t_legacy_lease_with_no_heartbeat_is_accepted(work: Path) -> None:
     double-drive this tool exists to prevent, in reverse. Contrast `t_malformed_is_corrupt`'s `no-updated`
     case: a missing `updated` IS corrupt (we cannot tell staleness); a missing `heartbeat` is NOT.
 
-    `updated` is a fixed FUTURE stamp so the lease reads FRESH whenever the suite runs.
+    The clock is FROZEN to `updated` so the legacy lease reads FRESH regardless of the wall-clock date —
+    the outcome is anchored to the frozen clock, never to a stamp being in the future.
 
     TEETH: add a "reject a lease with no heartbeat" check to read_lease and this goes red — read_lease
     raises Corrupt, and the same-token acquire/refresh stop returning `owned`.
     """
-    rec = {"agent": "legacy-driver", "updated": 2_000_000_000}
+    frozen = 2_000_000_000
+    rec = {"agent": "legacy-driver", "updated": frozen}
     p = put(work, rec)
     got = L.read_lease(p)
     L.check(got is not None and got.get("agent") == "legacy-driver",
             "a legacy lease with no `heartbeat` must read as a VALID held lease, never None/Corrupt")
     L.check(got is not None and "heartbeat" not in got, "read_lease must not invent a `heartbeat` the legacy lease never had")
-    code, out, _err = acquire(work, token="legacy-driver", heartbeat="w1")
-    L.check(code == 0 and verdict_of(out) == "owned",
-            "a same-token acquire over a heartbeat-less legacy lease must be `owned`, not refused")
-    rcode, rout, _ = L.run(["--file", str(p), "refresh", "--token", "legacy-driver"])
-    L.check(rcode == 0 and verdict_of(rout) == "owned",
-            "a plain refresh of a heartbeat-less legacy lease by its own token must be `owned`")
+    original = L.now
+    setattr(L, "now", lambda: frozen)  # freeze the clock so the legacy lease reads FRESH (age 0), independent of wall-clock date
+    try:
+        code, out, _err = acquire(work, token="legacy-driver", heartbeat="w1")
+        L.check(code == 0 and verdict_of(out) == "owned",
+                "a same-token acquire over a heartbeat-less legacy lease must be `owned`, not refused")
+        rcode, rout, _ = L.run(["--file", str(p), "refresh", "--token", "legacy-driver"])
+        L.check(rcode == 0 and verdict_of(rout) == "owned",
+                "a plain refresh of a heartbeat-less legacy lease by its own token must be `owned`")
+    finally:
+        setattr(L, "now", original)
 
 
 def t_read_reports_corrupt_without_deciding(work: Path) -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -456,6 +456,46 @@ def t_only_one_of_two_racing_claimers_wins(work: Path) -> None:
                 f"the self-believed owner {self_owners!r} must be the token actually in the lease {winner!r}")
 
 
+def t_lost_race_readback_refuses(work: Path) -> None:
+    """Post-write read-back: our write landed, but ANOTHER token is on disk when we read back — stand down.
+
+    The `race` fixture above pins the LOCK: real processes serialize through the `mkdir` claim, so the
+    post-write read-back always sees our own token there and the lost-race branch is never reached. That
+    fixture proves the lock works; it does NOT prove the guard behind it. This one does. It constructs the
+    exact state the read-back exists to catch — the cases the `mkdir` lock cannot cover (a forward-skew
+    sweep of a live claim, or a hand-rolled non-interoperating lock letting a second writer in): our write
+    lands, then a competitor stamps a DIFFERENT token before we read back. `write_lease` is wrapped to do
+    that once, so no real concurrency is needed.
+
+    With the read-back/lost-race block present -> `lost-race`, exit 1, we stand down. Delete that block
+    (emit our own `fresh` record without reading back) and this goes RED: `acquire` returns `adopted`,
+    exit 0, claiming ownership while `other` sits on disk — two self-believed drivers of one run.
+    """
+    p = lease_path(work)
+    L.check(not p.exists(), "fixture precondition: absent lease")
+    original_write = L.write_lease
+
+    def racing_write(path, rec):
+        original_write(path, rec)  # our real write lands (agent="mine")...
+        # ...then a competitor stamps a DIFFERENT token before acquire reads back. Only the first write
+        # races; restore immediately so nothing else is disturbed.
+        setattr(L, "write_lease", original_write)
+        original_write(path, {"agent": "other", "heartbeat": "w0", "updated": L.now()})
+
+    setattr(L, "write_lease", racing_write)
+    try:
+        code, out, err = acquire(work, token="mine", heartbeat="w1")
+    finally:
+        setattr(L, "write_lease", original_write)
+    L.check(code != 0 and verdict_of(out) == "lost-race",
+            "our write landed but the read-back shows ANOTHER token — the guard must return `lost-race` and "
+            "refuse, never claim ownership; without the read-back acquire falsely reports `adopted`/exit 0")
+    L.check(json.loads(p.read_text())["agent"] == "other",
+            "the competitor's token must remain on disk — the loser must not overwrite it")
+    L.check("lost the race" in err.lower() and "stand down" in err.lower(),
+            "the refusal must tell the loser it lost the race and to stand down")
+
+
 CASES = [
     ("no-heartbeat", "no proof of arming, no lease — the entire mechanism", t_no_heartbeat_refuses),
     ("no-heartbeat-absent", "an ABSENT lease refuses too — a fresh run has no wake yet",
@@ -501,4 +541,6 @@ CASES = [
     ("lock-swept", "a lock from a crashed claim is swept", t_a_stale_lock_is_swept),
     ("lock-released", "the lock is released on the refusal paths", t_the_lock_is_released_on_the_refusal_paths),
     ("race", "two real racing claimers, one lease", t_only_one_of_two_racing_claimers_wins),
+    ("lost-race-readback", "the post-write read-back refuses when a competitor's token won the disk",
+     t_lost_race_readback_refuses),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -252,6 +252,34 @@ def t_malformed_is_corrupt_never_adopted(work: Path) -> None:
                 f"the {name} refusal must explain why we will not guess")
 
 
+def t_legacy_lease_with_no_heartbeat_is_accepted(work: Path) -> None:
+    """A prose-era lease with NO `heartbeat` field is a VALID held lease, never corrupt — interop.
+
+    `read_lease` requires only `agent` and `updated`; `heartbeat` is OPTIONAL. A driver that hand-rolled
+    its lease from the prose (an older cache, a Codex session) wrote no `heartbeat`. Reading such a lease
+    as corrupt would refuse to see a LIVE legacy driver and let this tool adopt on top of it — the exact
+    double-drive this tool exists to prevent, in reverse. Contrast `t_malformed_is_corrupt`'s `no-updated`
+    case: a missing `updated` IS corrupt (we cannot tell staleness); a missing `heartbeat` is NOT.
+
+    `updated` is a fixed FUTURE stamp so the lease reads FRESH whenever the suite runs.
+
+    TEETH: add a "reject a lease with no heartbeat" check to read_lease and this goes red — read_lease
+    raises Corrupt, and the same-token acquire/refresh stop returning `owned`.
+    """
+    rec = {"agent": "legacy-driver", "updated": 2_000_000_000}
+    p = put(work, rec)
+    got = L.read_lease(p)
+    L.check(got is not None and got.get("agent") == "legacy-driver",
+            "a legacy lease with no `heartbeat` must read as a VALID held lease, never None/Corrupt")
+    L.check(got is not None and "heartbeat" not in got, "read_lease must not invent a `heartbeat` the legacy lease never had")
+    code, out, _err = acquire(work, token="legacy-driver", heartbeat="w1")
+    L.check(code == 0 and verdict_of(out) == "owned",
+            "a same-token acquire over a heartbeat-less legacy lease must be `owned`, not refused")
+    rcode, rout, _ = L.run(["--file", str(p), "refresh", "--token", "legacy-driver"])
+    L.check(rcode == 0 and verdict_of(rout) == "owned",
+            "a plain refresh of a heartbeat-less legacy lease by its own token must be `owned`")
+
+
 def t_read_reports_corrupt_without_deciding(work: Path) -> None:
     put(work, None, raw="{oops")
     code, out, _err = L.run(["--file", str(lease_path(work)), "read"])
@@ -329,6 +357,34 @@ def t_non_finite_is_corrupt(work: Path) -> None:
         L.check(p.read_bytes() == before, f"a {name} lease must not be overwritten")
         rcode, rout, _ = L.run(["--file", str(p), "read"])
         L.check(rcode != 0 and verdict_of(rout) == "corrupt", f"`read` must report a {name} lease corrupt")
+
+
+def t_lease_path_is_a_directory_is_corrupt(work: Path) -> None:
+    """An OS-level read failure must FAIL CLOSED as Corrupt, never fall open to absent/None.
+
+    Make the lease path unreadable in the most direct way a real filesystem allows: create a DIRECTORY
+    where `lease.json` belongs. `path.read_text` then raises `IsADirectoryError` — an `OSError`, so it is
+    NOT `FileNotFoundError` (absent) and NOT `UnicodeDecodeError` (the decode boundary). It lands in
+    read_lease's generic `except OSError` branch, which must raise Corrupt. If that branch is changed to
+    return None (fail OPEN), a live run gets adopted on top of an OS-level read failure.
+
+    TEETH: change read_lease's `except OSError` branch to return None and this goes red — read_lease
+    stops raising Corrupt, `read` reports absent, and acquire adopts instead of refusing.
+    """
+    p = lease_path(work)
+    p.mkdir()  # a directory at the lease path -> read_text raises IsADirectoryError (an OSError)
+    raised = False
+    try:
+        L.read_lease(p)
+    except L.Corrupt:
+        raised = True
+    L.check(raised, "read_lease must raise Corrupt on an OS-level read error (a directory at the lease "
+                    "path), never return None/absent through the generic `except OSError` branch")
+    rcode, rout, _ = L.run(["--file", str(p), "read"])
+    L.check(rcode != 0 and verdict_of(rout) == "corrupt",
+            "`read` must report an unreadable lease path as corrupt, not absent")
+    code, _out, _err = acquire(work, token="mine", heartbeat="w1")
+    L.check(code != 0, "acquire must REFUSE when the lease path cannot be read, never adopt on top of it")
 
 
 def t_write_lease_never_writes_non_finite(work: Path) -> None:
@@ -470,6 +526,28 @@ def t_a_held_lock_blocks(work: Path) -> None:
     (work / L.LOCK_NAME).mkdir()
     code, _out, err = acquire(work, token="t1", heartbeat="w1")
     L.check(code != 0, "a held claim.lock must block the check-and-set")
+    L.check("held" in err, "the refusal must say the lock is held")
+
+
+def t_lock_name_is_the_literal_claim_lock(work: Path) -> None:
+    """The lock name must be the LITERAL string "claim.lock" — the interop contract with prose drivers.
+
+    An older, prose-driven driver serializes the check-and-set by `mkdir claim.lock`. If this tool locked
+    under any OTHER name it would NOT mutually exclude that driver: both would "win" and drive one run.
+    So the name is asserted as a LITERAL here, deliberately NOT derived from `L.LOCK_NAME` — deriving the
+    fixture from the constant is exactly how a rename slips past (both sides move together and the suite
+    stays green), which is why the existing `t_a_held_lock_blocks` (built from `L.LOCK_NAME`) cannot catch
+    it.
+
+    TEETH: change LOCK_NAME to anything but "claim.lock" and this goes red twice — the literal constant
+    check fails, and a hand-rolled `mkdir claim.lock` no longer blocks this tool's acquire.
+    """
+    L.check(L.LOCK_NAME == "claim.lock",
+            f"the lock name must be the literal 'claim.lock' for interop with prose `mkdir claim.lock` "
+            f"drivers, got {L.LOCK_NAME!r}")
+    (work / "claim.lock").mkdir()  # a prose driver's literal lock — NOT built from L.LOCK_NAME
+    code, _out, err = acquire(work, token="t1", heartbeat="w1")
+    L.check(code != 0, "a literal `claim.lock` held by a prose driver must block this tool's check-and-set")
     L.check("held" in err, "the refusal must say the lock is held")
 
 
@@ -631,6 +709,8 @@ CASES = [
      t_exact_boundary_is_not_stale),
     ("corrupt-not-absent", "an unreadable lease is CORRUPT — adopting it would double-drive a live run",
      t_malformed_is_corrupt_never_adopted),
+    ("legacy-no-heartbeat", "a prose-era lease with no `heartbeat` field is a VALID held lease — interop",
+     t_legacy_lease_with_no_heartbeat_is_accepted),
     ("read-reports-corrupt", "`read` reports corruption rather than guessing",
      t_read_reports_corrupt_without_deciding),
     ("duplicate-key-corrupt", "a duplicate JSON key reads two ways — corrupt, never guessed",
@@ -638,6 +718,8 @@ CASES = [
     ("invalid-utf8-corrupt", "undecodable bytes fail closed to corrupt, never crash", t_invalid_utf8_is_corrupt),
     ("non-finite-corrupt", "NaN/Infinity anywhere is corrupt, not a value to round-trip",
      t_non_finite_is_corrupt),
+    ("lease-is-a-directory-corrupt", "an OS read error (a directory at the lease path) fails closed to "
+     "corrupt", t_lease_path_is_a_directory_is_corrupt),
     ("strict-json-on-disk", "write_lease writes strict JSON and refuses a non-finite value",
      t_write_lease_never_writes_non_finite),
     ("refresh-preserves-mode", "refresh preserves the lease's prior mode, never narrows to 0600",
@@ -655,6 +737,8 @@ CASES = [
     ("refresh-superseded", "refresh refuses once superseded", t_refresh_refuses_when_superseded),
     ("refresh-absent", "refresh does not conjure a lease", t_refresh_of_an_absent_lease_does_not_recreate_it),
     ("lock-blocks", "a held claim.lock blocks the check-and-set", t_a_held_lock_blocks),
+    ("lock-name-literal", "the lock name is the LITERAL 'claim.lock' — interop with prose `mkdir` drivers",
+     t_lock_name_is_the_literal_claim_lock),
     ("lock-sweep-scale", "a short claim-lock sweep re-opens the clock-skew mutual-exclusion hole",
      t_claim_lock_sweep_stays_on_the_lease_scale),
     ("lock-swept", "a lock from a crashed claim is swept", t_a_stale_lock_is_swept),

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Schema-owning accessor for the campaign run lease (lease.json).
+
+The lease is what stops two agents driving one run — `run-identity-and-lease.md` calls that "the bug this
+guards against". It was also the ONLY durable store in the campaign with no schema owner: `state.jsonl` has
+`ledger.py`, `followups.jsonl` has `followups.py`, the review artifacts have `review-pass.py`, CI snapshots
+have `ci-snapshot.py`. The lease had four reference docs and an `echo`.
+
+And it is not a value-write — it is a CHECK-AND-SET: take a lock, read, decide, write, read back, unlock,
+plus a stale-lock sweep and a staleness rule. Hand-rolled from prose, on every wake, by a fresh agent
+instance that remembers nothing. In run `g260717-1748-d76f0acb` a driver hand-rolled it with
+`mkdir`/`openssl`/`echo`/`rmdir`, eyeballed the read-back instead of comparing tokens, and skipped the
+stale-lock sweep entirely. It was safe only because the lease was absent and nobody else was driving.
+
+Four refusals this file exists to make, each one a thing the prose left undefined or a well-meaning driver
+would otherwise do:
+
+1. **A MALFORMED lease is `corrupt`, never `adopt`.** The prose says adopt when the lease is "absent or
+   stale" and says nothing about unparseable. A reader that lets "cannot parse" fall through to "absent"
+   ADOPTS A LIVE RUN. The asymmetry decides it: wrongly adopting gives two drivers on one ledger; wrongly
+   refusing an orphan stalls a run, which staleness and a human both recover.
+2. **`release` refuses unless the token matches.** The prose says "delete lease.json on normal exit" — a
+   superseded driver following that literally deletes the LIVE OWNER'S lease.
+3. **No `--heartbeat-id`, no lease.** The caller must hand over its proof that it has ALREADY armed the
+   heartbeat. This tool never inspects the proof and takes the caller's word for it — which is exactly why
+   it must name something already done. Arming was step 6 of the wake skeleton, after all the interesting
+   work, when an agent believes it is finished; it was skipped for an entire session and nothing noticed.
+   Requiring it here moves the failure from "forgot at the end", which nothing catches, to "cannot start".
+4. **No `--token`, no lease** — and `acquire` never mints one. The wake carries `--token`, so a caller
+   without one demonstrably never armed a wake that identifies it: its proof cannot be real.
+
+A future `updated` (clock skew) reads as FRESH, not stale — fail closed, same direction as (1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import NoReturn
+
+from _gauntlet.atomic import replace_text
+from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
+
+DESCRIPTION = "Schema-owning accessor for the campaign run lease (lease.json)."
+
+SIBLING = Path(__file__).resolve().parent / "lease-test.py"
+
+# --- constants: ONE defining site ---------------------------------------------
+#
+# `references/run-identity-and-lease.md` and `references/critical-rules.md` each state "~30 min" in prose
+# today — two sources of truth for one constant, which is what this repo's own rule forbids. Landing this
+# file means those sites NAME this constant instead of restating the number.
+#
+#   LEASE_STALE_AFTER      a lease older than this has a DEAD driver, so the run may be adopted. Long
+#                          enough that a busy driver is never mistaken for a dead one.
+#   CLAIM_LOCK_STALE_AFTER a claim.lock older than this was left by a process that died mid-claim. The
+#                          critical section is a read plus a write — sub-second — so this is far beyond any
+#                          live claim and far below LEASE_STALE_AFTER. The prose said "a few minutes",
+#                          which is not a number and cannot be implemented.
+LEASE_STALE_AFTER = 30 * 60
+CLAIM_LOCK_STALE_AFTER = 5 * 60
+
+LOCK_NAME = "claim.lock"
+FIELDS = ("agent", "heartbeat", "updated")
+
+EXIT_OK = 0
+EXIT_REFUSED = 1
+
+
+def fail(msg: str) -> NoReturn:
+    print(msg, file=sys.stderr)
+    raise SystemExit(EXIT_REFUSED)
+
+
+def now() -> int:
+    return int(time.time())
+
+
+def mint_token() -> str:
+    return secrets.token_hex(4)
+
+
+# --- the store ----------------------------------------------------------------
+
+class Corrupt(Exception):
+    """The lease exists and cannot be trusted. NEVER treated as absent."""
+
+
+def read_lease(path: Path) -> "dict | None":
+    """Return the lease, or None if ABSENT. Raise Corrupt if present and untrustworthy.
+
+    Absent and corrupt are DIFFERENT ANSWERS and must never collapse: absent means nobody is driving,
+    corrupt means we cannot tell. Only the first permits adoption.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise Corrupt(f"cannot read {path}: {exc}") from exc
+    if not raw.strip():
+        raise Corrupt(f"{path} is empty — a driver may hold this run; refusing to read that as 'absent'")
+    try:
+        rec = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise Corrupt(f"{path} is not valid JSON ({exc}) — refusing to read that as 'absent'") from exc
+    if not isinstance(rec, dict):
+        raise Corrupt(f"{path} holds {type(rec).__name__}, not a JSON object")
+    agent = rec.get("agent")
+    if not isinstance(agent, str) or not agent.strip():
+        raise Corrupt(f"{path} has no usable `agent` — cannot tell who is driving this run")
+    updated = rec.get("updated")
+    if isinstance(updated, bool) or not isinstance(updated, int):
+        raise Corrupt(f"{path} has a non-integer `updated` ({updated!r}) — cannot tell if it is stale")
+    return rec
+
+
+def write_lease(path: Path, rec: dict) -> None:
+    """Write the lease atomically, preserving any field this version does not know about."""
+    replace_text(path, json.dumps(rec) + "\n", temp_prefix=".lease.", encoding="utf-8")
+
+
+def age_of(rec: dict) -> int:
+    """Seconds since the lease was refreshed, floored at 0 so a skewed clock cannot report a negative age.
+
+    The floor is PRESENTATION ONLY — it is `is_stale`'s signed comparison that makes a future `updated`
+    read fresh, not this clamp. Do not credit it with more than it does.
+    """
+    return max(0, now() - int(rec["updated"]))
+
+
+def is_stale(rec: dict) -> bool:
+    """A lease is stale only once it is OLDER than the window.
+
+    The comparison is deliberately SIGNED and deliberately `>`: a future `updated` (clock skew) yields a
+    negative age, which is not greater than the window, so it reads FRESH. That is the fail-closed
+    direction and it is the rule doing the work — never `abs()` this, and never widen `>` to `>=`.
+    Manufacturing an adoption out of a skewed clock is the one error that puts two drivers on one run.
+    """
+    return age_of(rec) > LEASE_STALE_AFTER
+
+
+@contextmanager
+def claim_lock(path: Path):
+    """Serialize the check-and-set, sweeping a lock a crashed claim left behind.
+
+    Kept as `mkdir` DELIBERATELY. Other drivers still hand-roll this lock from the prose (a Codex session
+    on a different installed version, an older cache). A tool that locked with O_EXCL or flock would not
+    mutually exclude a prose-following driver: both would "win", and this file would CREATE the double-drive
+    it exists to prevent while looking more rigorous than what it replaced.
+    """
+    lock = path.parent / LOCK_NAME
+    try:
+        if time.time() - lock.stat().st_mtime > CLAIM_LOCK_STALE_AFTER:
+            lock.rmdir()  # abandoned by a process that died mid-claim
+    except (FileNotFoundError, OSError):
+        pass
+    try:
+        lock.mkdir(parents=False)
+    except FileExistsError:
+        fail(f"lease: {lock} is held — another agent is claiming this run right now. Retry shortly.")
+    except OSError as exc:
+        fail(f"lease: cannot create {lock}: {exc}")
+    try:
+        yield
+    finally:
+        try:
+            lock.rmdir()
+        except OSError:
+            pass
+
+
+def emit(verdict: str, rec: "dict | None", **extra) -> None:
+    out: "dict[str, object]" = {"verdict": verdict}
+    if rec is not None:
+        out.update({
+            "agent": rec.get("agent"),
+            "heartbeat": rec.get("heartbeat"),
+            "updated": rec.get("updated"),
+            "age_seconds": age_of(rec) if isinstance(rec.get("updated"), int) else None,
+        })
+    out["stale_after"] = LEASE_STALE_AFTER
+    out.update(extra)
+    print(json.dumps(out))
+
+
+# --- the refusal that carries the contract ------------------------------------
+#
+# The proof cannot be verified, so the ENFORCEMENT is this refusal and its value is the INSTRUCTION it
+# carries. Modelled on `ledger.py verdict` at a review-loop cap, the strongest rule in the campaign: it
+# exits non-zero and its stderr says what happened, WHAT STATE CHANGED, what NOT to do, and what to do
+# instead. It names no host mechanism — `runtime-adapter.md` owns that mapping — and it offers NO
+# alternative, because the moment it names a way to proceed without a proof, that way becomes the default.
+
+NO_HEARTBEAT = """\
+lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.
+lease: acquire requires --heartbeat-id: your PROOF that you have ALREADY armed the heartbeat for this
+       run. This tool never inspects it and takes your word for it — which is exactly why it must be
+       something you already did, not something you intend to do.
+lease: DO THIS, IN THIS ORDER: (1) arm the heartbeat for this run. `runtime-adapter.md` owns your host's
+       mechanism and tells you what your proof is; the wake's own invocation must carry
+       --run <id> --token <tok> --heartbeat-id <proof> so it can present the proof it was armed with.
+       (2) Re-run this command with that proof.
+lease: DO NOT take the lease first and arm afterwards. An arm at the end of a wake is the step that gets
+       forgotten — that is the entire reason this door refuses."""
+
+NO_TOKEN = """\
+lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.
+lease: acquire requires --token, and it does NOT mint one for you. The wake carries `--token <tok>`, so
+       the token must exist BEFORE you arm: a caller without one cannot have armed a wake that identifies
+       it, which means its --heartbeat-id cannot name a real wake.
+lease: DO THIS: run `lease.py mint` for a token, arm the heartbeat with it, then acquire with both."""
+
+
+# --- commands -----------------------------------------------------------------
+
+def cmd_mint(_path, _args) -> int:
+    print(mint_token())
+    return EXIT_OK
+
+
+def cmd_acquire(path: Path, args) -> int:
+    if not (args.token or "").strip():
+        fail(NO_TOKEN)
+    if not (args.heartbeat_id or "").strip():
+        fail(NO_HEARTBEAT)
+    token = args.token
+    with claim_lock(path):
+        try:
+            rec = read_lease(path)
+        except Corrupt as exc:
+            fail(f"lease: REFUSED — {exc}\n"
+                 f"lease: A lease that cannot be parsed is NOT an absent lease. Adopting it could put two "
+                 f"agents on one run; refusing only stalls this one. Nothing was written.\n"
+                 f"lease: Inspect {path} and, if the run is genuinely orphaned, remove it by hand.")
+        if rec is not None and not is_stale(rec) and rec["agent"] != token:
+            if not args.allow_takeover:
+                emit("superseded", rec, held_by=rec["agent"])
+                print(f"lease: REFUSED — a DIFFERENT agent holds this run (lease age {age_of(rec)}s). "
+                      f"You are not the driver: do not review, fix, merge, or relabel anything.\n"
+                      f"lease: If a human has agreed this run should be taken over, re-run with "
+                      f"--allow-takeover.", file=sys.stderr)
+                return EXIT_REFUSED
+            verdict = "adopted"
+        elif rec is None or is_stale(rec):
+            verdict = "adopted"
+        else:
+            verdict = "owned"
+
+        fresh = dict(rec) if rec is not None else {}
+        fresh.update({"agent": token, "heartbeat": args.heartbeat_id, "updated": now()})
+        write_lease(path, fresh)
+
+        # Read back: the write is not the proof. A concurrent claimer may have won.
+        try:
+            back = read_lease(path)
+        except Corrupt as exc:
+            fail(f"lease: wrote the lease and could not read it back: {exc}")
+        if back is None or back["agent"] != token:
+            emit("lost-race", back, expected=token)
+            print("lease: REFUSED — another agent's token is in the lease after our write. You lost the "
+                  "race and are NOT the driver. Stand down.", file=sys.stderr)
+            return EXIT_REFUSED
+        emit(verdict, back, token=token)
+        return EXIT_OK
+
+
+def cmd_refresh(path: Path, args) -> int:
+    """The heartbeat bump — 'still alive'. It does NOT re-arm, so it takes no proof."""
+    if not (args.token or "").strip():
+        fail(NO_TOKEN)
+    with claim_lock(path):
+        try:
+            rec = read_lease(path)
+        except Corrupt as exc:
+            fail(f"lease: REFUSED — {exc}\nlease: Nothing was written.")
+        if rec is None:
+            fail(f"lease: REFUSED — {path} is GONE. You believed you owned this run and its lease no longer "
+                 f"exists; something released or deleted it under you. Nothing was written. Re-acquire "
+                 f"explicitly rather than re-creating it here — a silently re-created lease hides that.")
+        if rec["agent"] != args.token:
+            emit("superseded", rec, held_by=rec["agent"])
+            print("lease: REFUSED — a different agent now holds this run. You were superseded while you "
+                  "worked. Stand down: do not merge, fix, or relabel anything.", file=sys.stderr)
+            return EXIT_REFUSED
+        rec["updated"] = now()
+        write_lease(path, rec)
+        emit("owned", rec)
+        return EXIT_OK
+
+
+def cmd_release(path: Path, args) -> int:
+    """Release on normal exit — and ONLY if the token matches.
+
+    The prose says "delete lease.json". A superseded driver that follows that literally deletes the LIVE
+    owner's lease and hands the run to anyone.
+    """
+    if not (args.token or "").strip():
+        fail(NO_TOKEN)
+    with claim_lock(path):
+        try:
+            rec = read_lease(path)
+        except Corrupt as exc:
+            fail(f"lease: REFUSED — {exc}\nlease: Refusing to delete a lease we cannot read. Nothing was "
+                 f"written.")
+        if rec is None:
+            emit("absent", None)
+            return EXIT_OK
+        if rec["agent"] != args.token:
+            emit("superseded", rec, held_by=rec["agent"])
+            print("lease: REFUSED — this lease belongs to a DIFFERENT agent. Deleting it would hand a live "
+                  "run to anyone. Nothing was written.", file=sys.stderr)
+            return EXIT_REFUSED
+        path.unlink()
+        emit("released", rec)
+        return EXIT_OK
+
+
+def cmd_read(path: Path, _args) -> int:
+    """ADVISORY status — taken WITHOUT the lock, so it may race a concurrent write.
+
+    Never make an ownership decision from this; that is `acquire`'s job. It exists for cross-run discovery
+    bucketing, which reads many leases and decides nothing.
+    """
+    try:
+        rec = read_lease(path)
+    except Corrupt as exc:
+        emit("corrupt", None, error=str(exc))
+        return EXIT_REFUSED
+    if rec is None:
+        emit("absent", None)
+        return EXIT_OK
+    emit("stale" if is_stale(rec) else "held", rec)
+    return EXIT_OK
+
+
+# --- self-test ----------------------------------------------------------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SelfTestFailure(msg)
+
+
+def run(argv: "list[str]") -> "tuple[int, str, str]":
+    """Drive the REAL CLI in-process and capture (exit code, stdout, stderr)."""
+    return capture_cli(main, argv)
+
+
+def sibling_cases() -> list:
+    """Load the sibling's fixtures — and FAIL LOUDLY if they are not there.
+
+    A self-test that passes because it found nothing to check reports health while checking nothing.
+    """
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
+            f"health. Every rule this file enforces is now unpinned."
+        )
+    mod = load_module_from_path("lease_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':26} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the lease's contract is broken.")
+        return 1
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for name, rule, fn in cases:
+            work = Path(tmpdir) / name
+            work.mkdir()
+            try:
+                fn(work)
+            except SelfTestFailure as exc:
+                print(f"FAIL     {name:26} -> {rule}\n         {exc}")
+                failures += 1
+            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
+                print(f"FAIL     {name:26} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+                failures += 1
+            else:
+                print(f"ok       {name:26} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the lease's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the lease's contract is intact.")
+    return 0
+
+
+# --- cli ----------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("--file", help="path to the run's lease (<rundir>/lease.json)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("mint", help="print a fresh agent token. Step ONE: the token must exist before you arm "
+                                "the heartbeat, because the wake carries it")
+
+    # NOTE: --token and --heartbeat-id are deliberately NOT argparse-`required`. They ARE required, and
+    # this file refuses without them — but argparse's "the following arguments are required:
+    # --heartbeat-id" is a DIAGNOSIS, and the whole mechanism here is the INSTRUCTION the refusal carries
+    # (NO_HEARTBEAT / NO_TOKEN). Letting argparse win the race would keep the exit code and throw away the
+    # only part that teaches the caller what to do. `lease-test.py` pins this.
+    a = sub.add_parser("acquire", help="take or refresh ownership of this run — the door every wake goes "
+                                       "through first")
+    a.add_argument("--token", help="REQUIRED. Your agent token (from `mint`). NEVER minted here: a caller "
+                                   "without one cannot have armed a wake that names it")
+    a.add_argument("--heartbeat-id",
+                   help="REQUIRED. Your PROOF that you have ALREADY armed the heartbeat. Never inspected — "
+                        "taken on your word, which is why it must name something already done. "
+                        "`runtime-adapter.md` tells you what your proof is")
+    a.add_argument("--allow-takeover", action="store_true",
+                   help="adopt a run a DIFFERENT live agent holds. Only after a human has agreed to it")
+
+    r = sub.add_parser("refresh", help="heartbeat the lease ('still alive'). Does not re-arm, takes no proof")
+    r.add_argument("--token", help="REQUIRED. Your agent token")
+
+    d = sub.add_parser("release", help="release on normal exit. Refuses unless the token matches")
+    d.add_argument("--token", help="REQUIRED. Your agent token")
+
+    sub.add_parser("read", help="ADVISORY read-only status (no lock — may race a write). For discovery "
+                                "bucketing; never decide ownership from it")
+
+    sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
+    return parser
+
+
+def dispatch(args) -> int:
+    if args.cmd == "self-test":
+        return self_test()
+    if args.cmd == "mint":
+        return cmd_mint(None, args)
+    if args.file is None:
+        build_parser().error("the following arguments are required: --file")
+    path = Path(args.file)
+    if not path.parent.is_dir():
+        fail(f"lease: {path.parent} does not exist — the run directory must be created before its lease")
+    return {
+        "acquire": cmd_acquire,
+        "refresh": cmd_refresh,
+        "release": cmd_release,
+        "read": cmd_read,
+    }[args.cmd](path, args)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    return dispatch(build_parser().parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -312,6 +312,14 @@ def cmd_acquire(path: Path, args) -> int:
         # Sample the wall clock EXACTLY ONCE for this whole decision. Reading it again mid-decision let a
         # backward step classify one record as both stale and fresh and fall through to `owned`, overwriting
         # a lease a DIFFERENT token holds. Every staleness branch below reads this one value.
+        #
+        # No fixture pins this single sample, and none can, because in this single-branch table it changes no
+        # (exit, verdict, token) outcome: `owned` is reachable ONLY through the `rec["agent"] == token`
+        # equality below, so the feared "fall through to `owned` overwriting a different token" is
+        # unreachable however many times the clock is read. Reverting to per-call reads alters only the
+        # cosmetic age printed in the `superseded` message — a display number, no behavioral surface. The
+        # single sample is cleanliness, not a pinnable rule; check that claim by reverting it and running
+        # self-test, which stays all-green.
         acquired_at = now()
         try:
             rec = read_lease(path)

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -199,6 +199,13 @@ def read_lease(path: Path) -> "dict | None":
     if not isinstance(agent, str) or not agent.strip():
         raise Corrupt(f"{path} has no usable `agent` — cannot tell who is driving this run")
     updated = rec.get("updated")
+    # This int-only check is also what makes a huge-exponent float harmless. `parse_constant` above
+    # catches the NaN/Infinity/-Infinity TOKENS, but not `1e10000`, which `parse_float` silently turns into
+    # `inf`. That does not matter: `updated` is the ONLY numeric field any decision reads, and it refuses
+    # every float here (finite or `inf`), so no non-finite value can ever reach a staleness decision. A
+    # `1e10000` surviving in an OPAQUE field (`heartbeat`, recorded verbatim and never inspected) touches
+    # nothing — and `lease.json` is git-ignored bookkeeping only this run's own driver writes, so an absurd
+    # value there is the single user's own foot, deliberately NOT guarded (a documented non-threat).
     if isinstance(updated, bool) or not isinstance(updated, int):
         raise Corrupt(f"{path} has a non-integer `updated` ({updated!r}) — cannot tell if it is stale")
     return rec

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -60,12 +60,28 @@ SIBLING = Path(__file__).resolve().parent / "lease-test.py"
 #
 #   LEASE_STALE_AFTER      a lease older than this has a DEAD driver, so the run may be adopted. Long
 #                          enough that a busy driver is never mistaken for a dead one.
-#   CLAIM_LOCK_STALE_AFTER a claim.lock older than this was left by a process that died mid-claim. The
-#                          critical section is a read plus a write — sub-second — so this is far beyond any
-#                          live claim and far below LEASE_STALE_AFTER. The prose said "a few minutes",
-#                          which is not a number and cannot be implemented.
+#   CLAIM_LOCK_STALE_AFTER a claim.lock older than this is swept as abandoned by a process that died
+#                          mid-claim. The prose said "a few minutes", which is not a number and cannot be
+#                          implemented — but the number matters more than it looks, because mtime is the
+#                          ONLY cross-driver signal here. The lock is a bare `mkdir claim.lock` kept
+#                          DELIBERATELY (see `claim_lock`) for interop with drivers that hand-roll it from
+#                          prose, and a hand-rolled lock carries no PID — so a liveness/PID check, the only
+#                          COMPLETE fix for a stale-sweep racing a live claim, is unavailable. The
+#                          threshold is the only lever left.
+#
+#                          If the system clock jumps FORWARD by more than this while a live driver is
+#                          inside its sub-second critical section (a read plus a write), a second driver
+#                          would sweep the LIVE lock and enter too, and the read-back does NOT catch a
+#                          serialized both-succeeded pair — TWO owners of one run. Setting this to the
+#                          lease-staleness SCALE (30 min, same magnitude as LEASE_STALE_AFTER, deliberately
+#                          — they are independent facts that happen to share it, NOT one aliased to the
+#                          other) means only an implausibly large forward clock jump could sweep a live
+#                          claim, while a genuinely crashed claim is still recovered on the same timescale
+#                          the lease already tolerates a dead driver. This MITIGATES the clock-skew
+#                          two-driver hole; it does NOT eliminate it. The residual risk is a forward clock
+#                          jump larger than 30 min landing inside a sub-second window — small, not zero.
 LEASE_STALE_AFTER = 30 * 60
-CLAIM_LOCK_STALE_AFTER = 5 * 60
+CLAIM_LOCK_STALE_AFTER = 30 * 60
 
 LOCK_NAME = "claim.lock"
 FIELDS = ("agent", "heartbeat", "updated")
@@ -311,6 +327,9 @@ def cmd_release(path: Path, args) -> int:
             fail(f"lease: REFUSED — {exc}\nlease: Refusing to delete a lease we cannot read. Nothing was "
                  f"written.")
         if rec is None:
+            # Release is idempotent: an already-absent lease is release's goal state, so there is no token
+            # to match and nothing to undo. The token check below guards a PRESENT live lease from deletion
+            # by a non-owner; absent is terminal cleanup already complete, reported, not refused.
             emit("absent", None)
             return EXIT_OK
         if rec["agent"] != args.token:

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -199,13 +199,16 @@ def read_lease(path: Path) -> "dict | None":
     if not isinstance(agent, str) or not agent.strip():
         raise Corrupt(f"{path} has no usable `agent` — cannot tell who is driving this run")
     updated = rec.get("updated")
-    # This int-only check is also what makes a huge-exponent float harmless. `parse_constant` above
+    # This int-only check is what keeps a huge-exponent float out of every DECISION. `parse_constant` above
     # catches the NaN/Infinity/-Infinity TOKENS, but not `1e10000`, which `parse_float` silently turns into
-    # `inf`. That does not matter: `updated` is the ONLY numeric field any decision reads, and it refuses
-    # every float here (finite or `inf`), so no non-finite value can ever reach a staleness decision. A
-    # `1e10000` surviving in an OPAQUE field (`heartbeat`, recorded verbatim and never inspected) touches
-    # nothing — and `lease.json` is git-ignored bookkeeping only this run's own driver writes, so an absurd
-    # value there is the single user's own foot, deliberately NOT guarded (a documented non-threat).
+    # `inf`. `updated` is the ONLY numeric field any decision reads, and it refuses every float here (finite
+    # or `inf`), so no non-finite value can reach a staleness decision. A `1e10000` can still SURVIVE in an
+    # opaque field (`heartbeat`, recorded verbatim and never inspected) and, if the owner later `refresh`es
+    # (which preserves unknown fields), reach `write_lease`, where `json.dumps(allow_nan=False)` RAISES —
+    # the refresh aborts non-zero, but the atomic temp-write never lands, so the on-disk lease is left
+    # intact. That noisy abort is NOT guarded to a clean refusal ON PURPOSE: `lease.json` is git-ignored
+    # bookkeeping only this run's own driver writes, so a `1e10000` there is the single user's own foot — a
+    # documented non-threat (`intent`/fu35), not a malformed lease this tool undertakes to reject cleanly.
     if isinstance(updated, bool) or not isinstance(updated, int):
         raise Corrupt(f"{path} has a non-integer `updated` ({updated!r}) — cannot tell if it is stale")
     return rec

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -38,6 +38,7 @@ import argparse
 import json
 import os
 import secrets
+import stat
 import sys
 import tempfile
 import time
@@ -145,6 +146,19 @@ def _reject_duplicate_keys(pairs: "list[tuple[str, object]]") -> dict:
     return dict(pairs)
 
 
+def _reject_non_finite(constant: str) -> NoReturn:
+    """`parse_constant` hook: reject the non-finite constants `json.loads` accepts by DEFAULT.
+
+    `json.loads` parses `NaN`, `Infinity`, and `-Infinity` anywhere a number may appear — a preserved
+    unknown field, a nested object, anything past the per-field checks. They are NOT strict JSON: a driver
+    hand-rolling a parser may reject them, and `json.dumps` cannot even re-serialize them without
+    `allow_nan=True`, so such a value round-trips to disk as INVALID JSON. A lease we cannot round-trip
+    cannot be trusted, so we refuse it at the PARSE boundary — the same fail-closed direction as bad bytes
+    or bad JSON, closing the whole "unparseable" class rather than the two example inputs.
+    """
+    raise ValueError(f"non-finite JSON constant {constant!r}")
+
+
 def read_lease(path: Path) -> "dict | None":
     """Return the lease, or None if ABSENT. Raise Corrupt if present and untrustworthy.
 
@@ -155,19 +169,30 @@ def read_lease(path: Path) -> "dict | None":
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
+    except UnicodeDecodeError as exc:
+        # A `UnicodeDecodeError` is a `ValueError` subclass, NOT an `OSError`, so it would otherwise escape
+        # the `except OSError` below and crash `read`/`acquire` with a raw traceback instead of failing
+        # closed. Undecodable bytes are the same fail-closed direction as bad JSON: a lease we cannot even
+        # decode cannot tell us who is driving, so it is Corrupt, never 'absent'.
+        raise Corrupt(f"{path} is not valid UTF-8 ({exc}) — a lease we cannot decode cannot tell us who is "
+                      f"driving; refusing to read that as 'absent'") from exc
     except OSError as exc:
         raise Corrupt(f"cannot read {path}: {exc}") from exc
     if not raw.strip():
         raise Corrupt(f"{path} is empty — a driver may hold this run; refusing to read that as 'absent'")
     try:
-        rec = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+        rec = json.loads(raw, object_pairs_hook=_reject_duplicate_keys, parse_constant=_reject_non_finite)
     except json.JSONDecodeError as exc:
         raise Corrupt(f"{path} is not valid JSON ({exc}) — refusing to read that as 'absent'") from exc
     except ValueError as exc:
-        # `_reject_duplicate_keys` raises a plain ValueError; JSONDecodeError (a ValueError subclass) is
-        # already handled above, so this only catches the duplicate-key case.
-        raise Corrupt(f"{path} has a {exc} — a lease that two parsers read differently cannot tell us who "
-                      f"is driving; refusing to read that as 'absent'") from exc
+        # Both `_reject_duplicate_keys` (a repeated member name) and `_reject_non_finite`
+        # (NaN/Infinity/-Infinity anywhere) raise a plain ValueError; JSONDecodeError, a ValueError
+        # subclass, is handled above. Either way the bytes are not a strict JSON object we can trust: a
+        # lease two parsers could read differently — or that is not strict JSON at all — cannot tell us
+        # who is driving.
+        raise Corrupt(f"{path} has a {exc} — a lease that two parsers could read differently, or that is "
+                      f"not strict JSON, cannot tell us who is driving; refusing to read that as 'absent'"
+                      ) from exc
     if not isinstance(rec, dict):
         raise Corrupt(f"{path} holds {type(rec).__name__}, not a JSON object")
     agent = rec.get("agent")
@@ -179,9 +204,32 @@ def read_lease(path: Path) -> "dict | None":
     return rec
 
 
+def _current_umask() -> int:
+    """Read the process umask. There is no read-only call, so set-to-0 then restore."""
+    mask = os.umask(0)
+    os.umask(mask)
+    return mask
+
+
 def write_lease(path: Path, rec: dict) -> None:
-    """Write the lease atomically, preserving any field this version does not know about."""
-    replace_text(path, json.dumps(rec) + "\n", temp_prefix=".lease.", encoding="utf-8")
+    """Write the lease atomically, preserving any field this version does not know about.
+
+    Two guards ride on the atomic replace:
+
+    - `allow_nan=False`, so this tool can NEVER itself put a non-finite number (NaN/Infinity) on disk.
+      `read_lease` refuses to read one back, so writing one would strand the run behind a corrupt lease of
+      our own making. If `rec` ever held one, `json.dumps` raises before anything is written.
+    - PERMISSION preservation. `replace_text` writes through a private 0600 `mkstemp` temp, so without this
+      every refresh/acquire would NARROW an existing lease's mode (e.g. 0664 -> 0600). An EXISTING lease
+      keeps its prior mode; a BRAND-NEW lease gets the umask-adjusted permissions an ordinary create would
+      produce. `mode=` chmods the temp BEFORE the rename, so the lease never appears on disk mis-permissioned.
+    """
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        mode = 0o666 & ~_current_umask()
+    replace_text(path, json.dumps(rec, allow_nan=False) + "\n",
+                 temp_prefix=".lease.", encoding="utf-8", mode=mode)
 
 
 def age_of(rec: dict, now_ts: "int | None" = None) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import secrets
 import sys
 import tempfile
@@ -52,6 +53,26 @@ DESCRIPTION = "Schema-owning accessor for the campaign run lease (lease.json)."
 
 SIBLING = Path(__file__).resolve().parent / "lease-test.py"
 
+# --- scope: a single shared, roughly-monotonic system clock -------------------
+#
+# This lease assumes ONE system clock, shared by every driver of a given run. Concurrent drivers are
+# same-machine — two sessions, or a resume of the same run — reading the same `time.time()`. That is the
+# whole threat model, and the user has ruled it so.
+#
+# A cross-host deployment where two INDEPENDENT, unsynchronized clocks disagree by more than the staleness
+# window is OUT OF SCOPE, and cannot be made sound here: the claim lock is a bare `mkdir` with no PID (kept
+# that way for interop, see `claim_lock`), so mtime is the ONLY cross-driver liveness signal, and a live
+# owner whose clock is behind is indistinguishable ON DISK from a dead one. No threshold separates them. It
+# is a declared non-goal, not a defect to fix — do NOT add clock-skew heuristics chasing it.
+#
+# On the ONE shared clock, the residual is BOUNDED but not zero. `is_stale`'s signed `>` reads a backward
+# step / future `updated` as FRESH (never manufacturing an adoption), and `cmd_acquire` samples the clock
+# exactly once so a step mid-decision cannot split one record two ways. What remains is a large FORWARD step
+# on that shared clock landing between an owner's refreshes (or inside a claim's sub-second critical
+# section): CLAIM_LOCK_STALE_AFTER's 30-min scale means only an implausibly large forward step could sweep a
+# live claim. This tool does NOT claim complete mutual exclusion under an arbitrarily misbehaving clock — it
+# bounds the shared-clock hazards it can, and names the cross-host one it cannot.
+#
 # --- constants: ONE defining site ---------------------------------------------
 #
 # `references/run-identity-and-lease.md` and `references/critical-rules.md` each state "~30 min" in prose
@@ -109,6 +130,21 @@ class Corrupt(Exception):
     """The lease exists and cannot be trusted. NEVER treated as absent."""
 
 
+def _reject_duplicate_keys(pairs: "list[tuple[str, object]]") -> dict:
+    """`object_pairs_hook` that raises on a repeated member name, at any object depth.
+
+    `json.loads` silently keeps the LAST of duplicate keys, so `{"agent":"other","agent":"mine"}` resolves
+    to `mine` — while a driver hand-rolling a parser that keeps the FIRST reads `other`. That cross-parser
+    disagreement is a two-driver seam, so a duplicate-keyed lease is Corrupt, not a value to guess at.
+    """
+    seen: set = set()
+    for key, _val in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate key {key!r}")
+        seen.add(key)
+    return dict(pairs)
+
+
 def read_lease(path: Path) -> "dict | None":
     """Return the lease, or None if ABSENT. Raise Corrupt if present and untrustworthy.
 
@@ -124,9 +160,14 @@ def read_lease(path: Path) -> "dict | None":
     if not raw.strip():
         raise Corrupt(f"{path} is empty — a driver may hold this run; refusing to read that as 'absent'")
     try:
-        rec = json.loads(raw)
+        rec = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
     except json.JSONDecodeError as exc:
         raise Corrupt(f"{path} is not valid JSON ({exc}) — refusing to read that as 'absent'") from exc
+    except ValueError as exc:
+        # `_reject_duplicate_keys` raises a plain ValueError; JSONDecodeError (a ValueError subclass) is
+        # already handled above, so this only catches the duplicate-key case.
+        raise Corrupt(f"{path} has a {exc} — a lease that two parsers read differently cannot tell us who "
+                      f"is driving; refusing to read that as 'absent'") from exc
     if not isinstance(rec, dict):
         raise Corrupt(f"{path} holds {type(rec).__name__}, not a JSON object")
     agent = rec.get("agent")
@@ -143,24 +184,31 @@ def write_lease(path: Path, rec: dict) -> None:
     replace_text(path, json.dumps(rec) + "\n", temp_prefix=".lease.", encoding="utf-8")
 
 
-def age_of(rec: dict) -> int:
+def age_of(rec: dict, now_ts: "int | None" = None) -> int:
     """Seconds since the lease was refreshed, floored at 0 so a skewed clock cannot report a negative age.
+
+    Pass `now_ts` to measure against a clock value sampled ONCE by the caller; omit it for a fresh read.
+    A single decision (see `cmd_acquire`) MUST pass one sampled value, so a clock step mid-decision cannot
+    split one record into two verdicts.
 
     The floor is PRESENTATION ONLY — it is `is_stale`'s signed comparison that makes a future `updated`
     read fresh, not this clamp. Do not credit it with more than it does.
     """
-    return max(0, now() - int(rec["updated"]))
+    ref = now() if now_ts is None else now_ts
+    return max(0, ref - int(rec["updated"]))
 
 
-def is_stale(rec: dict) -> bool:
+def is_stale(rec: dict, now_ts: "int | None" = None) -> bool:
     """A lease is stale only once it is OLDER than the window.
+
+    Pass `now_ts` to decide against a clock value sampled ONCE; omit it for a fresh read. See `age_of`.
 
     The comparison is deliberately SIGNED and deliberately `>`: a future `updated` (clock skew) yields a
     negative age, which is not greater than the window, so it reads FRESH. That is the fail-closed
     direction and it is the rule doing the work — never `abs()` this, and never widen `>` to `>=`.
     Manufacturing an adoption out of a skewed clock is the one error that puts two drivers on one run.
     """
-    return age_of(rec) > LEASE_STALE_AFTER
+    return age_of(rec, now_ts) > LEASE_STALE_AFTER
 
 
 @contextmanager
@@ -184,11 +232,23 @@ def claim_lock(path: Path):
         fail(f"lease: {lock} is held — another agent is claiming this run right now. Retry shortly.")
     except OSError as exc:
         fail(f"lease: cannot create {lock}: {exc}")
+    # Record the identity of the EXACT directory this call just created. If the stale-sweep of a LATER
+    # process removes our lock and re-creates its own (the documented forward-skew entry hole), the dir
+    # named `claim.lock` at cleanup time is a DIFFERENT one — a foreign process's live lock. Removing it
+    # would cascade a third driver in. So cleanup rmdirs only when the inode still matches ours. Inode
+    # identity needs no marker file inside the dir, so a hand-rolled `rmdir claim.lock` still interoperates.
+    try:
+        st = os.stat(lock)
+        mine = (st.st_dev, st.st_ino)
+    except OSError:
+        mine = None
     try:
         yield
     finally:
         try:
-            lock.rmdir()
+            st = os.stat(lock)
+            if mine is not None and (st.st_dev, st.st_ino) == mine:
+                lock.rmdir()
         except OSError:
             pass
 
@@ -249,6 +309,10 @@ def cmd_acquire(path: Path, args) -> int:
         fail(NO_HEARTBEAT)
     token = args.token
     with claim_lock(path):
+        # Sample the wall clock EXACTLY ONCE for this whole decision. Reading it again mid-decision let a
+        # backward step classify one record as both stale and fresh and fall through to `owned`, overwriting
+        # a lease a DIFFERENT token holds. Every staleness branch below reads this one value.
+        acquired_at = now()
         try:
             rec = read_lease(path)
         except Corrupt as exc:
@@ -256,16 +320,20 @@ def cmd_acquire(path: Path, args) -> int:
                  f"lease: A lease that cannot be parsed is NOT an absent lease. Adopting it could put two "
                  f"agents on one run; refusing only stalls this one. Nothing was written.\n"
                  f"lease: Inspect {path} and, if the run is genuinely orphaned, remove it by hand.")
-        if rec is not None and not is_stale(rec) and rec["agent"] != token:
+        # One staleness verdict, computed once off the single `acquired_at` sample, drives every branch.
+        # `owned` is therefore reachable ONLY when the record's token is ours; a different-token record is
+        # always `superseded` or (with --allow-takeover / staleness) `adopted`, never `owned`.
+        if rec is None or is_stale(rec, acquired_at):
+            verdict = "adopted"
+        elif rec["agent"] != token:
             if not args.allow_takeover:
                 emit("superseded", rec, held_by=rec["agent"])
-                print(f"lease: REFUSED — a DIFFERENT agent holds this run (lease age {age_of(rec)}s). "
-                      f"You are not the driver: do not review, fix, merge, or relabel anything.\n"
+                print(f"lease: REFUSED — a DIFFERENT agent holds this run (lease age "
+                      f"{age_of(rec, acquired_at)}s). You are not the driver: do not review, fix, merge, or "
+                      f"relabel anything.\n"
                       f"lease: If a human has agreed this run should be taken over, re-run with "
                       f"--allow-takeover.", file=sys.stderr)
                 return EXIT_REFUSED
-            verdict = "adopted"
-        elif rec is None or is_stale(rec):
             verdict = "adopted"
         else:
             verdict = "owned"
@@ -317,6 +385,10 @@ def cmd_release(path: Path, args) -> int:
 
     The prose says "delete lease.json". A superseded driver that follows that literally deletes the LIVE
     owner's lease and hands the run to anyone.
+
+    An ABSENT lease fails closed too: with no lease present there is no token to match against, so we
+    cannot confirm this caller was ever the owner. Symmetric with `refresh` and with the Purpose line "a
+    release refuses unless the token matches".
     """
     if not (args.token or "").strip():
         fail(NO_TOKEN)
@@ -327,11 +399,13 @@ def cmd_release(path: Path, args) -> int:
             fail(f"lease: REFUSED — {exc}\nlease: Refusing to delete a lease we cannot read. Nothing was "
                  f"written.")
         if rec is None:
-            # Release is idempotent: an already-absent lease is release's goal state, so there is no token
-            # to match and nothing to undo. The token check below guards a PRESENT live lease from deletion
-            # by a non-owner; absent is terminal cleanup already complete, reported, not refused.
+            # Release fails closed on an absent lease: with nothing present, no token can be matched.
             emit("absent", None)
-            return EXIT_OK
+            print("lease: REFUSED — there is no lease here to match your token against. Nothing was "
+                  "deleted. A release proves ownership by matching the token IN the lease; with no lease "
+                  "present there is nothing to match, so it fails closed — the same as refresh.",
+                  file=sys.stderr)
+            return EXIT_REFUSED
         if rec["agent"] != args.token:
             emit("superseded", rec, held_by=rec["agent"])
             print("lease: REFUSED — this lease belongs to a DIFFERENT agent. Deleting it would hand a live "


### PR DESCRIPTION
- add `lease.py`, the schema-owning accessor for the run lease, with 26 fixtures and a CI step
- require a proof of an armed heartbeat, and a token, before the lease can be taken
- refuse a malformed lease instead of reading it as absent, and a release whose token does not match
