### PR TITLE
add pr-adopt.py for mechanical PR adoption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,14 +99,16 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/followups-test.py \
             plugins/gauntlet/skills/campaign/scripts/nudge.py \
             plugins/gauntlet/skills/campaign/scripts/nudge-test.py \
+            plugins/gauntlet/skills/campaign/scripts/pr-adopt.py \
+            plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py \
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py \
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py \
             plugins/gauntlet/skills/campaign/scripts/lease.py \
             plugins/gauntlet/skills/campaign/scripts/lease-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "24" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 24 it was pointed at — it checked" \
+          if [ "${analyzed}" != "26" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 26 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -209,3 +211,13 @@ jobs:
       # MISSING sibling fails loudly, so this can never report an all-clear over a suite it did not run.
       - name: Run lease contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/lease.py self-test
+
+      # The PR-adoption tool's contract, executed. `pr-adopt.py` does the MECHANICAL half of taking a PR
+      # into a run — refuse fork/foreign/closed PRs (fail closed), register the ledger row, create-or-reuse
+      # the head worktree, apply the owner + reviewing labels — with the decision in a PURE `build_plan`
+      # so every refusal and computed row field is pinned offline, no live GitHub. It decides no tier and
+      # authors no intent; those stay the driver's. The sibling `pr-adopt-test.py` is loaded by path and a
+      # MISSING sibling fails loudly, so this can never report an all-clear over a suite it did not run. As
+      # with the suites above, the point of this step is that `py_compile` parses these files and runs neither.
+      - name: Run pr-adopt contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/pr-adopt.py self-test

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -52,6 +52,13 @@ gh label create gauntlet-run-<run-id> --color 5319E7 --description "gauntlet: ru
 
 ### Adopt one PR
 
+> The MECHANICAL steps below — **1, 2, 4, 5 and the row of step 3** — are performed by
+> `scripts/pr-adopt.py adopt` (`pr-adopt.py adopt --pr <N> --run-id <id> --file <state.jsonl> --tier <T>
+> --worktrees-root <p> --project-root <p>`). The driver still supplies the two JUDGMENT calls it does not
+> make: the review **TIER** (the `--tier` argument, triaged per Stage **2a-triage**) and the PR's
+> **INTENT** (step 3a). Its decision logic is a pure `build_plan` pinned by `pr-adopt-test.py`. The steps
+> stay below as the spec the tool implements; read them as the authority.
+
 For each `#PR` to adopt:
 
 1. **Read the PR** — one `gh pr view` for the facts the ledger row needs, **including the cross-repo

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -70,7 +70,7 @@ For each `#PR` to adopt:
    ```text
    run_argv(
      argv: ["gh", "pr", "view", pr,
-            "--json", "number,title,body,headRefName,headRefOid,baseRefName,labels,state,isCrossRepository,headRepositoryOwner,headRepository"],
+            "--json", "number,title,headRefName,headRefOid,baseRefName,labels,state,isCrossRepository,headRepositoryOwner,headRepository"],
      cwd: repository.project_root,
      stdin_file: null,
      stdout_file: path_join(<rundir>, concat("pr-", pr, ".json"))
@@ -81,10 +81,14 @@ For each `#PR` to adopt:
    `headRepositoryOwner`/`headRepository` name the fork. A same-repo PR has `isCrossRepository=false` and
    its head branch is on `origin`. **Campaign gates same-repo PRs only** — fork PRs are refused in step 2.
 
-   **`body` is in the field set because the review gate is measured against WHAT THE PR IS FOR** (step 3a).
-   It was absent, and its absence is the whole reason a reviewer could be asked *"is anything wrong with
-   this code?"* — a question with no fixed point — instead of *"does this PR do its job?"*
-   (`stage-2-review-gate.md`, "What the review is MEASURED AGAINST").
+   **`body` is deliberately NOT in this field set.** This read happens **before** the fork refusal (step 2),
+   and a fork PR's `body` is **attacker-controlled** content; the adoption DECISION — refuse / register /
+   worktree / label — never needs it, so it is never fetched or parsed here (a body read before the refusal
+   is content this pipeline would ingest from a PR it is about to reject). The PR's stated intent — what the
+   review gate is measured against (step 3a, `stage-2-review-gate.md`, "What the review is MEASURED
+   AGAINST") — is read from the body **separately**, when the driver authors `intent-<pr>.md`, and only for
+   a **same-repo** PR (forks are already refused), so the body it reads comes from a committer with write
+   access to this repo.
 
 2. **Refuse a foreign-owned PR.** If `labels` already contains a `gauntlet-run-*` label that is **not**
    this run's `gauntlet-run-<run-id>`, another run owns it — **do NOT adopt, relabel, or touch it**.

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -363,6 +363,19 @@ For each `#PR` to adopt:
    form writes the local branch directly and is **refused** when the branch already exists or is checked
    out. Let the create/reuse logic above handle the local branch.)
 
