### PR TITLE
mirror the review gate onto status labels via tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,16 @@ jobs:
       - name: Merge-check contract (the code-owned mapping, pinned by fixtures)
         run: python3 plugins/gauntlet/skills/campaign/scripts/merge-check.py self-test
 
+      # The status-label reconciler's contract, executed. This tool is the ONE way the gate's label swap
+      # (`gauntlet-accepted` <-> `gauntlet-reviewing`) is applied, so no driver hand-runs `gh pr edit` at
+      # the N gate-reset sites and misses it at one. `self-test` runs the sibling FIXTURES
+      # (`label-mirror-test.py`, loaded by path; a MISSING sibling fails loudly), which drive the real
+      # `mirror()` over a fake `gh` seam and pin: the exact swap argv, a no-op when the label is already
+      # right, a terminal row skipped with NO gh call, an unset tier and a missing row refused (exit 2),
+      # and a gh view/edit failure failing closed (exit 1). It touches only the two status labels.
+      - name: Label-mirror contract (the gate and its label move together)
+        run: python3 plugins/gauntlet/skills/campaign/scripts/label-mirror.py self-test
+
       # The Bundled Scripts table in campaign's SKILL.md declares itself COMPLETE: one row per bundled
       # script. A completeness claim with no check goes stale the first time a script lands without a
       # row — six scripts had already done exactly that before the table existed. This executes the

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -236,6 +236,7 @@ a line the tool writes.
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/ci-derivation-spec.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |
 | `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row + live PR view, crossing the ledger preconditions and both GitHub merge enums in one place | `references/stage-3-merge.md` |
+| `label-mirror.py` | `mirror` — reconcile a PR's status label with its review gate (the canonical idempotent `gauntlet-accepted`/`gauntlet-reviewing` swap), computed from the ledger row; touches only the two status labels | `references/stage-2-review-gate.md` |
 | `repair-pass.py` | Reassessment pass's door: `permitted` / `decide` — the closed decision enum, ownership guardrail, repair cap | `references/repair-pass.md` |
 | `followups.py` | Schema-owning accessor for the follow-up store (`.gauntlet/followups.jsonl`) — a durable work QUEUE, not an archive: entries are deleted once recorded elsewhere, kept when nothing else would remember | `references/followups.md` |
 | `nudge.py` | Advisory reminder printer for heartbeat start; always exits 0 | its own module docstring |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -159,7 +159,8 @@
   sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a gauntlet it did not. So the
   **gate and the label move together, in the same step**: every action that drops `reviews_ok` to 0 (a
   `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a conflict-resolving rebase, any other
-  content change on the head branch) MUST also restore `gauntlet-reviewing` on a PR carrying
+  content change on the head branch) MUST also reconcile the label by running `label-mirror.py mirror`
+  for the PR — the ONE way that swap is applied — which restores `gauntlet-reviewing` on a PR carrying
   `gauntlet-accepted`. Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
