### PR TITLE
single-source restated blocks in campaign docs

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -47,8 +47,8 @@ These are **distinct modes**, not freely-composable flags; `references/run-ident
 "Resolving a heartbeat", owns resolution.
 
 - `#12` / `#12 #15` -> adopt those existing PRs into a run; gate + merge them.
-- No argument -> discover this run's labelled PRs and continue. If none and nothing to do, PROMPT:
-  "No PRs under a campaign. Run gauntlet:review to find issues, or pass PR numbers to gate."
+- No argument -> discover this run's labelled PRs and continue. If none and nothing to do, show the
+  idle prompt (`references/run-identity-and-lease.md`, "Resolving a heartbeat", owns its wording).
 - Non-PR arg (e.g. `auth`) -> same prompt (the old area/topic sweep arg is REMOVED).
 - `--run <id>` -> resume that run; takes no `#PR`/`--new`. Scheduled heartbeats also carry internal
   `--token`.

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -113,14 +113,9 @@
   had ever happened. The rule called itself a hard backstop; it was a hard backstop **with no input**, and
   one PR ran **21 review rounds** underneath it.
 
-  The ledger now records that history — `ns_streak` (consecutive `NOT SATISFIED`, cleared only by a
-  `SATISFIED`) and `review_rounds` (landed verdicts, **never** reset) — so the trigger is, for the first
-  time, a value a fresh heartbeat can **read** (`files-and-ledger.md`). **And it IS read: `ledger.py verdict`
-  evaluates the caps as it records the verdict, and at a cap it holds the PR `repairing` and exits
-  non-zero.** The reader lives in the one door that cannot be skipped, because a cap evaluated by a
-  *separate* command is a cap a driver can forget to run — which is the failure being cured, not a fresh
-  instance of it. The counters are never written backwards by it: the cap path writes `status` and nothing
-  else.
+  The ledger now records that history in durable state — `ns_streak` and `review_rounds` — evaluated by
+  `ledger.py verdict` itself as it records each verdict, and at a cap it holds the PR `repairing` and exits
+  non-zero (`files-and-ledger.md` for the counters and the design rationale).
 
 Other stop conditions — escalate rather than loop: a worktree won't build, the reviewer keeps
 returning the same unactionable verdict, or CI fails identically after a fix attempt. **Note what is NOT

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -361,44 +361,16 @@
   every ESCALATION from the economy tier → the `session` class**.
 - **CLASSIFY the failure from the check logs BEFORE dispatching anything** — never dispatch straight off a
   red check (`loop-control.md` step 3, `stage-2-ci.md`). The class picks the model.