+   **Two fail-closed guarantees the pseudocode leaves implicit:**
+   - **On a re-adoption of the SAME worktree campaign itself created, PRESERVE its recorded
+     `worktree_owned`/`branch_owned`** rather than downgrading them to `no`. A first adopt that **created**
+     the worktree recorded `yes`; blanking that to `no` on a later heartbeat would strand the
+     campaign-created worktree from Stage-3 cleanup. The `existing is present` branch's `worktree_owned =
+     "no"` / `branch_owned = "no"` is the **first-discovery** value; when the discovered path equals the
+     path this run's row already recorded as campaign-created, keep the recorded ownership. A genuinely
+     pre-existing external checkout (first adoption, or a differently recorded path) stays `no`/`no`.
+   - **After the reuse fast-forward or the create, VERIFY the resolved worktree's `HEAD` equals the
+     recorded `head_sha`** and refuse on mismatch. A stale same-named local branch, or a remote that moved
+     since the adoption snapshot, would otherwise leave the checkout at a tip that is **not** the PR head
+     the ledger records — a silent stale adoption. Refuse rather than record a worktree that does not match.
+
    Record the **actual** resolved `worktree`; `default_worktree(repository, headRefName)` is only the
    **created default** used on the `git worktree add` path, while a reused checkout sits at some other
    absolute path. In the row's `worktree` (via `ledger.py … set --pr <N> --worktree …`), record

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -403,7 +403,9 @@ def t_readopt_changed_head_resets():
         _add_row(ledger, 12, head_sha=old, tier="HIGH")          # no worktree dir -> create path
         _record_verdict(ledger, 12, old)
         _record_verdict(ledger, 12, old)
-        _set_row(ledger, 12, ci="green")
+        # Stale liveness state describing the OLD head's CI, plus a green ci — all SHA-bound evidence.
+        _set_row(ledger, 12, ci="green", ci_fingerprint="deadbeef", settled_strikes="2",
+                 unusable_refetches="1", ci_stalled_since="2026-01-01T00:00:00Z")
         code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=new)
         check(code == 0, f"changed-head re-adopt succeeds (got {code}: {err})")
         check(_field(ledger, 12, "reviews_ok") == "0", "a MOVED head RESETS reviews_ok to 0")
@@ -411,6 +413,42 @@ def t_readopt_changed_head_resets():
         check(_field(ledger, 12, "head_sha") == new, "the row records the new head")
         check(_field(ledger, 12, "review_rounds") == "2",
               "review_rounds is MONOTONE — a re-adoption never resets the loop's memory")
+        # The SHA-bound liveness counters describe the OLD head; a moved head resets every one of them to
+        # its fresh-head default (ledger.py ROW_DEFAULTS), IN THE SAME ledger update as head_sha.
+        for field in M.LIVENESS_COUNTERS:
+            check(_field(ledger, 12, field) == M.L.ROW_DEFAULTS[field],
+                  f"a moved head RESETS the liveness counter {field} to its fresh-head default")
+
+
+def t_readopt_changed_head_preserves_held_status():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        old, new = "a" * 40, "b" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        _add_row(ledger, 12, head_sha=old, tier="HIGH")
+        _record_verdict(ledger, 12, old)
+        _record_verdict(ledger, 12, old)          # reviews_ok=2 at the OLD head
+        # The user then PARKED it: awaiting-user with a recorded ruling the park is waiting on.
+        _set_row(ledger, 12, status="awaiting-user", blocker_ruling="retry@2026-01-01T00:00:00Z")
+        check(_field(ledger, 12, "reviews_ok") == "2", "precondition: verdicts accrued before the park")
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=new)
+        check(code == 0, f"changed-head re-adopt of a held PR succeeds (got {code}: {err})")
+        check(_field(ledger, 12, "status") == "awaiting-user",
+              "a moved head PRESERVES status — it tracks a HUMAN decision, not the SHA, so re-adoption "
+              "never silently un-holds a PR the user has not ruled on")
+        check(_field(ledger, 12, "blocker_ruling") == "retry@2026-01-01T00:00:00Z",
+              "and preserves the blocker_ruling the park is waiting on")
+        # The SHA-bound EVIDENCE still resets even while status is held.
+        check(_field(ledger, 12, "reviews_ok") == "0", "the moved head still resets reviews_ok")
+        check(_field(ledger, 12, "ci") == "pending", "the moved head still resets ci")
+        # And the PR is STILL HELD: dispatch-check must forbid ordinary gate work on it.
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            dc = M.L.main(["--file", str(ledger), "dispatch-check", "--pr", "12"])
+        check(dc == M.L.EXIT_STOP,
+              f"dispatch-check must still report the preserved awaiting-user row HELD "
+              f"(exit {M.L.EXIT_STOP}); got {dc}")
 
 
 # --- fix 6: the ONE status label mirrors the live gate, mutually exclusive -----
@@ -506,7 +544,8 @@ CASES = [
     ("gh_scoped_to_project_root", "every gh command runs in project-root (fix 2)", t_gh_scoped_to_project_root),
     ("readopt_preserves_ownership", "re-adopting the same worktree keeps created-ownership (fix 4)", t_readopt_preserves_ownership),
     ("readopt_unchanged_head_preserves_verdicts", "an unchanged head keeps reviews_ok/ci (fix 5)", t_readopt_unchanged_head_preserves_verdicts),
-    ("readopt_changed_head_resets", "a moved head resets reviews_ok/ci, review_rounds stays (fix 5)", t_readopt_changed_head_resets),
+    ("readopt_changed_head_resets", "a moved head resets reviews_ok/ci and the liveness counters, review_rounds stays (fix 5)", t_readopt_changed_head_resets),
+    ("readopt_changed_head_preserves_held_status", "a moved head preserves a held status and stays HELD, resetting only SHA-bound evidence", t_readopt_changed_head_preserves_held_status),
     ("readopt_accepted_unchanged_head_labels", "accepted+unchanged head keeps gauntlet-accepted, mutually exclusive (fix 6)", t_readopt_accepted_unchanged_head_labels),
     ("readopt_changed_head_labels", "a moved head returns to gauntlet-reviewing, removes accepted (fix 6)", t_readopt_changed_head_labels),
     ("stale_local_branch_refused", "a worktree off a stale local branch is refused (fix 7)", t_stale_local_branch_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -205,8 +205,25 @@ def t_driver_cannot_assert_origin():
 #
 # `Recorder` replaces pr-adopt's `_run`: it RECORDS every argv+cwd, answers `gh pr view` from a canned
 # view, runs the real ledger IN-PROCESS against the temp store (so re-adoption reads back true state), and
-# answers `git` from the scenario knobs. That pins the executor's gh scoping, its worktree SHA checks, and
-# its ledger writes offline, with no live GitHub and no real git repo.
+# answers `git` from the scenario knobs. That pins the executor's gh scoping, the DISCOVERY chokepoint
+# (`git worktree list --porcelain -z`), its reuse/create branching, its worktree SHA checks, and its ledger
+# writes offline, with no live GitHub and no real git repo.
+#
+# The worktree-discovery scenario is `checkouts`: a list of (path, branch_ref_or_None) tuples the fake
+# renders as real `-z` porcelain, exactly as git would. A None branch is a DETACHED entry. Any path in
+# `checkouts` is OCCUPIED, so a `git worktree add` targeting it fails (exit 128) — the same fail-closed git
+# gives a detached/foreign checkout sitting at the default path.
+
+
+def _worktree_list_z(checkouts, head) -> str:
+    """Render `checkouts` as `git worktree list --porcelain -z` output: each field NUL-terminated, each
+    entry ended by an extra empty (NUL) field. A None branch renders as a `detached` entry."""
+    out = ""
+    for path, branch in checkouts:
+        out += f"worktree {path}\0HEAD {head}\0"
+        out += "detached\0" if branch is None else f"branch {branch}\0"
+        out += "\0"
+    return out
 
 def _ledger(*args) -> int:
     """Run the real ledger main quietly (its row JSON would otherwise pollute the self-test output)."""
@@ -247,11 +264,18 @@ def _labelset(argv, flag):
 
 
 class Recorder:
-    def __init__(self, *, view, worktree_head=None, local_branch_exists=False):
+    def __init__(self, *, view, worktree_head=None, local_branch_exists=False,
+                 checkouts=None, dirty=False, ff_fails=False):
         self.view = view
         self.calls: list = []
         self.worktree_head = worktree_head if worktree_head is not None else view["headRefOid"]
         self.local_branch_exists = local_branch_exists
+        self.checkouts = list(checkouts or [])
+        self.dirty = dirty
+        self.ff_fails = ff_fails
+
+    def _occupied(self):
+        return {path for path, _ in self.checkouts}
 
     def __call__(self, argv, *, cwd=None):
         self.calls.append({"argv": list(argv), "cwd": cwd})
@@ -268,11 +292,27 @@ class Recorder:
             return CompletedProcess(argv, code or 0, "", "ledger reported failure")
         if prog == "git":
             sub = argv[3] if len(argv) > 3 and argv[1] == "-C" else ""
+            if sub == "worktree":
+                wsub = argv[4] if len(argv) > 4 else ""
+                if wsub == "list":
+                    return CompletedProcess(argv, 0, _worktree_list_z(self.checkouts, self.worktree_head), "")
+                if wsub == "add":
+                    # `add <worktree> <branch>` or `add -b <branch> <worktree> <ref>`; find the target path.
+                    target = argv[7] if len(argv) > 5 and argv[5] == "-b" else argv[5]
+                    if target in self._occupied():
+                        return CompletedProcess(argv, 128, "", f"fatal: '{target}' already exists")
+                    return CompletedProcess(argv, 0, "", "")
+                return CompletedProcess(argv, 0, "", "")
             if sub == "show-ref":
                 return CompletedProcess(argv, 0 if self.local_branch_exists else 1, "", "")
+            if sub == "status":
+                return CompletedProcess(argv, 0, "M file\n" if self.dirty else "", "")
+            if sub == "merge":
+                return CompletedProcess(argv, 1 if self.ff_fails else 0, "",
+                                        "not a fast-forward" if self.ff_fails else "")
             if sub == "rev-parse":
                 return CompletedProcess(argv, 0, self.worktree_head + "\n", "")
-            return CompletedProcess(argv, 0, "", "")  # fetch / worktree add
+            return CompletedProcess(argv, 0, "", "")  # fetch
         return CompletedProcess(argv, 0, "", "")
 
     def gh_calls(self):
@@ -284,10 +324,15 @@ class Recorder:
                 return c["argv"]
         return None
 
+    def any_call(self, pred):
+        return any(pred(c["argv"]) for c in self.calls)
+
 
 def _adopt(d: Path, ledger: Path, v: dict, *, wroot: Path, worktree_head=None,
-           local_branch_exists=False, tier="HIGH", run_id="g1", repo=None):
-    rec = Recorder(view=v, worktree_head=worktree_head, local_branch_exists=local_branch_exists)
+           local_branch_exists=False, checkouts=None, dirty=False, ff_fails=False,
+           tier="HIGH", run_id="g1", repo=None):
+    rec = Recorder(view=v, worktree_head=worktree_head, local_branch_exists=local_branch_exists,
+                   checkouts=checkouts, dirty=dirty, ff_fails=ff_fails)
     argv = ["adopt", "--pr", str(v["number"]), "--run-id", run_id, "--file", str(ledger),
             "--tier", tier, "--worktrees-root", str(wroot), "--project-root", str(d)]
     if repo:
@@ -351,10 +396,12 @@ def t_readopt_preserves_ownership():
         wt.mkdir(parents=True)
         ledger = d / "state.jsonl"
         _init_ledger(ledger)
-        # First adopt CREATED this worktree — owner=yes.
+        # First adopt CREATED this worktree — owner=yes. Discovery finds the branch at that same path.
         _add_row(ledger, 12, head_sha=sha, worktree=str(wt), worktree_owned="yes", branch_owned="yes",
                  tier="HIGH", slug="fix-the-thing")
-        code, _, err, _ = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        checkouts = [(str(wt), "refs/heads/feat-x")]
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                 checkouts=checkouts)
         check(code == 0, f"unchanged-head re-adopt succeeds (got {code}: {err})")
         check(_field(ledger, 12, "worktree_owned") == "yes",
               "re-adoption of the SAME worktree PRESERVES worktree_owned=yes (campaign created it)")
@@ -362,7 +409,8 @@ def t_readopt_preserves_ownership():
         # Teeth: a FIRST adoption of a genuinely pre-existing external checkout is no/no.
         ledger2 = d / "state2.jsonl"
         _init_ledger(ledger2)
-        code2, _, err2, _ = _adopt(d, ledger2, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        code2, _, err2, _ = _adopt(d, ledger2, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=checkouts)
         check(code2 == 0, f"first adopt of a pre-existing checkout succeeds (got {code2}: {err2})")
         check(_field(ledger2, 12, "worktree_owned") == "no",
               "a pre-existing external checkout is worktree_owned=no on FIRST adoption")
@@ -386,7 +434,8 @@ def t_readopt_unchanged_head_preserves_verdicts():
         _record_verdict(ledger, 12, sha)          # reviews_ok -> 2
         _set_row(ledger, 12, ci="green")
         check(_field(ledger, 12, "reviews_ok") == "2", "precondition: two SATISFIED verdicts recorded")
-        code, _, err, _ = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                 checkouts=[(str(wt), "refs/heads/feat-x")])
         check(code == 0, f"unchanged-head re-adopt succeeds (got {code}: {err})")
         check(_field(ledger, 12, "reviews_ok") == "2",
               "an UNCHANGED head PRESERVES reviews_ok — the accumulated verdicts are not discarded")
@@ -466,7 +515,8 @@ def t_readopt_accepted_unchanged_head_labels():
                  tier="HIGH")
         _record_verdict(ledger, 12, sha)
         _record_verdict(ledger, 12, sha)          # reviews_ok=2 == required(HIGH)
-        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=[(str(wt), "refs/heads/feat-x")])
         check(code == 0, f"accepted re-adopt succeeds (got {code}: {err})")
         e = rec.one("gh", "pr", "edit")
         check(e is not None, "a gh pr edit is issued")
@@ -523,10 +573,174 @@ def t_reused_worktree_sha_mismatch_refused():
         _init_ledger(ledger)
         _add_row(ledger, 12, head_sha=old, worktree=str(wt), worktree_owned="no", branch_owned="no",
                  tier="HIGH")
-        code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=old)
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=old,
+                                 checkouts=[(str(wt), "refs/heads/feat-x")])
         check(code != 0, "a reused worktree not at the planned head must be REFUSED — fail closed")
         check("stale" in err.lower(), f"the refusal must SAY the checkout is stale; got {err!r}")
         check(new in err and old in err, "the refusal names both the planned and the actual SHA")
+
+
+# --- the worktree-discovery chokepoint: parse `git worktree list --porcelain -z` --------------------------
+
+def t_worktree_for_branch_parser():
+    z = _worktree_list_z([("/repo", "refs/heads/main"),
+                          ("/repo/.worktrees/feat-x", "refs/heads/feat-x"),
+                          ("/repo/.worktrees/detached", None),
+                          ("/repo/.worktrees/other", "refs/heads/other")], "a" * 40)
+    check(M.worktree_for_branch(z, "refs/heads/feat-x") == "/repo/.worktrees/feat-x",
+          "an exact `branch refs/heads/<name>` entry resolves to its worktree path")
+    check(M.worktree_for_branch(z, "refs/heads/main") == "/repo",
+          "the branch checked out at the ROOT resolves to the root path")
+    check(M.worktree_for_branch(z, "refs/heads/absent") is None,
+          "a branch checked out nowhere resolves to None (create a worktree)")
+    # A detached HEAD, or a differently-named branch, is NOT this branch's checkout.
+    check(M.worktree_for_branch(z, "refs/heads/detached") is None,
+          "a detached worktree never matches a branch ref — only `detached` was recorded, no branch line")
+    check(M.worktree_for_branch("", "refs/heads/feat-x") is None, "empty listing -> None")
+
+
+# --- fix: the WORKTREE is DISCOVERED, then reused-or-created across every cell -----------------------------
+#
+# Each cell drives the executor with a `checkouts` scenario and asserts the RECORDED worktree path is the
+# DISCOVERED one (never blindly the default), and that a refusal touches nothing further.
+
+BR = "refs/heads/feat-x"
+
+
+def _worktree_added(rec) -> bool:
+    return rec.any_call(lambda a: a[0] == "git" and "worktree" in a and "add" in a)
+
+
+def t_reuse_at_root():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        # The PR branch is checked out at the PROJECT ROOT — reuse THAT path, never `git worktree add`.
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=[(str(d), BR)])
+        check(code == 0, f"a branch checked out at the root adopts by REUSE (got {code}: {err})")
+        check(_field(ledger, 12, "worktree") == str(d),
+              "the RECORDED worktree is the discovered root path, not the default worktrees-root path")
+        check(_field(ledger, 12, "worktree_owned") == "no", "a reused root checkout is worktree_owned=no")
+        check(_field(ledger, 12, "branch_owned") == "no", "and branch_owned=no — campaign created neither")
+        check(not _worktree_added(rec),
+              "REUSE must NOT `git worktree add` (it exits 128 for a branch checked out elsewhere)")
+
+
+def t_reuse_at_other_worktree():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        other = d / "somewhere-else" / "feat-x"
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=[(str(other), BR)])
+        check(code == 0, f"a branch checked out at another worktree adopts by REUSE (got {code}: {err})")
+        check(_field(ledger, 12, "worktree") == str(other),
+              "the RECORDED worktree is the discovered other-worktree path")
+        check(not _worktree_added(rec), "REUSE of another worktree must NOT `git worktree add`")
+
+
+def t_reuse_default_clean():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"                      # the DEFAULT path — and it holds the branch, clean
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=[(str(wt), BR)])
+        check(code == 0, f"a clean branch checkout at the default path is REUSED (got {code}: {err})")
+        check(_field(ledger, 12, "worktree") == str(wt), "the recorded worktree is the default path")
+        check(_field(ledger, 12, "worktree_owned") == "no",
+              "a pre-existing checkout at the default path is still worktree_owned=no on first adoption")
+        check(rec.any_call(lambda a: a[0] == "git" and "merge" in a and "--ff-only" in a),
+              "a reused checkout is FAST-FORWARDED to the origin head before its SHA is verified")
+        check(not _worktree_added(rec), "a reused default checkout must NOT `git worktree add`")
+
+
+def t_detached_at_path_refused():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"                      # the default path is a DETACHED HEAD, not the branch
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        code, _, _, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                 checkouts=[(str(wt), None)])
+        check(code != 0, "a DETACHED checkout at the default path must REFUSE — it is not the branch")
+        check(rec.one("gh", "pr", "edit") is None, "a refusal touches nothing further — no gh pr edit")
+        check(_field(ledger, 12, "worktree") == "-",
+              "and the ledger worktree field is untouched (the row landed, the worktree never resolved)")
+
+
+def t_different_branch_at_path_refused():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"                      # the default path holds a DIFFERENT branch
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        code, _, _, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                 checkouts=[(str(wt), "refs/heads/some-other-branch")])
+        check(code != 0, "a DIFFERENT branch at the default path must REFUSE — the add hits an occupied path")
+        check(rec.one("gh", "pr", "edit") is None, "a refusal touches nothing further — no gh pr edit")
+        check(_field(ledger, 12, "worktree") == "-", "and the ledger worktree field is untouched")
+
+
+def t_dirty_at_path_refused():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        # The branch IS checked out at the default path, but the tree is DIRTY.
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=[(str(wt), BR)], dirty=True)
+        check(code != 0, "a DIRTY reused checkout must REFUSE — never adopt over uncommitted work")
+        check("dirty" in err.lower(), f"the refusal must SAY the checkout is dirty; got {err!r}")
+        check(rec.one("gh", "pr", "edit") is None, "a refusal touches nothing further — no gh pr edit")
+        check(_field(ledger, 12, "worktree") == "-", "and the ledger worktree field is untouched")
+
+
+def t_absent_creates_and_verifies():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        # No checkout of the branch ANYWHERE, and no local branch either -> create at the default path with -b.
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                   checkouts=[], local_branch_exists=False)
+        check(code == 0, f"an absent branch is CREATED at the default path (got {code}: {err})")
+        check(_field(ledger, 12, "worktree") == str(wt), "the recorded worktree is the default path")
+        check(_field(ledger, 12, "worktree_owned") == "yes", "a campaign-created worktree is worktree_owned=yes")
+        check(_field(ledger, 12, "branch_owned") == "yes",
+              "no pre-existing local branch -> campaign created it (branch_owned=yes, the -b path)")
+        check(rec.any_call(lambda a: a[0] == "git" and "worktree" in a and "add" in a and "-b" in a),
+              "the create path issues `git worktree add -b` from the fetched origin head")
+        # Teeth: a pre-existing LOCAL branch (checked out nowhere) is reused -> branch_owned=no, no -b.
+        ledger2 = d / "state2.jsonl"
+        _init_ledger(ledger2)
+        code2, _, err2, rec2 = _adopt(d, ledger2, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+                                      checkouts=[], local_branch_exists=True)
+        check(code2 == 0, f"an absent-worktree but existing local branch is CREATED (got {code2}: {err2})")
+        check(_field(ledger2, 12, "branch_owned") == "no",
+              "a pre-existing local branch is reused (branch_owned=no), not recreated")
+        check(rec2.any_call(lambda a: a[0] == "git" and "worktree" in a and "add" in a and "-b" not in a),
+              "with a local branch present, the add is plain `worktree add <path> <branch>` (no -b)")
 
 
 CASES = [
@@ -550,4 +764,12 @@ CASES = [
     ("readopt_changed_head_labels", "a moved head returns to gauntlet-reviewing, removes accepted (fix 6)", t_readopt_changed_head_labels),
     ("stale_local_branch_refused", "a worktree off a stale local branch is refused (fix 7)", t_stale_local_branch_refused),
     ("reused_worktree_sha_mismatch_refused", "a reused worktree not at the planned head is refused (fix 7)", t_reused_worktree_sha_mismatch_refused),
+    ("worktree_for_branch_parser", "the discovery chokepoint parses `git worktree list --porcelain -z` for the exact branch", t_worktree_for_branch_parser),
+    ("reuse_at_root", "a branch checked out at the ROOT is reused, no worktree add", t_reuse_at_root),
+    ("reuse_at_other_worktree", "a branch checked out at another worktree is reused at its discovered path", t_reuse_at_other_worktree),
+    ("reuse_default_clean", "a clean checkout at the default path is reused, fast-forwarded, SHA-verified", t_reuse_default_clean),
+    ("detached_at_path_refused", "a DETACHED HEAD at the default path fails closed, touches nothing further", t_detached_at_path_refused),
+    ("different_branch_at_path_refused", "a DIFFERENT branch at the default path fails closed", t_different_branch_at_path_refused),
+    ("dirty_at_path_refused", "a DIRTY reused checkout fails closed, touches nothing further", t_dirty_at_path_refused),
+    ("absent_creates_and_verifies", "an absent branch is created (with/without a pre-existing local branch), SHA-verified", t_absent_creates_and_verifies),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -13,8 +13,12 @@ it did not run.
 from __future__ import annotations
 
 import json
+import os
 import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
+from subprocess import CompletedProcess
 
 from _gauntlet.modules import load_module_from_path
 from _gauntlet.testing import capture_cli
@@ -42,11 +46,11 @@ def lbl(name: str) -> dict:
 
 
 def view(**kw) -> dict:
-    """A clean, same-repo, OPEN `gh pr view` payload; override any field with a keyword."""
+    """A clean, same-repo, OPEN `gh pr view` payload; override any field with a keyword. `body` is absent
+    on purpose — adoption never requests it (a fork PR's body is attacker-controlled), so it is not here."""
     base = {
         "number": 12,
         "title": "Fix the thing",
-        "body": "## Purpose\n- fix\n## Non-goals\n## Threat model\n- GitHub API",
         "headRefName": "feat-x",
         "headRefOid": "a" * 40,
         "baseRefName": "main",
@@ -61,7 +65,7 @@ def view(**kw) -> dict:
 
 
 def plan(**kw) -> dict:
-    args = {"run_id": "g1", "tier": "HIGH", "pr_origin": "external", "worktrees_root": "/wt"}
+    args = {"run_id": "g1", "tier": "HIGH", "worktrees_root": "/wt"}
     args.update({k: kw.pop(k) for k in list(kw) if k in args})
     return M.build_plan(view(**kw), **args)
 
@@ -69,8 +73,7 @@ def plan(**kw) -> dict:
 # --- refusals (fail closed) ---------------------------------------------------
 
 def t_refuse_fork():
-    p = M.build_plan(view(isCrossRepository=True), run_id="g1", tier="HIGH",
-                     pr_origin="external", worktrees_root="/wt")
+    p = M.build_plan(view(isCrossRepository=True), run_id="g1", tier="HIGH", worktrees_root="/wt")
     check(p["verdict"] == "refuse", "a cross-repo (fork) PR must be REFUSED")
     check("fork" in p["reason"].lower(), "the fork refusal reason must name the fork")
     check("their-fork" in p["reason"], "the fork refusal names the head fork owner/repo")
@@ -102,7 +105,7 @@ def t_refuse_closed():
 def t_adopt_same_repo():
     p = M.build_plan(view(headRefOid="b" * 40, headRefName="feat-x", baseRefName="main",
                           title="Fix the thing"),
-                     run_id="g1", tier="HIGH", pr_origin="external", worktrees_root="/wt")
+                     run_id="g1", tier="HIGH", worktrees_root="/wt")
     check(p["verdict"] == "adopt", "a clean same-repo OPEN PR must adopt")
     row = p["row"]
     check(row["head_sha"] == "b" * 40, "head_sha = headRefOid")
@@ -170,6 +173,323 @@ def t_cli_plan_adopts():
               "the printed labels_add == [owner label, gauntlet-reviewing]")
 
 
+# --- pr_origin is DERIVED from labels, never a caller flag (fix 3) -------------
+
+def t_pr_origin_from_label():
+    p = M.build_plan(view(labels=[lbl("gauntlet-authored")]), run_id="g1", tier="HIGH", worktrees_root="/wt")
+    check(p["row"]["pr_origin"] == "gauntlet",
+          "the gauntlet-authored label — and only it — makes pr_origin=gauntlet")
+    p2 = M.build_plan(view(labels=[lbl("bug"), lbl("gauntlet-run-g1")]),
+                      run_id="g1", tier="HIGH", worktrees_root="/wt")
+    check(p2["row"]["pr_origin"] == "external",
+          "any other label set defaults to external (the SAFE default)")
+    p3 = M.build_plan(view(labels=[]), run_id="g1", tier="HIGH", worktrees_root="/wt")
+    check(p3["row"]["pr_origin"] == "external", "no labels -> external")
+
+
+def t_driver_cannot_assert_origin():
+    """The `--pr-origin` flag is GONE from both subcommands, so a driver cannot claim `gauntlet` on a PR it
+    did not open — argparse rejects the flag outright."""
+    with tempfile.TemporaryDirectory() as d:
+        f = _write_view(d, view(labels=[]))
+        code, _, _ = capture_cli(M.main, ["plan", "--view-json", f, "--run-id", "g1", "--tier", "HIGH",
+                                          "--pr-origin", "gauntlet"])
+        check(code != 0, "the removed --pr-origin flag must be REJECTED on `plan`")
+        code2, _, _ = capture_cli(M.main, ["adopt", "--pr", "1", "--run-id", "g1", "--file", "x",
+                                           "--tier", "HIGH", "--worktrees-root", "w", "--project-root", "p",
+                                           "--pr-origin", "gauntlet"])
+        check(code2 != 0, "the removed --pr-origin flag must be REJECTED on `adopt` too")
+
+
+# --- the `adopt` EXECUTOR — driven with a fake `gh`/`git`/ledger boundary ------
+#
+# `Recorder` replaces pr-adopt's `_run`: it RECORDS every argv+cwd, answers `gh pr view` from a canned
+# view, runs the real ledger IN-PROCESS against the temp store (so re-adoption reads back true state), and
+# answers `git` from the scenario knobs. That pins the executor's gh scoping, its worktree SHA checks, and
+# its ledger writes offline, with no live GitHub and no real git repo.
+
+def _ledger(*args) -> int:
+    """Run the real ledger main quietly (its row JSON would otherwise pollute the self-test output)."""
+    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+        return M.L.main(list(args))
+
+
+def _init_ledger(ledger: Path, run_id: str = "g1") -> None:
+    _ledger("--file", str(ledger), "header", "set", "run_id", run_id)
+
+
+def _add_row(ledger: Path, pr, **fields) -> None:
+    argv = ["--file", str(ledger), "add-row", "--pr", str(pr)]
+    for k, v in fields.items():
+        argv += [f"--{k.replace('_', '-')}", str(v)]
+    _ledger(*argv)
+
+
+def _set_row(ledger: Path, pr, **fields) -> None:
+    argv = ["--file", str(ledger), "set", "--pr", str(pr)]
+    for k, v in fields.items():
+        argv += [f"--{k.replace('_', '-')}", str(v)]
+    _ledger(*argv)
+
+
+def _record_verdict(ledger: Path, pr, head_sha, verdict="satisfied") -> None:
+    _ledger("--file", str(ledger), "verdict", "--pr", str(pr), "--head-sha", head_sha, "--verdict", verdict)
+
+
+def _field(ledger: Path, pr, name):
+    _, rows = M.L.load(ledger)
+    row = M.L.find_row(rows, str(pr))
+    return row[name] if row else None
+
+
+def _labelset(argv, flag):
+    return {argv[i + 1] for i, a in enumerate(argv) if a == flag and i + 1 < len(argv)}
+
+
+class Recorder:
+    def __init__(self, *, view, worktree_head=None, local_branch_exists=False):
+        self.view = view
+        self.calls: list = []
+        self.worktree_head = worktree_head if worktree_head is not None else view["headRefOid"]
+        self.local_branch_exists = local_branch_exists
+
+    def __call__(self, argv, *, cwd=None):
+        self.calls.append({"argv": list(argv), "cwd": cwd})
+        prog = argv[0]
+        if prog == "gh":
+            if argv[1:3] == ["pr", "view"]:
+                return CompletedProcess(argv, 0, json.dumps(self.view), "")
+            return CompletedProcess(argv, 0, "", "")  # label create / pr edit
+        if prog == "python3":  # the ledger subprocess — run it for real against the temp store
+            try:
+                code = _ledger(*argv[2:])
+            except SystemExit as exc:
+                code = exc.code if isinstance(exc.code, int) else 1
+            return CompletedProcess(argv, code or 0, "", "ledger reported failure")
+        if prog == "git":
+            sub = argv[3] if len(argv) > 3 and argv[1] == "-C" else ""
+            if sub == "show-ref":
+                return CompletedProcess(argv, 0 if self.local_branch_exists else 1, "", "")
+            if sub == "rev-parse":
+                return CompletedProcess(argv, 0, self.worktree_head + "\n", "")
+            return CompletedProcess(argv, 0, "", "")  # fetch / worktree add
+        return CompletedProcess(argv, 0, "", "")
+
+    def gh_calls(self):
+        return [c for c in self.calls if c["argv"][0] == "gh"]
+
+    def one(self, *prefix):
+        for c in self.calls:
+            if c["argv"][: len(prefix)] == list(prefix):
+                return c["argv"]
+        return None
+
+
+def _adopt(d: Path, ledger: Path, v: dict, *, wroot: Path, worktree_head=None,
+           local_branch_exists=False, tier="HIGH", run_id="g1", repo=None):
+    rec = Recorder(view=v, worktree_head=worktree_head, local_branch_exists=local_branch_exists)
+    argv = ["adopt", "--pr", str(v["number"]), "--run-id", run_id, "--file", str(ledger),
+            "--tier", tier, "--worktrees-root", str(wroot), "--project-root", str(d)]
+    if repo:
+        argv += ["--repo", repo]
+    old = M._run
+    M._run = rec
+    try:
+        code, out, err = capture_cli(M.main, argv)
+    finally:
+        M._run = old
+    return code, out, err, rec
+
+
+# --- fix 1: `gh pr view` requests METADATA ONLY, never `body` ------------------
+
+def t_view_omits_body():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        v = view()
+        code, _, err, rec = _adopt(d, ledger, v, wroot=d / "wt")
+        check(code == 0, f"a clean adopt succeeds (got {code}: {err})")
+        va = rec.one("gh", "pr", "view")
+        check(va is not None, "the executor issues a `gh pr view`")
+        fields = set(va[va.index("--json") + 1].split(","))
+        check("body" not in fields, f"`gh pr view` must NOT request body; got {sorted(fields)}")
+        expected = {"number", "title", "headRefName", "headRefOid", "baseRefName", "labels", "state",
+                    "isCrossRepository", "headRepositoryOwner", "headRepository"}
+        check(fields == expected, f"the view field set must be exactly the decision metadata; got {sorted(fields)}")
+
+
+# --- fix 2: every gh command is scoped to project-root ------------------------
+
+def t_gh_scoped_to_project_root():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        check(str(d) != os.getcwd(),
+              "the test's project-root must differ from the invoking cwd for this check to have teeth")
+        code, _, err, rec = _adopt(d, ledger, view(), wroot=d / "wt")
+        check(code == 0, f"adopt succeeds (got {code}: {err})")
+        ghs = rec.gh_calls()
+        check(len(ghs) == 3, f"expected 3 gh calls (view, label create, pr edit); got {len(ghs)}")
+        for c in ghs:
+            check(c["cwd"] == str(d),
+                  f"every gh call must run in project-root {d}, not the invoking cwd; "
+                  f"{c['argv'][:3]} ran in {c['cwd']}")
+
+
+# --- fix 4: re-adoption of the SAME worktree preserves created-ownership -------
+
+def t_readopt_preserves_ownership():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"
+        wt.mkdir(parents=True)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        # First adopt CREATED this worktree — owner=yes.
+        _add_row(ledger, 12, head_sha=sha, worktree=str(wt), worktree_owned="yes", branch_owned="yes",
+                 tier="HIGH", slug="fix-the-thing")
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        check(code == 0, f"unchanged-head re-adopt succeeds (got {code}: {err})")
+        check(_field(ledger, 12, "worktree_owned") == "yes",
+              "re-adoption of the SAME worktree PRESERVES worktree_owned=yes (campaign created it)")
+        check(_field(ledger, 12, "branch_owned") == "yes", "and preserves branch_owned=yes")
+        # Teeth: a FIRST adoption of a genuinely pre-existing external checkout is no/no.
+        ledger2 = d / "state2.jsonl"
+        _init_ledger(ledger2)
+        code2, _, err2, _ = _adopt(d, ledger2, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        check(code2 == 0, f"first adopt of a pre-existing checkout succeeds (got {code2}: {err2})")
+        check(_field(ledger2, 12, "worktree_owned") == "no",
+              "a pre-existing external checkout is worktree_owned=no on FIRST adoption")
+        check(_field(ledger2, 12, "branch_owned") == "no", "and branch_owned=no")
+
+
+# --- fix 5: SHA-bound gate fields reset ONLY when the head moved ---------------
+
+def t_readopt_unchanged_head_preserves_verdicts():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"
+        wt.mkdir(parents=True)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        _add_row(ledger, 12, head_sha=sha, worktree=str(wt), worktree_owned="yes", branch_owned="yes",
+                 tier="HIGH")
+        _record_verdict(ledger, 12, sha)
+        _record_verdict(ledger, 12, sha)          # reviews_ok -> 2
+        _set_row(ledger, 12, ci="green")
+        check(_field(ledger, 12, "reviews_ok") == "2", "precondition: two SATISFIED verdicts recorded")
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        check(code == 0, f"unchanged-head re-adopt succeeds (got {code}: {err})")
+        check(_field(ledger, 12, "reviews_ok") == "2",
+              "an UNCHANGED head PRESERVES reviews_ok — the accumulated verdicts are not discarded")
+        check(_field(ledger, 12, "ci") == "green", "an unchanged head preserves ci")
+
+
+def t_readopt_changed_head_resets():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        old, new = "a" * 40, "b" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        _add_row(ledger, 12, head_sha=old, tier="HIGH")          # no worktree dir -> create path
+        _record_verdict(ledger, 12, old)
+        _record_verdict(ledger, 12, old)
+        _set_row(ledger, 12, ci="green")
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=new)
+        check(code == 0, f"changed-head re-adopt succeeds (got {code}: {err})")
+        check(_field(ledger, 12, "reviews_ok") == "0", "a MOVED head RESETS reviews_ok to 0")
+        check(_field(ledger, 12, "ci") == "pending", "a moved head RESETS ci to pending")
+        check(_field(ledger, 12, "head_sha") == new, "the row records the new head")
+        check(_field(ledger, 12, "review_rounds") == "2",
+              "review_rounds is MONOTONE — a re-adoption never resets the loop's memory")
+
+
+# --- fix 6: the ONE status label mirrors the live gate, mutually exclusive -----
+
+def t_readopt_accepted_unchanged_head_labels():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        wt = wroot / "feat-x"
+        wt.mkdir(parents=True)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        _add_row(ledger, 12, head_sha=sha, worktree=str(wt), worktree_owned="yes", branch_owned="yes",
+                 tier="HIGH")
+        _record_verdict(ledger, 12, sha)
+        _record_verdict(ledger, 12, sha)          # reviews_ok=2 == required(HIGH)
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha)
+        check(code == 0, f"accepted re-adopt succeeds (got {code}: {err})")
+        e = rec.one("gh", "pr", "edit")
+        check(e is not None, "a gh pr edit is issued")
+        check(_labelset(e, "--add-label") == {"gauntlet-run-g1", "gauntlet-accepted"},
+              f"an already-passed PR (gate met, unchanged head) ADDS run+accepted; got {e}")
+        check(_labelset(e, "--remove-label") == {"gauntlet-reviewing"},
+              f"and REMOVES the other status label in the same call; got {e}")
+
+
+def t_readopt_changed_head_labels():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        old, new = "a" * 40, "b" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        _add_row(ledger, 12, head_sha=old, tier="HIGH")
+        _record_verdict(ledger, 12, old)
+        _record_verdict(ledger, 12, old)          # was accepted at the OLD head
+        code, _, err, rec = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=new)
+        check(code == 0, f"changed-head re-adopt succeeds (got {code}: {err})")
+        e = rec.one("gh", "pr", "edit")
+        check(_labelset(e, "--add-label") == {"gauntlet-run-g1", "gauntlet-reviewing"},
+              f"a moved head (reviews_ok reset) goes back under review; got {e}")
+        check(_labelset(e, "--remove-label") == {"gauntlet-accepted"},
+              f"and the stale gauntlet-accepted is removed in the same call; got {e}")
+
+
+# --- fix 7: a reused/created worktree MUST match the planned head, else refuse -
+
+def t_stale_local_branch_refused():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        old, new = "a" * 40, "b" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        # PR head advanced to NEW; a same-named LOCAL branch sits at OLD; no worktree dir yet (create path).
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot,
+                                 worktree_head=old, local_branch_exists=True)
+        check(code != 0, "a worktree created off a STALE local branch must be REFUSED — fail closed")
+        check("stale" in err.lower(), f"the refusal must SAY the local branch was stale; got {err!r}")
+        check(new in err and old in err, "the refusal names both the planned and the actual SHA")
+
+
+def t_reused_worktree_sha_mismatch_refused():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        old, new = "a" * 40, "b" * 40
+        wt = wroot / "feat-x"
+        wt.mkdir(parents=True)                    # a reused checkout sitting at OLD
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        _add_row(ledger, 12, head_sha=old, worktree=str(wt), worktree_owned="no", branch_owned="no",
+                 tier="HIGH")
+        code, _, err, _ = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=old)
+        check(code != 0, "a reused worktree not at the planned head must be REFUSED — fail closed")
+        check("stale" in err.lower(), f"the refusal must SAY the checkout is stale; got {err!r}")
+        check(new in err and old in err, "the refusal names both the planned and the actual SHA")
+
+
 CASES = [
     ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),
     ("refuse_foreign_run", "a PR owned by another run is refused", t_refuse_foreign_run),
@@ -179,4 +499,15 @@ CASES = [
     ("slugify", "slugify yields a lowercase, dash-collapsed, untrimmed-dash-free slug", t_slugify),
     ("cli_plan_refuses_fork", "the plan CLI prints a refuse verdict and exits 0", t_cli_plan_refuses_fork),
     ("cli_plan_adopts", "the plan CLI prints an adopt verdict and exits 0", t_cli_plan_adopts),
+    ("pr_origin_from_label", "pr_origin is DERIVED from the gauntlet-authored label (fix 3)", t_pr_origin_from_label),
+    ("driver_cannot_assert_origin", "the --pr-origin flag is gone; a driver cannot claim gauntlet (fix 3)", t_driver_cannot_assert_origin),
+    ("view_omits_body", "`gh pr view` requests metadata only, never body (fix 1)", t_view_omits_body),
+    ("gh_scoped_to_project_root", "every gh command runs in project-root (fix 2)", t_gh_scoped_to_project_root),
+    ("readopt_preserves_ownership", "re-adopting the same worktree keeps created-ownership (fix 4)", t_readopt_preserves_ownership),
+    ("readopt_unchanged_head_preserves_verdicts", "an unchanged head keeps reviews_ok/ci (fix 5)", t_readopt_unchanged_head_preserves_verdicts),
+    ("readopt_changed_head_resets", "a moved head resets reviews_ok/ci, review_rounds stays (fix 5)", t_readopt_changed_head_resets),
+    ("readopt_accepted_unchanged_head_labels", "accepted+unchanged head keeps gauntlet-accepted, mutually exclusive (fix 6)", t_readopt_accepted_unchanged_head_labels),
+    ("readopt_changed_head_labels", "a moved head returns to gauntlet-reviewing, removes accepted (fix 6)", t_readopt_changed_head_labels),
+    ("stale_local_branch_refused", "a worktree off a stale local branch is refused (fix 7)", t_stale_local_branch_refused),
+    ("reused_worktree_sha_mismatch_refused", "a reused worktree not at the planned head is refused (fix 7)", t_reused_worktree_sha_mismatch_refused),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Fixtures for `pr-adopt.py` — the mechanical PR-adoption decision, pinned WITHOUT live GitHub.
+
+Every case drives the PURE surface (`build_plan` / `slugify`) or the `plan` CLI (via `capture_cli` and a
+`--view-json` file), so the whole refusal contract and every computed row field are checked offline. The
+`adopt` executor is a thin wrapper of `gh`/`git`/ledger calls around the same `build_plan`, so the decision
+it acts on is exactly what these fixtures pin.
+
+`pr-adopt.py self-test` FAILS LOUDLY if it cannot load this file — it can never report health over a suite
+it did not run.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
+
+OWNER = Path(__file__).resolve().parent / "pr-adopt.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("pr_adopt_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the pr-adopt tool at {OWNER}")
+    return mod
+
+
+M = _load_owner()
+
+
+def check(cond, msg) -> None:
+    if not cond:
+        raise M.SelfTestFailure(msg)
+
+
+def lbl(name: str) -> dict:
+    return {"name": name}
+
+
+def view(**kw) -> dict:
+    """A clean, same-repo, OPEN `gh pr view` payload; override any field with a keyword."""
+    base = {
+        "number": 12,
+        "title": "Fix the thing",
+        "body": "## Purpose\n- fix\n## Non-goals\n## Threat model\n- GitHub API",
+        "headRefName": "feat-x",
+        "headRefOid": "a" * 40,
+        "baseRefName": "main",
+        "labels": [],
+        "state": "OPEN",
+        "isCrossRepository": False,
+        "headRepositoryOwner": {"login": "someone"},
+        "headRepository": {"name": "their-fork"},
+    }
+    base.update(kw)
+    return base
+
+
+def plan(**kw) -> dict:
+    args = {"run_id": "g1", "tier": "HIGH", "pr_origin": "external", "worktrees_root": "/wt"}
+    args.update({k: kw.pop(k) for k in list(kw) if k in args})
+    return M.build_plan(view(**kw), **args)
+
+
+# --- refusals (fail closed) ---------------------------------------------------
+
+def t_refuse_fork():
+    p = M.build_plan(view(isCrossRepository=True), run_id="g1", tier="HIGH",
+                     pr_origin="external", worktrees_root="/wt")
+    check(p["verdict"] == "refuse", "a cross-repo (fork) PR must be REFUSED")
+    check("fork" in p["reason"].lower(), "the fork refusal reason must name the fork")
+    check("their-fork" in p["reason"], "the fork refusal names the head fork owner/repo")
+    # teeth: the same view with isCrossRepository False is NOT refused as a fork
+    check(plan(isCrossRepository=False)["verdict"] == "adopt",
+          "a same-repo PR must not be refused as a fork")
+
+
+def t_refuse_foreign_run():
+    p = plan(labels=[lbl("gauntlet-run-OTHER")])
+    check(p["verdict"] == "refuse", "a PR owned by another run must be REFUSED")
+    check("gauntlet-run-OTHER" in p["reason"], "the refusal names the OTHER run's owner label")
+    # teeth: an unrelated label does not trip the foreign-owner check
+    check(plan(labels=[lbl("bug"), lbl("gauntlet-authored")])["verdict"] == "adopt",
+          "a non-run label must not read as foreign ownership")
+
+
+def t_refuse_closed():
+    for st in ("MERGED", "CLOSED"):
+        p = plan(state=st)
+        check(p["verdict"] == "refuse", f"a {st} PR must be REFUSED — campaign gates OPEN PRs")
+        check(st.lower() in p["reason"].lower() or st in p["reason"],
+              f"the refusal reason must name the {st} state")
+    check(plan(state="OPEN")["verdict"] == "adopt", "an OPEN PR must adopt")
+
+
+# --- adopt --------------------------------------------------------------------
+
+def t_adopt_same_repo():
+    p = M.build_plan(view(headRefOid="b" * 40, headRefName="feat-x", baseRefName="main",
+                          title="Fix the thing"),
+                     run_id="g1", tier="HIGH", pr_origin="external", worktrees_root="/wt")
+    check(p["verdict"] == "adopt", "a clean same-repo OPEN PR must adopt")
+    row = p["row"]
+    check(row["head_sha"] == "b" * 40, "head_sha = headRefOid")
+    check(row["tier"] == "HIGH", "tier = the input, not triaged here")
+    check(row["ci"] == "pending", "ci initializes to pending")
+    check(row["status"] == "in_review", "status initializes to in_review")
+    check(row["reviews_ok"] == "0", "reviews_ok initializes to 0 (no verdicts yet)")
+    check(row["pr_origin"] == "external", "pr_origin = the input")
+    check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing"],
+          "labels_add == [our owner label, gauntlet-reviewing]")
+    check(p["worktree"] == str(Path("/wt") / "feat-x"), "worktree == worktrees_root / headRefName")
+    check(p["base"] == "main", "base == baseRefName (a HEADER field, carried under `base`)")
+    # teeth: base/worktree/ownership flags are NOT row fields — they are the caller's or step 5's
+    check("base" not in row and "base_branch" not in row and "worktree" not in row,
+          "base/base_branch/worktree must NOT be written as row fields")
+    check("worktree_owned" not in row and "branch_owned" not in row,
+          "worktree_owned/branch_owned are decided at step 5, never in the plan row")
+
+
+def t_adopt_when_already_ours():
+    p = plan(labels=[lbl("gauntlet-run-g1"), lbl("gauntlet-reviewing")])
+    check(p["verdict"] == "adopt", "a PR already carrying OUR run label re-adopts, never refuses")
+    check(p["row"]["status"] == "in_review", "re-adoption still yields the computed row")
+
+
+# --- slugify ------------------------------------------------------------------
+
+def t_slugify():
+    check(M.slugify("Fix the Thing!") == "fix-the-thing", "lowercase, punctuation → single dash")
+    check(M.slugify("  Hello, World  ") == "hello-world", "no leading/trailing dash, spaces collapse")
+    check(M.slugify("A/B: c__d") == "a-b-c-d", "every non-alnum run collapses to one dash")
+    s = M.slugify("!!! ??? !!!")
+    check(s == "" and not s.startswith("-") and not s.endswith("-"),
+          "an all-punctuation title slugs to the empty, dash-free string")
+
+
+# --- the `plan` CLI (the testable surface) ------------------------------------
+
+def _write_view(d: str, v: dict) -> str:
+    f = Path(d) / "view.json"
+    f.write_text(json.dumps(v), encoding="utf-8")
+    return str(f)
+
+
+def t_cli_plan_refuses_fork():
+    with tempfile.TemporaryDirectory() as d:
+        f = _write_view(d, view(isCrossRepository=True))
+        code, out, _ = capture_cli(M.main, ["plan", "--view-json", f, "--run-id", "g1", "--tier", "HIGH"])
+        check(code == 0, "`plan` always exits 0 — it prints a verdict, it does not gate")
+        p = json.loads(out)
+        check(p["verdict"] == "refuse", "`plan` prints the refuse verdict as JSON")
+        check("fork" in p["reason"].lower(), "the printed refusal names the fork")
+
+
+def t_cli_plan_adopts():
+    with tempfile.TemporaryDirectory() as d:
+        f = _write_view(d, view(title="Add pr-adopt", headRefName="feat-y", headRefOid="c" * 40))
+        code, out, _ = capture_cli(M.main, ["plan", "--view-json", f, "--run-id", "g1", "--tier", "HIGH"])
+        check(code == 0, "`plan` exits 0 on an adoptable PR")
+        p = json.loads(out)
+        check(p["verdict"] == "adopt", "`plan` prints the adopt verdict")
+        check(p["row"]["tier"] == "HIGH", "the printed row carries the input tier")
+        check(p["row"]["head_sha"] == "c" * 40, "the printed row's head_sha = headRefOid")
+        check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing"],
+              "the printed labels_add == [owner label, gauntlet-reviewing]")
+
+
+CASES = [
+    ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),
+    ("refuse_foreign_run", "a PR owned by another run is refused", t_refuse_foreign_run),
+    ("refuse_closed", "a MERGED/CLOSED PR is refused", t_refuse_closed),
+    ("adopt_same_repo", "a clean same-repo OPEN PR adopts with the computed row", t_adopt_same_repo),
+    ("adopt_when_already_ours", "a PR already carrying our run label re-adopts", t_adopt_when_already_ours),
+    ("slugify", "slugify yields a lowercase, dash-collapsed, untrimmed-dash-free slug", t_slugify),
+    ("cli_plan_refuses_fork", "the plan CLI prints a refuse verdict and exits 0", t_cli_plan_refuses_fork),
+    ("cli_plan_adopts", "the plan CLI prints an adopt verdict and exits 0", t_cli_plan_adopts),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -293,11 +293,11 @@ def _adopt(d: Path, ledger: Path, v: dict, *, wroot: Path, worktree_head=None,
     if repo:
         argv += ["--repo", repo]
     old = M._run
-    M._run = rec
+    setattr(M, "_run", rec)
     try:
         code, out, err = capture_cli(M.main, argv)
     finally:
-        M._run = old
+        setattr(M, "_run", old)
     return code, out, err, rec
 
 
@@ -313,6 +313,7 @@ def t_view_omits_body():
         check(code == 0, f"a clean adopt succeeds (got {code}: {err})")
         va = rec.one("gh", "pr", "view")
         check(va is not None, "the executor issues a `gh pr view`")
+        assert va is not None  # narrow for the type checker; `check` above is the readable guard
         fields = set(va[va.index("--json") + 1].split(","))
         check("body" not in fields, f"`gh pr view` must NOT request body; got {sorted(fields)}")
         expected = {"number", "title", "headRefName", "headRefOid", "baseRefName", "labels", "state",

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -52,6 +52,12 @@ RUN_LABEL_COLOR = "5319E7"
 # it opens). It is the ONLY thing that makes `pr_origin` = `gauntlet`; a driver cannot assert it by flag.
 GAUNTLET_AUTHORED_LABEL = "gauntlet-authored"
 
+# The SHA-bound liveness counters — stage-2-ci.md, "THE LIVENESS COUNTERS", owns the set and what each
+# member means. They describe the OLD head's CI, so a re-adoption at a moved head must reset them in the
+# same ledger update as head_sha; the reset VALUES come from ledger.py's ROW_DEFAULTS (the fresh-head
+# defaults), never a literal typed here.
+LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", "ci_stalled_since")
+
 
 def _load(name: str, filename: str):
     mod = load_module_from_path(name, _HERE / filename)
@@ -222,11 +228,15 @@ def cmd_adopt(args) -> int:
 
     # 4. Register the row — refresh in place if it exists, else add. Never a duplicate row.
     #
-    # The `add-row` initializers (ci=pending, reviews_ok=0, status=in_review, tier) apply to a NEW row.
-    # On a RE-ADOPTION they are SHA-bound gate state: reset them ONLY when the head SHA actually moved,
-    # otherwise a re-adopt would discard SATISFIED verdicts accumulated on unchanged content. `set` writes
-    # only the fields it NAMES, so preservation is the default — an unchanged-head refresh names none of
-    # the SHA-bound fields and they survive untouched.
+    # `set` writes only the fields it NAMES, so preservation is the default — a refresh names only what it
+    # must recompute and everything else survives untouched. What that is depends on whether the head moved:
+    #   * NEW row: initialize the SHA-bound gate fields AND `status` (the fresh row's starting state).
+    #   * MOVED head on an existing row: the new head is new evidence, so reset the SHA-bound EVIDENCE — the
+    #     review tally, ci, and the liveness counters — but PRESERVE `status`: it tracks a HUMAN decision,
+    #     not the SHA, so a head refresh must never un-hold a PR the user has not ruled on (awaiting-user,
+    #     aborted, repairing).
+    #   * UNCHANGED head on an existing row: name none of the SHA-bound fields — the accumulated verdicts,
+    #     ci and liveness state all describe content that is still there and are preserved.
     _, rows = L.load(Path(args.file))
     existing = L.find_row(rows, pr)
     head_changed = existing is not None and existing.get("head_sha") != planned_head
@@ -236,12 +246,17 @@ def cmd_adopt(args) -> int:
                    "--head-sha", planned_head,
                    "--slug", str(row["slug"]),
                    "--pr-origin", str(row["pr_origin"])]
-    if existing is None or head_changed:
-        # A NEW row, or a head that moved: (re)initialize the SHA-bound gate fields.
+    if existing is None:
         ledger_argv += ["--tier", str(row["tier"]),
                         "--ci", str(row["ci"]),
                         "--status", str(row["status"]),
                         "--reviews-ok", str(row["reviews_ok"])]
+    elif head_changed:
+        ledger_argv += ["--tier", str(row["tier"]),
+                        "--ci", str(row["ci"]),
+                        "--reviews-ok", str(row["reviews_ok"])]
+        for field in LIVENESS_COUNTERS:
+            ledger_argv += [f"--{field.replace('_', '-')}", str(L.ROW_DEFAULTS[field])]
     proc = _run(ledger_argv, cwd=args.project_root)
     if proc.returncode != 0:
         return _refuse(f"ledger {verb} for PR {pr} failed: {proc.stderr.strip()}")

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -40,12 +40,17 @@ _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "pr-adopt-test.py"
 LEDGER_PY = _HERE / "ledger.py"
 
-# The run owner label's prefix and the shared "under review" status label. The owner label's colour
+# The run owner label's prefix and the two MUTUALLY EXCLUSIVE status labels. The owner label's colour
 # matches the one pr-adoption.md's `gh label create` uses, so an idempotent `--force` create never churns
-# it.
+# it. A PR carries exactly ONE status label, mirroring the live review gate (pr-adoption.md, step 4).
 RUN_LABEL_PREFIX = "gauntlet-run-"
 REVIEWING_LABEL = "gauntlet-reviewing"
+ACCEPTED_LABEL = "gauntlet-accepted"
 RUN_LABEL_COLOR = "5319E7"
+
+# The label that marks a PR as authored by this pipeline (gauntlet:review's handoff applies it to every PR
+# it opens). It is the ONLY thing that makes `pr_origin` = `gauntlet`; a driver cannot assert it by flag.
+GAUNTLET_AUTHORED_LABEL = "gauntlet-authored"
 
 
 def _load(name: str, filename: str):
@@ -56,6 +61,9 @@ def _load(name: str, filename: str):
 
 
 L = _load("pr_adopt_ledger", "ledger.py")
+# `required(tier)` — the review gate's SATISFIED-verdict floor — is OWNED by review-pass.py
+# (`required_reviews`); the status label mirrors that gate, so reuse the owner rather than retype the rule.
+RP = _load("pr_adopt_review_pass", "review-pass.py")
 
 
 # --- pure decision surface ----------------------------------------------------
@@ -75,6 +83,22 @@ def slugify(title: str) -> str:
     return "".join(out).strip("-")
 
 
+def _pr_origin(view: dict) -> str:
+    """WHO WROTE THIS PR — DERIVED from the PR's own labels, never a caller flag (pr-adoption.md, step 3).
+
+    `gauntlet` ONLY when the PR carries the `gauntlet-authored` label, which gauntlet:review's handoff
+    applies to every PR it opens; `external` for everything else — the SAFE default. This is a security
+    boundary: `pr_origin = gauntlet` unlocks repair-pass's branch-content-rewriting decisions
+    (`repair-pass.md`, "The ownership guardrail"), so a driver must NOT be able to claim it on a PR it did
+    not open. Reading it from the label the pipeline itself applies removes that door entirely.
+    """
+    for lbl in view.get("labels") or []:
+        name = lbl.get("name") if isinstance(lbl, dict) else lbl
+        if name == GAUNTLET_AUTHORED_LABEL:
+            return "gauntlet"
+    return "external"
+
+
 def _fork_ref(view: dict) -> str:
     """`<owner>/<repo>` for the fork a cross-repo PR's head lives in, read defensively from the two
     objects `gh pr view` returns (each an object with `login`/`name`, or already a bare string)."""
@@ -85,7 +109,7 @@ def _fork_ref(view: dict) -> str:
     return f"{owner_s}/{repo_s}"
 
 
-def build_plan(view: dict, *, run_id: str, tier: str, pr_origin: str, worktrees_root: str) -> dict:
+def build_plan(view: dict, *, run_id: str, tier: str, worktrees_root: str) -> dict:
     """Decide adoptability and compute the row — PURE, from a parsed `gh pr view` dict.
 
     Returns `{"verdict": "refuse", "reason": ...}` for a PR that must NOT be adopted (pr-adoption.md
@@ -121,7 +145,7 @@ def build_plan(view: dict, *, run_id: str, tier: str, pr_origin: str, worktrees_
         "ci": "pending",
         "status": "in_review",
         "reviews_ok": "0",
-        "pr_origin": pr_origin,
+        "pr_origin": _pr_origin(view),
         "slug": slugify(str(view.get("title", ""))),
     }
     return {
@@ -149,8 +173,7 @@ def cmd_plan(args) -> int:
     """The TESTABLE surface: read a parsed view from disk, print the plan, exit 0 (refuse or adopt alike).
     No `gh`, no `git`, no ledger — pure `build_plan` over a file."""
     view = json.loads(Path(args.view_json).read_text(encoding="utf-8"))
-    plan = build_plan(view, run_id=args.run_id, tier=args.tier,
-                      pr_origin=args.pr_origin, worktrees_root=args.worktrees_root)
+    plan = build_plan(view, run_id=args.run_id, tier=args.tier, worktrees_root=args.worktrees_root)
     print(json.dumps(plan))
     return 0
 
@@ -158,14 +181,19 @@ def cmd_plan(args) -> int:
 def cmd_adopt(args) -> int:
     pr = str(args.pr)
     run_label = f"{RUN_LABEL_PREFIX}{args.run_id}"
+    # gh resolves its target repo from the CWD when `--repo` is absent, but git and the ledger run in
+    # `--project-root`. Left in the invoking checkout, gh would label a DIFFERENT repo than the one the
+    # ledger tracks. So scope every gh call to project-root; with `--repo` the flag wins and cwd is moot.
+    gh_cwd = args.project_root
 
-    # 1. Read the PR.
+    # 1. Read the PR — METADATA ONLY. `body` is deliberately NOT requested: on a fork PR it is
+    # attacker-controlled content, and adoption's decision never needs it, so it is never fetched or parsed.
     view_argv = ["gh", "pr", "view", pr]
     if args.repo:
         view_argv += ["--repo", args.repo]
-    view_argv += ["--json", "number,title,body,headRefName,headRefOid,baseRefName,labels,state,"
+    view_argv += ["--json", "number,title,headRefName,headRefOid,baseRefName,labels,state,"
                             "isCrossRepository,headRepositoryOwner,headRepository"]
-    proc = _run(view_argv)
+    proc = _run(view_argv, cwd=gh_cwd)
     if proc.returncode != 0:
         return _refuse(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
     try:
@@ -174,36 +202,46 @@ def cmd_adopt(args) -> int:
         return _refuse(f"`gh pr view {pr}` output is not JSON ({exc})")
 
     # 2. Decide. On refuse, touch NOTHING — no label, no row, no worktree.
-    plan = build_plan(view, run_id=args.run_id, tier=args.tier,
-                      pr_origin=args.pr_origin, worktrees_root=args.worktrees_root)
+    plan = build_plan(view, run_id=args.run_id, tier=args.tier, worktrees_root=args.worktrees_root)
     if plan["verdict"] == "refuse":
         return _refuse(str(plan["reason"]))
 
     branch = str(plan["branch"])
     worktree = str(plan["worktree"])
     row = plan["row"]
+    planned_head = str(row["head_sha"])
 
     # 3. Ensure the run owner label exists (idempotent — `--force` creates or updates).
     label_argv = ["gh", "label", "create", run_label, "--color", RUN_LABEL_COLOR,
                   "--description", f"gauntlet: run {args.run_id}", "--force"]
     if args.repo:
         label_argv += ["--repo", args.repo]
-    proc = _run(label_argv)
+    proc = _run(label_argv, cwd=gh_cwd)
     if proc.returncode != 0:
         return _refuse(f"could not create label {run_label}: {proc.stderr.strip()}")
 
     # 4. Register the row — refresh in place if it exists, else add. Never a duplicate row.
+    #
+    # The `add-row` initializers (ci=pending, reviews_ok=0, status=in_review, tier) apply to a NEW row.
+    # On a RE-ADOPTION they are SHA-bound gate state: reset them ONLY when the head SHA actually moved,
+    # otherwise a re-adopt would discard SATISFIED verdicts accumulated on unchanged content. `set` writes
+    # only the fields it NAMES, so preservation is the default — an unchanged-head refresh names none of
+    # the SHA-bound fields and they survive untouched.
     _, rows = L.load(Path(args.file))
-    verb = "set" if L.find_row(rows, pr) is not None else "add-row"
+    existing = L.find_row(rows, pr)
+    head_changed = existing is not None and existing.get("head_sha") != planned_head
+    verb = "set" if existing is not None else "add-row"
     ledger_argv = ["python3", str(LEDGER_PY), "--file", args.file, verb, "--pr", pr,
                    "--branch", branch,
-                   "--head-sha", str(row["head_sha"]),
+                   "--head-sha", planned_head,
                    "--slug", str(row["slug"]),
-                   "--tier", str(row["tier"]),
-                   "--ci", str(row["ci"]),
-                   "--status", str(row["status"]),
-                   "--reviews-ok", str(row["reviews_ok"]),
                    "--pr-origin", str(row["pr_origin"])]
+    if existing is None or head_changed:
+        # A NEW row, or a head that moved: (re)initialize the SHA-bound gate fields.
+        ledger_argv += ["--tier", str(row["tier"]),
+                        "--ci", str(row["ci"]),
+                        "--status", str(row["status"]),
+                        "--reviews-ok", str(row["reviews_ok"])]
     proc = _run(ledger_argv, cwd=args.project_root)
     if proc.returncode != 0:
         return _refuse(f"ledger {verb} for PR {pr} failed: {proc.stderr.strip()}")
@@ -212,13 +250,35 @@ def cmd_adopt(args) -> int:
     # and say the row/label already landed — a half-adoption must be VISIBLE, never silently absorbed.
     half = (f"(the run label {run_label} and the ledger row for PR {pr} were ALREADY written; "
             f"the PR's labels were NOT applied)")
+    # FETCH the PR head first so every worktree choice is made against ground truth, not a stale local ref.
+    fetch = _run(["git", "-C", args.project_root, "fetch", "origin",
+                  f"refs/heads/{branch}:refs/remotes/origin/{branch}"])
+    if fetch.returncode != 0:
+        return _refuse(f"git fetch of head {branch} failed: {fetch.stderr.strip()} {half}")
+
     if Path(worktree).is_dir():
-        worktree_owned, branch_owned = "no", "no"
+        # REUSE an existing checkout — but VERIFY it is at the planned head. A same-named worktree left at
+        # an older SHA would silently adopt stale content while the ledger records the new head. Fail closed.
+        rev = _run(["git", "-C", worktree, "rev-parse", "HEAD"])
+        if rev.returncode != 0:
+            return _refuse(f"git rev-parse HEAD in reused worktree {worktree} failed: "
+                           f"{rev.stderr.strip()} {half}")
+        actual = rev.stdout.strip()
+        if actual != planned_head:
+            return _refuse(f"reused worktree {worktree} is at {actual} but PR {pr}'s head is "
+                           f"{planned_head} — the checkout is STALE; refusing rather than adopt a worktree "
+                           f"that does not match the PR head {half}")
+        # PRESERVE created-ownership on a re-adoption of the SAME worktree: a first adopt that CREATED it
+        # recorded worktree_owned=yes, and clobbering that to `no` would strand it from Stage-3 cleanup.
+        # A genuinely pre-existing external checkout (first adoption, or a different recorded worktree) is
+        # `no`/`no`.
+        if existing is not None and existing.get("worktree") == worktree:
+            worktree_owned = existing.get("worktree_owned", "no")
+            branch_owned = existing.get("branch_owned", "no")
+        else:
+            worktree_owned, branch_owned = "no", "no"
     else:
-        fetch = _run(["git", "-C", args.project_root, "fetch", "origin",
-                      f"refs/heads/{branch}:refs/remotes/origin/{branch}"])
-        if fetch.returncode != 0:
-            return _refuse(f"git fetch of head {branch} failed: {fetch.stderr.strip()} {half}")
+        # CREATE the worktree from the fetched origin head — never an arbitrary same-named local branch.
         local = _run(["git", "-C", args.project_root, "show-ref", "--verify", "--quiet",
                       f"refs/heads/{branch}"])
         if local.returncode == 0:
@@ -230,6 +290,16 @@ def cmd_adopt(args) -> int:
             branch_owned = "yes"
         if add.returncode != 0:
             return _refuse(f"git worktree add for {branch} failed: {add.stderr.strip()} {half}")
+        # VERIFY the created worktree is at the planned head. A stale same-named local branch (the `add
+        # <worktree> <branch>` path) would put it at an older SHA — refuse rather than adopt the wrong tip.
+        rev = _run(["git", "-C", worktree, "rev-parse", "HEAD"])
+        if rev.returncode != 0:
+            return _refuse(f"git rev-parse HEAD in new worktree {worktree} failed: "
+                           f"{rev.stderr.strip()} {half}")
+        actual = rev.stdout.strip()
+        if actual != planned_head:
+            return _refuse(f"worktree {worktree} for branch {branch} is at {actual} but PR {pr}'s head is "
+                           f"{planned_head} — a STALE local branch was checked out; refusing {half}")
         worktree_owned = "yes"
 
     set_argv = ["python3", str(LEDGER_PY), "--file", args.file, "set", "--pr", pr,
@@ -239,11 +309,21 @@ def cmd_adopt(args) -> int:
     if proc.returncode != 0:
         return _refuse(f"ledger set of worktree fields for PR {pr} failed: {proc.stderr.strip()}")
 
-    # 6. Label it ours and under review.
-    edit_argv = ["gh", "pr", "edit", pr, "--add-label", run_label, "--add-label", REVIEWING_LABEL]
+    # 6. Label it ours and set the ONE status label from the LIVE gate. The two status labels are mutually
+    # exclusive, so whichever we apply, we remove the other IN THE SAME CALL. `gauntlet-accepted` only when
+    # the (preserved-or-reset) gate is met at THIS head — reviews_ok >= required(tier); otherwise it is
+    # under review. A fresh adoption and a head change both reset reviews_ok to 0, so they read as reviewing.
+    final = L.find_row(L.load(Path(args.file))[1], pr) or {}
+    reviews_ok = int(final.get("reviews_ok", "0") or "0")
+    tier_now = final.get("tier", str(row["tier"]))
+    gate_met = reviews_ok >= RP.required_reviews(tier_now)
+    status_label = ACCEPTED_LABEL if gate_met else REVIEWING_LABEL
+    other_label = REVIEWING_LABEL if gate_met else ACCEPTED_LABEL
+    edit_argv = ["gh", "pr", "edit", pr, "--add-label", run_label,
+                 "--add-label", status_label, "--remove-label", other_label]
     if args.repo:
         edit_argv += ["--repo", args.repo]
-    proc = _run(edit_argv)
+    proc = _run(edit_argv, cwd=gh_cwd)
     if proc.returncode != 0:
         return _refuse(f"`gh pr edit {pr}` (labels) failed: {proc.stderr.strip()} "
                        f"(the ledger row and worktree for PR {pr} were already written)")
@@ -255,7 +335,8 @@ def cmd_adopt(args) -> int:
         "row_written": True,
         "worktree": worktree,
         "worktree_owned": worktree_owned,
-        "labels": [run_label, REVIEWING_LABEL],
+        "labels_added": [run_label, status_label],
+        "label_removed": other_label,
     }))
     return 0
 
