### PR TITLE
add campaign nudge printer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,11 +96,13 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/repair-pass.py \
             plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py \
             plugins/gauntlet/skills/campaign/scripts/followups.py \
-            plugins/gauntlet/skills/campaign/scripts/followups-test.py | tee pyright.json
+            plugins/gauntlet/skills/campaign/scripts/followups-test.py \
+            plugins/gauntlet/skills/campaign/scripts/nudge.py \
+            plugins/gauntlet/skills/campaign/scripts/nudge-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "18" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 18 it was pointed at — it checked" \
+          if [ "${analyzed}" != "20" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 20 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -167,3 +169,14 @@ jobs:
       # A MISSING sibling fails loudly — it can never report an all-clear over a suite it did not run.
       - name: Follow-up store contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/followups.py self-test
+
+      # The nudge printer's rules, executed. It reminds the orchestrator each wake of what to check
+      # (heartbeat armed, fan out work, PR labels, a review that may have died) — a sticky-note printer,
+      # not gate machinery: it decides nothing and always exits 0. Each fixture pins a rule with teeth
+      # (fires when its condition holds, absent when it does not), so a printer that emitted every line
+      # unconditionally would go red. The sibling `nudge-test.py` is loaded by path; a MISSING sibling
+      # fails loudly, so this can never report health over a suite it did not run. As with the triage
+      # suite (follow-up fu18), the point of this step is that `py_compile` parses these files and runs
+      # neither.
+      - name: Nudge printer contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/nudge.py --self-test

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -107,7 +107,7 @@ def t_parked_pr_fires_only_its_own_reminder():
     check(has(lines, "PR 7: parked"), "a parked PR must nudge that it is parked")
     check(has(lines, "settled but not green"), "the park reminder must carry ci_reason")
     check(not has(lines, "PR 7: CI pending") and not has(lines, "PR 7: mergeable")
-          and not has(lines, "PR 7: review unfinished"),
+          and not has(lines, "PR 7: work due"),
           "a HELD PR must fire ONLY its held reminder — never review/CI/merge nudges")
 
 
@@ -140,16 +140,22 @@ def t_ci_pending_fires():
           "a green PR must NOT fire the CI-pending nudge")
 
 
-def t_review_alive_fires_only_with_a_progress_file():
+def t_work_due_fires_whenever_review_is_due():
+    """The work-due reminder fires whenever a PR needs review and isn't blocked — NOT keyed to any
+    progress file. This pins fu25: a first review (review_rounds=0) must fire, and it must not claim to
+    know the work is a 'review' specifically (an audit or fix may be what's live)."""
     with tempfile.TemporaryDirectory() as d:
         rd = Path(d)
         (rd / "intent-9.md").write_text("x", encoding="utf-8")  # keep the intent nudge quiet
-        r = [row(9, "in_review", reviews_ok=0, tier="HIGH", ci="green", review_rounds=2)]
-        check(not has(fire(r, rundir=rd), "reviewer is alive"),
-              "no progress file → no dispatched review → no liveness nudge")
-        (rd / "review-9-2.progress.jsonl").write_text("{}", encoding="utf-8")
-        check(has(fire(r, rundir=rd), "reviewer is alive"),
-              "a progress file for the current round → nudge to check the reviewer is alive")
+        # review_rounds=0, no progress file at all → the OLD rule missed this; the new one must fire.
+        r = [row(9, "in_review", reviews_ok=0, tier="HIGH", ci="green", review_rounds=0)]
+        check(has(fire(r, rundir=rd), "work due — make sure a dispatched review/audit/fix is live"),
+              "a first review (review_rounds=0) must fire the work-due nudge — the fu25 miss")
+        # not review-due → silent: enough verdicts (mergeable), or CI red.
+        check(not has(fire([row(9, "in_review", reviews_ok=2, tier="HIGH", ci="green")]), "work due"),
+              "a PR with its verdicts is NOT work-due — no work-due nudge")
+        check(not has(fire([row(9, "in_review", reviews_ok=0, tier="HIGH", ci="red")]), "work due"),
+              "a red-CI PR is not review-due — fix CI first, no work-due nudge")
 
 
 def t_mergeable_fires_when_counters_are_met():
