### PR TITLE
docs(campaign): standardize terminology on "heartbeat", drop "wake" as a noun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,16 +6,16 @@ tree. The consequences below are all non-obvious:
 
 ## This is a SINGLE-USER, advisory workflow — calibrate severity to that
 
-The gauntlet campaign, its lease, its wake / adoption / refresh machinery, and these plugin skills serve
+The gauntlet campaign, its lease, its heartbeat / adoption / refresh machinery, and these plugin skills serve
 **ONE user driving their own runs.** Do NOT chase airtight consistency or distributed-systems-grade
-correctness in the wake / lease / adoption / refresh paths. A momentary inconsistency the single user
+correctness in the heartbeat / lease / adoption / refresh paths. A momentary inconsistency the single user
 creates is one the single user notices and resolves — an **ACCEPTED RESIDUAL, not a gating defect.** (The
 user's stated policy.)
 
 - **The lease is advisory and LOOSE by design.** Its heartbeat-proof precondition gates the **FIRST
   acquire — taking a run**; an owner's `refresh` — **including refresh of its own STALE lease** — is not
   required to re-present proof. Findings of the form *"a stale/matching refresh revives a run without
-  re-proof"*, *"two agents could briefly both drive one run"*, or *"wake/adoption/refresh could be made
+  re-proof"*, *"two agents could briefly both drive one run"*, or *"heartbeat/adoption/refresh could be made
   more consistent/airtight"* are **accepted residuals, NOT defects** — the tool never promised otherwise.
 - **Calibrate finding severity to what the artifact IS.** A same-machine, single-user skill helper is not
   a web server facing millions of hostile requests. A guard being incomplete against an input only the one
@@ -37,7 +37,7 @@ Read `docs/runtime-compatibility.md` before changing manifests, marketplaces, sk
 validation.
 
 - NEVER require a host-specific tool name, agent type, model name, invocation form, environment variable,
-  or wake mechanism without an explicit host adapter and a safe fallback.
+  or heartbeat mechanism without an explicit host adapter and a safe fallback.
 - Resolve bundled resources from the directory containing the active `SKILL.md`. NEVER depend on
   `CLAUDE_PLUGIN_ROOT` or `PLUGIN_ROOT` being available to a worker.
 - When invocation syntax matters, document both forms: Claude Code `/plugin:skill`; Codex `$plugin:skill`.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -13,7 +13,7 @@ adapter; keep workflow rules shared.
 | Skill resources | May expose `CLAUDE_PLUGIN_ROOT` | Active skill path is supplied to the agent | Resolve from the directory containing active `SKILL.md`; pass absolute paths to workers. |
 | Agent dispatch | Agent tool and configured agent types | Available Codex multi-agent controls | Describe worker scope, permissions, model class, and output; do not require a host tool name. |
 | Model selection | Claude model aliases may be available | Session model or configured Codex agents | State required capability; map named models only inside host adapter. |
-| Wake/resume | `ScheduleWakeup` where available | Thread wake where available; bounded foreground wait otherwise | Persist state before waiting and provide an exact resume path. |
+| Heartbeat/resume | `ScheduleWakeup` where available | wakes its thread where available; bounded foreground wait otherwise | Persist state before waiting and provide an exact resume path. |
 | Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Fall back to a fresh native worker when it is absent or fails. Explicit or saved user choice overrides. |
 
 Campaign's exact cross-agent command lines live in

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -8,7 +8,7 @@ The centerpiece is [`gauntlet:campaign`](skills/campaign/README.md): hand it exi
 (`/gauntlet:campaign #12 #15` in Claude Code or `$gauntlet:campaign #12 #15` in Codex) and it gates each one to merge — defending that PR through repeated
 context-isolated review rounds until it passes a strict bar with green CI, fixing up whatever review
 or CI turns up on the PR itself, and then merging. It doesn't hunt for problems or write fixes from
-scratch; it drives PRs that already exist. Run it once — it uses scheduled wakes where available and
+scratch; it drives PRs that already exist. Run it once — it uses scheduled heartbeats where available and
 bounded waits otherwise, then keeps working unattended.
 
 Where do those PRs come from? [`gauntlet:review`](skills/review/README.md) is the front half. By
@@ -79,7 +79,7 @@ The plugin deliberately does **not** set how the host talks to you. That is your
 (`AGENTS.md`, `CLAUDE.md`, or an output style), not a plugin's, and a skill that dictated tone would just fight whatever
 you had already configured.
 
-It's still worth setting something. A campaign reports on every wake, for hours, and those updates are all
+It's still worth setting something. A campaign reports on every heartbeat, for hours, and those updates are all
 you see of it. Without a contract, the update that needs your decision reads much like the twenty that
 don't.
 

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -43,7 +43,7 @@ $gauntlet:campaign --new #20
 Give it one or more PR numbers and it **adopts** them into a run: it labels each PR so the run owns
 it, classifies the change by the *kind* of files it touches — human-facing docs vs code vs
 agent-consumed docs vs sensitive surfaces — to pick a review tier (the change's size never enters
-into it), then starts gating. Run it **once** — it uses the host's wake scheduler when available and
+into it), then starts gating. Run it **once** — it uses the host's heartbeat scheduler when available and
 keeps the current invocation alive with bounded waits otherwise. It keeps working until every adopted
 PR is merged or set aside; you don't need to re-run it.
 

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: campaign
 description: >-
-  Gates PRs to merge. A self-looping review-to-merge campaign: existing PRs are adopted into a run (pass PR numbers, or discover this run's labelled PRs), each PR is triaged to a review tier, and a per-PR review gauntlet (tier-dependent fresh, context-isolated SATISFIED verdicts on the whole PR diff, reviewed one at a time) plus event-driven CI monitoring gate an auto-merge. Multiple isolated runs (each keyed by a run-id, with a lease so only one agent drives each) can run concurrently in one repo. Drives its own loop through the active host's wake or bounded-wait mechanism — invoke once. Campaign never writes fixes from scratch; to find issues first use gauntlet:review. Args (distinct modes): #PR... | --new #PR... | --run ID | no args
+  Gates PRs to merge. A self-looping review-to-merge campaign: existing PRs are adopted into a run (pass PR numbers, or discover this run's labelled PRs), each PR is triaged to a review tier, and a per-PR review gauntlet (tier-dependent fresh, context-isolated SATISFIED verdicts on the whole PR diff, reviewed one at a time) plus event-driven CI monitoring gate an auto-merge. Multiple isolated runs (each keyed by a run-id, with a lease so only one agent drives each) can run concurrently in one repo. Drives its own loop through the active host's heartbeat or bounded-wait mechanism — invoke once. Campaign never writes fixes from scratch; to find issues first use gauntlet:review. Args (distinct modes): #PR... | --new #PR... | --run ID | no args
 ---
 
 # Campaign
@@ -32,7 +32,7 @@ confirmed fix and hand them straight here (`/gauntlet:campaign #PRs` in Claude C
 way PRs enter a campaign; you can also open them yourself.
 
 Invoke once. This skill drives its own loop through the runtime adapter. In Claude Code, do not wrap it
-in `/loop`; in Codex, keep the invocation alive when no wake scheduler is available.
+in `/loop`; in Codex, keep the invocation alive when no heartbeat scheduler is available.
 
 ## Args
 
@@ -48,7 +48,7 @@ resumes and takes no `#PR`/`--new`; `#PR` args alone start/adopt into a run. Inv
 - No argument -> discover this run's labelled PRs and continue. If none and nothing to do, PROMPT:
   "No PRs under a campaign. Run gauntlet:review to find issues, or pass PR numbers to gate."
 - Non-PR arg (e.g. `auth`) -> same prompt (the old area/topic sweep arg is REMOVED).
-- `--run <id>` -> resume specific run; self-wakes also carry internal `--token`.
+- `--run <id>` -> resume specific run; scheduled heartbeats also carry internal `--token`.
 - `--new` or "fresh run" -> force independent new run-id for a new PR set (with carryover).
 
 ## Bundled Scripts
@@ -126,7 +126,7 @@ PR's checks (SHA-pinned, both families), promotes the snapshot, verifies it (thr
 and decides **against the base branch's required set** (`--required-set`, from the ledger header —
 MANDATORY), printing the verdict and the ledger `ci` value as JSON
 (`references/stage-2-ci.md`, "THE DERIVATION IS A COMMAND", which owns the exact invocation).
-Run `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before derivation on every wake. It
+Run `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before derivation on every heartbeat. It
 owns both GitHub reads and the atomic ledger write, retries only `unknown`, and reuses a settled value.
 **NEVER derive `ci` by reading a command's output and judging it by eye** — that is what once wrote
 `ci = green` for a PR whose checks had not registered at all.
@@ -143,7 +143,7 @@ from one host into another.
 | Fresh-worker fallback review | **`session`** | Same job as a review pass; counts toward the gate identically. |
 | Review-fix (after `NOT SATISFIED`) | **`session`** | Authors code from scratch, judged only by another full review pass. A cheap bad fix burns a whole review pass and a gate reset — it *costs* more than the tier saves. |
 | Root-cause **mapper** | **`session`** | Read-only, but NOT low-judgment: it enumerates a full matrix and confirms each gap with a repro. A weaker model **under-maps**, which is the exact failure the mapper exists to prevent (`root-cause-pass.md`). "Read-only" is not a licence to downgrade. |
-| **Reassessment pass** (a PR at a review-loop cap) | **`session`** | It reads a PR's ENTIRE history at once and decides the **acceptance path** — rescope, re-intent, demote, root-cause, or abort. It is gate machinery, and it is the one judgment no wake in the failed run was ever able to make. A weaker model here mis-diagnoses the loop and repairs the wrong thing (`repair-pass.md`). |
+| **Reassessment pass** (a PR at a review-loop cap) | **`session`** | It reads a PR's ENTIRE history at once and decides the **acceptance path** — rescope, re-intent, demote, root-cause, or abort. It is gate machinery, and it is the one judgment no heartbeat in the failed run was ever able to make. A weaker model here mis-diagnoses the loop and repairs the wrong thing (`repair-pass.md`). |
 | **CI-fix — formatting/lint failure** | **`economy`** | **Downgraded ON PURPOSE when the host has a configured economy mapping.** It does not author a fix: it runs a deterministic formatter, **READS the resulting diff**, verifies it, and **escalates** anything it cannot verify (`references/stage-2-ci.md`). |
 | **CI-fix — everything else**, and every **escalation** from the cheap tier | **`session`** | Authors code that gets merged. CI does **not** validate it: a wrong fix can turn CI green — by weakening a check, or by being plain wrong in product code that no check covers. |
 
@@ -208,7 +208,7 @@ Always read before touching run state:
 - `references/run-identity-and-lease.md`
 - `references/files-and-ledger.md`
 
-Read `references/loop-control.md` at each wake before dispatch.
+Read `references/loop-control.md` at each heartbeat before dispatch.
 
 Read stage refs only when that stage/action is due:
 
@@ -232,16 +232,16 @@ Read stage refs only when that stage/action is due:
 
 - **PR-gating:** adopt PR -> triage tier -> watch CI + review PR HEAD -> merge. PRs are **adopted, not
   generated** — campaign gates existing PRs and never writes fixes from scratch.
-- **Work-conserving:** every wake reconciles, folds completions, launches all due work up to caps,
+- **Work-conserving:** every heartbeat reconciles, folds completions, launches all due work up to caps,
   drains still-ready PRs serially, then reschedules only when no useful action remains launchable.
-- **Driver never blocks:** reviews and CI watches run as background tasks — completions are wakes.
+- **Driver never blocks:** reviews and CI watches run as background tasks — completions are heartbeats.
   A PR with a **still-RUNNING** check always has a live watch — but a PR whose CI has **SETTLED** does
-  **not** (watching it burns a wake per second and observes nothing: `references/stage-2-ci.md`, "WATCH
+  **not** (watching it burns a heartbeat per second and observes nothing: `references/stage-2-ci.md`, "WATCH
   ONLY WHAT CAN MOVE"). A review doomed by a pending content change is stopped, not awaited.
 - **Run isolation:** touch only this run's `<rundir>`, ledger, labels, branches, PRs, and worktrees.
 - **One active driver:** lease controls ownership; never double-drive one run.
-- **Base branch is data:** read `base_branch` from ledger every wake; never assume `main`.
-- **Reviewer is data:** read `reviewer` from ledger every wake before dispatching any review; set once at run start, never re-derived from memory (else an explicit/preferred reviewer silently reverts to default on a self-wake or adoption).
+- **Base branch is data:** read `base_branch` from ledger every heartbeat; never assume `main`.
+- **Reviewer is data:** read `reviewer` from ledger every heartbeat before dispatching any review; set once at run start, never re-derived from memory (else an explicit/preferred reviewer silently reverts to default on a scheduled heartbeat or adoption).
 - **A logical model class is selected on every worker dispatch:** use `session` for gate and authored-code
   roles, and `economy` only for the bounded formatting/lint role. The runtime adapter owns the host
   mapping.
@@ -286,7 +286,7 @@ Read stage refs only when that stage/action is due:
   required, the third accepted value), which is not a verdict and routes on the progress file to
   `amended`/`incomplete`/`unusable`, never a tally.
 - **Verdicts go through `ledger.py verdict` — NEVER set `reviews_ok` by hand.** It bumps `review_rounds`
-  (**monotone, never reset — the loop's only memory across fresh-context wakes**), applies the tally, and
+  (**monotone, never reset — the loop's only memory across fresh-context heartbeats**), applies the tally, and
   moves `ns_streak`, atomically. `set` cannot RAISE the tally and no door can write the counters at all.
 - **Findings are claims, not facts:** on every `NOT SATISFIED`, a **dispatched context-isolated audit
   subagent** (not the orchestrator inline) verdicts each **gating** finding (CONFIRMED /
@@ -327,7 +327,7 @@ Read stage refs only when that stage/action is due:
   recording one **NEVER** discharges a finding — a CONFIRMED finding is still fixed
   (`references/followups.md`).
 
-## Wake Skeleton
+## Heartbeat Skeleton
 
 1. **Resolve run + lease;** adopt only absent/stale lease, stand down if fresh different owner.
 2. **Adopt `#PR` args + reconcile run-labelled PRs.** For each explicit `#PR`, adopt it per
@@ -347,7 +347,7 @@ Read stage refs only when that stage/action is due:
    stop in-flight reviews doomed by a content change.
 5. **Merge ready PRs** (never a parked one) one at a time until no candidate remains immediately ready
    after base refresh.
-6. **Launch audit + fallback wake — before sleeping, verify every due launch actually happened.** Re-run
+6. **Launch audit + fallback heartbeat — before sleeping, verify every due launch actually happened.** Re-run
    step 4's dispatch scan across both concurrency pools (CI-fix subagents and review passes each have
    their own cap): confirm every due review pass was launched, a CI watch is live for every PR with a
    **still-RUNNING** check (**not** for one whose CI has settled — that is the hot-spin bug), that every
@@ -356,10 +356,10 @@ Read stage refs only when that stage/action is due:
    unchanged fingerprint past the CI STALL CAP is at a cap too, and its watch will never wake anyone) —
    and — whenever any
    non-terminal work remains — the runtime adapter's heartbeat or bounded wait is actually active. If
-   any due launch or fallback wake is missing, launch it and re-audit. NEVER sleep with due work
+   any due launch or fallback heartbeat is missing, launch it and re-audit. NEVER sleep with due work
    un-launched or no path to the next reconcile.
 7. **Terminal -> carryover/report;** otherwise refresh the lease and follow `references/loop-control.md`,
-   "Reschedule or exit", exactly. A scheduled-wake host renders status after scheduling and returns. A
+   "Reschedule or exit", exactly. A scheduled-heartbeat host renders status after scheduling and returns. A
    scheduler-less host renders status, performs one bounded wait, then returns to step 1 to reconcile and
    repeats while non-terminal work remains; it does not take the scheduled-host return.
 

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -3,7 +3,7 @@
 - **1-hour cap per task** — one hour of wall-clock since `started` without merging. The cap catches a
   *stuck* task, not a slow external system, and the ledger records no separately-metered work time — so
   key it off recorded row state, not a running subtraction of durations nothing stores: **do not fire
-  the cap on a wake where the row is in a BOUNDED wait.** There are exactly three kinds, and **none is
+  the cap on a heartbeat where the row is in a BOUNDED wait.** There are exactly three kinds, and **none is
   a `ci` value**:
   - **a PARK** — `status == awaiting-api` (parked for user approval) or `status == awaiting-user` (parked
     for the user to adjudicate a **review standoff** or a **machine blocker** — `files-and-ledger.md`,
@@ -59,7 +59,7 @@
   and that park is exempt for its own reason (a **declared exit**, above). So a PR waiting on a live CI
   bound is never aborted out from under it: the bound either resolves, or it reaches the human. This cap's
   job is the **agent-controlled** row — the task stuck in campaign's own work (a hung review, a red PR
-  whose fix never lands), where nothing else is counting. Only a wake where
+  whose fix never lands), where nothing else is counting. Only a heartbeat where
   `started` is over an hour old *and* the row is agent-controlled — **it is in NONE of the three bounded
   waits above**: not parked, not `repairing`, and **NO** bound of the CI owner's set live for it (never a
   count of them, which rots the moment a set gains a member) — trips it.
@@ -89,7 +89,7 @@
   **The rule this replaces was "stop targeted patching on the 2nd `NOT SATISFIED` and run the root-cause
   pass", and it NEVER FIRED — not once, across 35 review rounds on two PRs.** It was not skipped in bad
   faith: it was **unevaluable**. Its trigger is a fact about *history* ("the second `NOT SATISFIED` on this
-  PR"), the ledger recorded no history, and every wake is a fresh agent instance holding exactly one
+  PR"), the ledger recorded no history, and every heartbeat is a fresh agent instance holding exactly one
   finding. It called itself a hard backstop; it was a hard backstop **with no sensor**. Do not restore it.
 
   What replaces it is a **counter with a cap**, on disk, evaluated by the tool that records the verdict:
@@ -109,13 +109,13 @@
   **THIS BACKSTOP HAD NO SENSOR, AND THAT IS WHY IT NEVER FIRED.** Its trigger — *"the second `NOT
   SATISFIED` on the same PR"* — is a **fact about history**, and nothing recorded any history: `reviews_ok`
   is zeroed on every `NOT SATISFIED`, so the ledger after twenty-one rounds read exactly as it did after
-  one. Each wake is a **fresh agent instance** holding a single round, so it could not know a second one
+  one. Each heartbeat is a **fresh agent instance** holding a single round, so it could not know a second one
   had ever happened. The rule called itself a hard backstop; it was a hard backstop **with no input**, and
   one PR ran **21 review rounds** underneath it.
 
   The ledger now records that history — `ns_streak` (consecutive `NOT SATISFIED`, cleared only by a
   `SATISFIED`) and `review_rounds` (landed verdicts, **never** reset) — so the trigger is, for the first
-  time, a value a fresh wake can **read** (`files-and-ledger.md`). **And it IS read: `ledger.py verdict`
+  time, a value a fresh heartbeat can **read** (`files-and-ledger.md`). **And it IS read: `ledger.py verdict`
   evaluates the caps as it records the verdict, and at a cap it holds the PR `repairing` and exits
   non-zero.** The reader lives in the one door that cannot be skipped, because a cap evaluated by a
   *separate* command is a cap a driver can forget to run — which is the failure being cured, not a fresh

--- a/plugins/gauntlet/skills/campaign/references/carryover.md
+++ b/plugins/gauntlet/skills/campaign/references/carryover.md
@@ -50,7 +50,7 @@ remove. Never silently drop an entry you're uncertain about.
 
 **The question must not stall the run.** Keep every uncertain entry in place and start the run's work
 immediately — surface the candidate list to the user in the same message and fold the answer in when
-it lands as its own wake (prune then). Same principle as "never hold the run hostage on a user prompt"
+it lands as its own heartbeat (prune then). Same principle as "never hold the run hostage on a user prompt"
 (Run lease). Note what was pruned (and what the user kept) so the decision is auditable next run.
 
 A run is distilled into the ledger **exactly once**, on its **normal exit** (all its PRs terminal) —

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -6,12 +6,12 @@
   clean up another run's work — scope every git/gh scan by that label.
 - One active driver per run, enforced by `<rundir>/lease.json` under an atomic `mkdir <rundir>/claim.lock`:
   take/adopt a run only inside the claim lock, and adopt ONLY when its lease is absent or stale
-  (`now - updated` > ~30 min); refresh the lease every wake AND around long foreground ops; on a
-  self-wake whose lease is fresh but bears a different token, **stand down** — never double-drive a ledger.
-- Every **scheduled** self-wake carries `--run <run-id> --token <agent-token>`; the token re-proves lease
-  ownership so a summarized wake never mistakes its own run for another's. A scheduler-less bounded wait
+  (`now - updated` > ~30 min); refresh the lease every heartbeat AND around long foreground ops; on a
+  scheduled heartbeat whose lease is fresh but bears a different token, **stand down** — never double-drive a ledger.
+- Every **scheduled** heartbeat carries `--run <run-id> --token <agent-token>`; the token re-proves lease
+  ownership so a summarized heartbeat never mistakes its own run for another's. A scheduler-less bounded wait
   retains the current invocation and token, then loops directly back to reconcile. Re-read `run_id` from
-  the ledger each wake, never from memory.
+  the ledger each heartbeat, never from memory.
 - Resume is intent-scoped: a fresh instance resumes via `--run <id>` or an **arg-less** bare invocation
   (adopts the sole orphaned run). A bare invocation **with `#PR` args** and `--new` start an independent
   new run (adopting those PRs) and never pre-empt other live runs; a **non-PR** arg starts nothing —
@@ -56,7 +56,7 @@
 - Concurrency is a **rolling cap (~8 in flight), never a barrier wave**: keep up to ~8 review passes
   and ~8 CI-fix subagents in flight, backfilling each freed slot immediately. Never let a draining
   group of PRs stall the backlog — Loop-control step 3 owns this refill.
-- Work-conserving dispatch is mandatory: every wake scans all PRs and launches every due
+- Work-conserving dispatch is mandatory: every heartbeat scans all PRs and launches every due
   action that fits a free slot before returning. Waiting is allowed only when no useful action is
   launchable anywhere in the run.
 - A PR with a **still-RUNNING** check must ALWAYS have a live watch: if **any evidence row classifies
@@ -64,16 +64,16 @@
   **NEVER** "any row is not yet terminal" / `.status != COMPLETED`, which is a negated test: it sweeps up
   every value GitHub adds tomorrow and silently watches it instead of letting it fall to the
   `UNKNOWN_VALUE` escalation) and the watch task has exited (including after any rebase/push), relaunch
-  the watch in the same wake — never wait for the heartbeat.
+  the watch in this same heartbeat — never wait for the next heartbeat.
 - **But NEVER relaunch a watch merely because `ci == pending`.** Once CI has **SETTLED** (no row can
   still move) there is nothing to block on: `gh pr checks --watch` returns in about **a second**, and a
-  task completion is **itself a wake** — so a settled-but-not-green PR would burn a fresh-context wake
+  task completion is **itself a heartbeat** — so a settled-but-not-green PR would burn a fresh-context heartbeat
   **every second, forever**, and observe nothing. A settled PR is resolved by the **`settled_strikes`
   escalation** (`stage-2-ci.md`, "SETTLED"), not by watching it harder.
 - **And the watch is NEVER the bound.** A row that stays `RUNNING` forever (a hung runner, a dead
   reporter) keeps `gh pr checks --watch` blocked forever, so the watch wakes no one and `pending` would
   absorb the PR — the exact wedge. **RUNNING-STALL** ends it: a `RUNNING` row plus a fingerprint that has
-  not changed for the **CI STALL CAP** escalates on the fallback wake (a scheduled heartbeat or bounded
+  not changed for the **CI STALL CAP** escalates on the fallback heartbeat (a scheduled heartbeat or bounded
   wait returning), timed by `ci_stalled_since` **on disk** (`stage-2-ci.md`, "RUNNING-STALL"). It bounds
   **TIME**, not derivations, because a derivation count
   tracks the run's load and would park a healthy slow build; and it does not park one, because **any**
@@ -81,7 +81,7 @@
 - Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.
-- Reconcile from ONE batched `gh pr list` snapshot per wake (`<rundir>/prs.json`), written with the
+- Reconcile from ONE batched `gh pr list` snapshot per heartbeat (`<rundir>/prs.json`), written with the
   **canonical `prs.json` command — the single owning definition is the block "The canonical `prs.json`
   command" in `files-and-ledger.md`**, which spells it in full, label and output path included (**ONE
   path, ONE schema, ONE command**). Never spell a variant of it here or anywhere else, and **NEVER drop
@@ -90,9 +90,9 @@
   at **30**. Per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth stays the
   SHA-pinned, SHA-verified snapshot of **both** check families (Stage 2b).
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs
-  immediately, ask the user asynchronously, and fold the answer in as its own wake.
+  immediately, ask the user asynchronously, and fold the answer in as its own heartbeat.
 - Public API surface/behavior changes need user confirmation by default (see Constraints). The
-  `api_changes` flag lives in the ledger header and is re-read every wake — never trust memory, never
+  `api_changes` flag lives in the ledger header and is re-read every heartbeat — never trust memory, never
   auto-merge an unapproved API break.
 - Before queueing a review pass on a PR, clear its preconditions on the current tip: address any
   GitHub Copilot review items (the active host form of `gauntlet:copilot-address-reviews <pr>`), fix any CI failures (one at a time,
@@ -103,7 +103,7 @@
   Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
   on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive
-  change always requires two). Re-derive the tier from `head_sha` each wake.
+  change always requires two). Re-derive the tier from `head_sha` each heartbeat.
 - **The review is measured against the PR's INTENT — never against "is anything wrong with this code?"**
   The reviewer is handed `<rundir>/intent-<pr>.md` **verbatim** and answers one question: **does this PR
   achieve its stated Purpose, without breaking anything reachable by an actor named in its Threat model?**
@@ -129,7 +129,7 @@
   `writer` field is what answers it.
 - **Record every verdict with `ledger.py verdict` — NEVER set `reviews_ok` by hand.** It bumps
   `review_rounds`, applies the tally, and moves `ns_streak` in one atomic write. **`review_rounds` is the
-  review loop's only memory across fresh-context wakes and is NEVER reset** — not by a fix, a rebase, a
+  review loop's only memory across fresh-context heartbeats and is NEVER reset** — not by a fix, a rebase, a
   content change or a re-triage. There is no flag at any door that can write it; `set` cannot even RAISE
   `reviews_ok` (only a verdict adds a verdict). Without that counter, the ledger after 21 review rounds is
   **indistinguishable** from the ledger after one, and every stopping rule of the form "on the second NOT
@@ -141,11 +141,11 @@
   **gate and the label move together, in the same step**: every action that drops `reviews_ok` to 0 (a
   `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a conflict-resolving rebase, any other
   content change on the head branch) MUST also run `gh pr edit <pr> --remove-label gauntlet-accepted
-  --add-label gauntlet-reviewing`. Never defer the swap to the next wake — that leaves the label lying
+  --add-label gauntlet-reviewing`. Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
   `ci = pending` and, because the head still **moved**, **resets the liveness counters** (`stage-2-ci.md`,
-  "THE LIVENESS COUNTERS"). Per-wake label reconcile is the self-healing backstop, never the mechanism
+  "THE LIVENESS COUNTERS"). Per-heartbeat label reconcile is the self-healing backstop, never the mechanism
   (`stage-2-review-gate.md`, "Status labels mirror the review gate").
 - **YOUR OWN diagnosis is a claim too — REPRODUCE the failure before you "fix" working code.** The rule
   below audits a *reviewer's* finding. It binds **your own** with equal force, and that is where it keeps
@@ -444,7 +444,7 @@
   The gate is unchanged; record the selected route and resulting reviewer in the report. See "The
   reviewer".
 - **RUN `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before CI derivation on every
-  wake.** It owns both base-branch declaration reads, their strict parse and union, and the atomic ledger
+  heartbeat.** It owns both base-branch declaration reads, their strict parse and union, and the atomic ledger
   write. A settled value is reused; only `unknown` is retried. See `stage-2-ci.md`, "WHAT WERE WE EXPECTING
   TO SEE?".
 - **DERIVE `ci` BY RUNNING `scripts/ci-status.py derive --pr <N> --head-sha <the ledger's> --rundir
@@ -479,7 +479,7 @@
 - The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN
-  head branch/SHA, never off `<base>` (see `pr-adoption.md`). Re-read it each wake (see "Base branch").
+  head branch/SHA, never off `<base>` (see `pr-adoption.md`). Re-read it each heartbeat (see "Base branch").
 - After every merge, fast-forward local `<base>` to `origin/<base>` (Stage 3 step 4) so subsequent
   `origin/<base>...HEAD` diffs and rebases branch off the just-merged tip, not a stale base. If the
   fast-forward fails, bail out — never force it.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -9,18 +9,18 @@ resume, reuse the existing dir). Per-run dirs are what keep concurrent runs' fil
 |------|----------|
 | `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
-| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-wake reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**: the canonical command is spelled in full in **"The canonical `prs.json` command"**, the command block directly below this table, and that block is its ONLY definition |
+| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-heartbeat reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**: the canonical command is spelled in full in **"The canonical `prs.json` command"**, the command block directly below this table, and that block is its ONLY definition |
 | `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
 | `review-<pr>-<n>.prompt.txt` | The reviewer prompt for round `n`, launch attempt 1, with the verbatim intent and JSON-encoded typed transport record bound as data. Written through `runtime-adapter.md`'s `write_bytes` and passed through `dispatch_native` or `run_argv` — never embedded in shell source (`stage-2-review-gate.md`) |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1), written by the sole producer assigned in `runtime-adapter.md`'s typed review record |
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it). Written through `scripts/review-pass.py plan-add`, never a heredoc |
 | `review-<pr>-<n>.progress.jsonl` | Reviewer progress events against the plan for round `n` (launch attempt 1), opened by the orchestrator's `pass_identity` line. **Every line is READ and validated through `scripts/review-pass.py` — and not every line is WRITTEN by it.** The `pass_identity` (`review-pass.py identity`) and the unit-progress events (the reviewer's `emit-progress.py`) are; a `plan_amendment_request` the reviewer appends **directly** is not — it is the one event the emit-only rule exempts. `stage-2-review-gate.md` owns that rule; see "Review-pass artifacts" below |
 | `review-<pr>-<n>.findings.jsonl` | The pass's FINDINGS, round `n` (launch attempt 1) — one validated record per finding, written **only** through `scripts/emit-finding.py`. A finding used to be prose in the report, so nothing could check its citation, bound its writer, or ask what it DEFENDED — and therefore nothing could ever **decline** one. Each record ANCHORS to the PR's intent: a `## Purpose` line quoted verbatim, or the actor who can actually write the bad input. `stage-2-review-gate.md` owns the schema and the gating rule |