@@ -270,7 +351,6 @@ def main(argv: "list[str] | None" = None) -> int:
     p.add_argument("--view-json", required=True, help="path to a parsed `gh pr view` JSON document")
     p.add_argument("--run-id", required=True, help="this run's id (the owner label is gauntlet-run-<id>)")
     p.add_argument("--tier", required=True, help="the review tier — an INPUT; this tool never triages")
-    p.add_argument("--pr-origin", default="external", help="who wrote the PR (default: external)")
     p.add_argument("--worktrees-root", default=".worktrees", help="root under which the head worktree sits")
 
     a = sub.add_parser("adopt", help="the real thing: read the PR, refuse/register/worktree/label")
@@ -280,8 +360,7 @@ def main(argv: "list[str] | None" = None) -> int:
     a.add_argument("--tier", required=True, help="the review tier — an INPUT; this tool never triages")
     a.add_argument("--worktrees-root", required=True, help="root under which the head worktree sits")
     a.add_argument("--project-root", required=True, help="the repo checkout git/ledger commands run in")
-    a.add_argument("--repo", help="owner/name (default: the current checkout's)")
-    a.add_argument("--pr-origin", default="external", help="who wrote the PR (default: external)")
+    a.add_argument("--repo", help="owner/name (default: the project-root checkout's)")
 
     sub.add_parser("self-test", help="run every fixture (pr-adopt-test.py's CASES)")
 

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -9,7 +9,9 @@ JUDGMENT; everything here is MECHANICS that a model transcribing a doc gets subt
   * READ the PR (one `gh pr view` for the fields the ledger row needs, including the cross-repo field);
   * REFUSE fork/foreign/closed PRs — FAIL CLOSED, touching nothing when it refuses (step 2);
   * REGISTER the ledger row (refresh in place if it exists, never a duplicate `add-row`) (step 3, row);
