### PR TITLE
add merge-check.py to decide merge-readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,9 +237,10 @@ jobs:
       # The merge-readiness decider's contract, executed. It is the ONE place the two GitHub merge enums
       # (`.mergeable`, `.mergeStateStatus`) are crossed with the ledger's preconditions to decide `merge`
       # vs `not-yet` — the miscross this replaces once turned a blocked merge into an infinite CI watch.
-      # Its fixtures (`merge-check-test.py`, loaded by path; a MISSING sibling fails loudly) pin the exact
-      # verdict AND reason for every branch, and its `doc-check` FAILS if stage-3-merge.md's two-enum table
-      # and the code stop enumerating the same value sets — so the doc that owns the mapping can never
-      # silently drift from the tool that implements it. It NEVER performs the merge; it only decides.
-      - name: Merge-check contract (+ stage-3-merge.md agrees with the code)
+      # `self-test` runs the sibling FIXTURES (`merge-check-test.py`, loaded by path; a MISSING sibling
+      # fails loudly), which pin the exact verdict AND reason for every branch — including that both enums
+      # are mapped TOTALLY (an unrecognized value of either PARKS) and that a gh-spawn failure fails closed.
+      # The code owns the mapping; stage-3-merge.md points at the tool rather than restating it, so there is
+      # no doc table to drift and no doc-check here. It NEVER performs the merge; it only decides.
+      - name: Merge-check contract (the code-owned mapping, pinned by fixtures)
         run: python3 plugins/gauntlet/skills/campaign/scripts/merge-check.py self-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,13 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py \
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py \
             plugins/gauntlet/skills/campaign/scripts/lease.py \
-            plugins/gauntlet/skills/campaign/scripts/lease-test.py | tee pyright.json
+            plugins/gauntlet/skills/campaign/scripts/lease-test.py \
+            plugins/gauntlet/skills/campaign/scripts/merge-check.py \
+            plugins/gauntlet/skills/campaign/scripts/merge-check-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "24" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 24 it was pointed at — it checked" \
+          if [ "${analyzed}" != "26" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 26 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -209,3 +211,13 @@ jobs:
       # MISSING sibling fails loudly, so this can never report an all-clear over a suite it did not run.
       - name: Run lease contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/lease.py self-test
+
+      # The merge-readiness decider's contract, executed. It is the ONE place the two GitHub merge enums
+      # (`.mergeable`, `.mergeStateStatus`) are crossed with the ledger's preconditions to decide `merge`
+      # vs `not-yet` — the miscross this replaces once turned a blocked merge into an infinite CI watch.
+      # Its fixtures (`merge-check-test.py`, loaded by path; a MISSING sibling fails loudly) pin the exact
+      # verdict AND reason for every branch, and its `doc-check` FAILS if stage-3-merge.md's two-enum table
+      # and the code stop enumerating the same value sets — so the doc that owns the mapping can never
+      # silently drift from the tool that implements it. It NEVER performs the merge; it only decides.
+      - name: Merge-check contract (+ stage-3-merge.md agrees with the code)
+        run: python3 plugins/gauntlet/skills/campaign/scripts/merge-check.py self-test

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -220,6 +220,7 @@ a line the tool writes.
 | `ci-status.py` | `derive` — how `ci` is DERIVED, always, the only way — and `required-set` | `references/stage-2-ci.md` |
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/stage-2-ci.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/stage-2-ci.md` |
+| `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row + live PR view, crossing the ledger preconditions and both GitHub merge enums in one place | `references/stage-3-merge.md` |
 | `repair-pass.py` | Reassessment pass's door: `permitted` / `decide` — the closed decision enum, ownership guardrail, repair cap | `references/repair-pass.md` |
 | `followups.py` | Schema-owning accessor for the follow-up store (`.gauntlet/followups.jsonl`) — a durable work QUEUE, not an archive: entries are deleted once recorded elsewhere, kept when nothing else would remember | `references/followups.md` |
 | `nudge.py` | Advisory reminder printer for heartbeat start; always exits 0 | its own module docstring |

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -303,8 +303,8 @@ Header field notes (the header fields above; per-row fields follow):
     `RUNNING` since when without the check set moving, which enum value was unrecognized, which VERIFY
     rule the snapshot failed, which read was denied.
   - **MERGE-PRECONDITION blockers** (`stage-3-merge.md`, "The merge precondition" — reached only with
-    **`ci = green`**): the PR is a **draft**, `mergeStateStatus` = `BLOCKED`, or an **unrecognized**
-    `mergeStateStatus` — the offending value named **verbatim**.
+    **`ci = green`**): any value `merge-check.py` parks (its `MERGEABLE` / `MERGE_STATE_STATUS`
+    catch-alls — any `— park` reason it emits) — the offending value named **verbatim**.
 
   Those two are the write sites that exist today, **not a bound on the set**: the class is the
   **property** — *campaign cannot move this PR without a human* (`status`, below, `awaiting-user` class
@@ -382,8 +382,8 @@ Header field notes (the header fields above; per-row fields follow):
        that **never stopped `RUNNING`** while nothing in the check set moved (`ci_stalled_since` at the CI
        STALL CAP — a hung runner, a dead reporter, a required check that queues and never starts), a
        snapshot that stayed **UNUSABLE** (`unusable_refetches` at its cap), a check carrying an
-       **unrecognized enum value**, a merge `BLOCKED` for a cause campaign cannot enumerate, an
-       **unrecognized `mergeStateStatus`**, or a **draft** PR (`stage-2-ci.md`, "SETTLED", "RUNNING-STALL"
+       **unrecognized enum value**, or **any merge precondition `merge-check.py` parks** (any `— park`
+       reason it emits) (`stage-2-ci.md`, "SETTLED", "RUNNING-STALL"
        and "UNUSABLE — the refetch is BOUNDED"; `stage-3-merge.md`, "The merge precondition"). **This is
        the exit from `pending` — in BOTH of its shapes**, the settled one and the forever-`RUNNING` one;
        without it, a stuck PR spins forever and no one is ever told. **Answered into**

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -53,6 +53,7 @@ The table maps **BOTH enums TOTALLY** — every value of each has its own row, s
 **only** on a value GitHub has genuinely added since. A value with no row is a **wedge**: it falls to the
 catch-all and parks a PR that nothing was wrong with.
 
+<!-- merge-precondition-table:start -->
 | Field / value | Meaning | Do |
 |---|---|---|
 | `.isDraft = true` | a **draft** PR — GitHub blocks the merge regardless of CI | **NEVER merge.** Park `awaiting-user`. |
@@ -67,6 +68,7 @@ catch-all and parks a PR that nothing was wrong with.
 | `.mergeStateStatus = BLOCKED` | the merge is blocked — **cause NOT enumerable** | **do not merge.** Park `awaiting-user`. **NEVER** map it to `ci = pending`. |
 | `.mergeStateStatus = UNKNOWN` | not computed yet | **re-poll, bounded** — see **"The UNKNOWN re-poll bound"** below |
 | **any other value** | GitHub added one | **park `awaiting-user`**, naming the value. Never guess. |
+<!-- merge-precondition-table:end -->
 
 **The UNKNOWN re-poll bound.** `UNKNOWN` is a value GitHub has **not computed yet** — it is not a verdict,
 and it resolves within seconds once GitHub finishes computing mergeability lazily. Re-poll it **in-heartbeat up

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -37,9 +37,14 @@ yields `merge`), so the miscross above cannot recur. Both enums are crossed **TO
 schema does not declare **parks**, never guesses. Act on the verdict:
 
 - `merge` → proceed to the merge steps below (step 1).
-- `not-yet <reason>` → do **NOT** merge; the reason names the block.
+- `not-yet <reason>` → do **NOT** merge; the reason names the block. Route on the reason's **action**
+  (the phrase the tool emits), never on a hand-copied list of enum values — a value the tool newly parks
+  then routes correctly with no edit here:
   - `rebase` reasons (base moved ahead / conflicts) → refresh the PR per step 6.
-  - `park awaiting-user` reasons (draft, `BLOCKED`) → park and name the blocker (below).
+  - the tool's **`— park`** reasons (any `not-yet` reason that ends in `— park` / `park awaiting-user`)
+    → park and name the blocker (below). This is the tool's catch-all for a merge GitHub blocks for a
+    cause campaign cannot clear itself — a draft, a `BLOCKED` merge state, **and any value neither enum
+    recognizes** — so routing on the `— park` action, not a fixed value list, keeps this bucket total.
   - `re-poll` reasons (merge state / mergeability not computed yet — `UNKNOWN`) → the **UNKNOWN re-poll
     bound** (below).
   - Everything else (`ci is …`, `N of M approvals`, `held`, stale head) → leave the PR; the next

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -27,51 +27,31 @@ answer lands the PR is skipped, never merged.
 else. Campaign's own SHA-pinned snapshot (`stage-2-ci.md`) is the **only** source of `ci`. Crossing these
 two wires is what turns a blocked merge into an infinite CI watch.
 
-**The merge-readiness decision is COMPUTED by `scripts/merge-check.py`, not read by eye.** It reads the
-ledger row plus the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid`)
-and prints `merge` or `not-yet <reason>` — crossing the held/open/draft/head/ci/reviews preconditions and
-then **both** enums in ONE place, so the miscross above cannot recur. **The two-enum table below is the
-mapping it implements**, and a `doc-check` in that script FAILS the build if this table and the code stop
-enumerating the same value sets — so the table stays the spec and can never silently drift from the tool.
+**The merge-readiness decision is COMPUTED, never read by eye:**
+`python3 <skill-dir>/scripts/merge-check.py check --pr <N> --file <state.jsonl>`. It reads the ledger
+row + the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid`) and
+prints `{"verdict":"merge"|"not-yet","reason":…}`, crossing — in ONE place — the held/open/draft/
+stale-head/ci/reviews preconditions and then **BOTH** GitHub enums (`.mergeable` first — `CONFLICTING`
+and `UNKNOWN` decide on their own, `MERGEABLE` falls through — then `.mergeStateStatus`, which alone
+yields `merge`), so the miscross above cannot recur. Both enums are crossed **TOTALLY**: a value GitHub's
+schema does not declare **parks**, never guesses. Act on the verdict:
 
-`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft` returns **two different enums** — say which
-field a value came from, and map **every** value of each (introspected from the schema, not recalled):
+- `merge` → proceed to the merge steps below (step 1).
+- `not-yet <reason>` → do **NOT** merge; the reason names the block.
+  - `rebase` reasons (base moved ahead / conflicts) → refresh the PR per step 6.
+  - `park awaiting-user` reasons (draft, `BLOCKED`) → park and name the blocker (below).
+  - `re-poll` reasons (merge state / mergeability not computed yet — `UNKNOWN`) → the **UNKNOWN re-poll
+    bound** (below).
+  - Everything else (`ci is …`, `N of M approvals`, `held`, stale head) → leave the PR; the next
+    heartbeat re-evaluates once that precondition changes.
 
-```
-MergeableState (.mergeable)       MERGEABLE CONFLICTING UNKNOWN
-MergeStateStatus (.mergeStateStatus)  DIRTY UNKNOWN BLOCKED BEHIND UNSTABLE HAS_HOOKS CLEAN
-```
+The mapping the tool crosses is **OWNED by `merge-check.py`** and pinned by its sibling fixtures
+(`merge-check-test.py`), which assert every enum value's verdict — that is what proves the mapping, not a
+table restated here for a reader to map by eye.
 
