### PR TITLE
add base-preflight to gate rebase before fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,13 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/heartbeat.py \
             plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py \
             plugins/gauntlet/skills/campaign/scripts/run-id.py \
-            plugins/gauntlet/skills/campaign/scripts/run-id-test.py | tee pyright.json
+            plugins/gauntlet/skills/campaign/scripts/run-id-test.py \
+            plugins/gauntlet/skills/campaign/scripts/base-preflight.py \
+            plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "28" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 28 it was pointed at — it checked" \
+          if [ "${analyzed}" != "30" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the 30 it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi
@@ -231,3 +233,13 @@ jobs:
       # so this can never report an all-clear over a suite it did not run.
       - name: Run-id contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/run-id.py self-test
+
+      # The base-preflight decider's contract, executed. It turns stage-2-review-gate.md's prose
+      # "rebase before you review/fix if CONFLICTING/DIRTY/BEHIND" precondition into a tested check: it
+      # DECIDES proceed / rebase-first / recheck from the live PR view and performs no rebase. Its fixtures
+      # pin the mapping TOTALLY over both GitHub enums (one per mergeStateStatus value, plus an unrecognised
+      # value that must re-poll, never guess) and drive the CLI's fail-closed `recheck` on a malformed view.
+      # `py_compile` above only parses it; the sibling `base-preflight-test.py` is loaded by path and a
+      # MISSING sibling fails loudly, so this can never report an all-clear over a suite it did not run.
+      - name: Base-preflight contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/base-preflight.py self-test

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -217,6 +217,7 @@ a line the tool writes.
 | `emit-progress.py` | Reviewer's door: append one unit-progress event (the only sanctioned way) | `references/stage-2-review-gate.md` |
 | `emit-finding.py` | Reviewer's door: record one FINDING (the only sanctioned way; findings must anchor or they do not gate) | `references/stage-2-review-gate.md` |
 | `reviewer-liveness.py` | Probe whether a dispatched reviewer's output stream is still moving; decides nothing, always exits 0 | `references/stage-2-review-gate.md` |
