### PR TITLE
docs(campaign): route lease prose through lease.py

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -4,10 +4,10 @@
   carrying its `gauntlet-run-<run-id>` label. Adopted PRs keep their OWN head branch, so ownership is
   scoped by that LABEL only (never a branch prefix). NEVER reconcile, review, fix, merge, relabel, or
   clean up another run's work — scope every git/gh scan by that label.
-- One active driver per run, enforced by `<rundir>/lease.json` under an atomic `mkdir <rundir>/claim.lock`:
-  take/adopt a run only inside the claim lock, and adopt ONLY when its lease is absent or stale
-  (`now - updated` > ~30 min); refresh the lease every heartbeat AND around long foreground ops; on a
-  scheduled heartbeat whose lease is fresh but bears a different token, **stand down** — never double-drive a ledger.
+- One active driver per run, enforced by the run lease `<rundir>/lease.json` — driven ONLY through
+  `scripts/lease.py` (`acquire` / `refresh` / `release`): act on its printed verdict, and on
+  `superseded` **stand down** — never double-drive a ledger. Refresh every heartbeat AND around long
+  foreground ops; `run-identity-and-lease.md`, "Run lease", owns when to call what.
 - Every **scheduled** heartbeat carries `--run <run-id> --token <agent-token>`; the token re-proves lease
   ownership so a summarized heartbeat never mistakes its own run for another's. A scheduler-less bounded wait
   retains the current invocation and token, then loops directly back to reconcile. Re-read `run_id` from

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -10,7 +10,7 @@ resume, reuse the existing dir). Per-run dirs are what keep concurrent runs' fil
 | `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
 | `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-heartbeat reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**: the canonical command is spelled in full in **"The canonical `prs.json` command"**, the command block directly below this table, and that block is its ONLY definition |
-| `lease.json` | This run's active-driver lease (`{agent, updated}`; see "Run lease") |
+| `lease.json` | This run's active-driver lease — read/written ONLY through `scripts/lease.py` (see "Run lease") |
 | `review-<pr>-<n>.prompt.txt` | The reviewer prompt for round `n`, launch attempt 1, with the verbatim intent and JSON-encoded typed transport record bound as data. Written through `runtime-adapter.md`'s `write_bytes` and passed through `dispatch_native` or `run_argv` — never embedded in shell source (`stage-2-review-gate.md`) |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1), written by the sole producer assigned in `runtime-adapter.md`'s typed review record |
 | `review-<pr>-<n>.plan.jsonl` | Orchestrator-authored review work units for round `n` (per-pass — a relaunch reuses it). Written through `scripts/review-pass.py plan-add`, never a heredoc |

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -9,14 +9,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 1. **Resolve repository context, then the run + lease, then init / resume / start fresh.** Call
    `runtime-adapter.md`'s repository-context resolver exactly once with the supplied checkout and carry
    that record for every path and Git cwd on this heartbeat. Then bind **which run this heartbeat is
