### PR TITLE
make campaign refs navigable for agents

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -1,5 +1,7 @@
 ## Bailout
 
+### 1-hour cap per task
+
 - **1-hour cap per task** — one hour of wall-clock since `started` without merging. The cap catches a
   *stuck* task, not a slow external system, and the ledger records no separately-metered work time — so
   key it off recorded row state, not a running subtraction of durations nothing stores: **do not fire

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -109,12 +109,9 @@ LOCAL state against that same PR / its head; the PR itself is left in place.
   aborts rather than looping (`repair_count`, capped): the mechanism that fixes non-convergence must not
   itself fail to converge.
 
-  **THIS BACKSTOP HAD NO SENSOR, AND THAT IS WHY IT NEVER FIRED.** Its trigger — *"the second `NOT
-  SATISFIED` on the same PR"* — is a **fact about history**, and nothing recorded any history: `reviews_ok`
-  is zeroed on every `NOT SATISFIED`, so the ledger after twenty-one rounds read exactly as it did after
-  one. Each heartbeat is a **fresh agent instance** holding a single round, so it could not know a second one
-  had ever happened. The rule called itself a hard backstop; it was a hard backstop **with no input**, and
-  one PR ran **21 review rounds** underneath it.
+  **THIS BACKSTOP HAD NO SENSOR — that is why it never fired** (the full account is above: its trigger was
+  a fact about *history* the ledger did not record, and each fresh-agent heartbeat held a single round, so
+  one PR ran **21 review rounds** underneath it).
 
   The ledger now records that history in durable state — `ns_streak` and `review_rounds` — evaluated by
   `ledger.py verdict` itself as it records each verdict, and at a cap it holds the PR `repairing` and exits

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -2,6 +2,11 @@
 
 ### 1-hour cap per task
 
+When it trips, abort cleanly and **retry once against the SAME adopted PR** (`attempts` += 1, reset
+`started`). The PR is user/externally owned — campaign never closes it and opens a replacement of
+its own. Instead, **rebuild the worktree from the PR's head branch** so the retry runs with fresh
+LOCAL state against that same PR / its head; the PR itself is left in place.
+
 - **1-hour cap per task** — one hour of wall-clock since `started` without merging. The cap catches a
   *stuck* task, not a slow external system, and the ledger records no separately-metered work time — so
   key it off recorded row state, not a running subtraction of durations nothing stores: **do not fire
@@ -65,10 +70,6 @@
   `started` is over an hour old *and* the row is agent-controlled — **it is in NONE of the three bounded
   waits above**: not parked, not `repairing`, and **NO** bound of the CI owner's set live for it (never a
   count of them, which rots the moment a set gains a member) — trips it.
-  When it trips, abort cleanly and **retry once against the SAME adopted PR** (`attempts` += 1, reset
-  `started`). The PR is user/externally owned — campaign never closes it and opens a replacement of
-  its own. Instead, **rebuild the worktree from the PR's head branch** so the retry runs with fresh
-  LOCAL state against that same PR / its head; the PR itself is left in place.
 - **The user's `abort` ruling on a parked PR takes this SAME path.** A `blocker_ruling = abort@<iso>`
   (`loop-control.md` step 3, "Only the user's answer unparks a PR") is a permanent abort of that PR, not a
   new mechanism: run exactly the procedure below, with the park's `ci_reason` as the recorded cause.

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -190,19 +190,19 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
   `repos/cli/cli/commits/trunk/status`. Whether *that* commit still carries zero statuses is a **live
   fact that changes**; the API's behavior **at zero** is the permanent point.)
 - **A SHORT READ IS NOT A GREEN — CHECK WHAT YOU COLLECTED AGAINST GITHUB'S OWN `total_count`, ON EVERY
-  PAGE.** Both REST families return it, and it counts the rows GitHub holds **for the commit, across ALL
-  pages**, not for the page it sits on (observed 2026-07-14: 27 check runs read at `per_page=5` returns six
+  PAGE.** Both REST families return it, and it counts the rows GitHub holds for the commit, across ALL
+  pages, not for the page it sits on (observed 2026-07-14: 27 check runs read at `per_page=5` returns six
   pages, each reporting `total_count=27`; the *count-is-the-cross-page-total* behavior is the permanent
-  point, the 27 is not). So `total_count` vs the rows the **slurp** collected is a completeness test, and a
-  read that is **short FAILS CLOSED** (`unusable`, refetch): a row GitHub holds and we do not have **could be
-  the failing one**, and a verdict derived from evidence we KNOW has a hole in it is the false green of this
-  whole file wearing a footnote. **Every page's count is checked, not the first alone** — GitHub RECOMPUTES
-  the count per request, so a check that registers between two page fetches makes a **later** page report a
+  point, the 27 is not). So `total_count` vs the rows the slurp collected is a completeness test, and a
+  read that is short FAILS CLOSED (`unusable`, refetch): a row GitHub holds and we do not have could be
+  the failing one, and a verdict derived from evidence we KNOW has a hole in it is the false green of this
+  whole file wearing a footnote. Every page's count is checked, not the first alone — GitHub RECOMPUTES
+  the count per request, so a check that registers between two page fetches makes a later page report a
   higher count than the first (page one says 31, we collect 31, page two says 32), and a rule that trusted
-  page one would wave the missing 32nd row through as green; pages that **disagree** about what the commit
-  holds fail closed for the same reason a short read does. **A note beside a green is not a disclosure, it is
-  a trapdoor** — the tool used to print exactly that, and it shipped a green anyway. **And a count we cannot
-  READ is refused too** (absent, or not an integer), **on any page**: a fail-closed rule that cannot fire is
+  page one would wave the missing 32nd row through as green; pages that disagree about what the commit
+  holds fail closed for the same reason a short read does. A note beside a green is not a disclosure, it is
+  a trapdoor — the tool used to print exactly that, and it shipped a green anyway. And a count we cannot
+  READ is refused too (absent, or not an integer), on any page: a fail-closed rule that cannot fire is
   not a rule.
 - **A PAGE MISSING ITS ROW ARRAY IS NOT A PAGE WITH NO ROWS — AND NO FIELD READ MAY DEFAULT.** The rule
   above was written and *still passed* on a response whose `statuses` member was simply **not there**:
@@ -467,25 +467,25 @@ wrong".** This is the rule this whole section opens with, and until the `source`
 commit-status fetch was SKIPPED, or died before appending anything"* produced the **byte-identical file**.
 So:
 
-- **EXACTLY ONE `source` marker per MANDATORY source** (`check-runs`, `status`, `rollup`), **and no
-  others.** A **missing** marker → **UNUSABLE** (*"a mandatory source was never queried — its failures
-  cannot be in this artifact"*). **NEVER green.** **TWO** markers for one source → unusable as well: if they
+- **EXACTLY ONE `source` marker per MANDATORY source** (`check-runs`, `status`, `rollup`), and no
+  others. A missing marker → **UNUSABLE** (*"a mandatory source was never queried — its failures
+  cannot be in this artifact"*). **NEVER green.** TWO markers for one source → unusable as well: if they
   disagreed the file would claim two things, and nothing would read the second. A marker for a source the
-  contract does not define is **present and not counted**, exactly like an unknown row type.
+  contract does not define is present and not counted, exactly like an unknown row type.
 - **`count` MUST EQUAL the rows of that source actually present** (`check-runs`→`checkrun`,
-  `status`→`status`, `rollup`→`witness`). A marker claiming **5** where **3** sit in the file means the
-  artifact is **TRUNCATED** — rows the fetch emitted did not survive promotion, and **a row that is not in
-  the file could be the failing one** → **UNUSABLE**. A `count` that is not a decimal integer is not a
-  count you can **compare**, and a comparison you cannot make is not one you may assume the result of.
+  `status`→`status`, `rollup`→`witness`). A marker claiming 5 where 3 sit in the file means the
+  artifact is TRUNCATED — rows the fetch emitted did not survive promotion, and a row that is not in
+  the file could be the failing one → **UNUSABLE**. A `count` that is not a decimal integer is not a
+  count you can compare, and a comparison you cannot make is not one you may assume the result of.
 - **`sha` MUST be GITHUB'S, and it is compared to the LEDGER'S `head_sha`** — the same two-sources rule as
-  the evidence rows, for the same reason: they **can** disagree, so the check **can** fail. A marker that
-  disagrees means **GitHub answered about another commit**, so every row that source contributed is about
+  the evidence rows, for the same reason: they can disagree, so the check can fail. A marker that
+  disagrees means GitHub answered about another commit, so every row that source contributed is about
   that commit → **UNUSABLE**.
 - **`sha` may be `"-"` EXACTLY where GitHub gives no oid** (the table above), and nowhere else. A `"-"` on
-  the **`status`** marker, or on a **`check-runs`** marker whose fetch **did** return rows, means the value
-  was **not built from the response** — and a marker whose sha is not GitHub's **cannot disagree with the
-  ledger, so it could never fail**: a **rubber stamp**. A **real sha on the `rollup`** marker is worse — it
-  is a value **we invented**, the same fabrication as a sha on a `witness` row. Both → **UNUSABLE**.
+  the `status` marker, or on a `check-runs` marker whose fetch did return rows, means the value
+  was not built from the response — and a marker whose sha is not GitHub's cannot disagree with the
+  ledger, so it could never fail: a rubber stamp. A real sha on the `rollup` marker is worse — it
+  is a value we invented, the same fabrication as a sha on a `witness` row. Both → **UNUSABLE**.
 
 **WHY A MARKER IS NOT A RUBBER STAMP.** It carries what **only a fetch that actually ran** could know: a
 `count` that must match the file it sits in, and a `sha` that must match a **ledger value it never saw**.

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -239,6 +239,9 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
   one we cannot read, and taking it for "no witnesses" makes containment a claim about the **empty set**,
   which passes trivially. Refuse it. This is the artifact's founding rule — *an absence must read as "we do
   not know", never as "nothing wrong"* — applied one level up, to the **response**.
+
+##### THE ROLLUP'S `StatusContext` ENTRIES MUST BE VISIBLE IN FAMILY (2)
+
 - **THE ROLLUP'S `StatusContext` ENTRIES MUST BE VISIBLE IN FAMILY (2), OR THE FETCH FAILS CLOSED.** The
   rollup lists commit statuses too, and a `StatusContext` in state **`EXPECTED`** is **a required status
   check that has not been posted yet** — the PR is *blocked* on it. **The REST commit-status API has no
@@ -264,6 +267,9 @@ machine-read convention as `state.jsonl` and the review plan/progress files (`fi
   the PR goes green. **The REQUIRED SET is the closure** (`stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?") — it is
   declared by the base branch, so it does not depend on the rollup showing up, and `green` requires every
   declared check to be **present and passing**.
+
+##### THE TWO SOURCES MUST AGREE ABOUT WHAT A CHECK SAYS
+
 - **THE TWO SOURCES MUST AGREE ABOUT WHAT A CHECK SAYS, OR THE FETCH FAILS CLOSED.** The rule above asks
   only whether a check **EXISTS** in both sources. It does **not** ask whether they **SAY THE SAME THING
   ABOUT IT** — and for as long as nobody asked, the tool believed whichever source it happened to parse. A

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -110,9 +110,8 @@
 - Before queueing a review pass on a PR, clear its preconditions on the current tip: address any
   GitHub Copilot review items (the active host form of `gauntlet:copilot-address-reviews <pr>`), fix any CI failures (one at a time,
   prefer a scoped subagent), and rebase away any conflict with `<base>`. PR-content changes reset
-  verdicts. Clean base-only rebase with unchanged PR diff keeps `reviews_ok`, sets `ci = pending`, and —
-  because the head still moved — **resets the liveness counters** (`stage-2-ci.md`, "THE LIVENESS
-  COUNTERS").
+  verdicts. Clean base-only rebase with unchanged PR diff keeps `reviews_ok`, sets `ci = pending`, and
+  **resets the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS").
   Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
   on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive
@@ -150,7 +149,8 @@
   `reviews_ok` (only a verdict adds a verdict). Without that counter, the ledger after 21 review rounds is
   **indistinguishable** from the ledger after one, and every stopping rule of the form "on the second NOT
   SATISFIED…" is a backstop with **no sensor** — which is exactly how one sat in this skill, unfired,
-  through 21 of them.
+  through 21 of them. A gate **reset** from a content change is still `set --reviews-ok 0`: **`verdict`
+  records what a reviewer *decided*, `set` records what a commit *did*.**
 - **NEVER leave `gauntlet-accepted` on a PR whose live content no longer holds `required(tier)`
   SATISFIED verdicts.** The label is a projection of `reviews_ok`, and it is the only run state a human
   sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a gauntlet it did not. So the
@@ -160,7 +160,7 @@
   `gauntlet-accepted`. Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
-  `ci = pending` and, because the head still **moved**, **resets the liveness counters** (`stage-2-ci.md`,
+  `ci = pending` and **resets the liveness counters** (`stage-2-ci.md`,
   "THE LIVENESS COUNTERS"). Per-heartbeat label reconcile is the self-healing backstop, never the mechanism
   (`stage-2-review-gate.md`, "Status labels mirror the review gate").
 - **YOUR OWN diagnosis is a claim too — REPRODUCE the failure before you "fix" working code.** The rule
@@ -217,14 +217,11 @@
   (`status = awaiting-user`), surface finding + refutation + evidence + the reviewer's counter, let the
   USER adjudicate, and keep driving the other PRs. A REFUTED finding does **NOT** park by itself — only
   the **re-raise** parks (`finding-audit.md`, "Audit every finding before you fix it"). The standoff
-  is **one of TWO `awaiting-user` classes**, and each has its own durable answer record: the standoff is
-  answered into `audit-<pr>-<n>.md`; a **machine blocker** — campaign cannot move the PR without a human,
-  which is the **property** that defines the class and the whole of it, **never a list of cases** (one
-  illustration: CI has SETTLED and is still not green; `ci_reason` names the blocker, whatever it is, and
-  `files-and-ledger.md`, `status`, `awaiting-user` class 2, **owns** the class) — is answered into
-  `blocker_ruling` = `retry`/`abort` (`files-and-ledger.md`, `status`;
-  `loop-control.md` step 3, "Only the user's answer unparks a PR"). **NEVER park into a state whose exit
-  is undefined.**
+  is **one of TWO `awaiting-user` classes**, each with its own durable answer record: the standoff is
+  answered into `audit-<pr>-<n>.md`; a **machine blocker** (campaign cannot move the PR without a human) is
+  answered into `blocker_ruling` = `retry`/`abort`. `files-and-ledger.md`, `status`, `awaiting-user`
+  class 2, **owns** the machine-blocker class; `loop-control.md` step 3, "Only the user's answer unparks a
+  PR", owns the unpark. **NEVER park into a state whose exit is undefined.**
 
 ### Held and parked PRs
 
@@ -328,12 +325,10 @@
   backstop is GONE — it triggered on history nothing recorded and NEVER FIRED, across 35 review rounds
   on two PRs.** The backstop now is a **counter with a cap** (`repair-pass.md`), and the root-cause pass
   is one of the five decisions it can reach.
-- **RECORD EVERY VERDICT WITH `ledger.py verdict` — NEVER hand-set `reviews_ok` for one.** It bumps the
-  loop's memory (`review_rounds`, **never** reset; `ns_streak`), applies the tally, and evaluates the
-  review-loop caps, **atomically**. Hand-setting the tally silently skips the counters and restores the
-  amnesia that let a PR run **21** review rounds while its row still read `reviews_ok=0`. (A gate **reset**
-  from a content change is still `set --reviews-ok 0` — `verdict` records what a reviewer *decided*, `set`
-  records what a commit *did*.)
+- **RECORD EVERY VERDICT WITH `ledger.py verdict` — NEVER hand-set `reviews_ok` for one.** The one atomic
+  write also **evaluates the review-loop caps** (at a cap → `status = repairing`, exit non-zero;
+  `repair-pass.md`). What else it bumps, why `set` cannot stand in, and the 21-round amnesia it prevents:
+  "Verdict accounting and labels" above.
 - **A PR THAT STOPS CONVERGING IS REPAIRED, NOT PROMPTED.** At a review-loop cap `ledger.py verdict` sets
   `status = repairing` and **exits non-zero**: dispatch **no** further targeted fix and **no** further
   review pass. Hand the PR's **whole history at once** to a context-isolated reassessment pass, which
@@ -354,8 +349,8 @@
 - Verdicts are pinned to reviewed PR content: any PR-content change (review fix / CI fix /
   conflict-resolving rebase / bot or manual PR-branch commit) makes prior verdicts stale. Base
   advancement with no conflict and unchanged PR diff does NOT invalidate verdicts; carry `reviews_ok`
-  forward, update `head_sha`, **reset the liveness counters** (the head moved, so the old head's evidence
-  is gone — `stage-2-ci.md`, "THE LIVENESS COUNTERS"), and require fresh CI.
+  forward, update `head_sha`, **reset the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"),
+  and require fresh CI.
 - Resume vs. fresh run is decided by **liveness**, not by `state.jsonl` existing: live work → resume;
   a finished prior run → ask the user before a fresh run; `--new` → fresh run with
   carryover (Loop control step 1). A finished run must never silently exit "all done" or silently
@@ -396,7 +391,7 @@
 - **ANY campaign commit to the PR head resets the gate** (`stage-2-ci.md`, "Any campaign commit to the PR
   head resets the gate") — economy-class CI-fix, `session`-class CI-fix, review-fix, or **refutation commit** alike. In the SAME step: reset
   `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, **reset the
-  liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS" — the new head is new evidence), re-derive CI
+  liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"), re-derive CI
   for the new tip and watch it **only if a row can still move** (`stage-2-ci.md`, "WATCH ONLY WHAT CAN
   MOVE" — a watch launched on a tip whose checks have not registered yet has nothing to block on and
   exits in about a second), and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -1,5 +1,9 @@
 ## Rules
 
+> **Quick reference (navigation, not authority):** every bullet points at its owner — the file or tool that owns the definition. The `###` groups below follow the rules' existing order.
+
+### Run identity and lease
+
 - Runs are isolated by `run_id`: a run touches ONLY its own `<rundir>`, its `state.jsonl`, and the PRs
   carrying its `gauntlet-run-<run-id>` label. Adopted PRs keep their OWN head branch, so ownership is
   scoped by that LABEL only (never a branch prefix). NEVER reconcile, review, fix, merge, relabel, or
@@ -21,6 +25,9 @@
   while pruning history, MAY edit or remove OTHER runs' files — but only those of **finished** runs
   (no live writer/lease), never a file an actively-driven run owns — so there's still no write
   contention with a live writer.
+
+### Scope, bookkeeping and follow-ups
+
 - Run-owned git/GitHub operations are authorized by invocation: `add`, `commit`, `push`, and — on
   adopted PRs — PR update, labels/checks/comments, and merge. Campaign ADOPTS existing PRs; it does not
   invent work. It opens a PR of its own in exactly ONE case: a **follow-up it has TAKEN UP** under the
@@ -51,6 +58,9 @@
 - NEVER use `--dangerously-bypass-approvals-and-sandbox` with an external reviewer; always
   `--sandbox workspace-write`.
 - One PR = one unit. Campaign gates whole adopted PRs; do not split or bundle them.
+
+### Loop, watches and CI truth
+
 - PR-gating loop is mandatory: adopt PR → triage tier → watch CI + review PR HEAD → merge. Campaign
   gates **existing** PRs; it NEVER writes fixes from scratch (only review/CI fixes on an adopted PR).
 - Concurrency is a **rolling cap (~8 in flight), never a barrier wave**: keep up to ~8 review passes
@@ -94,6 +104,9 @@
 - Public API surface/behavior changes need user confirmation by default (see Constraints). The
   `api_changes` flag lives in the ledger header and is re-read every heartbeat — never trust memory, never
   auto-merge an unapproved API break.
+
+### Review gate and findings
+
 - Before queueing a review pass on a PR, clear its preconditions on the current tip: address any
   GitHub Copilot review items (the active host form of `gauntlet:copilot-address-reviews <pr>`), fix any CI failures (one at a time,
   prefer a scoped subagent), and rebase away any conflict with `<base>`. PR-content changes reset
@@ -127,6 +140,9 @@
   reachability test says *"provenance is the wrong question"*, it is answering **is it TRUE?**, and it is
   right; it is **not** saying "never ask who can write the input" — that is the other question, and the
   `writer` field is what answers it.
+
+### Verdict accounting and labels
+
 - **Record every verdict with `ledger.py verdict` — NEVER set `reviews_ok` by hand.** It bumps
   `review_rounds`, applies the tally, and moves `ns_streak` in one atomic write. **`review_rounds` is the
   review loop's only memory across fresh-context heartbeats and is NEVER reset** — not by a fix, a rebase, a
@@ -209,6 +225,9 @@
   `blocker_ruling` = `retry`/`abort` (`files-and-ledger.md`, `status`;
   `loop-control.md` step 3, "Only the user's answer unparks a PR"). **NEVER park into a state whose exit
   is undefined.**
+
+### Held and parked PRs
+
 - **A HELD PR IS FROZEN — TAKE NO ACTION THAT MUTATES IT. ASK THE TOOL: `ledger.py … dispatch-check --pr
   <N>` exits non-zero.** A PR is **HELD** when it is **parked on a HUMAN** (`status = awaiting-user`, a
   standoff; `awaiting-api`, API approval) **or `repairing`** — it reached a review-loop cap, has stopped
@@ -347,6 +366,9 @@
 - Prune `.gauntlet/history/` at every fresh run: drop only entries unambiguously moot against
   current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
   prune an entry you're unsure about.
+
+### Fix dispatch and worker models
+
 - **Select a logical model class on EVERY worker dispatch** (`SKILL.md`, "Worker Dispatch";
   `runtime-adapter.md`). Never guess a model name from the other host.
 - **Model policy — NEVER DOWNGRADED: review passes, the subagent-fallback review, review-fixes, and the
@@ -451,6 +473,9 @@
   SEE?"). **A required set campaign could not read is NEVER green** — it is a `pending` outcome that
   escalates, because a check that never registered is **no row**, and no count of passing rows can rule it
   out. **NEVER claim more from a green than those rules allow.**
+
+### Merge and base hygiene
+
 - The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN

--- a/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
+++ b/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
@@ -26,7 +26,7 @@ remain diff content, never gate authority.
 
 ## Claude Code orchestrator → Codex reviewer (capability-gated)
 
-Use the external-reviewer argv in `review-dispatch.md`:
+The external-reviewer argv below is the canonical spelling; `review-dispatch.md` points here:
 
 ```text
 run_argv(

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -453,7 +453,6 @@ ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfi
 ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
 ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only)
-ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfied|not-satisfied
 ledger.py --file <state.jsonl> dispatch-check --pr N [--action ordinary|repair]
 ```
 

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -233,8 +233,9 @@ Header field notes (the header fields above; per-row fields follow):
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it
-  from the PR's title, body and diff). Set at adoption (`pr-adoption.md` step 3a) and **preserved** by every
-  refresh — a heartbeat is a fresh agent instance, and an intent invented twice is two intents.
+  from the PR's title, body and diff). Set at adoption (`pr-adoption.md` step 3a) and **preserved** — never
+  re-derived — by every refresh (a heartbeat is a fresh agent instance; `blocker_ruling` below owns the
+  durability rule).
 
   The distinction is the honest one and the final report states it: an `authored` intent is **the driver's
   CLAIM about what the PR is for**, not the author's, and a wrong intent block silently **narrows** a
@@ -252,7 +253,7 @@ Header field notes (the header fields above; per-row fields follow):
   looping. The mechanism that fixes non-convergence must not itself fail to converge. Like `review_rounds`,
   it has **no flag at any door** — a budget you can zero is not a bound.
 - `repair_decision` — `-`, or the last reassessment decision + when: `<decision>@<iso>`. Durable, because
-  the heartbeat that dispatches the repair may be a different agent instance from the one that decided it — and
+  a heartbeat may be a fresh agent instance (`blocker_ruling` below owns why) — and
   a repair may not be dispatched at all until this field is set (`ledger.py dispatch-check --action repair`).
   **DURABLE *and* SPENT EXACTLY ONCE per cap** — it is reset to `-` when the row **re-enters `repairing`**
   (`ledger.py verdict` at a cap), so a decision answers exactly the cap it was recorded for and a PR that
@@ -321,12 +322,9 @@ Header field notes (the header fields above; per-row fields follow):
   unparks with the liveness counters cleared; `abort` goes terminal `aborted`. The unpark is
   `loop-control.md` step 3, "Only the user's answer unparks a PR".
 
-  **DURABLE *and* SPENT EXACTLY ONCE — one ruling answers exactly ONE park.** It is set back to `-` when a
-  machine-blocker park is **ENTERED** and when a `retry` is **CONSUMED** (`stage-2-ci.md`, "THE RULING IS
-  CONSUMED EXACTLY ONCE" — that is the owning definition). That is what **scopes** a ruling to its park: a
-  ruling sitting on a **parked** row can only have been written while **that** park was open, so a stale
-  `retry` can never unpark a **later** blocker with no fresh user answer. `abort@<iso>` is **never**
-  cleared — it goes terminal, and a terminal row is never re-parked, so it stays as the record of why.
+  **DURABLE *and* SPENT EXACTLY ONCE — one ruling answers exactly ONE park** (`stage-2-ci.md`, "THE RULING
+  IS CONSUMED EXACTLY ONCE", is the owning definition: the clears at park **entry** and `retry` **consume**,
+  the scoping that keeps a stale `retry` off a later park, and why terminal `abort@<iso>` is never cleared).
   A **counter reset never touches it**: it is not one of the liveness counters.
 
   These live **on disk, not in the driver's head**: a heartbeat may be a fresh agent instance, and a counter —

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -477,6 +477,11 @@ a new name.
 to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decides nothing — no gate
 logic, no derived values.
 
+**Read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.
+A SHA (or any value) recovered from `table`'s grid is a truncated, escaped rendering, and feeding one back
+into a command or writing it to the store is a bug: this repo has already had a fabricated 8-char SHA
+written into a real ledger, and a truncated SHA escape into a command.
+
 **`table` is a PROJECTION — NEVER a source to read a value back out of.** Its output is *formatted for a
 human*, and the formatting is lossy in four ways:
 
@@ -519,11 +524,6 @@ human*, and the formatting is lossy in four ways:
   makes the omission notice trustworthy, and it is why an empty grid always **says which empty it is** —
   a ledger that holds nothing and a ledger whose every row is hidden print **different** markers, so an
   end-of-run table where everything merged can never be misread as a campaign that adopted no PRs.
-
-So **read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.
-A SHA (or any value) recovered from `table`'s grid is a truncated, escaped rendering, and feeding one back
-into a command or writing it to the store is a bug: this repo has already had a fabricated 8-char SHA
-written into a real ledger, and a truncated SHA escape into a command.
 
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
 errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -342,6 +342,8 @@ Header field notes (the header fields above; per-row fields follow):
   the run-wide `api_changes` header.
 - `status` — `in_review` → `merged`, or `aborted`; plus the **HELD** (non-terminal) statuses below.
 
+### `status` held and parked taxonomy
+
   **HELD is the PROPERTY the dispatch guard is keyed on: campaign takes NO action that MUTATES a held
   PR.** Never launch a review pass, a CI fix, a review fix, or a merge for it, and never rebase it, refresh
   its base, push to it, or relabel it (`loop-control.md` step 3, "held-status guard" — the property, of

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -180,11 +180,9 @@ about and one whose partial rejection strands the rest.
    `accepted`, and `reopened`.** A heartbeat that dies **after** the fix subagent opens the PR but **before**
    `open-pr` records it leaves the entry in `self-accepted` (or `accepted`/`reopened`) with **no durable
    fuN→PR key** to reconcile against — so the next heartbeat re-dispatches and can open a **duplicate PR within
-   one run**. Making that dispatch idempotent needs a durable key: a `followups.py` PR-reference field
-   written before `open-pr`, or a deterministic fuN-keyed branch required by the fix contract — **both are
-   deliberate NON-GOALS here** (one is a `followups.py` store change, the other a fix-subagent-contract
-   change), tracked as **a follow-up**. This is the same-run analogue of the cross-run race scoped out under
-   "Scope: one run's driver" above; **neither is solved by this documentation.**
+   one run**. This is the same-run analogue of the cross-run race scoped out under "Scope: one run's driver"
+   above — a non-goal for the same reason (the fix needs a `followups.py` store change or a fix-contract
+   change), tracked as **a follow-up**, not solved by this documentation.
 
 2. **NOT APPLICABLE → `refute`.** If the investigation cannot reproduce the claim, or shows the mechanism
    cannot occur, it is **refuted** — and that is its **most valuable** outcome, not a failure. A refuted

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -1,10 +1,14 @@
 ## Loop control
 
+> **Read when:** every heartbeat executes these steps in order; jump to the step you are in.
+
 The skill is **event-driven**. Read `runtime-adapter.md` before waiting. Reconciles come from the first
 invocation, a scheduled heartbeat when the host provides one, a **background task completing**, or the
 bounded-wait fallback returning. A completion may be a CI watch, a review, or a CI/review fix.
 
 **Every heartbeat — reconcile, dispatch, reschedule:**
+
+### Step 1 — Resolve repository context, then the run + lease, then init / resume / start fresh
 
 1. **Resolve repository context, then the run + lease, then init / resume / start fresh.** Call
    `runtime-adapter.md`'s repository-context resolver exactly once with the supplied checkout and carry
@@ -156,6 +160,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    **Settle the base branch's required-check set before any CI derivation:** run `scripts/ci-status.py
    required-set --ledger <rundir>/state.jsonl`. Run it every heartbeat; the command reuses a settled value and
    only retries `unknown`. `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?", owns its states and behavior.
+### Step 2 — Fold in completions
+
 2. **Fold in completions.** For any background task that finished (CI watch → **a HEARTBEAT, not an artifact**:
    the watch **only blocks** and produces **nothing**, so **this heartbeat** performs the SHA-pinned fetch of
    both check families, **promotes** it atomically to `ci-<pr>-<head_sha>.txt` and **verifies** its stamp
@@ -185,10 +191,14 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    never set `reviews_ok` by hand.
    For any completed task (review, CI watch,
    CI/review fix), record the result against the SHA it ran on and act per Stage 2.
+### Step 3 — Dispatch due work
+
 3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,
    not just the PR/job that woke you. Launch every due action that fits a free slot before returning.
    Launch only what is actually due *and not already in flight* (check ground truth first, never the
    ledger alone).
+
+   #### HELD-STATUS GUARD — a PROPERTY, not a list, and now a COMMAND
 
    **HELD-STATUS GUARD — a PROPERTY, not a list, and now a COMMAND. Apply it BEFORE every bullet below,
    and before every other action this skill takes on a PR.** While a PR's `status` is **HELD** the PR is
@@ -236,6 +246,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      mirror, when **someone else** pushed to the PR (step 1). Recording a change campaign did not make is
      not making one. What is frozen is **campaign's own action on the PR**; a park never licenses a
      lying label or a stale row.
+
+   #### Only the user's answer unparks a PR
+
    - **Only the user's answer unparks a PR — and EVERY park class names the durable record it is
      answered into.** An answer that lives only in this session is an answer a fresh agent re-asks. On
      the answer: **record it**, then unpark to the `status` **THAT ANSWER** dictates — the table below is
@@ -379,10 +392,14 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    that PR is the CORRECT state, never a stall to "fix" by dispatching work), or a genuinely full cap. If the run has **no PR at all**
    and none is in flight (no-arg idle), do not spin: show the **idle prompt**
    (`run-identity-and-lease.md`, "Resolving a heartbeat", owns its wording).
+### Step 4 — Merge queued PRs as a serialized drain
+
 4. **Merge** queued PRs as a serialized drain: re-confirm one candidate against the live SHA **and
    re-check it is not parked** (the held-status guard binds the merge too — Stage 3), merge
    it, sync `<base>`, reconcile remaining candidates, and repeat while another PR is immediately
    mergeable (Stage 3).
+### Step 5 — Reschedule or exit
+
 5. **Reschedule or exit.**
    - Any non-terminal PR remains (in review, pending CI, or awaiting a user ruling on a review-finding
      standoff / API approval / precondition) →
@@ -440,6 +457,8 @@ together — cannot corrupt state or act on a stale verdict (PR-content pinning 
 at the gate). The worst case is a wasted duplicate review, which is harmless: it's just another fresh,
 context-isolated re-roll anyway. The agent is also single-threaded per turn, so heartbeat *decisions* never truly race — only
 in-flight tasks do.
+
+#### Resume after a killed session
 
 **Resume after a killed session — including by a different agent instance:** in-flight background
 tasks die with the session, but nothing authoritative is lost. A new invocation reconciles against

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -158,12 +158,12 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 ### Step 2 — Fold in completions
 
 2. **Fold in completions.** For any background task that finished (CI watch → **a HEARTBEAT, not an artifact**:
-   the watch **only blocks** and produces **nothing**, so **this heartbeat** performs the SHA-pinned fetch of
-   both check families, **promotes** it atomically to `ci-<pr>-<head_sha>.txt` and **verifies** its stamp
-   against the ledger's **current** `head_sha` before parsing a single line of it — the CI state is
-   **never** decided from the watch's exit code (Stage 2b, "WHO DOES WHAT" and "VERIFY THE STAMP BEFORE
+   the watch only blocks and produces nothing, so this heartbeat performs the SHA-pinned fetch of
+   both check families, promotes it atomically to `ci-<pr>-<head_sha>.txt` and verifies its stamp
+   against the ledger's current `head_sha` before parsing a single line of it — the CI state is
+   never decided from the watch's exit code (Stage 2b, "WHO DOES WHAT" and "VERIFY THE STAMP BEFORE
    PARSING"); review →
-   the **active launch attempt's** output file, with its progress file as liveness evidence — attempt 1
+   the active launch attempt's output file, with its progress file as liveness evidence — attempt 1
    uses `.prompt.txt` and writes `review-<pr>-<n>.txt` / `.progress.jsonl` / `.findings.jsonl`; a
    relaunch uses and writes `review-<pr>-<n>.a<k>.*`, and
    only the attempt named in the current `pass_identity` is read or counted (Stage 2a). **Before a
@@ -172,13 +172,13 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    an ad-hoc parse; anything but `ok` means the verdict is not tallied (Stage 2a, "Does this pass COUNT?").
    **`--verdict` is REQUIRED** — it is what lets the tool check the one rule it can, so a COMPLETE pass
    verified without it is `unusable`, never `ok` (a rule a driver can switch off by forgetting a flag is
-   not a gate). That rule is an **if and only if**: **`not-satisfied` exactly when at least one GATING
-   finding stands** — a verdict that blocks a PR
+   not a gate). That rule is an if and only if: `not-satisfied` exactly when at least one GATING
+   finding stands — a verdict that blocks a PR
    must name what blocks it, and a finding that blocks a PR cannot be waved through by the verdict. Either
    way round is `unusable` (Stage 2a, "Does this pass COUNT?").
    **A pass that raised a separate request instead of ruling passes `verify --verdict deferred`** (the
    report's terminal line is `VERDICT: DEFERRED`, or the progress file holds an unruled
-   `plan_amendment_request`): `deferred` is not a verdict, so it is **never tallied** — the tool routes on
+   `plan_amendment_request`): `deferred` is not a verdict, so it is never tallied — the tool routes on
    the progress file and returns `amended` (fold the amendment, re-run the pass) or `incomplete`
    (relaunch), and only a binary `satisfied`/`not-satisfied` ever reaches the ledger below.
    **Then record the verdict with `scripts/ledger.py verdict --pr <N> --head-sha <sha> --verdict …`** — the

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -26,38 +26,31 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    `awaiting-user`).
    Three cases:
 
-   - **This run has live work → resume.** **A dead review pass — no verdict and no live task — is
-     dispatched by its relaunch budget alone:** read the highest-numbered attempt's `pass_identity`
-     and dispatch on `launch_attempt` **alone**: `1` → relaunch once (as attempt `2`); `2` → the
-     relaunch is spent, so take the **fresh-worker fallback** (Stage 2a). **Reconcile against ground
-     truth** (do NOT redo *completed* work — a CI task whose output file is missing may be re-launched,
-     since in-flight tasks die with their session. A **review** whose output file is missing is NOT
-     simply re-launched: resolve its **active launch attempt** first (Stage 2a) by that algorithm.
-     **Launch evidence is irrelevant on this path** — the task is already dead, so whether it managed
-     to write a `started` line before dying says nothing about whether it will ever produce a verdict.
-     A missing output file must never re-arm the relaunch budget, and a dead attempt `2` must never be
-     left un-dispatched):
-     for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
-     the ledger — write every ledger update through `scripts/ledger.py … set/header set` **by field
-     name** (`files-and-ledger.md`), never by hand-editing rows by column position.
+   - **This run has live work → resume.** A dead review pass — no verdict, no live task — is resolved by
+     its relaunch budget alone (highest-numbered `launch_attempt`: `1` → relaunch once as attempt `2`;
+     `2` → **fresh-worker fallback**), **NOT by a blind re-launch**; the full algorithm and why launch
+     evidence is irrelevant on this path live in **"Resume after a killed session"** below (Stage 2a).
+     **Reconcile against ground truth** — do NOT redo *completed* work; a CI task whose output file is
+     missing may be re-launched, since in-flight tasks die with their session — then, for each of this
+     run's branches/PRs read the live SHA, CI status, and verdict files, and refresh the ledger: write
+     every ledger update through `scripts/ledger.py … set/header set` **by field name**
+     (`files-and-ledger.md`), never by hand-editing rows by column position.
 
      **This refresh is itself a gate-reset site — relabel here, in this step.** When it detects that a
      PR's live `head_sha` has moved with the PR diff changed (a formatter/bot commit, a manual push,
      any content change this run did not dispatch), it resets `reviews_ok` to 0 — and MUST, in the same
      step, relabel a PR carrying `gauntlet-accepted` back to `gauntlet-reviewing`
      (`stage-2-review-gate.md`, "Status labels mirror the review gate").
