### PR TITLE
docs(campaign): surface heartbeat ledger render

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -107,9 +107,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     due launch actually happened, every PR at a liveness cap was escalated rather than left spinning,
     and a heartbeat or bounded wait is armed whenever non-terminal work remains. NEVER sleep with due
     work un-launched or no path to the next reconcile. Then follow `references/loop-control.md`,
-    "Reschedule or exit", exactly: a scheduled-heartbeat host renders status after scheduling and
-    returns; a scheduler-less host performs one bounded wait and returns to the reconcile step while
-    non-terminal work remains.
+    "Reschedule or exit", exactly: a scheduled-heartbeat host renders the status — the `ledger.py table`
+    output that block defines — after scheduling and returns; a scheduler-less host renders the same
+    status, performs one bounded wait, and returns to the reconcile step while non-terminal work remains.
 
 **Review gate — stage 2a** (`references/stage-2-review-gate.md`)
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -405,7 +405,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      can be declared hung before that cap once the stream falls quiet (`stage-2-review-gate.md`, the
      stdout-stream liveness signal), so while such a review is streaming, a shorter poll toward that
      quiet window is a real check, not a bare re-reconcile. ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
-     both means a hung or orphaned run wakes no one. Run
+     both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
+     heartbeat that reschedules, never skipped, and its first and mandatory element is the ledger table
+     itself.** Run
      `ledger.py --file <state.jsonl> table` and include its output verbatim, fenced, in the status
      message. **Verbatim means WHOLE** — including every `#` line it prints below the grid. The default
      view is a **filtered** one and those lines are what disclose the filtering

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -289,12 +289,14 @@ For the heartbeat fallback, choose exactly one lifecycle:
    invocation, run-id, and token — `heartbeat.py callback --run <run-id> --token <agent-token>
    --invocation <campaign-invocation>` — and schedule its **stdout** (the `<campaign-invocation> --run
    <run-id> --token <agent-token>` line the tool prints) at the delay selected by `loop-control.md`, then
-   render status and return. Letting the tool build the line is what enforces the guarantee: the callback
+   render the status — the `ledger.py table` output `loop-control.md` "Reschedule or exit" defines — and
+   return. Letting the tool build the line is what enforces the guarantee: the callback
    carries **only** `--run` and `--token` and **never** `--new`/`#PR` (start-time args that would mint a
    fresh run each heartbeat) or `--heartbeat-id` (an acquire-time proof) — and the tool refuses any value
    that is empty or carries whitespace, closing the argument-injection seam. The future invocation begins
    at the heartbeat/reconcile entry.
-2. **Scheduler-less host:** keep the current campaign invocation alive, render status, and use the host's
+2. **Scheduler-less host:** keep the current campaign invocation alive, render the status (the
+   `ledger.py table` output `loop-control.md` "Reschedule or exit" defines), and use the host's
    bounded wait/poll mechanism until the first task completion or protected 5-minute/15-minute deadline.
    When that wait returns, go directly back to the heartbeat/reconcile entry and repeat while non-terminal
    work remains. Do **not** take the scheduled-host return after a bounded wait.


### PR DESCRIPTION
- name the ledger table at the "render status" pointers (SKILL.md, runtime-adapter.md) so "status" is not opaque
- mark the loop-control render a required step whose first element is the ledger table
- docs only; the render instruction was intact but too buried to fire each heartbeat
