### PR TITLE
run the cheap-fixer symlink preflight as a tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,17 @@ jobs:
       - name: Base-preflight contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/base-preflight.py self-test
 
+      # The format-preflight guard's contract, executed. It turns stage-2-ci.md's PREFLIGHT prose (the
+      # cheap CI-fixer must refuse to format a file whose write could land OUTSIDE the worktree — the file
+      # or any path component is a symlink) into a tested command, so the check no longer depends on a model
+      # hand-running `lstat` on every component. Its fixtures build REAL temp trees and drive the real walk:
+      # a symlinked file, a symlinked parent (shallow and deep), a missing file, a directory, absolute paths
+      # in and out of the worktree, and that a worktree behind a symlinked root is still allowed — each
+      # pinned with an `ok` counterpart so a constant verdict goes red. `py_compile` above only parses it;
+      # the sibling `format-preflight-test.py` is loaded by path and a MISSING sibling fails loudly.
+      - name: Format-preflight contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/format-preflight.py self-test
+
       # The merge-readiness decider's contract, executed. It is the ONE place the two GitHub merge enums
       # (`.mergeable`, `.mergeStateStatus`) are crossed with the ledger's preconditions to decide `merge`
       # vs `not-yet` — the miscross this replaces once turned a blocked merge into an infinite CI watch.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -231,6 +231,7 @@ a line the tool writes.
 | `emit-finding.py` | Reviewer's door: record one FINDING (the only sanctioned way; findings must anchor or they do not gate) | `references/stage-2-review-gate.md` |
 | `reviewer-liveness.py` | Probe whether a dispatched reviewer's output stream is still moving; decides nothing, always exits 0 | `references/stage-2-review-gate.md` |
 | `base-preflight.py` | Decide proceed / rebase-first / recheck from a PR's live merge-state before review or fix; performs no rebase | `references/stage-2-review-gate.md` |
+| `format-preflight.py` | `check` — refuse to format any file whose formatter-write could escape the worktree (the file, or any path component, is a symlink); reads only, formats nothing | `references/stage-2-ci.md` |
 | `ci-status.py` | `derive` — how `ci` is DERIVED, always, the only way — `liveness` — the recorder: writes `ci` + the liveness counters, parks at any cap — and `required-set` | `references/stage-2-ci.md` |
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/ci-derivation-spec.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -775,8 +775,10 @@ Its job, in order:
 
 1. **CLASSIFY** the failure from the check logs.
 2. **FIX IT.** For a formatting/lint failure, that is running the standard formatter for that language.
-   It **chooses the tool** — campaign does not hand it a command line — subject to the hard rules below,
-   and it **PREFLIGHTS every file** before formatting it (hard rules: symlink / symlinked parent).
+   It **chooses the tool** — campaign does not hand it a command line — subject to the hard rules below.
+   Before formatting, it **PREFLIGHTS every file** with the `format-preflight.py check` command (the
+   PREFLIGHT hard rule below owns the exact command line, its exit codes, and the "none left → ESCALATE"
+   rule) and formats **only** the files that come back `ok` — never a file the tool `refused`.
 3. **READ THE RESULTING DIFF.** This step is not optional and is not a formality. Verify **all** of:
    - the diff contains **ONLY** what the fix should have produced (a formatting fix produces formatting);
    - **no file it did not intend to touch** was touched;
@@ -807,12 +809,28 @@ Its job, in order:
   a repo-supplied `gofmt` is arbitrary code execution. Run tools from the **environment**, never from the
   tree.
 - **NEVER hand a tool a bare glob or a whole directory** (`gofmt -w .`). **Name the files you are fixing.**
-- **PREFLIGHT EVERY FILE BEFORE FORMATTING IT — refuse it if the write can land outside the worktree:**
-  - it **IS a symlink** (`lstat`, never `stat`);
-  - **ANY directory component of its path is a symlink**.
+- **PREFLIGHT EVERY FILE BEFORE FORMATTING IT — refuse any file whose write could land OUTSIDE the
+  worktree. Do NOT hand-run this with `lstat`; run the command** (resolved as
+  `<skill-dir>/scripts/format-preflight.py`, the same resolution rule as every other bundled script —
+  `SKILL.md`, "Bundled Scripts"):
 