-**The two enums answer DIFFERENT questions, and `.mergeable` NEVER answers the merge question.**
-`.mergeable` says whether the branches **can be combined at all**; `.mergeStateStatus` says whether the
-merge is **permitted right now**. So `MERGEABLE` is **NECESSARY BUT NOT SUFFICIENT** — a `MERGEABLE` PR
-is routinely `BLOCKED`, `BEHIND` or `UNSTABLE`, and merging on `.mergeable` alone would merge straight
-over a blocked, stale, or non-passing PR. **`MERGEABLE` does NOT mean "merge it"; only the
-`.mergeStateStatus` rows below decide that.** The two are read together, never one instead of the other.
-
-The table maps **BOTH enums TOTALLY** — every value of each has its own row, so the catch-all fires
-**only** on a value GitHub has genuinely added since. A value with no row is a **wedge**: it falls to the
-catch-all and parks a PR that nothing was wrong with.
-
-<!-- merge-precondition-table:start -->
-| Field / value | Meaning | Do |
-|---|---|---|
-| `.isDraft = true` | a **draft** PR — GitHub blocks the merge regardless of CI | **NEVER merge.** Park `awaiting-user`. |
-| `.mergeable = MERGEABLE` | the branches **can** be combined — **the ONLY non-blocking `.mergeable` value, and the one EVERY healthy PR carries** | **NOT a licence to merge.** The `.mergeable` precondition is satisfied and **nothing else is decided**: fall through to the `.mergeStateStatus` rows below, which decide whether the merge may actually run. |
-| `.mergeable = CONFLICTING` | conflicts with the base | refresh the PR per step 6 |
-| `.mergeable = UNKNOWN` | **not computed yet** (GitHub computes mergeability lazily) | **re-poll, bounded** — see **"The UNKNOWN re-poll bound"** below; **never** read as a verdict |
-| `.mergeStateStatus = CLEAN` | mergeable, everything green | **merge** |
-| `.mergeStateStatus = HAS_HOOKS` | mergeable; the repo has pre-receive hooks | **merge** |
-| `.mergeStateStatus = BEHIND` | base has moved ahead | refresh the PR per step 6 → gate reset |
-| `.mergeStateStatus = DIRTY` | conflicts | refresh the PR per step 6 |
-| `.mergeStateStatus = UNSTABLE` | a check is **non-passing** — which **INCLUDES STILL RUNNING** | **do not merge.** Do **NOT** touch `ci` and do **NOT** dispatch a CI-fix — campaign's own snapshot decides that. |
-| `.mergeStateStatus = BLOCKED` | the merge is blocked — **cause NOT enumerable** | **do not merge.** Park `awaiting-user`. **NEVER** map it to `ci = pending`. |
-| `.mergeStateStatus = UNKNOWN` | not computed yet | **re-poll, bounded** — see **"The UNKNOWN re-poll bound"** below |
-| **any other value** | GitHub added one | **park `awaiting-user`**, naming the value. Never guess. |
-<!-- merge-precondition-table:end -->
-
-**The UNKNOWN re-poll bound.** `UNKNOWN` is a value GitHub has **not computed yet** — it is not a verdict,
-and it resolves within seconds once GitHub finishes computing mergeability lazily. Re-poll it **in-heartbeat up
+**The UNKNOWN re-poll bound.** A `not-yet` whose reason is a **`re-poll`** (`.mergeStateStatus` or
+`.mergeable` = `UNKNOWN` — a value GitHub has **not computed yet**) is not a verdict, and it resolves
+within seconds once GitHub finishes computing mergeability lazily. Re-poll it **in-heartbeat up
 to 3 times**, with a short backoff between re-polls (a few seconds) — the initial Stage-3 fetch that
 returned `UNKNOWN` is what triggers this loop and is **not** one of the three. If it is **still** `UNKNOWN`
 after the third re-poll, do **NOT** merge on this heartbeat — leave the PR and let the **next heartbeat** re-evaluate it: **the
@@ -80,7 +60,7 @@ that stays `UNKNOWN` across heartbeats is bounded by the heartbeat cadence, so *
 the in-heartbeat cap is a fixed 3, and the coarse retry is the heartbeat loop itself. Never read `UNKNOWN` as
 `MERGEABLE`, and never let a perpetually-`UNKNOWN` PR either merge or wedge.
 