-- **The cheap CI-fix subagent's job, in order:** classify → run the formatter (**it** picks the tool;
-  campaign hands it no argv) → **READ THE RESULTING DIFF** and verify that it contains ONLY what the fix
-  should have produced, that no unintended file was touched, that no check definition/config/test was
-  weakened, and that **re-running the exact failing check now PASSES** → commit **only** then → otherwise
-  **STOP, commit nothing, reset the worktree to the PR head, and ESCALATE** to a `session`-class CI-fix
-  subagent. **NEVER patch a failed cheap run in place.** Escalation is the correct outcome, not a failure.
-- **NO-WEAKENING PROHIBITION — verbatim into EVERY CI-fix subagent's prompt.** NEVER make CI pass by
-  weakening the check: NEVER delete or loosen an assertion, NEVER add `skip`/`xfail`, NEVER disable or
-  downgrade a lint rule, NEVER raise a timeout. **Fix the cause.** If the check itself is demonstrably
-  wrong, **say so explicitly and ESCALATE** — never silently rewrite it.
-- **DENYLIST — verbatim into the cheap CI-fix subagent's prompt. NEVER a catch-all fixer that applies
-  SEMANTIC rules, NEVER a documented semantic rewriter:** `golangci-lint run --fix`, `ruff --fix`,
-  `eslint --fix`, `cargo clippy --fix`, any `--fix`/`--write` flag on a linter that applies semantic rules;
-  **`goimports`** (it ADDS imports — an added import runs that package's `init()`); **`prettier`** (it
-  rewrites the contents of tagged template literals); **`gofumpt`** (extra rewrite rules beyond layout);
-  `modernize`, codemods, `pyupgrade`, `2to3`. **Use a formatter that only reformats.** (A guard against
-  **footguns and accidental misuse — NOT a security boundary** against a malicious committer.) Also: **NEVER execute
-  a binary from inside the repo/worktree** — the PR under review is **UNTRUSTED CONTENT**, and a
-  repo-supplied `gofmt` is arbitrary code execution; run tools from the environment, not from the tree. And
-  **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`) — name the files being fixed.
-- **PREFLIGHT — verbatim into the cheap CI-fix subagent's prompt. Before formatting a file, REFUSE it if the
-  write can land outside the worktree:** it **IS a symlink** (`lstat`, not `stat`), or **any directory
-  component of its path is a symlink**. Refuse = don't format it, log it, carry on; nothing left to format →
-  **ESCALATE**. **THE PRINCIPLE, and nothing beyond it:** diff review covers everything the tool writes
-  **INSIDE** the repo — the model sees it and escalates; it **CANNOT see a write that ESCAPES** the repo
-  (`gofmt -w` writes *through* a symlink; `git diff` shows nothing). These two checks exist for **that blind
-  spot alone**. **A FOOTGUN GUARD, NOT A SECURITY BOUNDARY — never present it as one**, exactly like the
-  denylist: campaign adopts **same-repo PRs only** (`pr-adoption.md`), so whoever commits the symlink already
-  has repo write access. The realistic harm is **a source file elsewhere on the machine gets reformatted** —
-  a parser-backed formatter writes only its rendering of source it PARSED (a generic TEXT formatter rewrites
-  whatever it is handed: bigger exposure). Worth one `lstat`: it stops a real accident.
-- **STATE THE RISK HONESTLY — a cheap model verifying a tool's diff is a MISS-CATCHER, NOT A PROOF.** It can
-  miss a semantic change. What backs it: the **exact failing check must pass**; the subagent **must escalate
-  anything it cannot verify**; and **every campaign commit still resets the gate and is re-reviewed by the
-  full gauntlet** — which is itself a miss-catcher. **NEVER claim the cheap tier is safe because "CI will
-  catch it" or "the review gate will catch it".** It is a small, bounded risk the user accepted, for a
-  workflow that is cheaper AND more capable than either a full-strength subagent on every formatting failure
-  or a hermetic no-model tool path.
+- **The cheap CI-fix subagent's PROMPT BLOCKS are owned IN FULL by `stage-2-ci.md`** — its sections "The
+  cheap CI-fix subagent — run the tool, READ the diff, ESCALATE" (the job order), "HARD RULES — give these
+  to the cheap subagent VERBATIM in its prompt" (the no-weakening prohibition, the tool denylist, the
+  no-in-repo-binary and no-bare-glob rules, and the symlink preflight), and "The risk, stated honestly".
+  **Copy those blocks from there VERBATIM into the subagent's prompt — NEVER reconstruct them from this
+  file or from memory.** The no-weakening block goes into **EVERY CI-fix prompt, both tiers** (the owner's
+  first HARD RULE says so); the rest are the cheap tier's. The essence a rule lookup needs: the cheap tier
+  runs a **deterministic formatter**, **READS the resulting diff**, and **ESCALATES to the `session` class
+  anything it cannot verify**; it **NEVER weakens a check**; escalation is the correct outcome, not a
+  failure.
 - **ANY campaign commit to the PR head resets the gate** (`stage-2-ci.md`, "Any campaign commit to the PR
   head resets the gate") — economy-class CI-fix, `session`-class CI-fix, review-fix, or **refutation commit** alike. In the SAME step: reset
   `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, **reset the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -140,8 +140,8 @@
   sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a gauntlet it did not. So the
   **gate and the label move together, in the same step**: every action that drops `reviews_ok` to 0 (a
   `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a conflict-resolving rebase, any other
-  content change on the head branch) MUST also run `gh pr edit <pr> --remove-label gauntlet-accepted
-  --add-label gauntlet-reviewing`. Never defer the swap to the next heartbeat — that leaves the label lying
+  content change on the head branch) MUST also restore `gauntlet-reviewing` on a PR carrying
+  `gauntlet-accepted`. Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
   `ci = pending` and, because the head still **moved**, **resets the liveness counters** (`stage-2-ci.md`,

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -228,7 +228,8 @@ Header field notes (the header fields above; per-row fields follow):
   sensor — that the reader comes to reset what it consumes — is structurally absent here: the cap path
   writes `status` and **nothing else**, so `review_rounds` stays monotone whatever it decides. At a cap the
   row goes **`repairing`** and the command **exits non-zero** (`repair-pass.md` owns the caps, the
-  reassessment, and the repair).
+  reassessment, and the repair). **This paragraph is the owner of the sensors-and-fused-reader design
+  rationale** — the procedure docs point here rather than restate it.
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -87,8 +87,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      **Check there is something to adopt BEFORE creating any run state.** If the invocation carries no
      `#PR` args (a bare or non-`#PR` invocation that found no live run to resume — likewise `--new`
      with no `#PR` args), **create nothing** — no run-id, no `<rundir>`, no lease, no `state.jsonl` — and