@@ -394,7 +395,8 @@
   failure.
 - **ANY campaign commit to the PR head resets the gate** (`stage-2-ci.md`, "Any campaign commit to the PR
   head resets the gate") — economy-class CI-fix, `session`-class CI-fix, review-fix, or **refutation commit** alike. In the SAME step: reset
-  `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`; the new commit
+  `reviews_ok` to 0 AND reconcile the label by running `label-mirror.py mirror` for the PR (it restores
+  `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`); the new commit
   moves `head_sha`, so writing it through the accessor **resets the liveness counters** at the door
   (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); re-derive CI
   for the new tip and watch it **only if `liveness` reports `watch_warranted`** (`stage-2-ci.md`, "WATCH

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -39,8 +39,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      **This refresh is itself a gate-reset site — relabel here, in this step.** When it detects that a
      PR's live `head_sha` has moved with the PR diff changed (a formatter/bot commit, a manual push,
      any content change this run did not dispatch), it resets `reviews_ok` to 0 — and MUST, in the same
-     step, relabel a PR carrying `gauntlet-accepted` back to `gauntlet-reviewing`
-     (`stage-2-review-gate.md`, "Status labels mirror the review gate").
+     step, reconcile the label by running `label-mirror.py mirror` for that PR, which restores
+     `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`
+     (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool).
      Do NOT defer this to the label-reconcile pass below — that pass is only the **backstop** ("This
      reconcile is a backstop, not the mechanism", below). (A clean base-only advance with the PR
      diff unchanged does not reset the gate, so it keeps `gauntlet-accepted`.)
@@ -126,14 +127,17 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    **Reconcile labels too** (idempotent, retroactive, **scoped to this run**). Ensure the labels exist
    (`gh label create … --force`, including this run's `gauntlet-run-<run-id>`), then for every PR **of
    this run** (its `gauntlet-run-<run-id>` label — the only ownership marker for adopted PRs): ensure
-   it carries `gauntlet-run-<run-id>`, and **overwrite** its status label to match its **live** gate
-   state. **Never touch another run's PRs.**
+   it carries `gauntlet-run-<run-id>`, and **reconcile its status label by running `label-mirror.py
+   mirror` for it** — the tool overwrites the status label to match the PR's **live** gate state. (The
+   `gauntlet-run-<run-id>` ownership label is adoption's, and the tool never touches it — ensure it
+   separately, as above.) **Never touch another run's PRs.**
 
-   **Always apply one status label AND remove the other — never merely add.** The two status labels are
-   mutually exclusive, so a purely additive reconcile cannot repair the one state it most needs to: a
+   **The tool applies one status label AND removes the other — never merely add.** The two status labels
+   are mutually exclusive, so a purely additive reconcile cannot repair the one state it most needs to: a
    PR wearing **both** labels (what a missed swap at a reset site actually produces) would keep the
-   contradictory label forever, because adding a label it already carries changes nothing. Write it
-   unconditionally, in one call per PR, so the outcome does not depend on which labels are already there:
+   contradictory label forever, because adding a label it already carries changes nothing. The swap it
+   applies — shown as the SPEC it implements, one call per PR, direction picked from the live gate, NOT a
+   command to paste by hand:
 
    ```
    # current HEAD holds required(tier) SATISFIED verdicts:

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -163,10 +163,12 @@ For each `#PR` to adopt:
    - **On a REFRESH of an existing row, only re-read `head_sha`/`ci` from ground truth; reset
      `reviews_ok` to `0` and re-triage `tier` only if** reconciliation detects a PR-content change
      since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
-     site: in the same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`**
-     (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Step 4's `--add-label
-     gauntlet-reviewing` alone is NOT sufficient: it would leave the stale `gauntlet-accepted` in
-     place, so the PR would carry **both** status labels and still publicly claim it passed.
+     site: in the same step, reconcile the label by running `label-mirror.py mirror` for the PR**, which
+     restores `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`
+     (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool). A
+     bare `--add-label gauntlet-reviewing` is NOT sufficient: it would leave the stale `gauntlet-accepted`
+     in place, so the PR would carry **both** status labels and still publicly claim it passed — the tool
+     removes the other label in the same call.
 
      **PRESERVE EVERY FIELD THIS STEP DOES NOT EXPLICITLY RECOMPUTE.**
      That is a **property, not a list** — and deliberately so, because the list that stood here was one:
@@ -288,6 +290,11 @@ For each `#PR` to adopt:
 4. **Label it ours, and set the status label from the LIVE gate.** Add this run's owner label, then
    apply the status label that matches the PR's gate state **as it stands after step 3** — never a
    hardcoded `gauntlet-reviewing`.
+
+   **This ADOPTION-time labeling stays a raw `gh pr edit`, NOT `label-mirror.py mirror`** — because the
+   same call also adds this run's `gauntlet-run-<run-id>` ownership label, which is out of the tool's
+   scope (the tool touches only the two status labels). Once the row is adopted, every LATER status-label
+   reconcile is the tool's job ("Status labels mirror the review gate").
 
    **The status labels are mutually exclusive** — a PR carries exactly one — so whichever you apply,
    remove the other in the same call. Which one you apply is decided by the live gate, not by the fact

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -761,9 +761,10 @@ it: an economy-class CI-fix worker, a `session`-class CI-fix worker, a review-fi
 REFUTATION of a review finding (`finding-audit.md`, "Audit every finding before you fix it").**
 Every one of them MUST, in the same step:
 
-- **reset `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** —
-  the gate and its label move together, never one without the other (`stage-2-review-gate.md`, "Status
-  labels mirror the review gate");
+- **reset `reviews_ok` to 0 AND reconcile the label by running `label-mirror.py mirror` for the PR** (it
+  restores `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`) — the gate and its label move
+  together, never one without the other (`stage-2-review-gate.md`, "Status labels mirror the review
+  gate", owns the swap and the tool);
 - **re-derive `ci` from a fresh snapshot for the NEW `head_sha`, and launch a watch if — and only if —
   `liveness` then reports `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE" above). Writing the new
   `head_sha` through the accessor **resets the liveness counters** at the door ("THE LIVENESS COUNTERS"

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -679,10 +679,11 @@ Then, per verdict:
 **NOT SATISFIED** → run this action sequence, in order:
 
 1. **Void the tally and restore the label in the same step.** The SHA's tally is void (`ledger.py verdict
-   … --verdict not-satisfied` does it) **and, in the same step, restore `gauntlet-reviewing` if the PR
-   carries `gauntlet-accepted`** ("Status labels mirror the review gate", below). This applies the moment
-   the verdict lands, *before* any fix is written: a PR whose latest verdict says NOT SATISFIED must never
-   still read `gauntlet-accepted` on GitHub.
+   … --verdict not-satisfied` does it) **and, in the same step, reconcile the label by running
+   `label-mirror.py mirror` for this PR** — it restores `gauntlet-reviewing` on a PR carrying
+   `gauntlet-accepted` ("Status labels mirror the review gate", below, owns the swap and the tool). This
+   applies the moment the verdict lands, *before* any fix is written: a PR whose latest verdict says NOT
+   SATISFIED must never still read `gauntlet-accepted` on GitHub.
 2. **Dispatch the context-isolated AUDIT subagent.** **Only GATING findings reach the fix path at all** —
    a non-gating finding is recorded as a follow-up and no fix is dispatched for it (the gating rule, above;
    `verify` has already refused the pass if a `not-satisfied` recorded none). Then — unless `verdict` just
@@ -728,7 +729,9 @@ Then, per verdict:
   (2a-triage owns the formula). If the tally is still short of the target — e.g. the **first** SATISFIED on a
   `required==2` PR — the next heartbeat launches the next (corroborating) review on the same SHA. When the
   tally **reaches** `required(tier)` on the same SHA, the review gate is met for this HEAD — swap the
-  PR's label: `gh pr edit <pr> --remove-label gauntlet-reviewing --add-label gauntlet-accepted`.
+  PR's label by running `label-mirror.py mirror` for it ("Status labels mirror the review gate", below,
+  owns the swap; it applies `--add-label gauntlet-accepted --remove-label gauntlet-reviewing` from the
+  live gate).
 
 The audit contract — verdicts, reachability test, refutation handling, termination — is `finding-audit.md`; a reviewer's finding is a CLAIM, and no fix is dispatched for an unaudited finding.
 