-**EVERY `awaiting-user` park in this table is a MACHINE-BLOCKER park, and it MUST declare its exit** — a
+**EVERY `awaiting-user` park a `not-yet` verdict names is a MACHINE-BLOCKER park, and it MUST declare its exit** — a
 park whose exit event never comes is the same wedge it was meant to prevent. So, in the same step: write
 `ci_reason` **naming the blocker** (the draft state, `BLOCKED`, or the unrecognized value verbatim),
 **clear `blocker_ruling` to `-`** (park entry spends nothing and answers nothing — a ruling already on the
@@ -107,8 +87,9 @@ subagent at a check that is merely **still running**.
    may have moved the tip past the recorded `head_sha` and reset the gates —
    **and re-fetch `origin/<base>` and re-check
    `gh pr view <pr> --json mergeable,mergeStateStatus,isDraft`** — a concurrent run sharing this base may
-   have advanced it since the PR was last reviewed. Read the result through **"The merge precondition"**
-   below, which maps **every** value of both enums.
+   have advanced it since the PR was last reviewed. Feed the ledger row and that live view to
+   **`merge-check.py check`** (**"The merge precondition"** above), which crosses **every** value of both
+   enums and returns the verdict.
 2. Push guard: `gh pr view <pr> --json state --jq .state` (PR number from the ledger row) must be
    `OPEN`.
 3. Merge — always `gh pr merge <pr> --squash` (use the repo's prevailing merge method if not squash),

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -27,6 +27,13 @@ answer lands the PR is skipped, never merged.
 else. Campaign's own SHA-pinned snapshot (`stage-2-ci.md`) is the **only** source of `ci`. Crossing these
 two wires is what turns a blocked merge into an infinite CI watch.
 
+**The merge-readiness decision is COMPUTED by `scripts/merge-check.py`, not read by eye.** It reads the
+ledger row plus the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid`)
+and prints `merge` or `not-yet <reason>` — crossing the held/open/draft/head/ci/reviews preconditions and
+then **both** enums in ONE place, so the miscross above cannot recur. **The two-enum table below is the
+mapping it implements**, and a `doc-check` in that script FAILS the build if this table and the code stop
+enumerating the same value sets — so the table stays the spec and can never silently drift from the tool.
+
 `gh pr view <pr> --json mergeable,mergeStateStatus,isDraft` returns **two different enums** — say which
 field a value came from, and map **every** value of each (introspected from the schema, not recalled):
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -89,9 +89,8 @@ ROW_FIELDS = (
     "ci_stalled_since",   # UTC ISO-8601 of the first derivation that saw this stall; at the cap -> escalate
     # The MACHINE-BLOCKER reason: what campaign cannot get past without a human, in a form they can act
     # on -- the question `blocker_ruling` answers. NOT merely "why `ci` is not green": that is one class
-    # of it. The merge-precondition parks (stage-3-merge.md: a draft PR, BLOCKED, an unrecognized
-    # mergeStateStatus) write it with `ci` GREEN. The `ci_` prefix understates it; files-and-ledger.md
-    # owns the definition.
+    # of it. The merge-precondition parks (stage-3-merge.md: any value merge-check.py parks) write it with
+    # `ci` GREEN. The `ci_` prefix understates it; files-and-ledger.md owns the definition.
     "ci_reason",
     # Durable answer to a machine-blocker park: - | retry@<iso> | abort@<iso>. Durable AND spent exactly
     # once: set back to `-` on park ENTRY and on consuming a `retry`, so a ruling can only ever answer the

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -201,14 +201,36 @@ def _doc_check_quiet(doc: Path) -> int:
         return M.doc_check(doc)
 
 
+def _table_rows(mss_values, mergeable_values) -> str:
+    """A minimal merge-precondition TABLE — each enum token in a Markdown table row (leading `|`), which is
+    the ONLY shape doc_enum reads. Used by the drift fixtures so they exercise the real table-row path."""
+    rows = ([f"| `.mergeStateStatus = {v}` | meaning | do |" for v in mss_values]
+            + [f"| `.mergeable = {v}` | meaning | do |" for v in mergeable_values])
+    return "| Field / value | Meaning | Do |\n|---|---|---|\n" + "\n".join(rows) + "\n"
+
+
 def t_doc_check_detects_a_dropped_value():
     with tempfile.TemporaryDirectory() as d:
         doc = Path(d) / "stage-3-merge.md"
-        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # drop one
-        body = ([f"`.mergeStateStatus = {v}`" for v in states]
-                + [f"`.mergeable = {v}`" for v in M.MERGEABLE])
-        doc.write_text("\n".join(body) + "\n", encoding="utf-8")
+        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # drop one FROM THE TABLE
+        doc.write_text(_table_rows(states, M.MERGEABLE), encoding="utf-8")
         check(_doc_check_quiet(doc) == 1, "a doc missing a mergeStateStatus value the code handles must FAIL")
+
+
+def t_doc_check_prose_cannot_mask_a_dropped_table_row():
+    # The exact bypass this pins: a value dropped from the TABLE but still named in PROSE outside it must
+    # NOT sneak back into the extracted set. The old whole-doc regex would pick the prose token up, the sets
+    # would match, and doc-check would PASS while the table silently lost a row. Scoped to table rows, the
+    # prose contributes nothing, the set is short a value, and doc-check FAILS as it must.
+    with tempfile.TemporaryDirectory() as d:
+        doc = Path(d) / "stage-3-merge.md"
+        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # HAS_HOOKS is gone FROM THE TABLE
+        table = _table_rows(states, M.MERGEABLE)
+        prose = ("\nNote: a `.mergeStateStatus = HAS_HOOKS` PR still merges — but this line is PROSE, not a\n"
+                 "table row, so it must NOT count toward the enumerated set.\n")
+        doc.write_text(table + prose, encoding="utf-8")
+        check(_doc_check_quiet(doc) == 1,
+              "a value dropped from the TABLE but named only in PROSE must STILL fail doc-check")
 
 
 def t_doc_check_fails_when_it_finds_nothing():
@@ -241,5 +263,7 @@ CASES = [
     ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
     ("doc-agrees", "the shipped doc agrees with the code", t_doc_check_agrees_with_the_shipped_doc),
     ("doc-drift-caught", "doc-check FAILS when the doc drops a value", t_doc_check_detects_a_dropped_value),
+    ("doc-prose-cant-mask", "prose outside the table can't mask a dropped table row",
+     t_doc_check_prose_cannot_mask_a_dropped_table_row),
     ("doc-empty-fails", "doc-check FAILS when it extracts nothing", t_doc_check_fails_when_it_finds_nothing),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Fixtures for `merge-check.py` — the merge-readiness decider.
+
+They live in a SIBLING file, and `merge-check.py self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE HAS TEETH. It asserts the EXACT verdict AND, where the wording is load-bearing, the EXACT
+reason — a suite that only checked `verdict == "not-yet"` would pass against a decider that returned the
+wrong reason, and the reason is what the driver acts on. The ordering fixtures (held/stale/ci over the
+enums) pin FIRST-FAILING-CHECK-WINS: a fully clean+green view that still returns not-yet proves the earlier
+check outranks the enums.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
+
+OWNER = Path(__file__).resolve().parent / "merge-check.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("merge_check_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the merge-readiness decider at {OWNER}")
+    return mod
+
+
+M = _load_owner()
+L = M.L
+
+SHA_A = "a" * 40   # the reviewed head
+SHA_B = "b" * 40   # a head the tip has moved to
+
+
+def row(*, status="in_review", head_sha=SHA_A, ci="green", tier="HIGH", reviews_ok=2) -> dict:
+    r = dict(L.ROW_DEFAULTS)
+    r.update(pr="9", status=status, head_sha=head_sha, ci=ci, tier=tier, reviews_ok=str(reviews_ok))
+    r["id"] = "pr9"
+    return r
+
+
+def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN", isDraft=False, state="OPEN",
+         headRefOid=SHA_A) -> dict:
+    return {"mergeable": mergeable, "mergeStateStatus": mergeStateStatus, "isDraft": isDraft,
+            "state": state, "headRefOid": headRefOid}
+
+
+def decide(r: dict, v: dict) -> dict:
+    return M.decide(r, v, required=M.REQUIRED)
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise M.SelfTestFailure(msg)
+
+
+def expect(r: dict, v: dict, verdict: str, reason: "str | None" = None) -> None:
+    got = decide(r, v)
+    check(got["verdict"] == verdict, f"expected verdict {verdict!r}, got {got!r}")
+    if reason is not None:
+        check(got["reason"] == reason, f"expected reason {reason!r}, got {got['reason']!r}")
+
+
+# --- merge verdicts -----------------------------------------------------------
+
+def t_clean_and_all_met():
+    expect(row(), view(), "merge", "")
+
+
+def t_has_hooks_merges():
+    expect(row(), view(mergeStateStatus="HAS_HOOKS"), "merge", "")
+
+
+# --- held FREEZES, whatever the counters or enums say -------------------------
+
+def t_held_never_merges():
+    # A fully clean+green+2/2 view — the ONLY thing stopping the merge is the held status.
+    for status in (L.REPAIR_STATUS, "awaiting-user", "awaiting-api"):
+        expect(row(status=status), view(), "not-yet", f"held ({status})")
+
+
+# --- ledger preconditions, in order -------------------------------------------
+
+def t_not_open():
+    expect(row(), view(state="MERGED"), "not-yet", "pr is MERGED, not open")
+    expect(row(), view(state="CLOSED"), "not-yet", "pr is CLOSED, not open")
+
+
+def t_draft():
+    expect(row(), view(isDraft=True), "not-yet", "draft — park awaiting-user")
+
+
+def t_stale_sha():
+    # ci green + CLEAN, but the tip moved — stale SHA outranks ci and the enums.
+    got = decide(row(head_sha=SHA_A), view(headRefOid=SHA_B))
+    check(got["verdict"] == "not-yet", f"a moved head must not merge, got {got!r}")
+    check("moved off the reviewed SHA" in got["reason"] and SHA_B[:7] in got["reason"]
+          and SHA_A[:7] in got["reason"], f"the stale-SHA reason must name both short SHAs, got {got!r}")
+
+
+def t_ci_not_green():
+    # CLEAN view, but ci is not green — ci is checked before the enums, and mergeStateStatus NEVER feeds ci.
+    expect(row(ci="pending"), view(), "not-yet", "ci is pending, not green")
+    expect(row(ci="red"), view(), "not-yet", "ci is red, not green")
+
+
+def t_short_reviews():
+    # 1 of 2 for a HIGH PR — short of required(tier).
+    expect(row(tier="HIGH", reviews_ok=1), view(), "not-yet", "1 of 2 approvals")
+    # TRIVIAL needs only 1 — pins required(tier): 1/1 + CLEAN merges.
+    expect(row(tier="TRIVIAL", reviews_ok=1), view(), "merge", "")
+    # ...and a TRIVIAL PR with 0 verdicts is still short.
+    expect(row(tier="TRIVIAL", reviews_ok=0), view(), "not-yet", "0 of 1 approvals")
+
+
+# --- the two GitHub enums, TOTALLY --------------------------------------------
+
+def t_mergestate_behind():
+    expect(row(), view(mergeStateStatus="BEHIND"), "not-yet", "base moved ahead — rebase")
+
+
+def t_mergestate_dirty():
+    expect(row(), view(mergeStateStatus="DIRTY"), "not-yet", "conflicts — rebase")
+
+
+def t_mergestate_unstable():
+    expect(row(), view(mergeStateStatus="UNSTABLE"), "not-yet",
+           "a check is non-passing (may still be running) — not campaign's ci signal")
+
+
+def t_mergestate_blocked():
+    expect(row(), view(mergeStateStatus="BLOCKED"), "not-yet", "GitHub says BLOCKED — park awaiting-user")
+
+
+def t_mergestate_unknown():
+    expect(row(), view(mergeStateStatus="UNKNOWN"), "not-yet", "merge state not computed yet — re-poll")
+
+
+def t_conflicting_mergeable():
+    # CONFLICTING is decided on .mergeable alone; .mergeStateStatus is not even consulted.
+    expect(row(), view(mergeable="CONFLICTING", mergeStateStatus="CLEAN"), "not-yet",
+           "conflicts with base — rebase")
+
+
+def t_unknown_mergeable():
+    expect(row(), view(mergeable="UNKNOWN", mergeStateStatus="CLEAN"), "not-yet",
+           "mergeability not computed yet — re-poll")
+
+
+def t_unknown_mergestate_value_parks():
+    # A value GitHub's schema does not declare — the catch-all parks it, never guesses. Pins TOTALITY.
+    expect(row(), view(mergeStateStatus="FROZEN"), "not-yet", "unknown merge state FROZEN — park, never guess")
+
+
+def t_unknown_mergeable_value_parks():
+    expect(row(), view(mergeable="WOBBLY"), "not-yet", "unknown mergeable value WOBBLY — park")
+
+
+# --- CLI: a recorded view makes `check` testable without gh --------------------
+
+def t_cli_injected_view():
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        vjson = Path(d) / "view.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+        code, out, err = capture_cli(
+            M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+        check(code == 0, f"the CLI must exit 0 on a computed verdict (stderr: {err})")
+        check(json.loads(out) == {"verdict": "merge", "reason": ""},
+              f"the CLI should print the merge verdict, got {out!r}")
+
+
+def t_cli_no_ledger_row():
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])  # holds pr 9, not pr 42
+        code, out, _err = capture_cli(
+            M.main, ["check", "--pr", "42", "--file", str(led), "--view-json", str(led)])
+        check(code == 0, "a PR with no ledger row is a computed not-yet, not an error")
+        check(json.loads(out) == {"verdict": "not-yet", "reason": "no ledger row"},
+              f"a missing row must decide `no ledger row` without ever reading the view, got {out!r}")
+
+
+# --- the drift guard has teeth ------------------------------------------------
+
+def t_doc_check_agrees_with_the_shipped_doc():
+    check(M.doc_check(M.DOC) == 0, "the shipped stage-3-merge.md must agree with the code that runs")
+
+
+def _doc_check_quiet(doc: Path) -> int:
+    """Run doc_check but swallow its (intentionally alarming) FAIL output — these fixtures WANT it to fail,
+    so its report must not pollute the self-test transcript with lines that look like a real break."""
+    with redirect_stdout(io.StringIO()):
+        return M.doc_check(doc)
+
+
+def t_doc_check_detects_a_dropped_value():
+    with tempfile.TemporaryDirectory() as d:
+        doc = Path(d) / "stage-3-merge.md"
+        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # drop one
+        body = ([f"`.mergeStateStatus = {v}`" for v in states]
+                + [f"`.mergeable = {v}`" for v in M.MERGEABLE])
+        doc.write_text("\n".join(body) + "\n", encoding="utf-8")
+        check(_doc_check_quiet(doc) == 1, "a doc missing a mergeStateStatus value the code handles must FAIL")
+
+
+def t_doc_check_fails_when_it_finds_nothing():
+    with tempfile.TemporaryDirectory() as d:
+        doc = Path(d) / "stage-3-merge.md"
+        doc.write_text("this table names no enum values at all\n", encoding="utf-8")
+        check(_doc_check_quiet(doc) == 1, "a doc that enumerates zero values must FAIL — a check with no "
+                                          "subject never passes")
+
+
+CASES = [
+    ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
+    ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),
+    ("held-frozen", "a held PR never merges, whatever the counters/enums say", t_held_never_merges),
+    ("not-open", "a merged/closed PR is not a candidate", t_not_open),
+    ("draft", "a draft PR is parked, not merged", t_draft),
+    ("stale-sha", "a moved head outranks ci and the enums", t_stale_sha),
+    ("ci-not-green", "ci is checked before the enums; mergeStateStatus never feeds ci", t_ci_not_green),
+    ("short-reviews", "reviews_ok < required(tier) blocks; required(tier) is 1 for TRIVIAL", t_short_reviews),
+    ("mss-behind", "BEHIND -> rebase", t_mergestate_behind),
+    ("mss-dirty", "DIRTY -> rebase", t_mergestate_dirty),
+    ("mss-unstable", "UNSTABLE -> non-passing, not campaign's ci", t_mergestate_unstable),
+    ("mss-blocked", "BLOCKED -> park awaiting-user", t_mergestate_blocked),
+    ("mss-unknown", "UNKNOWN merge state -> re-poll", t_mergestate_unknown),
+    ("mergeable-conflicting", "CONFLICTING decided on .mergeable alone", t_conflicting_mergeable),
+    ("mergeable-unknown", "UNKNOWN mergeability -> re-poll", t_unknown_mergeable),
+    ("mss-unknown-value-parks", "an unrecognised merge state parks (totality)", t_unknown_mergestate_value_parks),
+    ("mergeable-unknown-value-parks", "an unrecognised mergeable value parks", t_unknown_mergeable_value_parks),
+    ("cli-injected-view", "check --view-json decides without gh and exits 0", t_cli_injected_view),
+    ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
+    ("doc-agrees", "the shipped doc agrees with the code", t_doc_check_agrees_with_the_shipped_doc),
+    ("doc-drift-caught", "doc-check FAILS when the doc drops a value", t_doc_check_detects_a_dropped_value),
+    ("doc-empty-fails", "doc-check FAILS when it extracts nothing", t_doc_check_fails_when_it_finds_nothing),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -243,6 +243,32 @@ def t_cli_view_wrong_type_field():
     _cli_malformed_view(v, "isDraft")
 
 