-| `intent-<pr>.md` | **What this PR is FOR** — `## Purpose` / `## Non-goals` / `## Threat model`. Written at adoption (`pr-adoption.md`), from the PR body when it carries one and **authored by the driver** from the diff/title/body when it does not; re-read every wake, never re-derived. It is passed to the reviewer **verbatim**, and it is what the **pass** is measured against: `review-pass.py verify` loads it for **every** pass it judges — including one that found nothing — so a PR with no usable block here earns **no verdicts at all** (`stage-2-review-gate.md`, "Does this pass COUNT?"). **LOCAL and git-ignored — campaign NEVER writes it back to the PR** |
+| `intent-<pr>.md` | **What this PR is FOR** — `## Purpose` / `## Non-goals` / `## Threat model`. Written at adoption (`pr-adoption.md`), from the PR body when it carries one and **authored by the driver** from the diff/title/body when it does not; re-read every heartbeat, never re-derived. It is passed to the reviewer **verbatim**, and it is what the **pass** is measured against: `review-pass.py verify` loads it for **every** pass it judges — including one that found nothing — so a PR with no usable block here earns **no verdicts at all** (`stage-2-review-gate.md`, "Does this pass COUNT?"). **LOCAL and git-ignored — campaign NEVER writes it back to the PR** |
 | `review-<pr>-<n>.a<k>.prompt.txt` / `.a<k>.txt` / `.a<k>.progress.jsonl` / `.a<k>.findings.jsonl` | The same four per-attempt artifacts for **launch attempt `k ≥ 2`** — a relaunched pass writes here, never over attempt 1's files, so a killed-but-alive attempt can't corrupt the live one. Only the attempt named in the active `pass_identity` is read or counted as gate output (see `stage-2-review-gate.md`). The plan and the intent are **not** per-attempt: the plan is per-pass, the intent per-PR |
-| `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, written **BY THE WAKE** running **`scripts/ci-status.py derive`** after the watch completes (**the watch never writes it**), promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Carries a **`source` completion marker per mandatory source**, so a source that was **never queried** is `unusable`, not a silent green (`stage-2-ci.md`). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
+| `ci-<pr>-<head_sha>.txt` | Latest **SHA-pinned** CI snapshot for a PR — check runs **AND** commit statuses, written **BY THE HEARTBEAT** running **`scripts/ci-status.py derive`** after the watch completes (**the watch never writes it**), promoted atomically, and **stamped with the `head_sha` it describes** (verify the stamp before parsing). Carries a **`source` completion marker per mandatory source**, so a source that was **never queried** is `unusable`, not a silent green (`stage-2-ci.md`). Never the watch stream, and never `gh pr checks` — its output carries **no SHA** |
 | `audit-<pr>-<n>.md` | A dispatched context-isolated audit subagent's verdicts on round `n`'s gating findings — CONFIRMED / ADJUSTED / REFUTED, each with evidence. A REFUTED finding's reasoning is recorded here **and** written into the tree as an inline comment at the site, committed like any other change (`stage-2-review-gate.md`, "Audit every finding before you fix it") |
-| `repair-<pr>-<k>.md` | The **reassessment pass**'s decision record for repair `k`: the whole round-by-round history it was handed, the ONE decision it returned, and why (`repair-pass.md`). Written **before** the decision is recorded — `repair-pass.py decide` refuses a `--record` that is missing or empty, because a wake is a fresh agent instance and a justification held only in a dead agent's context can never be audited |
+| `repair-<pr>-<k>.md` | The **reassessment pass**'s decision record for repair `k`: the whole round-by-round history it was handed, the ONE decision it returned, and why (`repair-pass.md`). Written **before** the decision is recorded — `repair-pass.py decide` refuses a `--record` that is missing or empty, because a heartbeat is a fresh agent instance and a justification held only in a dead agent's context can never be audited |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
 **The canonical `prs.json` command — this block is THE definition.** Every other site defers to it, and
@@ -42,7 +42,7 @@ run_argv(
 )
 ```
 
-`pr-adoption.md` (discovery) and `loop-control.md`'s per-wake PR scan (the `prs.json` block in step 1)
+`pr-adoption.md` (discovery) and `loop-control.md`'s per-heartbeat PR scan (the `prs.json` block in step 1)
 each run this command
 inline, **identically** — same label, same flags, same `--json` field set, same path. That is intended:
 they are the same scan. What is forbidden is a **different** spelling anywhere.