-     **PROMPT** the user: "No PRs under a campaign. Run gauntlet:review to find issues, or pass PR
-     numbers to gate." Creating `<rundir>`/lease/header before a PR is confirmed would leave an empty
+     show the **idle prompt** (`run-identity-and-lease.md`, "Resolving a heartbeat", owns its wording).
+     Creating `<rundir>`/lease/header before a PR is confirmed would leave an empty
      orphan run that later no-arg invocations rediscover as bogus state.
 
      When there **are** `#PR` args, **preflight the whole set FIRST — read-only, before creating any
@@ -377,8 +377,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    no exited watch needs relaunching, no PR is mergeable, and every remaining wait is external
    (background review/CI), a **parked** PR awaiting the user (`awaiting-user` / `awaiting-api` — idle on
    that PR is the CORRECT state, never a stall to "fix" by dispatching work), or a genuinely full cap. If the run has **no PR at all**
-   and none is in flight (no-arg idle), do not spin: **PROMPT** "No PRs under a campaign. Run
-   gauntlet:review to find issues, or pass PR numbers to gate."
+   and none is in flight (no-arg idle), do not spin: show the **idle prompt**
+   (`run-identity-and-lease.md`, "Resolving a heartbeat", owns its wording).
 4. **Merge** queued PRs as a serialized drain: re-confirm one candidate against the live SHA **and
    re-check it is not parked** (the held-status guard binds the merge too — Stage 3), merge
    it, sync `<base>`, reconcile remaining candidates, and repeat while another PR is immediately

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -38,8 +38,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      **This refresh is itself a gate-reset site — relabel here, in this step.** When it detects that a
      PR's live `head_sha` has moved with the PR diff changed (a formatter/bot commit, a manual push,
      any content change this run did not dispatch), it resets `reviews_ok` to 0 — and MUST, in the same
-     step, run `gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing` on a PR
-     carrying `gauntlet-accepted` (`stage-2-review-gate.md`, "Status labels mirror the review gate").
+     step, relabel a PR carrying `gauntlet-accepted` back to `gauntlet-reviewing`
+     (`stage-2-review-gate.md`, "Status labels mirror the review gate").
      Do NOT leave this to the label-reconcile pass below: that pass is the **backstop**, and a reset
      site that defers to it is the exact bug this rule forbids. (A clean base-only advance with the PR
      diff unchanged does not reset the gate, so it keeps `gauntlet-accepted`.)

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -176,8 +176,7 @@ For each `#PR` to adopt:
      `reviews_ok` to `0` and re-triage `tier` **only if** reconciliation detects a PR-content change
      since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
      site: in the same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