+def t_cli_gh_spawn_failure():
+    # gh ABSENT (or not executable): subprocess.run raises OSError BEFORE any returncode. It must fail
+    # CLOSED through the one `except ViewError` — a structured not-yet, a NON-ZERO exit, and NO traceback —
+    # never an uncaught FileNotFoundError with no verdict on stdout. Simulate the spawn failure by patching
+    # the module's subprocess.run; drive the real CLI with NO --view-json so it takes load_view's gh path.
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+    real_run = M.subprocess.run
+    M.subprocess.run = boom
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+            # capture_cli only catches SystemExit, so an uncaught spawn traceback would ESCAPE here and fail
+            # this fixture — that is the teeth.
+            code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--file", str(led), "--repo", "o/n"])
+    finally:
+        M.subprocess.run = real_run
+    check(code != 0, f"a gh-spawn failure must exit non-zero (fail closed), got {code} (stderr: {err})")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet",
+          f"a gh-spawn failure must decide not-yet, never merge, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the failed view fetch, got {result['reason']!r}")
+
+
 CASES = [
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),
@@ -270,4 +296,5 @@ CASES = [
     ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
     ("cli-view-missing-field", "a view missing a field fails closed, never KeyError", t_cli_view_missing_field),
     ("cli-view-wrong-type", "a view field of the wrong JSON type fails closed", t_cli_view_wrong_type_field),
+    ("cli-gh-spawn-failure", "a gh-spawn failure fails closed, no traceback", t_cli_gh_spawn_failure),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -12,10 +12,8 @@ check outranks the enums.
 
 from __future__ import annotations
 
-import io
 import json
 import tempfile
-from contextlib import redirect_stdout
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
@@ -245,112 +243,6 @@ def t_cli_view_wrong_type_field():
     _cli_malformed_view(v, "isDraft")
 
 
-# --- the drift guard has teeth ------------------------------------------------
-
-def t_doc_check_agrees_with_the_shipped_doc():
-    check(M.doc_check(M.DOC) == 0, "the shipped stage-3-merge.md must agree with the code that runs")
-
-
-def _doc_check_quiet(doc: Path) -> int:
-    """Run doc_check but swallow its (intentionally alarming) FAIL output — these fixtures WANT it to fail,
-    so its report must not pollute the self-test transcript with lines that look like a real break."""
-    with redirect_stdout(io.StringIO()):
-        return M.doc_check(doc)
-
-
-START = M.PRECONDITION_TABLE_START
-END = M.PRECONDITION_TABLE_END
-
-
-def _table_rows(mss_values, mergeable_values, *, meaning_tokens=()) -> str:
-    """A minimal merge-precondition TABLE wrapped in the start/end markers doc_enum requires. Each enum token
-    sits in the FIRST cell of its row — the only cell doc_enum reads. `meaning_tokens` inject extra
-    `.mergeStateStatus = X` strings into a row's MEANING (second) cell; those must NOT count. Used by the
-    drift fixtures so they exercise the real marked-table, first-cell path."""
-    rows = ([f"| `.mergeStateStatus = {v}` | meaning | do |" for v in mss_values]
-            + [f"| `.mergeable = {v}` | meaning | do |" for v in mergeable_values]
-            + [f"| `.mergeStateStatus = CLEAN` | also names `.mergeStateStatus = {t}` here | do |"
-               for t in meaning_tokens])
-    return (f"{START}\n| Field / value | Meaning | Do |\n|---|---|---|\n"
-            + "\n".join(rows) + f"\n{END}\n")
-
-
-def t_doc_check_detects_a_dropped_value():
-    with tempfile.TemporaryDirectory() as d:
-        doc = Path(d) / "stage-3-merge.md"
-        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # drop one FROM THE TABLE
-        doc.write_text(_table_rows(states, M.MERGEABLE), encoding="utf-8")
-        check(_doc_check_quiet(doc) == 1, "a doc missing a mergeStateStatus value the code handles must FAIL")
-
-
-def t_doc_check_prose_cannot_mask_a_dropped_table_row():
-    # The exact bypass this pins: a value dropped from the TABLE but still named in PROSE outside it must
-    # NOT sneak back into the extracted set. The old whole-doc regex would pick the prose token up, the sets
-    # would match, and doc-check would PASS while the table silently lost a row. Scoped to table rows, the
-    # prose contributes nothing, the set is short a value, and doc-check FAILS as it must.
-    with tempfile.TemporaryDirectory() as d:
-        doc = Path(d) / "stage-3-merge.md"
-        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # HAS_HOOKS is gone FROM THE TABLE
-        table = _table_rows(states, M.MERGEABLE)
-        prose = ("\nNote: a `.mergeStateStatus = HAS_HOOKS` PR still merges — but this line is PROSE, not a\n"
-                 "table row, so it must NOT count toward the enumerated set.\n")
-        doc.write_text(table + prose, encoding="utf-8")
-        check(_doc_check_quiet(doc) == 1,
-              "a value dropped from the TABLE but named only in PROSE must STILL fail doc-check")
-
-
-def t_doc_check_another_table_outside_markers_cannot_mask_a_dropped_row():
-    # Bypass #1: a value dropped from the MARKED precondition table, but still carried by ANOTHER `|`-table
-    # elsewhere in the doc (outside the markers). Scoped to the marked region, the second table contributes
-    # NOTHING, the set is short a value, and doc-check FAILS as it must.
-    with tempfile.TemporaryDirectory() as d:
-        doc = Path(d) / "stage-3-merge.md"
-        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # HAS_HOOKS gone from the MARKED table
-        marked = _table_rows(states, M.MERGEABLE)
-        other = ("\n### An unrelated table, OUTSIDE the markers\n\n"
-                 "| Field / value | Meaning | Do |\n|---|---|---|\n"
-                 "| `.mergeStateStatus = HAS_HOOKS` | some other context | do |\n")
-        doc.write_text(marked + other, encoding="utf-8")
-        check(_doc_check_quiet(doc) == 1,
-              "a value dropped from the MARKED table but named in another table OUTSIDE the markers must "
-              "STILL fail doc-check")
-
-
-def t_doc_check_meaning_cell_inside_markers_cannot_mask_a_dropped_row():
-    # Bypass #2: a value dropped from its own value-column row, but still mentioned in a later (MEANING) cell
-    # of a row INSIDE the markers. Only the FIRST cell (the value column) is read, so the meaning-cell token
-    # contributes NOTHING, the set is short a value, and doc-check FAILS as it must.
-    with tempfile.TemporaryDirectory() as d:
-        doc = Path(d) / "stage-3-merge.md"
-        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # no HAS_HOOKS value-column row
-        doc.write_text(_table_rows(states, M.MERGEABLE, meaning_tokens=("HAS_HOOKS",)), encoding="utf-8")
-        check(_doc_check_quiet(doc) == 1,
-              "a value named only in a MEANING cell inside the markers must STILL fail doc-check")
-
-
-def t_doc_check_fails_when_markers_are_absent():
-    # No markers at all — the drift-guard cannot LOCATE its table, so it must fail loudly, never pass.
-    with tempfile.TemporaryDirectory() as d:
-        doc = Path(d) / "stage-3-merge.md"
-        body = _table_rows(list(M.MERGE_STATE_STATUS), M.MERGEABLE)
-        body = body.replace(START + "\n", "").replace(END + "\n", "")  # strip both markers
-        doc.write_text(body, encoding="utf-8")
-        check(_doc_check_quiet(doc) == 1, "a doc with no precondition-table markers must FAIL — an "
-                                          "unlocatable table is never a pass")
-
-
-def t_doc_check_fails_when_it_finds_nothing():
-    # Markers PRESENT (so the table is located) but the marked region names ZERO enum values — the
-    # empty-extraction branch, distinct from the markers-absent one above.
-    with tempfile.TemporaryDirectory() as d:
-        doc = Path(d) / "stage-3-merge.md"
-        doc.write_text(f"{START}\n| Field / value | Meaning | Do |\n|---|---|---|\n"
-                       f"| this table names no enum values at all | meaning | do |\n{END}\n",
-                       encoding="utf-8")
-        check(_doc_check_quiet(doc) == 1, "a doc that enumerates zero values must FAIL — a check with no "
-                                          "subject never passes")
-
-
 CASES = [
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),
@@ -378,15 +270,4 @@ CASES = [
     ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
     ("cli-view-missing-field", "a view missing a field fails closed, never KeyError", t_cli_view_missing_field),
     ("cli-view-wrong-type", "a view field of the wrong JSON type fails closed", t_cli_view_wrong_type_field),
-    ("doc-agrees", "the shipped doc agrees with the code", t_doc_check_agrees_with_the_shipped_doc),
-    ("doc-drift-caught", "doc-check FAILS when the doc drops a value", t_doc_check_detects_a_dropped_value),
-    ("doc-prose-cant-mask", "prose outside the table can't mask a dropped table row",
-     t_doc_check_prose_cannot_mask_a_dropped_table_row),
-    ("doc-other-table-cant-mask", "another table OUTSIDE the markers can't mask a dropped row",
-     t_doc_check_another_table_outside_markers_cannot_mask_a_dropped_row),
-    ("doc-meaning-cell-cant-mask", "a MEANING cell inside the markers can't mask a dropped row",
-     t_doc_check_meaning_cell_inside_markers_cannot_mask_a_dropped_row),
-    ("doc-markers-absent-fails", "doc-check FAILS when the precondition-table markers are absent",
-     t_doc_check_fails_when_markers_are_absent),
-    ("doc-empty-fails", "doc-check FAILS when it extracts nothing", t_doc_check_fails_when_it_finds_nothing),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -201,12 +201,21 @@ def _doc_check_quiet(doc: Path) -> int:
         return M.doc_check(doc)
 
 
-def _table_rows(mss_values, mergeable_values) -> str:
-    """A minimal merge-precondition TABLE — each enum token in a Markdown table row (leading `|`), which is
-    the ONLY shape doc_enum reads. Used by the drift fixtures so they exercise the real table-row path."""
+START = M.PRECONDITION_TABLE_START
+END = M.PRECONDITION_TABLE_END
+
+
+def _table_rows(mss_values, mergeable_values, *, meaning_tokens=()) -> str:
+    """A minimal merge-precondition TABLE wrapped in the start/end markers doc_enum requires. Each enum token
+    sits in the FIRST cell of its row — the only cell doc_enum reads. `meaning_tokens` inject extra
+    `.mergeStateStatus = X` strings into a row's MEANING (second) cell; those must NOT count. Used by the
+    drift fixtures so they exercise the real marked-table, first-cell path."""
     rows = ([f"| `.mergeStateStatus = {v}` | meaning | do |" for v in mss_values]
-            + [f"| `.mergeable = {v}` | meaning | do |" for v in mergeable_values])
-    return "| Field / value | Meaning | Do |\n|---|---|---|\n" + "\n".join(rows) + "\n"
+            + [f"| `.mergeable = {v}` | meaning | do |" for v in mergeable_values]
+            + [f"| `.mergeStateStatus = CLEAN` | also names `.mergeStateStatus = {t}` here | do |"
+               for t in meaning_tokens])
+    return (f"{START}\n| Field / value | Meaning | Do |\n|---|---|---|\n"
+            + "\n".join(rows) + f"\n{END}\n")
 
 
 def t_doc_check_detects_a_dropped_value():
@@ -233,10 +242,54 @@ def t_doc_check_prose_cannot_mask_a_dropped_table_row():
               "a value dropped from the TABLE but named only in PROSE must STILL fail doc-check")
 
 
-def t_doc_check_fails_when_it_finds_nothing():
+def t_doc_check_another_table_outside_markers_cannot_mask_a_dropped_row():
+    # Bypass #1: a value dropped from the MARKED precondition table, but still carried by ANOTHER `|`-table
+    # elsewhere in the doc (outside the markers). Scoped to the marked region, the second table contributes
+    # NOTHING, the set is short a value, and doc-check FAILS as it must.
     with tempfile.TemporaryDirectory() as d:
         doc = Path(d) / "stage-3-merge.md"