@@ -797,7 +800,20 @@ is only ever as true as the moment it was last written.
 
 **THE RULE — the gate and the label move together, in the same step.** Any action that takes
 `reviews_ok` to `0` (or otherwise voids the tally) MUST, in that same step, restore
-`gauntlet-reviewing` on a PR that currently carries `gauntlet-accepted`:
+`gauntlet-reviewing` on a PR that currently carries `gauntlet-accepted` — and, symmetrically, an action
+that brings the tally UP to `required(tier)` swaps it to `gauntlet-accepted`.
+
+**`label-mirror.py mirror` is THE way that swap is applied — never a hand-run `gh pr edit`.** It reads the
+PR's ledger row, computes the desired label from `reviews_ok` and `required(tier)` exactly as the gate
+does, and applies the canonical idempotent swap only if the label is not already right (a terminal row is
+skipped; a tier nobody set is refused). Run it in the same step as the reset, once per PR:
+
+```
+python3 <skill-dir>/scripts/label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name
+```
+
+The swap it applies — shown as the SPEC it implements, NOT a command to paste by hand (the tool picks the
+direction from the live gate; here is the reviewing-restoring one):
 
 ```
 gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -217,8 +217,10 @@ subagent at a check that is merely **still running**.
      either, which right after a push is the common case (no check has registered yet). CI must return
      green before merging.
    - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0 AND, in that
-     same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** — the gate and its
-     label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Update
+     same step, reconcile the label by running `label-mirror.py mirror` for the PR** (it restores
+     `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`) — the gate and its
+     label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap
+     and the tool). Update
      `head_sha` to the
      new tip through the accessor, which **resets the liveness counters** (a new head is new evidence — `stage-2-ci.md`, "THE
      LIVENESS COUNTERS"; the clean-rebase branch above does the same, and this branch is no different in

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Fixtures for `label-mirror.py` — the status-label reconciler.
+
+They live in a SIBLING file, and `label-mirror.py self-test` FAILS LOUDLY if it cannot load them.
+
+EVERY FIXTURE HAS TEETH. Each drives the REAL `mirror()` over a temp ledger (built through the ledger
+accessor) and a FAKE `gh` seam (recorded responses, no network), and asserts the JSON FIELDS — not just the
+exit code. The swap case pins the EXACT argv, because the argv is what actually moves the label; the
+terminal and refusal cases assert the fake was NEVER called, because "makes no GitHub call" is the whole
+promise there.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+OWNER = Path(__file__).resolve().parent / "label-mirror.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("label_mirror_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the label-mirror at {OWNER}")
+    return mod
+
+
+M = _load_owner()
+L = M.L
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise M.SelfTestFailure(msg)
+
+
+class FakeGh:
+    """A recorded `gh` runner. Answers `pr view` and `pr edit` from canned responses, records every argv,
+    and REFUSES any other command — a fixture that reaches an unexpected `gh` call is a fixture testing
+    something it did not mean to."""
+
+    def __init__(self, *, view=None, edit=(0, "", "")) -> None:
+        self.view = view          # (returncode, stdout, stderr) for `gh pr view`, or None to refuse it
+        self.edit = edit          # (returncode, stdout, stderr) for `gh pr edit`
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str]) -> "subprocess.CompletedProcess[str]":
+        self.calls.append(argv)
+        if argv[:3] == ["gh", "pr", "view"]:
+            resp = self.view
+        elif argv[:3] == ["gh", "pr", "edit"]:
+            resp = self.edit
+        else:
+            raise AssertionError(f"unexpected gh call: {argv}")
+        if resp is None:
+            raise AssertionError(f"gh call not expected in this fixture: {argv}")
+        rc, out, err = resp
+        return subprocess.CompletedProcess(argv, rc, out, err)
+
+    @property
+    def edited(self) -> bool:
+        return any(a[:3] == ["gh", "pr", "edit"] for a in self.calls)
+
+
+def view_with(*labels: str) -> tuple:
+    """A successful `gh pr view --json labels` response carrying exactly these label names."""
+    return (0, json.dumps({"labels": [{"name": n} for n in labels]}), "")
+
+
+def build_ledger(d: Path, *, status="in_review", tier="STANDARD", reviews_ok="0", pr="9") -> Path:
+    led = d / "state.jsonl"
+    header = dict(L.HEADER_DEFAULTS)
+    header["run_id"] = "g1"
+    row = dict(L.ROW_DEFAULTS)
+    row.update(pr=pr, status=status, tier=tier, reviews_ok=reviews_ok)
+    L.dump(led, header, [row])
+    return led
+
+
+def drive(led: Path, pr: str, repo: str, fake: FakeGh, *, dry_run=False) -> tuple:
+    """Run the REAL `mirror()` with the fake seam; return (exit_code, parsed_stdout_or_None, stderr)."""
+    out, err = StringIO(), StringIO()
+    try:
+        with redirect_stdout(out), redirect_stderr(err):
+            code = M.mirror(led, pr, repo, dry_run=dry_run, run=fake)
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+    text = out.getvalue().strip()
+    parsed = json.loads(text) if text else None
+    return code, parsed, err.getvalue()
+
+
+REPO = "o/n"
+SWAP_TO_ACCEPTED = ["gh", "pr", "edit", "9", "--repo", REPO,
+                    "--add-label", "gauntlet-accepted", "--remove-label", "gauntlet-reviewing"]
+
+
+# --- the swap is applied, with the EXACT argv ---------------------------------
+
+def t_reviewing_to_accepted_swaps():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")   # 2/2 -> accepted
+        fake = FakeGh(view=view_with("gauntlet-reviewing", "gauntlet-run-g1"))
+        code, out, _err = drive(led, "9", REPO, fake)
+    check(code == 0, f"a met gate must reconcile and exit 0, got {code}")
+    check(out is not None and out["changed"] is True, f"a reviewing->accepted swap must report changed, got {out!r}")
+    check(out["desired"] == "gauntlet-accepted", f"desired must be accepted, got {out!r}")
+    check(out["required"] == 2 and out["reviews_ok"] == 2, f"tier/tally must be reported, got {out!r}")
+    check(out["current"] == ["gauntlet-reviewing", "gauntlet-run-g1"], f"current labels must be reported, got {out!r}")
+    check(out["argv"] == SWAP_TO_ACCEPTED, f"the argv must be the canonical idempotent swap, got {out.get('argv')!r}")
+    check(fake.edited, "the swap must actually call `gh pr edit`")
+
+
+# --- already right: no swap, no edit call -------------------------------------
+
+def t_accepted_stays():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
+        fake = FakeGh(view=view_with("gauntlet-accepted"), edit=None)  # edit=None => any edit is a failure
+        code, out, _err = drive(led, "9", REPO, fake)
+    check(code == 0, f"an already-accepted PR reconciles to a no-op, got {code}")
+    check(out["changed"] is False, f"no swap is needed, got {out!r}")
+    check("argv" not in out, f"a no-op reconcile prints no argv, got {out!r}")
+    check(not fake.edited, "an already-right label must trigger NO `gh pr edit`")
+
+
+def t_reviewing_stays():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="1")   # 1/2 -> reviewing
+        fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=None)
+        code, out, _err = drive(led, "9", REPO, fake)
+    check(code == 0, f"a short gate already reviewing is a no-op, got {code}")
+    check(out["desired"] == "gauntlet-reviewing" and out["changed"] is False, f"expected reviewing no-op, got {out!r}")
+    check(not fake.edited, "an already-reviewing label must trigger NO edit")
+
+
+# --- refusals: a missing row and an unset tier, both before any gh call -------
+
+def t_missing_row_refused():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), pr="9")            # holds pr 9
+        fake = FakeGh(view=None, edit=None)            # any gh call is a failure
+        code, out, err = drive(led, "42", REPO, fake)  # ask for pr 42
+    check(code == 2, f"a missing row must refuse loudly (exit 2), got {code}")
+    check(out is None and "no ledger row for pr 42" in err, f"the refusal must name the missing row, got {err!r}")
+    check(fake.calls == [], "a missing row must be refused BEFORE any gh call")
+
+
+def t_unset_tier_refused():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="-", reviews_ok="2")   # tier nobody set
+        fake = FakeGh(view=None, edit=None)
+        code, out, err = drive(led, "9", REPO, fake)
+    check(code == 2, f"a tier nobody set must refuse loudly (exit 2), got {code}")
+    check(out is None and "tier is '-'" in err, f"the refusal must name the unset tier, got {err!r}")
+    check(fake.calls == [], "an unset tier must be refused BEFORE any gh call")
+
+
+# --- terminal rows are skipped with NO gh call at all -------------------------
+
+def t_terminal_skipped_no_gh():
+    for status in ("merged", "aborted"):
+        with tempfile.TemporaryDirectory() as d:
+            led = build_ledger(Path(d), status=status, tier="STANDARD", reviews_ok="2")
+            fake = FakeGh(view=None, edit=None)   # ANY gh call fails the fixture
+            code, out, _err = drive(led, "9", REPO, fake)
+        check(code == 0, f"a {status} row is skipped, exit 0, got {code}")
+        check(out == {"pr": "9", "skipped": "terminal"}, f"a {status} row prints the terminal skip, got {out!r}")
+        check(fake.calls == [], f"a {status} row must make NO gh call at all")
+
+
+# --- a gh view failure fails closed to exit 1 ---------------------------------
+
+def t_gh_view_failure_exit_1():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
+        fake = FakeGh(view=(1, "", "gh: could not resolve to a PullRequest"), edit=None)
+        code, out, err = drive(led, "9", REPO, fake)
+    check(code == 1, f"a failed `gh pr view` must fail closed (exit 1), got {code}")
+    check(out is None, "a failed view prints no verdict JSON")
+    check("exited 1" in err and "could not resolve" in err, f"the stderr must show the gh failure, got {err!r}")
+    check(not fake.edited, "a failed view must never reach the edit")
+
+
+# --- a gh edit failure fails closed to exit 1 ---------------------------------
+
+def t_gh_edit_failure_exit_1():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
+        fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=(1, "", "gh: label not found"))
+        code, out, err = drive(led, "9", REPO, fake)
+    check(code == 1, f"a failed `gh pr edit` must fail closed (exit 1), got {code}")
+    check(out is None, "a failed edit prints no success JSON — the swap did not land")
+    check("exited 1" in err and "label not found" in err, f"the stderr must show the gh failure, got {err!r}")
+    check(fake.edited, "the edit WAS attempted (that is what failed)")
+
+
+# --- dry-run computes the swap but applies nothing ----------------------------
+
+def t_dry_run_no_edit():
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
+        fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=None)  # any edit fails the fixture
+        code, out, _err = drive(led, "9", REPO, fake, dry_run=True)
+    check(code == 0, f"a dry-run exits 0, got {code}")
+    check(out["changed"] is True and out["argv"] == SWAP_TO_ACCEPTED,
+          f"a dry-run must show the swap it WOULD apply, got {out!r}")
+    check(not fake.edited, "a dry-run must apply NOTHING — no `gh pr edit`")
+
+
+# --- the required(tier) boundary, exactly, for TRIVIAL(1) and STANDARD(2) -----
+
+def t_required_boundary():
+    # (tier, reviews_ok, expected desired) — each straddles required(tier) by exactly one.
+    for tier, ok, desired in [
+        ("TRIVIAL", "1", "gauntlet-accepted"),    # 1/1 meets the floor
+        ("TRIVIAL", "0", "gauntlet-reviewing"),   # 0/1 short
+        ("STANDARD", "2", "gauntlet-accepted"),   # 2/2 meets the floor
+        ("STANDARD", "1", "gauntlet-reviewing"),  # 1/2 short
+        ("HIGH", "2", "gauntlet-accepted"),       # HIGH needs 2, like STANDARD
+    ]:
+        with tempfile.TemporaryDirectory() as d:
+            led = build_ledger(Path(d), tier=tier, reviews_ok=ok)
+            # Seed current with the OTHER label so the swap is always "changed" and observable.
+            other = "gauntlet-reviewing" if desired == "gauntlet-accepted" else "gauntlet-accepted"
+            fake = FakeGh(view=view_with(other))
+            code, out, _err = drive(led, "9", REPO, fake)
+        check(code == 0, f"[{tier} {ok}] exit 0, got {code}")
+        check(out["desired"] == desired, f"[{tier} {ok}/{out['required']}] desired must be {desired}, got {out!r}")
+
+
+CASES = [
+    ("reviewing-to-accepted", "a met gate swaps reviewing->accepted with the exact argv", t_reviewing_to_accepted_swaps),
+    ("accepted-stays", "an already-accepted PR is a no-op — no edit call", t_accepted_stays),
+    ("reviewing-stays", "an already-reviewing short gate is a no-op — no edit call", t_reviewing_stays),
+    ("missing-row", "a PR with no ledger row is refused (exit 2), before any gh call", t_missing_row_refused),
+    ("unset-tier", "a tier nobody set is refused (exit 2), before any gh call", t_unset_tier_refused),
+    ("terminal-skip", "a merged/aborted row is skipped with NO gh call at all", t_terminal_skipped_no_gh),
+    ("view-failure", "a failed `gh pr view` fails closed (exit 1), never reaches the edit", t_gh_view_failure_exit_1),
+    ("edit-failure", "a failed `gh pr edit` fails closed (exit 1), no success JSON", t_gh_edit_failure_exit_1),
+    ("dry-run", "a dry-run shows the swap argv but applies nothing", t_dry_run_no_edit),
+    ("required-boundary", "reviews_ok at exactly required(tier) picks accepted; one under picks reviewing", t_required_boundary),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Reconcile a PR's STATUS LABEL with its review gate — the ONE way the label swap is done.
+
+THE RULE THIS ENCODES: the gate and its label move together (`stage-2-review-gate.md`, "Status labels
+mirror the review gate"). A PR whose tip holds `required(tier)` SATISFIED verdicts wears
+`gauntlet-accepted`; otherwise it wears `gauntlet-reviewing`. The label is a PROJECTION of `reviews_ok`,
+and it is the one piece of run state a human reads on GitHub — a stale `gauntlet-accepted` is a false
+PUBLIC claim that a PR passed a gauntlet it did not.
+
+WHY THIS IS A COMMAND AND NOT A `gh pr edit` A DRIVER TYPES BY HAND. The swap was a two-command idiom the
+orchestrator ran at every gate-reset site — the verdict tally, a CI/review fix push, a conflict rebase, a
+re-adoption. A step a fresh-context heartbeat must re-derive and retype at N sites is a step it forgets at
+one of them, and the miss is invisible until a human reads the wrong label on GitHub. This tool reads the
+ledger row, computes the desired label the same way the gate does, and applies the canonical idempotent
+swap — so no driver hand-runs it and no driver runs it wrong.
+
+    label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name [--dry-run]
+    label-mirror.py self-test   run every fixture (label-mirror-test.py)
+
+It touches EXACTLY the two status labels and nothing else. A run's ownership label (`gauntlet-run-<id>`)
+is adoption's business (`pr-adoption.md`) and is NEVER added or removed here. A terminal row
+(`merged`/`aborted`) is DONE: the tool skips it and makes no GitHub call at all. It FAILS CLOSED — a row
+that is missing, or whose `tier` nobody set, is refused loudly (exit 2), never defaulted; a `gh` call that
+fails or returns output it cannot parse is exit 1 with the stderr shown, never a guess.
+
+`required(tier)` is REUSED from `nudge.py`, never retyped — the same helper `merge-check.py` borrows. This
+tool holds no second opinion about how many verdicts a tier needs.
+
+THE FIXTURE SUITE IS THE SIBLING `label-mirror-test.py`, this tool's EXECUTABLE CONTRACT; `self-test`
+loads it by a `__file__`-relative path and FAILS LOUDLY if it is missing — a self-test that passes because
+it found no tests is not a passing gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, NoReturn
+
+from _gauntlet.modules import load_module_from_path
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "label-mirror-test.py"     # the fixture suite — this tool's executable contract
+
+
+def _load(name: str, filename: str):
+    mod = load_module_from_path(name, _HERE / filename)
+    if mod is None:
+        raise RuntimeError(f"cannot load {filename}")
+    return mod
+
+
+# The schema owner. `load` and `COUNT_RE` are imported, never restated — the ledger format has one parser,
+# and the count format ("a decimal from 0 up") has one definition.
+L = _load("label_mirror_ledger", "ledger.py")
+
+# `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped, exactly as `merge-check.py` does. The
+# rule already lives in `nudge.py`; a copy here would be the drift this repo keeps killing.
+_N = _load("label_mirror_nudge", "nudge.py")
+REQUIRED = _N.required
+
+# --- the two labels, and NOTHING ELSE is ever added or removed ------------------------------------
+ACCEPTED = "gauntlet-accepted"
+REVIEWING = "gauntlet-reviewing"
+
+# TERMINAL — a DONE row is skipped, no GitHub call at all. `merged`/`aborted` are the two terminal
+# statuses (the ledger `status` field, `files-and-ledger.md`, owns the vocabulary).
+TERMINAL = ("merged", "aborted")
+
+# The triage tiers (`stage-2-review-gate.md`, 2a-triage, owns the vocabulary). This ALLOW-LIST exists only
+# to REFUSE a tier nobody set: `nudge.required()` maps any non-`TRIVIAL` value to 2, so a `-` or a typo'd
+# tier would silently pick `gauntlet-reviewing` — a label chosen for a PR that was never triaged. An
+# explicit membership test refuses it instead. `required()` still owns the COUNT for a tier that IS set.
+TIERS = ("TRIVIAL", "STANDARD", "HIGH")
+
+
+# A `gh` runner: argv -> a finished process (`.returncode`, `.stdout`, `.stderr`). Injected so the suite
+# drives the whole tool with RECORDED responses and no network; the default talks to real `gh`.
+Runner = Callable[[list[str]], "subprocess.CompletedProcess[str]"]
+
+
+def _real_run(argv: list[str]) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
+
+
+class LabelError(Exception):
+    """A `gh` call failed or returned output we cannot read. The reconcile fails CLOSED — exit 1."""
+
+
+def fail(msg: str) -> NoReturn:
+    """An OPERATOR ERROR — a row that is missing, or a tier nobody set. Not a GitHub failure, and not a
+    reconcile outcome: the caller handed us something we cannot act on. Exit 2, never a default."""
+    print(f"label-mirror: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def parse_reviews_ok(row: dict) -> int:
+    """`reviews_ok` as a NUMBER, refusing anything that is not one — the same count format the ledger holds
+    every tally to (`COUNT_RE`, imported). A hand-edited `reviews_ok` of `-` or `two` is a corrupt store,
+    not a number to guess at, and greening or reviewing a PR off it would be a label chosen from garbage."""
+    value = row["reviews_ok"]
+    if not L.COUNT_RE.match(value):
+        fail(f"pr {row['pr']}: reviews_ok is {value!r}, not a count (a decimal from 0 up) — a value the "
+             f"gate cannot count is a corrupt store, never a label to pick from")
+    return int(value)
+
+
+def desired_and_other(tier: str, reviews_ok: int) -> "tuple[str, str]":
+    """(desired label, the OTHER label) for a row whose `tier` is already known-valid. PURE.
+
+    `gauntlet-accepted` iff the tally meets `required(tier)`, else `gauntlet-reviewing`. The count is
+    `required(tier)`'s to own; this only compares against it.
+    """
+    if reviews_ok >= REQUIRED(tier):
+        return ACCEPTED, REVIEWING
+    return REVIEWING, ACCEPTED
+
+
+def current_labels(run: Runner, pr: str, repo: str) -> list[str]:
+    """The PR's current label NAMES, from `gh pr view <pr> --repo <repo> --json labels`.
+
+    Every failure raises `LabelError`, which the caller turns into a fail-closed exit 1: a spawn failure, a
+    non-zero exit, output that is not JSON, or a `labels` array that is absent or malformed. A label set we
+    cannot READ is never treated as an empty one — that would let a swap fire against a PR whose real labels
+    we never saw.
+    """
+    argv = ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "labels"]
+    try:
+        proc = run(argv)
+    except OSError as exc:
+        raise LabelError(f"could not run `gh pr view {pr}`: {exc}") from exc
+    if proc.returncode != 0:
+        raise LabelError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise LabelError(f"`gh pr view {pr}` response is not JSON ({exc})") from exc
+    labels = data.get("labels") if isinstance(data, dict) else None
+    if not isinstance(labels, list):
+        raise LabelError(f"`gh pr view {pr}` response has no `labels` array — got {data!r}")
+    names: list[str] = []
+    for entry in labels:
+        if not isinstance(entry, dict) or not isinstance(entry.get("name"), str):
+            raise LabelError(f"`gh pr view {pr}` returned a label without a string `name`: {entry!r}")
+        names.append(entry["name"])
+    return names
+
+
+def apply_swap(run: Runner, argv: list[str], pr: str) -> None:
+    """Run the canonical idempotent swap. A spawn failure or non-zero exit raises `LabelError` — exit 1."""
+    try:
+        proc = run(argv)
+    except OSError as exc:
+        raise LabelError(f"could not run `gh pr edit {pr}`: {exc}") from exc
+    if proc.returncode != 0:
+        raise LabelError(f"`gh pr edit {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
+
+
+def mirror(ledger_path: Path, pr: str, repo: str, *, dry_run: bool = False,
+           run: Runner = _real_run) -> int:
+    """Reconcile ONE PR's status label with its gate. Print one JSON object; return the exit code.
+
+    Order: no row -> refuse (2); a terminal row -> skip, no GitHub call; a tier nobody set -> refuse (2);
+    then read the live labels and apply the idempotent swap only if the label is not already right.
+    """
+    _header, rows = L.load(ledger_path)
+    pr = str(pr)
+    row = next((r for r in rows if r["pr"] == pr), None)
+    if row is None:
+        fail(f"no ledger row for pr {pr} — a PR this run never adopted has no gate to mirror a label from")
+
+    status = row["status"]
+    if status in TERMINAL:
+        # DONE. Touch nothing — a merged/aborted PR's labels are not campaign's to move.
+        print(json.dumps({"pr": pr, "skipped": "terminal"}))
+        return 0
+
+    tier = row["tier"]
+    if tier not in TIERS:
+        fail(f"pr {pr}: tier is {tier!r}, not one of {'/'.join(TIERS)} — a tier nobody set cannot pick a "
+             f"label. Triage the PR first (`stage-2-review-gate.md`, 2a-triage)")
+
+    reviews_ok = parse_reviews_ok(row)
+    required = REQUIRED(tier)
+    desired, other = desired_and_other(tier, reviews_ok)
+    argv = ["gh", "pr", "edit", pr, "--repo", repo, "--add-label", desired, "--remove-label", other]
+
+    try:
+        current = current_labels(run, pr, repo)
+    except LabelError as exc:
+        print(f"label-mirror: {exc}", file=sys.stderr)
+        return 1
+
+    # Already right: the desired label is present AND the other absent. Anything else needs the swap —
+    # desired missing, the other lingering, or both labels at once (what a missed swap actually leaves).
+    changed = not (desired in current and other not in current)
+
+    out: dict = {"pr": pr, "tier": tier, "reviews_ok": reviews_ok, "required": required,
+                 "desired": desired, "current": current, "changed": changed}
+    if changed or dry_run:
+        out["argv"] = argv
+
+    if changed and not dry_run:
+        try:
+            apply_swap(run, argv, pr)
+        except LabelError as exc:
+            print(f"label-mirror: {exc}", file=sys.stderr)
+            return 1
+
+    print(json.dumps(out))
+    return 0
+
+
+# --- self-test: the executable contract lives in the SIBLING module ------------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def _sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture suite is NOT AT {SIBLING} — `self-test` has NO SUBJECT, and a check that cannot "
+            f"find the thing it tests must FAIL, never pass.")
+    mod = load_module_from_path("label_mirror_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    """Run the sibling suite over every fixture. Non-zero on any failure."""
+    failures = 0
+    try:
+        cases = _sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the label-mirror's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:30} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} fixture(s) failed — the label-mirror's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the label-mirror's contract is intact.")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    m = sub.add_parser("mirror", help="reconcile one PR's status label with its review gate")
+    m.add_argument("--ledger", required=True, type=Path, help="the run ledger (<rundir>/state.jsonl)")
+    m.add_argument("--pr", required=True, help="PR number")
+    m.add_argument("--repo", required=True, help="owner/name — NEVER resolved from the checkout")
+    m.add_argument("--dry-run", action="store_true", help="print the decision and argv, apply nothing")
+
+    sub.add_parser("self-test", help="run every fixture (label-mirror-test.py)")
+
+    args = p.parse_args(argv)
+
+    if args.cmd == "self-test":
+        return self_test()
+    return mirror(args.ledger, args.pr, args.repo, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
- `label-mirror.py mirror` computes and applies the status-label swap from the ledger gate
- reuses `required(tier)`; injectable gh seam; 10 fixtures; all relabel sites now run the tool