@@ -188,7 +194,7 @@ CASES = [
     ("repairing-splits", "repairing splits on whether a decision is recorded", t_repairing_splits_on_decision),
     ("intent-missing", "intent nudge fires only without the file", t_intent_missing_fires_only_without_the_file),
     ("ci-pending", "pending CI nudges to re-derive", t_ci_pending_fires),
-    ("review-alive", "the liveness nudge needs a dispatched progress file", t_review_alive_fires_only_with_a_progress_file),
+    ("work-due", "the work-due nudge fires whenever review is due (fu25)", t_work_due_fires_whenever_review_is_due),
     ("mergeable", "mergeable nudge respects required(tier)", t_mergeable_fires_when_counters_are_met),
     ("terminal-quiet", "a terminal PR fires no per-PR line", t_terminal_pr_fires_no_per_pr_line),
     ("never-blocks", "a nudge always exits 0", t_a_nudge_never_blocks),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Fixtures for `nudge.py` — the sticky-note reminder rules.
+
+They live in a SIBLING file, and `nudge.py --self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE MUST PIN A RULE with TEETH: it asserts the reminder fires when its condition holds AND is
+ABSENT when it does not. A rule that only ever checked "the line is present" would pass against a printer
+that emits every line unconditionally — which is no printer at all.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+OWNER = Path(__file__).resolve().parent / "nudge.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("nudge_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the nudge printer at {OWNER}")
+    return mod
+
+
+N = _load_owner()
+L = N.L
+
+
+def header(**kw) -> dict:
+    return dict(L.HEADER_DEFAULTS, **{k: str(v) for k, v in kw.items()})
+
+
+def row(pr, status, **kw) -> dict:
+    r = dict(L.ROW_DEFAULTS, pr=str(pr), status=status)
+    r.update({k: str(v) for k, v in kw.items()})
+    r["id"] = f"pr{pr}"
+    return r
+
+
+def fire(rows, *, hdr=None, n_followups=0, rundir=None) -> list:
+    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir)
+
+
+def has(lines, substr) -> bool:
+    return any(substr in line for line in lines)
+
+
+def check(cond, msg):
+    if not cond:
+        raise N.SelfTestFailure(msg)
+
+
+# --- always-fire floor --------------------------------------------------------
+
+def t_heartbeat_always_fires():
+    for rows in ([], [row(1, "in_review")], [row(1, "merged")]):
+        check(has(fire(rows), "heartbeat/wake is armed"),
+              "the heartbeat reminder must fire EVERY wake, whatever the ledger holds")
+
+
+def t_header_reread_always_fires():
+    check(has(fire([]), "re-read the ledger header FRESH"),
+          "the header-reread reminder must fire every wake")
+
+
+# --- PR labels ----------------------------------------------------------------
+
+def t_labels_fire_only_with_an_active_pr():
+    check(has(fire([row(1, "in_review")]), "labels still mirror its gate state"),
+          "the labels reminder must fire when a PR is active")
+    check(not has(fire([]), "labels still mirror"),
+          "the labels reminder must NOT fire with no PRs — nothing to relabel")
+    check(not has(fire([row(1, "merged"), row(2, "aborted")]), "labels still mirror"),
+          "the labels reminder must NOT fire when every PR is terminal")
+
+
+# --- run-level ----------------------------------------------------------------
+
+def t_required_set_unknown():
+    check(has(fire([], hdr=header(required_set="unknown")), "required_set is UNKNOWN"),
+          "an unknown required_set must nudge to derive it")
+    check(not has(fire([], hdr=header(required_set="none")), "required_set is UNKNOWN"),
+          "a known required_set must NOT fire the derive nudge")
+
+
+def t_fanout_fires_only_with_open_work():
+    check(has(fire([row(1, "in_review")]), "fan out more work"),
+          "an open PR must nudge to fan out")
+    check(not has(fire([row(1, "merged")]), "fan out more work"),
+          "no open PR must NOT nudge to fan out")
+
+
+def t_followups_fire_only_when_open():
+    check(has(fire([], n_followups=3), "3 open follow-up"),
+          "open follow-ups must nudge, with the count")
+    check(not has(fire([], n_followups=0), "open follow-up"),
+          "zero open follow-ups must NOT nudge")
+
+
+# --- held PRs short-circuit ---------------------------------------------------
+
+def t_parked_pr_fires_only_its_own_reminder():
+    lines = fire([row(7, "awaiting-user", ci_reason="settled but not green")])
+    check(has(lines, "PR 7: PARKED"), "a parked PR must nudge that it is parked")
+    check(has(lines, "settled but not green"), "the park reminder must carry ci_reason")
+    check(not has(lines, "PR 7: CI is pending") and not has(lines, "PR 7: reads mergeable")
+          and not has(lines, "PR 7: a review looks dispatched"),
+          "a HELD PR must fire ONLY its held reminder — never review/CI/merge nudges")
+
+
+def t_repairing_splits_on_decision():
+    no_dec = fire([row(7, "repairing", repair_decision="-")])
+    check(has(no_dec, "repairing with NO decision"), "repairing + no decision → reassess nudge")
+    check(not has(no_dec, "dispatch that repair"), "no-decision repairing must not say dispatch")
+    with_dec = fire([row(7, "repairing", repair_decision="demote@2026-01-01T00:00:00Z")])
+    check(has(with_dec, "dispatch that repair"), "repairing + decision → dispatch nudge")
+    check(not has(with_dec, "NO decision"), "decided repairing must not say NO decision")
+
+
+# --- per-PR in-flight ---------------------------------------------------------
+
+def t_intent_missing_fires_only_without_the_file():
+    with tempfile.TemporaryDirectory() as d:
+        rd = Path(d)
+        r = [row(9, "in_review", reviews_ok=0, tier="HIGH")]
+        check(has(fire(r, rundir=rd), "no intent-9.md"),
+              "a review-due PR with no intent file must nudge to write it")
+        (rd / "intent-9.md").write_text("x", encoding="utf-8")
+        check(not has(fire(r, rundir=rd), "no intent-9.md"),
+              "once the intent file exists the nudge must STOP")
+
+
+def t_ci_pending_fires():
+    check(has(fire([row(9, "in_review", ci="pending")]), "PR 9: CI is pending"),
+          "a pending-CI PR must nudge to re-derive")
+    check(not has(fire([row(9, "in_review", ci="green")]), "PR 9: CI is pending"),
+          "a green PR must NOT fire the CI-pending nudge")
+
+
+def t_review_alive_fires_only_with_a_progress_file():
+    with tempfile.TemporaryDirectory() as d:
+        rd = Path(d)
+        (rd / "intent-9.md").write_text("x", encoding="utf-8")  # keep the intent nudge quiet
+        r = [row(9, "in_review", reviews_ok=0, tier="HIGH", ci="green", review_rounds=2)]
+        check(not has(fire(r, rundir=rd), "review agent is still alive"),
+              "no progress file → no dispatched review → no liveness nudge")
+        (rd / "review-9-2.progress.jsonl").write_text("{}", encoding="utf-8")
+        check(has(fire(r, rundir=rd), "review agent is still alive"),
+              "a progress file for the current round → nudge to check the reviewer is alive")
+
+
+def t_mergeable_fires_when_counters_are_met():
+    check(has(fire([row(9, "in_review", reviews_ok=2, tier="HIGH", ci="green")]), "reads mergeable"),
+          "reviews_ok >= required and green → nudge to check merge-readiness")
+    check(not has(fire([row(9, "in_review", reviews_ok=1, tier="HIGH", ci="green")]), "reads mergeable"),
+          "short of required verdicts → NOT mergeable, no merge nudge")
+    # TRIVIAL needs only 1
+    check(has(fire([row(9, "in_review", reviews_ok=1, tier="TRIVIAL", ci="green")]), "reads mergeable"),
+          "a TRIVIAL PR needs only 1 verdict to read mergeable")
+
+
+def t_terminal_pr_fires_no_per_pr_line():
+    lines = fire([row(9, "merged"), row(10, "aborted")])
+    check(not has(lines, "PR 9:") and not has(lines, "PR 10:"),
+          "a terminal PR must produce NO per-PR reminder")
+
+
+def t_a_nudge_never_blocks():
+    # main() over a real ledger file exits 0 no matter what it prints.
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        led.write_text('{"type": "header", "run_id": "g1", "required_set": "unknown"}\n', encoding="utf-8")
+        code = N.main(["--file", str(led)])
+        check(code == 0, "the nudge printer must ALWAYS exit 0 — it reminds, it never blocks")
+
+
+CASES = [
+    ("heartbeat-always", "the heartbeat reminder fires every wake", t_heartbeat_always_fires),
+    ("header-always", "the header-reread reminder fires every wake", t_header_reread_always_fires),
+    ("labels-active-only", "the labels reminder fires only with an active PR", t_labels_fire_only_with_an_active_pr),
+    ("required-set-unknown", "unknown required_set nudges to derive it", t_required_set_unknown),
+    ("fanout-open-only", "fan-out nudges only with open work", t_fanout_fires_only_with_open_work),
+    ("followups-open-only", "follow-ups nudge only when open, with the count", t_followups_fire_only_when_open),
+    ("parked-short-circuits", "a parked PR fires only its held reminder", t_parked_pr_fires_only_its_own_reminder),
+    ("repairing-splits", "repairing splits on whether a decision is recorded", t_repairing_splits_on_decision),
+    ("intent-missing", "intent nudge fires only without the file", t_intent_missing_fires_only_without_the_file),
+    ("ci-pending", "pending CI nudges to re-derive", t_ci_pending_fires),
+    ("review-alive", "the liveness nudge needs a dispatched progress file", t_review_alive_fires_only_with_a_progress_file),
+    ("mergeable", "mergeable nudge respects required(tier)", t_mergeable_fires_when_counters_are_met),
+    ("terminal-quiet", "a terminal PR fires no per-PR line", t_terminal_pr_fires_no_per_pr_line),
+    ("never-blocks", "a nudge always exits 0", t_a_nudge_never_blocks),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -62,34 +62,34 @@ def t_heartbeat_always_fires():
 
 
 def t_header_reread_always_fires():
-    check(has(fire([]), "re-read the ledger header FRESH"),
+    check(has(fire([]), "re-read the ledger header"),
           "the header-reread reminder must fire every wake")
 
 
 # --- PR labels ----------------------------------------------------------------
 
 def t_labels_fire_only_with_an_active_pr():
-    check(has(fire([row(1, "in_review")]), "labels still mirror its gate state"),
+    check(has(fire([row(1, "in_review")]), "labels match its gate state"),
           "the labels reminder must fire when a PR is active")
-    check(not has(fire([]), "labels still mirror"),
+    check(not has(fire([]), "labels match"),
           "the labels reminder must NOT fire with no PRs — nothing to relabel")
-    check(not has(fire([row(1, "merged"), row(2, "aborted")]), "labels still mirror"),
+    check(not has(fire([row(1, "merged"), row(2, "aborted")]), "labels match"),
           "the labels reminder must NOT fire when every PR is terminal")
 
 
 # --- run-level ----------------------------------------------------------------
 
 def t_required_set_unknown():
-    check(has(fire([], hdr=header(required_set="unknown")), "required_set is UNKNOWN"),
+    check(has(fire([], hdr=header(required_set="unknown")), "required_set is unknown"),
           "an unknown required_set must nudge to derive it")
-    check(not has(fire([], hdr=header(required_set="none")), "required_set is UNKNOWN"),
+    check(not has(fire([], hdr=header(required_set="none")), "required_set is unknown"),
           "a known required_set must NOT fire the derive nudge")
 
 
 def t_fanout_fires_only_with_open_work():
-    check(has(fire([row(1, "in_review")]), "fan out more work"),
+    check(has(fire([row(1, "in_review")]), "fan out work"),
           "an open PR must nudge to fan out")
-    check(not has(fire([row(1, "merged")]), "fan out more work"),
+    check(not has(fire([row(1, "merged")]), "fan out work"),
           "no open PR must NOT nudge to fan out")
 
 
@@ -104,20 +104,20 @@ def t_followups_fire_only_when_open():
 
 def t_parked_pr_fires_only_its_own_reminder():
     lines = fire([row(7, "awaiting-user", ci_reason="settled but not green")])
-    check(has(lines, "PR 7: PARKED"), "a parked PR must nudge that it is parked")
+    check(has(lines, "PR 7: parked"), "a parked PR must nudge that it is parked")
     check(has(lines, "settled but not green"), "the park reminder must carry ci_reason")
-    check(not has(lines, "PR 7: CI is pending") and not has(lines, "PR 7: reads mergeable")
-          and not has(lines, "PR 7: a review looks dispatched"),
+    check(not has(lines, "PR 7: CI pending") and not has(lines, "PR 7: mergeable")
+          and not has(lines, "PR 7: review unfinished"),
           "a HELD PR must fire ONLY its held reminder — never review/CI/merge nudges")
 
 
 def t_repairing_splits_on_decision():
     no_dec = fire([row(7, "repairing", repair_decision="-")])
-    check(has(no_dec, "repairing with NO decision"), "repairing + no decision → reassess nudge")
-    check(not has(no_dec, "dispatch that repair"), "no-decision repairing must not say dispatch")
+    check(has(no_dec, "repairing, no decision"), "repairing + no decision → reassess nudge")
+    check(not has(no_dec, "dispatch decision"), "no-decision repairing must not say dispatch")
     with_dec = fire([row(7, "repairing", repair_decision="demote@2026-01-01T00:00:00Z")])
-    check(has(with_dec, "dispatch that repair"), "repairing + decision → dispatch nudge")
-    check(not has(with_dec, "NO decision"), "decided repairing must not say NO decision")
+    check(has(with_dec, "dispatch decision"), "repairing + decision → dispatch nudge")
+    check(not has(with_dec, "no decision"), "decided repairing must not say NO decision")
 
 
 # --- per-PR in-flight ---------------------------------------------------------
@@ -134,9 +134,9 @@ def t_intent_missing_fires_only_without_the_file():
 
 
 def t_ci_pending_fires():
-    check(has(fire([row(9, "in_review", ci="pending")]), "PR 9: CI is pending"),
+    check(has(fire([row(9, "in_review", ci="pending")]), "PR 9: CI pending"),
           "a pending-CI PR must nudge to re-derive")
-    check(not has(fire([row(9, "in_review", ci="green")]), "PR 9: CI is pending"),
+    check(not has(fire([row(9, "in_review", ci="green")]), "PR 9: CI pending"),
           "a green PR must NOT fire the CI-pending nudge")
 
 
@@ -145,20 +145,20 @@ def t_review_alive_fires_only_with_a_progress_file():
         rd = Path(d)
         (rd / "intent-9.md").write_text("x", encoding="utf-8")  # keep the intent nudge quiet
         r = [row(9, "in_review", reviews_ok=0, tier="HIGH", ci="green", review_rounds=2)]
-        check(not has(fire(r, rundir=rd), "review agent is still alive"),
+        check(not has(fire(r, rundir=rd), "reviewer is alive"),
               "no progress file → no dispatched review → no liveness nudge")
         (rd / "review-9-2.progress.jsonl").write_text("{}", encoding="utf-8")
-        check(has(fire(r, rundir=rd), "review agent is still alive"),
+        check(has(fire(r, rundir=rd), "reviewer is alive"),
               "a progress file for the current round → nudge to check the reviewer is alive")
 
 
 def t_mergeable_fires_when_counters_are_met():
-    check(has(fire([row(9, "in_review", reviews_ok=2, tier="HIGH", ci="green")]), "reads mergeable"),
+    check(has(fire([row(9, "in_review", reviews_ok=2, tier="HIGH", ci="green")]), "mergeable"),
           "reviews_ok >= required and green → nudge to check merge-readiness")
-    check(not has(fire([row(9, "in_review", reviews_ok=1, tier="HIGH", ci="green")]), "reads mergeable"),
+    check(not has(fire([row(9, "in_review", reviews_ok=1, tier="HIGH", ci="green")]), "mergeable"),
           "short of required verdicts → NOT mergeable, no merge nudge")
     # TRIVIAL needs only 1
-    check(has(fire([row(9, "in_review", reviews_ok=1, tier="TRIVIAL", ci="green")]), "reads mergeable"),
+    check(has(fire([row(9, "in_review", reviews_ok=1, tier="TRIVIAL", ci="green")]), "mergeable"),
           "a TRIVIAL PR needs only 1 verdict to read mergeable")
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""The nudge printer — sticky-note reminders the campaign orchestrator prints at the top of every wake.
+
+Every wake is a fresh agent instance, and the campaign's obligations live in prose it re-derives by hand.
+So it forgets: it forgets to arm the fallback heartbeat, it drives off a stale ledger instead of fanning
+out, it lets a review agent die unnoticed, it forgets to swap a PR's labels as the gate moves. This tool
+reads the durable state and PRINTS what the orchestrator should CHECK — the same audit the wake skeleton
+describes in prose, computed from disk so an amnesiac wake is handed it rather than told to remember it.
+
+**It is a REMINDER, not a supervisor.** Every rule is a CHEAP read (ledger fields, an open-follow-up
+count, whether a `<rundir>` file exists) → a short "check X" string. It NEVER derives CI, counts verdicts,
+decides merge-readiness, evaluates a liveness cap, or judges whether a review agent is actually alive —
+those tools already exist and it only reminds the orchestrator to run them. It decides nothing about
+whether a PR may merge; it is branch-owned, dogfoodable, and always exits 0. A reminder you can ignore is
+the point: its value is being DELIVERED at the wake, computed and concrete, not forcing anything.
+
+The design and the full obligation inventory it was trimmed from live in `.gauntlet/DESIGN-nudge-printer.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+DESCRIPTION = "Print per-wake reminders for the campaign orchestrator (sticky notes, not a supervisor)."
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "nudge-test.py"
+
+
+def _load(name: str, filename: str):
+    mod = load_module_from_path(name, _HERE / filename)
+    if mod is None:
+        raise RuntimeError(f"cannot load {filename}")
+    return mod
+
+
+L = _load("nudge_ledger", "ledger.py")
+F = _load("nudge_followups", "followups.py")
+
+# A held PR is FROZEN — it fires ONLY its held reminder, never review/CI/merge nudges. The enumeration
+# lives in ledger.py; never retype it (a new held status inherits the freeze with no edit here).
+HELD = L.HELD_STATUSES
+REPAIRING = L.REPAIR_STATUS
+TERMINAL = ("merged", "aborted")
+OPEN_FOLLOWUP_HIDDEN = F.TABLE_HIDDEN_STATES  # a follow-up in one of these is closed, not open work
+
+
+def required(tier: str) -> int:
+    """1 if TRIVIAL, else 2. Untriaged ('-'/'') counts as needs-review (target 2) — never under-remind."""
+    return 1 if tier == "TRIVIAL" else 2
+
+
+def open_followups(followups_path: "Path | None") -> int:
+    if followups_path is None or not followups_path.exists():
+        return 0
+    entries = F.load(followups_path)
+    return sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN)
+
+
+def rundir_has(rundir: "Path | None", name: str) -> bool:
+    return rundir is not None and (rundir / name).exists()
+
+
+def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None") -> list:
+    """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings."""
+    out: list = []
+    active = [r for r in rows if r["status"] not in TERMINAL]
+
+    # --- always-fire floor -----------------------------------------------------
+    out.append("check the fallback heartbeat/wake is armed — a task-notification only fires while "
+               "something is watching.")
+    out.append("re-read the ledger header FRESH this wake (base_branch, reviewer, required_set, "
+               "skill_version) — never from memory.")
+    if active:
+        out.append("check each active PR's labels still mirror its gate state "
+                   "(gauntlet-reviewing while under review, gauntlet-accepted once it passes) — easy to "
+                   "forget the swap on a long run.")
+
+    # --- run-level -------------------------------------------------------------
+    if header.get("required_set") == "unknown":
+        out.append("required_set is UNKNOWN — derive the base branch's required set; nothing can go green "
+                   "until you do.")
+    if active:
+        out.append(f"{len(active)} PR(s) still open — reconcile against ground truth and check if you can "
+                   f"fan out more work up to caps; don't drive off the ledger alone.")
+    if n_followups:
+        out.append(f"{n_followups} open follow-up(s) — check if you can start on any (investigate freely; "
+                   f"act only on a corroborated one; never publish without the user).")
+
+    # --- per-PR reminders ------------------------------------------------------
+    # A HELD PR (parked or repairing) fires ONLY its held reminder. That exclusion is enforced by the
+    # `status == "in_review"` guard on every in-flight rule below — a held PR is never in_review, so it
+    # reaches none of them. No explicit short-circuit is needed (and one would be an untestable no-op).
+    for r in active:
+        pr = r["pr"]
+        status = r["status"]
+        if status == REPAIRING:
+            if r.get("repair_decision", "-") == "-":
+                out.append(f"PR {pr}: repairing with NO decision — run its reassessment pass; do NOT "
+                           f"dispatch a plain fix.")
+            else:
+                out.append(f"PR {pr}: repairing with a recorded decision "
+                           f"({r['repair_decision']}) — dispatch that repair and nothing else.")
+        elif status in HELD:  # awaiting-user / awaiting-api
+            why = r.get("ci_reason", "-")
+            tail = f" ({why})" if why and why != "-" else ""
+            out.append(f"PR {pr}: PARKED on the user{tail} — check its question was surfaced, and take "
+                       f"NO action that mutates it.")
+
+        # in-flight rules — each gated on in_review, so held PRs above fire none of them
+        need = required(r["tier"])
+        ok = int(r["reviews_ok"]) if r["reviews_ok"].isdigit() else 0
+        ci = r["ci"]
+        if status == "in_review" and ok < need and not rundir_has(rundir, f"intent-{pr}.md"):
+            out.append(f"PR {pr}: no intent-{pr}.md — write it before any review pass (a pass with no "
+                       f"intent is unusable).")
+        if status == "in_review" and ci == "pending":
+            out.append(f"PR {pr}: CI is pending for the current head — re-derive CI (the derivation is a "
+                       f"command; never judge checks by eye).")
+        if (status == "in_review" and ok < need and ci != "red"
+                and rundir_has(rundir, f"review-{pr}-{r['review_rounds']}.progress.jsonl")):
+            out.append(f"PR {pr}: a review looks dispatched but unfinished — check the review agent is "
+                       f"still alive (a dead reviewer leaves the progress file frozen).")
+        if status == "in_review" and ok >= need and ci == "green":
+            out.append(f"PR {pr}: reads mergeable by the counters — check if it's ready to merge "
+                       f"(re-confirm against the live head + base first).")
+
+    return out
+
+
+def render(header: dict, rows: list, n_followups: int, rundir: "Path | None") -> str:
+    lines = reminders(header, rows, n_followups, rundir)
+    run_id = header.get("run_id", "-")
+    head = f"NUDGE (run {run_id}) — {len(lines)} reminder(s):"
+    body = "\n".join(f"  - {line}" for line in lines)
+    return head + ("\n" + body if body else "")
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("--file", help="the run ledger (<rundir>/state.jsonl)")
+    parser.add_argument("--followups", help="the follow-up store (.gauntlet/followups.jsonl)")
+    parser.add_argument("--rundir", help="the run directory, for intent/CI/progress file checks")
+    parser.add_argument("--self-test", action="store_true", help="run every fixture and assert the rules "
+                                                                 "this file enforces still hold")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if args.file is None:
+        parser.error("the following arguments are required: --file")
+    header, rows = L.load(Path(args.file))
+    n_followups = open_followups(Path(args.followups) if args.followups else None)
+    rundir = Path(args.rundir) if args.rundir else None
+    print(render(header, rows, n_followups, rundir))
+    return 0  # a nudge NEVER blocks — it only reminds
+
+
+# --- self-test ----------------------------------------------------------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SelfTestFailure(msg)
+
+
+def sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
+                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
+    mod = load_module_from_path("nudge_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the nudge printer's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:30} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the nudge printer's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the nudge printer's contract is intact.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -109,9 +109,13 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None")
             out.append(f"PR {pr}: no intent-{pr}.md — write it before reviewing.")
         if status == "in_review" and ci == "pending":
             out.append(f"PR {pr}: CI pending — re-derive it.")