-        doc.write_text("this table names no enum values at all\n", encoding="utf-8")
+        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # HAS_HOOKS gone from the MARKED table
+        marked = _table_rows(states, M.MERGEABLE)
+        other = ("\n### An unrelated table, OUTSIDE the markers\n\n"
+                 "| Field / value | Meaning | Do |\n|---|---|---|\n"
+                 "| `.mergeStateStatus = HAS_HOOKS` | some other context | do |\n")
+        doc.write_text(marked + other, encoding="utf-8")
+        check(_doc_check_quiet(doc) == 1,
+              "a value dropped from the MARKED table but named in another table OUTSIDE the markers must "
+              "STILL fail doc-check")
+
+
+def t_doc_check_meaning_cell_inside_markers_cannot_mask_a_dropped_row():
+    # Bypass #2: a value dropped from its own value-column row, but still mentioned in a later (MEANING) cell
+    # of a row INSIDE the markers. Only the FIRST cell (the value column) is read, so the meaning-cell token
+    # contributes NOTHING, the set is short a value, and doc-check FAILS as it must.
+    with tempfile.TemporaryDirectory() as d:
+        doc = Path(d) / "stage-3-merge.md"
+        states = [v for v in M.MERGE_STATE_STATUS if v != "HAS_HOOKS"]  # no HAS_HOOKS value-column row
+        doc.write_text(_table_rows(states, M.MERGEABLE, meaning_tokens=("HAS_HOOKS",)), encoding="utf-8")
+        check(_doc_check_quiet(doc) == 1,
+              "a value named only in a MEANING cell inside the markers must STILL fail doc-check")
+
+
+def t_doc_check_fails_when_markers_are_absent():
+    # No markers at all — the drift-guard cannot LOCATE its table, so it must fail loudly, never pass.
+    with tempfile.TemporaryDirectory() as d:
+        doc = Path(d) / "stage-3-merge.md"
+        body = _table_rows(list(M.MERGE_STATE_STATUS), M.MERGEABLE)
+        body = body.replace(START + "\n", "").replace(END + "\n", "")  # strip both markers
+        doc.write_text(body, encoding="utf-8")
+        check(_doc_check_quiet(doc) == 1, "a doc with no precondition-table markers must FAIL — an "
+                                          "unlocatable table is never a pass")
+
+
+def t_doc_check_fails_when_it_finds_nothing():
+    # Markers PRESENT (so the table is located) but the marked region names ZERO enum values — the
+    # empty-extraction branch, distinct from the markers-absent one above.
+    with tempfile.TemporaryDirectory() as d:
+        doc = Path(d) / "stage-3-merge.md"
+        doc.write_text(f"{START}\n| Field / value | Meaning | Do |\n|---|---|---|\n"
+                       f"| this table names no enum values at all | meaning | do |\n{END}\n",
+                       encoding="utf-8")
         check(_doc_check_quiet(doc) == 1, "a doc that enumerates zero values must FAIL — a check with no "
                                           "subject never passes")
 
@@ -265,5 +318,11 @@ CASES = [
     ("doc-drift-caught", "doc-check FAILS when the doc drops a value", t_doc_check_detects_a_dropped_value),
     ("doc-prose-cant-mask", "prose outside the table can't mask a dropped table row",
      t_doc_check_prose_cannot_mask_a_dropped_table_row),
+    ("doc-other-table-cant-mask", "another table OUTSIDE the markers can't mask a dropped row",
+     t_doc_check_another_table_outside_markers_cannot_mask_a_dropped_row),
+    ("doc-meaning-cell-cant-mask", "a MEANING cell inside the markers can't mask a dropped row",
+     t_doc_check_meaning_cell_inside_markers_cannot_mask_a_dropped_row),
+    ("doc-markers-absent-fails", "doc-check FAILS when the precondition-table markers are absent",
+     t_doc_check_fails_when_markers_are_absent),
     ("doc-empty-fails", "doc-check FAILS when it extracts nothing", t_doc_check_fails_when_it_finds_nothing),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -188,6 +188,41 @@ def t_cli_no_ledger_row():
               f"a missing row must decide `no ledger row` without ever reading the view, got {out!r}")
 
 
