### PR TITLE
Add reviewer stdout-stream liveness probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,13 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/followups.py \
             plugins/gauntlet/skills/campaign/scripts/followups-test.py \
             plugins/gauntlet/skills/campaign/scripts/nudge.py \
-            plugins/gauntlet/skills/campaign/scripts/nudge-test.py | tee pyright.json
+            plugins/gauntlet/skills/campaign/scripts/nudge-test.py \
+            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py \
+            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "20" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 20 it was pointed at — it checked" \
+          if [ "${analyzed}" != "22" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 22 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -180,3 +182,13 @@ jobs:
       # neither.
       - name: Nudge printer contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/nudge.py --self-test
+
+      # The reviewer-liveness probe's rules, executed. It reports whether a background reviewer's stdout
+      # stream is still growing — a finer PROCESS-liveness signal than the unit-granular progress file —
+      # by stat'ing the file only, never reading it. Like the nudge printer it decides nothing and always
+      # exits 0; each fixture pins a verdict on BOTH sides of a boundary (a constant-returning probe would
+      # go red). The sibling `reviewer-liveness-test.py` is loaded by path; a MISSING sibling fails loudly,
+      # so this can never report health over a suite it did not run. As with the suites above, the point of
+      # this step is that `py_compile` parses these files and runs neither.
+      - name: Reviewer liveness probe contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py self-test

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -402,7 +402,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      sit undetected for a full normal interval — otherwise **~15 min**, matching the Stage 2a meaningful-progress
      threshold: with no launch deadline pending, nothing can declare a review stalled before then, so a
      shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