-     Do NOT leave this to the label-reconcile pass below: that pass is the **backstop**, and a reset
-     site that defers to it is the exact bug this rule forbids. (A clean base-only advance with the PR
+     Do NOT defer this to the label-reconcile pass below — that pass is only the **backstop** ("This
+     reconcile is a backstop, not the mechanism", below). (A clean base-only advance with the PR
      diff unchanged does not reset the gate, so it keeps `gauntlet-accepted`.)
 
      **And whenever this refresh writes a NEW `head_sha` — gate reset or not — RESET THE LIVENESS
-     COUNTERS** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"), in the same `ledger.py … set` call. This
-     covers **both** cases above: the content change that resets the gate, **and** the clean base-only
-     advance that does not. The new head is new evidence, so the old head's liveness counters describe
-     nothing — carried forward, they park a healthy PR early, on a budget it never spent at this SHA.
-     **NAME the set; do NOT unpack it here.** A gloss that lists the set's members is a **restatement**,
-     even standing next to a correct pointer — it is the part a reader believes, and it goes stale the
-     moment the set gains a member (this line's did, when `ci_stalled_since` joined).
+     COUNTERS** (`stage-2-ci.md`, "THE LIVENESS COUNTERS", which owns why), in the same `ledger.py … set`
+     call. This covers **both** cases above: the content change that resets the gate, **and** the clean
+     base-only advance that does not. **NAME the set; do NOT unpack it here** — a gloss that lists the
+     set's members is a **restatement** that goes stale the moment the set gains a member (this line's
+     did, when `ci_stalled_since` joined).
 
      Do the PR scan as
      **one batched snapshot per heartbeat** — the **same canonical command** `pr-adoption.md` runs, writing the
@@ -272,12 +265,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      | **`awaiting-user`, review standoff** — a REFUTED finding the fresh reviewer re-raised | the ruling in `<rundir>/audit-<pr>-<n>.md` | `in_review`; ruled **valid** → the finding is fixed like a CONFIRMED one, ruled **invalid** → normal flow |
      | **`awaiting-user`, machine blocker** — campaign cannot move this PR without a human; that **property** IS the class, **never a list of cases** (one illustration: CI has SETTLED and is still not green). Do not enumerate the members here — `files-and-ledger.md`, `status`, `awaiting-user` class 2, **owns** the class, and `ci_reason` names the blocker at every one of them, present or future | `blocker_ruling` = `retry@<iso>` / `abort@<iso>` | `retry` → `in_review`, **RESET THE LIVENESS COUNTERS**, and **SPEND the ruling: `blocker_ruling` = `-`** (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "THE RULING IS CONSUMED EXACTLY ONCE"), then re-derive CI on the next heartbeat; `abort` → terminal `aborted` (the ruling **stays** — it is the record of why) |
 
-     **A `retry` that clears nothing re-escalates on its first derivation** — the strikes are still at
-     the cap — so the counter reset is **part of the unpark, not an optimization**. It buys the PR a
-     fresh liveness budget and no more: if CI still does not move, the same bound re-parks it, this time
-     reporting that the retry did not move CI (`stage-2-ci.md`, "SETTLED" / "UNUSABLE — the refetch is
-     BOUNDED"). The loop is bounded by the **human**: campaign never re-asks unprompted, and every park
-     is a fresh question backed by a fresh snapshot.
+     **The counter reset is part of the unpark, not an optimization**: a `retry` that clears nothing
+     re-escalates on its first derivation (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "SETTLED" /
+     "UNUSABLE — the refetch is BOUNDED", own why). The loop is bounded by the **human**: campaign never
+     re-asks unprompted, and every park is a fresh question backed by a fresh snapshot.
 
      **A `retry` is SPENT when it is consumed — one ruling answers exactly ONE park.** Write `status =
      in_review`, the counter reset, and `blocker_ruling` = `-` in the **same** `ledger.py … set --pr <N>`

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -26,15 +26,17 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    `awaiting-user`).
    Three cases:
 
-   - **This run has live work → resume.** **Reconcile against ground truth** (do NOT redo *completed*
-     work — a CI task whose output file is missing may be re-launched, since in-flight tasks die with
-     their session. A **review** whose output file is missing is NOT simply re-launched: resolve its
-     **active launch attempt** first (Stage 2a) — read the highest-numbered attempt's `pass_identity`
+   - **This run has live work → resume.** **A dead review pass — no verdict and no live task — is
+     dispatched by its relaunch budget alone:** read the highest-numbered attempt's `pass_identity`
      and dispatch on `launch_attempt` **alone**: `1` → relaunch once (as attempt `2`); `2` → the
-     relaunch is spent, so take the **fresh-worker fallback**. **Launch evidence is irrelevant on
-     this path** — the task is already dead, so whether it managed to write a `started` line before
-     dying says nothing about whether it will ever produce a verdict. A missing output file must never
-     re-arm the relaunch budget, and a dead attempt `2` must never be left un-dispatched):
+     relaunch is spent, so take the **fresh-worker fallback** (Stage 2a). **Reconcile against ground
+     truth** (do NOT redo *completed* work — a CI task whose output file is missing may be re-launched,
+     since in-flight tasks die with their session. A **review** whose output file is missing is NOT
+     simply re-launched: resolve its **active launch attempt** first (Stage 2a) by that algorithm.
+     **Launch evidence is irrelevant on this path** — the task is already dead, so whether it managed
+     to write a `started` line before dying says nothing about whether it will ever produce a verdict.
+     A missing output file must never re-arm the relaunch budget, and a dead attempt `2` must never be
+     left un-dispatched):
      for each of this run's branches/PRs read the live SHA, CI status, and verdict files, and refresh
      the ledger — write every ledger update through `scripts/ledger.py … set/header set` **by field
      name** (`files-and-ledger.md`), never by hand-editing rows by column position.
@@ -413,15 +415,19 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      heartbeat also recovers a killed/orphaned session through a later scheduled heartbeat; if a scheduler-less
      invocation is killed, durable state permits a later explicit resume (see "Resume after a killed
      session"). **Size the scheduled delay or bounded wait to the nearest stall it guards:**
-     **~5 min** while any dispatched review pass is still awaiting its first line of **launch evidence**
-     — its Stage 2a launch deadline is then the soonest thing that can fire, and a hung launch must not
-     sit undetected for a full normal interval — otherwise **~15 min**, matching the Stage 2a meaningful-progress
-     threshold: with no launch deadline pending, nothing can declare a review stalled before then, so a
-     shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
-     heartbeat). **One exception carries new signal:** a background-task review watched via its stdout stream
-     can be declared hung before that cap once the stream falls quiet (`stage-2-review-gate.md`, the
-     stdout-stream liveness signal), so while such a review is streaming, a shorter poll toward that
-     quiet window is a real check, not a bare re-reconcile. ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
+     - **Any dispatched review pass still awaiting its first line of launch evidence → ~5 min:** its
+       Stage 2a launch deadline is then the soonest thing that can fire, and a hung launch must not
+       sit undetected for a full normal interval.
+     - **A background-task review streaming its stdout → poll toward the quiet window:** it can be
+       declared hung before the ~15-min cap once the stream falls quiet (`stage-2-review-gate.md`, the
+       stdout-stream liveness signal), so while such a review is streaming, a shorter poll toward that
+       quiet window is a real check, not a bare re-reconcile.
+     - **Otherwise → ~15 min:** matching the Stage 2a meaningful-progress
+       threshold — with no launch deadline pending, nothing can declare a review stalled before then, so a
+       shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
+       heartbeat).
+
+     ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
      both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
      heartbeat that reschedules, never skipped, and its first and mandatory element is the ledger table
      itself.** Run

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -160,7 +160,15 @@ For each `#PR` to adopt:
      who wrote this"* is not *"I wrote this"*. It is **NOT** `worktree_owned`/`branch_owned`: those say
      whether campaign created the local checkout and branch, which is a **cleanup** question, and a PR can
      have a campaign-created worktree and still belong entirely to someone else.