-   for** and confirm you may drive it, per "Run identity and concurrency": a `--run <id>` scheduled heartbeat
-   presents its `--token` and, under the run's claim lock, continues if the token matches the lease,
-   adopts if the lease is absent/stale, or **stands down** if a fresh lease bears a different token; a
-   bare invocation **with `#PR` args** starts a NEW run adopting those PRs, while an **arg-less** bare
-   invocation discovers runs and adopts the sole **orphaned** one (asks among several, refuses to
-   hijack an actively-driven one); a bare invocation with a **non-PR** arg starts nothing — it hits
-   the idle prompt (run `gauntlet:review`, or pass PR numbers).
-   This claim-locked lease check is what guarantees **no two agents drive one ledger**.
+   for** and confirm you may drive it — `run-identity-and-lease.md`, "Resolving a heartbeat", owns the
+   whole resolution: which arg mode does what, and which `lease.py` call to present a token to. Drive
+   only on an `owned`/`adopted` verdict; on `superseded` or any refusal, **stand down**.
+   This lease gate is what guarantees **no two agents drive one ledger**.
 
    Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.jsonl`
    exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label so another run's
@@ -102,8 +98,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      disagree or any PR is refused, prompt and create nothing** — so a rejected set never leaves an
      empty orphan run behind. **Only once the full set passes preflight**: call `create_run_directory`
      **first** — it mints the run-id and atomically creates `<rundir>` — and derive `run_id` from the
-     returned directory's final path component; **then** mint the agent token (separate, run-id-independent),
-     and write the lease **and `state.jsonl` header** — now with `run_id` set and `base_branch` filled
+     returned directory's final path component; **then** take the run per `run-identity-and-lease.md`,
+     "Take a run" (token, heartbeat arming, `lease.py acquire` — in that order),
+     and write the `state.jsonl` header — now with `run_id` set and `base_branch` filled
      from the agreed `baseRefName` (known from preflight). Then **adopt** each PR
      (ledger row + labels + worktree, and a CI watch **only when one is due** — `pr-adoption.md` owns what
      adoption produces and when the watch is warranted); a death mid-adoption still leaves
@@ -427,8 +424,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      this run's block to its own file `.gauntlet/history/<run-id>.md` — merged PRs, aborted
      PRs + why, and declined-API PRs; per-run files never
      contend, see "Fresh runs and carryover"), **release the run** (delete this run's
-     `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, and delete
-     `<rundir>/lease.json`; the shared status labels stay), emit the final report, and **do not
+     `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, and release
+     the lease — `lease.py … release --token <tok>`; the shared status labels stay), emit the final report, and **do not
      reschedule**. This run's loop ends. **Leave
      `<rundir>` in place** (do NOT delete it here) — its terminal `state.jsonl` is what lets a later bare
      invocation detect *this* *finished* run and take the "ask the user" branch in step 1 instead of a

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -77,27 +77,33 @@ snapshot another run may have overwritten.
 ### Run lease — one active driver at a time
 
 Namespacing keeps two *runs* apart; the **lease** keeps two *agents* from driving the **same** run.
-Each run has `<rundir>/lease.json`:
+Each run has `<rundir>/lease.json`: who is driving (`agent` — a token), the heartbeat proof presented
+when the run was taken (`heartbeat`), and the last refresh time (`updated`). `scripts/lease.py` is its
+schema-owning accessor and the ONLY door to the file (`mint` / `acquire` / `refresh` / `release` /
+`read`) — never hand-read, hand-write, or hand-delete it. The whole check-and-set lives inside the
+tool: the claim lock and its stale-lock sweep, the staleness window (`LEASE_STALE_AFTER` — long enough
+that a busy driver is never mistaken for a dead one, so staleness flags a *dead* driver), the
+corrupt-lease refusal, and the read-back. Do not unpack those mechanics here: present a token, act on
+the verdict the tool prints.
 
-```
-{ "agent": "<token>", "updated": <unix-ts> }   # token = the agent holding the run; ts = last heartbeat
-```
-
-- **Mint** an agent token (`openssl rand -hex 4`) when you first take a run — at fresh-run start or on
-  adoption — keep it in context, **and put it in your scheduled heartbeat prompt** (`--token <tok>`) so a
-  summarized/amnesiac heartbeat recovers it from the prompt instead of guessing. **You own the run iff the
-  token you present (prompt `--token`, else in-context) equals the lease's `agent`.**
-- **Claim atomically.** Taking or adopting a run is a check-and-set that MUST be serialized against
-  other agents: acquire an atomic lock first — `mkdir <rundir>/claim.lock` (fails if held) — then read
-  the lease, decide, write your token + fresh `updated`, and `rmdir` the lock. Two agents racing to
-  adopt can't both win because only one `mkdir` succeeds. (A crashed claim leaves a stale
-  `claim.lock`; treat one whose mtime is older than a few minutes as abandoned and clear it.)
-- **Heartbeat.** Rewrite the lease with `updated = $(date +%s)` every heartbeat once you're the confirmed
+- **Take a run** — at fresh-run start or on adoption — **in this order**: (1) `lease.py mint` prints
+  your agent token; (2) arm the scheduled heartbeat carrying it (`--token <tok>`, via `heartbeat.py
+  callback` — `runtime-adapter.md` owns the host mechanism); (3) `lease.py --file <rundir>/lease.json
+  acquire --token <tok> --heartbeat-id <proof>`, where the proof names the arming you ALREADY did
+  (`runtime-adapter.md` says what your host's proof is). `acquire` refuses without both and never mints
+  a token itself — arming comes FIRST, so a driver that dies mid-work is still resumed by its own
+  heartbeat. Keep the token in context; the heartbeat prompt already carries it, so a
+  summarized/amnesiac heartbeat recovers it from the prompt instead of guessing.
+- **You own the run iff the verdict says so.** `acquire`/`refresh` print a verdict, and the verdict —
+  not your write, not an eyeballed read of the file — is the proof: `owned`/`adopted` → drive;
+  `superseded`/`lost-race`/any refusal → you are NOT the driver — do not review, fix, merge, or
+  relabel; report and stop.
+- **Heartbeat.** `lease.py … refresh --token <tok>` every heartbeat once you're the confirmed
   owner, **and** immediately before and after any long *foreground* step, should one be unavoidable,
   so a busy turn still looks alive. All long work — reviews, CI watches, and fix subagents —
-  is backgrounded, so turns stay short and the per-heartbeat refresh normally suffices. A lease is
-  **stale** only once `now - updated` exceeds **~30 min** — comfortably longer than any single
-  foreground operation, so liveness flags a *dead* driver, not a busy one.
+  is backgrounded, so turns stay short and the per-heartbeat refresh normally suffices. `refresh` takes
+  no proof (it does not re-arm) and refreshes even your own stale lease; if it refuses because the
+  lease is GONE, do not re-create it — re-arm and `acquire` explicitly.
 - **Never hold the run hostage on a user prompt.** Do NOT block the loop waiting on a user answer —
   that freezes the heartbeat and could let the run be declared stale mid-drive. Park the PR
   (`awaiting-api` for an API-changing fix; `awaiting-user` for a **review standoff** — a refutation the
@@ -109,23 +115,27 @@ Each run has `<rundir>/lease.json`:
   and the **unpark** it triggers (`files-and-ledger.md`, `status`; `loop-control.md` step 3, "Only the
   user's answer unparks a PR") — a park with no defined exit is the wedge one level up (Constraints;
   `stage-2-review-gate.md`).
-- **Adopt only an orphaned run.** Safe to take over only when the lease is **absent or stale** (under
-  the claim lock). After writing your token, re-read: if it isn't yours, you lost the race — stand down.
-- **Stand down if superseded.** On a scheduled heartbeat, present your `--token`: if the lease is **fresh** and
-  its `agent` is a **different** token, you were superseded (a takeover while you were hung) — do NOT
-  drive; report and stop. Never overwrite a fresh lease you don't own. (Carrying the token in the
-  prompt removes any amnesia ambiguity — a scheduled heartbeat always knows its own token.)
-- **Release** on normal exit: delete `lease.json` (with the owner label) so the finished run shows no
-  active driver.
+- **Adopt only an orphaned run.** `acquire` adopts only a lease that is **absent or stale**; a fresh
+  lease under a different token answers `superseded` — pass `--allow-takeover` only after the user has
+  agreed to take over a live run. A lease the tool cannot parse is **`corrupt`, never "absent"**: it
+  refuses rather than adopt. Inspect the file and remove it by hand only when the user confirms the
+  run is genuinely orphaned.
+- **Stand down if superseded.** On a scheduled heartbeat, present your `--token`: a `superseded`
+  answer means a takeover while you were hung — do NOT drive; report and stop. (Carrying the token in
+  the prompt removes any amnesia ambiguity — a scheduled heartbeat always knows its own token.)
+- **Release** on normal exit: `lease.py … release --token <tok>` (with the owner label) so the
+  finished run shows no active driver. It refuses unless the token matches, so a superseded driver can
+  never delete the live owner's lease.
 
 ### Resolving a heartbeat (Loop control step 1 applies this)
 
-1. **`--run <id>` given** (every scheduled heartbeat; also a manual targeted resume). Load `<rundir>/state.jsonl`.
-   Under the claim lock, compare the token you present to the lease: **matches** (scheduled heartbeat with
-   `--token`) → refresh lease, reconcile, continue; **lease absent/stale** → adopt (write token, fresh
-   ts, read-back); **lease fresh but a different token** → for a scheduled heartbeat, stand down (superseded);
-   for a **manual** `--run` with no matching token, another agent appears active, so **confirm takeover
-   with the user** before adopting.
+1. **`--run <id>` given** (every scheduled heartbeat; also a manual targeted resume). Load `<rundir>/state.jsonl`,
+   then present a token to `lease.py`. **Scheduled heartbeat** (token in the prompt's `--token`) →
+   `refresh`: `owned` → reconcile, continue; `superseded` → stand down; refused because the lease is
+   gone → re-arm, then `acquire`. **Manual `--run` with no token in hand** → `lease.py read` (advisory
+   status only): `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another
+   agent appears active, so **confirm takeover with the user** before `acquire --allow-takeover`;
+   `corrupt` → see "Adopt only an orphaned run".
 2. **Bare invocation** → the arg decides intent:
    - **`#PR` args are given** (`<campaign-invocation> #12 #15`, no `--run`) → **start a NEW run** that
      **adopts those PRs** (see "PR adoption"). Passing PRs is an explicit "gate these now", so it never