-  Refuse = **do not format that file**; log it; carry on with the rest. If nothing is left to format,
-  **ESCALATE**.
+  ```
+  python3 <skill-dir>/scripts/format-preflight.py check --worktree <worktree> <files…>
+  ```
+
+  It prints one JSON object — a per-file `results` list, each `ok` or `refused` with a reason — and its
+  EXIT CODE is the signal: **`0`** every file is ok; **`3`** at least one is refused; **`2`** operator
+  error (no worktree / no files). **Format ONLY the files it returns `ok`; do NOT format any `refused`
+  one. If nothing is left to format (every file refused, or exit `2`), ESCALATE.**
+
+  **THE SPEC THE TOOL IMPLEMENTS — this is what the command enforces, not a second procedure to hand-run.**
+  A file is refused when its formatter-write could escape the worktree, decided per file in order:
+  - **ANY directory component of its path is a symlink** (`lstat`, never `stat`) — the write goes THROUGH
+    it — or a component is missing;
+  - the file itself **IS a symlink** (`lstat`, never `stat`), is missing, or is not a regular file.
+
+  (`realpath` is deliberately NOT the test — it collapses the very links the check exists to see; the tool
+  walks each component and `lstat`s it. A worktree that itself sits behind a symlink is allowed.)
 
   **THE PRINCIPLE — do not generalise it into anything more.** Diff review covers everything the tool
   writes **INSIDE** the repo: the model SEES it and escalates (an injected `-cpuprofile=prof.go` writes

--- a/plugins/gauntlet/skills/campaign/scripts/format-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/format-preflight-test.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Fixtures for `format-preflight.py` — the formatter-write-escape guard.
+
+They live in a SIBLING file, and `format-preflight.py self-test` FAILS LOUDLY if it cannot load them.
+
+Every fixture builds a REAL temp tree and drives the guard's real `os.lstat` walk — there is no mocking,
+because the whole point of the tool is what the filesystem actually reports about links and components.
+EACH FIXTURE PINS A RULE WITH TEETH: it asserts a refusal on one side of a boundary AND an `ok` on the
+other (a regular file where a symlink is refused, a real component where a symlinked one is refused), so a
+guard that returned a constant verdict would go red.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+OWNER = Path(__file__).resolve().parent / "format-preflight.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("format_preflight_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the format-preflight guard at {OWNER}")
+    return mod
+
+
+R = _load_owner()
+
+
+def check(cond, msg):
+    if not cond:
+        raise R.SelfTestFailure(msg)
+
+
+def _result_for(worktree: str, file_arg: str) -> dict:
+    """Drive the whole `run_check` path (worktree normalization included) and return the one result."""
+    payload, _code = R.run_check(worktree, [file_arg])
+    results = payload["results"]
+    check(len(results) == 1, f"expected exactly one result, got {results!r}")
+    return results[0]
+
+
+def _refused_reason(worktree: str, file_arg: str) -> str:
+    r = _result_for(worktree, file_arg)
+    check(r["status"] == "refused", f"{file_arg!r} must be refused, got {r!r}")
+    return r["reason"]
+
+
+# --- a plain regular file is OK ----------------------------------------------
+
+def t_regular_file_is_ok():
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "f.txt").write_text("x\n", encoding="utf-8")
+        r = _result_for(d, "f.txt")
+        check(r["status"] == "ok" and r["reason"] is None,
+              f"a plain regular file must read ok with no reason, got {r!r}")
+        payload, code = R.run_check(d, ["f.txt"])
+        check(code == R.EXIT_OK, f"an all-ok run must exit {R.EXIT_OK}, got {code}")
+        check(payload["counts"] == {"ok": 1, "refused": 0, "total": 1},
+              f"counts must tally one ok, got {payload['counts']!r}")
+
+
+# --- the file IS a symlink ----------------------------------------------------
+
+def t_file_that_is_a_symlink_is_refused():
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "real.txt").write_text("x\n", encoding="utf-8")
+        os.symlink("real.txt", str(Path(d) / "link.txt"))
+        check(_refused_reason(d, "link.txt") == "symlink",
+              "a file that IS a symlink must be refused 'symlink' (the formatter writes THROUGH it)")
+        # teeth: the real target it points at reads ok — the tool is not refusing everything.
+        check(_result_for(d, "real.txt")["status"] == "ok",
+              "the real file the link points at must read ok")
+
+
+# --- a symlinked PARENT directory --------------------------------------------
+
+def t_file_under_symlinked_dir_is_refused_naming_component():
+    with tempfile.TemporaryDirectory() as d:
+        os.mkdir(Path(d) / "realdir")
+        (Path(d) / "realdir" / "f.txt").write_text("x\n", encoding="utf-8")
+        os.symlink("realdir", str(Path(d) / "linkdir"))
+        check(_refused_reason(d, "linkdir/f.txt") == "symlink-parent:linkdir",
+              "a file under a symlinked dir must be refused 'symlink-parent:linkdir', naming the component")
+        # teeth: the same file via the REAL directory reads ok.
+        check(_result_for(d, "realdir/f.txt")["status"] == "ok",
+              "the same file reached through the real directory must read ok")
+
+
+def t_symlinked_component_deep_in_path():
+    # a/blink/c where blink is a symlink deep in the path — the walk must catch it AT that component.
+    with tempfile.TemporaryDirectory() as d:
+        os.makedirs(Path(d) / "a" / "realb")
+        (Path(d) / "a" / "realb" / "c").write_text("x\n", encoding="utf-8")
+        os.symlink("realb", str(Path(d) / "a" / "blink"))  # a/blink -> a/realb
+        check(_refused_reason(d, "a/blink/c") == "symlink-parent:blink",
+              "a symlinked component DEEP in the path must be refused 'symlink-parent:blink'")
+        # teeth: the real path a/realb/c reads ok — only the linked component is refused.
+        check(_result_for(d, "a/realb/c")["status"] == "ok",
+              "the deep file via its real components must read ok")
+
+
+# --- missing file, and a non-regular file ------------------------------------
+
+def t_missing_file_is_refused():
+    with tempfile.TemporaryDirectory() as d:
+        check(_refused_reason(d, "nope.txt") == "missing",
+              "a file that is not there must be refused 'missing'")
+
+
+def t_directory_passed_as_file_is_refused():
+    with tempfile.TemporaryDirectory() as d:
+        os.mkdir(Path(d) / "somedir")
+        check(_refused_reason(d, "somedir") == "not-a-regular-file",
+              "a directory handed in as a file must be refused 'not-a-regular-file'")
+
+
+# --- absolute paths: inside is OK, outside is refused ------------------------
+
+def t_absolute_path_inside_worktree_is_ok():
+    with tempfile.TemporaryDirectory() as d:
+        os.mkdir(Path(d) / "sub")
+        (Path(d) / "sub" / "f.txt").write_text("x\n", encoding="utf-8")
+        abs_inside = str(Path(d) / "sub" / "f.txt")
+        r = _result_for(d, abs_inside)
+        check(r["status"] == "ok", f"an absolute path INSIDE the worktree must read ok, got {r!r}")
+
+
+def t_absolute_path_outside_worktree_is_refused():
+    with tempfile.TemporaryDirectory() as d, tempfile.TemporaryDirectory() as other:
+        outside = Path(other) / "elsewhere.txt"
+        outside.write_text("x\n", encoding="utf-8")
+        check(_refused_reason(d, str(outside)) == "outside-worktree",
+              "an absolute path OUTSIDE the worktree must be refused 'outside-worktree'")
+        # teeth: a relative path that climbs out with `..` is the same refusal, from the same lexical test.
+        check(_refused_reason(d, "../climb-out.txt") == "outside-worktree",
+              "a relative path climbing out with `..` must be refused 'outside-worktree'")
+
+
+# --- operator errors: no files, and no worktree ------------------------------
+
+def t_zero_files_is_operator_error():
+    with tempfile.TemporaryDirectory() as d:
+        payload, code = R.run_check(d, [])
+        check(code == R.EXIT_OPERATOR, f"zero files must exit {R.EXIT_OPERATOR}, got {code}")
+        check("error" in payload and "nothing" in payload["error"],
+              f"a zero-file run must carry an explanatory error, got {payload!r}")
+
+
+def t_missing_worktree_refuses_whole_run():
+    with tempfile.TemporaryDirectory() as d:
+        gone = str(Path(d) / "no-such-worktree")
+        payload, code = R.run_check(gone, ["f.txt"])
+        check(code == R.EXIT_OPERATOR,
+              f"a worktree that is not a directory must exit {R.EXIT_OPERATOR}, got {code}")
+        check("error" in payload, "a missing worktree must return an error payload, inspecting no file")
+
+
+def t_file_passed_as_worktree_refuses_whole_run():
+    with tempfile.TemporaryDirectory() as d:
+        f = Path(d) / "not-a-dir"
+        f.write_text("x\n", encoding="utf-8")
+        payload, code = R.run_check(str(f), ["anything"])
+        check(code == R.EXIT_OPERATOR,
+              f"a regular file passed as the worktree must exit {R.EXIT_OPERATOR}, got {code}")
+        check("error" in payload, "a non-directory worktree must return an error payload, inspecting no file")
+
+
+# --- a worktree BEHIND a symlink is allowed (the docstring boundary) ----------
+
+def t_symlinked_worktree_root_is_allowed():
+    with tempfile.TemporaryDirectory() as d:
+        os.mkdir(Path(d) / "realwt")
+        (Path(d) / "realwt" / "f.txt").write_text("x\n", encoding="utf-8")
+        os.symlink("realwt", str(Path(d) / "wtlink"))
+        payload, code = R.run_check(str(Path(d) / "wtlink"), ["f.txt"])
+        check(code == R.EXIT_OK,
+              "a worktree reached through a symlinked root is allowed — its files must still preflight ok")
+        check(payload["results"][0]["status"] == "ok",
+              "a file directly under a symlinked worktree root must read ok, not symlink-parent")
+
+
+# --- a mixed list: per-file results, correct counts, exit 3 ------------------
+
+def t_mixed_list_reports_per_file_and_exits_refused():
+    with tempfile.TemporaryDirectory() as d:
+        (Path(d) / "good.txt").write_text("x\n", encoding="utf-8")
+        (Path(d) / "real.txt").write_text("x\n", encoding="utf-8")
+        os.symlink("real.txt", str(Path(d) / "badlink"))
+        payload, code = R.run_check(d, ["good.txt", "badlink", "missing.txt"])
+        check(code == R.EXIT_REFUSED, f"a list with any refusal must exit {R.EXIT_REFUSED}, got {code}")
+        check(payload["counts"] == {"ok": 1, "refused": 2, "total": 3},
+              f"counts must tally 1 ok / 2 refused / 3 total, got {payload['counts']!r}")
+        by_file = {r["file"]: r for r in payload["results"]}
+        check(by_file["good.txt"]["status"] == "ok", "good.txt must be ok")
+        check(by_file["badlink"]["reason"] == "symlink", "badlink must be refused 'symlink'")
+        check(by_file["missing.txt"]["reason"] == "missing", "missing.txt must be refused 'missing'")
+        # order is preserved: results follow the argument order the worker passed.
+        check([r["file"] for r in payload["results"]] == ["good.txt", "badlink", "missing.txt"],
+              "results must preserve the input file order")
+
+
+CASES = [
+    ("regular-ok", "a plain regular file reads ok", t_regular_file_is_ok),
+    ("file-is-symlink", "a file that is a symlink is refused 'symlink'", t_file_that_is_a_symlink_is_refused),
+    ("symlinked-parent", "a symlinked parent dir refuses, naming the component",
+     t_file_under_symlinked_dir_is_refused_naming_component),
+    ("symlinked-deep", "a symlinked component deep in the path is caught", t_symlinked_component_deep_in_path),
+    ("missing-file", "a missing file is refused 'missing'", t_missing_file_is_refused),
+    ("dir-as-file", "a directory handed in as a file is refused", t_directory_passed_as_file_is_refused),
+    ("abs-inside-ok", "an absolute path inside the worktree reads ok", t_absolute_path_inside_worktree_is_ok),
+    ("abs-outside-refused", "an absolute (or `..`) path outside the worktree is refused",
+     t_absolute_path_outside_worktree_is_refused),
+    ("zero-files-operator", "zero files is operator error (exit 2)", t_zero_files_is_operator_error),
+    ("missing-worktree", "a missing worktree refuses the whole run (exit 2)", t_missing_worktree_refuses_whole_run),
+    ("file-as-worktree", "a file passed as the worktree refuses the whole run", t_file_passed_as_worktree_refuses_whole_run),
+    ("symlinked-worktree-ok", "a worktree behind a symlink is allowed", t_symlinked_worktree_root_is_allowed),
+    ("mixed-list", "a mixed list reports per-file and exits 3 with correct counts",
+     t_mixed_list_reports_per_file_and_exits_refused),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/format-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/format-preflight.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Refuse to format a file whose write could land OUTSIDE the worktree.
+
+The cheap CI-fix subagent runs a formatter (`gofmt -w`, …) that writes bytes back through the path it is
+given. A formatter writes THROUGH a symlink: point one at a file elsewhere on the machine and the bytes
+land there, while `git diff` inside the worktree shows NOTHING — the one write the diff-reading model
+cannot see. `stage-2-ci.md` ("The cheap CI-fix subagent", the PREFLIGHT hard rule) states the guard in
+prose a worker executed by hand with `lstat`; this turns that prose into a COMMAND, so the check does not
+depend on a model remembering to `lstat` every component.
+
+A file is REFUSED when its write could escape the worktree, decided in order:
+  (a) the worktree must exist and be a directory, or the whole run is refused (operator error);
+  (b) EVERY directory component from the worktree root down to the file's parent is checked: a component
+      that is a symlink refuses the file (the formatter would write THROUGH it); a component that does not
+      exist refuses it (a file that is not there is not a file you format);
+  (c) the file itself: a missing file, a symlink, or anything that is not a regular file (a directory,
+      fifo, socket, device) is refused.
+
+WHY `os.lstat`, NEVER `stat`, and NEVER `realpath` as the primary test: `stat` FOLLOWS symlinks, so it
+reports the target and hides the very link the check exists to see; `os.path.realpath` collapses the whole
+chain of links before we can look at any single component, so it ERASES the escape instead of catching it.
+The check therefore walks the path one component at a time and `lstat`s each, so a symlink is seen AS a
+symlink. The under-worktree test is likewise LEXICAL (compare normalized paths, no `realpath`) for the same
+reason: resolving the path would follow the links we are trying to detect.
+
+THE WORKTREE MAY ITSELF LIVE BEHIND A SYMLINK, and that is allowed — worktrees legitimately sit under a
+symlinked home. So the worktree path is NOT resolved through `realpath`; every component is compared
+RELATIVE to the worktree, and only the components BELOW the worktree are what the walk inspects. A
+symlinked worktree root is fine; a symlinked component inside it is not.
+
+FOOTGUN GUARD, NOT A SECURITY BOUNDARY. This stops a real accident — a vendored symlink walking the
+formatter out of the tree to leave a confusing dirty file in another project. It is NOT a defence against
+a malicious committer (campaign adopts same-repo PRs only; whoever commits a symlink already has write
+access). `stage-2-ci.md`, "THE PRINCIPLE" / "STATE IT HONESTLY", owns that framing; do not generalise this
+tool into anything more.
+
+The tool only READS (`os.lstat`, `os.path`): it never writes, never formats, never follows a link.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "format-preflight-test.py"     # the fixture suite — this tool's executable contract
+
+# Exit codes are the worker's signal, and each is distinct:
+#   0  every named file is OK to format.
+#   3  at least one file is refused — format ONLY the `ok` list; if none are ok, ESCALATE (stage-2-ci.md).
+#   2  operator error (no worktree / not a directory / no files) — the caller passed something unusable.
+EXIT_OK = 0
+EXIT_OPERATOR = 2
+EXIT_REFUSED = 3
+
+
+def _ok(file_arg: str) -> dict:
+    return {"file": file_arg, "status": "ok", "reason": None}
+
+
+def _refused(file_arg: str, reason: str) -> dict:
+    return {"file": file_arg, "status": "refused", "reason": reason}
+
+
+def _normalize(worktree_abs: str, file_arg: str) -> "tuple[str, list[str] | None, str | None]":
+    """Resolve `file_arg` against the worktree LEXICALLY and return `(file_abs, parts, error)`.
+
+    PURE — no filesystem access. `error` is `"outside-worktree"` when the path (an absolute one, or a
+    relative one that climbs out with `..`) does not sit under the worktree; then `parts` is `None`.
+    Otherwise `parts` is the path components BELOW the worktree, in order, with `.`/empty segments dropped
+    (`[]` when `file_arg` names the worktree itself). Normalization is lexical on purpose — `realpath`
+    would collapse the symlinks the walk exists to catch (see the module docstring).
+    """
+    if os.path.isabs(file_arg):
+        file_abs = os.path.normpath(file_arg)
+    else:
+        file_abs = os.path.normpath(os.path.join(worktree_abs, file_arg))
+    rel = os.path.relpath(file_abs, worktree_abs)
+    # `..` (exactly, or as the first segment) is the only way a lexical relpath climbs above the base; an
+    # absolute path elsewhere yields one too. Either way the write would land outside the worktree.
+    if rel == os.pardir or rel.startswith(os.pardir + os.sep):
+        return (file_abs, None, "outside-worktree")
+    parts = [p for p in rel.split(os.sep) if p not in ("", os.curdir)]
+    return (file_abs, parts, None)
+
+
+def check_file(worktree_abs: str, file_arg: str) -> dict:
+    """Preflight ONE file under an already-normalized worktree. Returns a result dict; reads only.
+
+    `worktree_abs` must be an absolute, normalized directory path (see `run_check`). The walk `lstat`s each
+    component shallow-to-deep and RETURNS on the first refusal, so it never `lstat`s THROUGH a symlink it
+    has already flagged.
+    """
+    _file_abs, parts, err = _normalize(worktree_abs, file_arg)
+    if err is not None:
+        return _refused(file_arg, err)
+    assert parts is not None
+
+    # (b) Every directory component from the worktree root down to the file's PARENT (parts[:-1]).
+    for i in range(len(parts) - 1):
+        comp = parts[i]
+        comp_path = os.path.join(worktree_abs, *parts[: i + 1])
+        try:
+            st = os.lstat(comp_path)
+        except (FileNotFoundError, NotADirectoryError):
+            # Missing, or a non-directory earlier in the chain makes this component unreachable — either
+            # way the file is not there to format.
+            return _refused(file_arg, f"missing:{comp}")
+        if stat.S_ISLNK(st.st_mode):
+            return _refused(file_arg, f"symlink-parent:{comp}")
+
+    # (c) The file itself (or the worktree root when `parts` is empty — a directory, caught below).
+    target = os.path.join(worktree_abs, *parts) if parts else worktree_abs
+    try:
+        st = os.lstat(target)
+    except (FileNotFoundError, NotADirectoryError):
+        return _refused(file_arg, "missing")
+    if stat.S_ISLNK(st.st_mode):
+        return _refused(file_arg, "symlink")
+    if not stat.S_ISREG(st.st_mode):
+        return _refused(file_arg, "not-a-regular-file")
+    return _ok(file_arg)
+
+
+def run_check(worktree: str, files: "list[str]") -> "tuple[dict, int]":
+    """Preflight every file. Returns `(payload, exit_code)`; performs only reads.
+
+    Operator errors (exit 2) — a worktree that is not a directory, or an empty file list — return an
+    `{"error": ...}` payload and never inspect a file. Otherwise the payload carries `worktree`, the
+    per-file `results`, and `counts`; exit 0 iff every file is ok, else exit 3.
+    """
+    worktree_abs = os.path.abspath(worktree)
+    # `isdir` FOLLOWS symlinks by design: a worktree behind a symlinked home is legitimate and allowed.
+    if not os.path.isdir(worktree_abs):
+        return ({"error": f"worktree is not a directory: {worktree}", "worktree": worktree_abs},
+                EXIT_OPERATOR)
+    if not files:
+        return ({"error": "a preflight of nothing checks nothing", "worktree": worktree_abs},
+                EXIT_OPERATOR)
+
+    results = [check_file(worktree_abs, f) for f in files]
+    n_ok = sum(1 for r in results if r["status"] == "ok")
+    n_refused = len(results) - n_ok
+    payload = {
+        "worktree": worktree_abs,
+        "results": results,
+        "counts": {"ok": n_ok, "refused": n_refused, "total": len(results)},
+    }
+    return (payload, EXIT_OK if n_refused == 0 else EXIT_REFUSED)
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("check", help="refuse any file whose formatter-write could escape the worktree")
+    c.add_argument("--worktree", required=True, help="the worktree the writes must stay inside")
+    # nargs='*' (not '+') so that ZERO files is OUR operator error with a message, not argparse's bare exit.
+    c.add_argument("files", nargs="*", help="files to preflight (relative to --worktree, or absolute)")
+
+    sub.add_parser("self-test", help="run every fixture (format-preflight-test.py)")
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "self-test":
+        return self_test()
+    payload, code = run_check(args.worktree, args.files)
+    print(json.dumps(payload))
+    return code
+
+
+# --- self-test: the executable contract lives in the SIBLING module ------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise SelfTestFailure(msg)
+
+
+def sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
+            f"health. Every rule this file enforces is now unpinned.")
+    mod = load_module_from_path("format_preflight_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':32} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the format-preflight guard's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:32} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:32} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:32} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the format-preflight guard's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the format-preflight guard's contract is intact.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
- `format-preflight.py check` encodes the PREFLIGHT prompt rule; workers format only `ok` files
- 13 fixtures on real temp trees; prompt block carries the command and stays self-contained