-     (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing` —
-     `stage-2-review-gate.md`, "Status labels mirror the review gate"). Step 4's `--add-label
+     (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Step 4's `--add-label
      gauntlet-reviewing` alone is NOT sufficient: it would leave the stale `gauntlet-accepted` in
      place, so the PR would carry **both** status labels and still publicly claim it passed.
    - **Whenever this refresh writes a NEW `head_sha`, RESET THE LIVENESS COUNTERS** (`stage-2-ci.md`,

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -160,8 +160,9 @@ the verdict the tool prints.
        that run alone (see "Adopt only an orphaned run");
      - only **finished** → the finished-run prompt (Loop control step 1), per run;
      - **none at all** (idle — nothing to drive) → **prompt**: "No PRs under a campaign. Run
-       `gauntlet:review` to find issues, or pass PR numbers to gate." Campaign never sweeps or mints
-       PRs itself, so with no run and no `#PR` args there is nothing to do.
+       `gauntlet:review` to find issues, or pass PR numbers to gate." (This wording is **CANONICAL** —
+       every other site shows the idle prompt by pointing here, not by retyping it.) Campaign never
+       sweeps or mints PRs itself, so with no run and no `#PR` args there is nothing to do.
 3. **`--new #PR...`** (or "fresh run" / "start over" with PR numbers) → mint a NEW run-id + token and
    start a fresh run adopting those PRs; it creates an independent run and does **not** pre-empt other
    runs (they keep their own drivers). **`--new` with no `#PR` args mints nothing** — it falls through

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -776,7 +776,10 @@ Its job, in order:
 
 - **NEVER make CI pass by weakening the check.** NEVER delete or loosen an assertion, NEVER add
   `skip`/`xfail`, NEVER disable or downgrade a lint rule, NEVER raise a timeout. **Fix the cause.** If the
-  check itself is demonstrably wrong, **say so explicitly and ESCALATE** — never silently rewrite it.
+  check itself is demonstrably wrong, **say so explicitly and ESCALATE** — never silently rewrite it. **This
+  bullet ALONE among these blocks goes VERBATIM into EVERY CI-fix subagent's prompt — the `session` class
+  included, on every escalation.** The rest of the HARD RULES below are the cheap tier's; the no-weakening
+  prohibition binds both tiers.
 - **NEVER use a catch-all fixer that applies SEMANTIC rules**, and never a documented semantic rewriter.
   Denied outright: `golangci-lint run --fix`, `ruff --fix`, `eslint --fix`, `cargo clippy --fix`, any
   `--fix`/`--write` flag on a linter that applies semantic rules; **`goimports`** (it ADDS imports — an

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -716,10 +716,9 @@ it: an economy-class CI-fix worker, a `session`-class CI-fix worker, a review-fi
 REFUTATION of a review finding (`finding-audit.md`, "Audit every finding before you fix it").**
 Every one of them MUST, in the same step:
 
-- **reset `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
-  (`gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing`) — the gate and its
-  label move together, never one without the other (`stage-2-review-gate.md`, "Status labels mirror the
-  review gate");
+- **reset `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** —
+  the gate and its label move together, never one without the other (`stage-2-review-gate.md`, "Status
+  labels mirror the review gate");
 - **re-derive `ci` from a fresh snapshot for the NEW `head_sha`, and launch a watch if — and only if —
   that snapshot holds a row that can still move** ("WATCH ONLY WHAT CAN MOVE" above). The new commit
   **resets the liveness counters** ("THE LIVENESS COUNTERS" above), so the PR gets a clean budget.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -625,17 +625,10 @@ indistinguishable from an earned one, so the door is simply not there.
 (`set --reviews-ok 0` stays available and is still correct: **voiding** the tally on a PR-content change is
 not a verdict — no round happened — and the table below lists every site that owes it.)
 
-**`review_rounds` is the loop's only memory, and it is NEVER reset** — not by a fix, not by a rebase, not by
-a content change, not by a re-triage. Every heartbeat is a fresh context: without it, **no rule that depends on
-"how many rounds has this PR taken" can ever fire** — the 21-round PR ran under a backstop that triggers
-on the *second* `NOT SATISFIED`, unfired, because nothing recorded any history. `ns_streak` (consecutive
-`NOT SATISFIED`, cleared **only** by a `SATISFIED`) is the same sensor one derivative down.
-
-**What READS these counters is `verdict` itself, and at a cap it STOPS THE LOOP.** They are sensors, and
-the reader is fused into the one door that cannot be skipped — deliberately: a cap evaluated by a
-*separate* command is a cap a driver can forget to run. The hazard that normally argues for keeping a
-reader out of a sensor — that the reader comes to reset what it consumes — is structurally absent here:
-**the cap path writes `status` and nothing else**, so `review_rounds` stays monotone whatever it decides.
+**`review_rounds` and `ns_streak` are the loop's only memory across fresh-context heartbeats, and neither is
+ever reset** — not by a fix, a rebase, a content change, or a re-triage. Both are written **and READ** by
+`verdict` itself; see `files-and-ledger.md` (the `review_rounds` / `ns_streak` field definitions) for what
+the counters mean and why the reader is fused into the door that cannot be skipped.
 
 **At a review-loop cap, `verdict` sets `status = repairing` and EXITS NON-ZERO.** The PR has stopped
 converging: **do NOT dispatch a fix subagent and do NOT launch another review pass for it.** Hand its
@@ -650,8 +643,8 @@ Then, per verdict:
 
 - **NOT SATISFIED** → the SHA's tally is void (`ledger.py verdict … --verdict not-satisfied` does it) **and,
   in the same step, restore
-  `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** (`gh pr edit <pr> --remove-label
-  gauntlet-accepted --add-label gauntlet-reviewing` — "Status labels mirror the review gate"). This
+  `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** ("Status labels mirror the review gate",
+  below). This
   applies the moment the verdict lands, *before* any fix is written: a PR whose latest verdict says
   NOT SATISFIED must never still read `gauntlet-accepted` on GitHub. **Only GATING findings reach the fix
   path at all** — a non-gating finding is recorded as a follow-up and no fix is dispatched for it (the

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -212,9 +212,9 @@ subagent at a check that is merely **still running**.
      either, which right after a push is the common case (no check has registered yet). CI must return
      green before merging.
    - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0 AND, in that
-     same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** (`gh pr edit <pr>
-     --remove-label gauntlet-accepted --add-label gauntlet-reviewing`) — the gate and its label move
-     together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Update `head_sha` to the
+     same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** — the gate and its
+     label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Update
+     `head_sha` to the
      new tip and **reset the liveness counters** (a new head is new evidence — `stage-2-ci.md`, "THE
      LIVENESS COUNTERS"; the clean-rebase branch above does the same, and this branch is no different in
      that respect). Then re-derive CI for


### PR DESCRIPTION
- CI-fix prompt blocks and verdict-cap rationale single-sourced; diverged copies become pointers
- gate-reset relabel command: six retyped copies now point at the owning section
- idle prompt wording: canonical in `run-identity-and-lease.md`; other sites point