@@ -139,12 +149,15 @@ Each run has `<rundir>/lease.json`:
      silently caps at **30** without it, and a run missed by the scan reads exactly like a run that does
      not exist, so the driver would start a duplicate or fail to resume an orphan. Like `prs.json`, the
      cap **bounds** the scan rather than proving it complete) ∪ run-ids with a `<rundir>/` (its `state.jsonl` or
-     `lease.json`), each **actively-driven** (fresh lease),
-     **orphaned** (non-terminal, lease absent/stale), or **finished** (terminal, no open PR):
+     `lease.json`), each bucketed by `lease.py read` (advisory status — never decide ownership from it;
+     that is `acquire`'s job): **actively-driven** (`held`),
+     **orphaned** (non-terminal, `absent`/`stale`), or **finished** (terminal, no open PR):
      - exactly one **orphaned** → adopt and resume it ("pick up where the previous instance left off"),
        reconciling its run-labelled PRs (see "PR adoption");
      - several orphaned → list them (id, #open PRs) and **ask which to resume, or start new**;
      - only **actively-driven** → each has a live driver; do NOT hijack — offer to start a **new** run;
+     - a lease reading **`corrupt`** → neither driven nor adoptable; report it to the user and leave
+       that run alone (see "Adopt only an orphaned run");
      - only **finished** → the finished-run prompt (Loop control step 1), per run;
      - **none at all** (idle — nothing to drive) → **prompt**: "No PRs under a campaign. Run
        `gauntlet:review` to find issues, or pass PR numbers to gate." Campaign never sweeps or mints

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -15,12 +15,12 @@ stale-lock sweep entirely. It was safe only because the lease was absent and nob
 Four refusals this file exists to make, each one a thing the prose left undefined or a well-meaning driver
 would otherwise do:
 
-1. **A MALFORMED lease is `corrupt`, never `adopt`.** The prose says adopt when the lease is "absent or
-   stale" and says nothing about unparseable. A reader that lets "cannot parse" fall through to "absent"
-   ADOPTS A LIVE RUN. The asymmetry decides it: wrongly adopting gives two drivers on one ledger; wrongly
-   refusing an orphan stalls a run, which staleness and a human both recover.
-2. **`release` refuses unless the token matches.** The prose says "delete lease.json on normal exit" — a
-   superseded driver following that literally deletes the LIVE OWNER'S lease.
+1. **A MALFORMED lease is `corrupt`, never `adopt`.** The prose once said only adopt when the lease is
+   "absent or stale", leaving unparseable undefined. A reader that lets "cannot parse" fall through to
+   "absent" ADOPTS A LIVE RUN. The asymmetry decides it: wrongly adopting gives two drivers on one ledger;
+   wrongly refusing an orphan stalls a run, which staleness and a human both recover.
+2. **`release` refuses unless the token matches.** The prose once said "delete lease.json on normal
+   exit" — a superseded driver following that literally deletes the LIVE OWNER'S lease.
 3. **No `--heartbeat-id`, no lease.** The caller must hand over its proof that it has ALREADY armed the
    heartbeat. This tool never inspects the proof and takes the caller's word for it — which is exactly why
    it must name something already done. Arming was step 6 of the heartbeat skeleton, after all the interesting
@@ -76,9 +76,9 @@ SIBLING = Path(__file__).resolve().parent / "lease-test.py"
 #
 # --- constants: ONE defining site ---------------------------------------------
 #
-# `references/run-identity-and-lease.md` and `references/critical-rules.md` each state "~30 min" in prose
-# today — two sources of truth for one constant, which is what this repo's own rule forbids. Landing this
-# file means those sites NAME this constant instead of restating the number.
+# `references/run-identity-and-lease.md` NAMES `LEASE_STALE_AFTER` instead of restating the number, and
+# `references/critical-rules.md` defers to it. Keep it that way: a prose copy of the value is a second
+# source of truth for one constant, which is what this repo's own rule forbids.
 #
 #   LEASE_STALE_AFTER      a lease older than this has a DEAD driver, so the run may be adopted. Long
 #                          enough that a busy driver is never mistaken for a dead one.
@@ -450,8 +450,8 @@ def cmd_refresh(path: Path, args) -> int:
 def cmd_release(path: Path, args) -> int:
     """Release on normal exit — and ONLY if the token matches.
 
-    The prose says "delete lease.json". A superseded driver that follows that literally deletes the LIVE
-    owner's lease and hands the run to anyone.
+    The prose once said "delete lease.json". A superseded driver that follows that literally deletes the
+    LIVE owner's lease and hands the run to anyone.
 
     An ABSENT lease fails closed too: with no lease present there is no token to match against, so we
     cannot confirm this caller was ever the owner. Symmetric with `refresh` and with the Purpose line "a


### PR DESCRIPTION
- replace hand-rolled lease mechanics in run-identity-and-lease.md with lease.py verbs
- point lease restatements in critical-rules, files-and-ledger, loop-control at the owner
- retense lease.py comments describing the replaced prose; define the corrupt-lease outcome