+| `base-preflight.py` | Decide proceed / rebase-first / recheck from a PR's live merge-state before review or fix; performs no rebase | `references/stage-2-review-gate.md` |
 | `ci-status.py` | `derive` — how `ci` is DERIVED, always, the only way — and `required-set` | `references/stage-2-ci.md` |
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/stage-2-ci.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/stage-2-ci.md` |

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -39,6 +39,16 @@ about **not re-deriving the problem**, the sweep rule is about **not shipping ha
 licence to ignore the other. A fixer that sweeps the tree to find the sites its own change invalidated is
 **obeying** the scope rule, not breaking it — it is not re-deriving anything, it is finishing.
 
+### PRE-FLIGHT — the base must be current before ANY fix is dispatched
+
+**BEFORE dispatching ANY fix subagent (review-fix or CI-fix) for a PR, run
+`scripts/base-preflight.py check --pr <N>`.** If it does not print `proceed`, do **NOT** dispatch the fix:
+REBASE the PR onto `<base>` first (per `stage-2-review-gate.md`'s conflict-rebase), then re-run the
+pre-flight. A `rebase-first` verdict means the branch conflicts with its base or the base has moved ahead; a
+`recheck` means mergeability is not computed yet — re-poll. A fix authored on a stale or conflicting base is
+wasted work: it is re-reviewed against the rebased tip anyway, and its diff may not even apply. The tool
+DECIDES only — it performs no rebase; the driver rebases when told, exactly as at the review-gate site.
+
 ### SCOPE — bounds the reading
 
 **Scope every fix subagent.** Hand it the worktree path and the **concrete issue list** (for a CI-fix:

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -42,12 +42,20 @@ licence to ignore the other. A fixer that sweeps the tree to find the sites its 
 ### PRE-FLIGHT — the base must be current before ANY fix is dispatched
 
 **BEFORE dispatching ANY fix subagent (review-fix or CI-fix) for a PR, run
-`scripts/base-preflight.py check --pr <N>`.** If it does not print `proceed`, do **NOT** dispatch the fix:
-REBASE the PR onto `<base>` first (per `stage-2-review-gate.md`'s conflict-rebase), then re-run the
-pre-flight. A `rebase-first` verdict means the branch conflicts with its base or the base has moved ahead; a
-`recheck` means mergeability is not computed yet — re-poll. A fix authored on a stale or conflicting base is
-wasted work: it is re-reviewed against the rebased tip anyway, and its diff may not even apply. The tool
-DECIDES only — it performs no rebase; the driver rebases when told, exactly as at the review-gate site.
+`scripts/base-preflight.py check --pr <N>`.** It prints ONE of three verdicts, and the action **splits by
+verdict** — only `proceed` clears the dispatch, and the other two are NOT the same response:
+
+- **`proceed`** → the base is current; **dispatch the fix**.
+- **`rebase-first`** → the branch conflicts with its base or the base has moved ahead; do **NOT** dispatch.
+  **REBASE the PR onto `<base>`** (per `stage-2-review-gate.md`'s conflict-rebase), then **re-run the
+  pre-flight**.
+- **`recheck`** → mergeability is not computed yet (or the view carried a value nobody has classified); do
+  **NOT** dispatch and do **NOT** rebase — **re-poll**, then **re-run the pre-flight**. Rebasing here would
+  act on a view GitHub has not finished computing.
+
+A fix authored on a stale or conflicting base is wasted work: it is re-reviewed against the rebased tip
+anyway, and its diff may not even apply. The tool DECIDES only — it performs no rebase; the driver rebases
+only on `rebase-first`, exactly as at the review-gate site.
 
 ### SCOPE — bounds the reading
 

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -42,8 +42,8 @@ licence to ignore the other. A fixer that sweeps the tree to find the sites its 
 ### PRE-FLIGHT — the base must be current before ANY fix is dispatched
 
 **BEFORE dispatching ANY fix subagent (review-fix or CI-fix) for a PR, run
-`scripts/base-preflight.py check --pr <N>`.** It prints ONE of three verdicts, and the action **splits by
-verdict** — only `proceed` clears the dispatch, and the other two are NOT the same response:
+`python3 scripts/base-preflight.py check --pr <N>`.** It prints ONE of three verdicts, and the action
+**splits by verdict** — only `proceed` clears the dispatch, and the other two are NOT the same response:
 
 - **`proceed`** → the base is current; **dispatch the fix**.
 - **`rebase-first`** → the branch conflicts with its base or the base has moved ahead; do **NOT** dispatch.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -72,9 +72,12 @@ review gate"), and the review re-starts on the clean tip:
 - **Merge conflicts with `<base>`.** If GitHub flags the PR conflicting/behind
   (`gh pr view <pr> --json mergeable,mergeStateStatus` → `CONFLICTING` / `DIRTY` / `BEHIND`), rebase
   it onto `<base>` before reviewing. This CONFLICTING/DIRTY/BEHIND condition is now DECIDED by
-  `scripts/base-preflight.py check --pr <pr>`, which prints `rebase-first` for exactly these states (and
-  `proceed` when the base is current); it is the enforced form of this rule and it is also the pre-flight
-  gate before any fix subagent is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean rebase with the PR diff unchanged keeps `reviews_ok` but
+  `python3 scripts/base-preflight.py check --pr <pr>`, which prints `rebase-first` for exactly these states
+  (and `proceed` when the base is current) — but only once BOTH enum values are recognized and computed; an
+  UNKNOWN or unrecognized value returns `recheck` FIRST, before any rebase-first classification, so re-poll
+  and re-run rather than rebase on a half-computed view (`base-preflight.py` is the owner of the full
+  mapping). It is the enforced form of this rule and it is also the pre-flight gate before any fix subagent
+  is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean rebase with the PR diff unchanged keeps `reviews_ok` but
   sets `ci = pending` **and resets the liveness counters** — the gate does not reset, but the `head_sha`
   **moved**, and **every** `head_sha` change resets them (`stage-2-ci.md`, "THE LIVENESS COUNTERS");
   conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -71,7 +71,10 @@ review gate"), and the review re-starts on the clean tip:
   PRs may fix CI concurrently within the cap.
 - **Merge conflicts with `<base>`.** If GitHub flags the PR conflicting/behind
   (`gh pr view <pr> --json mergeable,mergeStateStatus` → `CONFLICTING` / `DIRTY` / `BEHIND`), rebase
-  it onto `<base>` before reviewing. Clean rebase with the PR diff unchanged keeps `reviews_ok` but
+  it onto `<base>` before reviewing. This CONFLICTING/DIRTY/BEHIND condition is now DECIDED by
+  `scripts/base-preflight.py check --pr <pr>`, which prints `rebase-first` for exactly these states (and
+  `proceed` when the base is current); it is the enforced form of this rule and it is also the pre-flight
+  gate before any fix subagent is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean rebase with the PR diff unchanged keeps `reviews_ok` but
   sets `ci = pending` **and resets the liveness counters** — the gate does not reset, but the `head_sha`
   **moved**, and **every** `head_sha` change resets them (`stage-2-ci.md`, "THE LIVENESS COUNTERS");
   conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -183,6 +183,24 @@ def t_cli_malformed():
               f"the reason must say which field is missing, got {result['reason']!r}")
 
 
+def t_cli_bad_project_root_fails_closed():
+    # An invalid --project-root makes subprocess.run raise OSError (NotADirectoryError/FileNotFoundError)
+    # BEFORE any returncode exists. That must be caught and turned into a fail-closed `recheck` with a
+    # NON-ZERO exit and NO traceback — never proceed, never crash. No --view-json, so load_view takes the
+    # gh/subprocess path; the bad cwd trips it before gh is ever consulted.
+    bad_root = Path(tempfile.gettempdir()) / "base-preflight-no-such-dir-xyz-000"
+    check(not bad_root.exists(), f"the test's bogus --project-root must not exist: {bad_root}")
+    code, out, err = capture_cli(
+        M.main, ["check", "--pr", "9", "--project-root", str(bad_root)])
+    check(code != 0, f"a bad --project-root must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"a bad --project-root must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck",
+          f"a bad --project-root must decide recheck, never proceed, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
 CASES = [
     ("clean-proceeds", "CLEAN -> proceed", t_clean_proceeds),
     ("has-hooks-proceeds", "HAS_HOOKS -> proceed", t_has_hooks_proceeds),
@@ -208,4 +226,6 @@ CASES = [
     ("cli-proceed", "check --view-json on a CLEAN view exits 0 with proceed", t_cli_proceed),
     ("cli-rebase-first", "check --view-json on a DIRTY view exits non-zero with rebase-first", t_cli_rebase_first),
     ("cli-malformed", "a view missing a field fails closed to recheck, never KeyError", t_cli_malformed),
+    ("cli-bad-project-root", "an invalid --project-root fails closed to recheck, no traceback",
+     t_cli_bad_project_root_fails_closed),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Fixtures for `base-preflight.py` — the base-currency decider.
+
+They live in a SIBLING file, and `base-preflight.py self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE HAS TEETH. It asserts the EXACT verdict AND, where the wording is load-bearing, the EXACT
+reason — a suite that only checked `verdict == "rebase-first"` would pass against a decider that returned the
+wrong reason, and the reason is what the driver acts on. There is one fixture PER `mergeStateStatus` value so
+the mapping is pinned TOTALLY over the enum, plus the unrecognised-value fixture that pins the catch-all.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
+
+OWNER = Path(__file__).resolve().parent / "base-preflight.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("base_preflight_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the base-currency decider at {OWNER}")
+    return mod
+
+
+M = _load_owner()
+
+
+def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN") -> dict:
+    return {"mergeable": mergeable, "mergeStateStatus": mergeStateStatus}
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise M.SelfTestFailure(msg)
+
+
+def expect(v: dict, verdict: str, reason: "str | None" = None) -> None:
+    got = M.decide(v)
+    check(got["verdict"] == verdict, f"expected verdict {verdict!r}, got {got!r}")
+    if reason is not None:
+        check(got["reason"] == reason, f"expected reason {reason!r}, got {got['reason']!r}")
+
+
+# --- one fixture PER mergeStateStatus value (mergeable defaults to MERGEABLE) --------------------
+# The four base-current states clear a fix; DIRTY/BEHIND demand a rebase; UNKNOWN re-polls. Together they
+# cover every value in MERGE_STATE_STATUS_VALUES, so the mapping is pinned TOTALLY over the enum.
+
+def t_clean_proceeds():
+    expect(view(mergeStateStatus="CLEAN"), "proceed", "branch is current with base")
+
+
+def t_has_hooks_proceeds():
+    expect(view(mergeStateStatus="HAS_HOOKS"), "proceed", "branch is current with base")
+
+
+def t_unstable_proceeds():
+    # UNSTABLE is about a non-passing/still-running CHECK, not a stale base — a fix/review may proceed.
+    expect(view(mergeStateStatus="UNSTABLE"), "proceed", "branch is current with base")
+
+
+def t_blocked_proceeds():
+    # BLOCKED is about branch-protection/permissions, not a stale base — base-currency still clears.
+    expect(view(mergeStateStatus="BLOCKED"), "proceed", "branch is current with base")
+
+
+def t_dirty_rebases():
+    expect(view(mergeStateStatus="DIRTY"), "rebase-first", "conflicts with base — rebase before reviewing/fixing")
+
+
+def t_behind_rebases():
+    expect(view(mergeStateStatus="BEHIND"), "rebase-first", "base has moved ahead — rebase first")
+
+
+def t_unknown_mergestate_rechecks():
+    expect(view(mergeStateStatus="UNKNOWN"), "recheck", "mergeability not computed yet — re-poll")
+
+
+def t_every_mergestate_value_is_mapped():
+    # TOTALITY, mechanically: every value the schema declares for mergeStateStatus resolves to a verdict
+    # (never a crash), and to one of the three legal verdicts. The per-value fixtures above pin WHICH; this
+    # pins that NONE is left unmapped.
+    for value in M.MERGE_STATE_STATUS_VALUES:
+        got = M.decide(view(mergeStateStatus=value))
+        check(got["verdict"] in (M.PROCEED, M.REBASE_FIRST, M.RECHECK),
+              f"mergeStateStatus={value!r} produced a non-verdict {got!r}")
+
+
+# --- mergeable enum -----------------------------------------------------------
+
+def t_conflicting_rebases():
+    # CONFLICTING is decided on .mergeable alone; even a CLEAN merge state cannot clear it.
+    expect(view(mergeable="CONFLICTING", mergeStateStatus="CLEAN"), "rebase-first",
+           "conflicts with base — rebase before reviewing/fixing")
+
+
+def t_unknown_mergeable_rechecks():
+    expect(view(mergeable="UNKNOWN", mergeStateStatus="CLEAN"), "recheck",
+           "mergeability not computed yet — re-poll")
+
+
+# --- the totality catch-all ---------------------------------------------------
+
+def t_unrecognised_mergestate_value_rechecks():
+    # A value GitHub's schema does not declare — the catch-all re-polls it, never guesses `proceed`. Pins
+    # that the mapping is TOTAL: an unclassified value is fail-closed, not silently cleared.
+    expect(view(mergeStateStatus="FROZEN"), "recheck", "unknown merge state FROZEN — re-poll, never guess")
+
+
+# --- CLI: a recorded view makes `check` testable without gh --------------------
+
+def t_cli_proceed():
+    with tempfile.TemporaryDirectory() as d:
+        vjson = Path(d) / "view.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
+        check(code == 0, f"a `proceed` verdict must exit 0 (stderr: {err})")
+        check(json.loads(out) == {"verdict": "proceed", "reason": "branch is current with base"},
+              f"the CLI should print the proceed verdict, got {out!r}")
+
+
+def t_cli_rebase_first():
+    with tempfile.TemporaryDirectory() as d:
+        vjson = Path(d) / "view.json"
+        vjson.write_text(json.dumps(view(mergeStateStatus="DIRTY")), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
+        check(code != 0, f"a `rebase-first` verdict must exit non-zero so a caller can gate on $? (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "rebase-first",
+              f"a DIRTY view must decide rebase-first, got {result!r}")
+        check(result["reason"] == "conflicts with base — rebase before reviewing/fixing",
+              f"the rebase-first reason drifted, got {result['reason']!r}")
+
+
+def t_cli_malformed():
+    # A valid JSON object MISSING mergeStateStatus — decide() would KeyError on it; the boundary fails closed
+    # to a structured recheck with a NON-ZERO exit and NO traceback, never `proceed`.
+    with tempfile.TemporaryDirectory() as d:
+        vjson = Path(d) / "view.json"
+        vjson.write_text(json.dumps({"mergeable": "MERGEABLE"}), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
+        check(code != 0, f"a malformed view must exit non-zero (fail closed), got {code} (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "recheck",
+              f"a malformed view must decide recheck, never proceed, got {result!r}")
+        check(result["reason"].startswith("malformed PR view:"),
+              f"the reason must name the malformed view, got {result['reason']!r}")
+        check("mergeStateStatus" in result["reason"],
+              f"the reason must say which field is missing, got {result['reason']!r}")
+
+
+CASES = [
+    ("clean-proceeds", "CLEAN -> proceed", t_clean_proceeds),
+    ("has-hooks-proceeds", "HAS_HOOKS -> proceed", t_has_hooks_proceeds),
+    ("unstable-proceeds", "UNSTABLE is a check signal, not a stale base -> proceed", t_unstable_proceeds),
+    ("blocked-proceeds", "BLOCKED is a permission signal, not a stale base -> proceed", t_blocked_proceeds),
+    ("dirty-rebases", "DIRTY -> rebase-first", t_dirty_rebases),
+    ("behind-rebases", "BEHIND -> rebase-first", t_behind_rebases),
+    ("unknown-mergestate-rechecks", "UNKNOWN merge state -> recheck", t_unknown_mergestate_rechecks),
+    ("mergestate-total", "every mergeStateStatus value maps to a verdict (totality)",
+     t_every_mergestate_value_is_mapped),
+    ("conflicting-rebases", "CONFLICTING decided on .mergeable alone -> rebase-first", t_conflicting_rebases),
+    ("unknown-mergeable-rechecks", "UNKNOWN mergeability -> recheck", t_unknown_mergeable_rechecks),
+    ("unrecognised-value-rechecks", "an unrecognised merge state re-polls (totality catch-all)",
+     t_unrecognised_mergestate_value_rechecks),
+    ("cli-proceed", "check --view-json on a CLEAN view exits 0 with proceed", t_cli_proceed),
+    ("cli-rebase-first", "check --view-json on a DIRTY view exits non-zero with rebase-first", t_cli_rebase_first),
+    ("cli-malformed", "a view missing a field fails closed to recheck, never KeyError", t_cli_malformed),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -112,6 +112,35 @@ def t_unrecognised_mergestate_value_rechecks():
     expect(view(mergeStateStatus="FROZEN"), "recheck", "unknown merge state FROZEN — re-poll, never guess")
 
 
+# --- cross-enum precedence: UNKNOWN / unrecognised WINS over a recognised rebase state ------------
+# A view with a recognised CONFLICTING/DIRTY/BEHIND on ONE half and an UNKNOWN or unrecognised value on the
+# OTHER must NOT be steered to `rebase-first` on the half we recognise — the uncomputed/unclassified half
+# wins and we re-poll on a full view. These pin the ordering: fail-safe BEFORE act.
+
+def t_conflicting_with_unknown_mergestate_rechecks():
+    # CONFLICTING mergeable but mergeStateStatus not yet computed — re-poll, do NOT rebase on half a view.
+    expect(view(mergeable="CONFLICTING", mergeStateStatus="UNKNOWN"), "recheck",
+           "mergeability not computed yet — re-poll")
+
+
+def t_conflicting_with_unrecognised_mergestate_rechecks():
+    # CONFLICTING mergeable but an unrecognised merge state (one GitHub added since) — re-poll, never guess.
+    expect(view(mergeable="CONFLICTING", mergeStateStatus="FROZEN"), "recheck",
+           "unknown merge state FROZEN — re-poll, never guess")
+
+
+def t_dirty_with_unknown_mergeable_rechecks():
+    # DIRTY merge state but mergeable not yet computed — the uncomputed half wins over the DIRTY rebase state.
+    expect(view(mergeable="UNKNOWN", mergeStateStatus="DIRTY"), "recheck",
+           "mergeability not computed yet — re-poll")
+
+
+def t_behind_with_unknown_mergeable_rechecks():
+    # BEHIND merge state but mergeable not yet computed — the uncomputed half wins over the BEHIND rebase state.
+    expect(view(mergeable="UNKNOWN", mergeStateStatus="BEHIND"), "recheck",
+           "mergeability not computed yet — re-poll")
+
+
 # --- CLI: a recorded view makes `check` testable without gh --------------------
 
 def t_cli_proceed():
@@ -168,6 +197,14 @@ CASES = [
     ("unknown-mergeable-rechecks", "UNKNOWN mergeability -> recheck", t_unknown_mergeable_rechecks),
     ("unrecognised-value-rechecks", "an unrecognised merge state re-polls (totality catch-all)",
      t_unrecognised_mergestate_value_rechecks),
+    ("conflicting+unknown-rechecks", "CONFLICTING + UNKNOWN merge state re-polls, never rebases",
+     t_conflicting_with_unknown_mergestate_rechecks),
+    ("conflicting+unrecognised-rechecks", "CONFLICTING + unrecognised merge state re-polls, never rebases",
+     t_conflicting_with_unrecognised_mergestate_rechecks),
+    ("dirty+unknown-mergeable-rechecks", "DIRTY + UNKNOWN mergeable re-polls, never rebases",
+     t_dirty_with_unknown_mergeable_rechecks),
+    ("behind+unknown-mergeable-rechecks", "BEHIND + UNKNOWN mergeable re-polls, never rebases",
+     t_behind_with_unknown_mergeable_rechecks),
     ("cli-proceed", "check --view-json on a CLEAN view exits 0 with proceed", t_cli_proceed),
     ("cli-rebase-first", "check --view-json on a DIRTY view exits non-zero with rebase-first", t_cli_rebase_first),
     ("cli-malformed", "a view missing a field fails closed to recheck, never KeyError", t_cli_malformed),

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -155,8 +155,15 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None",
     if repo:
         argv += ["--repo", repo]
     argv += ["--json", VIEW_FIELDS]
-    proc = subprocess.run(  # noqa: S603
-        argv, capture_output=True, text=True, check=False, cwd=project_root)
+    try:
+        proc = subprocess.run(  # noqa: S603
+            argv, capture_output=True, text=True, check=False, cwd=project_root)
+    except OSError as exc:
+        # subprocess.run RAISES before it ever produces a returncode when the executable is missing
+        # (FileNotFoundError) or `--project-root` is not a usable directory (NotADirectoryError) — both are
+        # OSError. Uncaught, that prints a traceback and never fails closed; turn it into a ViewError so the
+        # caller emits a structured `recheck` and exits non-zero, exactly like a non-zero `gh` exit.
+        raise ViewError(f"could not run `gh pr view {pr}`: {exc}") from exc
     if proc.returncode != 0:
         raise ViewError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
     try:

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""DECIDE whether a PR's branch is current with its base BEFORE a review or a fix is authored on it.
+
+This enforces the rebase-before-review/fix precondition `stage-2-review-gate.md` states in prose: if a PR
+is CONFLICTING/DIRTY/BEHIND with `<base>`, rebase it before reviewing or fixing. That prose was a rule a
+model re-derived by eye every heartbeat, and a fix authored on a stale/conflicting base is wasted — it is
+re-reviewed against the rebased tip anyway. This turns the prose into an enforced check.
+
+It DECIDES one of `proceed` / `rebase-first` / `recheck` from the live PR view and PERFORMS NO REBASE: the
+driver rebases when told `rebase-first`, then re-runs this. Deciding and doing are two jobs and this is only
+the first — nothing here runs `git rebase`/`git merge` or edits a branch.
+
+    base-preflight.py check --pr 31 [--repo owner/name] [--view-json <path>] [--project-root <dir>]
+    base-preflight.py self-test   run every fixture (base-preflight-test.py)
+
+The verdict is printed as JSON on stdout, and the EXIT CODE gates a caller's `$?`: 0 for `proceed`, non-zero
+for `rebase-first` and `recheck` (and for a view that could not be fetched or was malformed — those fail
+CLOSED to `recheck`, never `proceed`). The fixture suite is the SIBLING `base-preflight-test.py`, this
+tool's executable contract; `self-test` loads it by a `__file__`-relative path and FAILS LOUDLY if it is
+missing — a self-test that passes because it found no tests is not a passing gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "base-preflight-test.py"     # the fixture suite — this tool's executable contract
+
+
+# --- the verdicts -------------------------------------------------------------
+#
+# `proceed` is the ONLY verdict that clears a review/fix onto this branch; `rebase-first` says the base is
+# stale/conflicting and a rebase must land first; `recheck` is NEVER a verdict — it says the mergeability is
+# not yet computed (or is a value nobody has classified), so re-poll and decide again. Every non-`proceed`
+# outcome fails CLOSED: this tool would rather send the driver back to rebase or re-poll than wave a fix onto
+# a base it could not confirm was current.
+PROCEED = "proceed"
+REBASE_FIRST = "rebase-first"
+RECHECK = "recheck"
+
+
+# --- the two GitHub enums, as data so `decide` reads ONE source, mapped TOTALLY -------------------
+#
+# The AUTHORITATIVE value sets are GitHub's schema, as `stage-3-merge.md` records them. This tool judges ONLY
+# base-currency, so the two enums are crossed for exactly one question — is the branch current enough with
+# its base? — never for merge-readiness (that is `merge-check.py`'s job, downstream, over the same enums).
+# The mapping below is TOTAL over both sets: every value has a home, and a value in NEITHER set is one GitHub
+# added since — the catch-all in `decide` re-polls it rather than guessing.
+MERGEABLE_VALUES = frozenset({"MERGEABLE", "CONFLICTING", "UNKNOWN"})
+MERGE_STATE_STATUS_VALUES = frozenset(
+    {"DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"})
+
+# The `mergeStateStatus` values that mean the base is CURRENT ENOUGH to author a review/fix on. UNSTABLE and
+# BLOCKED are about CHECKS/PERMISSIONS, NOT a stale base — a non-passing check or a branch-protection block
+# does not make the base moved-ahead, so a fix/review may proceed; this tool judges base-currency alone.
+# DIRTY/BEHIND/UNKNOWN are deliberately ABSENT: each is handled by an earlier rule in `decide`.
+BASE_CURRENT_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE", "BLOCKED"})
+
+
+def _verdict(verdict: str, reason: str) -> dict:
+    return {"verdict": verdict, "reason": reason}
+
+
+def decide(view: dict) -> dict:
+    """PURE. Return `{"verdict": ..., "reason": ...}` for one PR view. No I/O. Assumes a validated view (see
+    `validate_view`), so `view["mergeable"]` and `view["mergeStateStatus"]` are present strings.
+
+    The order is deliberate and FIRST-MATCHING-RULE-WINS: a conflict is reported before a moved base, both
+    are reported before an uncomputed mergeability, and only a fully computed, non-conflicting, current view
+    reaches `proceed`. A value in NEITHER enum falls to the totality catch-all and re-polls — it is never
+    guessed into `proceed`.
+    """
+    mergeable = view["mergeable"]
+    mss = view["mergeStateStatus"]
+
+    # 1. CONFLICTS WITH BASE — the branch cannot combine with its base. A fix authored here fights the merge.
+    if mergeable == "CONFLICTING" or mss == "DIRTY":
+        return _verdict(REBASE_FIRST, "conflicts with base — rebase before reviewing/fixing")
+
+    # 2. BASE MOVED AHEAD — no conflict, but the base has commits this branch lacks; rebase to review the tip.
+    if mss == "BEHIND":
+        return _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
+
+    # 3. NOT COMPUTED YET — GitHub has not finished computing mergeability. NEVER a verdict: re-poll.
+    if mergeable == "UNKNOWN" or mss == "UNKNOWN":
+        return _verdict(RECHECK, "mergeability not computed yet — re-poll")
+
+    # 4. CURRENT WITH BASE — mergeable AND a base-current merge state. The one verdict that clears a fix.
+    if mergeable == "MERGEABLE" and mss in BASE_CURRENT_STATES:
+        return _verdict(PROCEED, "branch is current with base")
+
+    # 5. TOTALITY CATCH-ALL — an unrecognised value of either enum. By here `mergeable` is not CONFLICTING or
+    #    UNKNOWN and `mss` is not DIRTY/BEHIND/UNKNOWN, so the offending value is whichever enum is outside its
+    #    schema set. Re-poll, never guess a fix onto a merge state nobody has classified.
+    unknown = mergeable if mergeable not in MERGEABLE_VALUES else mss
+    return _verdict(RECHECK, f"unknown merge state {unknown} — re-poll, never guess")
+
+
+# --- obtain the live PR view ---------------------------------------------------
+
+VIEW_FIELDS = "mergeable,mergeStateStatus"
+
+# Every field `decide` reads off the view, each a string. `validate_view` pins this at the boundary so
+# `decide` may assume a shaped view and never raises `KeyError`/`TypeError` on a value the caller handed in.
+_VIEW_STR_FIELDS = ("mergeable", "mergeStateStatus")
+
+
+class ViewError(Exception):
+    """The live PR view could not be obtained. The decision fails CLOSED — never `proceed`."""
+
+
+def validate_view(view: object) -> "str | None":
+    """`None` if `view` is a JSON object carrying `mergeable` and `mergeStateStatus` as strings; otherwise a
+    short description of the FIRST thing wrong. PURE — no I/O. The CLI turns a non-`None` result into a
+    fail-closed `recheck`, so `decide` is never reached with a malformed view (learned from a prior tool that
+    could KeyError past its boundary)."""
+    if not isinstance(view, dict):
+        return f"view is not a JSON object (got {type(view).__name__})"
+    for name in _VIEW_STR_FIELDS:
+        if name not in view:
+            return f"missing field {name!r}"
+        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
+        if not isinstance(view[name], str):
+            return f"field {name!r} must be a string, got {type(view[name]).__name__}"
+    return None
+
+
+def load_view(pr: str, repo: "str | None", view_json: "str | None",
+              project_root: "str | None") -> dict:
+    """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
+    `gh pr view` itself. Any failure raises `ViewError`, which the caller turns into a fail-closed `recheck`.
+    """
+    if view_json is not None:
+        try:
+            return json.loads(Path(view_json).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ViewError(str(exc)) from exc
+    argv = ["gh", "pr", "view", str(pr)]
+    if repo:
+        argv += ["--repo", repo]
+    argv += ["--json", VIEW_FIELDS]
+    proc = subprocess.run(  # noqa: S603
+        argv, capture_output=True, text=True, check=False, cwd=project_root)
+    if proc.returncode != 0:
+        raise ViewError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ViewError(f"gh response is not JSON ({exc})") from exc
+
+
+def check(pr: str, repo: "str | None", view_json: "str | None",
+          project_root: "str | None") -> int:
+    """Fetch the live view, decide, print the verdict as JSON. EXIT 0 only on `proceed`; every other outcome
+    (rebase-first, recheck, an unfetchable or malformed view) exits non-zero so a caller can gate on `$?`."""
+    try:
+        view = load_view(pr, repo, view_json, project_root)
+    except ViewError as exc:
+        print(json.dumps(_verdict(RECHECK, f"could not fetch PR view: {exc}")))
+        return 1
+    # A syntactically valid but INCOMPLETE/WRONG-TYPED view must fail CLOSED here, never crash `decide` with a
+    # KeyError/TypeError and never say `proceed`. Mirrors the fetch-failure recheck above.
+    problem = validate_view(view)
+    if problem is not None:
+        print(json.dumps(_verdict(RECHECK, f"malformed PR view: {problem}")))
+        return 1
+    result = decide(view)
+    print(json.dumps(result))
+    return 0 if result["verdict"] == PROCEED else 1
+
+
+# --- self-test: the executable contract lives in the SIBLING module ------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
+            f"health. Every rule this file enforces is now unpinned.")
+    mod = load_module_from_path("base_preflight_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the base-preflight decider's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:30} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the base-preflight decider's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the base-preflight decider's contract is intact.")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("check", help="decide base-currency for one PR from its live view")
+    c.add_argument("--pr", required=True)
+    c.add_argument("--repo", help="owner/name (default: the current checkout's)")
+    c.add_argument("--view-json", help="a recorded `gh pr view` JSON — decide without calling gh")
+    c.add_argument("--project-root", help="run `gh pr view` with this as its working directory")
+
+    sub.add_parser("self-test", help="run every fixture (base-preflight-test.py)")
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "self-test":
+        return self_test()
+    return check(args.pr, args.repo, args.view_json, args.project_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -72,35 +72,44 @@ def decide(view: dict) -> dict:
     """PURE. Return `{"verdict": ..., "reason": ...}` for one PR view. No I/O. Assumes a validated view (see
     `validate_view`), so `view["mergeable"]` and `view["mergeStateStatus"]` are present strings.
 
-    The order is deliberate and FIRST-MATCHING-RULE-WINS: a conflict is reported before a moved base, both
-    are reported before an uncomputed mergeability, and only a fully computed, non-conflicting, current view
-    reaches `proceed`. A value in NEITHER enum falls to the totality catch-all and re-polls — it is never
-    guessed into `proceed`.
+    The order is deliberate and FIRST-MATCHING-RULE-WINS, and it fails safe BEFORE it acts: an unrecognised
+    value of EITHER enum re-polls first, then an uncomputed mergeability re-polls, and only then is a conflict
+    or a moved base allowed to say `rebase-first`. This ordering is load-bearing — a view like
+    `{mergeable: CONFLICTING, mergeStateStatus: UNKNOWN}` or `{..., mergeStateStatus: FROZEN}` (a value GitHub
+    added since) must NOT be steered to `rebase-first` on the half of the view we DO recognise while the other
+    half is uncomputed or unclassified. UNKNOWN/unrecognised WINS: re-poll and decide again on a full view,
+    never guess. Only a fully computed, recognised, non-conflicting, current view reaches `proceed`.
     """
     mergeable = view["mergeable"]
     mss = view["mergeStateStatus"]
 
-    # 1. CONFLICTS WITH BASE — the branch cannot combine with its base. A fix authored here fights the merge.
-    if mergeable == "CONFLICTING" or mss == "DIRTY":
-        return _verdict(REBASE_FIRST, "conflicts with base — rebase before reviewing/fixing")
+    # 1. UNRECOGNISED VALUE of EITHER enum — a value GitHub's schema does not declare (one it added since).
+    #    Fail safe BEFORE any rebase/proceed decision: re-poll, never guess onto a value nobody classified.
+    if mergeable not in MERGEABLE_VALUES or mss not in MERGE_STATE_STATUS_VALUES:
+        unknown = mergeable if mergeable not in MERGEABLE_VALUES else mss
+        return _verdict(RECHECK, f"unknown merge state {unknown} — re-poll, never guess")
 
-    # 2. BASE MOVED AHEAD — no conflict, but the base has commits this branch lacks; rebase to review the tip.
-    if mss == "BEHIND":
-        return _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
-
-    # 3. NOT COMPUTED YET — GitHub has not finished computing mergeability. NEVER a verdict: re-poll.
+    # 2. NOT COMPUTED YET — GitHub has not finished computing mergeability for EITHER enum. NEVER a verdict:
+    #    re-poll. This wins over rebase-first: a recognised CONFLICTING/DIRTY/BEHIND on one half cannot decide
+    #    the branch while the other half is still UNKNOWN.
     if mergeable == "UNKNOWN" or mss == "UNKNOWN":
         return _verdict(RECHECK, "mergeability not computed yet — re-poll")
 
-    # 4. CURRENT WITH BASE — mergeable AND a base-current merge state. The one verdict that clears a fix.
+    # 3. CONFLICTS WITH BASE — the branch cannot combine with its base. A fix authored here fights the merge.
+    if mergeable == "CONFLICTING" or mss == "DIRTY":
+        return _verdict(REBASE_FIRST, "conflicts with base — rebase before reviewing/fixing")
+
+    # 4. BASE MOVED AHEAD — no conflict, but the base has commits this branch lacks; rebase to review the tip.
+    if mss == "BEHIND":
+        return _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
+
+    # 5. CURRENT WITH BASE — mergeable AND a base-current merge state. The one verdict that clears a fix.
     if mergeable == "MERGEABLE" and mss in BASE_CURRENT_STATES:
         return _verdict(PROCEED, "branch is current with base")
 
-    # 5. TOTALITY CATCH-ALL — an unrecognised value of either enum. By here `mergeable` is not CONFLICTING or
-    #    UNKNOWN and `mss` is not DIRTY/BEHIND/UNKNOWN, so the offending value is whichever enum is outside its
-    #    schema set. Re-poll, never guess a fix onto a merge state nobody has classified.
-    unknown = mergeable if mergeable not in MERGEABLE_VALUES else mss
-    return _verdict(RECHECK, f"unknown merge state {unknown} — re-poll, never guess")
+    # 6. DEFENSIVE CATCH-ALL — unreachable after step 1 pinned both enums to their schema sets and steps 2-5
+    #    covered every recognised combination. Fail closed rather than fall off the end of the function.
+    return _verdict(RECHECK, "mergeability not computed yet — re-poll")
 
 
 # --- obtain the live PR view ---------------------------------------------------


### PR DESCRIPTION
- add base-preflight.py: decides proceed/rebase-first/recheck from a PR's live merge state, deciding only, no rebase
- wire it as the pre-flight before any fix subagent (fix-subagent-contract.md); note it at the review-gate precondition
- add sibling fixtures and a CI step; bump ci.yml pyright count 28 to 30 — sibling PRs edit it, last to merge rebases