-  * CREATE-OR-REUSE the PR-head worktree (step 5);
+  * RESOLVE the PR-head worktree — DISCOVER the branch's actual checkout via `git worktree list` and REUSE
+    it (fast-forwarded, clean), else CREATE one at the default path; fail closed on a dirty/detached/foreign
+    checkout or a head-SHA mismatch (step 5);
   * LABEL the PR ours + under review (step 4).
 
 The decision logic lives in a PURE `build_plan()` (and a pure `slugify()`), so every refusal and every
@@ -87,6 +89,31 @@ def slugify(title: str) -> str:
             out.append("-")
             prev_dash = True
     return "".join(out).strip("-")
+
+
+def worktree_for_branch(porcelain_z: str, branch_ref: str) -> "str | None":
+    """Resolve the worktree that has `branch_ref` (e.g. `refs/heads/feat-x`) checked out, from the output of
+    `git worktree list --porcelain -z` — the ONE discovery chokepoint (pr-adoption.md step 5,
+    `parse_nul_porcelain_for_exact_branch`). Returns that worktree's path, or None when the branch is checked
+    out NOWHERE (so a fresh worktree must be created).
+
+    Only an exact `branch refs/heads/<name>` entry matches. A worktree whose HEAD is DETACHED, or on a
+    DIFFERENT branch, returns None for this branch — which is why a detached or foreign checkout sitting at
+    the default path is never mistaken for the branch (its later head-branch pushes would fail).
+
+    The `-z` porcelain format terminates every field with NUL and ends each worktree entry with an extra
+    empty field; splitting on NUL and resetting the current path on the empty field walks entries safely."""
+    current: "str | None" = None
+    for token in porcelain_z.split("\0"):
+        if token == "":
+            current = None
+            continue
+        label, _, value = token.partition(" ")
+        if label == "worktree":
+            current = value
+        elif label == "branch" and value == branch_ref:
+            return current
+    return None
 
 
 def _pr_origin(view: dict) -> str:
@@ -213,7 +240,7 @@ def cmd_adopt(args) -> int:
         return _refuse(str(plan["reason"]))
 
     branch = str(plan["branch"])
-    worktree = str(plan["worktree"])
+    base = str(plan["base"])
     row = plan["row"]
     planned_head = str(row["head_sha"])
 
@@ -261,61 +288,93 @@ def cmd_adopt(args) -> int:
     if proc.returncode != 0:
         return _refuse(f"ledger {verb} for PR {pr} failed: {proc.stderr.strip()}")
 
-    # 5. Create-or-reuse the PR-head worktree, off the PR's OWN head branch. On any git failure, refuse
-    # and say the row/label already landed — a half-adoption must be VISIBLE, never silently absorbed.
+    # 5. Resolve the PR-head worktree — DISCOVER the branch's ACTUAL checkout, never assume the default path.
+    # On any git failure, refuse and say the row/label already landed — a half-adoption must be VISIBLE.
     half = (f"(the run label {run_label} and the ledger row for PR {pr} were ALREADY written; "
             f"the PR's labels were NOT applied)")
-    # FETCH the PR head first so every worktree choice is made against ground truth, not a stale local ref.
-    fetch = _run(["git", "-C", args.project_root, "fetch", "origin",
-                  f"refs/heads/{branch}:refs/remotes/origin/{branch}"])
-    if fetch.returncode != 0:
-        return _refuse(f"git fetch of head {branch} failed: {fetch.stderr.strip()} {half}")
+    branch_ref = f"refs/heads/{branch}"
+    origin_ref = f"refs/remotes/origin/{branch}"
+    # FETCH both tracking refs first, so every worktree choice is made against ground truth, not a stale
+    # local ref. The review step diffs origin/<base>...HEAD, so the base tracking ref must exist too.
+    for ref in (base, branch):
+        fetch = _run(["git", "-C", args.project_root, "fetch", "origin",
+                      f"refs/heads/{ref}:refs/remotes/origin/{ref}"])
+        if fetch.returncode != 0:
+            return _refuse(f"git fetch of {ref} failed: {fetch.stderr.strip()} {half}")
 