@@ -85,7 +85,7 @@ repo root, `.gauntlet/` (git-ignored; add `.gauntlet/` to `.gitignore` if missin
 
 **Only `.gauntlet/tmp/` is disposable — never `rm -rf .gauntlet/` itself.** That would take **every
 durable store in the table above** with it — the carryover history, and the follow-up ledger, which
-(unlike `state.jsonl`, a cache that re-derives itself from `gh` every wake) **nothing can rebuild**.
+(unlike `state.jsonl`, a cache that re-derives itself from `gh` every heartbeat) **nothing can rebuild**.
 Scratch cleanup targets `.gauntlet/tmp/**` and nothing above it.
 
 The history tree keeps **one file per run** (`<run-id>.md`) so concurrent runs never clobber a shared
@@ -107,13 +107,13 @@ the **active launch attempt's** review output files for which verdicts exist on 
 attempt named in that pass's `pass_identity`, so a relaunch's verdict is never missed and a dead
 attempt's is never counted). `git rev-parse HEAD` is used
 ONLY to validate/read an existing worktree when one is checked out — never as the primary source of a
-PR's live head (an adopted PR may have no local branch/worktree at all). Every wake re-derives what's
+PR's live head (an adopted PR may have no local branch/worktree at all). Every heartbeat re-derives what's
 due from those, then refreshes this file. So a stale or half-written ledger is self-healing — never
 act on it without reconciling against gh (and any existing worktree) first.
 
 The store is **JSONL** — one JSON object per line, `cat`/`grep`/`jq`-able. The first line is the
 run-config header record (`{"type": "header", …}` — the run's config, **every field of it** re-read each
-wake, never from memory; the fields are the ones `ledger.py`'s `HEADER_FIELDS` declares and "Header-record
+heartbeat, never from memory; the fields are the ones `ledger.py`'s `HEADER_FIELDS` declares and "Header-record
 fields" below defines, and no reader may keep its own copy of that list); each
 following line is one adopted PR's row record (`{"type": "row", …}`). Every record is **self-describing**
 — fields are keyed by NAME, never by column position:
@@ -136,13 +136,13 @@ live `headRefOid` and pasted into commands; an abbreviated one silently fails bo
 shortened SHA into the store, and never reconstruct one from a display.** The ONLY place a SHA is ever
 shortened is `table`'s rendering (below) — that is display-only and does not exist on disk.
 
-Header-record fields: `run_id` (this run's identity — namespaces its dir/label/wakes; set once),
+Header-record fields: `run_id` (this run's identity — namespaces its dir/label/heartbeats; set once),
 `base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
 once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
 `reviewer` (`default` (per-host cross-engine route with native fallback — see "The reviewer") | `codex` | `claude` | `<other>` — the selected reviewer; set once, see
 "The reviewer"), `required_set` (what `base_branch` **requires** — `stage-2-ci.md`, "What were we
 expecting to see?", owns the three states, the format, and the reads that produce them; re-read every
-wake while it is `unknown`), `skill_version` (**which copy of the rules actually governed this run**).
+heartbeat while it is `unknown`), `skill_version` (**which copy of the rules actually governed this run**).
 
 `skill_version` is read at startup from the **running plugin's** `plugin.json` (`SKILL.md`) and stated in
 the final report. **It is not cosmetic.** The harness loads this skill from the **installed plugin cache**,
@@ -210,7 +210,7 @@ Header field notes (the header fields above; per-row fields follow):
   there is **no `--review-rounds` flag at any door**: a door that can write a counter is a door that can
   zero it, and the rule is enforced by the flag's ABSENCE rather than by a promise.
 
-  **It is the review loop's only memory across fresh-context wakes.** `reviews_ok` is a gate tally and is
+  **It is the review loop's only memory across fresh-context heartbeats.** `reviews_ok` is a gate tally and is
   correctly zeroed on every NOT SATISFIED — which means that without this field, **the ledger after 21
   review rounds is indistinguishable from the ledger after one**, and every stopping rule of the form "on
   the second NOT SATISFIED…" is a backstop with **no sensor**. That is not a hypothetical either: one PR ran
@@ -233,7 +233,7 @@ Header field notes (the header fields above; per-row fields follow):
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it
   from the PR's title, body and diff). Set at adoption (`pr-adoption.md` step 3a) and **preserved** by every
-  refresh — a wake is a fresh agent instance, and an intent invented twice is two intents.
+  refresh — a heartbeat is a fresh agent instance, and an intent invented twice is two intents.
 
   The distinction is the honest one and the final report states it: an `authored` intent is **the driver's
   CLAIM about what the PR is for**, not the author's, and a wrong intent block silently **narrows** a
@@ -251,14 +251,14 @@ Header field notes (the header fields above; per-row fields follow):
   looping. The mechanism that fixes non-convergence must not itself fail to converge. Like `review_rounds`,
   it has **no flag at any door** — a budget you can zero is not a bound.
 - `repair_decision` — `-`, or the last reassessment decision + when: `<decision>@<iso>`. Durable, because
-  the wake that dispatches the repair may be a different agent instance from the one that decided it — and
+  the heartbeat that dispatches the repair may be a different agent instance from the one that decided it — and
   a repair may not be dispatched at all until this field is set (`ledger.py dispatch-check --action repair`).
   **DURABLE *and* SPENT EXACTLY ONCE per cap** — it is reset to `-` when the row **re-enters `repairing`**
   (`ledger.py verdict` at a cap), so a decision answers exactly the cap it was recorded for and a PR that
   reaches a cap **again** must earn a fresh `decide` (which spends `repair_count`, so the bound holds).
   `abort@…` is terminal and is never cleared.
 - `tier` — the adaptive review tier derived from `head_sha`: `TRIVIAL` | `STANDARD` | `HIGH`. Re-derived
-  every wake and re-triaged on any content change; drives `required(tier)` and the review depth.
+  every heartbeat and re-triaged on any content change; drives `required(tier)` and the review depth.
 - `ci` — `green` / `red` / `pending` for `head_sha`. (**There is no `none`.** It was documented but no
   procedure could ever write it.)
 - `ci_fingerprint` — digest of the last **verified** CI snapshot. **What it covers and exactly how it is
@@ -279,7 +279,7 @@ Header field notes (the header fields above; per-row fields follow):
   fingerprint did **not** change (`stage-2-ci.md`, "RUNNING-STALL" — the definition; the cap lives there
   and nowhere else). A **clock, not a tally**, and that is deliberate: a `RUNNING` row that is merely
   **SLOW** and one that is **DEAD** are indistinguishable on a fingerprint, and derivations are driven by
-  wakes whose cadence depends on the run's load — so only elapsed **TIME** separates them. It is on disk
+  heartbeats whose cadence depends on the run's load — so only elapsed **TIME** separates them. It is on disk
   precisely so `now - ci_stalled_since` is computable by a fresh agent instance that remembers nothing.
   Cleared (`-`) on any fingerprint change, on any `head_sha` change, and whenever a **machine action** is
   due or in flight for this PR at this `head_sha` (a fix that pushes will replace these rows). At the cap,
@@ -311,7 +311,7 @@ Header field notes (the header fields above; per-row fields follow):
   2) — so **any** future park with that property writes its reason here, with no edit to this bullet.
 - `blocker_ruling` — durable record of the user's answer to a **machine-blocker park** (the `status`
   taxonomy below): `-` (none yet) | `retry@<iso>` | `abort@<iso>`. It is the **answer** to the question
-  `ci_reason` **asks**, and it exists for the same reason `api_approval` does: a wake may be a fresh
+  `ci_reason` **asks**, and it exists for the same reason `api_approval` does: a heartbeat may be a fresh
   agent instance, so an answer held only in context is an answer the user is asked for twice. `retry`
   unparks with the liveness counters cleared; `abort` goes terminal `aborted`. The unpark is
   `loop-control.md` step 3, "Only the user's answer unparks a PR".
@@ -324,13 +324,13 @@ Header field notes (the header fields above; per-row fields follow):
   cleared — it goes terminal, and a terminal row is never re-parked, so it stays as the record of why.
   A **counter reset never touches it**: it is not one of the liveness counters.
 
-  These live **on disk, not in the driver's head**: a wake may be a fresh agent instance, and a counter —
+  These live **on disk, not in the driver's head**: a heartbeat may be a fresh agent instance, and a counter —
   or a ruling — that dies with the context never reaches its cap.
 - `attempts` — task attempts so far (for the retry-once bailout).
 - `started` — wall-clock start of the current attempt (for the 1-hour cap).
 - `api_approval` — durable record of the user's decision on this PR's API-changing fix: `-`
   (not an API change, or not yet decided) | `approved@<iso>` | `declined@<iso>`. Written the moment
-  the user answers, so a later wake — or a fresh agent that adopted the run — reads it and never
+  the user answers, so a later heartbeat — or a fresh agent that adopted the run — reads it and never
   re-asks about a PR already decided. It records the decision (an input); `status` stays the
   live position, so the two never contradict: `approved` pairs with the PR back in normal
   gate flow, `declined` with a terminal `aborted`. A one-off approval lands here only; it never flips
@@ -358,7 +358,7 @@ Header field notes (the header fields above; per-row fields follow):
   1. **PARKED — waiting on a HUMAN** (`awaiting-api`, `awaiting-user`). No amount of machine work can
      resolve it. The user's answer unparks the PR **to the `status` that answer dictates** — a **RESUME**
      answer (`approved`, a standoff ruling, `retry`) to `in_review`, with normal dispatch resuming on the
-     next wake; a **TERMINAL** answer (`declined`, `abort`) to `aborted`, which never resumes. Per class,
+     next heartbeat; a **TERMINAL** answer (`declined`, `abort`) to `aborted`, which never resumes. Per class,
      below — and `loop-control.md` step 3, "Only the user's answer unparks a PR", owns the mapping.
   2. **`repairing` — waiting on the REASSESSMENT PASS, not on a human.** The PR reached a review-loop cap
      (`review_rounds` or `ns_streak`), so it has stopped converging and **must not take another targeted
@@ -395,7 +395,7 @@ Header field notes (the header fields above; per-row fields follow):
 
     Same park mechanics as
     `awaiting-api` for both: `reviews_ok` stays 0, no review pass is launched for this PR, the other PRs
-    keep being driven, and the answer folds in as its own wake (`loop-control.md` step 3, "Only the
+    keep being driven, and the answer folds in as its own heartbeat (`loop-control.md` step 3, "Only the
     user's answer unparks a PR" — the owning definition of the record + unpark for **every** park class).
     NEVER park without surfacing the question, and NEVER park into a state whose exit is undefined.
 
@@ -428,7 +428,7 @@ by name and the script keeps the store canonical.
 This mirrors how `stage-2-review-gate.md` treats `emit-progress.py`: the file stays **plaintext and
 human-readable** JSONL (`cat`/`grep`/`jq`-able), the accessor just owns the schema and writes the
 canonical layout — the store is now JSONL owned by the script. `state.jsonl` is still a cache reconciled
-against ground truth every wake (above) — the accessor changes *how* records are written, not what the
+against ground truth every heartbeat (above) — the accessor changes *how* records are written, not what the
 ledger means.
 
 Resolve its absolute path as `<skill-dir>/scripts/ledger.py` (skill dir = the directory holding the
@@ -467,7 +467,7 @@ the one kind of work a `repairing` row accepts, and it is refused until the reas
 the row — otherwise a driver could call its next targeted fix "the repair" and go on whacking moles under
 a new name.
 
-`table` is the user-facing status view: the end-of-wake report renders it whenever the run goes back
+`table` is the user-facing status view: the end-of-heartbeat report renders it whenever the run goes back
 to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decides nothing — no gate
 logic, no derived values.
 

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -119,7 +119,7 @@ the one line it was pointed at and leave the class intact:
 
 This is a **report** requirement, not just a search requirement: a sweep nobody can audit did not happen.
 
-**THE ORCHESTRATOR RECORDS EVERY SITE THE FIXER LEFT ALONE — as a follow-up, in the same wake it reads the
+**THE ORCHESTRATOR RECORDS EVERY SITE THE FIXER LEFT ALONE — as a follow-up, in the same heartbeat it reads the
 report.** The block above makes the subagent report the sites it deliberately did not touch (and any
 pre-existing defect it noticed and declined to fix); **that report dies with the subagent**, so a
 disposition nobody wrote down is a defect nobody will ever see again. Record each one through

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -97,7 +97,7 @@ middle step.
 ## WORKING A FOLLOW-UP — the active loop, one entry at a time
 
 The threshold above says what the driver **may** do. This is the **procedure** that does it — the loop
-that turns an open follow-up into either a refutation or a merged PR. Run it when a wake has **spare
+that turns an open follow-up into either a refutation or a merged PR. Run it when a heartbeat has **spare
 capacity** and the gated PRs do not need the driver right now (the nudge's "start on follow-ups" reminder
 is one prompt for it). It is **work-conserving, never blocking**: it runs *alongside* gating the campaign's
 PRs, never instead of them, and it holds the run hostage on nothing.
@@ -161,10 +161,10 @@ about and one whose partial rejection strands the rest.
      ruling **authorized**: if the user approved a **FIX**, dispatch the scoped fix subagent under the
      approved scope, which opens the PR, then `open-pr` records it (→ `in-pr`) and step 4 adopts it — no
      reconciliation, exactly as `self-accepted` resumes; if the user approved **PUBLICATION**, that is the
-     **publish** path (Tier 3), **not** a fix. If a fresh wake **cannot tell which** the ruling was for,
+     **publish** path (Tier 3), **not** a fix. If a fresh heartbeat **cannot tell which** the ruling was for,
      **SURFACE the entry to the user** rather than assume a fix. The same-run idempotency note below covers
-     its interrupted-wake gap.
-   - **`in-pr`** — a PR is open and named in the entry, but an interrupted wake may have recorded `open-pr`
+     its interrupted-heartbeat gap.
+   - **`in-pr`** — a PR is open and named in the entry, but an interrupted heartbeat may have recorded `open-pr`
      **without** finishing ADOPTION. Adoption is a campaign action, not a store edge — no `in-pr`
      transition performs it — so "defer to the graph" strands the PR. On resume, **reconcile the recorded
      PR against the current run and ADOPT it** (the existing idempotent adoption, step 4) if it lacks a run
@@ -174,12 +174,12 @@ about and one whose partial rejection strands the rest.
    - **`reopened`** — its PR died and it already carries the decision it earned, so it does **not** re-decide:
      it resumes at opening the **replacement** PR. Dispatch the fixer, which opens the replacement PR, then
      `open-pr` records it (→ `in-pr`) and step 4 adopts it — no reconciliation, same as `self-accepted`. The
-     same-run idempotency note below covers its interrupted-wake gap.
+     same-run idempotency note below covers its interrupted-heartbeat gap.
 
-   **Same-run idempotency is a deliberate non-goal — the interrupted-wake gap for `self-accepted`,
-   `accepted`, and `reopened`.** A wake that dies **after** the fix subagent opens the PR but **before**
+   **Same-run idempotency is a deliberate non-goal — the interrupted-heartbeat gap for `self-accepted`,
+   `accepted`, and `reopened`.** A heartbeat that dies **after** the fix subagent opens the PR but **before**
    `open-pr` records it leaves the entry in `self-accepted` (or `accepted`/`reopened`) with **no durable
-   fuN→PR key** to reconcile against — so the next wake re-dispatches and can open a **duplicate PR within
+   fuN→PR key** to reconcile against — so the next heartbeat re-dispatches and can open a **duplicate PR within
    one run**. Making that dispatch idempotent needs a durable key: a `followups.py` PR-reference field
    written before `open-pr`, or a deterministic fuN-keyed branch required by the fix contract — **both are
    deliberate NON-GOALS here** (one is a `followups.py` store change, the other a fix-subagent-contract
@@ -252,10 +252,10 @@ time. So:
   its history intact — the finding, the ACT grounds or the user's ruling, and the PR that died. It never
   vanishes with the PR, and it is never stuck in "being worked on" forever.
 
-**Move it in the wake that SAW the event** — the same rule as recording one the moment it is noticed, and
-for the same reason: the driver's memory of it dies with the driver's context. The wake that opens the PR
-addressing a follow-up runs `open-pr`; the wake that observes that PR **merged** or **closed** runs
-`merged` / `closed-unmerged`. A follow-up whose PR landed three wakes ago and still sits in `in-pr` is a
+**Move it in the heartbeat that SAW the event** — the same rule as recording one the moment it is noticed, and
+for the same reason: the driver's memory of it dies with the driver's context. The heartbeat that opens the PR
+addressing a follow-up runs `open-pr`; the heartbeat that observes that PR **merged** or **closed** runs
+`merged` / `closed-unmerged`. A follow-up whose PR landed three heartbeats ago and still sits in `in-pr` is a
 queue nobody can trust to say what is left to do.
 
 **AND REJECTIONS ARE KEPT.** A `rejected` entry stays in the store — hidden from the default view (nobody
@@ -276,7 +276,7 @@ disposable, and a follow-up must outlive the run that found it.
 Two consequences follow, and both are why this is not just another `state.jsonl`:
 
 - **It is the SOURCE OF TRUTH, not a cache.** `state.jsonl` is a hint reconciled against GitHub every
-  wake, so a lost row heals itself. **Nothing can rebuild a lost follow-up** — it exists nowhere else, by
+  heartbeat, so a lost row heals itself. **Nothing can rebuild a lost follow-up** — it exists nowhere else, by
   design. A lost entry is lost forever.
 - **It has MANY writers.** The lease makes `state.jsonl` single-writer; **every concurrent run** writes
   this one. Its accessor locks the read-modify-write for that reason — hand-editing the file races with a
@@ -428,7 +428,7 @@ job is to hold claims a human can audit.
 DELIBERATE act rather than an oversight**. It is a footgun guard, **NOT** a security boundary.
 
 **The user's ruling is DURABLE DATA.** `accept`/`reject` stamp when it was made, for the same reason the
-ledger's `api_approval` records `approved@<iso>` rather than living in the driver's head: **a later wake
+ledger's `api_approval` records `approved@<iso>` rather than living in the driver's head: **a later heartbeat
 is a fresh agent that never saw the conversation**, and it must not re-ask a question the user already
 answered. **Nothing the driver does alone stamps it** — not an investigation, not a `take-up`, not opening
 a PR, not `publish`. A ruling written by anything but the user would launder the driver's action into the
@@ -467,7 +467,7 @@ hid and the flag that reveals them. Read a value back with `get --field`, **neve
 **What the driver may do with what it surfaces is the THRESHOLD above — do not re-derive it here.**
 Surfacing an entry to the user *is* how consensus gets reached, and it must never hold the run hostage
 (`run-identity-and-lease.md`, "Never hold the run hostage on a user prompt"): raise them alongside the
-report and fold any answer in as its own wake. **A `candidate` is a question, not a task**: the driver has
+report and fold any answer in as its own heartbeat. **A `candidate` is a question, not a task**: the driver has
 not investigated it yet, so it has nothing to act on and nothing to say. The FIRST move on a fresh
 candidate is to INVESTIGATE it — the active loop above, when there is spare capacity — because that is
 how the question gets answered. Surfacing it to the user is the THRESHOLD fallback (when the driver

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -4,12 +4,12 @@ The skill is **event-driven**. Read `runtime-adapter.md` before waiting. Reconci
 invocation, a scheduled heartbeat when the host provides one, a **background task completing**, or the
 bounded-wait fallback returning. A completion may be a CI watch, a review, or a CI/review fix.
 
-**Every wake — reconcile, dispatch, reschedule:**
+**Every heartbeat — reconcile, dispatch, reschedule:**
 
 1. **Resolve repository context, then the run + lease, then init / resume / start fresh.** Call
    `runtime-adapter.md`'s repository-context resolver exactly once with the supplied checkout and carry
-   that record for every path and Git cwd on this wake. Then bind **which run this wake is
-   for** and confirm you may drive it, per "Run identity and concurrency": a `--run <id>` self-wake
+   that record for every path and Git cwd on this heartbeat. Then bind **which run this heartbeat is
+   for** and confirm you may drive it, per "Run identity and concurrency": a `--run <id>` scheduled heartbeat
    presents its `--token` and, under the run's claim lock, continues if the token matches the lease,
    adopts if the lease is absent/stale, or **stands down** if a fresh lease bears a different token; a
    bare invocation **with `#PR` args** starts a NEW run adopting those PRs, while an **arg-less** bare
@@ -58,7 +58,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      moment the set gains a member (this line's did, when `ci_stalled_since` joined).
 
      Do the PR scan as
-     **one batched snapshot per wake** — the **same canonical command** `pr-adoption.md` runs, writing the
+     **one batched snapshot per heartbeat** — the **same canonical command** `pr-adoption.md` runs, writing the
      **same path with the same schema** (they are the same scan; two spellings of it is how a reader of
      `prs.json` ends up with fields that are not there, or a snapshot scoped to the wrong PRs). Its owning
      definition is the block **"The canonical `prs.json` command"** in `files-and-ledger.md`; copy it
@@ -77,16 +77,16 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 
      — and drive reconcile from that file; fall back to per-PR `gh pr view` only where the snapshot
      isn't enough (merge-gate CI truth stays the SHA-pinned, SHA-verified snapshot of **both** check
-     families, Stage 2b). Wake
+     families, Stage 2b). Heartbeat
      turnaround is throughput: every serial `gh` call in reconcile delays every dispatch behind it. Re-read
      **the ledger header's run config — EVERY field of it, whatever they are** (`files-and-ledger.md` owns
-     that set; do NOT keep a copy of it here, a list beside a property goes stale the wake a field is
+     that set; do NOT keep a copy of it here, a list beside a property goes stale the heartbeat a field is
      added). It governs the run, and must be
-     consulted fresh each wake, never from memory (a wake may be a fresh agent instance that just
+     consulted fresh each heartbeat, never from memory (a heartbeat may be a fresh agent instance that just
      adopted the run, so an explicit/preferred reviewer would otherwise
      be lost and silently revert to the default; Constraints, Base branch, "The reviewer",
      "PR adoption"). Refresh
-     the lease. This is the path every `--run` self-wake takes.
+     the lease. This is the path every `--run` scheduled heartbeat takes.
    - **No run bound and none live (no `gauntlet-run-*` PR, no non-terminal `<rundir>`) → first run.**
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no
      `#PR` args (a bare or non-`#PR` invocation that found no live run to resume — likewise `--new`
@@ -113,7 +113,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      first)." A new run needs a `#PR` set, so collect PR numbers (equivalently direct the user to
      `<campaign-invocation> --new #PR...`); on a PR set, start a fresh run **with carryover** (see "Fresh
      runs and carryover") — **no run-id/lease/`state.jsonl` is created until that set passes preflight**.
-     With no PR numbers (or "no"), emit that run's final report and stop. This prompt is the *only* wake
+     With no PR numbers (or "no"), emit that run's final report and stop. This prompt is the *only* heartbeat
      that asks the user about scope.
 
    **The `--new` fresh-run signal short-circuits the above — but only WITH `#PR` args:** `--new #PR...`
@@ -155,10 +155,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    operation.
 
    **Settle the base branch's required-check set before any CI derivation:** run `scripts/ci-status.py
-   required-set --ledger <rundir>/state.jsonl`. Run it every wake; the command reuses a settled value and
+   required-set --ledger <rundir>/state.jsonl`. Run it every heartbeat; the command reuses a settled value and
    only retries `unknown`. `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?", owns its states and behavior.
-2. **Fold in completions.** For any background task that finished (CI watch → **a WAKE, not an artifact**:
-   the watch **only blocks** and produces **nothing**, so **this wake** performs the SHA-pinned fetch of
+2. **Fold in completions.** For any background task that finished (CI watch → **a HEARTBEAT, not an artifact**:
+   the watch **only blocks** and produces **nothing**, so **this heartbeat** performs the SHA-pinned fetch of
    both check families, **promotes** it atomically to `ci-<pr>-<head_sha>.txt` and **verifies** its stamp
    against the ledger's **current** `head_sha` before parsing a single line of it — the CI state is
    **never** decided from the watch's exit code (Stage 2b, "WHO DOES WHAT" and "VERIFY THE STAMP BEFORE
@@ -230,7 +230,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    - **The ONE exception is the CI watch: OBSERVING a PR is not mutating it.** The park **does not change
      the watch either way** — it follows the normal policy, `stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE":
      alive while an evidence row can still `RUN`, **not** relaunched once CI has SETTLED (relaunching a
-     settled PR's watch burns a wake per second and observes nothing). Parking never stops a warranted
+     settled PR's watch burns a heartbeat per second and observes nothing). Parking never stops a warranted
      watch and never starts an unwarranted one. But do **NOT** dispatch a CI *fix*.
    - **Recording ground truth is not mutating either.** Reconcile still READS a parked PR (live SHA, CI,
      labels) and writes what it read to the ledger — including a `reviews_ok` reset, and its label
@@ -243,7 +243,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      the authority, and it is **NOT always `in_review`**:
      - a **RESUME** answer (`api_approval` = `approved`, a standoff ruling either way, `blocker_ruling` =
        `retry`) → `ledger.py … set --pr <N> --status in_review`, and resume normal dispatch — including any
-       rebase or base refresh the PR has been owed while frozen — from the next wake. A parked PR that has
+       rebase or base refresh the PR has been owed while frozen — from the next heartbeat. A parked PR that has
        fallen **behind** its base simply **stays behind** until then; it is not dropped from the run, just
        frozen.
      - a **TERMINAL** answer (`api_approval` = `declined`, `blocker_ruling` = `abort`) → `--status aborted`
@@ -256,7 +256,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      |---|---|---|
      | **`awaiting-api`** — an API-changing fix | `api_approval` = `approved@<iso>` / `declined@<iso>` | `approved` → `in_review`; `declined` → terminal `aborted` |
      | **`awaiting-user`, review standoff** — a REFUTED finding the fresh reviewer re-raised | the ruling in `<rundir>/audit-<pr>-<n>.md` | `in_review`; ruled **valid** → the finding is fixed like a CONFIRMED one, ruled **invalid** → normal flow |
-     | **`awaiting-user`, machine blocker** — campaign cannot move this PR without a human; that **property** IS the class, **never a list of cases** (one illustration: CI has SETTLED and is still not green). Do not enumerate the members here — `files-and-ledger.md`, `status`, `awaiting-user` class 2, **owns** the class, and `ci_reason` names the blocker at every one of them, present or future | `blocker_ruling` = `retry@<iso>` / `abort@<iso>` | `retry` → `in_review`, **RESET THE LIVENESS COUNTERS**, and **SPEND the ruling: `blocker_ruling` = `-`** (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "THE RULING IS CONSUMED EXACTLY ONCE"), then re-derive CI on the next wake; `abort` → terminal `aborted` (the ruling **stays** — it is the record of why) |
+     | **`awaiting-user`, machine blocker** — campaign cannot move this PR without a human; that **property** IS the class, **never a list of cases** (one illustration: CI has SETTLED and is still not green). Do not enumerate the members here — `files-and-ledger.md`, `status`, `awaiting-user` class 2, **owns** the class, and `ci_reason` names the blocker at every one of them, present or future | `blocker_ruling` = `retry@<iso>` / `abort@<iso>` | `retry` → `in_review`, **RESET THE LIVENESS COUNTERS**, and **SPEND the ruling: `blocker_ruling` = `-`** (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "THE RULING IS CONSUMED EXACTLY ONCE"), then re-derive CI on the next heartbeat; `abort` → terminal `aborted` (the ruling **stays** — it is the record of why) |
 
      **A `retry` that clears nothing re-escalates on its first derivation** — the strikes are still at
      the cap — so the counter reset is **part of the unpark, not an optimization**. It buys the PR a
@@ -287,7 +287,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 
    - **no `repair_decision` yet** → dispatch the **reassessment pass** (`repair-pass.md`): a
      context-isolated worker in the **`session`** class, handed **every round's verdict and finding, the
-     diff-growth curve, the intent artifact, and the current diff — all at once**. No wake has ever had
+     diff-growth curve, the intent artifact, and the current diff — all at once**. No heartbeat has ever had
      that view; it is why 21 rounds passed unnoticed. It returns ONE decision from a closed enum, recorded
      with `repair-pass.py decide` (which refuses a decision this PR may not take — see the ownership
      guardrail).
@@ -357,14 +357,14 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      follow them there; do NOT restate them here. Different PRs may fix CI concurrently within the cap.
    - CI snapshot holds a **still-RUNNING** evidence row (an evidence row that classifies `RUNNING` under
      Stage 2b CLASSIFY — never "a row that is not terminal") for a PR whose watch task has already exited →
-     **relaunch the watch in this same wake**. A PR with a row that can still move must never sit
-     unwatched until the fallback wake; the fallback lifecycle is not the mechanism. **But NEVER relaunch
+     **relaunch the watch in this same heartbeat**. A PR with a row that can still move must never sit
+     unwatched until the fallback heartbeat; the fallback lifecycle is not the mechanism. **But NEVER relaunch
      it merely because `ci == pending`** — once CI has SETTLED nothing can move, `gh pr checks --watch`
-     exits in about a second, and its completion is itself a wake: that is a wake per second, forever
+     exits in about a second, and its completion is itself a heartbeat: that is a heartbeat per second, forever
      (Stage 2b, "WATCH ONLY WHAT CAN MOVE"). A settled PR is resolved by the `settled_strikes`
      escalation, not by watching it harder. **And a row that never leaves `RUNNING` is resolved by
      RUNNING-STALL** (Stage 2b): its watch blocks forever and completes never, so the escalation lands on
-     **this fallback wake**, once `ci_stalled_since` has stood at the same fingerprint for the CI STALL
+     **this fallback heartbeat**, once `ci_stalled_since` has stood at the same fingerprint for the CI STALL
      CAP. **A watch is never a bound.**
    - about to dispatch content-changing work on a PR (review fix, CI fix, copilot-address,
      conflict-resolving rebase) while a review is in flight on that PR → **stop that review task
@@ -388,13 +388,13 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    - Any non-terminal PR remains (in review, pending CI, or awaiting a user ruling on a review-finding
      standoff / API approval / precondition) →
      refresh this run's lease, then choose the runtime adapter's scheduled-heartbeat or bounded-wait
-     branch. A scheduled self-wake uses `<campaign-invocation> --run <run-id> --token <agent-token>` —
-     exactly those two flags: `--run` rebinds the wake to this run and `--token` re-proves ownership of
+     branch. A scheduled heartbeat uses `<campaign-invocation> --run <run-id> --token <agent-token>` —
+     exactly those two flags: `--run` rebinds the heartbeat to this run and `--token` re-proves ownership of
      its lease. It **never replays `--new` or the original `#PR` adoption args** — the run is resumed,
      not re-created, and carrying `--new` would mint a new run every heartbeat. A scheduler-less bounded
-     wait retains the current invocation and token instead of constructing a self-wake. Both are a
-     **fallback lifecycle, not a tight poll**: background completions are the primary wake. A scheduled
-     heartbeat also recovers a killed/orphaned session through a later self-wake; if a scheduler-less
+     wait retains the current invocation and token instead of constructing a scheduled heartbeat. Both are a
+     **fallback lifecycle, not a tight poll**: background completions are the primary heartbeat. A scheduled
+     heartbeat also recovers a killed/orphaned session through a later scheduled heartbeat; if a scheduler-less
      invocation is killed, durable state permits a later explicit resume (see "Resume after a killed
      session"). **Size the scheduled delay or bounded wait to the nearest stall it guards:**
      **~5 min** while any dispatched review pass is still awaiting its first line of **launch evidence**
@@ -402,7 +402,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      sit undetected for a full normal interval — otherwise **~15 min**, matching the Stage 2a meaningful-progress
      threshold: with no launch deadline pending, nothing can declare a review stalled before then, so a
      shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
-     wake). **One exception carries new signal:** a background-task review watched via its stdout stream
+     heartbeat). **One exception carries new signal:** a background-task review watched via its stdout stream
      can be declared hung before that cap once the stream falls quiet (`stage-2-review-gate.md`, the
      stdout-stream liveness signal), so while such a review is streaming, a shorter poll toward that
      quiet window is a real check, not a bare re-reconcile. ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
@@ -413,9 +413,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      (`files-and-ledger.md`, "`table` is a PROJECTION"); drop them and the user is shown a subset
      presented as the whole ledger. Never re-type, trim, or re-align it. Then one line per remaining
      wait naming what it waits on (review in flight, CI watch, parked on the user's answer). Render it
-     after every ledger write of the wake — the ledger was reconciled this wake, so the table is the
+     after every ledger write during this heartbeat — the ledger was reconciled this heartbeat, so the table is the
      state the next reconcile resumes from. Then take exactly one runtime branch:
-     - **Scheduled-wake host:** schedule the self-wake, render the status above, and return. The scheduled
+     - **Scheduled-heartbeat host:** schedule the heartbeat, render the status above, and return. The scheduled
        invocation begins again at step 1.
      - **Scheduler-less bounded-wait host:** render the same status, wait only until the first task
        completion or the nearest protected deadline, then go directly back to step 1 and reconcile.
@@ -433,11 +433,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      silent exit. (A stale heartbeat firing after exit harmlessly re-hits the finished-run branch via
      its `--run <run-id>`; with the lease released it reads as an un-driven finished run.)
 
-**Idempotency is the load-bearing property.** Because every wake re-derives from git/gh and launches
+**Idempotency is the load-bearing property.** Because every heartbeat re-derives from git/gh and launches
 only work not already in flight, a relaunch after a killed session — or two completions landing close
 together — cannot corrupt state or act on a stale verdict (PR-content pinning rejects stale verdicts
 at the gate). The worst case is a wasted duplicate review, which is harmless: it's just another fresh,
-context-isolated re-roll anyway. The agent is also single-threaded per turn, so wake *decisions* never truly race — only
+context-isolated re-roll anyway. The agent is also single-threaded per turn, so heartbeat *decisions* never truly race — only
 in-flight tasks do.
 
 **Resume after a killed session — including by a different agent instance:** in-flight background
@@ -457,7 +457,7 @@ and the PR would stall forever, which is the very failure this feature exists to
 evidence answers "is this **live** process working?" and is meaningful **only** for the in-flight
 ~5-min launch check; once the task is gone, the only question is how much relaunch budget remains. It
 binds to the run via
-`--run <id>` (what every self-wake carries, so a fresh instance adopting an orphaned run's heartbeat
+`--run <id>` (what every scheduled heartbeat carries, so a fresh instance adopting an orphaned run's heartbeat
 just works) or, for a bare re-invocation, by discovering live runs and adopting the sole **orphaned**
 one (asking among several). Adoption is gated on the **run lease**: an agent takes over only a run
 whose lease is absent or stale, so it can always tell whether another agent is still driving that

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -9,7 +9,7 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 - **no-arg discovery** (`<campaign-invocation>`, resume) — reconcile the PRs already labelled for this run:
 
   ```text
-  # THE canonical run snapshot — the SAME command loop-control's per-wake PR scan (the `prs.json`
+  # THE canonical run snapshot — the SAME command loop-control's per-heartbeat PR scan (the `prs.json`
   # block in step 1) runs. ONE path, ONE schema.
   # Owning definition: "The canonical `prs.json` command" in files-and-ledger.md. Copy it whole;
   # never spell a variant.
@@ -24,7 +24,7 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   ```
 
   Every open PR carrying this run's owner label is already ours — refresh its row from that snapshot.
-  A PR with the label but no row is a re-adoption after an amnesiac wake; a row whose PR is gone
+  A PR with the label but no row is a re-adoption after an amnesiac heartbeat; a row whose PR is gone
   (merged/closed) reconciles to its terminal status.
 
   **`--limit` is NOT optional** — `gh pr list` silently caps at **30** items without it, and a truncated
@@ -146,7 +146,7 @@ For each `#PR` to adopt:
    - **On a REFRESH of an existing row, PRESERVE EVERY FIELD THIS STEP DOES NOT EXPLICITLY RECOMPUTE.**
      That is a **property, not a list** — and deliberately so, because the list that stood here was one:
      `ledger.py … set` writes only the fields it **NAMES**, so preservation is the **default**, and this
-     step's job is to name nothing it must not clobber. Everything a previous wake wrote and a later one
+     step's job is to name nothing it must not clobber. Everything a previous heartbeat wrote and a later one
      still needs therefore survives untouched — **including every field added to the schema after this
      line was written**. **The members are NOT retyped here, and marking a retyped list "examples" would
      not save it**: a member missing from such a list is a field a refresh silently clobbers, and the
@@ -159,7 +159,7 @@ For each `#PR` to adopt:
      **Preserving `blocker_ruling` here is safe because it is cleared at its
      own park boundaries** — at park **entry** and when a `retry` is **consumed** (`stage-2-ci.md`, "THE
      RULING IS CONSUMED EXACTLY ONCE") — so a ruling this refresh can see is either still **awaiting its
-     park's exit** (preserving it is the whole point: a wake may be a fresh agent instance) or the
+     park's exit** (preserving it is the whole point: a heartbeat may be a fresh agent instance) or the
      **terminal** record of an `abort`. A **spent** ruling is never on the row for this step to resurrect.
      Only re-read `head_sha`/`ci` from ground truth; reset
      `reviews_ok` to `0` and re-triage `tier` **only if** reconciliation detects a PR-content change
@@ -259,7 +259,7 @@ For each `#PR` to adopt:
      CLI arguments"* / *"nobody else — the store is a git-ignored local file only the driver writes"*.
 
    **On a RE-ADOPTION, do not re-author.** `intent` is one of the fields the refresh **preserves** (step 3),
-   and `intent-<pr>.md` is re-read, never re-derived — a wake is a fresh agent instance, and an intent
+   and `intent-<pr>.md` is re-read, never re-derived — a heartbeat is a fresh agent instance, and an intent
    invented twice is two intents. Re-author only if the file is **gone** (a wiped `<rundir>`), and say so.
 
 4. **Label it ours, and set the status label from the LIVE gate.** Add this run's owner label, then
@@ -370,10 +370,10 @@ For each `#PR` to adopt:
 6. **Ensure a live CI watch when — and ONLY when — a check can still move.** The warrant for a watch is a
    **still-RUNNING evidence row** in the PR's snapshot, **never the `ci` value** (Stage 2b, `stage-2-ci.md`
    — "WATCH ONLY WHAT CAN MOVE"): a PR whose CI has **SETTLED** gets **no watch**, because
-   `gh pr checks --watch` on it exits in about a second and its completion is itself a wake — a wake per
+   `gh pr checks --watch` on it exits in about a second and its completion is itself a heartbeat — a heartbeat per
    second, forever, observing nothing. A watch on a run that is still moving wakes the driver when it
    settles. **The backgrounded command is the watch and NOTHING ELSE** — its **ONLY** job is to **block**
-   until the run settles, so that **its completion becomes a wake**:
+   until the run settles, so that **its completion becomes a heartbeat**:
 
    ```
    # run in background. This is the WHOLE command: it BLOCKS, and that is all it does.
@@ -382,10 +382,10 @@ For each `#PR` to adopt:
 
    **The background task does NOT fetch, and does NOT write `<rundir>/ci-<pr>-<head_sha>.txt`.** The watch
    only **blocks** — it is **never evidence**, and its exit code is **never** a CI verdict. The evidence is
-   the SHA-pinned fetch of **both** check families, which the **WAKE** performs — **by running
+   the SHA-pinned fetch of **both** check families, which the **HEARTBEAT** performs — **by running
    `scripts/ci-status.py derive`**, which fetches, promotes atomically, verifies against the ledger's
    current `head_sha`, and decides (Stage 2b, `stage-2-ci.md` — "THE DERIVATION IS A COMMAND" and "WHO DOES
-   WHAT"). Only the wake knows the SHA the ledger currently holds, so only the wake can pin the fetch to it.
+   WHAT"). Only the heartbeat knows the SHA the ledger currently holds, so only the heartbeat can pin the fetch to it.
    **NEVER derive CI from `gh pr checks`:** its output carries **NO SHA**, so it can report the **previous**
    commit's passing checks — and **never by reading a command's output and judging it**, which is how a
    `ci = green` was once written for a PR with no checks at all.
@@ -394,6 +394,6 @@ For each `#PR` to adopt:
    watches).
 
 Adoption produces only the registered, labelled row (and a CI watch when due). Reviews, CI fixes, and
-merges are driven by Loop control on later wakes — this file just gets each PR **into** the run.
+merges are driven by Loop control on later heartbeats — this file just gets each PR **into** the run.
 
 ---

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -6,7 +6,7 @@ is the entire point, and is explained by the section that ends this file.
 
 ### Why this exists
 
-The review gate had **no memory and could not see its own non-convergence.** Every wake is a fresh agent
+The review gate had **no memory and could not see its own non-convergence.** Every heartbeat is a fresh agent
 instance; `reviews_ok` is zeroed on every `NOT SATISFIED`; and nothing counted rounds. So the ledger after
 21 review rounds was **indistinguishable from the ledger after 1**, and the skill's stopping rules — "run
 the root-cause pass on the 2nd `NOT SATISFIED`", the 1-hour cap — were rules with **no sensor**. They sat
@@ -15,7 +15,7 @@ in the skill, unfired, for 8.5 hours.
 Two PRs ran **21** and **14** adversarial review rounds. Nearly every round produced a **true** finding, a
 fix was dispatched, the fix added code, and the next round found more — in the late rounds, more *in the
 guards the loop itself had just added*. Neither PR converged. A human stopped it, and could only do so by
-holding all 21 rounds in mind **at once**. That view is what no wake had, and it is what this pass restores.
+holding all 21 rounds in mind **at once**. That view is what no heartbeat had, and it is what this pass restores.
 
 **The reviewer was not malfunctioning.** It was doing exactly what it was asked, and what it was asked has
 **no fixed point**: an open-ended adversarial mandate over a growing surface always has one more true thing
@@ -65,7 +65,7 @@ first.
 
 Dispatch **one context-isolated worker** in the **`session` class** (it decides the acceptance path — never
 downgrade it; `SKILL.md`, "Worker Dispatch"), and hand it **THE WHOLE HISTORY AT ONCE**. This is the
-crux: **no wake has ever had this view**, which is exactly why 21 rounds could pass unnoticed.
+crux: **no heartbeat has ever had this view**, which is exactly why 21 rounds could pass unnoticed.
 
 It receives, in one prompt:
 
@@ -97,7 +97,7 @@ repair-pass.py --file <state.jsonl> decide --pr <N> --decision <one of the five>
 ```
 
 `--record` is **refused if it does not exist or is empty**. The reasoning — the history the pass saw, the
-decision, and why — must be **on disk**: every wake is a fresh agent instance, and a justification that
+decision, and why — must be **on disk**: every heartbeat is a fresh agent instance, and a justification that
 lives only in the context of an agent that has already exited is one nobody can audit.
 
 ### The repair is dispatched only after its decision is recorded
@@ -149,7 +149,7 @@ never the ordinary fix.
 ### Why every part of this is a command and not a paragraph
 
 The rules that failed on 2026-07-14 did not fail by being ignored. **They failed by being unevaluable.**
-The 2nd-`NOT SATISFIED` backstop triggers on a fact about history that nothing recorded, read by a wake
+The 2nd-`NOT SATISFIED` backstop triggers on a fact about history that nothing recorded, read by a heartbeat
 that remembers nothing. The 1-hour cap was never computed by anything, and its own word — *"stuck"* — did
 not describe a loop that produced a real finding and a real fix every single round. It **looked like
 progress**, one round at a time, all night.

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -9,7 +9,7 @@ reviewer is chosen per run. Map host operations through `runtime-adapter.md`.
 **Reviewer selection IS gate machinery, so the choice is resolved from TRUSTED state ONLY** — never from
 a file inside the checkout under review (see priority 2). Resolve once **at run start, and record the
 choice as the ledger `reviewer` header field BEFORE any candidate evidence is read** (see
-`files-and-ledger.md`) so every later wake — including a self-wake or a fresh agent that adopted the
+`files-and-ledger.md`) so every later heartbeat — including a scheduled heartbeat or a fresh agent that adopted the
 run — re-reads it before launching any review pass and never silently reverts to the default; also
 note it in the final report. Resolve in priority order:
 

--- a/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
@@ -19,7 +19,7 @@ string of `NOT SATISFIED` findings that are siblings in one structured space —
 different instance — is the same signal arriving late; treat it identically.)
 
 **The old "no later than the 2nd `NOT SATISFIED`" backstop is GONE — do not look for it, and do not
-restore it.** It triggered on a fact about history that nothing recorded, evaluated by a wake that
+restore it.** It triggered on a fact about history that nothing recorded, evaluated by a heartbeat that
 remembers nothing, and it **never fired once** across 35 review rounds on two PRs
 (`bailout-and-final-report.md`). What backstops this pass now is a **counter with a cap**: at a review-loop
 cap the PR goes `repairing` and a reassessment pass sees **every round at once** and returns one decision —

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -5,7 +5,7 @@ measured against. It is **not assumed to be `main`**: it is the **adopted PRs' `
 `gh pr view`), which may be a release or integration branch. When several PRs are adopted at once they
 must **agree** on `baseRefName`; if they disagree, stop and prompt (one run targets one base). Resolve
 it **once** at the start of a run and record it in the ledger header as `base_branch`; re-read it from
-the ledger every wake, never from memory.
+the ledger every heartbeat, never from memory.
 
 Throughout this doc, `<base>` means that branch and `origin/<base>` its remote-tracking branch.
 Concretely: adopted PRs already target `<base>` (their `baseRefName`), every review diffs
@@ -42,8 +42,8 @@ rundir = create_run_directory(repository, run_id) || run_id=…
 derivation, and bare atomic create. Do not unpack that operation here.
 
 Record it in the ledger header field `run_id` (`ledger.py --file <state.jsonl> header set run_id
-<run-id>`) and re-read it every wake (`ledger.py … header get run_id`, like `base_branch`); never trust
-in-context memory for it — a wake may be a fresh agent instance. It flows into:
+<run-id>`) and re-read it every heartbeat (`ledger.py … header get run_id`, like `base_branch`); never trust
+in-context memory for it — a heartbeat may be a fresh agent instance. It flows into:
 
 | Owned by the run | Namespaced form |
 |------------------|-----------------|
@@ -52,7 +52,7 @@ in-context memory for it — a wake may be a fresh agent instance. It flows into
 | PR owner label   | `gauntlet-run-<run-id>` — the **authoritative "mine" marker**. Every adopted PR is tagged with it; it, not any branch name, is what makes a PR this run's. |
 | branch           | the **adopted PR's own `headRefName`** — campaign reuses the PR's existing branch and does NOT mint a `fix-<run-id>-...` branch, so ownership can't be read off the branch name (that's the label's job). |
 | worktree         | the ledger-recorded `worktree` path resolved by the repository-context-aware adoption operation; only a campaign-created worktree (`worktree_owned = yes`) is ever removed (see "PR adoption" / Stage 3) |
-| self-wake prompt | `<campaign-invocation> --run <run-id> --token <agent-token>` — resolve the host form through `runtime-adapter.md`; carry **only** these two flags so a summarized wake re-proves ownership without guessing. It **never** carries `--new` or the original `#PR` adoption args: those are **start-time-only** (they *create/adopt*), whereas `--run` **resumes** an existing run — replaying `--new` on a self-wake would mint a fresh run every heartbeat. |
+| scheduled heartbeat prompt | `<campaign-invocation> --run <run-id> --token <agent-token>` — resolve the host form through `runtime-adapter.md`; carry **only** these two flags so a summarized heartbeat re-proves ownership without guessing. It **never** carries `--new` or the original `#PR` adoption args: those are **start-time-only** (they *create/adopt*), whereas `--run` **resumes** an existing run — replaying `--new` on a scheduled heartbeat would mint a fresh run every heartbeat. |
 
 **Isolation invariant — a run touches ONLY its own work.** It reads/writes only its `<rundir>`, only
 its `state.jsonl`, and only PRs carrying its `gauntlet-run-<run-id>` label (adopted PRs keep their own
@@ -82,18 +82,18 @@ Each run has `<rundir>/lease.json`:
 ```
 
 - **Mint** an agent token (`openssl rand -hex 4`) when you first take a run — at fresh-run start or on
-  adoption — keep it in context, **and put it in your self-wake prompt** (`--token <tok>`) so a
-  summarized/amnesiac wake recovers it from the prompt instead of guessing. **You own the run iff the
+  adoption — keep it in context, **and put it in your scheduled heartbeat prompt** (`--token <tok>`) so a
+  summarized/amnesiac heartbeat recovers it from the prompt instead of guessing. **You own the run iff the
   token you present (prompt `--token`, else in-context) equals the lease's `agent`.**
 - **Claim atomically.** Taking or adopting a run is a check-and-set that MUST be serialized against
   other agents: acquire an atomic lock first — `mkdir <rundir>/claim.lock` (fails if held) — then read
   the lease, decide, write your token + fresh `updated`, and `rmdir` the lock. Two agents racing to
   adopt can't both win because only one `mkdir` succeeds. (A crashed claim leaves a stale
   `claim.lock`; treat one whose mtime is older than a few minutes as abandoned and clear it.)
-- **Heartbeat.** Rewrite the lease with `updated = $(date +%s)` every wake once you're the confirmed
+- **Heartbeat.** Rewrite the lease with `updated = $(date +%s)` every heartbeat once you're the confirmed
   owner, **and** immediately before and after any long *foreground* step, should one be unavoidable,
   so a busy turn still looks alive. All long work — reviews, CI watches, and fix subagents —
-  is backgrounded, so turns stay short and the per-wake refresh normally suffices. A lease is
+  is backgrounded, so turns stay short and the per-heartbeat refresh normally suffices. A lease is
   **stale** only once `now - updated` exceeds **~30 min** — comfortably longer than any single
   foreground operation, so liveness flags a *dead* driver, not a busy one.
 - **Never hold the run hostage on a user prompt.** Do NOT block the loop waiting on a user answer —
@@ -103,25 +103,25 @@ Each run has `<rundir>/lease.json`:
   *campaign cannot move this PR without a human*, with `ci_reason` naming whatever it was. This file
   deliberately enumerates **no** blocker cases — `files-and-ledger.md`, `status`, `awaiting-user` class
   2, owns the class), surface the question, keep driving the other PRs, reschedule, and fold
-  the answer in when it lands as its own wake. Each class names the **durable record** it is answered into
+  the answer in when it lands as its own heartbeat. Each class names the **durable record** it is answered into
   and the **unpark** it triggers (`files-and-ledger.md`, `status`; `loop-control.md` step 3, "Only the
   user's answer unparks a PR") — a park with no defined exit is the wedge one level up (Constraints;
   `stage-2-review-gate.md`).
 - **Adopt only an orphaned run.** Safe to take over only when the lease is **absent or stale** (under
   the claim lock). After writing your token, re-read: if it isn't yours, you lost the race — stand down.
-- **Stand down if superseded.** On a self-wake, present your `--token`: if the lease is **fresh** and
+- **Stand down if superseded.** On a scheduled heartbeat, present your `--token`: if the lease is **fresh** and
   its `agent` is a **different** token, you were superseded (a takeover while you were hung) — do NOT
   drive; report and stop. Never overwrite a fresh lease you don't own. (Carrying the token in the
-  prompt removes any amnesia ambiguity — a self-wake always knows its own token.)
+  prompt removes any amnesia ambiguity — a scheduled heartbeat always knows its own token.)
 - **Release** on normal exit: delete `lease.json` (with the owner label) so the finished run shows no
   active driver.
 
-### Resolving a wake (Loop control step 1 applies this)
+### Resolving a heartbeat (Loop control step 1 applies this)
 
-1. **`--run <id>` given** (every self-wake; also a manual targeted resume). Load `<rundir>/state.jsonl`.
-   Under the claim lock, compare the token you present to the lease: **matches** (self-wake with
+1. **`--run <id>` given** (every scheduled heartbeat; also a manual targeted resume). Load `<rundir>/state.jsonl`.
+   Under the claim lock, compare the token you present to the lease: **matches** (scheduled heartbeat with
    `--token`) → refresh lease, reconcile, continue; **lease absent/stale** → adopt (write token, fresh
-   ts, read-back); **lease fresh but a different token** → for a self-wake, stand down (superseded);
+   ts, read-back); **lease fresh but a different token** → for a scheduled heartbeat, stand down (superseded);
    for a **manual** `--run` with no matching token, another agent appears active, so **confirm takeover
    with the user** before adopting.
 2. **Bare invocation** → the arg decides intent:

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -270,24 +270,24 @@ native worker's inherited session model is the implementation of `session`; reco
 the final report. Never guess a model name from the other host. An unavailable `economy` mapping raises
 cost but does not lower the gate.
 
-## Background work and wakeups
+## Background work and heartbeats
 
 Reviews, fixes, audits, reassessments, and CI watches remain asynchronous logical tasks. Fold a
 completion into the same reconcile loop regardless of the host mechanism that reports it.
 
 For the heartbeat fallback, choose exactly one lifecycle:
 
-1. **Scheduled-wake host:** schedule `<campaign-invocation> --run <run-id> --token <agent-token>` at the
+1. **Scheduled-heartbeat host:** schedule `<campaign-invocation> --run <run-id> --token <agent-token>` at the
    delay selected by `loop-control.md`, render status, and return. The future invocation begins at the
-   wake/reconcile entry.
+   heartbeat/reconcile entry.
 2. **Scheduler-less host:** keep the current campaign invocation alive, render status, and use the host's
    bounded wait/poll mechanism until the first task completion or protected 5-minute/15-minute deadline.
-   When that wait returns, go directly back to the wake/reconcile entry and repeat while non-terminal
+   When that wait returns, go directly back to the heartbeat/reconcile entry and repeat while non-terminal
    work remains. Do **not** take the scheduled-host return after a bounded wait.
 
-The second path is how Codex CLI sessions operate when no scheduled-wakeup capability is available. If
+The second path is how Codex CLI sessions operate when no scheduled-heartbeat capability is available. If
 the process is killed, durable run state and the lease takeover rules allow a later invocation to resume;
-the skill does not pretend a wake was scheduled when none was.
+the skill does not pretend a heartbeat was scheduled when none was.
 
 ## Reviewer selection and diversity
 

--- a/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
+++ b/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
@@ -33,12 +33,12 @@ Handling depends on the run's `api_changes` flag, stored in the ledger header:
   break, and ask whether to proceed. Keep working the other PRs meanwhile. On approval, apply it
   and set `api_approval: approved@<iso>` (the PR resumes normal gating); if the user declines,
   set `api_approval: declined@<iso>`, set the PR aside as skipped (status `aborted`), and report
-  it. Both decisions are durable: before re-asking on a later wake, check `api_approval` — a PR
+  it. Both decisions are durable: before re-asking on a later heartbeat, check `api_approval` — a PR
   already approved or declined is settled, never re-ask it.
 - **`allowed`** — proceed without asking. Set this *only* when the user, at invocation, explicitly
   said API breakage is acceptable (e.g. "allow API changes" / "ignore breakage").
 
-**Store the flag in the ledger and re-consult it every wake.** Derive the `api_changes` header field
+**Store the flag in the ledger and re-consult it every heartbeat.** Derive the `api_changes` header field
 (`ask` | `allowed`) once from the invocation and record it via `ledger.py --file <state.jsonl> header
 set api_changes <ask|allowed>`. A run is long, so NEVER trust in-context
 memory for this — re-read the flag from the ledger before any API-affecting change, so the behavior

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -1,7 +1,7 @@
 ### 2b. CI (event-driven)
 
 Each PR has a background task that waits on `gh pr checks --watch`. **The watch only BLOCKS — it is
-never evidence.** When the task completes, a wake **fetches a fresh snapshot pinned to the PR's current
+never evidence.** When the task completes, a heartbeat **fetches a fresh snapshot pinned to the PR's current
 `head_sha`**, verifies it, and decides `ci` **from the snapshot's contents — NEVER from the watch's exit
 code** — then writes the `ci`/`reviews_ok` result through `scripts/ledger.py … set --pr <N> --ci <state>
 [--reviews_ok 0]` **by field name** (`files-and-ledger.md`), never by hand-editing the row by column
@@ -9,7 +9,7 @@ position.
 
 #### THE DERIVATION IS A COMMAND — RUN IT. NEVER DERIVE `ci` BY READING TERMINAL OUTPUT.
 
-**The wake derives `ci` by RUNNING `scripts/ci-status.py`, and by nothing else:**
+**The heartbeat derives `ci` by RUNNING `scripts/ci-status.py`, and by nothing else:**
 
 ```sh
 python3 <skill>/scripts/ci-status.py derive --pr <N> --head-sha <the LEDGER's head_sha> --rundir <rundir> \
@@ -58,20 +58,20 @@ model **reading output and forming an impression** did. A program cannot get tir
 decide that "no checks" is close enough to "passing" — so that step is now a program. **The shell commands
 below are the SPEC the tool implements — they are documentation, NOT a second procedure to hand-run.**
 
-#### WHO DOES WHAT — the background task ONLY WATCHES; the WAKE fetches. This section is the DEFINITION.
+#### WHO DOES WHAT — the background task ONLY WATCHES; the HEARTBEAT fetches. This section is the DEFINITION.
 
 **This split is normative, and every other file defers to it** (`pr-adoption.md`, `loop-control.md`):
 
 | Actor | Does | Does NOT |
 |---|---|---|
-| **The background task** | **BLOCKS on `gh pr checks <pr> --watch`, and NOTHING else.** Its **ONLY** job is to block, so that **its completion becomes a wake**. | It **NEVER** fetches, **NEVER** writes `ci-<pr>-<head_sha>.txt`, and **NEVER** produces evidence of any kind. |
-| **The wake** | **RUNS `scripts/ci-status.py derive`** (above), which **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci`. | It **NEVER** derives `ci` by READING the output of `gh pr checks` — or of anything else. |
+| **The background task** | **BLOCKS on `gh pr checks <pr> --watch`, and NOTHING else.** Its **ONLY** job is to block, so that **its completion becomes a heartbeat**. | It **NEVER** fetches, **NEVER** writes `ci-<pr>-<head_sha>.txt`, and **NEVER** produces evidence of any kind. |
+| **The heartbeat** | **RUNS `scripts/ci-status.py derive`** (above), which **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci`. | It **NEVER** derives `ci` by READING the output of `gh pr checks` — or of anything else. |
 
 **WHY the fetch cannot live in the background task:** the fetch must be pinned to the `head_sha` **the
-LEDGER currently holds**, and **only the wake knows that**. A background task that fetched at its own
+LEDGER currently holds**, and **only the heartbeat knows that**. A background task that fetched at its own
 completion time would pin to whatever SHA *it* saw and could **promote an artifact for a SHA the ledger has
 already moved past** — the exact false-green this section exists to prevent, smuggled back in through the
-producer. **A watch completion yields a WAKE, never an artifact.**
+producer. **A watch completion yields a HEARTBEAT, never an artifact.**
 
 **NEVER derive CI from `gh pr checks`.** Its output **carries no SHA at all** (`--json headSha` →
 *Unknown JSON field*), so you can never prove which commit it describes — right after a push it can
@@ -845,8 +845,8 @@ ever re-ordered again.
     dropped**, and it outranks `pending`: a still-running row does **not** postpone the park.
 - **pending** → any evidence row classifies `RUNNING` → leave `ci = pending`. **This is the ONLY outcome
   that warrants a watch** ("WATCH ONLY WHAT CAN MOVE" below): a row can still move on its own, so if the
-  watch task has exited, **relaunch it in this same wake** — a PR with a still-RUNNING row must never sit
-  unwatched waiting for the fallback wake. **It is also BOUNDED**: "a row can still move" is a claim the row
+  watch task has exited, **relaunch it in this same heartbeat** — a PR with a still-RUNNING row must never sit
+  unwatched waiting for the fallback heartbeat. **It is also BOUNDED**: "a row can still move" is a claim the row
   makes, not a promise it keeps, so if the whole check set then sits unchanged for the CI STALL CAP, the
   PR escalates ("RUNNING-STALL", below). `pending` is not a place a PR may live forever.
 - **pending (nothing registered)** → the snapshot lists **zero evidence rows**. **Zero evidence rows is NOT
@@ -857,7 +857,7 @@ ever re-ordered again.
   SEE?" below). We do not know what this commit was supposed to show, so **no snapshot of it can be
   green** — not even an all-`PASS` one. **Do NOT watch it**: no row moving would answer the question that
   is open. It is **bounded like every other `pending`**: nothing is RUNNING, so SETTLED below strikes it
-  and escalates at the STRIKE CAP, naming the read that failed. Re-attempt the read each wake while it is
+  and escalates at the STRIKE CAP, naming the read that failed. Re-attempt the read each heartbeat while it is
   `unknown` — a transient failure clears itself well inside that budget.
 - **pending (required check missing)** → `required_set` is **DECLARED** and a declared required check has
   **no row** in the snapshot (matched on name **and** producer — below). **A check that has not registered
@@ -893,7 +893,7 @@ TOKEN's grants** — so a fine-grained token owned by an admin reads `admin: tru
 `Administration: read`. **A rule keyed on that probe declares "proven unprotected" on a branch it simply
 cannot see.**
 
-Run the required-set command before CI derivation on every wake:
+Run the required-set command before CI derivation on every heartbeat:
 
 ```sh
 python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl [--repo <owner>/<repo>]
@@ -904,7 +904,7 @@ GitHub call to one repository, reads both declaration sources, validates every r
 sorts the declarations, validates the result through `ci-snapshot.py`'s strict parser, and writes the
 canonical value through `ledger.py`'s atomic store. It exits 0 for a settled `declared:…` or `none`, 1 for
 `unknown`, and 2 for a caller or ledger error. A settled value is returned without another GitHub read, so
-the same command is safe to run on every wake and retries only an `unknown` value.
+the same command is safe to run on every heartbeat and retries only an `unknown` value.
 
 The command owns two mandatory reads. They do **not** need the same permission: **`GET
 /repos/{o}/{r}/branches/{b}` needs `Contents: read`**, while **`GET
@@ -937,7 +937,7 @@ state it does not have** (`files-and-ledger.md` owns the field; this block owns 
 
 **WHEN: read it once per run, before the first CI derivation** — it is a property of `base_branch`, which is
 itself set once (`files-and-ledger.md`, "Base branch"), so one read serves every PR in the run. **And read
-it AGAIN, every wake, for as long as it is `unknown`** — that is the whole of its retry policy, and it is
+it AGAIN, every heartbeat, for as long as it is `unknown`** — that is the whole of its retry policy, and it is
 what keeps a transient failure (a network blip, a rate limit) from parking PRs that were never really
 blocked: a read that recovers before the STRIKE CAP costs the run nothing at all. **Once it is `declared:…`
 or `none`, it is SETTLED — do not re-read it**, and never overwrite a successful read with a later failure.
@@ -1102,7 +1102,7 @@ file kills on sight (CLASSIFY, above).
 REPAIRING.** `SETTLED` and `RUNNING-STALL` are about **CI**, not about **campaign**: a **red** PR whose
 rows are all terminal is SETTLED on the **first** derivation, and a CI-fix subagent in flight does **not**
 change `head_sha` until it pushes — so an ungated strike rule would park, within the **STRIKE CAP**'s worth
-of wakes, the exact PR the driver is actively fixing, and an ungated stall clock would start timing a
+of heartbeats, the exact PR the driver is actively fixing, and an ungated stall clock would start timing a
 `RUNNING` row the driver is about to make irrelevant.
 
 **MACHINE ACTION** = **any work campaign dispatches that can produce a new `head_sha` on this PR.** That
@@ -1135,11 +1135,11 @@ test `loop-control.md` step 3 already applies** to suppress a duplicate dispatch
 already in flight for that PR/SHA"). The strike rule and the stall clock read that same fact; they do not
 invent a second one.
 
-**Due** = **this wake would launch it** — it is not in flight, and nothing but a free concurrency slot is
+**Due** = **this heartbeat would launch it** — it is not in flight, and nothing but a free concurrency slot is
 missing. That, too, is a **property, not a fixed list of scans**: whichever rule OWNS that dispatch is the
 one that says so. For a CI fix it is `loop-control.md` step 3's dispatch scan; for a rebase it is the rule
 that owns the rebase (Stage 2a's preconditions, `stage-2-review-gate.md`; the step-6 reconcile,
-`stage-3-merge.md`) finding the PR behind/conflicting on this wake. A PR **frozen by a park** has **no**
+`stage-3-merge.md`) finding the PR behind/conflicting on this heartbeat. A PR **frozen by a park** has **no**
 machine action due — the held-status guard forbids every one of them (`loop-control.md`), so nothing is
 coming, which is why the park is the terminus and not another wait.
 
@@ -1186,17 +1186,17 @@ too.** A park whose exit event never comes is the same wedge, one level up. So t
 - **Records that answer DURABLY in the ledger's `blocker_ruling`** (`files-and-ledger.md`) the moment it
   lands, and unparks per `loop-control.md` step 3, "Only the user's answer unparks a PR" — which also
   **clears the liveness counters**, so the retry gets a fresh budget instead of re-escalating on its first
-  derivation. A wake may be a fresh agent instance: an answer that lives only in the driver's head is an
+  derivation. A heartbeat may be a fresh agent instance: an answer that lives only in the driver's head is an
   answer that gets re-asked.
 
 **NOTHING THIS SECTION RELIES ON LIVES IN THE DRIVER'S HEAD — and that is a PROPERTY, not the list that
-used to stand here.** A wake may be a fresh agent instance, so: **if a LATER derivation, the escalation
+used to stand here.** A heartbeat may be a fresh agent instance, so: **if a LATER derivation, the escalation
 prompt, or the unpark has to read it, it is a LEDGER FIELD.** The durable set is therefore **the ledger row
 schema itself** — `files-and-ledger.md`'s row-field definitions, and the `ROW_FIELDS`/`ROW_DEFAULTS` in
 `scripts/ledger.py` that own it — and a field added there is durable **with no edit to this section**. A
 list retyped here rots the next time one is added, and the one that stood here rotted **twice**: it first
 dropped `ci_reason`, the very thing the park asks the user about, and its replacement dropped
-`ci_fingerprint`, without which every wake sees CI as having moved and **no bound ever fires at all**.
+`ci_fingerprint`, without which every heartbeat sees CI as having moved and **no bound ever fires at all**.
 There is no third attempt: **the members are not retyped here, in any form, marked or not.** Write every
 one of them through `scripts/ledger.py … set --pr <N>` **by field name**, like every other field
 (`files-and-ledger.md`).
@@ -1207,11 +1207,11 @@ added to the schema tomorrow is already covered here:
 - **A COUNTER that dies never reaches its cap.** A fresh instance restarts the count from zero, so the
   bound never fires.
 - **A CLOCK is worse**: it does not merely lose the elapsed time, it **silently restarts** it. Every clock
-  is therefore a **timestamp on disk**, so that **any** wake computes the elapsed time from the ledger
+  is therefore a **timestamp on disk**, so that **any** heartbeat computes the elapsed time from the ledger
   alone, remembering nothing.
 - **EVIDENCE OF WHAT CI LOOKED LIKE LAST TIME is worse still, because losing it looks like SUCCESS.** The
   derivation decides that CI **moved** by comparing this snapshot against what the row says it saw before;
-  with that gone, **every** wake sees motion, **every** wake resets the counters and the clock, and the
+  with that gone, **every** heartbeat sees motion, **every** heartbeat resets the counters and the clock, and the
   bounds never fire — the wedge this whole section exists to close, reopened silently and with no error.
 - **A REASON that dies leaves the park UNANSWERABLE.** The escalation prompt above is built from the
   blocker the human is being asked to rule on; a fresh agent that lost it cannot even ask the question, so
@@ -1223,7 +1223,7 @@ itself.** `blocker_ruling` must be **DURABLE** (it survives a context loss) **AN
 answers the park it was written for, and no other). Both halves, or neither holds:
 
 - **ENTERING a machine-blocker park sets `blocker_ruling` = `-`** (ESCALATE above), in the **same**
-  `ledger.py … set` call that writes `status = awaiting-user` — one atomic row write, so no wake can ever
+  `ledger.py … set` call that writes `status = awaiting-user` — one atomic row write, so no heartbeat can ever
   observe a freshly parked row still carrying the previous park's answer.
 - **CONSUMING a `retry` sets it back to `-`** in the same call that unparks the PR (`loop-control.md`
   step 3).
@@ -1309,8 +1309,8 @@ the healthy build**, and a rule that parks healthy PRs gets turned off, which le
 
 **THE BOUND IS A DURATION, NOT A DERIVATION COUNT. This is a deliberate choice and it is the crux.**
 
-- **A derivation count measures the RUN'S LOAD, not this PR's CI.** Derivations are driven by **wakes**,
-  and a wake is the fallback lifecycle (**a ~5–15 min scheduled heartbeat or bounded wait returning**,
+- **A derivation count measures the RUN'S LOAD, not this PR's CI.** Derivations are driven by **heartbeats**,
+  and a heartbeat is the fallback lifecycle (**a ~5–15 min scheduled heartbeat or bounded wait returning**,
   `loop-control.md` step 5) **or any background task, on ANY PR, completing**. So on a busy run three
   derivations can land within seconds of one another — a
   derivation bound would park a 40-minute build that had barely started, for no reason but that **other**
@@ -1323,7 +1323,7 @@ the healthy build**, and a rule that parks healthy PRs gets turned off, which le
   SETTLED PR has **nothing that could move** — there is no slow-vs-dead question to answer.
 - **It is computed FROM DISK, never from the driver's memory of when it last looked.** `ci_stalled_since`
   is a UTC ISO-8601 timestamp in the **ledger**; `now - ci_stalled_since` is a subtraction any fresh agent
-  instance can do on its first wake. A duration accumulated in context is a duration that resets to zero
+  instance can do on its first heartbeat. A duration accumulated in context is a duration that resets to zero
   every time the session dies — which is the failure that made these counters durable in the first place.
 
 **WHY IT DOES NOT PARK A HEALTHY SLOW CHECK.** The clock is **not** "how long the build has been running".
@@ -1359,9 +1359,9 @@ elsewhere** — refer to the cap **by name**.
 > is a coincidence**: change the cap to 4h and GitHub's limit still reads **6 hours**. Do not "unify"
 > them, and do not read that literal as a restatement to be swept.
 
-**Where the wake comes from while a stalled row is watched.** A hung `RUNNING` row keeps `gh pr checks
+**Where the heartbeat comes from while a stalled row is watched.** A hung `RUNNING` row keeps `gh pr checks
 --watch` **blocked forever**, so the watch never completes and never wakes anyone — the escalation is
-therefore evaluated by the fallback lifecycle like any other derivation. A scheduled-wake host uses a
+therefore evaluated by the fallback lifecycle like any other derivation. A scheduled-heartbeat host uses a
 heartbeat; a scheduler-less host keeps the invocation alive and loops after each bounded wait
 (`loop-control.md` step 5). **A bound that could only be reached by the event it is waiting for would not
 be a bound at all.**
@@ -1373,7 +1373,7 @@ about it — and "refetch until it works" is an absorbing state with no exit, wh
 It gets its own counter, on the same shape:
 
 ```
-snapshot for this head_sha is UNUSABLE  -> unusable_refetches += 1 ; refetch on the NEXT wake
+snapshot for this head_sha is UNUSABLE  -> unusable_refetches += 1 ; refetch on the NEXT heartbeat
 snapshot for this head_sha is VERIFIED  -> unusable_refetches = 0      # any usable outcome, incl. red/pending
 head_sha changed                        -> unusable_refetches = 0
 unusable_refetches >= 3                 -> ESCALATE (above)  # 3 == THE REFETCH CAP. This line is its ONE
@@ -1392,7 +1392,7 @@ unusable_refetches >= 3                 -> ESCALATE (above)  # 3 == THE REFETCH 
   snapshot raced a push — and a fresh fetch usually clears them; a SETTLED-but-not-green snapshot is,
   by construction, **not** transient. The extra headroom buys the transient case free retries, and it
   still terminates.
-- **The WAKE is the backoff — never tight-loop inside one.** UNUSABLE gets **no watch** ("WATCH ONLY WHAT
+- **The HEARTBEAT is the backoff — never tight-loop inside one.** UNUSABLE gets **no watch** ("WATCH ONLY WHAT
   CAN MOVE" below), so the next attempt arrives on the scheduled heartbeat, after one bounded wait, or
   on another task's completion. At most **one** refetch per reconcile.
 - On escalation `ci_reason` names **the VERIFY rule that failed and the line/row that failed it** (not
@@ -1406,19 +1406,19 @@ The watch is warranted by **a row that can still move**, never by the `ci` value
 
 | DECIDE outcome | Watch? |
 |---|---|
-| **pending** — an evidence row classifies `RUNNING` | **YES** — ensure a watch task is alive; relaunch it in this same wake if it has exited. **The watch is not the bound**: if that row never finishes, the watch blocks forever and RUNNING-STALL is what ends it, on the fallback wake. |
+| **pending** — an evidence row classifies `RUNNING` | **YES** — ensure a watch task is alive; relaunch it in this same heartbeat if it has exited. **The watch is not the bound**: if that row never finishes, the watch blocks forever and RUNNING-STALL is what ends it, on the fallback heartbeat. |
 | **pending (nothing registered)** — zero evidence rows | **NO.** Nothing to block on. SETTLED escalates it. |
 | **pending (required check missing)** — a declared check has no row | **NO.** Every row present is terminal (a running one would have matched plain `pending` above), so nothing can move. SETTLED escalates it, naming the check. |
-| **pending (required set unreadable)** — `required_set` is `unknown` | **NO.** The open question is what the base branch REQUIRES; no row finishing would answer it. Re-attempt the read each wake; SETTLED escalates it. |
+| **pending (required set unreadable)** — `required_set` is `unknown` | **NO.** The open question is what the base branch REQUIRES; no row finishing would answer it. Re-attempt the read each heartbeat; SETTLED escalates it. |
 | **red** — but some row still `RUNNING` | **YES** — that row can still move; the CI fix runs regardless. |
 | **red** — every row terminal | **NO.** The CI fix moves it, not the watch. |
 | **UNKNOWN_VALUE** | **NO.** The park is the resolution. |
-| **UNUSABLE** | **NO.** Refetch on the **next wake** (the wake *is* the backoff), **bounded by the REFETCH CAP** — then ESCALATE ("UNUSABLE — the refetch is BOUNDED"). |
+| **UNUSABLE** | **NO.** Refetch on the **next heartbeat** (the heartbeat *is* the backoff), **bounded by the REFETCH CAP** — then ESCALATE ("UNUSABLE — the refetch is BOUNDED"). |
 | **green** | **NO.** |
 
 **NEVER relaunch the watch merely because `ci == pending`.** On a settled PR `gh pr checks --watch`
 **exits in about a second** — there is nothing left to block on — and a task completion is **itself a
-wake**. So "pending → relaunch the watch" on a settled-but-not-green PR burns a **fresh-context wake
+heartbeat**. So "pending → relaunch the watch" on a settled-but-not-green PR burns a **fresh-context heartbeat
 every second or two, forever**, doing nothing. Watch only when at least one row can still move.
 
 #### Any campaign commit to the PR head resets the gate
@@ -1437,7 +1437,7 @@ Every one of them MUST, in the same step:
   **resets the liveness counters** ("THE LIVENESS COUNTERS" above), so the PR gets a clean budget.
   **NEVER launch the watch unconditionally on the push**: at that instant the checks may not have
   registered yet, the snapshot holds **zero evidence rows**, and `gh pr checks --watch` would exit in
-  about a second — a wake per second, forever, on a PR nothing is watching *for*;
+  about a second — a heartbeat per second, forever, on a PR nothing is watching *for*;
 - **re-enter Stage 2a.**
 
 The verdicts on the old SHA describe content that no longer exists, and a `gauntlet-accepted` label on

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -4,7 +4,7 @@
 
 Before the review gauntlet, triage each PR to a **risk tier**. Triage is **deterministic** and
 **size-agnostic** — there are **NO line-count or file-count thresholds**; only *what kind* of file the
-PR touches and whether the change is systemic. Re-derive the tier **every wake** from the PR's current
+PR touches and whether the change is systemic. Re-derive the tier **every heartbeat** from the PR's current
 `head_sha` and pin it there; record it in the ledger `tier` column via `scripts/ledger.py … set --pr
 <N> --tier <tier>` (by field name — the schema-owning accessor, `files-and-ledger.md`; never hand-edit
 the row by column position). Default to **STANDARD** whenever you are unsure. `reviews_ok` target = `required(tier)`: **1 if `tier==TRIVIAL`, else 2**.
@@ -33,7 +33,7 @@ the row by column position). Default to **STANDARD** whenever you are unsure. `r
 - Re-triage and **escalate** (never de-escalate below what the content warrants) when: a `NOT
   SATISFIED` lands, a `plan_amendment_request` is raised, or a content change **adds a
   CODE/agent-doc/SENSITIVE file** to a PR that was TRIVIAL.
-- Tier is pinned to `head_sha` and re-derived every wake; on any uncertainty default STANDARD.
+- Tier is pinned to `head_sha` and re-derived every heartbeat; on any uncertainty default STANDARD.
 
 ### 2a. The review gauntlet
 
@@ -45,7 +45,7 @@ precondition fix (including the conflict rebase below), no CI fix, no review fix
 else that changes it (`loop-control.md` step 3, "held-status guard" — the governing property; these
 are only examples). Held leaves
 `reviews_ok < required(tier)`, so the review-launch rule MUST read `status` too — otherwise the next
-wake re-reviews a PR that is **waiting on a HUMAN** (a park) and a `SATISFIED` verdict merges it **without
+heartbeat re-reviews a PR that is **waiting on a HUMAN** (a park) and a `SATISFIED` verdict merges it **without
 the user's ruling**, or re-reviews a PR that has **stopped converging** (`repairing`) and spends round 22
 of a loop that has already been told to stop. The park does **not** change its CI watch either way — observing is not mutating, so the
 watch follows the normal policy (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE": alive while a row can still
@@ -82,9 +82,9 @@ Only launch a review pass once all three are clear for the current tip.
 
 Run reviews **one at a time per PR** — never two at once for the same SHA. When a PR's tip
 (`head_sha`) has fewer than `required(tier)` SATISFIED verdicts (2, or 1 for TRIVIAL) and no review
-already running for it, the wake's dispatch step launches **one** review pass by the selected reviewer
+already running for it, the heartbeat's dispatch step launches **one** review pass by the selected reviewer
 (see "The reviewer") — a **fresh**, context-isolated pass over the whole `origin/<base>...HEAD` diff, run as
-a **background** task (its completion is a wake; the loop folds the verdict in at step 2). For a
+a **background** task (its completion is a heartbeat; the loop folds the verdict in at step 2). For a
 `required==2` tier the second, corroborating review is launched only **after** the first comes back
 SATISFIED — so a still-broken commit never burns the second review before the first has said "fix it"
 (a TRIVIAL PR needs no second pass). (Reviews for *different* PRs still run concurrently, up to the ~8
@@ -135,7 +135,7 @@ file is a plaintext file in a directory the reviewer can write to.
 The hand-written artifacts are what this replaces, and each had already failed: a `printf`-ed
 `pass_identity` put a **TRUNCATED SHA** into real state; the emit tool accepted a `done` for a unit that
 **was never planned** (the rule was prose, enforced by nobody); and the tally was re-derived by eye with
-an ad-hoc parser written fresh each wake — the same "read it by eye, write down the answer" that produced
+an ad-hoc parser written fresh each heartbeat — the same "read it by eye, write down the answer" that produced
 a false `ci = green`. `verify` refuses a short sha, a malformed identifier of any kind, an unplanned unit,
 an evidence-free `done`, a `done`
 that no `started` precedes, a SECOND `done` for a unit already finished, a `pass_identity` that names
@@ -225,7 +225,7 @@ Rules:
   event naming the gap rather than silently reviewing only the listed units — an unraised omission is a
   reviewer failure. Requesting an amendment is the *only* sanctioned response: the reviewer never
   rewrites the plan or self-grants units, and unapproved amendments do NOT count as plan units. The
-  orchestrator folds that request on the next wake and either updates the plan + restarts the review
+  orchestrator folds that request on the next heartbeat and either updates the plan + restarts the review
   pass, or ignores it with a note; the reviewer completes the existing units meanwhile.
 
 Progress JSONL schema. Unit-progress events use the REQUIRED exact key names verbatim; `type` is
@@ -310,7 +310,7 @@ fires — **and unless it PARSES as a real moment**: `2026-99-99T99:99:99Z` has 
 a month 99 is not a month; the deadline is arithmetic on this value, so a shape check alone cannot protect
 it). Three rules depend on it: a late verdict is ignored unless its attempt
 id still matches the active pass; `dispatched_at` is the clock the launch check below measures against;
-and `launch_attempt` (`1`, then `2` on a relaunch) is how a *later wake* — possibly a fresh agent —
+and `launch_attempt` (`1`, then `2` on a relaunch) is how a *later heartbeat* — possibly a fresh agent —
 knows whether this pass has already been relaunched once. A progress file holding **only** this line is
 therefore evidence that the reviewer has produced nothing — not evidence of a missing file.
 
@@ -404,7 +404,7 @@ Meaningful progress = a `done` event for a planned unit, or an accepted plan ame
 events and vague "still working" lines prove only process liveness and MUST NOT reset the meaningful
 progress timer. The reviewer MUST append progress events immediately as units complete, not batch them
 at final output. If no meaningful progress lands for ~15 min while the review process is still alive,
-mark the review suspicious; if it remains stale on the next wake, treat it as a reviewer system
+mark the review suspicious; if it remains stale on the next heartbeat, treat it as a reviewer system
 failure: apply `reviewer.md`'s retry budget and `runtime-adapter.md`'s owned transition. Ignore any
 late verdict from a stale/superseded attempt unless its attempt id still matches the active review pass.
 
@@ -458,7 +458,7 @@ So the question changes, and every rule below follows from it:
 > THREAT MODEL?**
 
 The intent block is `<rundir>/intent-<pr>.md`, written at adoption (`pr-adoption.md`) and re-read every
-wake — never re-derived, because a wake is a fresh agent instance and an intent invented twice is two
+heartbeat — never re-derived, because a heartbeat is a fresh agent instance and an intent invented twice is two
 intents. It is **local, git-ignored driver bookkeeping**: campaign never writes it back to the PR.
 
 ```markdown
@@ -780,7 +780,7 @@ boundary; a future adapter that proves `os_filesystem_isolation` supplies aliase
 
 **Before a verdict is tallied at all, verify the pass's artifacts.** A verdict is only worth as much as
 the pass that produced it, and "was this pass real?" was, until now, decided by reading three files by eye
-with a parser written fresh each wake. That is precisely how a driver read `gh pr checks` by eye and wrote
+with a parser written fresh each heartbeat. That is precisely how a driver read `gh pr checks` by eye and wrote
 `ci = green` on zero evidence — the same hole, one layer up.
 
 ```
@@ -849,7 +849,7 @@ indistinguishable from an earned one, so the door is simply not there.
 not a verdict — no round happened — and the table below lists every site that owes it.)
 
 **`review_rounds` is the loop's only memory, and it is NEVER reset** — not by a fix, not by a rebase, not by
-a content change, not by a re-triage. Every wake is a fresh context: without it, **no rule that depends on
+a content change, not by a re-triage. Every heartbeat is a fresh context: without it, **no rule that depends on
 "how many rounds has this PR taken" can ever fire.** That is not hypothetical. It is how PR #42 ran **21
 review rounds** while a "hard backstop" that triggers on the *second* `NOT SATISFIED` sat in this skill,
 unfired — the trigger is a fact about history, and nothing recorded any history. The final ledger row read
@@ -890,7 +890,7 @@ Then, per verdict:
   dispatch a scoped fix subagent** into `<worktree>` (the PR row's ledger `worktree` column value) with
   the **audited** issue list (**CONFIRMED + ADJUSTED only**); it
   commits + pushes → HEAD advances (a second gate reset — relabel again if the first was somehow
-  skipped). A later wake starts a fresh review on the new tip. (Because reviews are sequential, no
+  skipped). A later heartbeat starts a fresh review on the new tip. (Because reviews are sequential, no
   second review was spent on this broken commit.) Any **REFUTED** finding is **written into the tree** —
   an inline comment at the site stating why the mechanism cannot occur — and committed like any other
   change, so the next reviewer reads it and can flag it if it is wrong. That commit is PR content: it
@@ -919,7 +919,7 @@ Then, per verdict:
   --reviews-ok`, which refuses to raise the tally). It **never** trips a review-loop cap. The gate is met
   once this SHA holds `required(tier)` SATISFIED verdicts
   (2, or 1 for TRIVIAL). If the tally is still short of the target — e.g. the **first** SATISFIED on a
-  `required==2` PR — the next wake launches the next (corroborating) review on the same SHA. When the
+  `required==2` PR — the next heartbeat launches the next (corroborating) review on the same SHA. When the
   tally **reaches** `required(tier)` on the same SHA, the review gate is met for this HEAD — swap the
   PR's label: `gh pr edit <pr> --remove-label gauntlet-reviewing --add-label gauntlet-accepted`.
 
@@ -1069,7 +1069,7 @@ worker reviewer and a `codex exec` reviewer both receive it.
   review pass, a CI fix, a review fix, or a merge for that PR (`loop-control.md` step 3;
   `stage-3-merge.md`) — `reviews_ok` stays 0, so a re-review would let a `SATISFIED` verdict merge the PR
   with the disputed finding never adjudicated. Only the user's answer unparks it (`status` →
-  `in_review`), and **the ruling is recorded durably in `<rundir>/audit-<pr>-<n>.md`** — a wake may be a
+  `in_review`), and **the ruling is recorded durably in `<rundir>/audit-<pr>-<n>.md`** — a heartbeat may be a
   fresh agent instance, and an answer held only in context is one the user is asked for twice
   (`loop-control.md` step 3, "Only the user's answer unparks a PR"). Ruling the finding **invalid** → drop
   it and return to the normal flow; **valid** → fix it exactly like a CONFIRMED finding.
@@ -1152,7 +1152,7 @@ is only ever as true as the moment it was last written.
 gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing
 ```
 
-Never write the ledger reset and defer the label to "the next wake". A `gauntlet-accepted` label on a
+Never write the ledger reset and defer the label to "the next heartbeat". A `gauntlet-accepted` label on a
 PR whose live content no longer holds `required(tier)` verdicts is a **false public claim that the PR
 passed its gauntlet** — the label is what a human reads on GitHub, and it is the one part of this
 run's state that is visible to people who will never see the ledger. Between the reset and the next
@@ -1169,7 +1169,7 @@ that drop `reviews_ok` to 0):
 | Copilot-item fix pushed | Stage 2a preconditions, above |
 | Conflict-resolving rebase — at **either** of the two sites that rebase a PR | **Stage 2a preconditions, above** (the pre-review rebase of a `CONFLICTING`/`DIRTY`/`BEHIND` PR) **and** `stage-3-merge.md`'s step-6 reconcile. Naming only one of them is how the relabel goes missing at the other; the *event* owes the relabel, wherever it happens |
 | Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |
-| Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the wake that *detects* it resets the gate, so it relabels there |
+| Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the heartbeat that *detects* it resets the gate, so it relabels there |
 
 **Every row names a place where `reviews_ok` is written to 0 — never "the reconcile pass".** The
 label-reconcile in Loop control is the backstop that *heals* a missed swap; naming it as the mechanism
@@ -1187,5 +1187,5 @@ resets the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS") — th
 off **different** events, and this row is exactly where they part company.
 
 **Reconcile is the backstop, not the mechanism.** Loop control re-derives every label from the live
-gate each wake so a missed swap self-heals, exactly as the CI-watch heartbeat backstops a missed watch.
+gate each heartbeat so a missed swap self-heals, exactly as the CI-watch heartbeat backstops a missed watch.
 Relying on it as the primary path is the bug this rule exists to prevent.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -62,13 +62,13 @@ catch-all and parks a PR that nothing was wrong with.
 | **any other value** | GitHub added one | **park `awaiting-user`**, naming the value. Never guess. |
 
 **The UNKNOWN re-poll bound.** `UNKNOWN` is a value GitHub has **not computed yet** — it is not a verdict,
-and it resolves within seconds once GitHub finishes computing mergeability lazily. Re-poll it **in-wake up
+and it resolves within seconds once GitHub finishes computing mergeability lazily. Re-poll it **in-heartbeat up
 to 3 times**, with a short backoff between re-polls (a few seconds) — the initial Stage-3 fetch that
 returned `UNKNOWN` is what triggers this loop and is **not** one of the three. If it is **still** `UNKNOWN`
-after the third re-poll, do **NOT** merge on this wake — leave the PR and let the **next wake** re-evaluate it: **the
-wake is the backoff** (`stage-2-ci.md`, "The WAKE is the backoff — never tight-loop inside one"). A value
-that stays `UNKNOWN` across wakes is bounded by the wake cadence, so **no persisted counter is needed** —
-the in-wake cap is a fixed 3, and the coarse retry is the wake loop itself. Never read `UNKNOWN` as
+after the third re-poll, do **NOT** merge on this heartbeat — leave the PR and let the **next heartbeat** re-evaluate it: **the
+heartbeat is the backoff** (`stage-2-ci.md`, "The HEARTBEAT is the backoff — never tight-loop inside one"). A value
+that stays `UNKNOWN` across heartbeats is bounded by the heartbeat cadence, so **no persisted counter is needed** —
+the in-heartbeat cap is a fixed 3, and the coarse retry is the heartbeat loop itself. Never read `UNKNOWN` as
 `MERGEABLE`, and never let a perpetually-`UNKNOWN` PR either merge or wedge.
 
 **EVERY `awaiting-user` park in this table is a MACHINE-BLOCKER park, and it MUST declare its exit** — a
@@ -92,7 +92,7 @@ blocker instead.**
 **`UNSTABLE` means non-*passing*, which includes *pending*.** Treating it as red would dispatch a CI-fix
 subagent at a check that is merely **still running**.
 
-1. **Serialize merge operations, not wakes.** A wake may merge multiple PRs, but only one at a time.
+1. **Serialize merge operations, not heartbeats.** A heartbeat may merge multiple PRs, but only one at a time.
    Before each merge, re-confirm the PR is still **not parked** and that both gates still hold against the live PR head SHA
    (`gh pr view <pr> --json headRefOid --jq .headRefOid`, PR number from the ledger row) — a late push
    may have moved the tip past the recorded `head_sha` and reset the gates —
@@ -200,7 +200,7 @@ subagent at a check that is merely **still running**.
    "THE LIVENESS COUNTERS"); a conflict-resolving rebase would reset
    `reviews_ok`, relabel, and relaunch work — and would **change the PR's content**, which can invalidate
    the very refutation or API change the user was parked to adjudicate. **A parked PR that has fallen
-   behind simply STAYS behind** until the user answers; it is re-reconciled normally on the wake after it
+   behind simply STAYS behind** until the user answers; it is re-reconciled normally on the heartbeat after it
    unparks. **Do NOT drop its row** — it stays in the run, and the park **does not change its CI watch
    either way** (observation, not mutation): the watch follows the normal policy (`stage-2-ci.md`, "WATCH
    ONLY WHAT CAN MOVE") — relaunched while a row is still RUNNING, **not** relaunched once CI has settled.
@@ -211,7 +211,7 @@ subagent at a check that is merely **still running**.
      **keep its status label as-is** (the gate did not reset, so an accepted PR stays
      `gauntlet-accepted`), update `head_sha` to the new tip, set `ci = pending`, **reset the liveness
      counters** (new commit, new evidence — `stage-2-ci.md`, "THE LIVENESS COUNTERS"), **and re-derive CI
-     from a snapshot of the new tip in the same wake, launching a watch only if that snapshot holds a
+     from a snapshot of the new tip in the same heartbeat, launching a watch only if that snapshot holds a
      still-RUNNING row** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched until the
      heartbeat while its checks are running — but it must not be watched when **nothing** is running
      either, which right after a push is the common case (no check has registered yet). CI must return
@@ -227,7 +227,7 @@ subagent at a check that is merely **still running**.
      Stage 2.
    - Still open, **not parked**, mergeable, not behind/dirty/conflicting, same live `head_sha`,
      `reviews_ok >= required(tier)`, and `ci == green` → still immediately mergeable; return to step 1
-     in the same wake.
+     in the same heartbeat.
 
 Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -143,7 +143,7 @@ def check_fixture(name: str, got: dict, fx: dict) -> list[str]:
     if got["ci"] != want["ci"]:
         bad.append(f"ledger ci {got['ci']!r}, expected {want['ci']!r}")
     if want.get("promoted") is False and got["snapshot"] is not None:
-        bad.append("an artifact was PROMOTED for a fetch that FAILED — a later wake would read it as evidence")
+        bad.append("an artifact was PROMOTED for a fetch that FAILED — a later heartbeat would read it as evidence")
     return bad
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1268,7 +1268,7 @@ def promote(rows: list[dict], rundir: Path, pr: str, head_sha: str) -> Path:
 
     Nothing is promoted unless every fetch SUCCEEDED: this is only ever called after `build_snapshot`
     returns, and any FetchError above aborts before this line. A partial artifact is not a snapshot, and a
-    half-written one left in <rundir> is worse than none — a later wake would read it as evidence.
+    half-written one left in <rundir> is worse than none — a later heartbeat would read it as evidence.
     """
     tmp = rundir / f".ci-{pr}.{os.getpid()}"
     tmp.write_text("".join(json.dumps(r, ensure_ascii=False) + "\n" for r in rows), encoding="utf-8")
@@ -1320,7 +1320,7 @@ def derive(fetch: Fetch, repo: str, pr: str, head_sha: str, rundir: Path, requir
     try:
         rows, head_now, evidence = build_snapshot(fetch, repo, pr, head_sha)
     except FetchError as exc:
-        # A source that could not be read leaves NO artifact — there is nothing on disk for a later wake to
+        # A source that could not be read leaves NO artifact — there is nothing on disk for a later heartbeat to
         # mistake for evidence, and no verdict is derived from a fetch we know to be incomplete. The
         # `promote` below is NEVER reached, and that is the whole of the "no partial artifact" rule.
         return result(pr, head_sha, SNAP.UNUSABLE, f"FETCH FAILED — {exc}", None, {}, None, required)

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/ci-status/fetch-fails.json
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/ci-status/fetch-fails.json
@@ -1,5 +1,5 @@
 {
-  "why": "a `gh` call that FAILED. There is no evidence, so there is no verdict from evidence — and NOTHING is promoted: a partial artifact left in the rundir is what a later wake would read as a snapshot. Treat it as fine and it derives GREEN off a fetch that never happened",
+  "why": "a `gh` call that FAILED. There is no evidence, so there is no verdict from evidence — and NOTHING is promoted: a partial artifact left in the rundir is what a later heartbeat would read as a snapshot. Treat it as fine and it derives GREEN off a fetch that never happened",
   "required_set": "none",
   "pr": "35",
   "api": {

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -354,7 +354,7 @@ def t_transition_graph(tmp: Path) -> None:
 def t_ruling_is_recorded(tmp: Path) -> None:
     """The USER'S RULING is stamped into `decided`; the driver's own bookkeeping is NOT.
 
-    A ruling that is not durable gets re-asked by the next wake — a fresh agent never saw the
+    A ruling that is not durable gets re-asked by the next heartbeat — a fresh agent never saw the
     conversation. It is the same reason the ledger's `api_approval` records `approved@<iso>` rather than
     living in the driver's head. `publish`/`open-pr` are the driver's own steps and must NOT stamp it: a
     `decided` written by anything but the user would launder the driver's action into the user's consent.

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -565,7 +565,7 @@ def load(path: Path) -> "list[dict]":
 def dump(path: Path, entries: "list[dict]", high: int) -> None:
     """Write the whole store ATOMICALLY — a temp file in the same directory, then `os.replace()`.
 
-    A partial write here is not a corrupt cache that the next wake heals: it is data that exists NOWHERE
+    A partial write here is not a corrupt cache that the next heartbeat heals: it is data that exists NOWHERE
     else. `os.replace()` is atomic on POSIX, so a reader (or a crash) sees either the old store or the
     new one, never half of one.
 

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -82,12 +82,12 @@ def t_no_heartbeat_refuses(work: Path) -> None:
 def t_no_heartbeat_refuses_on_an_absent_lease(work: Path) -> None:
     """The easy way to reintroduce the bug: check the proof only on the `owned` path.
 
-    A fresh run is the case with NO wake yet — exactly the one that must not sail through.
+    A fresh run is the case with NO heartbeat yet — exactly the one that must not sail through.
     """
     L.check(not lease_path(work).exists(), "fixture precondition: no lease yet")
     code, _out, _err = acquire(work, token="t1")
     L.check(code != 0, "an ABSENT lease must refuse without a proof too — a fresh run is the case with no "
-                       "wake armed yet, so checking only the `owned` path defeats the whole door")
+                       "heartbeat armed yet, so checking only the `owned` path defeats the whole door")
 
 
 def t_empty_heartbeat_is_not_a_proof(work: Path) -> None:
@@ -112,8 +112,8 @@ def t_argparse_must_not_steal_the_refusal(work: Path) -> None:
 
 
 def t_no_token_refuses_and_never_mints(work: Path) -> None:
-    """A caller with no token never armed a wake that identifies it: its proof cannot be real."""
-    code, _out, err = acquire(work, heartbeat="wake-1")
+    """A caller with no token never armed a heartbeat that identifies it: its proof cannot be real."""
+    code, _out, err = acquire(work, heartbeat="hb-1")
     L.check(code != 0, "acquire with NO --token must REFUSE")
     L.check(not lease_path(work).exists(), "a refused acquire must write NOTHING — and must NOT mint a "
                                            "token to make itself succeed")
@@ -124,7 +124,7 @@ def t_no_token_refuses_and_never_mints(work: Path) -> None:
 
 def t_proof_is_stored_verbatim(work: Path) -> None:
     """The tool never parses, normalizes, or validates the proof's content."""
-    hostile = "  wake id/with spaces --and-dashes é中 $(echo no) `echo no`  "
+    hostile = "  heartbeat id/with spaces --and-dashes é中 $(echo no) `echo no`  "
     code, out, _err = acquire(work, token="t1", heartbeat=hostile)
     L.check(code == 0, "a proof with odd bytes is still a proof — the tool does not inspect it")
     L.check(json.loads(out)["heartbeat"] == hostile, "the proof must round-trip VERBATIM")
@@ -136,13 +136,13 @@ def t_a_new_proof_is_not_a_generation_mismatch(work: Path) -> None:
     """Pins the REJECTED design out: `heartbeat` is a record, not a generation to match.
 
     An earlier draft compared the presented proof to the stored one and stood down on a mismatch. It could
-    never have worked: a wake has two things to say ("I am H1" / "I armed H2") and one flag to say them in.
+    never have worked: a heartbeat has two things to say ("I am H1" / "I armed H2") and one flag to say them in.
     """
-    acquire(work, token="t1", heartbeat="wake-1")
-    code, out, _err = acquire(work, token="t1", heartbeat="wake-2")
-    L.check(code == 0, "re-acquiring with a DIFFERENT proof is normal — each wake arms its own successor")
+    acquire(work, token="t1", heartbeat="hb-1")
+    code, out, _err = acquire(work, token="t1", heartbeat="hb-2")
+    L.check(code == 0, "re-acquiring with a DIFFERENT proof is normal — each heartbeat arms its own successor")
     L.check(verdict_of(out) == "owned", "same token on a fresh lease is `owned`, whatever the proof says")
-    L.check(json.loads(lease_path(work).read_text())["heartbeat"] == "wake-2",
+    L.check(json.loads(lease_path(work).read_text())["heartbeat"] == "hb-2",
             "the lease records the LATEST proof")
 
 
@@ -693,7 +693,7 @@ def t_lost_race_readback_refuses(work: Path) -> None:
 
 CASES = [
     ("no-heartbeat", "no proof of arming, no lease — the entire mechanism", t_no_heartbeat_refuses),
-    ("no-heartbeat-absent", "an ABSENT lease refuses too — a fresh run has no wake yet",
+    ("no-heartbeat-absent", "an ABSENT lease refuses too — a fresh run has no heartbeat yet",
      t_no_heartbeat_refuses_on_an_absent_lease),
     ("blank-heartbeat", "a whitespace proof is refused, never trimmed into a value",
      t_empty_heartbeat_is_not_a_proof),

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -7,7 +7,7 @@ guards against". It was also the ONLY durable store in the campaign with no sche
 have `ci-snapshot.py`. The lease had four reference docs and an `echo`.
 
 And it is not a value-write — it is a CHECK-AND-SET: take a lock, read, decide, write, read back, unlock,
-plus a stale-lock sweep and a staleness rule. Hand-rolled from prose, on every wake, by a fresh agent
+plus a stale-lock sweep and a staleness rule. Hand-rolled from prose, on every heartbeat, by a fresh agent
 instance that remembers nothing. In run `g260717-1748-d76f0acb` a driver hand-rolled it with
 `mkdir`/`openssl`/`echo`/`rmdir`, eyeballed the read-back instead of comparing tokens, and skipped the
 stale-lock sweep entirely. It was safe only because the lease was absent and nobody else was driving.
@@ -23,11 +23,11 @@ would otherwise do:
    superseded driver following that literally deletes the LIVE OWNER'S lease.
 3. **No `--heartbeat-id`, no lease.** The caller must hand over its proof that it has ALREADY armed the
    heartbeat. This tool never inspects the proof and takes the caller's word for it — which is exactly why
-   it must name something already done. Arming was step 6 of the wake skeleton, after all the interesting
+   it must name something already done. Arming was step 6 of the heartbeat skeleton, after all the interesting
    work, when an agent believes it is finished; it was skipped for an entire session and nothing noticed.
    Requiring it here moves the failure from "forgot at the end", which nothing catches, to "cannot start".
-4. **No `--token`, no lease** — and `acquire` never mints one. The wake carries `--token`, so a caller
-   without one demonstrably never armed a wake that identifies it: its proof cannot be real.
+4. **No `--token`, no lease** — and `acquire` never mints one. The heartbeat carries `--token`, so a caller
+   without one demonstrably never armed a heartbeat that identifies it: its proof cannot be real.
 
 A future `updated` (clock skew) reads as FRESH, not stale — fail closed, same direction as (1).
 """
@@ -339,17 +339,17 @@ lease: acquire requires --heartbeat-id: your PROOF that you have ALREADY armed t
        run. This tool never inspects it and takes your word for it — which is exactly why it must be
        something you already did, not something you intend to do.
 lease: DO THIS, IN THIS ORDER: (1) arm the heartbeat for this run. `runtime-adapter.md` owns your host's
-       mechanism and tells you what your proof is; the wake's own invocation must carry
+       mechanism and tells you what your proof is; the heartbeat's own invocation must carry
        --run <id> --token <tok> --heartbeat-id <proof> so it can present the proof it was armed with.
        (2) Re-run this command with that proof.
-lease: DO NOT take the lease first and arm afterwards. An arm at the end of a wake is the step that gets
+lease: DO NOT take the lease first and arm afterwards. An arm at the end of a heartbeat is the step that gets
        forgotten — that is the entire reason this door refuses."""
 
 NO_TOKEN = """\
 lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.
-lease: acquire requires --token, and it does NOT mint one for you. The wake carries `--token <tok>`, so
-       the token must exist BEFORE you arm: a caller without one cannot have armed a wake that identifies
-       it, which means its --heartbeat-id cannot name a real wake.
+lease: acquire requires --token, and it does NOT mint one for you. The heartbeat carries `--token <tok>`, so
+       the token must exist BEFORE you arm: a caller without one cannot have armed a heartbeat that identifies
+       it, which means its --heartbeat-id cannot name a real heartbeat.
 lease: DO THIS: run `lease.py mint` for a token, arm the heartbeat with it, then acquire with both."""
 
 
@@ -575,17 +575,17 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     sub.add_parser("mint", help="print a fresh agent token. Step ONE: the token must exist before you arm "
-                                "the heartbeat, because the wake carries it")
+                                "the heartbeat, because the heartbeat carries it")
 
     # NOTE: --token and --heartbeat-id are deliberately NOT argparse-`required`. They ARE required, and
     # this file refuses without them — but argparse's "the following arguments are required:
     # --heartbeat-id" is a DIAGNOSIS, and the whole mechanism here is the INSTRUCTION the refusal carries
     # (NO_HEARTBEAT / NO_TOKEN). Letting argparse win the race would keep the exit code and throw away the
     # only part that teaches the caller what to do. `lease-test.py` pins this.
-    a = sub.add_parser("acquire", help="take or refresh ownership of this run — the door every wake goes "
+    a = sub.add_parser("acquire", help="take or refresh ownership of this run — the door every heartbeat goes "
                                        "through first")
     a.add_argument("--token", help="REQUIRED. Your agent token (from `mint`). NEVER minted here: a caller "
-                                   "without one cannot have armed a wake that names it")
+                                   "without one cannot have armed a heartbeat that names it")
     a.add_argument("--heartbeat-id",
                    help="REQUIRED. Your PROOF that you have ALREADY armed the heartbeat. Never inspected — "
                         "taken on your word, which is why it must name something already done. "

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1116,7 +1116,7 @@ def t_review_rounds_never_reset(L: ModuleType, tmp: Path) -> None:
             code, out, err = cli(L, ["--file", str(path), *door, f"--{field.replace('_', '-')}", "0"])
             check(code == 2,
                   f"`{door[0]} --{field}` was ACCEPTED (exit {code}) — a door that can WRITE this counter "
-                  f"is a door that can RESET it, and it is the loop's only memory across wakes:\n{out}{err}")
+                  f"is a door that can RESET it, and it is the loop's only memory across heartbeats:\n{out}{err}")
             check("unrecognized arguments" in err,
                   f"`{door[0]} --{field}` failed, but not because the flag does not EXIST: {err!r}")
 
@@ -1354,7 +1354,7 @@ def t_round_cap_fires(L: ModuleType, tmp: Path) -> None:
     """At ROUND_CAP, a NOT SATISFIED holds the row `repairing` and EXITS NON-ZERO.
 
     Non-zero is the entire point. The skill's own "hard backstop" on the 2nd NOT SATISFIED sat unfired
-    through 35 review rounds because nothing COMPUTED it — it was prose, evaluated by a fresh-context wake
+    through 35 review rounds because nothing COMPUTED it — it was prose, evaluated by a fresh-context heartbeat
     that could not see round 1 from round 21. A driver that dispatches a fix after this has a FAILED
     COMMAND in its transcript, not a judgment call.
     """

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -76,14 +76,14 @@ ROW_FIELDS = (
     "api_approval", "status",
     # Liveness (stage-2-ci.md, "SETTLED" and "UNUSABLE — the refetch is BOUNDED"). A non-green `ci` is
     # not enough to know whether CI is still MOVING or has STOPPED — these carry that, and they must
-    # survive a context loss (a wake may be a fresh agent instance), so they live on disk and not in the
+    # survive a context loss (a heartbeat may be a fresh agent instance), so they live on disk and not in the
     # driver's head. A counter that dies with the context never reaches its cap.
     "ci_fingerprint",     # digest of the last VERIFIED CI snapshot; UNCHANGED + nothing running == SETTLED
     "settled_strikes",    # consecutive derivations seen SETTLED-but-not-green; at the cap -> escalate
     "unusable_refetches", # consecutive UNUSABLE snapshots (they have NO fingerprint); at the cap -> escalate
     # UNCHANGED + a row still RUNNING == RUNNING-STALL: something CLAIMS it can still move, and nothing in
     # the check set has. A TIMESTAMP, not a tally, and that is the point: SLOW and DEAD look identical on a
-    # fingerprint, and derivations are driven by wakes whose cadence tracks the RUN'S LOAD, not this PR's
+    # fingerprint, and derivations are driven by heartbeats whose cadence tracks the RUN'S LOAD, not this PR's
     # CI — so a derivation count would park a healthy 40-minute build on a busy run. Only elapsed TIME
     # tells them apart. On disk so `now - ci_stalled_since` needs nothing but the ledger.
     "ci_stalled_since",   # UTC ISO-8601 of the first derivation that saw this stall; at the cap -> escalate
@@ -104,7 +104,7 @@ ROW_FIELDS = (
     # NOT SATISFIED — which means the ledger after 21 rounds is INDISTINGUISHABLE from the ledger after
     # one, and every stopping rule that says "on the second NOT SATISFIED…" is a backstop with no sensor.
     #
-    # A wake is a fresh agent instance. A counter that lives in the driver's head does not exist.
+    # A heartbeat is a fresh agent instance. A counter that lives in the driver's head does not exist.
     "review_rounds",   # landed verdicts, ever, for this PR. MONOTONE — NEVER reset, by anything.
     "ns_streak",       # consecutive NOT SATISFIED. Reset ONLY by a SATISFIED.
     # WHERE THIS PR'S INTENT CAME FROM — the PROVENANCE of `<rundir>/intent-<pr>.md`:
@@ -139,7 +139,7 @@ ROW_FIELDS = (
     "pr_origin",
     # THE REPAIR'S OWN BOUND — the mechanism that fixes non-convergence must not itself fail to converge.
     "repair_count",     # reassessment decisions taken. At REPAIR_CAP the only decision left is ABORT.
-    "repair_decision",  # - | <decision>@<iso> — durable, so the wake that DISPATCHES a repair can be a
+    "repair_decision",  # - | <decision>@<iso> — durable, so the heartbeat that DISPATCHES a repair can be a
                         # different agent instance from the one that DECIDED it. RESET to `-` when the row
                         # RE-ENTERS `repairing` (`cmd_verdict` at a cap), scoping a decision to ONE cap: the
                         # next repair must be earned by a fresh `decide` (which spends `repair_count`), so
@@ -158,7 +158,7 @@ ROW_DEFAULTS = {
 # The two fields `verdict` OWNS — and the ONLY reason they are not settable through `set`/`add-row` is
 # that a door which can write them is a door that can RESET them.
 #
-# `review_rounds` is the loop's only memory across fresh-context wakes, and its whole value is that it is
+# `review_rounds` is the loop's only memory across fresh-context heartbeats, and its whole value is that it is
 # MONOTONE. A rule stating "never reset it" is an exhortation; REMOVING THE DOOR is a mechanism. So there
 # is no `--review-rounds` flag to type: `verdict` increments them, and nothing else writes them at all.
 # (`reviews_ok` is different — a content change legitimately voids the tally, so `set --reviews-ok 0`
@@ -332,7 +332,7 @@ def dump(path: Path, header: dict, rows: list[dict]) -> None:
     """Write the WHOLE store — ATOMICALLY. The ledger is never partly written, ever.
 
     This used to be `path.write_text(...)`, which is a TRUNCATE-then-write: the target is emptied first and
-    the bytes go in after. Interrupt it — a crash, a full disk, a killed wake — and what is left on disk is
+    the bytes go in after. Interrupt it — a crash, a full disk, a killed heartbeat — and what is left on disk is
     a ledger that is empty or cut in half, and `load()` (correctly) refuses a headerless file. The run's
     ONLY memory would be gone, and nothing could tell that from a run that had never started.
 
@@ -496,7 +496,7 @@ def cmd_verdict(path: Path, args) -> int:
       * bumps `review_rounds` — **always, on every verdict, and it is NEVER reset.** This is the loop's
         only memory. Not the fix that follows, not a rebase, not a content change, not a re-triage may
         take it back, because every one of those is a thing that HAPPENED and a round that HAPPENED is a
-        round the next wake must be able to see. There is no `--review-rounds` flag anywhere in this
+        round the next heartbeat must be able to see. There is no `--review-rounds` flag anywhere in this
         tool to argue with;
       * applies the TALLY — `satisfied` adds one to `reviews_ok`; `not-satisfied` VOIDS it (the SHA's
         verdicts are worthless the moment one pass says the content is wrong);

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -57,13 +57,13 @@ def check(cond, msg):
 
 def t_heartbeat_always_fires():
     for rows in ([], [row(1, "in_review")], [row(1, "merged")]):
-        check(has(fire(rows), "heartbeat/wake is armed"),
-              "the heartbeat reminder must fire EVERY wake, whatever the ledger holds")
+        check(has(fire(rows), "heartbeat is armed"),
+              "the heartbeat reminder must fire EVERY heartbeat, whatever the ledger holds")
 
 
 def t_header_reread_always_fires():
     check(has(fire([]), "re-read the ledger header"),
-          "the header-reread reminder must fire every wake")
+          "the header-reread reminder must fire every heartbeat")
 
 
 # --- PR labels ----------------------------------------------------------------
@@ -184,8 +184,8 @@ def t_a_nudge_never_blocks():
 
 
 CASES = [
-    ("heartbeat-always", "the heartbeat reminder fires every wake", t_heartbeat_always_fires),
-    ("header-always", "the header-reread reminder fires every wake", t_header_reread_always_fires),
+    ("heartbeat-always", "the heartbeat reminder fires every heartbeat", t_heartbeat_always_fires),
+    ("header-always", "the header-reread reminder fires every heartbeat", t_header_reread_always_fires),
     ("labels-active-only", "the labels reminder fires only with an active PR", t_labels_fire_only_with_an_active_pr),
     ("required-set-unknown", "unknown required_set nudges to derive it", t_required_set_unknown),
     ("fanout-open-only", "fan-out nudges only with open work", t_fanout_fires_only_with_open_work),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""The nudge printer — sticky-note reminders the campaign orchestrator prints at the top of every wake.
+"""The nudge printer — sticky-note reminders the campaign orchestrator prints at the top of every heartbeat.
 
-Every wake is a fresh agent instance, and the campaign's obligations live in prose it re-derives by hand.
+Every heartbeat is a fresh agent instance, and the campaign's obligations live in prose it re-derives by hand.
 So it forgets: it forgets to arm the fallback heartbeat, it drives off a stale ledger instead of fanning
 out, it lets a review agent die unnoticed, it forgets to swap a PR's labels as the gate moves. This tool
-reads the durable state and PRINTS what the orchestrator should CHECK — the same audit the wake skeleton
-describes in prose, computed from disk so an amnesiac wake is handed it rather than told to remember it.
+reads the durable state and PRINTS what the orchestrator should CHECK — the same audit the heartbeat skeleton
+describes in prose, computed from disk so an amnesiac heartbeat is handed it rather than told to remember it.
 
 **It is a REMINDER, not a supervisor.** Every rule is a CHEAP read (ledger fields, an open-follow-up
 count, whether a `<rundir>` file exists) → a short "check X" string. It NEVER derives CI, counts verdicts,
 decides merge-readiness, evaluates a liveness cap, or judges whether a review agent is actually alive —
 those tools already exist and it only reminds the orchestrator to run them. It decides nothing about
 whether a PR may merge; it is branch-owned, dogfoodable, and always exits 0. A reminder you can ignore is
-the point: its value is being DELIVERED at the wake, computed and concrete, not forcing anything.
+the point: its value is being DELIVERED at the heartbeat, computed and concrete, not forcing anything.
 
 The design and the full obligation inventory it was trimmed from live in `.gauntlet/DESIGN-nudge-printer.md`.
 """
@@ -25,7 +25,7 @@ from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
 
-DESCRIPTION = "Print per-wake reminders for the campaign orchestrator (sticky notes, not a supervisor)."
+DESCRIPTION = "Print per-heartbeat reminders for the campaign orchestrator (sticky notes, not a supervisor)."
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "nudge-test.py"
@@ -71,7 +71,7 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None")
     active = [r for r in rows if r["status"] not in TERMINAL]
 
     # --- always-fire floor -----------------------------------------------------
-    out.append("check the heartbeat/wake is armed.")
+    out.append("check the heartbeat is armed.")
     out.append("re-read the ledger header (base_branch, reviewer, required_set, skill_version).")
     if active:
         out.append("check each active PR's labels match its gate state.")

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -181,10 +181,10 @@ def t_only_a_capped_pr_may_be_reassessed(tmp: Path) -> None:
 
 
 def t_a_decision_needs_a_record(tmp: Path) -> None:
-    """No decision without its REASONING ON DISK. Every wake is a fresh agent that remembers nothing.
+    """No decision without its REASONING ON DISK. Every heartbeat is a fresh agent that remembers nothing.
 
     The whole failure was a loop that could not see itself. A decision whose justification lives only in
-    the context of an agent that has already exited is a decision the next wake — and the user — cannot
+    the context of an agent that has already exited is a decision the next heartbeat — and the user — cannot
     audit, and it would be the one artifact of the mechanism that has no evidence behind it.
     """
     path, _ = setup(tmp, "norec.jsonl", pr_origin="gauntlet")

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -2,7 +2,7 @@
 """The REASSESSMENT PASS's door — the only sanctioned way to record what to do about a PR that has stopped
 converging.
 
-The campaign review gate had no memory. Every wake was a fresh agent instance, `reviews_ok` was zeroed on
+The campaign review gate had no memory. Every heartbeat was a fresh agent instance, `reviews_ok` was zeroed on
 every NOT SATISFIED, and nothing counted rounds — so the ledger after 21 review rounds was indistinguishable
 from the ledger after 1, and every stopping rule in the skill was a rule with NO SENSOR. Two PRs ran 21 and
 14 adversarial rounds, produced a true finding almost every time, and never converged. A human stopped it at
@@ -186,12 +186,12 @@ def cmd_decide(path: Path, args) -> int:
              f"with; it is what happens when the loop stops converging.")
 
     # THE DECISION RECORD MUST EXIST BEFORE IT IS RECORDED. A decision whose reasoning is only in a dead
-    # agent's context is a decision nobody can audit — and every wake is a fresh agent instance.
+    # agent's context is a decision nobody can audit — and every heartbeat is a fresh agent instance.
     record = Path(args.record)
     if not record.exists() or not record.read_text().strip():
         fail(f"--record {record} does not exist or is empty. Write the reassessment's reasoning — the "
              f"round-by-round history it saw, the decision, and WHY — before recording the decision. A "
-             f"decision with no record on disk cannot be audited by the next wake, which remembers nothing.")
+             f"decision with no record on disk cannot be audited by the next heartbeat, which remembers nothing.")
 
     allowed = permitted_for(row)
     if args.decision not in allowed:

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -293,7 +293,7 @@ class Tables:
                                      "…and at the PROGRESS door, which is where the strip used to be. A hand-written event naming ` u01 ` is told its unit id is malformed — not told the unit is 'not in the plan', which is the wrong lesson and was the old message"),
             "amendment-padded-unit-id": (PLAN, [ident(), amendment(proposed_unit=json.loads(unit(" u99 ")))], UNUSABLE,
                                          "NOT AN ID",
-                                         "…and at the THIRD intake: an amendment's `proposed_unit` is what the orchestrator FOLDS INTO THE PLAN, so an id the plan door would refuse must be refused here too — or the plan acquires, one wake later, exactly the unmatchable unit this rule exists to keep out of it"),
+                                         "…and at the THIRD intake: an amendment's `proposed_unit` is what the orchestrator FOLDS INTO THE PLAN, so an id the plan door would refuse must be refused here too — or the plan acquires, one heartbeat later, exactly the unmatchable unit this rule exists to keep out of it"),
             "amendment-unit-not-object": (PLAN, [ident(), amendment(proposed_unit="u99")], UNUSABLE, "not a JSON object",
                                           "the amendment's proposed_unit is a STRING. This is the one place a non-dict unit can reach `check_unit` — the plan's own lines are objects by the time it runs — and it used to be handed straight to `set()`"),
             "plan-missing": (None, WORKED, UNUSABLE, "no plan at",
@@ -489,7 +489,7 @@ class Tables:
                 PLAN, [ident(), started("u01")], None, None, None, UNUSABLE, "THE RUN SKIPPED A STEP",
                 "the pass is still WORKING (u01 started, nothing done) and its PR has no intent — and it is "
                 "refused for the INTENT, not merely reported `incomplete`. A run that dispatched a reviewer "
-                "with nothing to measure it against is broken from the first wake, and the earliest verdict "
+                "with nothing to measure it against is broken from the first heartbeat, and the earliest verdict "
                 "that can say so is the one that should"),
 
             # --- the finding's own shape -------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -145,7 +145,7 @@ STATUSES = (STARTED, DONE)
 # machine-checked, and that rule is an IF AND ONLY IF (`decide`): **NOT SATISFIED exactly when at least one
 # GATING finding stands.** Both halves of it refuse a pass and neither can grant one. The spelling is the
 # ledger's (`ledger.py verdict --verdict satisfied|not-satisfied`), because the same string is typed at both
-# doors by the same driver in the same step, and two spellings of one verdict is a bug waiting for a wake.
+# doors by the same driver in the same step, and two spellings of one verdict is a bug waiting for a heartbeat.
 SATISFIED, NOT_SATISFIED = "satisfied", "not-satisfied"
 VERDICTS = (SATISFIED, NOT_SATISFIED)
 # `deferred` is NOT a verdict — it is the reviewer saying "I did not render a verdict, I raised a separate
@@ -379,7 +379,7 @@ ID_FORMATS: "dict[str, tuple[re.Pattern[str], str, str]]" = {
     "pass": (re.compile(rf"^{COUNT}\Z"), "a decimal number from 1 up",
              "it is COMPARED to the number in the FILENAME, and a value we cannot compare proves nothing"),
     "launch_attempt": (re.compile(rf"^{COUNT}\Z"), "a decimal number from 1 up",
-                       "it is COMPARED to the attempt in the FILENAME — it is how a later wake knows the "
+                       "it is COMPARED to the attempt in the FILENAME — it is how a later heartbeat knows the "
                        "pass was already relaunched — and a value we cannot compare proves nothing"),
     "head_sha": (SHA_RE, "40 LOWERCASE hex — `git rev-parse HEAD`, NEVER an abbreviation",
                  "A short sha has escaped into this repo's real state TWICE, once through a hand-written "
@@ -463,8 +463,8 @@ PLAN_NAME_RE = re.compile(rf"^review-{COUNT}-{COUNT}\.plan\.jsonl\Z")
 PROGRESS_SUFFIX, FINDINGS_SUFFIX = ".progress.jsonl", ".findings.jsonl"
 FINDINGS_NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-{COUNT}(?:\.a{ATTEMPT})?\.findings\.jsonl\Z")
 
-# The INTENT — what this PR is FOR. One per PR, written at adoption (`pr-adoption.md`), re-read every wake
-# and never re-derived: a wake is a fresh agent instance, and an intent held only in context is one that
+# The INTENT — what this PR is FOR. One per PR, written at adoption (`pr-adoption.md`), re-read every heartbeat
+# and never re-derived: a heartbeat is a fresh agent instance, and an intent held only in context is one that
 # gets invented a second time, differently.
 #
 # **EVERY PASS IS JUDGED AGAINST ONE — `evaluate` loads it whatever the pass found, and that is the whole
@@ -1124,7 +1124,7 @@ def check_identity_shape(ident: dict, where: str) -> None:
 
     The identity is the pass's attempt id and its dispatch clock, and three rules downstream depend on it:
     a late verdict is ignored unless its attempt id still matches; the ~5-minute launch deadline is
-    measured from `dispatched_at`; `launch_attempt` is how a *later* wake — possibly a fresh agent — knows
+    measured from `dispatched_at`; `launch_attempt` is how a *later* heartbeat — possibly a fresh agent — knows
     the pass was already relaunched once. Every one of those is a COMPARISON, and a comparison against a
     malformed value is not one.
     """


### PR DESCRIPTION
## What

Standardize the campaign's terminology: the scheduled re-invocation event is a **heartbeat**. The docs and scripts had been using "wake" (noun) and "heartbeat" interchangeably for the same thing. This sweep removes "wake" **as a noun** and keeps it **only as an action verb** ("a watch that wakes the driver", "woken").

## Scope

37 files, **280 insertions / 280 deletions** — every edit a same-line substitution. Pure terminology; **no behavior change**.

- **Nouns renamed:** `each wake`→`each heartbeat`, `per-wake`→`per-heartbeat`, `self-wake`→`scheduled heartbeat`, `wake skeleton`→`heartbeat skeleton`, `scheduled-wake host`→`scheduled-heartbeat host`, `in-wake`→`in-heartbeat`, `wakeups`→`heartbeats`, etc.
- **Verbs kept:** "a watch that wakes no one", "wakes the driver", "wakes up", "will never wake anyone".
- **Tool names kept verbatim:** `ScheduleWakeup`, `CronCreate`.
- **Reworded (not literal) where the two former terms were contrasted:** a handful of sentences distinguished the *current cycle* ("the same wake") from the *next scheduled event* ("the heartbeat"). Those now read "this same heartbeat" vs "the next heartbeat" so the distinction survives.
- Test heartbeat-id fixture values `"wake-1"`/`"wake-2"` → `"hb-1"`/`"hb-2"` (with their assertions).

## Verification

- All contract self-tests pass: ledger (46), review-pass (60 rules), lease (39), followups (26), repair-pass (10), nudge (14), ci-status (36 + doc-agrees).
- `scripts/validate-plugins.sh` → all checks passed (both hosts, transport contract, bundled scripts).
- Final grep confirms every remaining "wake" is a verb or a tool name.

No plugin version bump (ordinary `plugins/**` change).