-        if (status == "in_review" and ok < need and ci != "red"
-                and rundir_has(rundir, f"review-{pr}-{r['review_rounds']}.progress.jsonl")):
-            out.append(f"PR {pr}: review unfinished — check the reviewer is alive.")
+        if status == "in_review" and ok < need and ci != "red":
+            # Work is DUE. The nudge cannot tell from disk whether a review/audit/fix is actually running
+            # (that liveness lives in the session, not the ledger) or which KIND is running — so it does not
+            # try. It reminds to make sure SOMETHING is live, or to launch one. An earlier version probed
+            # review-<pr>-<review_rounds>.progress.jsonl and missed a first review (review_rounds=0) — the
+            # exact miss dogfooding and the review both caught (fu25).
+            out.append(f"PR {pr}: work due — make sure a dispatched review/audit/fix is live, or launch one.")
         if status == "in_review" and ok >= need and ci == "green":
             out.append(f"PR {pr}: mergeable by counters — check merge-readiness.")
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -71,25 +71,18 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None")
     active = [r for r in rows if r["status"] not in TERMINAL]
 
     # --- always-fire floor -----------------------------------------------------
-    out.append("check the fallback heartbeat/wake is armed — a task-notification only fires while "
-               "something is watching.")
-    out.append("re-read the ledger header FRESH this wake (base_branch, reviewer, required_set, "
-               "skill_version) — never from memory.")
+    out.append("check the heartbeat/wake is armed.")
+    out.append("re-read the ledger header (base_branch, reviewer, required_set, skill_version).")
     if active:
-        out.append("check each active PR's labels still mirror its gate state "
-                   "(gauntlet-reviewing while under review, gauntlet-accepted once it passes) — easy to "
-                   "forget the swap on a long run.")
+        out.append("check each active PR's labels match its gate state.")
 
     # --- run-level -------------------------------------------------------------
     if header.get("required_set") == "unknown":
-        out.append("required_set is UNKNOWN — derive the base branch's required set; nothing can go green "
-                   "until you do.")
+        out.append("required_set is unknown — derive it.")
     if active:
-        out.append(f"{len(active)} PR(s) still open — reconcile against ground truth and check if you can "
-                   f"fan out more work up to caps; don't drive off the ledger alone.")
+        out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
     if n_followups:
-        out.append(f"{n_followups} open follow-up(s) — check if you can start on any (investigate freely; "
-                   f"act only on a corroborated one; never publish without the user).")
+        out.append(f"{n_followups} open follow-up(s) — start any you can.")
 
     # --- per-PR reminders ------------------------------------------------------
     # A HELD PR (parked or repairing) fires ONLY its held reminder. That exclusion is enforced by the
@@ -100,34 +93,27 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None")
         status = r["status"]
         if status == REPAIRING:
             if r.get("repair_decision", "-") == "-":
-                out.append(f"PR {pr}: repairing with NO decision — run its reassessment pass; do NOT "
-                           f"dispatch a plain fix.")
+                out.append(f"PR {pr}: repairing, no decision — run the reassessment pass.")
             else:
-                out.append(f"PR {pr}: repairing with a recorded decision "
-                           f"({r['repair_decision']}) — dispatch that repair and nothing else.")
+                out.append(f"PR {pr}: repairing — dispatch decision ({r['repair_decision']}), nothing else.")
         elif status in HELD:  # awaiting-user / awaiting-api
             why = r.get("ci_reason", "-")
             tail = f" ({why})" if why and why != "-" else ""
-            out.append(f"PR {pr}: PARKED on the user{tail} — check its question was surfaced, and take "
-                       f"NO action that mutates it.")
+            out.append(f"PR {pr}: parked{tail} — surface the question, don't mutate it.")
 
         # in-flight rules — each gated on in_review, so held PRs above fire none of them
         need = required(r["tier"])
         ok = int(r["reviews_ok"]) if r["reviews_ok"].isdigit() else 0
         ci = r["ci"]
         if status == "in_review" and ok < need and not rundir_has(rundir, f"intent-{pr}.md"):
-            out.append(f"PR {pr}: no intent-{pr}.md — write it before any review pass (a pass with no "
-                       f"intent is unusable).")
+            out.append(f"PR {pr}: no intent-{pr}.md — write it before reviewing.")
         if status == "in_review" and ci == "pending":
-            out.append(f"PR {pr}: CI is pending for the current head — re-derive CI (the derivation is a "
-                       f"command; never judge checks by eye).")
+            out.append(f"PR {pr}: CI pending — re-derive it.")
         if (status == "in_review" and ok < need and ci != "red"
                 and rundir_has(rundir, f"review-{pr}-{r['review_rounds']}.progress.jsonl")):
-            out.append(f"PR {pr}: a review looks dispatched but unfinished — check the review agent is "
-                       f"still alive (a dead reviewer leaves the progress file frozen).")
+            out.append(f"PR {pr}: review unfinished — check the reviewer is alive.")
         if status == "in_review" and ok >= need and ci == "green":
-            out.append(f"PR {pr}: reads mergeable by the counters — check if it's ready to merge "
-                       f"(re-confirm against the live head + base first).")
+            out.append(f"PR {pr}: mergeable by counters — check merge-readiness.")
 
     return out
 


### PR DESCRIPTION
- add `nudge.py`, a sticky-note printer the orchestrator runs each wake
- reminds to check: heartbeat, fanning out work, PR labels, follow-ups, a dead review
- reminders only — decides nothing, derives no CI, always exits 0; 14 teeth-bearing fixtures + CI step