-     wake). ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
+     wake). **One exception carries new signal:** a background-task review watched via its stdout stream
+     can be declared hung before that cap once the stream falls quiet (`stage-2-review-gate.md`, the
+     stdout-stream liveness signal), so while such a review is streaming, a shorter poll toward that
+     quiet window is a real check, not a bare re-reconcile. ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
      both means a hung or orphaned run wakes no one. Run
      `ledger.py --file <state.jsonl> table` and include its output verbatim, fenced, in the status
      message. **Verbatim means WHOLE** — including every `#` line it prints below the grid. The default

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -419,7 +419,7 @@ content** (the transcript is large enough to flood the driver's context). Use it
 stream written within the quiet window (`alive`) means the process is emitting, so do **not** declare a
 false stall while the progress file is merely coarse-stale; a stream unwritten past the window (`quiet`),
 **and an `absent` stream, corroborate a hang ONLY AFTER launch evidence exists** — the reviewer wrote at
-least one line after `pass_identity` (a `started` event, a finding, or an amendment) and then went quiet —
+least one line after `pass_identity` (a `started` event or an amendment) and then went quiet —
 in which case apply `reviewer.md`'s retry budget without waiting the full meaningful-progress cap.
 **BEFORE launch evidence, a `quiet`/`absent` stream is NOT a hang signal:** the launch-evidence gate (the
 Stage 2a launch deadline, above) still owns that window, and triggering the retry budget there would kill a

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -408,22 +408,34 @@ mark the review suspicious; if it remains stale on the next wake, treat it as a 
 failure: apply `reviewer.md`'s retry budget and `runtime-adapter.md`'s owned transition. Ignore any
 late verdict from a stale/superseded attempt unless its attempt id still matches the active review pass.
 
-**A finer liveness signal for a background-task reviewer: its OUTPUT STREAM.** The meaningful-progress
+**A finer liveness signal for a background-task reviewer whose stdout is captured INCREMENTALLY: its
+OUTPUT STREAM.** The meaningful-progress
 timer above is unit-granular — a `done` event fires only when a whole unit completes, minutes apart — so
 BETWEEN units a live reviewer grinding one unit and a hung one look identical until the ~15-min cap. A
-cross-engine reviewer launched as a background task also writes a stdout stream that grows CONTINUOUSLY
+background-task reviewer whose stdout is captured as it is produced writes a stream that grows CONTINUOUSLY
 while the model emits, which is a far finer **process-liveness** signal. Read it with
 `reviewer-liveness.py probe --stream <task-output-file>`, which **stats the file only — never reads its
 content** (the transcript is large enough to flood the driver's context). Use its verdict two ways: a
 stream written within the quiet window (`alive`) means the process is emitting, so do **not** declare a
-false stall while the progress file is merely coarse-stale; a stream unwritten past the window (`quiet`)
-**corroborates** a hang, so apply `reviewer.md`'s retry budget without waiting the full meaningful-progress
-cap. **This is process liveness, NOT meaningful progress** — exactly like the `started`/"still working"
+false stall while the progress file is merely coarse-stale; a stream unwritten past the window (`quiet`),
+**and an `absent` stream, corroborate a hang ONLY AFTER launch evidence exists** — the reviewer wrote at
+least one line after `pass_identity` (a `started` event, a finding, or an amendment) and then went quiet —
+in which case apply `reviewer.md`'s retry budget without waiting the full meaningful-progress cap.
+**BEFORE launch evidence, a `quiet`/`absent` stream is NOT a hang signal:** the launch-evidence gate (the
+Stage 2a launch deadline, above) still owns that window, and triggering the retry budget there would kill a
+healthy warming-up reviewer or pre-empt the launch-evidence recovery. **This is process liveness, NOT
+meaningful progress** — exactly like the `started`/"still working"
 lines above, a growing stream **MUST NOT reset the meaningful-progress timer**: a reviewer that streams
 forever without completing a unit is still stalled at that cap. The stream signal makes a dead process
-caught sooner; it never extends patience for one that will not converge. It applies **only** to the
-background-task (cross-engine) route — a native-worker reviewer's transcript is not safely pollable, so
-that route keeps the progress-file-plus-completion model (`reviewer.md`, native-worker path).
+caught sooner; it never extends patience for one that will not converge. **The signal needs the stdout to
+be captured INCREMENTALLY**, so it applies only to a background-task reviewer whose stream grows as the
+model emits — the Claude-Code→codex route qualifies (codex streams its reasoning to the captured stdout).
+A reviewer whose output is BUFFERED until completion exposes no growing stream: `claude -p --output-format
+text` (the Codex→claude route) writes nothing until the end (realtime streaming needs `--output-format
+stream-json`), so a HEALTHY such reviewer's file stays unwritten and the probe reads a FALSE `quiet` — the
+driver MUST NOT rely on its `quiet` verdict for that route. A native-worker reviewer's transcript is not
+safely pollable either, so that route likewise keeps the progress-file-plus-completion model
+(`reviewer.md`, native-worker path).
 
 ### What the review is MEASURED AGAINST — the PR's intent
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -408,6 +408,23 @@ mark the review suspicious; if it remains stale on the next wake, treat it as a 
 failure: apply `reviewer.md`'s retry budget and `runtime-adapter.md`'s owned transition. Ignore any
 late verdict from a stale/superseded attempt unless its attempt id still matches the active review pass.
 
+**A finer liveness signal for a background-task reviewer: its OUTPUT STREAM.** The meaningful-progress
+timer above is unit-granular — a `done` event fires only when a whole unit completes, minutes apart — so
+BETWEEN units a live reviewer grinding one unit and a hung one look identical until the ~15-min cap. A
+cross-engine reviewer launched as a background task also writes a stdout stream that grows CONTINUOUSLY
+while the model emits, which is a far finer **process-liveness** signal. Read it with
+`reviewer-liveness.py probe --stream <task-output-file>`, which **stats the file only — never reads its
+content** (the transcript is large enough to flood the driver's context). Use its verdict two ways: a
+stream written within the quiet window (`alive`) means the process is emitting, so do **not** declare a
+false stall while the progress file is merely coarse-stale; a stream unwritten past the window (`quiet`)
+**corroborates** a hang, so apply `reviewer.md`'s retry budget without waiting the full meaningful-progress
+cap. **This is process liveness, NOT meaningful progress** — exactly like the `started`/"still working"
+lines above, a growing stream **MUST NOT reset the meaningful-progress timer**: a reviewer that streams
+forever without completing a unit is still stalled at that cap. The stream signal makes a dead process
+caught sooner; it never extends patience for one that will not converge. It applies **only** to the
+background-task (cross-engine) route — a native-worker reviewer's transcript is not safely pollable, so
+that route keeps the progress-file-plus-completion model (`reviewer.md`, native-worker path).
+
 ### What the review is MEASURED AGAINST — the PR's intent
 
 **THE REVIEWER USED TO BE TOLD WHAT THE CODE WAS. IT WAS NEVER TOLD WHAT THE CODE WAS FOR.** The dispatch

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fixtures for `reviewer-liveness.py` — the stdout-stream liveness probe.
+
+They live in a SIBLING file, and `reviewer-liveness.py self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE PINS A RULE WITH TEETH: it asserts the verdict on one side of a boundary AND the opposite
+verdict on the other, so a probe that returned a constant would go red. The probe reports facts and
+decides nothing; these fixtures pin exactly which fact each input produces.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+OWNER = Path(__file__).resolve().parent / "reviewer-liveness.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("reviewer_liveness_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the reviewer-liveness probe at {OWNER}")
+    return mod
+
+
+R = _load_owner()
+WINDOW = R.DEFAULT_QUIET_WINDOW_SECONDS
+
+
+def check(cond, msg):
+    if not cond:
+        raise R.SelfTestFailure(msg)
+
+
+def classify(*, exists, size, mtime_epoch, now_epoch, quiet_window=WINDOW):
+    return R.classify(exists=exists, size=size, mtime_epoch=mtime_epoch,
+                      now_epoch=now_epoch, quiet_window=quiet_window)
+
+
+# --- alive vs quiet: the core boundary ----------------------------------------
+
+def t_recent_write_reads_alive():
+    # A stream written well within the window is a live, emitting process.
+    v = classify(exists=True, size=4096, mtime_epoch=1000.0, now_epoch=1000.0 + 5)
+    check(v["verdict"] == "alive", "a stream written 5s ago (window 180s) must read 'alive', not "
+          f"{v['verdict']!r}")
+
+
+def t_quiet_past_window_reads_quiet():
+    # No write for longer than the window is a hung-process candidate.
+    v = classify(exists=True, size=4096, mtime_epoch=1000.0, now_epoch=1000.0 + WINDOW + 30)
+    check(v["verdict"] == "quiet", f"a stream unwritten for window+30s must read 'quiet', not "
+          f"{v['verdict']!r}")
+
+
+def t_window_boundary_is_closed_on_quiet():
+    # The boundary is EXACT and closed on 'quiet': age == window is quiet; one second less is alive.
+    at_window = classify(exists=True, size=1, mtime_epoch=1000.0, now_epoch=1000.0 + WINDOW)
+    just_under = classify(exists=True, size=1, mtime_epoch=1000.0, now_epoch=1000.0 + WINDOW - 1)
+    check(at_window["verdict"] == "quiet", "age == window must read 'quiet' (boundary closed on quiet)")
+    check(just_under["verdict"] == "alive", "age == window-1 must read 'alive' — the boundary has teeth")
+
+
+def t_future_mtime_reads_alive():
+    # A future mtime (clock skew, or a write mid-stat) is a FRESH write — never 'quiet'.
+    v = classify(exists=True, size=10, mtime_epoch=1000.0, now_epoch=1000.0 - 60)
+    check(v["verdict"] == "alive", "a future mtime (negative age) must read 'alive', never 'quiet'")
+
+
+# --- absent stream ------------------------------------------------------------
+
+def t_absent_stream_reads_absent():
+    v = classify(exists=False, size=None, mtime_epoch=None, now_epoch=1000.0)
+    check(v["verdict"] == "absent", "a missing stream file must read 'absent'")
+    check(v["stream_bytes"] is None and v["age_seconds"] is None,
+          "an absent stream reports no size and no age")
+
+
+# --- the reported facts, and that it STATS (never reads) ----------------------
+
+def t_reports_size_when_present_and_none_when_absent():
+    present = classify(exists=True, size=777, mtime_epoch=1000.0, now_epoch=1000.0 + 1)
+    absent = classify(exists=False, size=None, mtime_epoch=None, now_epoch=1000.0)
+    check(present["stream_bytes"] == 777, "a present stream must report its byte size")
+    check(absent["stream_bytes"] is None, "an absent stream must report None, never a number — teeth")
+
+
+def t_probe_uses_real_stat_never_reads_content():
+    # Exercise the real os.stat path: size comes from stat, verdict from the file's own mtime — the probe
+    # never opens the file for reading. An old mtime reads 'quiet'; a fresh one reads 'alive'.
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "review-1-1.out"
+        body = b"streamed reasoning tokens\n" * 100
+        p.write_bytes(body)
+        os.utime(p, (1000.0, 1000.0))  # mtime far in the past relative to our injected 'now'
+        stale = R.probe(str(p), WINDOW, now_epoch=1000.0 + WINDOW + 5)
+        check(stale["verdict"] == "quiet", "a real file with an old mtime must read 'quiet' via os.stat")
+        check(stale["stream_bytes"] == len(body),
+              "stream_bytes must equal the file's real size (proving it stat'd, not guessed)")
+        fresh = R.probe(str(p), WINDOW, now_epoch=1000.0 + 1)
+        check(fresh["verdict"] == "alive", "the same file read at a fresh 'now' must read 'alive' — teeth")
+
+
+def t_missing_path_probes_absent():
+    with tempfile.TemporaryDirectory() as d:
+        gone = Path(d) / "never-created.out"
+        v = R.probe(str(gone), WINDOW, now_epoch=1000.0)
+        check(v["verdict"] == "absent", "probing a nonexistent path must read 'absent', never crash")
+
+
+CASES = [
+    ("recent-alive", "a recent write reads alive", t_recent_write_reads_alive),
+    ("quiet-past-window", "no write past the window reads quiet", t_quiet_past_window_reads_quiet),
+    ("boundary-closed-quiet", "age == window is quiet; window-1 is alive", t_window_boundary_is_closed_on_quiet),
+    ("future-mtime-alive", "a future mtime reads alive, never quiet", t_future_mtime_reads_alive),
+    ("absent-reads-absent", "a missing stream reads absent with no size/age", t_absent_stream_reads_absent),
+    ("reports-size", "size reported when present, None when absent", t_reports_size_when_present_and_none_when_absent),
+    ("stats-never-reads", "probe stats the real file (size from stat), never reads it", t_probe_uses_real_stat_never_reads_content),
+    ("missing-path-absent", "probing a missing path reads absent, never crashes", t_missing_path_probes_absent),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
@@ -9,6 +9,8 @@ decides nothing; these fixtures pin exactly which fact each input produces.
 """
 from __future__ import annotations
 
+import builtins
+import io
 import os
 import tempfile
 from pathlib import Path
@@ -89,17 +91,50 @@ def t_reports_size_when_present_and_none_when_absent():
 
 def t_probe_uses_real_stat_never_reads_content():
     # Exercise the real os.stat path: size comes from stat, verdict from the file's own mtime — the probe
-    # never opens the file for reading. An old mtime reads 'quiet'; a fresh one reads 'alive'.
+    # never OPENS the file for reading. An old mtime reads 'quiet'; a fresh one reads 'alive'.
+    #
+    # TEETH for the load-bearing safety property: the transcript is large, so probe() must reach its
+    # result via os.stat ALONE and never open the stream (opening + reading it would flood the driver's
+    # context). We PIN that here by forbidding open during the probe() call: builtins.open and io.open are
+    # patched to raise the instant anything tries to open the stream path, so a future regression that
+    # starts reading the transcript turns this fixture RED instead of passing green. os.stat is left
+    # untouched, so the size/mtime path a correct probe uses still works. The tempfile is written BEFORE
+    # the guard is installed, so only the probe() call runs under it, and the originals are restored in a
+    # finally so the patch cannot leak to another fixture.
     with tempfile.TemporaryDirectory() as d:
         p = Path(d) / "review-1-1.out"
         body = b"streamed reasoning tokens\n" * 100
         p.write_bytes(body)
         os.utime(p, (1000.0, 1000.0))  # mtime far in the past relative to our injected 'now'
-        stale = R.probe(str(p), WINDOW, now_epoch=1000.0 + WINDOW + 5)
+        target = os.path.realpath(str(p))
+
+        real_builtins_open = builtins.open
+        real_io_open = io.open
+
+        def _forbid_stream_open(orig):
+            def guarded(file, *args, **kwargs):
+                try:
+                    same = os.path.realpath(os.fspath(file)) == target
+                except TypeError:
+                    same = False  # a non-path (e.g. an int fd) is never our stream
+                if same:
+                    raise AssertionError(
+                        "probe() OPENED the stream file — it must stat only, never read the transcript")
+                return orig(file, *args, **kwargs)
+            return guarded
+
+        builtins.open = _forbid_stream_open(real_builtins_open)
+        io.open = _forbid_stream_open(real_io_open)
+        try:
+            stale = R.probe(str(p), WINDOW, now_epoch=1000.0 + WINDOW + 5)
+            fresh = R.probe(str(p), WINDOW, now_epoch=1000.0 + 1)
+        finally:
+            builtins.open = real_builtins_open
+            io.open = real_io_open
+
         check(stale["verdict"] == "quiet", "a real file with an old mtime must read 'quiet' via os.stat")
         check(stale["stream_bytes"] == len(body),
               "stream_bytes must equal the file's real size (proving it stat'd, not guessed)")
-        fresh = R.probe(str(p), WINDOW, now_epoch=1000.0 + 1)
         check(fresh["verdict"] == "alive", "the same file read at a fresh 'now' must read 'alive' — teeth")
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Report whether a dispatched reviewer's OUTPUT STREAM is still moving.
+
+The review gate already declares a reviewer stalled when no MEANINGFUL PROGRESS —
+a planned unit `done`, or an accepted amendment — lands for ~15 min
+(`stage-2-review-gate.md`). That timer is deliberately coarse: progress events
+fire only when a whole unit completes, minutes apart, so BETWEEN units a live
+reviewer grinding one unit and a hung one look identical until the cap.
+
+A cross-engine reviewer launched as a background task writes its reasoning to a
+stdout stream that grows CONTINUOUSLY while the model emits — a far finer
+PROCESS-LIVENESS signal than the unit-granular progress file. This probe reads
+that stream's SIZE and MTIME ONLY (never its content — the transcript is large
+and reading it would flood the driver's context) and reports whether it was
+written within a quiet window.
+
+It DECIDES NOTHING and always exits 0. It is a MISS-CATCHER, not a verdict: a
+growing stream proves the process is ALIVE, so the driver need not declare a
+false stall while the progress file is merely coarse-stale; a stream quiet past
+the window CORROBORATES a hang, so the driver can apply `reviewer.md`'s retry
+budget without waiting the full meaningful-progress cap. Crucially, stream growth
+is PROCESS liveness, NOT meaningful progress: it MUST NOT reset the
+meaningful-progress timer (`stage-2-review-gate.md`) — a reviewer that streams
+forever without completing a unit is still stalled at that cap. This signal kills
+a hung process faster; it never extends patience for one that will not converge.
+
+Only the background-task (cross-engine) route has a pollable stream. A
+native-worker reviewer's transcript is not safely pollable, so that route keeps
+the progress-file + completion-notification model; do not point this probe at it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+DESCRIPTION = "Report a background reviewer's stdout-stream liveness (stat only; decides nothing)."
+
+# A live streaming reviewer writes its stdout far more often than this; a stream with NO write for a
+# full window, while no meaningful progress has landed, is a hung-process candidate. Kept well under the
+# ~15-min meaningful-progress cap so a dead process is caught sooner, never later.
+DEFAULT_QUIET_WINDOW_SECONDS = 180
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "reviewer-liveness-test.py"
+
+
+def classify(*, exists: bool, size: "int | None", mtime_epoch: "float | None",
+             now_epoch: float, quiet_window: int) -> dict:
+    """Pure verdict from a stat result. `alive` iff the stream was written within the window.
+
+    - absent: no stream file yet (the task has not started, or its output is gone).
+    - alive:  age < quiet_window — written recently, so the process is emitting NOW.
+    - quiet:  age >= quiet_window — no write for a full window; a hung-process candidate to
+              corroborate against the (unchanged) meaningful-progress state before acting.
+    The boundary is closed on `quiet`: age == quiet_window reads `quiet`.
+    """
+    if not exists:
+        return {"verdict": "absent", "stream_bytes": None, "age_seconds": None,
+                "quiet_window_seconds": quiet_window}
+    assert mtime_epoch is not None
+    age = now_epoch - mtime_epoch
+    verdict = "quiet" if age >= quiet_window else "alive"
+    return {"verdict": verdict, "stream_bytes": size, "age_seconds": age,
+            "quiet_window_seconds": quiet_window}
+
+
+def probe(stream: str, quiet_window: int, now_epoch: float) -> dict:
+    """Stat the stream file (never read it) and classify. Missing file -> absent."""
+    try:
+        st = os.stat(stream)
+    except FileNotFoundError:
+        return classify(exists=False, size=None, mtime_epoch=None,
+                        now_epoch=now_epoch, quiet_window=quiet_window)
+    return classify(exists=True, size=st.st_size, mtime_epoch=st.st_mtime,
+                    now_epoch=now_epoch, quiet_window=quiet_window)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    sub = parser.add_subparsers(dest="cmd")
+
+    p = sub.add_parser("probe", help="report the stream's liveness verdict as JSON")
+    p.add_argument("--stream", required=True,
+                   help="path to the reviewer's background-task stdout file (stat'd, never read)")
+    p.add_argument("--quiet-window-seconds", "--quiet_window_seconds", type=int,
+                   default=DEFAULT_QUIET_WINDOW_SECONDS,
+                   help=f"a stream unwritten for this long reads 'quiet' (default {DEFAULT_QUIET_WINDOW_SECONDS})")
+    p.add_argument("--now-epoch", "--now_epoch", type=float, default=None,
+                   help="reference 'now' as epoch seconds (default: the wall clock)")
+
+    sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "self-test":
+        return self_test()
+    if args.cmd == "probe":
+        now = args.now_epoch if args.now_epoch is not None else _now()
+        print(json.dumps(probe(args.stream, args.quiet_window_seconds, now)))
+        return 0
+    parser.print_help()
+    return 2
+
+
+def _now() -> float:
+    import time
+    return time.time()
+
+
+# --- self-test ----------------------------------------------------------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SelfTestFailure(msg)
+
+
+def sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
+                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
+    mod = load_module_from_path("reviewer_liveness_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':32} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the reviewer-liveness probe's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:32} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:32} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:32} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the reviewer-liveness probe's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the reviewer-liveness probe's contract is intact.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
@@ -7,8 +7,8 @@ a planned unit `done`, or an accepted amendment — lands for ~15 min
 fire only when a whole unit completes, minutes apart, so BETWEEN units a live
 reviewer grinding one unit and a hung one look identical until the cap.
 
-A cross-engine reviewer launched as a background task writes its reasoning to a
-stdout stream that grows CONTINUOUSLY while the model emits — a far finer
+A background-task reviewer whose stdout is captured INCREMENTALLY writes its
+reasoning to a stream that grows CONTINUOUSLY while the model emits — a far finer
 PROCESS-LIVENESS signal than the unit-granular progress file. This probe reads
 that stream's SIZE and MTIME ONLY (never its content — the transcript is large
 and reading it would flood the driver's context) and reports whether it was
@@ -16,17 +16,27 @@ written within a quiet window.
 
 It DECIDES NOTHING and always exits 0. It is a MISS-CATCHER, not a verdict: a
 growing stream proves the process is ALIVE, so the driver need not declare a
-false stall while the progress file is merely coarse-stale; a stream quiet past
-the window CORROBORATES a hang, so the driver can apply `reviewer.md`'s retry
-budget without waiting the full meaningful-progress cap. Crucially, stream growth
+false stall while the progress file is merely coarse-stale; a `quiet` (or
+`absent`) stream CORROBORATES a hang ONLY AFTER launch evidence exists — the
+reviewer wrote at least one line after `pass_identity` and then went quiet — in
+which case the driver can apply `reviewer.md`'s retry budget without waiting the
+full meaningful-progress cap. Before launch evidence the Stage 2a launch-evidence
+deadline owns that window, so a `quiet`/`absent` stream there is NOT a hang signal
+(`stage-2-review-gate.md`). Crucially, stream growth
 is PROCESS liveness, NOT meaningful progress: it MUST NOT reset the
 meaningful-progress timer (`stage-2-review-gate.md`) — a reviewer that streams
 forever without completing a unit is still stalled at that cap. This signal kills
 a hung process faster; it never extends patience for one that will not converge.
 
-Only the background-task (cross-engine) route has a pollable stream. A
-native-worker reviewer's transcript is not safely pollable, so that route keeps
-the progress-file + completion-notification model; do not point this probe at it.
+The signal needs the stdout to be captured INCREMENTALLY. The background-task
+Claude-Code→codex route qualifies: codex streams its reasoning to the captured
+stdout as it emits. A reviewer whose output is BUFFERED until completion exposes
+no growing stream — `claude -p --output-format text` (the Codex→claude route)
+writes nothing until the end (realtime streaming needs `--output-format
+stream-json`), so a HEALTHY such reviewer reads a FALSE `quiet`; do not rely on
+this probe's `quiet` verdict there. A native-worker reviewer's transcript is not
+safely pollable either, so that route likewise keeps the progress-file +
+completion-notification model; do not point this probe at those routes.
 """
 from __future__ import annotations
 
@@ -86,7 +96,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     p = sub.add_parser("probe", help="report the stream's liveness verdict as JSON")
     p.add_argument("--stream", required=True,
-                   help="path to the reviewer's background-task stdout file (stat'd, never read)")
+                   help="path to the reviewer's incrementally-captured background-task stdout file (stat'd, never read)")
     p.add_argument("--quiet-window-seconds", "--quiet_window_seconds", type=int,
                    default=DEFAULT_QUIET_WINDOW_SECONDS,
                    help=f"a stream unwritten for this long reads 'quiet' (default {DEFAULT_QUIET_WINDOW_SECONDS})")


### PR DESCRIPTION
## What

Adds `reviewer-liveness.py`, a small probe that reports whether a background-task reviewer's **stdout stream** is still growing — a finer *process-liveness* signal than the unit-granular progress file the review gate already watches.

## Why

The gate declares a reviewer stalled only when no **meaningful progress** (a planned unit `done`) lands for ~15 min. That timer is coarse: between units, a live reviewer grinding one unit and a hung one are indistinguishable until the cap. In this campaign a hung codex reviewer twice took ~10 min to catch, and a coarse-stale progress file nearly triggered a false kill of a reviewer that was actively producing output.

A cross-engine reviewer launched as a background task writes a stdout stream that grows continuously while the model emits. Polling that stream's size/mtime distinguishes "alive, between units" from "hung" in seconds.

## How it behaves

- `reviewer-liveness.py probe --stream <task-output-file>` **stats the file only — never reads its content** (the transcript is large enough to flood the driver's context). Reports `alive` / `quiet` / `absent` with size and age.
- The driver uses it two ways: a stream written within the quiet window is `alive` (don't declare a false stall while the progress file is merely coarse-stale); a stream `quiet` past the window corroborates a hang (apply the retry budget without waiting the full meaningful-progress cap).
- It is **process liveness, not meaningful progress**: a growing stream **never resets** the meaningful-progress timer (that rule is unchanged), so it catches a dead process sooner without extending patience for a non-converging one.
- **Cross-engine (background-task) route only** — a native-worker transcript is not safely pollable.

## Scope

- New: `reviewer-liveness.py` + sibling `reviewer-liveness-test.py` (8 fixtures, each pinning a verdict on both sides of its boundary).
- Docs: a refinement paragraph in `stage-2-review-gate.md` (at the meaningful-progress rule it extends) and a one-clause amendment in `loop-control.md`'s wake-sizing.
- CI: pyright list extended to 22, plus a `Reviewer liveness probe contract` self-test step.
- The probe decides nothing and always exits 0; it changes no gate machinery.