-    if Path(worktree).is_dir():
-        # REUSE an existing checkout — but VERIFY it is at the planned head. A same-named worktree left at
-        # an older SHA would silently adopt stale content while the ledger records the new head. Fail closed.
-        rev = _run(["git", "-C", worktree, "rev-parse", "HEAD"])
-        if rev.returncode != 0:
-            return _refuse(f"git rev-parse HEAD in reused worktree {worktree} failed: "
-                           f"{rev.stderr.strip()} {half}")
-        actual = rev.stdout.strip()
-        if actual != planned_head:
-            return _refuse(f"reused worktree {worktree} is at {actual} but PR {pr}'s head is "
-                           f"{planned_head} — the checkout is STALE; refusing rather than adopt a worktree "
-                           f"that does not match the PR head {half}")
-        # PRESERVE created-ownership on a re-adoption of the SAME worktree: a first adopt that CREATED it
-        # recorded worktree_owned=yes, and clobbering that to `no` would strand it from Stage-3 cleanup.
-        # A genuinely pre-existing external checkout (first adoption, or a different recorded worktree) is
-        # `no`/`no`.
+    # DISCOVERY CHOKEPOINT: the branch may already be checked out — at the project root, at the default
+    # worktree path, or at any other worktree — and `git worktree add` REFUSES a branch checked out elsewhere
+    # (exit 128, one checkout per branch), which would leave a half-adoption. Ask git where it actually is,
+    # once, and record THAT path — never blindly add at the default.
+    listing = _run(["git", "-C", args.project_root, "worktree", "list", "--porcelain", "-z"])
+    if listing.returncode != 0:
+        return _refuse(f"git worktree list failed: {listing.stderr.strip()} {half}")
+    existing_checkout = worktree_for_branch(listing.stdout, branch_ref)
+
+    if existing_checkout is not None:
+        # REUSE the discovered checkout — wherever it sits (root, the default path, or another worktree). It
+        # must be CLEAN (never adopt over uncommitted work) and fast-forwardable to the fetched origin head.
+        worktree = existing_checkout
+        status = _run(["git", "-C", worktree, "status", "--porcelain", "--untracked-files=all"])
+        if status.returncode != 0:
+            return _refuse(f"git status in reused worktree {worktree} failed: "
+                           f"{status.stderr.strip()} {half}")
+        if status.stdout.strip():
+            return _refuse(f"reused worktree {worktree} for branch {branch} is DIRTY (uncommitted changes) "
+                           f"— refusing to adopt over a dirty tree {half}")
+        ff = _run(["git", "-C", worktree, "merge", "--ff-only", origin_ref])
+        if ff.returncode != 0:
+            return _refuse(f"fast-forward of reused worktree {worktree} to origin/{branch} failed "
+                           f"(it is not a fast-forward of the PR head): {ff.stderr.strip()} {half}")
+        # PRESERVE created-ownership on a re-adoption of the SAME worktree campaign itself created: a first
+        # adopt that CREATED it recorded worktree_owned=yes, and clobbering that to `no` would strand it from
+        # Stage-3 cleanup. A genuinely pre-existing external checkout (first adoption, or a differently
+        # recorded worktree) is `no`/`no`.
         if existing is not None and existing.get("worktree") == worktree:
             worktree_owned = existing.get("worktree_owned", "no")
             branch_owned = existing.get("branch_owned", "no")
         else:
             worktree_owned, branch_owned = "no", "no"
     else:
-        # CREATE the worktree from the fetched origin head — never an arbitrary same-named local branch.
-        local = _run(["git", "-C", args.project_root, "show-ref", "--verify", "--quiet",
-                      f"refs/heads/{branch}"])
+        # No checkout of the branch anywhere → CREATE one at the default path from the fetched origin head. A
+        # detached HEAD, or a DIFFERENT branch, occupying the default path is NOT this branch's checkout —
+        # discovery returned None — so `git worktree add` below hits an occupied path and FAILS CLOSED here,
+        # never a silent adoption of a checkout that is not the PR head.
+        worktree = str(plan["worktree"])
+        local = _run(["git", "-C", args.project_root, "show-ref", "--verify", "--quiet", branch_ref])
         if local.returncode == 0:
+            # The local branch exists but is checked out nowhere: add a worktree on it, then bring it to the
+            # fetched origin head. Never `-B` — that could reset a pre-existing local branch.
             add = _run(["git", "-C", args.project_root, "worktree", "add", worktree, branch])
+            if add.returncode != 0:
+                return _refuse(f"git worktree add for {branch} failed: {add.stderr.strip()} {half}")
+            ff = _run(["git", "-C", worktree, "merge", "--ff-only", origin_ref])
+            if ff.returncode != 0:
+                return _refuse(f"fast-forward of new worktree {worktree} to origin/{branch} failed: "
+                               f"{ff.stderr.strip()} {half}")
             branch_owned = "no"
-        else:
+        elif local.returncode == 1:
+            # No local branch either (ref absent): create it from the fetched origin head.
             add = _run(["git", "-C", args.project_root, "worktree", "add", "-b", branch, worktree,
-                        f"refs/remotes/origin/{branch}"])
+                        origin_ref])
+            if add.returncode != 0:
+                return _refuse(f"git worktree add -b for {branch} failed: {add.stderr.strip()} {half}")
             branch_owned = "yes"
-        if add.returncode != 0:
-            return _refuse(f"git worktree add for {branch} failed: {add.stderr.strip()} {half}")
-        # VERIFY the created worktree is at the planned head. A stale same-named local branch (the `add
-        # <worktree> <branch>` path) would put it at an older SHA — refuse rather than adopt the wrong tip.
-        rev = _run(["git", "-C", worktree, "rev-parse", "HEAD"])
-        if rev.returncode != 0:
-            return _refuse(f"git rev-parse HEAD in new worktree {worktree} failed: "
-                           f"{rev.stderr.strip()} {half}")
-        actual = rev.stdout.strip()
-        if actual != planned_head:
-            return _refuse(f"worktree {worktree} for branch {branch} is at {actual} but PR {pr}'s head is "
-                           f"{planned_head} — a STALE local branch was checked out; refusing {half}")
+        else:
+            return _refuse(f"git show-ref for {branch} failed unexpectedly (exit {local.returncode}): "
+                           f"{local.stderr.strip()} {half}")
         worktree_owned = "yes"