+def _cli_malformed_view(bad_view: dict, missing_or_wrong: str) -> None:
+    """Drive the real CLI with a syntactically valid but malformed `--view-json`. It must fail CLOSED: a
+    structured not-yet naming the malformed view, a NON-ZERO exit, and NO traceback — never a KeyError and
+    never `merge`."""
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        vjson = Path(d) / "view.json"
+        vjson.write_text(json.dumps(bad_view), encoding="utf-8")
+        code, out, err = capture_cli(
+            M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+        check(code != 0, f"a malformed view must exit non-zero (fail closed), got {code} (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "not-yet",
+              f"a malformed view must decide not-yet, never merge, got {result!r}")
+        check(result["reason"].startswith("malformed PR view:"),
+              f"the reason must name the malformed view, got {result['reason']!r}")
+        check(missing_or_wrong in result["reason"],
+              f"the reason must say what is wrong ({missing_or_wrong!r}), got {result['reason']!r}")
+
+
+def t_cli_view_missing_field():
+    # A valid JSON object MISSING mergeStateStatus — decide() would KeyError on it; the boundary parks it.
+    v = view()
+    del v["mergeStateStatus"]
+    _cli_malformed_view(v, "mergeStateStatus")
+
+
+def t_cli_view_wrong_type_field():
+    # isDraft handed in as a STRING, not a bool — a wrong JSON type must fail closed like a missing field.
+    v = view()
+    v["isDraft"] = "false"
+    _cli_malformed_view(v, "isDraft")
+
+
 # --- the drift guard has teeth ------------------------------------------------
 
 def t_doc_check_agrees_with_the_shipped_doc():
@@ -314,6 +349,8 @@ CASES = [
     ("mergeable-unknown-value-parks", "an unrecognised mergeable value parks", t_unknown_mergeable_value_parks),
     ("cli-injected-view", "check --view-json decides without gh and exits 0", t_cli_injected_view),
     ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
+    ("cli-view-missing-field", "a view missing a field fails closed, never KeyError", t_cli_view_missing_field),
+    ("cli-view-wrong-type", "a view field of the wrong JSON type fails closed", t_cli_view_wrong_type_field),
     ("doc-agrees", "the shipped doc agrees with the code", t_doc_check_agrees_with_the_shipped_doc),
     ("doc-drift-caught", "doc-check FAILS when the doc drops a value", t_doc_check_detects_a_dropped_value),
     ("doc-prose-cant-mask", "prose outside the table can't mask a dropped table row",

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -85,6 +85,28 @@ def t_held_never_merges():
         expect(row(status=status), view(), "not-yet", f"held ({status})")
 
 
+# --- the status ALLOW-LIST: only `in_review` is a merge candidate -------------
+
+def t_terminal_status_never_merges():
+    # THE REPRO: a TERMINAL row (aborted/merged) with a fully clean+green+2/2 view and a matching SHA once
+    # printed `{"verdict":"merge"}` — it would have merged an aborted PR. The allow-list parks anything that
+    # is not `in_review`, naming the offending status so the reason is actionable. `merged` is the same trap.
+    for status in ("aborted", "merged"):
+        expect(row(status=status), view(), "not-yet", f"row status is {status}, not in_review")
+
+
+def t_unexpected_status_never_merges():
+    # An ALLOW-LIST, not a reject-list: a status nobody enumerated (a future one, a typo) STILL parks — it is
+    # not `in_review`, so it never reaches a merge verdict, whatever the counters and enums say.
+    expect(row(status="quarantined"), view(), "not-yet", "row status is quarantined, not in_review")
+
+
+def t_in_review_is_the_one_that_merges():
+    # The allow-list did NOT break the happy path: an `in_review` row with every precondition met + CLEAN
+    # still merges. (row()'s default status is already in_review; state it explicitly for this fixture.)
+    expect(row(status="in_review"), view(), "merge", "")
+
+
 # --- ledger preconditions, in order -------------------------------------------
 
 def t_not_open():
@@ -333,6 +355,11 @@ CASES = [
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),
     ("held-frozen", "a held PR never merges, whatever the counters/enums say", t_held_never_merges),
+    ("terminal-frozen", "a terminal row (aborted/merged) never merges — the allow-list repro",
+     t_terminal_status_never_merges),
+    ("unexpected-frozen", "an unexpected status parks — allow-list, not reject-list",
+     t_unexpected_status_never_merges),
+    ("in-review-merges", "only in_review clears the status allow-list", t_in_review_is_the_one_that_merges),
     ("not-open", "a merged/closed PR is not a candidate", t_not_open),
     ("draft", "a draft PR is parked, not merged", t_draft),
     ("stale-sha", "a moved head outranks ci and the enums", t_stale_sha),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""DECIDE whether a PR may merge — from its ledger row plus its live GitHub view. GATE MACHINERY.
+
+It prints ONE verdict: `merge` (every precondition met) or `not-yet` with a concrete `reason`. It NEVER
+merges anything, and it wires into no merge step — deciding and doing are two jobs, and this is only the
+first. `gh pr merge` lives in `stage-3-merge.md`, downstream of a `merge` verdict; nothing here runs it.
+
+WHY THIS IS A COMMAND AND NOT A TABLE A DRIVER READS BY EYE. The merge decision crosses FIVE ledger
+preconditions (held, open, draft, live head == reviewed head, ci, reviews) and then TWO GitHub enums
+(`.mergeable` and `.mergeStateStatus`) that answer DIFFERENT questions — `.mergeable` says the branches
+CAN be combined, `.mergeStateStatus` says the merge is PERMITTED RIGHT NOW. Reading one for the other is
+the miscross that once turned a BLOCKED merge into an infinite CI watch (`stage-3-merge.md`): a PR that was
+`.mergeable = MERGEABLE` with a fully green rollup, blocked only because it was a draft, was mapped to
+`ci = pending` and watched forever, because nothing was ever going to move. This tool is the ONE place the
+two enums are crossed, so nobody does it by hand and nobody does it wrong.
+
+`.mergeable = MERGEABLE` is NECESSARY BUT NOT SUFFICIENT: it falls THROUGH to `.mergeStateStatus`, which is
+the only field that yields `merge`. Both enums are mapped TOTALLY — every value GitHub's schema declares has
+its own row, and a value with NO row is a WEDGE, so the catch-all PARKS it rather than guessing. The table
+this implements is `references/stage-3-merge.md`'s merge-precondition table, and `doc-check` FAILS the build
+if the doc and this code stop enumerating the same value sets — neither may add or drop a value alone.
+
+    merge-check.py check --pr 31 --file <state.jsonl> [--repo owner/name] [--view-json <path>]
+    merge-check.py doc-check   assert stage-3-merge.md's two enum sets equal the sets `decide` handles
+    merge-check.py self-test   run every fixture (merge-check-test.py), then doc-check
+
+The fixture suite is the SIBLING `merge-check-test.py`, this tool's EXECUTABLE CONTRACT; `self-test` loads
+it by a `__file__`-relative path and FAILS LOUDLY if it is missing — a self-test that passes because it
+found no tests is not a passing gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "merge-check-test.py"     # the fixture suite — this tool's executable contract
+DOC = _HERE.parent / "references" / "stage-3-merge.md"
+
+
+def _load(name: str, filename: str):
+    mod = load_module_from_path(name, _HERE / filename)
+    if mod is None:
+        raise RuntimeError(f"cannot load {filename}")
+    return mod
+
+
+# The schema owner. `HELD_STATUSES`, `REPAIR_STATUS` and `load` are imported, never restated — a new held
+# status inherits the merge freeze here with no edit, and the file format has exactly one parser.
+L = _load("merge_check_ledger", "ledger.py")
+HELD_STATUSES = L.HELD_STATUSES
+REPAIR_STATUS = L.REPAIR_STATUS
+
+# `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped. The rule already lives in `nudge.py`
+# (and `review-pass.py`); a third copy here would be the drift this repo keeps killing. So merge-check
+# borrows the existing helper rather than spelling `1 if TRIVIAL else 2` a third time.
+_N = _load("merge_check_nudge", "nudge.py")
+REQUIRED = _N.required
+
+
+# --- the two GitHub enums, as data so `decide` and `doc-check` read ONE source -------------------
+#
+# `.mergeable` — MERGEABLE is the ONLY value that does not decide on its own; it FALLS THROUGH to
+# `.mergeStateStatus`. So its row is the FALL_THROUGH sentinel, not a verdict. The other two are terminal
+# not-yets. A value in NEITHER row is one GitHub added since — the catch-all parks it.
+FALL_THROUGH = "fall-through"
+MERGEABLE = {
+    "MERGEABLE": FALL_THROUGH,
+    "CONFLICTING": "conflicts with base — rebase",
+    "UNKNOWN": "mergeability not computed yet — re-poll",
+}
+
+# `.mergeStateStatus` — CLEAN and HAS_HOOKS are the ONLY two that clear the merge; every other value is a
+# terminal not-yet. This is `stage-3-merge.md`'s merge-precondition table, value for value. A value with no
+# row here parks via the catch-all in `decide`, never guesses — `doc-check` pins that this set equals the
+# doc's.
+MERGE = "merge"
+NOT_YET = "not-yet"
+MERGE_STATE_STATUS = {
+    "CLEAN": (MERGE, ""),
+    "HAS_HOOKS": (MERGE, ""),
+    "BEHIND": (NOT_YET, "base moved ahead — rebase"),
+    "DIRTY": (NOT_YET, "conflicts — rebase"),
+    "UNSTABLE": (NOT_YET, "a check is non-passing (may still be running) — not campaign's ci signal"),
+    "BLOCKED": (NOT_YET, "GitHub says BLOCKED — park awaiting-user"),
+    "UNKNOWN": (NOT_YET, "merge state not computed yet — re-poll"),
+}
+
+
+def _merge() -> dict:
+    return {"verdict": MERGE, "reason": ""}
+
+
+def _not_yet(reason: str) -> dict:
+    return {"verdict": NOT_YET, "reason": reason}
+
+
+def _short(sha: str) -> str:
+    """A SHA as git abbreviates it, for the REASON only. Equality is always compared on the FULL value."""
+    return sha[:7] if len(sha) > 7 else sha
+
+
+def decide(row: dict, view: dict, *, required) -> dict:
+    """PURE. Return `{"verdict": "merge"|"not-yet", "reason": str}` for one PR. No I/O.
+
+    The order is FIRST-FAILING-CHECK-WINS, and it is deliberate: a held PR is FROZEN regardless of counters,
+    so it is asked before anything else; the two GitHub enums are asked LAST, only once every ledger
+    precondition has already passed. `required` is the gate's `required(tier)` helper, passed in.
+    """
+    # 1. HELD — a parked or repairing PR is FROZEN, whatever its counters or the enums say.
+    status = row["status"]
+    if status in HELD_STATUSES or status == REPAIR_STATUS:
+        return _not_yet(f"held ({status})")
+
+    # 2. NOT OPEN — a merged/closed PR is not a merge candidate.
+    state = view["state"]
+    if state != "OPEN":
+        return _not_yet(f"pr is {state}, not open")
+
+    # 3. DRAFT — GitHub blocks the merge regardless of CI.
+    if view["isDraft"]:
+        return _not_yet("draft — park awaiting-user")
+
+    # 4. STALE SHA — the gate was recorded against `row.head_sha`; if the live head has MOVED, every verdict
+    #    describes a commit that is no longer the tip. Compared on the FULL sha; displayed short.
+    head_now = view["headRefOid"]
+    if head_now != row["head_sha"]:
+        return _not_yet(
+            f"PR head {_short(head_now)} moved off the reviewed SHA {_short(row['head_sha'])} — re-gate")
+
+    # 5. CI — campaign's own SHA-pinned snapshot is the ONLY source of `ci`. `.mergeStateStatus` never feeds
+    #    it (that miscross is this tool's founding bug).
+    ci = row["ci"]
+    if ci != "green":
+        return _not_yet(f"ci is {ci}, not green")
+
+    # 6. REVIEWS — the gate tally must meet `required(tier)`.
+    ok = int(row["reviews_ok"])
+    need = required(row["tier"])
+    if ok < need:
+        return _not_yet(f"{ok} of {need} approvals")
+
+    # 7. THE TWO GITHUB ENUMS, crossed TOTALLY. `.mergeable` first, then `.mergeStateStatus`.
+    mergeable = view["mergeable"]
+    handling = MERGEABLE.get(mergeable)
+    if handling is None:
+        return _not_yet(f"unknown mergeable value {mergeable} — park")
+    if handling != FALL_THROUGH:
+        return _not_yet(handling)
+    # `.mergeable = MERGEABLE`: NOT a licence to merge — decide on `.mergeStateStatus`.
+    mss = view["mergeStateStatus"]
+    row_mss = MERGE_STATE_STATUS.get(mss)
+    if row_mss is None:
+        return _not_yet(f"unknown merge state {mss} — park, never guess")
+    verdict, reason = row_mss
+    return _merge() if verdict == MERGE else _not_yet(reason)
+
+
+# --- obtain the live PR view ---------------------------------------------------
+
+VIEW_FIELDS = "mergeable,mergeStateStatus,isDraft,state,headRefOid"
+
+
+class ViewError(Exception):
+    """The live PR view could not be obtained. The decision fails CLOSED — never `merge`."""
+
+
+def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
+    """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
+    `gh pr view` itself. Any failure raises `ViewError`, which the caller turns into a fail-closed not-yet.
+    """
+    if view_json is not None:
+        try:
+            return json.loads(Path(view_json).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ViewError(str(exc)) from exc
+    argv = ["gh", "pr", "view", str(pr)]
+    if repo:
+        argv += ["--repo", repo]
+    argv += ["--json", VIEW_FIELDS]
+    proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
+    if proc.returncode != 0:
+        raise ViewError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ViewError(f"gh response is not JSON ({exc})") from exc
+
+
+def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None") -> int:
+    """Read the ledger row + the live view, decide, print the verdict as JSON. Exit 0 on a computed verdict;
+    a view that could not be fetched is a fail-closed not-yet, and a non-zero exit is fine there."""
+    _header, rows = L.load(ledger_path)
+    row = next((r for r in rows if r["pr"] == str(pr)), None)
+    if row is None:
+        print(json.dumps(_not_yet("no ledger row")))
+        return 0
+    try:
+        view = load_view(pr, repo, view_json)
+    except ViewError as exc:
+        print(json.dumps(_not_yet(f"could not fetch PR view: {exc}")))
+        return 1
+    print(json.dumps(decide(row, view, required=REQUIRED)))
+    return 0
+
+
+# --- doc-check: the doc and the code cannot silently disagree ------------------
+
+def doc_enum(text: str, field: str) -> set:
+    """The set of `<field>` values `stage-3-merge.md`'s merge-precondition table enumerates, read off the
+    backticked `.<field> = VALUE` tokens the table uses (e.g. `.mergeStateStatus = CLEAN`). The fenced enum
+    block above the table writes the same values differently and is not matched here — the TABLE is the
+    contract this tool implements, so the table is what is pinned.
+    """
+    return set(re.findall(rf"\.{field}\s*=\s*([A-Z_]+)", text))
+
+
+def doc_check(doc: Path) -> int:
+    """Assert `stage-3-merge.md` and this code enumerate the SAME two enum value sets.
+
+    Neither the doc nor `decide` may add or drop a `.mergeable` or `.mergeStateStatus` value without the
+    other. A check that finds NOTHING must never pass, so an empty extraction (a renamed/reformatted table)
+    FAILS exactly as a mismatch does.
+    """
+    if not doc.exists():
+        print(f"FAIL     the doc is not at {doc} — a check that cannot find its subject NEVER passes")
+        return 1
+    text = doc.read_text(encoding="utf-8")
+
+    checks = [
+        ("mergeable", doc_enum(text, "mergeable"), set(MERGEABLE),
+         "MERGEABLE is necessary-not-sufficient; dropping a value here wedges a PR or merges over it"),
+        ("mergeStateStatus", doc_enum(text, "mergeStateStatus"), set(MERGE_STATE_STATUS),
+         "the merge-precondition table; a value in the doc but not the code (or vice versa) is a silent drift"),
+    ]
+    failures = 0
+    for field, doc_set, code_set, why in checks:
+        if not doc_set:
+            failures += 1
+            print(f"FAIL     .{field:20} the doc enumerates ZERO values — the table is GONE, renamed, or "
+                  f"reformatted, and a check with no subject must never report success")
+            continue
+        if doc_set == code_set:
+            print(f"ok       .{field:20} {' '.join(sorted(code_set))}")
+            continue
+        failures += 1
+        print(f"FAIL     .{field:20} doc/code DISAGREE\n"
+              f"         code says: {' '.join(sorted(code_set))}\n"
+              f"         doc says:  {' '.join(sorted(doc_set))}\n"
+              f"         missing from the doc: {' '.join(sorted(code_set - doc_set)) or '—'}   "
+              f"only in the doc: {' '.join(sorted(doc_set - code_set)) or '—'}\n"
+              f"         {why}")
+    print()
+    if failures:
+        print(f"{failures} disagreement(s) between {doc.name} and the code that runs. ONE of them is wrong "
+              f"and a reader will believe the other.")
+        return 1
+    print(f"{len(checks)} checks: {doc.name} and merge-check.py agree — both enum sets, mapped totally.")
+    return 0
+
+
+# --- self-test: the executable contract lives in the SIBLING module ------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def _sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture suite is NOT AT {SIBLING} — `self-test` has NO SUBJECT, and a check that cannot "
+            f"find the thing it tests must FAIL, never pass.")
+    mod = load_module_from_path("merge_check_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    """Run the sibling suite over every fixture, then `doc-check`. Non-zero on any failure."""
+    failures = 0
+    try:
+        cases = _sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the merge-readiness decider's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:30} -> {rule}")
+    print()
+    # The DOC-CHECK is part of the contract: the code may not silently drift from stage-3-merge.md.
+    doc_rc = doc_check(DOC)
+    print()
+    if failures or doc_rc != 0:
+        print(f"{failures} fixture(s) failed and doc-check {'FAILED' if doc_rc else 'passed'} — the "
+              f"merge-readiness decider's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold and stage-3-merge.md agrees — the decider's contract is intact.")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("check", help="decide merge-readiness for one PR (ledger row + live PR view)")
+    c.add_argument("--pr", required=True)
+    c.add_argument("--file", required=True, type=Path, help="the run ledger (<rundir>/state.jsonl)")
+    c.add_argument("--repo", help="owner/name (default: the current checkout's)")
+    c.add_argument("--view-json", help="a recorded `gh pr view` JSON — decide without calling gh")
+
+    d = sub.add_parser("doc-check", help="assert stage-3-merge.md's two enum sets equal the code's")
+    d.add_argument("--doc", type=Path, default=DOC)
+
+    sub.add_parser("self-test", help="run every fixture (merge-check-test.py), then doc-check")
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "self-test":
+        return self_test()
+    if args.cmd == "doc-check":
+        return doc_check(args.doc)
+    return check(args.pr, args.file, args.repo, args.view_json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -172,6 +172,31 @@ class ViewError(Exception):
     """The live PR view could not be obtained. The decision fails CLOSED — never `merge`."""
 
 
+# Every field `decide` reads off the view, with the JSON type it requires. `isDraft` is a bool; the other
+# four are strings. `validate_view` pins this at the boundary so `decide` may assume a shaped view and never
+# raises `KeyError`/`TypeError` on a value the caller handed in.
+_VIEW_STR_FIELDS = ("mergeable", "mergeStateStatus", "state", "headRefOid")
+
+
+def validate_view(view: object) -> "str | None":
+    """`None` if `view` is a JSON object carrying every field `decide` consumes at the right JSON type;
+    otherwise a short description of the FIRST thing wrong. PURE — no I/O. The CLI turns a non-`None` result
+    into a fail-closed not-yet, so `decide` is never reached with a malformed view."""
+    if not isinstance(view, dict):
+        return f"view is not a JSON object (got {type(view).__name__})"
+    for field in _VIEW_STR_FIELDS:
+        if field not in view:
+            return f"missing field {field!r}"
+        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
+        if not isinstance(view[field], str):
+            return f"field {field!r} must be a string, got {type(view[field]).__name__}"
+    if "isDraft" not in view:
+        return "missing field 'isDraft'"
+    if not isinstance(view["isDraft"], bool):
+        return f"field 'isDraft' must be a bool, got {type(view['isDraft']).__name__}"
+    return None
+
+
 def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
     """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
     `gh pr view` itself. Any failure raises `ViewError`, which the caller turns into a fail-closed not-yet.
@@ -206,6 +231,12 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
         view = load_view(pr, repo, view_json)
     except ViewError as exc:
         print(json.dumps(_not_yet(f"could not fetch PR view: {exc}")))
+        return 1
+    # A syntactically valid but INCOMPLETE/WRONG-TYPED view must fail CLOSED here, never crash `decide` with
+    # a KeyError/TypeError and never say `merge`. Mirrors the fetch-failure not-yet above.
+    problem = validate_view(view)
+    if problem is not None:
+        print(json.dumps(_not_yet(f"malformed PR view: {problem}")))
         return 1
     print(json.dumps(decide(row, view, required=REQUIRED)))
     return 0

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -216,7 +216,14 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
     if repo:
         argv += ["--repo", repo]
     argv += ["--json", VIEW_FIELDS]
-    proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
+    # SPAWN failure (gh absent or not executable) raises OSError from subprocess.run itself, BEFORE any
+    # returncode exists. Route it through the same `ViewError` as the non-zero and non-JSON branches, so
+    # every gh-path failure fails CLOSED via the one `except ViewError` — never an uncaught traceback with
+    # no verdict on stdout.
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
+    except OSError as exc:
+        raise ViewError(f"could not run `gh pr view {pr}`: {exc}") from exc
     if proc.returncode != 0:
         raise ViewError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
     try:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -52,11 +52,12 @@ def _load(name: str, filename: str):
     return mod
 
 
-# The schema owner. `HELD_STATUSES`, `REPAIR_STATUS` and `load` are imported, never restated — a new held
-# status inherits the merge freeze here with no edit, and the file format has exactly one parser.
+# The schema owner. `HELD_STATUSES` and `load` are imported, never restated — the file format has exactly
+# one parser, and the held set is imported only to make the parked-vs-terminal reason accurate. The merge
+# gate itself does NOT enumerate held statuses: `decide` ALLOW-LISTS `in_review` (below), so a new held
+# status — or any other non-`in_review` status — is frozen by that allow-list with no edit here.
 L = _load("merge_check_ledger", "ledger.py")
 HELD_STATUSES = L.HELD_STATUSES
-REPAIR_STATUS = L.REPAIR_STATUS
 
 # `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped. The rule already lives in `nudge.py`
 # (and `review-pass.py`); a third copy here would be the drift this repo keeps killing. So merge-check
@@ -110,14 +111,21 @@ def _short(sha: str) -> str:
 def decide(row: dict, view: dict, *, required) -> dict:
     """PURE. Return `{"verdict": "merge"|"not-yet", "reason": str}` for one PR. No I/O.
 
-    The order is FIRST-FAILING-CHECK-WINS, and it is deliberate: a held PR is FROZEN regardless of counters,
-    so it is asked before anything else; the two GitHub enums are asked LAST, only once every ledger
-    precondition has already passed. `required` is the gate's `required(tier)` helper, passed in.
+    The order is FIRST-FAILING-CHECK-WINS, and it is deliberate: the status ALLOW-LIST is asked before
+    anything else, so a PR that is not `in_review` (held, terminal, or anything else) is frozen regardless
+    of counters; the two GitHub enums are asked LAST, only once every ledger precondition has already
+    passed. `required` is the gate's `required(tier)` helper, passed in.
     """
-    # 1. HELD — a parked or repairing PR is FROZEN, whatever its counters or the enums say.
+    # 1. STATUS ALLOW-LIST — only an `in_review` row is EVER a merge candidate. This is an ALLOW-LIST, not a
+    #    reject-list, and that is the whole point: every OTHER status parks, so nothing can slip through to a
+    #    `merge` verdict — not a held `awaiting-*`/`repairing`, not a TERMINAL `aborted`/`merged`, not any
+    #    status added to the ledger later. It SUBSUMES the old held freeze (a held PR is simply not
+    #    `in_review`); the held set is consulted ONLY to keep the reason accurate (parked vs terminal/other).
     status = row["status"]
-    if status in HELD_STATUSES or status == REPAIR_STATUS:
-        return _not_yet(f"held ({status})")
+    if status != "in_review":
+        if status in HELD_STATUSES:
+            return _not_yet(f"held ({status})")
+        return _not_yet(f"row status is {status}, not in_review")
 
     # 2. NOT OPEN — a merged/closed PR is not a merge candidate.
     state = view["state"]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -213,22 +213,53 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
 
 # --- doc-check: the doc and the code cannot silently disagree ------------------
 
-def doc_enum(text: str, field: str) -> set:
-    """The set of `<field>` values `stage-3-merge.md`'s merge-precondition table enumerates, read off the
-    backticked `.<field> = VALUE` tokens the table uses (e.g. `.mergeStateStatus = CLEAN`).
+# The merge-precondition table is DELIMITED in the doc by these two markers, each on its own line — the
+# start immediately before the header row, the end immediately after the last row. They make the extraction
+# UNAMBIGUOUS: `doc_enum` reads the ONE table between them and nothing else. Without a hard boundary, ANOTHER
+# `|`-table elsewhere in the doc (or a value dropped from this table but still named in a second table) could
+# supply the token the precondition table no longer has, and the drift-guard would PASS over a lost value.
+PRECONDITION_TABLE_START = "<!-- merge-precondition-table:start -->"
+PRECONDITION_TABLE_END = "<!-- merge-precondition-table:end -->"
 
-    The extraction is scoped to the doc's Markdown TABLE ROWS — a line whose first non-space character is
-    `|` — and NOTHING else. That scoping is load-bearing, not cosmetic: a value dropped from the table
-    itself but still named in PROSE somewhere in the doc (the fenced enum block above the table, a worked
-    example, a `.mergeStateStatus = BLOCKED` sentence) would otherwise supply the token the table no longer
-    has, and the drift-guard would PASS while the table it is meant to pin has silently lost a value. The
-    TABLE is the contract this tool implements, so ONLY the table rows are read — prose cannot mask a
-    dropped row.
+
+def precondition_table_rows(text: str) -> "list[str] | None":
+    """The lines strictly BETWEEN the two precondition-table markers, or `None` if the markers are absent,
+    empty, or out of order. `None` is a HARD FAIL for `doc_check` — a table it cannot locate is never a pass.
+    """
+    lines = text.splitlines()
+    start = next((i for i, l in enumerate(lines) if l.strip() == PRECONDITION_TABLE_START), None)
+    end = next((i for i, l in enumerate(lines) if l.strip() == PRECONDITION_TABLE_END), None)
+    if start is None or end is None or end <= start + 1:
+        return None
+    return lines[start + 1:end]
+
+
+def doc_enum(rows: "list[str]", field: str) -> set:
+    """The set of `<field>` values the merge-precondition table enumerates, read off the backticked
+    `.<field> = VALUE` tokens (e.g. `.mergeStateStatus = CLEAN`).
+
+    `rows` are ONLY the lines between the precondition-table markers (see `precondition_table_rows`), and
+    within each table row ONLY the FIRST `|`-delimited cell — the "Field / value" column — is read. Both
+    scopings are load-bearing, not cosmetic, and each closes a distinct bypass:
+
+    - Marker scoping: a value dropped from THIS table but still named in prose or in ANOTHER `|`-table
+      elsewhere in the doc would otherwise supply the token this table no longer has — the drift-guard would
+      PASS while the table it pins has silently lost a value.
+    - First-cell scoping: a value dropped from its own row but still mentioned in a later cell (a "Meaning"
+      or "Do" cell) of some row INSIDE the markers would likewise sneak the token back in. Only the value
+      column declares what the table enumerates; the prose cells describe it and must not contribute.
+
+    The TABLE's value column is the contract this tool implements, so ONLY it is read — nothing else can mask
+    a dropped row.
     """
     enum = set()
-    for line in text.splitlines():
-        if line.lstrip().startswith("|"):
-            enum.update(re.findall(rf"\.{field}\s*=\s*([A-Z_]+)", line))
+    for line in rows:
+        if not line.lstrip().startswith("|"):
+            continue
+        cells = line.split("|")
+        # cells[0] is the empty string before the leading `|`; cells[1] is the "Field / value" column.
+        first_cell = cells[1] if len(cells) > 1 else ""
+        enum.update(re.findall(rf"\.{field}\s*=\s*([A-Z_]+)", first_cell))
     return enum
 
 
@@ -236,18 +267,25 @@ def doc_check(doc: Path) -> int:
     """Assert `stage-3-merge.md` and this code enumerate the SAME two enum value sets.
 
     Neither the doc nor `decide` may add or drop a `.mergeable` or `.mergeStateStatus` value without the
-    other. A check that finds NOTHING must never pass, so an empty extraction (a renamed/reformatted table)
-    FAILS exactly as a mismatch does.
+    other. A check that finds NOTHING must never pass, so absent markers (an unlocatable table) and an empty
+    extraction (a renamed/reformatted table) both FAIL exactly as a mismatch does.
     """
     if not doc.exists():
         print(f"FAIL     the doc is not at {doc} — a check that cannot find its subject NEVER passes")
         return 1
     text = doc.read_text(encoding="utf-8")
 
+    rows = precondition_table_rows(text)
+    if rows is None:
+        print(f"FAIL     the merge-precondition-table markers "
+              f"({PRECONDITION_TABLE_START} … {PRECONDITION_TABLE_END}) are absent, empty, or out of order "
+              f"in {doc.name} — a drift-guard that cannot LOCATE its table must never report success")
+        return 1
+
     checks = [
-        ("mergeable", doc_enum(text, "mergeable"), set(MERGEABLE),
+        ("mergeable", doc_enum(rows, "mergeable"), set(MERGEABLE),
          "MERGEABLE is necessary-not-sufficient; dropping a value here wedges a PR or merges over it"),
-        ("mergeStateStatus", doc_enum(text, "mergeStateStatus"), set(MERGE_STATE_STATUS),
+        ("mergeStateStatus", doc_enum(rows, "mergeStateStatus"), set(MERGE_STATE_STATUS),
          "the merge-precondition table; a value in the doc but not the code (or vice versa) is a silent drift"),
     ]
     failures = 0

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -16,13 +16,13 @@ two enums are crossed, so nobody does it by hand and nobody does it wrong.
 
 `.mergeable = MERGEABLE` is NECESSARY BUT NOT SUFFICIENT: it falls THROUGH to `.mergeStateStatus`, which is
 the only field that yields `merge`. Both enums are mapped TOTALLY — every value GitHub's schema declares has
-its own row, and a value with NO row is a WEDGE, so the catch-all PARKS it rather than guessing. The table
-this implements is `references/stage-3-merge.md`'s merge-precondition table, and `doc-check` FAILS the build
-if the doc and this code stop enumerating the same value sets — neither may add or drop a value alone.
+its own row, and a value with NO row is a WEDGE, so the catch-all PARKS it rather than guessing. This mapping
+is the OWNER of the merge-readiness decision; `references/stage-3-merge.md` now DELEGATES that decision to a
+single `merge-check.py check` call rather than restating it as a by-eye table, and the sibling fixtures pin
+every value's verdict.
 
     merge-check.py check --pr 31 --file <state.jsonl> [--repo owner/name] [--view-json <path>]
-    merge-check.py doc-check   assert stage-3-merge.md's two enum sets equal the sets `decide` handles
-    merge-check.py self-test   run every fixture (merge-check-test.py), then doc-check
+    merge-check.py self-test   run every fixture (merge-check-test.py)
 
 The fixture suite is the SIBLING `merge-check-test.py`, this tool's EXECUTABLE CONTRACT; `self-test` loads
 it by a `__file__`-relative path and FAILS LOUDLY if it is missing — a self-test that passes because it
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -42,7 +41,6 @@ from _gauntlet.modules import load_module_from_path
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "merge-check-test.py"     # the fixture suite — this tool's executable contract
-DOC = _HERE.parent / "references" / "stage-3-merge.md"
 
 
 def _load(name: str, filename: str):
@@ -66,7 +64,7 @@ _N = _load("merge_check_nudge", "nudge.py")
 REQUIRED = _N.required
 
 
-# --- the two GitHub enums, as data so `decide` and `doc-check` read ONE source -------------------
+# --- the two GitHub enums, as data so `decide` reads ONE source ----------------------------------
 #
 # `.mergeable` — MERGEABLE is the ONLY value that does not decide on its own; it FALLS THROUGH to
 # `.mergeStateStatus`. So its row is the FALL_THROUGH sentinel, not a verdict. The other two are terminal
@@ -79,9 +77,9 @@ MERGEABLE = {
 }
 
 # `.mergeStateStatus` — CLEAN and HAS_HOOKS are the ONLY two that clear the merge; every other value is a
-# terminal not-yet. This is `stage-3-merge.md`'s merge-precondition table, value for value. A value with no
-# row here parks via the catch-all in `decide`, never guesses — `doc-check` pins that this set equals the
-# doc's.
+# terminal not-yet. This mapping is the OWNER of the merge-readiness decision; `stage-3-merge.md` DELEGATES
+# to it. A value with no row here parks via the catch-all in `decide`, never guesses; the sibling fixtures
+# pin every value's verdict.
 MERGE = "merge"
 NOT_YET = "not-yet"
 MERGE_STATE_STATUS = {
@@ -250,109 +248,6 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
     return 0
 
 
-# --- doc-check: the doc and the code cannot silently disagree ------------------
-
-# The merge-precondition table is DELIMITED in the doc by these two markers, each on its own line — the
-# start immediately before the header row, the end immediately after the last row. They make the extraction
-# UNAMBIGUOUS: `doc_enum` reads the ONE table between them and nothing else. Without a hard boundary, ANOTHER
-# `|`-table elsewhere in the doc (or a value dropped from this table but still named in a second table) could
-# supply the token the precondition table no longer has, and the drift-guard would PASS over a lost value.
-PRECONDITION_TABLE_START = "<!-- merge-precondition-table:start -->"
-PRECONDITION_TABLE_END = "<!-- merge-precondition-table:end -->"
-
-
-def precondition_table_rows(text: str) -> "list[str] | None":
-    """The lines strictly BETWEEN the two precondition-table markers, or `None` if the markers are absent,
-    empty, or out of order. `None` is a HARD FAIL for `doc_check` — a table it cannot locate is never a pass.
-    """
-    lines = text.splitlines()
-    start = next((i for i, l in enumerate(lines) if l.strip() == PRECONDITION_TABLE_START), None)
-    end = next((i for i, l in enumerate(lines) if l.strip() == PRECONDITION_TABLE_END), None)
-    if start is None or end is None or end <= start + 1:
-        return None
-    return lines[start + 1:end]
-
-
-def doc_enum(rows: "list[str]", field: str) -> set:
-    """The set of `<field>` values the merge-precondition table enumerates, read off the backticked
-    `.<field> = VALUE` tokens (e.g. `.mergeStateStatus = CLEAN`).
-
-    `rows` are ONLY the lines between the precondition-table markers (see `precondition_table_rows`), and
-    within each table row ONLY the FIRST `|`-delimited cell — the "Field / value" column — is read. Both
-    scopings are load-bearing, not cosmetic, and each closes a distinct bypass:
-
-    - Marker scoping: a value dropped from THIS table but still named in prose or in ANOTHER `|`-table
-      elsewhere in the doc would otherwise supply the token this table no longer has — the drift-guard would
-      PASS while the table it pins has silently lost a value.
-    - First-cell scoping: a value dropped from its own row but still mentioned in a later cell (a "Meaning"
-      or "Do" cell) of some row INSIDE the markers would likewise sneak the token back in. Only the value
-      column declares what the table enumerates; the prose cells describe it and must not contribute.
-
-    The TABLE's value column is the contract this tool implements, so ONLY it is read — nothing else can mask
-    a dropped row.
-    """
-    enum = set()
-    for line in rows:
-        if not line.lstrip().startswith("|"):
-            continue
-        cells = line.split("|")
-        # cells[0] is the empty string before the leading `|`; cells[1] is the "Field / value" column.
-        first_cell = cells[1] if len(cells) > 1 else ""
-        enum.update(re.findall(rf"\.{field}\s*=\s*([A-Z_]+)", first_cell))
-    return enum
-
-
-def doc_check(doc: Path) -> int:
-    """Assert `stage-3-merge.md` and this code enumerate the SAME two enum value sets.
-
-    Neither the doc nor `decide` may add or drop a `.mergeable` or `.mergeStateStatus` value without the
-    other. A check that finds NOTHING must never pass, so absent markers (an unlocatable table) and an empty
-    extraction (a renamed/reformatted table) both FAIL exactly as a mismatch does.
-    """
-    if not doc.exists():
-        print(f"FAIL     the doc is not at {doc} — a check that cannot find its subject NEVER passes")
-        return 1
-    text = doc.read_text(encoding="utf-8")
-
-    rows = precondition_table_rows(text)
-    if rows is None:
-        print(f"FAIL     the merge-precondition-table markers "
-              f"({PRECONDITION_TABLE_START} … {PRECONDITION_TABLE_END}) are absent, empty, or out of order "
-              f"in {doc.name} — a drift-guard that cannot LOCATE its table must never report success")
-        return 1
-
-    checks = [
-        ("mergeable", doc_enum(rows, "mergeable"), set(MERGEABLE),
-         "MERGEABLE is necessary-not-sufficient; dropping a value here wedges a PR or merges over it"),
-        ("mergeStateStatus", doc_enum(rows, "mergeStateStatus"), set(MERGE_STATE_STATUS),
-         "the merge-precondition table; a value in the doc but not the code (or vice versa) is a silent drift"),
-    ]
-    failures = 0
-    for field, doc_set, code_set, why in checks:
-        if not doc_set:
-            failures += 1
-            print(f"FAIL     .{field:20} the doc enumerates ZERO values — the table is GONE, renamed, or "
-                  f"reformatted, and a check with no subject must never report success")
-            continue
-        if doc_set == code_set:
-            print(f"ok       .{field:20} {' '.join(sorted(code_set))}")
-            continue
-        failures += 1
-        print(f"FAIL     .{field:20} doc/code DISAGREE\n"
-              f"         code says: {' '.join(sorted(code_set))}\n"
-              f"         doc says:  {' '.join(sorted(doc_set))}\n"
-              f"         missing from the doc: {' '.join(sorted(code_set - doc_set)) or '—'}   "
-              f"only in the doc: {' '.join(sorted(doc_set - code_set)) or '—'}\n"
-              f"         {why}")
-    print()
-    if failures:
-        print(f"{failures} disagreement(s) between {doc.name} and the code that runs. ONE of them is wrong "
-              f"and a reader will believe the other.")
-        return 1
-    print(f"{len(checks)} checks: {doc.name} and merge-check.py agree — both enum sets, mapped totally.")
-    return 0
-
-
 # --- self-test: the executable contract lives in the SIBLING module ------------
 
 class SelfTestFailure(AssertionError):
@@ -375,7 +270,7 @@ def _sibling_cases() -> list:
 
 
 def self_test() -> int:
-    """Run the sibling suite over every fixture, then `doc-check`. Non-zero on any failure."""
+    """Run the sibling suite over every fixture. Non-zero on any failure."""
     failures = 0
     try:
         cases = _sibling_cases()
@@ -396,14 +291,10 @@ def self_test() -> int:
         else:
             print(f"ok       {name:30} -> {rule}")
     print()
-    # The DOC-CHECK is part of the contract: the code may not silently drift from stage-3-merge.md.
-    doc_rc = doc_check(DOC)
-    print()
-    if failures or doc_rc != 0:
-        print(f"{failures} fixture(s) failed and doc-check {'FAILED' if doc_rc else 'passed'} — the "
-              f"merge-readiness decider's contract is broken.")
+    if failures:
+        print(f"{failures} fixture(s) failed — the merge-readiness decider's contract is broken.")
         return 1
-    print(f"all {len(cases)} fixtures hold and stage-3-merge.md agrees — the decider's contract is intact.")
+    print(f"all {len(cases)} fixtures hold — the decider's contract is intact.")
     return 0
 
 
@@ -417,17 +308,12 @@ def main(argv: "list[str] | None" = None) -> int:
     c.add_argument("--repo", help="owner/name (default: the current checkout's)")
     c.add_argument("--view-json", help="a recorded `gh pr view` JSON — decide without calling gh")
 
-    d = sub.add_parser("doc-check", help="assert stage-3-merge.md's two enum sets equal the code's")
-    d.add_argument("--doc", type=Path, default=DOC)
-
-    sub.add_parser("self-test", help="run every fixture (merge-check-test.py), then doc-check")
+    sub.add_parser("self-test", help="run every fixture (merge-check-test.py)")
 
     args = p.parse_args(argv)
 
     if args.cmd == "self-test":
         return self_test()
-    if args.cmd == "doc-check":
-        return doc_check(args.doc)
     return check(args.pr, args.file, args.repo, args.view_json)
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -215,11 +215,21 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
 
 def doc_enum(text: str, field: str) -> set:
     """The set of `<field>` values `stage-3-merge.md`'s merge-precondition table enumerates, read off the
-    backticked `.<field> = VALUE` tokens the table uses (e.g. `.mergeStateStatus = CLEAN`). The fenced enum
-    block above the table writes the same values differently and is not matched here — the TABLE is the
-    contract this tool implements, so the table is what is pinned.
+    backticked `.<field> = VALUE` tokens the table uses (e.g. `.mergeStateStatus = CLEAN`).
+
+    The extraction is scoped to the doc's Markdown TABLE ROWS — a line whose first non-space character is
+    `|` — and NOTHING else. That scoping is load-bearing, not cosmetic: a value dropped from the table
+    itself but still named in PROSE somewhere in the doc (the fenced enum block above the table, a worked
+    example, a `.mergeStateStatus = BLOCKED` sentence) would otherwise supply the token the table no longer
+    has, and the drift-guard would PASS while the table it is meant to pin has silently lost a value. The
+    TABLE is the contract this tool implements, so ONLY the table rows are read — prose cannot mask a
+    dropped row.
     """
-    return set(re.findall(rf"\.{field}\s*=\s*([A-Z_]+)", text))
+    enum = set()
+    for line in text.splitlines():
+        if line.lstrip().startswith("|"):
+            enum.update(re.findall(rf"\.{field}\s*=\s*([A-Z_]+)", line))
+    return enum
 
 
 def doc_check(doc: Path) -> int:


### PR DESCRIPTION
- decide merge-readiness from the ledger row and the live PR view
- cross both GitHub merge enums totally; an unknown value parks; never merges
- doc-check keeps stage-3-merge.md and the code in sync