-   - **On a REFRESH of an existing row, PRESERVE EVERY FIELD THIS STEP DOES NOT EXPLICITLY RECOMPUTE.**
+   - **On a REFRESH of an existing row, only re-read `head_sha`/`ci` from ground truth; reset
+     `reviews_ok` to `0` and re-triage `tier` only if** reconciliation detects a PR-content change
+     since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
+     site: in the same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
+     (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Step 4's `--add-label
+     gauntlet-reviewing` alone is NOT sufficient: it would leave the stale `gauntlet-accepted` in
+     place, so the PR would carry **both** status labels and still publicly claim it passed.
+
+     **PRESERVE EVERY FIELD THIS STEP DOES NOT EXPLICITLY RECOMPUTE.**
      That is a **property, not a list** — and deliberately so, because the list that stood here was one:
      `ledger.py … set` writes only the fields it **NAMES**, so preservation is the **default**, and this
      step's job is to name nothing it must not clobber. Everything a previous heartbeat wrote and a later one
@@ -178,13 +186,6 @@ For each `#PR` to adopt:
      RULING IS CONSUMED EXACTLY ONCE") — so a ruling this refresh can see is either still **awaiting its
      park's exit** (preserving it is the whole point: a heartbeat may be a fresh agent instance) or the
      **terminal** record of an `abort`. A **spent** ruling is never on the row for this step to resurrect.
-     Only re-read `head_sha`/`ci` from ground truth; reset
-     `reviews_ok` to `0` and re-triage `tier` **only if** reconciliation detects a PR-content change
-     since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
-     site: in the same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
-     (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Step 4's `--add-label
-     gauntlet-reviewing` alone is NOT sufficient: it would leave the stale `gauntlet-accepted` in
-     place, so the PR would carry **both** status labels and still publicly claim it passed.
    - **Whenever this refresh writes a NEW `head_sha`, RESET THE LIVENESS COUNTERS** (`stage-2-ci.md`,
      "THE LIVENESS COUNTERS") in the same `ledger.py … set` call — **whether or not the gate reset with
      it**: a clean base-only advance moves the head without touching `reviews_ok`, and it still means the
@@ -204,9 +205,16 @@ For each `#PR` to adopt:
    MEASURED AGAINST"). Without it, the reviewer is asked *"is anything wrong with this code?"* — a question
    with no fixed point, and one that ran a PR through 21 review rounds without converging.
 
-   **It is LOCAL, git-ignored driver bookkeeping. Campaign NEVER writes it back to the PR** — no `gh pr
-   edit`, no comment, no commit. The PR belongs to its author; this is the driver's working note about it,
-   and it lives with the run's other artifacts under `<rundir>`.
+   The three-branch decision:
+   - **A PR whose body already carries a usable intent block** (by the test below) → **COPY IT VERBATIM**
+     into `intent-<pr>.md`. Record `intent = stated@<iso>`.
+   - **Otherwise the driver AUTHORS it** — from the PR's **diff, title and body** — writes it to
+     `intent-<pr>.md`, and **proceeds**. Record `intent = authored@<iso>`. "Otherwise" includes a body
+     that carries the three headings but leaves an anchor empty: author the missing section rather than
+     copying a block the tool will refuse. Do **NOT** stop and ask the user: the driver can act here, so
+     it acts.
+   - Only if it **cannot form an intent block at all** (an empty PR, a diff it cannot characterise) does
+     it **refuse the adoption** and report that PR to the user, adopting the rest.
 
    The format is exactly three sections:
 
@@ -219,6 +227,10 @@ For each `#PR` to adopt:
    - Who can write the inputs this code reads: <...>
    - Who cannot: <...>
    ```
+
+   **It is LOCAL, git-ignored driver bookkeeping. Campaign NEVER writes it back to the PR** — no `gh pr
+   edit`, no comment, no commit. The PR belongs to its author; this is the driver's working note about it,
+   and it lives with the run's other artifacts under `<rundir>`.
 
    **USABLE means the parser will take it — `review-pass.py` is the definition, and this is the same rule
    stated for a human:** all three headings, **at least one `## Purpose` bullet, AND at least one
@@ -241,17 +253,6 @@ For each `#PR` to adopt:
    `review-pass.py intent-check --file <rundir>/intent-<pr>.md`. A non-zero exit refuses adoption for that
    PR until the artifact is corrected. This is the same parser `verify` uses, moved before review dispatch;
    never spend a review to learn that its intent could not be read.
-
-   **A PR whose body already carries a usable intent block** (by the test above) → **COPY IT VERBATIM** into
-   `intent-<pr>.md`. Record `intent = stated@<iso>`.
-
-   **Otherwise the driver AUTHORS it** — from the PR's **diff, title and body** — writes it to
-   `intent-<pr>.md`, and **proceeds**. Record `intent = authored@<iso>`. "Otherwise" includes a body that
-   carries the three headings but leaves an anchor empty: author the missing section rather than copying a
-   block the tool will refuse. Do **NOT** stop and ask the user:
-   the driver can act here, so it acts. Only if it **cannot form an intent block at all** (an empty PR, a
-   diff it cannot characterise) does it **refuse the adoption** and report that PR to the user, adopting the
-   rest.
 
    **The file is READ BY THE TOOL, on every pass.** `review-pass.py verify` loads `intent-<pr>.md` for
    **every** pass it judges — whatever that pass found, and even when it found nothing — so an absent,

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -61,6 +61,8 @@ gh label create gauntlet-run-<run-id> --color 5319E7 --description "gauntlet: ru
 
 For each `#PR` to adopt:
 
+#### Step 1 — Read the PR
+
 1. **Read the PR** — one `gh pr view` for the facts the ledger row needs, **including the cross-repo
    field** so the refusal check below can reject fork PRs:
 
@@ -90,6 +92,8 @@ For each `#PR` to adopt:
    a **same-repo** PR (forks are already refused), so the body it reads comes from a committer with write
    access to this repo.
 
+#### Step 2 — Refuse a foreign-owned PR
+
 2. **Refuse a foreign-owned PR.** If `labels` already contains a `gauntlet-run-*` label that is **not**
    this run's `gauntlet-run-<run-id>`, another run owns it — **do NOT adopt, relabel, or touch it**.
    Tell the user that PR is owned by that other run and to let that run finish or release it first.
@@ -112,6 +116,8 @@ For each `#PR` to adopt:
    label. Tell the user fork PRs aren't supported: push a same-repo branch and open the PR from it (or
    re-open from a branch in this repo) so campaign can adopt it. Only a same-repo PR
    (`isCrossRepository=false`) adopts normally.
+
+#### Step 3 — Register the ledger row — refresh, never duplicate
 
 3. **Register the ledger row — refresh, never duplicate.** Write the row through
    `scripts/ledger.py` (the schema-owning accessor — `references/files-and-ledger.md`), addressing
@@ -190,6 +196,8 @@ For each `#PR` to adopt:
 
    The ownership marker for an adopted PR is the **label**, not the branch name (its branch won't match
    the `fix-<run-id>-` prefix) — so labelling in step 4 is what makes the PR ours.
+
+#### Step 3a — Write the PR's INTENT
 
 3a. **Write the PR's INTENT — `<rundir>/intent-<pr>.md`.** This is the input the review gate is measured
    against, and the reviewer receives it **verbatim** (`stage-2-review-gate.md`, "What the review is
@@ -272,6 +280,8 @@ For each `#PR` to adopt:
    and `intent-<pr>.md` is re-read, never re-derived — a heartbeat is a fresh agent instance, and an intent
    invented twice is two intents. Re-author only if the file is **gone** (a wiped `<rundir>`), and say so.
 
+#### Step 4 — Label it ours, and set the status label from the LIVE gate
+
 4. **Label it ours, and set the status label from the LIVE gate.** Add this run's owner label, then
    apply the status label that matches the PR's gate state **as it stands after step 3** — never a
    hardcoded `gauntlet-reviewing`.
@@ -295,6 +305,8 @@ For each `#PR` to adopt:
    of leaving a stale `gauntlet-accepted` in place. The label tracks the gate in **both** directions.
    (`--remove-label` on a label the PR does not carry is a harmless no-op, so neither form needs a
    pre-check for the label's presence — only for the gate's state.)
+
+#### Step 5 — Create the PR-head worktree before the first review pass
 
 5. **Create the PR-head worktree before the first review pass — off the PR's OWN head, never `<base>`.**
    The review itself needs a real checkout: the selected reviewer receives `<worktree>` as explicit
@@ -362,6 +374,8 @@ For each `#PR` to adopt:
    form writes the local branch directly and is **refused** when the branch already exists or is checked
    out. Let the create/reuse logic above handle the local branch.)
 
+   #### Two fail-closed guarantees the pseudocode leaves implicit
+
    **Two fail-closed guarantees the pseudocode leaves implicit:**
    - **On a re-adoption of the SAME worktree campaign itself created, PRESERVE its recorded
      `worktree_owned`/`branch_owned`** rather than downgrading them to `no`. A first adopt that **created**
@@ -389,6 +403,8 @@ For each `#PR` to adopt:
    the PR also go here; stage only the specific
    source files changed (explicit paths, never `git add -A`). Fix commits are pushed back to the PR's
    head branch on `origin`.
+
+#### Step 6 — Ensure a live CI watch when — and ONLY when — a check can still move
 
 6. **Ensure a live CI watch when — and ONLY when — a check can still move.** The warrant for a watch is a
    **still-RUNNING evidence row** in the PR's snapshot, **never the `ci` value** (Stage 2b, `stage-2-ci.md`

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -4,23 +4,6 @@
 Everything below is a command that exits non-zero, not a rule an attentive agent has to remember — which
 is the entire point, and is explained by the section that ends this file.
 
-### Why this exists
-
-The review gate had **no memory and could not see its own non-convergence.** Every heartbeat is a fresh agent
-instance; `reviews_ok` is zeroed on every `NOT SATISFIED`; and nothing counted rounds. So the ledger after
-21 review rounds was **indistinguishable from the ledger after 1**, and the skill's stopping rules — "run
-the root-cause pass on the 2nd `NOT SATISFIED`", the 1-hour cap — were rules with **no sensor**. They sat
-in the skill, unfired, for 8.5 hours.
-
-Two PRs ran **21** and **14** adversarial review rounds. Nearly every round produced a **true** finding, a
-fix was dispatched, the fix added code, and the next round found more — in the late rounds, more *in the
-guards the loop itself had just added*. Neither PR converged. A human stopped it, and could only do so by
-holding all 21 rounds in mind **at once**. That view is what no heartbeat had, and it is what this pass restores.
-
-**The reviewer was not malfunctioning.** It was doing exactly what it was asked, and what it was asked has
-**no fixed point**: an open-ended adversarial mandate over a growing surface always has one more true thing
-to say. Do not look for a bug in the reviewer. The bug is that nothing could **count**.
-
 ### The trigger — the loop's memory, and the caps on it
 
 `ledger.py` carries the memory. Two counters, and `ledger.py verdict` is the **ONLY** sanctioned way to
@@ -54,6 +37,23 @@ corroborating pass from merging must never be torn up. (On the real record this 
 and the prose is the copy people read. `ledger.py`'s comment defends each number against the real record,
 and `ledger-test.py` **replays that record** so a re-tuned cap states, in its own failure message, what the
 new number would have done to two PRs that really ran.
+
+### Why this exists
+
+The review gate had **no memory and could not see its own non-convergence.** Every heartbeat is a fresh agent
+instance; `reviews_ok` is zeroed on every `NOT SATISFIED`; and nothing counted rounds. So the ledger after
+21 review rounds was **indistinguishable from the ledger after 1**, and the skill's stopping rules — "run
+the root-cause pass on the 2nd `NOT SATISFIED`", the 1-hour cap — were rules with **no sensor**. They sat
+in the skill, unfired, for 8.5 hours.
+
+Two PRs ran **21** and **14** adversarial review rounds. Nearly every round produced a **true** finding, a
+fix was dispatched, the fix added code, and the next round found more — in the late rounds, more *in the
+guards the loop itself had just added*. Neither PR converged. A human stopped it, and could only do so by
+holding all 21 rounds in mind **at once**. That view is what no heartbeat had, and it is what this pass restores.
+
+**The reviewer was not malfunctioning.** It was doing exactly what it was asked, and what it was asked has
+**no fixed point**: an open-ended adversarial mandate over a growing surface always has one more true thing
+to say. Do not look for a bug in the reviewer. The bug is that nothing could **count**.
 
 ### A cap is a MODE SWITCH, not a doorbell
 

--- a/plugins/gauntlet/skills/campaign/references/review-dispatch.md
+++ b/plugins/gauntlet/skills/campaign/references/review-dispatch.md
@@ -167,21 +167,12 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    TRANSPORT.report.path yourself; the orchestrator's typed process transport captures it.
 ```
 
-Pass that artifact as data. Use the following external Codex argv only when the runtime transition
+Pass that artifact as data. Build the external Codex record only when the runtime transition
 returns `launch-external` or `retry-external`; no other action constructs this external record or
-launches this operation. On that route, `-` tells `codex exec` to read prompt bytes from `stdin_file`,
-which supplies immediate EOF; launch the typed operation in the background:
-
-```text
-run_argv(
-  argv: ["codex", "exec", "--sandbox", "workspace-write", "-c",
-         "sandbox_workspace_write.network_access=true", "--skip-git-repo-check",
-         "-C", transport.review_root, "-o", transport.report.path, "-"],
-  cwd: transport.review_root,
-  stdin_file: transport.prompt_path,
-  stdout_file: null
-)
-```
+launches this operation. Its argv is the canonical block in `cross-agent-reviewers.md` ("Claude Code
+orchestrator → Codex reviewer") — this file does not re-spell it. On that route, `-` tells `codex exec`
+to read prompt bytes from `stdin_file`, which supplies immediate EOF; launch the typed operation in the
+background.
 
 Never embed the bound prompt in a shell argument or shell source. Also: NEVER pass destructive
 instructions (delete, force-push, reset) to `codex exec`, and NEVER use

--- a/plugins/gauntlet/skills/campaign/references/review-dispatch.md
+++ b/plugins/gauntlet/skills/campaign/references/review-dispatch.md
@@ -2,12 +2,16 @@
 
 This file is the dispatch half of Stage 2a (`stage-2-review-gate.md`, "The review gauntlet"); the gate policy, the artifact contract, and verdict handling stay there, and this file owns how a review pass is materialized and launched.
 
+### Build the transport record
+
 **Orchestrator:** build one `ReviewTransport` record through `runtime-adapter.md`; never substitute its
 dynamic values into command prose. Resolve the two emitter paths relative to the active `SKILL.md`,
 derive all attempt paths from the same launch attempt, and serialize the record with a real JSON encoder.
 Then bind `<TRANSPORT-RECORD>` and `<INTENT>` in one non-rescanning `bind_review_prompt` call and
 materialize its result through `write_bytes`. The reviewer must receive concrete record values, never
 literal unresolved field names.
+
+### Resolve the active attempt's paths
 
 `<prompt-file>`, `<review-output>`, `<progress-file>` and `<findings-file>` resolve to the **active launch
 attempt's** files — NOT to fixed names. The attempt-artifact table ("Each launch attempt owns its own
@@ -34,6 +38,8 @@ as explicit review input. Review commands address it by absolute path with `run_
 it. `runtime-adapter.md` owns the transport-specific isolation semantics,
 including the native path's disclosed lack of an OS boundary when the host supplies none.
 
+### Fetch `origin/<base>` before the first dispatch
+
 **Fetch `origin/<base>` fresh before the first review dispatch.** The review diffs
 `origin/<base>...HEAD` — a **remote-tracking** ref, not a possibly-absent local `<base>` (adoption
 fetches only the PR head, so a local `<base>` may not exist, and a PR may target a stale or as-yet-
@@ -51,11 +57,15 @@ run_argv(
 This is idempotent and safe to repeat; run it (or rely on adoption's step-5 base fetch) before the
 review launches. All review diffs then use `origin/<base>...HEAD`.
 
+### Bind the intent verbatim
+
 **Orchestrator: pass the VERBATIM CONTENTS of the active `intent-<pr>.md` as `bind_review_prompt`'s
 `intent` value** — the whole
 block, not a summary and not a path. A reviewer handed a path is a reviewer that may not read it; a reviewer
 handed a summary is measured against the summary. Store the resolved emitter paths in the transport
 record; do not put them into executable prose.
+
+### The prompt template — verbatim, test-pinned
 
 The following is the prompt template, **not shell source**. The trailing backslash-newline pairs only
 wrap the displayed prose; omit them when materializing the prompt. Use `runtime-adapter.md`'s
@@ -166,6 +176,8 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    "external-process-capture", return the report only as the process's final output and do not write \
    TRANSPORT.report.path yourself; the orchestrator's typed process transport captures it.
 ```
+
+### Build the external record and launch
 
 Pass that artifact as data. Build the external Codex record only when the runtime transition
 returns `launch-external` or `retry-external`; no other action constructs this external record or

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -36,23 +36,20 @@ note it in the final report. Resolve in priority order:
    disclosed in the final report. **No paired CLI is required for the campaign to run** — the native
    fallback is always available.
 
-**Reviewer diversity is the default, not an add-on.** The gate's passes are already fresh,
-context-isolated re-rolls, but two native workers share the orchestrator's model, so they are less
-independent than a *different* engine would be. So the default reviewer runs a **different engine than the
-orchestrator**: Claude Code reviews with `codex exec`, Codex reviews with `claude -p`. It launches at
-native-limitation level whenever the paired CLI is present — engine diversity needs no OS sandbox. A
-same-engine process (Codex → another `codex exec`, Claude Code → another `claude -p`) provides fresh
-context only and must not be reported as diversity. A fresh native worker on the active host is the
-complete, valid **fallback** when the paired CLI is absent or the cross-engine process fails after its
-retry.
-
-**The default cross-engine reviewer also reduces native-worker cost.**
-Review passes dominate campaign's native-worker spend: each one re-reads the **whole** `origin/<base>...HEAD`
-diff, runs `required(tier)` times per SHA, and re-runs **from scratch** on every gate reset (a content
-change voids the tally). A PR that takes several fix rounds can therefore spend many full-diff passes.
-The default cross-engine route moves all of that off the native-worker pool; a native-worker fallback
-(paired CLI absent) does not. That is a benefit of the default, not a separate knob — the reviewer choice
-is owned above.
+**Reviewer diversity is the default, not an add-on — and it also reduces native-worker cost.** The gate's
+passes are already fresh, context-isolated re-rolls, but two native workers share the orchestrator's model,
+so they are less independent than a *different* engine would be. So the default reviewer runs a
+**different engine than the orchestrator**: Claude Code reviews with `codex exec`, Codex reviews with
+`claude -p`. It launches at native-limitation level whenever the paired CLI is present — engine diversity
+needs no OS sandbox. A same-engine process (Codex → another `codex exec`, Claude Code → another `claude
+-p`) provides fresh context only and must not be reported as diversity. A fresh native worker on the
+active host is the complete, valid **fallback** when the paired CLI is absent or the cross-engine process
+fails after its retry. The cost benefit compounds the diversity one: review passes dominate campaign's
+native-worker spend — each re-reads the **whole** `origin/<base>...HEAD` diff, runs `required(tier)` times
+per SHA, and re-runs **from scratch** on every gate reset (a content change voids the tally), so a PR that
+takes several fix rounds can spend many full-diff passes — and the default cross-engine route moves all of
+that off the native-worker pool, while a native-worker fallback (paired CLI absent) does not. Both are
+benefits of the default, not separate knobs — the reviewer choice is owned above.
 
 **A REVIEW PASS IS NEVER RUN ON A DOWNGRADED MODEL.** Whether the reviewer is a native worker or the
 worker fallback for a failed external reviewer, the pass runs in the **`session` class** — it *is* the

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -188,9 +188,9 @@ ReviewTransport {
 ```
 
 For a native action **and for a native-level cross-engine action** (the normal case now), `review_root`
-is the absolute active run-artifact directory and makes no isolation claim. Only a future OS-proving
-adapter that returns the three `os_filesystem_isolation` properties true uses aliases inside its proved
-view. A cross-engine route whose paired CLI is absent is `unavailable` and never constructs this record. The JSON encoding is the prompt's `<TRANSPORT-RECORD>` data
+is the absolute active run-artifact directory and makes no isolation claim (only a future OS-proving
+adapter uses aliases inside a proved view — "Review isolation capability and transition" above). A
+cross-engine route whose paired CLI is absent is `unavailable` and never constructs this record. The JSON encoding is the prompt's `<TRANSPORT-RECORD>` data
 block and the intent is its `<INTENT>` block;
 `bind_review_prompt` binds both without rescanning inserted bytes. Do not substitute record fields into
 prose commands. The active attempt's prompt/progress/findings/report basenames keep the `a<k>` identity
@@ -255,11 +255,10 @@ the installed review contract or producing valid artifacts, treat that attempt a
 failure; after the documented retry/fallback budget is exhausted, park the PR as a machine blocker.
 
 A cross-engine verdict-rendering process launches at this **same native-limitation level** whenever its
-paired CLI is present; it renders a diverse-engine verdict but is **not** a stronger security boundary
-than the native worker, and must never be reported as one. It may claim a stronger OS/filesystem boundary
-**only** from an `available` `ReviewIsolationCapability` whose three `os_filesystem_isolation` properties
-are proved true. A prompt saying "do not edit" does not create that boundary, and its absence never blocks
-the launch or parks the pass. For Codex specifically, `--ignore-rules` disables execpolicy `.rules`; it
+paired CLI is present — it renders a diverse-engine verdict, is **not** a stronger security boundary than
+the native worker, and must never be reported as one ("Review isolation capability and transition" above
+owns the rule and the one condition — three proved `os_filesystem_isolation` properties — under which a
+stronger claim is legitimate). For Codex specifically, `--ignore-rules` disables execpolicy `.rules`; it
 does **not** disable `AGENTS.md` discovery. The external argv in `cross-agent-reviewers.md` launches at
 native level today, and the same argv serves a future adapter that additionally proves the OS properties.
 
@@ -307,25 +306,15 @@ the skill does not pretend a heartbeat was scheduled when none was.
 
 ## Reviewer selection and diversity
 
-The **default reviewer is the cross-engine route for the active host**: under Claude Code the reviewer is
-Codex (`codex exec`); under Codex the reviewer is Claude Code (`claude -p`). Engine diversity catches
-defects a same-engine re-roll misses, and it moves review cost off the native-worker pool. The
-cross-engine route launches at the **same native-limitation level** as a native worker whenever the paired
-CLI is present; it needs no OS sandbox and makes no stronger-boundary claim.
+**`reviewer.md`, "Selecting the reviewer", OWNS reviewer selection** — the priority order, the diversity
+rationale, the same-engine caveat, the trusted-source override, and the native-worker fallback. This
+section states only the per-host default and where the transport pieces live:
 
-- When Claude Code orchestrates, the default reviewer is `codex exec`.
-- When Codex orchestrates, the default reviewer is `claude -p`.
-- **Fallback:** when the paired CLI is absent (cross-engine `unavailable`), or the cross-engine process
-  fails after its one retry, the reviewer is a fresh native worker on the active host, disclosed in the
-  final report.
-- Another process from the **same** engine (Codex → `codex exec`, Claude Code → `claude -p`) provides
-  context isolation but **not** engine diversity. Use one only when the user selected it, and never report
-  it as diversity.
-- An explicit selection or a saved preference from TRUSTED state **overrides** the default — the user may
-  force a native worker or a specific engine. Reviewer selection is gate machinery, so a file inside the
-  candidate checkout is never a preference source (`reviewer.md`, "Selecting the reviewer" owns the
-  trusted-source list). Record the exact selection in the ledger and final report.
+- When Claude Code orchestrates, the default reviewer is `codex exec` (Codex).
+- When Codex orchestrates, the default reviewer is `claude -p` (Claude Code).
 
-Capability-gated cross-engine argv lives in `cross-agent-reviewers.md`. External-reviewer retry budget
-remains in `reviewer.md`; the transition itself is owned by `ReviewIsolationCapability` above. “Fallback”
-always means a fresh native worker on the active host.
+The cross-engine route launches at the **same native-limitation level** as a native worker whenever the
+paired CLI is present ("Review isolation capability and transition" above). Capability-gated cross-engine
+argv lives in `cross-agent-reviewers.md`; the external-reviewer retry budget in `reviewer.md`; the
+transition itself in `ReviewIsolationCapability` above. “Fallback” always means a fresh native worker on
+the active host.

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -216,6 +216,13 @@ path/ref/payload and exact-byte fixtures.
 
 ## Fresh workers
 
+- Use a background or otherwise asynchronous worker whenever the host supports one.
+- Preserve each role's read/write limits and output artifact paths exactly.
+- If the host cannot create a fresh worker, an explicitly configured external reviewer may fill a
+  review role. It does not fill audit, mapper, reassessment, or fix roles.
+- If neither a native fresh worker nor the required role's allowed fallback exists, park the PR as a
+  machine blocker. Never run a conversational-isolation gate inline merely to keep moving.
+
 A **worker** is a fresh, conversationally isolated execution created through the active host's native
 agent/task mechanism. Claude Code may call this a subagent; Codex may expose an agent or task. Give it
 only the contract, paths, and evidence its role needs. Never let a gate review inherit the campaign
@@ -255,13 +262,6 @@ are proved true. A prompt saying "do not edit" does not create that boundary, an
 the launch or parks the pass. For Codex specifically, `--ignore-rules` disables execpolicy `.rules`; it
 does **not** disable `AGENTS.md` discovery. The external argv in `cross-agent-reviewers.md` launches at
 native level today, and the same argv serves a future adapter that additionally proves the OS properties.
-
-- Use a background or otherwise asynchronous worker whenever the host supports one.
-- Preserve each role's read/write limits and output artifact paths exactly.
-- If the host cannot create a fresh worker, an explicitly configured external reviewer may fill a
-  review role. It does not fill audit, mapper, reassessment, or fix roles.
-- If neither a native fresh worker nor the required role's allowed fallback exists, park the PR as a
-  machine blocker. Never run a conversational-isolation gate inline merely to keep moving.
 
 ## Model classes
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -393,61 +393,61 @@ of heartbeats, the exact PR the driver is actively fixing, and an ungated stall 
 
 ##### MACHINE ACTION — any work that can produce a new `head_sha`
 
-**MACHINE ACTION** = **any work campaign dispatches that can produce a new `head_sha` on this PR.** That
-**PROPERTY is the definition, and it is the whole of it.** **APPLY THE PROPERTY — NEVER CONSULT A LIST.**
+**MACHINE ACTION** = any work campaign dispatches that can produce a new `head_sha` on this PR. That
+PROPERTY is the definition, and it is the whole of it. **APPLY THE PROPERTY — NEVER CONSULT A LIST.**
 Of any work in question, ask: *when it completes, can it put a new commit on this PR's head?* If yes it is
-a MACHINE ACTION, **whether or not it appears in any enumeration anywhere in this repo** — the same idiom
-as the parked-PR guard's "does this MUTATE the PR?, **not** is it on a list" (`SKILL.md`). A set defined
-by a property but **applied** through its examples is a set that silently shrinks every time a member is
+a MACHINE ACTION, whether or not it appears in any enumeration anywhere in this repo — the same idiom
+as the parked-PR guard's "does this MUTATE the PR?, not is it on a list" (`SKILL.md`). A set defined
+by a property but applied through its examples is a set that silently shrinks every time a member is
 added somewhere else — which is exactly how the list below went stale once already.
 
 - **NON-NORMATIVE EXAMPLES. Illustrative only; they DO NOT BOUND THE SET:** a CI-fix subagent (either
   tier, including an escalation from the cheap one), a review-fix subagent, a copilot-address fix, a
-  refutation commit, and **every rebase and base refresh — the conflict-resolving rebase and the CLEAN
-  BASE-ONLY one alike** (Stage 2a's precondition rebase, `stage-2-review-gate.md`; the post-merge
+  refutation commit, and every rebase and base refresh — the conflict-resolving rebase and the CLEAN
+  BASE-ONLY one alike (Stage 2a's precondition rebase, `stage-2-review-gate.md`; the post-merge
   reconcile, `stage-3-merge.md` step 6). Work that has the property but is missing from this list is
-  **still** a machine action.
+  still a machine action.
 - **The CLEAN BASE-ONLY REBASE IS ONE — it is the member this list omitted, and the omission parked
-  healthy PRs.** It qualifies for exactly the reason every other member does: **it MOVES `head_sha`**
+  healthy PRs.** It qualifies for exactly the reason every other member does: it MOVES `head_sha`
   ("THE LIVENESS COUNTERS" below, which resets the counters at it for that same reason). Whether it also
-  resets the **gate** is a **DIFFERENT QUESTION** — it does not — and it is **not this one**: the property
-  here is `head_sha`, not `reviews_ok`. A PR merely **DUE** for a clean rebase would otherwise keep
-  striking (or keep its stall clock running) against a head the rebase is about to replace, and **park —
-  a spurious park, with the work already on its way**.
+  resets the gate is a DIFFERENT QUESTION — it does not — and it is not this one: the property
+  here is `head_sha`, not `reviews_ok`. A PR merely DUE for a clean rebase would otherwise keep
+  striking (or keep its stall clock running) against a head the rebase is about to replace, and park —
+  a spurious park, with the work already on its way.
 - **The CI watch is NOT a machine action, and neither is a review pass.** They fail the property: neither
   pushes a commit, so neither can move CI. A settled PR under review is still settled, a stalled one is
   still stalled, and suppressing either bound for them would wedge the PR exactly as before.
 
-**In flight** = dispatched for this PR at this `head_sha` and not yet completed — **the same in-flight
-test `loop-control.md` step 3 already applies** to suppress a duplicate dispatch ("CI red and no fix is
+**In flight** = dispatched for this PR at this `head_sha` and not yet completed — the same in-flight
+test `loop-control.md` step 3 already applies to suppress a duplicate dispatch ("CI red and no fix is
 already in flight for that PR/SHA"). The strike rule and the stall clock read that same fact; they do not
 invent a second one.
 
-**Due** = **this heartbeat would launch it** — it is not in flight, and nothing but a free concurrency slot is
-missing. That, too, is a **property, not a fixed list of scans**: whichever rule OWNS that dispatch is the
+**Due** = this heartbeat would launch it — it is not in flight, and nothing but a free concurrency slot is
+missing. That, too, is a property, not a fixed list of scans: whichever rule OWNS that dispatch is the
 one that says so. For a CI fix it is `loop-control.md` step 3's dispatch scan; for a rebase it is the rule
 that owns the rebase (Stage 2a's preconditions, `stage-2-review-gate.md`; the step-6 reconcile,
-`stage-3-merge.md`) finding the PR behind/conflicting on this heartbeat. A PR **frozen by a park** has **no**
+`stage-3-merge.md`) finding the PR behind/conflicting on this heartbeat. A PR frozen by a park has no
 machine action due — the held-status guard forbids every one of them (`loop-control.md`), so nothing is
 coming, which is why the park is the terminus and not another wait.
 
 **IT STILL TERMINATES — a liveness rule that can be suppressed forever is not a liveness rule.** The STOP
-is keyed to a machine action being **DUE or IN FLIGHT**, and **every machine action ENDS**, so the STOP
+is keyed to a machine action being DUE or IN FLIGHT, and every machine action ENDS, so the STOP
 ends with it — the broader definition above does not widen it into a wedge:
 
-- **A fix subagent is bounded**: a stuck task is retried **once** and then aborted permanently, and "CI
+- **A fix subagent is bounded**: a stuck task is retried once and then aborted permanently, and "CI
   fails identically after a fix attempt" is itself a stop condition (`bailout-and-final-report.md`).
-- **A rebase is bounded by construction**: it either lands a new head — which **resets the counters at the
-  site that moved it**, the correct outcome, not a suppression — or it fails; either way it is afterwards
+- **A rebase is bounded by construction**: it either lands a new head — which resets the counters at the
+  site that moved it, the correct outcome, not a suppression — or it fails; either way it is afterwards
   neither due nor in flight.
-- **DUE cannot persist**: the only thing a due action waits on is a **free concurrency slot**, and slots
+- **DUE cannot persist**: the only thing a due action waits on is a free concurrency slot, and slots
   free as work completes.
 
-So a PR whose machine actions are **all exhausted** — a **red** PR whose CI-fix budget is **spent**, not
-behind or conflicting, so no rebase is owed — has **none due and none in flight**: the STOP does not fire,
-strikes accrue (or the stall clock runs) on the next derivations, and **it reaches its cap and parks**,
-like any other settled or stalled PR. The gate suppresses a bound **only while work that can move
-`head_sha` is actually coming**, never merely because the PR is red.
+So a PR whose machine actions are all exhausted — a red PR whose CI-fix budget is spent, not
+behind or conflicting, so no rebase is owed — has none due and none in flight: the STOP does not fire,
+strikes accrue (or the stall clock runs) on the next derivations, and it reaches its cap and parks,
+like any other settled or stalled PR. The gate suppresses a bound only while work that can move
+`head_sha` is actually coming, never merely because the PR is red.
 
 ##### ESCALATE — park the PR and tell the user
 
@@ -502,12 +502,12 @@ added to the schema tomorrow is already covered here:
 
 - **A COUNTER that dies never reaches its cap.** A fresh instance restarts the count from zero, so the
   bound never fires.
-- **A CLOCK is worse**: it does not merely lose the elapsed time, it **silently restarts** it. Every clock
-  is therefore a **timestamp on disk**, so that **any** heartbeat computes the elapsed time from the ledger
+- **A CLOCK is worse**: it does not merely lose the elapsed time, it silently restarts it. Every clock
+  is therefore a timestamp on disk, so that any heartbeat computes the elapsed time from the ledger
   alone, remembering nothing.
 - **EVIDENCE OF WHAT CI LOOKED LIKE LAST TIME is worse still, because losing it looks like SUCCESS.** The
-  derivation decides that CI **moved** by comparing this snapshot against what the row says it saw before;
-  with that gone, **every** heartbeat sees motion, **every** heartbeat resets the counters and the clock, and the
+  derivation decides that CI moved by comparing this snapshot against what the row says it saw before;
+  with that gone, every heartbeat sees motion, every heartbeat resets the counters and the clock, and the
   bounds never fire — the wedge this whole section exists to close, reopened silently and with no error.
 - **A REASON that dies leaves the park UNANSWERABLE.** The escalation prompt above is built from the
   blocker the human is being asked to rule on; a fresh agent that lost it cannot even ask the question, so

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -10,6 +10,13 @@ different write: its `0`-reset belongs **only** to a campaign commit landing on 
 campaign commit to the PR head resets the gate", below, through `scripts/ledger.py … set --pr <N>
 --reviews_ok 0`. An ordinary derivation is observation, not a content change, and never touches it.)
 
+> **Jump by question (navigation, not authority — the sections below govern):**
+> - `derive` returned a verdict → "ACT ON THE VERDICT"
+> - a required-check-set question → "WHAT WERE WE EXPECTING TO SEE?"
+> - a PR stuck or parked → SETTLED / "ESCALATE" / "THE PARK MUST DECLARE ITS OWN EXIT" (all under "`pending` MUST NOT BE AN ABSORBING STATE")
+> - a watch question → "WATCH ONLY WHAT CAN MOVE"
+> - a CI-fix dispatch → "Classify, then set the model class"
+
 #### THE DERIVATION IS A COMMAND — RUN IT. NEVER DERIVE `ci` BY READING TERMINAL OUTPUT.
 
 **The heartbeat derives `ci` by RUNNING `scripts/ci-status.py`, and by nothing else:**
@@ -384,6 +391,8 @@ change `head_sha` until it pushes — so an ungated strike rule would park, with
 of heartbeats, the exact PR the driver is actively fixing, and an ungated stall clock would start timing a
 `RUNNING` row the driver is about to make irrelevant.
 
+##### MACHINE ACTION — any work that can produce a new `head_sha`
+
 **MACHINE ACTION** = **any work campaign dispatches that can produce a new `head_sha` on this PR.** That
 **PROPERTY is the definition, and it is the whole of it.** **APPLY THE PROPERTY — NEVER CONSULT A LIST.**
 Of any work in question, ask: *when it completes, can it put a new commit on this PR's head?* If yes it is
@@ -440,6 +449,8 @@ strikes accrue (or the stall clock runs) on the next derivations, and **it reach
 like any other settled or stalled PR. The gate suppresses a bound **only while work that can move
 `head_sha` is actually coming**, never merely because the PR is red.
 
+##### ESCALATE — park the PR and tell the user
+
 **ESCALATE** = park the PR (`status = awaiting-user`, `ci_reason` = the blocker **named**: which check
 never registered, **which check has been `RUNNING` since when without the check set moving**, which value
 was unrecognized, which read was denied), **and `blocker_ruling` = `-` in
@@ -452,6 +463,8 @@ abort the run or close the PR — the run's other PRs keep going. At **this** pa
 bare restatement of `ci`. (The field itself is **wider than CI**: it is the durable machine-blocker reason,
 and `stage-3-merge.md`'s merge-precondition parks write it with `ci` **green**. `files-and-ledger.md` owns
 that definition.) A park that cannot name its blocker is not actionable.
+
+##### THE PARK MUST DECLARE ITS OWN EXIT
 
 **THE PARK MUST DECLARE ITS OWN EXIT — the invariant at the top of this section binds `awaiting-user`
 too.** A park whose exit event never comes is the same wedge, one level up. So the escalation:
@@ -501,6 +514,8 @@ added to the schema tomorrow is already covered here:
   the park has no exit.
 - **A RULING that dies gets re-asked** ("THE RULING IS CONSUMED EXACTLY ONCE" below).
 
+##### THE RULING IS CONSUMED EXACTLY ONCE
+
 **THE RULING IS CONSUMED EXACTLY ONCE — a durable answer that is never spent is a park that unparks
 itself.** `blocker_ruling` must be **DURABLE** (it survives a context loss) **AND spent EXACTLY ONCE** (it
 answers the park it was written for, and no other). Both halves, or neither holds:
@@ -521,6 +536,8 @@ a spent `retry` on the row, and the next park would read it as its own answer. (
 `head_sha` instead would **not** work: a `retry` that fails to move CI re-parks the PR at the **same**
 `head_sha` (`loop-control.md` step 3), so a `head_sha`-scoped ruling would satisfy that re-park with no
 fresh user answer — the exact failure this rule exists to prevent.)
+
+##### THE LIVENESS COUNTERS
 
 **THE LIVENESS COUNTERS — one name for the set, so a new counter never leaves a stale restatement.** They
 are `ci_fingerprint`, `settled_strikes`, `unusable_refetches`, and `ci_stalled_since`.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -480,8 +480,8 @@ too.** A park whose exit event never comes is the same wedge, one level up. So t
 - **Records that answer DURABLY in the ledger's `blocker_ruling`** (`files-and-ledger.md`) the moment it
   lands, and unparks per `loop-control.md` step 3, "Only the user's answer unparks a PR" — which also
   **clears the liveness counters**, so the retry gets a fresh budget instead of re-escalating on its first
-  derivation. A heartbeat may be a fresh agent instance: an answer that lives only in the driver's head is an
-  answer that gets re-asked.
+  derivation. A heartbeat may be a fresh agent instance, so the answer must be durable ("HOW state dies
+  with the context is a CLASS" below).
 
 **NOTHING THIS SECTION RELIES ON LIVES IN THE DRIVER'S HEAD — and that is a PROPERTY, not the list that
 used to stand here.** A heartbeat may be a fresh agent instance, so: **if a LATER derivation, the escalation
@@ -490,7 +490,7 @@ schema itself** — `files-and-ledger.md`'s row-field definitions, and the `ROW_
 `scripts/ledger.py` that own it — and a field added there is durable **with no edit to this section**. A
 list retyped here rots the next time one is added, and the one that stood here rotted **twice**: it first
 dropped `ci_reason`, the very thing the park asks the user about, and its replacement dropped
-`ci_fingerprint`, without which every heartbeat sees CI as having moved and **no bound ever fires at all**.
+`ci_fingerprint`, whose loss silently reopens the wedge ("HOW state dies with the context is a CLASS" below).
 There is no third attempt: **the members are not retyped here, in any form, marked or not.** Every write
 goes through the owning tool, **by field name**, never by hand-editing the row: the derivation-driven
 fields are `ci-status.py liveness`'s ("THE BOOKKEEPING IS A COMMAND", above), and everything else —
@@ -624,8 +624,8 @@ the healthy build**, and a rule that parks healthy PRs gets turned off, which le
   SETTLED PR has **nothing that could move** — there is no slow-vs-dead question to answer.
 - **It is computed FROM DISK, never from the driver's memory of when it last looked.** `ci_stalled_since`
   is a UTC ISO-8601 timestamp in the **ledger**; `now - ci_stalled_since` is a subtraction any fresh agent
-  instance can do on its first heartbeat. A duration accumulated in context is a duration that resets to zero
-  every time the session dies — which is the failure that made these counters durable in the first place.
+  instance can do on its first heartbeat (why a clock lives on disk, not in context: "HOW state dies with
+  the context is a CLASS" above).
 
 **WHY IT DOES NOT PARK A HEALTHY SLOW CHECK.** The clock is **not** "how long the build has been running".
 It is **"how long NOT ONE row in the whole check set has changed state"** — the fingerprint covers every
@@ -740,8 +740,8 @@ Every one of them MUST, in the same step:
   that snapshot holds a row that can still move** ("WATCH ONLY WHAT CAN MOVE" above). The new commit
   **resets the liveness counters** ("THE LIVENESS COUNTERS" above), so the PR gets a clean budget.
   **NEVER launch the watch unconditionally on the push**: at that instant the checks may not have
-  registered yet, the snapshot holds **zero evidence rows**, and `gh pr checks --watch` would exit in
-  about a second — a heartbeat per second, forever, on a PR nothing is watching *for*;
+  registered yet, so watch only if the fresh snapshot holds a row that can still move ("WATCH ONLY WHAT
+  CAN MOVE" above);
 - **re-enter Stage 2a.**
 
 The verdicts on the old SHA describe content that no longer exists, and a `gauntlet-accepted` label on
@@ -837,10 +837,9 @@ Its job, in order:
 A cheap model verifying a tool's diff is a **MISS-CATCHER, NOT A PROOF.** It can miss a semantic change.
 
 What backs it: the **exact failing check must pass**; the subagent **must escalate anything it cannot
-verify**; and **every commit campaign pushes is still gated by the full review gauntlet** — any campaign
-commit to the PR head resets `reviews_ok` to 0, restores `gauntlet-reviewing`, resets the liveness
-counters ("THE LIVENESS COUNTERS"), re-derives CI for the new tip and watches it **only if a row can still
-move** ("WATCH ONLY WHAT CAN MOVE"), and re-enters Stage 2a in the `session` class.
+verify**; and **every commit campaign pushes is still gated by the full review gauntlet** — it resets the
+gate and re-enters Stage 2a in the `session` class ("Any campaign commit to the PR head resets the gate"
+above owns the full action list).
 
 This trades a **small, bounded risk** for a workflow that is **cheaper AND more capable** than either a
 full-strength subagent on every formatting failure or a hermetic no-model tool path. **The user accepts

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -1,5 +1,11 @@
 ## Stage 2 — Gates (orchestrator-owned, reactive)
 
+> **Jump by question (navigation, not authority — the sections below govern):**
+> - a NOT SATISFIED verdict landed → "Recording a verdict"
+> - launching a review pass → "Preconditions — clear Copilot items, CI, and conflicts before reviewing" + `review-dispatch.md`
+> - did the pass count → "Does this pass COUNT?"
+> - the status labels look wrong → "Status labels mirror the review gate"
+
 ### 2a-triage. PR triage — file class & risk tier (deterministic, per `head_sha`)
 
 Before the review gauntlet, triage each PR to a **risk tier**. Triage is **deterministic** and
@@ -37,6 +43,8 @@ the row by column position). Default to **STANDARD** whenever you are unsure. `r
 
 ### 2a. The review gauntlet
 
+#### A HELD PR IS NOT REVIEWABLE — check `status` FIRST, and check it with the TOOL
+
 **A HELD PR IS NOT REVIEWABLE — check `status` FIRST, and check it with the TOOL.** Run `ledger.py …
 dispatch-check --pr <N>`: it exits non-zero on every **HELD** status (`files-and-ledger.md`, `status` —
 the owner; `HELD_STATUSES` in `scripts/ledger.py` is the one place they are enumerated, so **never retype
@@ -50,6 +58,8 @@ the user's ruling**, or re-reviews a PR that has **stopped converging** (`repair
 of a loop that has already been told to stop. The park does **not** change its CI watch either way — observing is not mutating, so the
 watch follows the normal policy (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE": alive while a row can still
 move, **not** relaunched once CI has SETTLED). Everything else waits for the user's answer.
+
+#### Preconditions — clear Copilot items, CI, and conflicts before reviewing
 
 **Preconditions — clear Copilot items, CI, and conflicts before reviewing.** A review pass is
 expensive and is invalidated by any PR-content change, so never spend one on a PR whose current tip
@@ -98,6 +108,8 @@ cap; it's only the two reviews for the same PR that serialize.) Each pass is a s
 shared context, so the second verdict is a fresh, context-isolated execution rather than a
 continuation influenced by the first.
 
+#### Kill doomed passes — don't let them finish
+
 **Kill doomed passes — don't let them finish.** If a precondition goes dirty while a review is in
 flight on a PR — CI turns red, Copilot items land, a conflict appears — or any content-changing fix
 is about to be dispatched for it, **stop the in-flight review task before dispatching the fix**: its
@@ -110,6 +122,8 @@ Route every selected reviewer through `runtime-adapter.md`'s capability/transiti
 contract and counts toward the gate exactly like an external pass; when native workers are already the
 selected reviewer, that is the normal path rather than a fallback. Do not restate transport properties
 or park conditions here.
+
+#### A REVIEW PASS'S ARTIFACTS HAVE A TOOL — `scripts/review-pass.py`
 
 **A REVIEW PASS'S ARTIFACTS HAVE A TOOL — `scripts/review-pass.py`. NEVER hand-parse one, and never
 hand-write a line the tool writes.** The plan, the `pass_identity`, every unit-progress event, and the read
@@ -147,12 +161,16 @@ file is a plaintext file in a directory the reviewer can write to.
 refusal list. **`emit` refuses every one of those it can see, by calling the SAME functions** — one
 implementation, both doors, so a rule cannot hold at one and not the other.
 
+#### EVERY IDENTIFIER HAS ONE LEGAL FORM, AND NO DOOR REPAIRS ONE
+
 **EVERY IDENTIFIER HAS ONE LEGAL FORM, AND NO DOOR REPAIRS ONE.** A unit `id`/`unit` is lowercase letters
 then digits (`u01`); `pr`, `pass` and `launch_attempt` are decimal numbers from 1 up; `head_sha` is 40
 lowercase hex. A value outside its form is an ERROR, never a variant to be trimmed or normalized into
 shape: a door that repairs an identifier creates a second spelling of it that every other door must then
 remember, and a FORMAT leaves nothing to convert. A format also refuses what cleanliness cannot —
 `a3f29c1` is perfectly clean, and simply not a commit id.
+
+#### ANYTHING THE TOOL WRITES, IT CAN READ BACK
 
 **ANYTHING THE TOOL WRITES, IT CAN READ BACK — a write is REFUSED unless the file it would produce
 verifies.** Every write command runs the READ side's whole-file check on the bytes it is about to
@@ -164,6 +182,8 @@ holds ANY BYTES**, not merely any non-blank text. **EMPTY MEANS NO BYTES**: a fi
 is not empty, it is a file with a blank line, and `verify` refuses the pass for exactly that. The one
 read-side rule no write can enforce is the LIVE HEAD comparison — the tip can move after a sound file is
 written, which is the whole reason a tally is voided when PR content changes.
+
+#### Review work-plan ledger — orchestrator-owned, target-generic
 
 **Review work-plan ledger — orchestrator-owned, target-generic.** Before launching each review pass,
 write `<rundir>/review-<pr>-<n>.plan.jsonl` (through `review-pass.py plan-add` — one unit per call, each
@@ -227,6 +247,8 @@ backticked span, or a filename). Do NOT rename to `unit_done`/`unit_id`/`id`/`no
 other event types for unit progress. Unit-progress events carry ONLY the exact required keys above
 (no extra keys such as `ts`); each event's required keys must be present and named exactly.
 
+#### A `done` REQUIRES an earlier `started` — enforced by ORDER, at both doors
+
 **A `done` REQUIRES an earlier `started` for the same unit — enforced by ORDER, at both doors.** A unit
 that was never begun cannot have been finished, so a `done` standing alone, or standing *above* its
 `started` in this append-only file, makes the pass `unusable`: a progress file carrying a `done` for
@@ -241,6 +263,8 @@ follows `started`, no second `done` — are ONE predicate that both doors call.)
 The `plan_amendment_request` event keeps its existing shape; its `ts` must be a real UTC ISO-8601
 timestamp (the same clock rule `pass_identity.dispatched_at` obeys) and its `reason` must be non-empty —
 an amendment holds a pass back, so it must say something the orchestrator can rule on.
+
+#### Calling `emit-progress.py` is the ONLY sanctioned way to record a unit-progress event
 
 **Calling `emit-progress.py` is the ONLY sanctioned way to record a unit-progress event
 (`started`/`done`).** The reviewer MUST NOT ever write those unit-progress events into the progress
@@ -283,6 +307,8 @@ That example is **the real PR #43 round-11 finding**, and it is the one to keep 
 was **added by an earlier fix round of this very gauntlet**, and it still **GATES** — because `network` names
 an actor who can really send that reply, and it quotes the PR's purpose verbatim.
 
+#### `pass_identity` is the pass's attempt id and its dispatch clock
+
 **`pass_identity` is the pass's attempt id and its dispatch clock.** The orchestrator writes it — with
 `review-pass.py identity`, **never** a `printf` — as the
 **first line** of the launch attempt's progress file **before** launching the reviewer process, so that
@@ -300,6 +326,8 @@ therefore evidence that the reviewer has produced nothing — not evidence of a 
 **The attempt id is `pr` + `pass` + `head_sha` + `launch_attempt` — all four.** A relaunch keeps the
 first three, so without `launch_attempt` the two launch attempts of one pass are indistinguishable and
 a killed-but-not-dead attempt could be mistaken for the live one.
+
+#### Each launch attempt owns its own artifacts — a relaunch NEVER reuses the dead attempt's files
 
 **Each launch attempt owns its own artifacts — a relaunch NEVER reuses the dead attempt's files.**
 A process that survived its kill still writes to the paths it was given, so reusing them would let a
@@ -332,6 +360,8 @@ in the typed review record, so the reviewer receives concrete data rather than s
 reviewer MUST invoke that argv through `runtime-adapter.md`'s typed boundary to emit each event, which
 writes the canonical shape by construction; a non-zero exit means the inputs were rejected and must be
 fixed and re-run.
+
+#### Launch check — prove the reviewer actually started
 
 **Launch check — prove the reviewer actually started.** A dispatch can fail in a way that produces
 **no events at all**: an external reviewer launched without the prompt-file stdin redirect,
@@ -381,6 +411,8 @@ rule is sized for a reviewer working slowly, not one that never woke up. Gate ev
   the PR-level retry-once bailout, and charging a reviewer's failure to launch against it could abort
   a perfectly good PR for a fault that was never in its diff.
 
+#### Meaningful progress — the stronger bar
+
 Meaningful progress = a `done` event for a planned unit, or an accepted plan amendment. `started`
 events and vague "still working" lines prove only process liveness and MUST NOT reset the meaningful
 progress timer. The reviewer MUST append progress events immediately as units complete, not batch them
@@ -388,6 +420,8 @@ at final output. If no meaningful progress lands for ~15 min while the review pr
 mark the review suspicious; if it remains stale on the next heartbeat, treat it as a reviewer system
 failure: apply `reviewer.md`'s retry budget and `runtime-adapter.md`'s owned transition. Ignore any
 late verdict from a stale/superseded attempt unless its attempt id still matches the active review pass.
+
+#### A finer liveness signal — the reviewer's OUTPUT STREAM
 
 **A finer liveness signal for a background-task reviewer whose stdout is captured INCREMENTALLY: its
 OUTPUT STREAM.** The meaningful-progress
@@ -641,6 +675,8 @@ never be torn up for a repair.
 
 Then, per verdict:
 
+#### NOT SATISFIED
+
 - **NOT SATISFIED** → the SHA's tally is void (`ledger.py verdict … --verdict not-satisfied` does it) **and,
   in the same step, restore
   `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** ("Status labels mirror the review gate",
@@ -681,6 +717,8 @@ Then, per verdict:
   contract's **sweep-and-report block into the prompt verbatim** — a review defect whose fix changes a
   definition or a fact is not done until every site that restates it is correct, and every site found is
   reported. Scope bounds the READING; the sweep bounds the WRITING; the fixer owes you both.
+#### SATISFIED
+
 - **SATISFIED** → record it (`ledger.py … verdict --pr <N> --head-sha <sha> --verdict satisfied`, which
   bumps `reviews_ok` and `review_rounds` and clears `ns_streak` in one write — **never** `set
   --reviews-ok`, which refuses to raise the tally). It **never** trips a review-loop cap. The gate is met
@@ -721,6 +759,8 @@ STANDARD/HIGH PR, one for a TRIVIAL PR). Its only aggregate use (when a PR has �
 when **both** accepting passes on the same content name the same area, note that convergence in the
 report, and the orchestrator MAY add a plan unit covering it the next time the PR content changes and a
 fresh review round starts — but it never blocks the current gate.
+
+#### Gate is `required(tier)` fresh, context-isolated SATISFIED verdicts on the same PR content
 
 **Gate is `required(tier)` fresh, context-isolated SATISFIED verdicts on the same PR content** —
 2a-triage owns the formula and the file classes. A `NOT SATISFIED`, a `plan_amendment_request`, or a

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -88,9 +88,9 @@ review gate"), and the review re-starts on the clean tip:
   UNKNOWN or unrecognized value returns `recheck` FIRST, before any rebase-first classification, so re-poll
   and re-run rather than rebase on a half-computed view (`base-preflight.py` is the owner of the full
   mapping). It is the enforced form of this rule and it is also the pre-flight gate before any fix subagent
-  is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean rebase with the PR diff unchanged keeps `reviews_ok` but
-  sets `ci = pending` **and resets the liveness counters** — the gate does not reset, but the `head_sha`
-  **moved**, and **every** `head_sha` change resets them (`stage-2-ci.md`, "THE LIVENESS COUNTERS");
+  is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean base-only rebase with the PR diff unchanged keeps `reviews_ok` but still moves `head_sha`, so it
+  sets `ci = pending` **and resets the liveness counters** ("Status labels mirror the review gate"
+  Exception, below, owns this rule; `stage-2-ci.md`, "THE LIVENESS COUNTERS");
   conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,
   exactly as the step-6 reconcile does at its own (`stage-3-merge.md`), and it therefore **relabels in the
   same step** ("Status labels mirror the review gate", below).
@@ -547,13 +547,10 @@ real defect — the PR #43 round-11 finding shown above sat in code an earlier r
 it **GATES** (`writer=network`, and it quotes the PR's purpose). The same PR's round-15 finding — proof
 machinery that misses an input **nobody can write**, attacking a declared non-goal — does not.
 
-`review-pass.py verify` **exits non-zero** when: the PR has **no usable intent block** for the pass to be
-measured against (checked for **every** pass — see below); a `NOT SATISFIED` pass records **no gating
-finding**; a `SATISFIED` pass records **one that stands**; **no verdict is given at all for a pass that is
-COMPLETE** (`--verdict` is REQUIRED — the rule below cannot be switched off by omitting its input); a
-`deferred` pass is **complete with no outstanding `plan_amendment_request`** (a deferral that points at
-nothing — it owes a binary verdict); a required field is missing; `writer` is outside the enum; `purpose`
-is not a verbatim `## Purpose` line; or `writer` contradicts the repro. It still **cannot say `SATISFIED`** and still **cannot raise `reviews_ok`**
+`review-pass.py verify` **exits non-zero** on any defect in the pass's artifacts — a missing intent block,
+a verdict that does not cohere with the findings (in either direction), a missing verdict on a COMPLETE
+pass, a spurious `deferred`, or a malformed finding record — the `unusable` row of the verify table below
+enumerates them in full. It still **cannot say `SATISFIED`** and still **cannot raise `reviews_ok`**
 — it can only ever **subtract** a pass, never grant one.
 
 **THE VERDICT/FINDINGS RULE IS AN IF AND ONLY IF, AND BOTH HALVES ARE ENFORCED: `NOT SATISFIED` exactly
@@ -774,8 +771,7 @@ prose. Record the reviewed SHA
 (`git rev-parse HEAD`) with each pass. A verdict counts while its SHA equals the live tip. It also
 continues to count after `<base>` advances if the PR is still non-conflicting and the PR diff/content
 is unchanged (e.g. clean base-only rebase); carry `reviews_ok` forward to the new `head_sha`, set
-`ci = pending`, and **reset the liveness counters** — the head moved, so the old head's CI liveness
-describes nothing (`stage-2-ci.md`, "THE LIVENESS COUNTERS"). The moment PR content changes — review fix, CI fix, conflict-resolving rebase, a
+`ci = pending`, and **reset the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"). The moment PR content changes — review fix, CI fix, conflict-resolving rebase, a
 formatter/bot commit on the PR branch, or manual push — earlier verdicts are stale and `reviews_ok`
 drops to 0. Pinning to SHA plus the clean-base-only exception makes the gate verifiable from git while
 not burning reviews merely because another PR merged cleanly. A `NOT SATISFIED` invalidates that

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -61,7 +61,8 @@ move, **not** relaunched once CI has SETTLED). Everything else waits for the use
 
 #### Preconditions — clear Copilot items, CI, and conflicts before reviewing
 
-**Preconditions — clear Copilot items, CI, and conflicts before reviewing.** A review pass is
+**Only launch a review pass once all three are clear for the current tip.** Clear Copilot items, CI,
+and conflicts before reviewing: a review pass is
 expensive and is invalidated by any PR-content change, so never spend one on a PR whose current tip
 still has review-blocking issues. Before launching a pass on a **non-parked** PR, check three things
 and clear any that are dirty. Each fix changes PR content, so `reviews_ok` resets to 0 **and the status label is restored to
@@ -93,8 +94,6 @@ review gate"), and the review re-starts on the clean tip:
   conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,
   exactly as the step-6 reconcile does at its own (`stage-3-merge.md`), and it therefore **relabels in the
   same step** ("Status labels mirror the review gate", below).
-
-Only launch a review pass once all three are clear for the current tip.
 
 Run reviews **one at a time per PR** — never two at once for the same SHA. When a PR's tip
 (`head_sha`) has fewer than `required(tier)` SATISFIED verdicts (2a-triage owns the formula) and no review
@@ -424,7 +423,17 @@ late verdict from a stale/superseded attempt unless its attempt id still matches
 #### A finer liveness signal — the reviewer's OUTPUT STREAM
 
 **A finer liveness signal for a background-task reviewer whose stdout is captured INCREMENTALLY: its
-OUTPUT STREAM.** The meaningful-progress
+OUTPUT STREAM.** **The signal needs the stdout to
+be captured INCREMENTALLY**, so it applies only to a background-task reviewer whose stream grows as the
+model emits — the Claude-Code→codex route qualifies (codex streams its reasoning to the captured stdout).
+A reviewer whose output is BUFFERED until completion exposes no growing stream: `claude -p --output-format
+text` (the Codex→claude route) writes nothing until the end (realtime streaming needs `--output-format
+stream-json`), so a HEALTHY such reviewer's file stays unwritten and the probe reads a FALSE `quiet` — the
+driver MUST NOT rely on its `quiet` verdict for that route. A native-worker reviewer's transcript is not
+safely pollable either, so that route likewise keeps the progress-file-plus-completion model
+(`reviewer.md`, native-worker path).
+
+The meaningful-progress
 timer above is unit-granular — a `done` event fires only when a whole unit completes, minutes apart — so
 BETWEEN units a live reviewer grinding one unit and a hung one look identical until the ~15-min cap. A
 background-task reviewer whose stdout is captured as it is produced writes a stream that grows CONTINUOUSLY
@@ -442,15 +451,7 @@ healthy warming-up reviewer or pre-empt the launch-evidence recovery. **This is 
 meaningful progress** — exactly like the `started`/"still working"
 lines above, a growing stream **MUST NOT reset the meaningful-progress timer**: a reviewer that streams
 forever without completing a unit is still stalled at that cap. The stream signal makes a dead process
-caught sooner; it never extends patience for one that will not converge. **The signal needs the stdout to
-be captured INCREMENTALLY**, so it applies only to a background-task reviewer whose stream grows as the
-model emits — the Claude-Code→codex route qualifies (codex streams its reasoning to the captured stdout).
-A reviewer whose output is BUFFERED until completion exposes no growing stream: `claude -p --output-format
-text` (the Codex→claude route) writes nothing until the end (realtime streaming needs `--output-format
-stream-json`), so a HEALTHY such reviewer's file stays unwritten and the probe reads a FALSE `quiet` — the
-driver MUST NOT rely on its `quiet` verdict for that route. A native-worker reviewer's transcript is not
-safely pollable either, so that route likewise keeps the progress-file-plus-completion model
-(`reviewer.md`, native-worker path).
+caught sooner; it never extends patience for one that will not converge.
 
 ### What the review is MEASURED AGAINST — the PR's intent
 
@@ -677,29 +678,31 @@ Then, per verdict:
 
 #### NOT SATISFIED
 
-- **NOT SATISFIED** → the SHA's tally is void (`ledger.py verdict … --verdict not-satisfied` does it) **and,
-  in the same step, restore
-  `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** ("Status labels mirror the review gate",
-  below). This
-  applies the moment the verdict lands, *before* any fix is written: a PR whose latest verdict says
-  NOT SATISFIED must never still read `gauntlet-accepted` on GitHub. **Only GATING findings reach the fix
-  path at all** — a non-gating finding is recorded as a follow-up and no fix is dispatched for it (the
-  gating rule, above; `verify` has already refused the pass if a `not-satisfied` recorded none). **Then —
-  unless `verdict` just held the PR for repair, in which case NO fix is dispatched at all — dispatch a
-  context-isolated AUDIT SUBAGENT to AUDIT
-  the gating findings — see
-  `finding-audit.md`; NEVER dispatch a fix for an unaudited finding — and, for
-  its CONFIRMED/ADJUSTED verdicts,
-  dispatch a scoped fix subagent** into `<worktree>` (the PR row's ledger `worktree` column value) with
-  the **audited** issue list (**CONFIRMED + ADJUSTED only**); it
-  commits + pushes → HEAD advances (a second gate reset — relabel again if the first was somehow
-  skipped). A later heartbeat starts a fresh review on the new tip. (Because reviews are sequential, no
-  second review was spent on this broken commit.) Any **REFUTED** finding is **written into the tree** —
-  an inline comment at the site stating why the mechanism cannot occur — and committed like any other
-  change, so the next reviewer reads it and can flag it if it is wrong. That commit is PR content: it
-  resets the gate through the same rule.
+**NOT SATISFIED** → run this action sequence, in order:
 
-  **Run the review-fix in the `session` class — NEVER downgraded** (`SKILL.md`, "Worker Dispatch"). The one
+1. **Void the tally and restore the label in the same step.** The SHA's tally is void (`ledger.py verdict
+   … --verdict not-satisfied` does it) **and, in the same step, restore `gauntlet-reviewing` if the PR
+   carries `gauntlet-accepted`** ("Status labels mirror the review gate", below). This applies the moment
+   the verdict lands, *before* any fix is written: a PR whose latest verdict says NOT SATISFIED must never
+   still read `gauntlet-accepted` on GitHub.
+2. **Dispatch the context-isolated AUDIT subagent.** **Only GATING findings reach the fix path at all** —
+   a non-gating finding is recorded as a follow-up and no fix is dispatched for it (the gating rule, above;
+   `verify` has already refused the pass if a `not-satisfied` recorded none). Then — unless `verdict` just
+   held the PR for repair, in which case NO fix is dispatched at all — **dispatch a context-isolated AUDIT
+   SUBAGENT to AUDIT the gating findings** — see `finding-audit.md`; **NEVER dispatch a fix for an
+   unaudited finding**.
+3. **Dispatch the review-fix for CONFIRMED/ADJUSTED findings only.** For its CONFIRMED/ADJUSTED verdicts,
+   **dispatch a scoped fix subagent** into `<worktree>` (the PR row's ledger `worktree` column value) with
+   the **audited** issue list (**CONFIRMED + ADJUSTED only**); it commits + pushes → HEAD advances (a
+   second gate reset — relabel again if the first was somehow skipped). A later heartbeat starts a fresh
+   review on the new tip. (Because reviews are sequential, no second review was spent on this broken
+   commit.)
+4. **A REFUTED finding's reasoning goes into the tree.** Any **REFUTED** finding is **written into the
+   tree** — an inline comment at the site stating why the mechanism cannot occur — and committed like any
+   other change, so the next reviewer reads it and can flag it if it is wrong. That commit is PR content:
+   it resets the gate through the same rule.
+
+  **Why the session class:** **Run the review-fix in the `session` class — NEVER downgraded** (`SKILL.md`, "Worker Dispatch"). The one
   deliberate downgrade in this skill is the CI-fix subagent for a **formatting/lint** failure, which runs a
   formatter and verifies its diff (`stage-2-ci.md`); a review defect is **authored code**, and this subagent
   writes it from scratch. Its output is **code that gets merged**, and its only
@@ -707,6 +710,7 @@ Then, per verdict:
   weak fix produces a plausible-looking commit, the next pass returns `NOT SATISFIED`, the gate resets,
   and the whole diff is re-reviewed: the cheap wrong fix is paid for twice, and it is the expensive half
   that pays. Worst case the pass misses it and the defect merges.
+
   **Dispatch it under the fix-subagent contract** (`fix-subagent-contract.md` — the complete DEFINITION
   for every fix subagent, CI or review; **read it before dispatching**). The review-specific inputs it
   asks for are the worktree path and the concrete issue list (CONFIRMED + ADJUSTED only).
@@ -766,14 +770,7 @@ fresh review round starts — but it never blocks the current gate.
 2a-triage owns the formula and the file classes. A `NOT SATISFIED`, a `plan_amendment_request`, or a
 content change that adds a CODE/agent-doc/SENSITIVE file re-triages the PR upward (Stage 2a-triage),
 which can raise the target — so a PR can never merge on a single pass once its content stops being pure
-prose. For a two-pass gate the passes are
-not statistically or epistemically independent observations — they judge the same diff under the same
-review task and protocol (and, when both passes run the same reviewer, the same model and prompt), so
-their verdicts are correlated and this is not a probabilistic proof of correctness. What the second pass
-buys is a re-roll of a stochastic reviewer: a fresh execution, with none of the first pass's context
-to anchor it, that can catch a defect the first pass happened to miss — worth the spend for code and
-agent-facing instructions, where a surviving defect is expensive, but not for pure human prose, where
-one adversarial pass is proportionate. Record the reviewed SHA
+prose. Record the reviewed SHA
 (`git rev-parse HEAD`) with each pass. A verdict counts while its SHA equals the live tip. It also
 continues to count after `<base>` advances if the PR is still non-conflicting and the PR diff/content
 is unchanged (e.g. clean base-only rebase); carry `reviews_ok` forward to the new `head_sha`, set
@@ -784,6 +781,15 @@ drops to 0. Pinning to SHA plus the clean-base-only exception makes the gate ver
 not burning reviews merely because another PR merged cleanly. A `NOT SATISFIED` invalidates that
 content's tally even before a fix lands. The `required(tier)` SATISFIED verdicts and green CI must all
 describe the same live PR content; CI must still be green for the current HEAD SHA.
+
+For a two-pass gate the passes are
+not statistically or epistemically independent observations — they judge the same diff under the same
+review task and protocol (and, when both passes run the same reviewer, the same model and prompt), so
+their verdicts are correlated and this is not a probabilistic proof of correctness. What the second pass
+buys is a re-roll of a stochastic reviewer: a fresh execution, with none of the first pass's context
+to anchor it, that can catch a defect the first pass happened to miss — worth the spend for code and
+agent-facing instructions, where a surviving defect is expensive, but not for pure human prose, where
+one adversarial pass is proportionate.
 
 ### Status labels mirror the review gate — relabel is part of the reset, not a later chore
 

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -75,6 +75,8 @@ protection, or gives up, and answers. The record and the unpark are defined once
 (`status`) and `loop-control.md` step 3, "Only the user's answer unparks a PR"; never invent a second
 mechanism here.
 
+#### `BLOCKED` and `UNSTABLE` — what each merge state means
+
 **`BLOCKED` does NOT mean "a required check is missing or failing."** It means the merge is blocked **for
 any reason** — including a **draft** PR, or one **awaiting a human approving review**, or a ruleset
 campaign cannot read. Verified: `cli/cli` PR #13856 reads `BLOCKED` with `mergeable = MERGEABLE` **and a


### PR DESCRIPTION
- real headings + question-routers over the big refs; operative rule leads each block
- repeated in-file rationale trimmed to owner + pointer (audited); saturated sections de-bolded
- fixes: external argv owner corrected to `cross-agent-reviewers.md`; dup `verdict` synopsis line dropped