+
+    # VERIFY the resolved worktree is at the PLANNED head — after any fast-forward or create. A checkout that
+    # cannot be brought to the recorded head is STALE (a same-named local branch left behind, or a remote
+    # moved since the snapshot); refuse rather than record a worktree that does not match the PR head.
+    rev = _run(["git", "-C", worktree, "rev-parse", "HEAD"])
+    if rev.returncode != 0:
+        return _refuse(f"git rev-parse HEAD in worktree {worktree} failed: {rev.stderr.strip()} {half}")
+    actual = rev.stdout.strip()
+    if actual != planned_head:
+        return _refuse(f"worktree {worktree} for branch {branch} is at {actual} but PR {pr}'s head is "
+                       f"{planned_head} — the checkout is STALE (does not match the PR head); refusing {half}")
 
     set_argv = ["python3", str(LEDGER_PY), "--file", args.file, "set", "--pr", pr,
                 "--worktree", worktree, "--worktree-owned", worktree_owned,

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Adopt a PR into a run — the MECHANICAL half, as a command instead of a shell block in a doc.
+
+`references/pr-adoption.md` is the authority; this tool performs its steps 1, 2, 4, 5 and the row of
+step 3. It does NOT decide the review TIER (that is a triage judgment — passed in as `--tier`) and it does
+NOT author the PR's INTENT (step 3a — the driver's working note about what the PR is for). Those two are
+JUDGMENT; everything here is MECHANICS that a model transcribing a doc gets subtly wrong under load:
+
+  * READ the PR (one `gh pr view` for the fields the ledger row needs, including the cross-repo field);
+  * REFUSE fork/foreign/closed PRs — FAIL CLOSED, touching nothing when it refuses (step 2);
+  * REGISTER the ledger row (refresh in place if it exists, never a duplicate `add-row`) (step 3, row);
+  * CREATE-OR-REUSE the PR-head worktree (step 5);
+  * LABEL the PR ours + under review (step 4).
+
+The decision logic lives in a PURE `build_plan()` (and a pure `slugify()`), so every refusal and every
+computed row field is pinned by an offline fixture with no live GitHub — the sibling `pr-adopt-test.py` is
+this tool's executable contract. `adopt` is the thin executor that runs the real `gh`/`git`/ledger
+commands around that plan.
+
+  pr-adopt.py plan  --view-json <f> --run-id <id> --tier <T>   # PURE: parse a view, print the plan, exit 0
+  pr-adopt.py adopt --pr <N> --run-id <id> --file <state.jsonl> --tier <T> \
+                    --worktrees-root <p> --project-root <p>    # the real thing: gh + git + ledger
+
+pr-adopt performs NO review and NO merge. It gets a PR INTO the run; Loop control drives it from there.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "pr-adopt-test.py"
+LEDGER_PY = _HERE / "ledger.py"
+
+# The run owner label's prefix and the shared "under review" status label. The owner label's colour
+# matches the one pr-adoption.md's `gh label create` uses, so an idempotent `--force` create never churns
+# it.
+RUN_LABEL_PREFIX = "gauntlet-run-"
+REVIEWING_LABEL = "gauntlet-reviewing"
+RUN_LABEL_COLOR = "5319E7"
+
+
+def _load(name: str, filename: str):
+    mod = load_module_from_path(name, _HERE / filename)
+    if mod is None:
+        raise RuntimeError(f"cannot load {filename}")
+    return mod
+
+
+L = _load("pr_adopt_ledger", "ledger.py")
+
+
+# --- pure decision surface ----------------------------------------------------
+
+def slugify(title: str) -> str:
+    """A filesystem-safe slug: lowercase, every run of non-alphanumerics collapsed to one `-`, no leading
+    or trailing dash. An all-punctuation title slugs to the empty string, which is a fine `-`-free value."""
+    out: list[str] = []
+    prev_dash = False
+    for ch in title.lower():
+        if ch.isalnum() and ch.isascii():
+            out.append(ch)
+            prev_dash = False
+        elif not prev_dash:
+            out.append("-")
+            prev_dash = True
+    return "".join(out).strip("-")
+
+
+def _fork_ref(view: dict) -> str:
+    """`<owner>/<repo>` for the fork a cross-repo PR's head lives in, read defensively from the two
+    objects `gh pr view` returns (each an object with `login`/`name`, or already a bare string)."""
+    owner = view.get("headRepositoryOwner")
+    repo = view.get("headRepository")
+    owner_s = owner.get("login") if isinstance(owner, dict) else owner
+    repo_s = repo.get("name") if isinstance(repo, dict) else repo
+    return f"{owner_s}/{repo_s}"
+
+
+def build_plan(view: dict, *, run_id: str, tier: str, pr_origin: str, worktrees_root: str) -> dict:
+    """Decide adoptability and compute the row — PURE, from a parsed `gh pr view` dict.
+
+    Returns `{"verdict": "refuse", "reason": ...}` for a PR that must NOT be adopted (pr-adoption.md
+    step 2), else `{"verdict": "adopt", "row": {...computed fields...}, "labels_add": [...], "branch": ...,
+    "worktree": ..., "base": ...}`. FAIL CLOSED: every refusal is checked before any adopt field is built.
+    """
+    # A fork PR is untrusted, attacker-controllable content this autonomous pipeline would read and act on,
+    # and it has no push target for fix commits — campaign gates SAME-REPO PRs only (step 2).
+    if view.get("isCrossRepository") is True:
+        return {"verdict": "refuse",
+                "reason": f"fork PR (head in {_fork_ref(view)}) — campaign gates same-repo PRs only; "
+                          f"push a same-repo branch"}
+
+    # A `gauntlet-run-*` label that is not OURS means another run owns this PR — never steal its label.
+    ours = f"{RUN_LABEL_PREFIX}{run_id}"
+    for lbl in view.get("labels") or []:
+        name = lbl.get("name") if isinstance(lbl, dict) else lbl
+        if isinstance(name, str) and name.startswith(RUN_LABEL_PREFIX) and name != ours:
+            return {"verdict": "refuse", "reason": f"owned by another run ({name})"}
+
+    # Campaign gates OPEN PRs; a merged/closed PR is terminal, not adoptable.
+    state = view.get("state")
+    if state != "OPEN":
+        return {"verdict": "refuse", "reason": f"PR is {state}, not open"}
+
+    branch = view["headRefName"]
+    # COMPUTED fields only. `base_branch` is a HEADER field, not a row field, so `baseRefName` rides the
+    # plan under `base` for the caller and is never written as a row field. `worktree_owned`/`branch_owned`
+    # are decided at worktree creation (step 5), never here.
+    row = {
+        "head_sha": view["headRefOid"],
+        "tier": tier,
+        "ci": "pending",
+        "status": "in_review",
+        "reviews_ok": "0",
+        "pr_origin": pr_origin,
+        "slug": slugify(str(view.get("title", ""))),
+    }
+    return {
+        "verdict": "adopt",
+        "row": row,
+        "labels_add": [ours, REVIEWING_LABEL],
+        "branch": branch,
+        "worktree": str(Path(worktrees_root) / branch),
+        "base": view["baseRefName"],
+    }
+
+
+# --- executor -----------------------------------------------------------------
+
+def _run(argv: list[str], *, cwd: "str | None" = None) -> subprocess.CompletedProcess:
+    return subprocess.run(argv, capture_output=True, text=True, check=False, cwd=cwd)  # noqa: S603
+
+
+def _refuse(reason: str) -> int:
+    print(f"pr-adopt: REFUSED — {reason}", file=sys.stderr)
+    return 1
+
+
+def cmd_plan(args) -> int:
+    """The TESTABLE surface: read a parsed view from disk, print the plan, exit 0 (refuse or adopt alike).
+    No `gh`, no `git`, no ledger — pure `build_plan` over a file."""
+    view = json.loads(Path(args.view_json).read_text(encoding="utf-8"))
+    plan = build_plan(view, run_id=args.run_id, tier=args.tier,
+                      pr_origin=args.pr_origin, worktrees_root=args.worktrees_root)
+    print(json.dumps(plan))
+    return 0
+
+
+def cmd_adopt(args) -> int:
+    pr = str(args.pr)
+    run_label = f"{RUN_LABEL_PREFIX}{args.run_id}"
+
+    # 1. Read the PR.
+    view_argv = ["gh", "pr", "view", pr]
+    if args.repo:
+        view_argv += ["--repo", args.repo]
+    view_argv += ["--json", "number,title,body,headRefName,headRefOid,baseRefName,labels,state,"
+                            "isCrossRepository,headRepositoryOwner,headRepository"]
+    proc = _run(view_argv)
+    if proc.returncode != 0:
+        return _refuse(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
+    try:
+        view = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return _refuse(f"`gh pr view {pr}` output is not JSON ({exc})")
+
+    # 2. Decide. On refuse, touch NOTHING — no label, no row, no worktree.
+    plan = build_plan(view, run_id=args.run_id, tier=args.tier,
+                      pr_origin=args.pr_origin, worktrees_root=args.worktrees_root)
+    if plan["verdict"] == "refuse":
+        return _refuse(str(plan["reason"]))
+
+    branch = str(plan["branch"])
+    worktree = str(plan["worktree"])
+    row = plan["row"]
+
+    # 3. Ensure the run owner label exists (idempotent — `--force` creates or updates).
+    label_argv = ["gh", "label", "create", run_label, "--color", RUN_LABEL_COLOR,
+                  "--description", f"gauntlet: run {args.run_id}", "--force"]
+    if args.repo:
+        label_argv += ["--repo", args.repo]
+    proc = _run(label_argv)
+    if proc.returncode != 0:
+        return _refuse(f"could not create label {run_label}: {proc.stderr.strip()}")
+
+    # 4. Register the row — refresh in place if it exists, else add. Never a duplicate row.
+    _, rows = L.load(Path(args.file))
+    verb = "set" if L.find_row(rows, pr) is not None else "add-row"
+    ledger_argv = ["python3", str(LEDGER_PY), "--file", args.file, verb, "--pr", pr,
+                   "--branch", branch,
+                   "--head-sha", str(row["head_sha"]),
+                   "--slug", str(row["slug"]),
+                   "--tier", str(row["tier"]),
+                   "--ci", str(row["ci"]),
+                   "--status", str(row["status"]),
+                   "--reviews-ok", str(row["reviews_ok"]),
+                   "--pr-origin", str(row["pr_origin"])]
+    proc = _run(ledger_argv, cwd=args.project_root)
+    if proc.returncode != 0:
+        return _refuse(f"ledger {verb} for PR {pr} failed: {proc.stderr.strip()}")
+
+    # 5. Create-or-reuse the PR-head worktree, off the PR's OWN head branch. On any git failure, refuse
+    # and say the row/label already landed — a half-adoption must be VISIBLE, never silently absorbed.
+    half = (f"(the run label {run_label} and the ledger row for PR {pr} were ALREADY written; "
+            f"the PR's labels were NOT applied)")
+    if Path(worktree).is_dir():
+        worktree_owned, branch_owned = "no", "no"
+    else:
+        fetch = _run(["git", "-C", args.project_root, "fetch", "origin",
+                      f"refs/heads/{branch}:refs/remotes/origin/{branch}"])
+        if fetch.returncode != 0:
+            return _refuse(f"git fetch of head {branch} failed: {fetch.stderr.strip()} {half}")
+        local = _run(["git", "-C", args.project_root, "show-ref", "--verify", "--quiet",
+                      f"refs/heads/{branch}"])
+        if local.returncode == 0:
+            add = _run(["git", "-C", args.project_root, "worktree", "add", worktree, branch])
+            branch_owned = "no"
+        else:
+            add = _run(["git", "-C", args.project_root, "worktree", "add", "-b", branch, worktree,
+                        f"refs/remotes/origin/{branch}"])
+            branch_owned = "yes"
+        if add.returncode != 0:
+            return _refuse(f"git worktree add for {branch} failed: {add.stderr.strip()} {half}")
+        worktree_owned = "yes"
+
+    set_argv = ["python3", str(LEDGER_PY), "--file", args.file, "set", "--pr", pr,
+                "--worktree", worktree, "--worktree-owned", worktree_owned,
+                "--branch-owned", branch_owned]
+    proc = _run(set_argv, cwd=args.project_root)
+    if proc.returncode != 0:
+        return _refuse(f"ledger set of worktree fields for PR {pr} failed: {proc.stderr.strip()}")
+
+    # 6. Label it ours and under review.
+    edit_argv = ["gh", "pr", "edit", pr, "--add-label", run_label, "--add-label", REVIEWING_LABEL]
+    if args.repo:
+        edit_argv += ["--repo", args.repo]
+    proc = _run(edit_argv)
+    if proc.returncode != 0:
+        return _refuse(f"`gh pr edit {pr}` (labels) failed: {proc.stderr.strip()} "
+                       f"(the ledger row and worktree for PR {pr} were already written)")
+
+    # 7. Adoption summary.
+    print(json.dumps({
+        "pr": pr,
+        "run_id": args.run_id,
+        "row_written": True,
+        "worktree": worktree,
+        "worktree_owned": worktree_owned,
+        "labels": [run_label, REVIEWING_LABEL],
+    }))
+    return 0
+
+
+# --- CLI ----------------------------------------------------------------------
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("plan", help="PURE: parse a `gh pr view` JSON file, print the adoption plan, exit 0")
+    p.add_argument("--view-json", required=True, help="path to a parsed `gh pr view` JSON document")
+    p.add_argument("--run-id", required=True, help="this run's id (the owner label is gauntlet-run-<id>)")
+    p.add_argument("--tier", required=True, help="the review tier — an INPUT; this tool never triages")
+    p.add_argument("--pr-origin", default="external", help="who wrote the PR (default: external)")
+    p.add_argument("--worktrees-root", default=".worktrees", help="root under which the head worktree sits")
+
+    a = sub.add_parser("adopt", help="the real thing: read the PR, refuse/register/worktree/label")
+    a.add_argument("--pr", required=True, help="PR number to adopt")
+    a.add_argument("--run-id", required=True, help="this run's id")
+    a.add_argument("--file", required=True, help="the run ledger (<rundir>/state.jsonl)")
+    a.add_argument("--tier", required=True, help="the review tier — an INPUT; this tool never triages")
+    a.add_argument("--worktrees-root", required=True, help="root under which the head worktree sits")
+    a.add_argument("--project-root", required=True, help="the repo checkout git/ledger commands run in")
+    a.add_argument("--repo", help="owner/name (default: the current checkout's)")
+    a.add_argument("--pr-origin", default="external", help="who wrote the PR (default: external)")
+
+    sub.add_parser("self-test", help="run every fixture (pr-adopt-test.py's CASES)")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "self-test":
+        return self_test()
+    if args.cmd == "plan":
+        return cmd_plan(args)
+    return cmd_adopt(args)
+
+
+# --- self-test ----------------------------------------------------------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
+                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
+    mod = load_module_from_path("pr_adopt_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — pr-adopt's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:30} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — pr-adopt's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — pr-adopt's contract is intact.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -64,9 +64,12 @@ def check_document_contract() -> None:
 
     # The per-PR `gh pr view` adoption snapshot is the same class: typed run_argv, its output path a
     # Path in stdout_file via path_join, never `> <rundir>/pr-<pr>.json`.
+    # `body` is deliberately ABSENT — a fork PR's body is attacker-controlled and this pre-refusal read
+    # never needs it (pr-adoption.md, step 1; scripts/pr-adopt.py). The intent read (step 3a) fetches it
+    # separately, for a same-repo PR only.
     pr_view_argv = " ".join((
         'argv: ["gh", "pr", "view", pr, "--json", '
-        '"number,title,body,headRefName,headRefOid,baseRefName,labels,state,'
+        '"number,title,headRefName,headRefOid,baseRefName,labels,state,'
         'isCrossRepository,headRepositoryOwner,headRepository"],'
     ).split())
     require(pr_view_argv in " ".join(adoption.split()),


### PR DESCRIPTION
- adopt a same-repo PR into a run: ledger row, run labels, PR-head worktree
- refuse fork, foreign-owned, and non-open PRs fail-closed
- tier is an input and intent stays the driver's; pure build_plan + executor
