### PR TITLE
reset liveness counters at the head-sha write door

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -111,7 +111,8 @@
   GitHub Copilot review items (the active host form of `gauntlet:copilot-address-reviews <pr>`), fix any CI failures (one at a time,
   prefer a scoped subagent), and rebase away any conflict with `<base>`. PR-content changes reset
   verdicts. Clean base-only rebase with unchanged PR diff keeps `reviews_ok`, sets `ci = pending`, and
-  **resets the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS").
+  moves `head_sha` — so writing the new head through `ledger.py … set --head-sha` makes the accessor
+  **reset the liveness counters** at the door (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); never hand-reset.
   Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
   on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive
@@ -160,7 +161,8 @@
   `gauntlet-accepted`. Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
-  `ci = pending` and **resets the liveness counters** (`stage-2-ci.md`,
+  `ci = pending` and, because it moves `head_sha`, the accessor **resets the liveness counters** at that
+  head write (`stage-2-ci.md`,
   "THE LIVENESS COUNTERS"). Per-heartbeat label reconcile is the self-healing backstop, never the mechanism
   (`stage-2-review-gate.md`, "Status labels mirror the review gate").
 - **YOUR OWN diagnosis is a claim too — REPRODUCE the failure before you "fix" working code.** The rule
@@ -349,8 +351,8 @@
 - Verdicts are pinned to reviewed PR content: any PR-content change (review fix / CI fix /
   conflict-resolving rebase / bot or manual PR-branch commit) makes prior verdicts stale. Base
   advancement with no conflict and unchanged PR diff does NOT invalidate verdicts; carry `reviews_ok`
-  forward, update `head_sha`, **reset the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"),
-  and require fresh CI.
+  forward, update `head_sha` through `ledger.py … set --head-sha` — which **resets the liveness counters**
+  at the door (`stage-2-ci.md`, "THE LIVENESS COUNTERS") — and require fresh CI.
 - Resume vs. fresh run is decided by **liveness**, not by `state.jsonl` existing: live work → resume;
   a finished prior run → ask the user before a fresh run; `--new` → fresh run with
   carryover (Loop control step 1). A finished run must never silently exit "all done" or silently
@@ -390,13 +392,16 @@
   failure.
 - **ANY campaign commit to the PR head resets the gate** (`stage-2-ci.md`, "Any campaign commit to the PR
   head resets the gate") — economy-class CI-fix, `session`-class CI-fix, review-fix, or **refutation commit** alike. In the SAME step: reset
-  `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`, **reset the
-  liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"), re-derive CI
+  `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`; the new commit
+  moves `head_sha`, so writing it through the accessor **resets the liveness counters** at the door
+  (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); re-derive CI
   for the new tip and watch it **only if a row can still move** (`stage-2-ci.md`, "WATCH ONLY WHAT CAN
   MOVE" — a watch launched on a tip whose checks have not registered yet has nothing to block on and
   exits in about a second), and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
-- **THE LIVENESS COUNTERS reset on EVERY `head_sha` change — gate reset or not** (`stage-2-ci.md`, "THE
-  LIVENESS COUNTERS", which names every site). A `head_sha` change and a gate reset are **not** the same
+- **THE LIVENESS COUNTERS reset on EVERY `head_sha` change — gate reset or not, and the ledger accessor
+  enforces it at the head write** (`stage-2-ci.md`, "THE LIVENESS COUNTERS", which names every site): write
+  the new `head_sha` through `ledger.py … set --head-sha` and its door resets the set — no site hand-resets.
+  A `head_sha` change and a gate reset are **not** the same
   event: a `NOT SATISFIED` verdict resets the gate with no new head (the counters stay — CI did not move),
   and a **clean base-only rebase** moves the head without resetting the gate (the counters reset — the old
   head's evidence is gone). Carried onto a new head, the old head's counters park a **healthy** PR early,

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -196,9 +196,10 @@ Header field notes (the header fields above; per-row fields follow):
   and `tier` are pinned to this exact SHA (re-triage on any content change). `reviews_ok` is pinned to
   this SHA **unless** the only change is a clean base-only rebase/merge with the PR diff unchanged;
   then carry `reviews_ok` forward to the new `head_sha`, set `ci = pending`, and — because the head
-  **moved** — **reset the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"). A clean rebase
+  **moved** — the ledger accessor **resets the liveness counters** at the `set --head-sha` write itself
+  (`stage-2-ci.md`, "THE LIVENESS COUNTERS"; ledger.py's `apply_head_sha`). A clean rebase
   does not reset the *gate*, but it **is** a `head_sha` change, and **every** `head_sha` change resets
-  those counters: the old head's strikes and stall clock measured evidence that no longer exists.
+  those counters at the door: the old head's strikes and stall clock measured evidence that no longer exists.
 - `reviews_ok` — number of fresh, context-isolated SATISFIED verdicts recorded against this PR's
   current content. Target = `required(tier)`: **1 if `tier == TRIVIAL`, else 2** (Stage **2a-triage**).
   **Only `ledger.py verdict` may RAISE it** — `set --reviews-ok <n>` refuses any value above the current
@@ -273,13 +274,14 @@ Header field notes (the header fields above; per-row fields follow):
   due or in flight* for the PR at this `head_sha` (`stage-2-ci.md`, "SETTLED", owns the gate — a PR the
   driver is actively repairing is never struck). Counted by `ci-status.py liveness`, never by hand. At
   the **STRIKE CAP**, escalate: park `awaiting-user`
-  naming the blocker. Reset to `0` on any `head_sha` change or fingerprint change.
+  naming the blocker. Reset to `0` on any `head_sha` change (the ledger `set --head-sha` accessor does this
+  itself — ledger.py's `apply_head_sha`) or fingerprint change (by `ci-status.py liveness`).
 - `unusable_refetches` — consecutive derivations whose snapshot was **UNUSABLE** at this `head_sha`. An
   UNUSABLE snapshot has **no fingerprint** (its rows were never trusted), so it can never be a
   `settled_strike`: it gets its own counter, counted by `ci-status.py liveness`. At the **REFETCH CAP**,
   escalate the same way. Reset to `0`
-  on any `head_sha` change and on any **VERIFIED** snapshot (`stage-2-ci.md`, "UNUSABLE — the refetch is
-  BOUNDED").
+  on any `head_sha` change (the ledger `set --head-sha` accessor does this itself) and on any **VERIFIED**
+  snapshot (by `ci-status.py liveness`) (`stage-2-ci.md`, "UNUSABLE — the refetch is BOUNDED").
 - `ci_stalled_since` — `-`, or the **UTC ISO-8601 timestamp** of the first derivation that saw the check
   set **RUNNING-STALLED** at this fingerprint: an evidence row still classifies `RUNNING` **and** the
   fingerprint did **not** change (`stage-2-ci.md`, "RUNNING-STALL" — the definition; the cap lives there
@@ -287,7 +289,8 @@ Header field notes (the header fields above; per-row fields follow):
   **SLOW** and one that is **DEAD** are indistinguishable on a fingerprint, and derivations are driven by
   heartbeats whose cadence depends on the run's load — so only elapsed **TIME** separates them. It is on disk
   precisely so `now - ci_stalled_since` is computable by a fresh agent instance that remembers nothing.
-  Cleared (`-`) on any fingerprint change, on any `head_sha` change, and whenever a **machine action** is
+  Cleared (`-`) on any fingerprint change (by `ci-status.py liveness`), on any `head_sha` change (the ledger
+  `set --head-sha` accessor does this itself), and whenever a **machine action** is
   due or in flight for this PR at this `head_sha` (a fix that pushes will replace these rows). At the cap,
   escalate: park `awaiting-user`, `ci_reason` naming the check that never finished and how long the check
   set sat unchanged.

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -45,12 +45,13 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      reconcile is a backstop, not the mechanism", below). (A clean base-only advance with the PR
      diff unchanged does not reset the gate, so it keeps `gauntlet-accepted`.)
 
-     **And whenever this refresh writes a NEW `head_sha` — gate reset or not — RESET THE LIVENESS
-     COUNTERS** (`stage-2-ci.md`, "THE LIVENESS COUNTERS", which owns why), in the same `ledger.py … set`
-     call. This covers **both** cases above: the content change that resets the gate, **and** the clean
-     base-only advance that does not. **NAME the set; do NOT unpack it here** — a gloss that lists the
-     set's members is a **restatement** that goes stale the moment the set gains a member (this line's
-     did, when `ci_stalled_since` joined).
+     **And whenever this refresh writes a NEW `head_sha` — gate reset or not — the ledger accessor RESETS
+     THE LIVENESS COUNTERS for you** (`stage-2-ci.md`, "THE LIVENESS COUNTERS", which owns why): write the
+     new `head_sha` through `ledger.py … set --head-sha` and its door resets the whole set in the same row
+     write. This covers **both** cases above: the content change that resets the gate, **and** the clean
+     base-only advance that does not. **Do NOT hand-reset the counters** — the door owns it, and a gloss
+     that lists the set's members here is a **restatement** that goes stale the moment the set gains a
+     member (this line's did, when `ci_stalled_since` joined).
 
      Do the PR scan as
      **one batched snapshot per heartbeat** — the **same canonical command** `pr-adoption.md` runs, writing the

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -186,14 +186,16 @@ For each `#PR` to adopt:
      RULING IS CONSUMED EXACTLY ONCE") — so a ruling this refresh can see is either still **awaiting its
      park's exit** (preserving it is the whole point: a heartbeat may be a fresh agent instance) or the
      **terminal** record of an `abort`. A **spent** ruling is never on the row for this step to resurrect.
-   - **Whenever this refresh writes a NEW `head_sha`, RESET THE LIVENESS COUNTERS** (`stage-2-ci.md`,
-     "THE LIVENESS COUNTERS") in the same `ledger.py … set` call — **whether or not the gate reset with
-     it**: a clean base-only advance moves the head without touching `reviews_ok`, and it still means the
-     old head's strikes, stall clock and refetch count describe evidence that no longer exists. Carried
-     onto the new head they park a healthy PR early. **Reset the SET, never a list retyped here** — a
-     counter added to it is inherited by this site with no edit. (This is one of the **explicit
-     recomputes** the preserve-by-default rule above defers to: the counters are pinned to `head_sha`, not
-     to the user, so a new head voids them.)
+   - **Whenever this refresh writes a NEW `head_sha`, the ledger accessor RESETS THE LIVENESS COUNTERS**
+     (`stage-2-ci.md`, "THE LIVENESS COUNTERS") — **whether or not the gate reset with it**: write the new
+     `head_sha` through `ledger.py … set --head-sha` (or `pr-adopt`, which routes through it) and its door
+     resets the whole set in the same row write. A clean base-only advance moves the head without touching
+     `reviews_ok`, and it still means the old head's strikes, stall clock and refetch count describe evidence
+     that no longer exists; carried onto the new head they park a healthy PR early — the door prevents that.
+     **Do NOT hand-reset the counters here** — the accessor owns it, and a list retyped at this site goes
+     stale the next time the set gains a member. (This is one of the **explicit recomputes** the
+     preserve-by-default rule above defers to: the counters are pinned to `head_sha`, not to the user, so a
+     new head voids them — at the door.)
 
    The ownership marker for an adopted PR is the **label**, not the branch name (its branch won't match
    the `fix-<run-id>-` prefix) — so labelling in step 4 is what makes the PR ours.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -561,28 +561,38 @@ BOUNDED wait rather than a wedge.
 
 **Reset them TOGETHER — EVERY member of the set, each back to its `ROW_DEFAULTS` value** (`scripts/ledger.py`
 owns those defaults; **never retype them here**, or the reset rots the next time the set gains a member) — at
-exactly two kinds of site:
+exactly two kinds of site, and the two RESET THEMSELVES DIFFERENTLY:
 
-1. **Any `head_sha` change — whether or not the gate resets with it.** The new head is new evidence, so
-   the old head's liveness says nothing about it. **THE TRIGGER IS THE PROPERTY — "this site wrote a new
-   `head_sha`" — and NOT membership of a list.** Every site that writes one resets them, including a site
-   added after this paragraph was written, with **no edit here**. Today's sites, **illustratively and
-   NON-EXHAUSTIVELY**: **"Any campaign commit to the PR head resets the gate"** (below — CI-fix,
-   review-fix, copilot-item fix, refutation commit); **Stage 2a's precondition rebase**
-   (`stage-2-review-gate.md`) and **`stage-3-merge.md`, step 6's reconcile** — for each, BOTH branches: a
-   clean base-only rebase, which does **not** reset the gate, and a conflict-resolving rebase, which does;
-   **`loop-control.md` step 1's ledger refresh** and **`pr-adoption.md` step 3's row refresh** (a
-   formatter/bot commit, a manual push, any content change this run did not dispatch).
+1. **Any `head_sha` change — whether or not the gate resets with it — and THE ACCESSOR DOES IT FOR YOU.**
+   The new head is new evidence, so the old head's liveness says nothing about it. **THE TRIGGER IS THE
+   PROPERTY — "this site wrote a new `head_sha`" — and NOT membership of a list.** This reset is enforced
+   **at the write door, not by prose at each site**: `scripts/ledger.py … set --head-sha <new>` (and
+   `pr-adopt`, which routes through it) resets every member of the set to its default in the SAME row write,
+   on any genuine head move — ledger.py's `apply_head_sha`. **So a site that writes a new `head_sha` through
+   the accessor NEED NOT and MUST NOT hand-reset the counters**: write the new head through the accessor and
+   the door resets them. A `--settled-strikes 0` typed beside the head write is redundant, and a hand-reset
+   that lists the members is exactly the stale restatement this door removes. Every site that writes a head
+   through the accessor gets the reset, including one added after this paragraph, with **no edit here**.
+   Today's sites, **illustratively and NON-EXHAUSTIVELY**: **"Any campaign commit to the PR head resets the
+   gate"** (below — CI-fix, review-fix, copilot-item fix, refutation commit); **Stage 2a's precondition
+   rebase** (`stage-2-review-gate.md`) and **`stage-3-merge.md`, step 6's reconcile** — for each, BOTH
+   branches: a clean base-only rebase, which does **not** reset the gate, and a conflict-resolving rebase,
+   which does; **`loop-control.md` step 1's ledger refresh** and **`pr-adoption.md` step 3's row refresh** (a
+   formatter/bot commit, a manual push, any content change this run did not dispatch). Each writes the new
+   `head_sha` through the accessor, so each gets the reset from the door — none hand-resets.
 2. **An unpark by `retry`** (`loop-control.md` step 3) — no new head, but the user changed something
    **outside** the PR (they re-ran the workflow, killed the hung runner, registered the missing check), so
-   the strikes and the stall clock that measured the old attempt are void.
+   the strikes and the stall clock that measured the old attempt are void. **This reset stays EXPLICIT** —
+   there is NO `head_sha` change for the door to fire on, so the unpark writes the counters back to their
+   defaults itself, in the same `ledger.py … set` call that spends the ruling.
 
 **`liveness`'s stale-derivation refusal ("THE BOOKKEEPING IS A COMMAND", above) is NOT a substitute for
-the site doing it — it is the seam that makes the site's reset SAFE.** The sites above **write the new
-`head_sha` to the row**, so by the time CI is re-derived the ledger already reads the new head and there
-is nothing left to detect. The reset belongs **at the site that moves `head_sha`**; what `liveness` adds
-is the other half: a derivation still pinned to the OLD head is refused outright, so stale evidence can
-never spend the budget the site just reset.
+the head write doing it — it is the seam that makes that reset SAFE.** The sites above **write the new
+`head_sha` to the row** through the accessor, so by the time CI is re-derived the ledger already reads the
+new head, the counters are already reset, and there is nothing left to detect. The reset belongs **with the
+`head_sha` write itself** — the accessor performs it when the site moves the head; what `liveness` adds is
+the other half: a derivation still pinned to the OLD head is refused outright, so stale evidence can never
+spend the budget the head write just reset.
 
 **A gate reset is NOT the trigger — a `head_sha` change is.** The two are not the same set and never map
 onto each other: a `NOT SATISFIED` verdict resets the gate with **no** new head (the counters stay — CI
@@ -737,8 +747,9 @@ Every one of them MUST, in the same step:
   the gate and its label move together, never one without the other (`stage-2-review-gate.md`, "Status
   labels mirror the review gate");
 - **re-derive `ci` from a fresh snapshot for the NEW `head_sha`, and launch a watch if — and only if —
-  that snapshot holds a row that can still move** ("WATCH ONLY WHAT CAN MOVE" above). The new commit
-  **resets the liveness counters** ("THE LIVENESS COUNTERS" above), so the PR gets a clean budget.
+  that snapshot holds a row that can still move** ("WATCH ONLY WHAT CAN MOVE" above). Writing the new
+  `head_sha` through the accessor **resets the liveness counters** at the door ("THE LIVENESS COUNTERS"
+  above), so the PR gets a clean budget.
   **NEVER launch the watch unconditionally on the push**: at that instant the checks may not have
   registered yet, so watch only if the fresh snapshot holds a row that can still move ("WATCH ONLY WHAT
   CAN MOVE" above);

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -89,7 +89,8 @@ review gate"), and the review re-starts on the clean tip:
   and re-run rather than rebase on a half-computed view (`base-preflight.py` is the owner of the full
   mapping). It is the enforced form of this rule and it is also the pre-flight gate before any fix subagent
   is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean base-only rebase with the PR diff unchanged keeps `reviews_ok` but still moves `head_sha`, so it
-  sets `ci = pending` **and resets the liveness counters** ("Status labels mirror the review gate"
+  sets `ci = pending`, and writing the new head through `ledger.py … set --head-sha` makes the accessor
+  **reset the liveness counters** at the door ("Status labels mirror the review gate"
   Exception, below, owns this rule; `stage-2-ci.md`, "THE LIVENESS COUNTERS");
   conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,
   exactly as the step-6 reconcile does at its own (`stage-3-merge.md`), and it therefore **relabels in the
@@ -771,7 +772,8 @@ prose. Record the reviewed SHA
 (`git rev-parse HEAD`) with each pass. A verdict counts while its SHA equals the live tip. It also
 continues to count after `<base>` advances if the PR is still non-conflicting and the PR diff/content
 is unchanged (e.g. clean base-only rebase); carry `reviews_ok` forward to the new `head_sha`, set
-`ci = pending`, and **reset the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS"). The moment PR content changes — review fix, CI fix, conflict-resolving rebase, a
+`ci = pending` — writing the new head through the accessor **resets the liveness counters** at the door
+(`stage-2-ci.md`, "THE LIVENESS COUNTERS"). The moment PR content changes — review fix, CI fix, conflict-resolving rebase, a
 formatter/bot commit on the PR branch, or manual push — earlier verdicts are stale and `reviews_ok`
 drops to 0. Pinning to SHA plus the clean-base-only exception makes the gate verifiable from git while
 not burning reviews merely because another PR merged cleanly. A `NOT SATISFIED` invalidates that
@@ -831,9 +833,10 @@ Search for both.
 
 **Exception — a clean base-only rebase** (PR diff unchanged) carries `reviews_ok` forward and therefore
 **keeps** `gauntlet-accepted`. The gate did not reset, so the label does not move. Gate and label stay in
-lockstep in both directions. **It is still a `head_sha` change, though**, so it sets `ci = pending` **and
-resets the liveness counters** (`stage-2-ci.md`, "THE LIVENESS COUNTERS") — the gate and the counters key
-off **different** events, and this row is exactly where they part company.
+lockstep in both directions. **It is still a `head_sha` change, though**, so it sets `ci = pending`, and
+writing the new head through the accessor **resets the liveness counters** at the door (`stage-2-ci.md`,
+"THE LIVENESS COUNTERS") — the gate and the counters key off **different** events, and this row is exactly
+where they part company.
 
 **Reconcile is the backstop, not the mechanism.** Loop control re-derives every label from the live
 gate each heartbeat so a missed swap self-heals, exactly as the CI-watch heartbeat backstops a missed watch.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -193,8 +193,8 @@ subagent at a check that is merely **still running**.
    (`ledger.py … dispatch-check --pr <N>` — parked on a human, or `repairing`) is **FROZEN**
    (`loop-control.md` step 3,
    "held-status guard"): this reconcile MUTATES a PR, so it is exactly what the guard forbids. A clean
-   rebase would move its `head_sha`, set `ci = pending` and reset its liveness counters (`stage-2-ci.md`,
-   "THE LIVENESS COUNTERS"); a conflict-resolving rebase would reset
+   rebase would move its `head_sha`, set `ci = pending` and — at that head write — the accessor would reset
+   its liveness counters (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); a conflict-resolving rebase would reset
    `reviews_ok`, relabel, and relaunch work — and would **change the PR's content**, which can invalidate
    the very refutation or API change the user was parked to adjudicate. **A parked PR that has fallen
    behind simply STAYS behind** until the user answers; it is re-reconciled normally on the heartbeat after it
@@ -206,8 +206,9 @@ subagent at a check that is merely **still running**.
    invalidate gauntlet reviews.** Rebase only if GitHub flags the PR behind/conflicting:
    - Clean rebase (no conflicts) → verify the PR's own diff/content is unchanged → keep `reviews_ok`,
      **keep its status label as-is** (the gate did not reset, so an accepted PR stays
-     `gauntlet-accepted`), update `head_sha` to the new tip, set `ci = pending`, **reset the liveness
-     counters** (new commit, new evidence — `stage-2-ci.md`, "THE LIVENESS COUNTERS"), **and re-derive CI
+     `gauntlet-accepted`), update `head_sha` to the new tip through `ledger.py … set --head-sha` (which
+     **resets the liveness counters** at the door — new commit, new evidence — `stage-2-ci.md`, "THE
+     LIVENESS COUNTERS"), set `ci = pending`, **and re-derive CI
      from a snapshot of the new tip in the same heartbeat, launching a watch only if that snapshot holds a
      still-RUNNING row** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched until the
      heartbeat while its checks are running — but it must not be watched when **nothing** is running
@@ -217,7 +218,7 @@ subagent at a check that is merely **still running**.
      same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** — the gate and its
      label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Update
      `head_sha` to the
-     new tip and **reset the liveness counters** (a new head is new evidence — `stage-2-ci.md`, "THE
+     new tip through the accessor, which **resets the liveness counters** (a new head is new evidence — `stage-2-ci.md`, "THE
      LIVENESS COUNTERS"; the clean-rebase branch above does the same, and this branch is no different in
      that respect). Then re-derive CI for
      the new tip — watching it only if a row can still move ("WATCH ONLY WHAT CAN MOVE") — and re-enter

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1222,6 +1222,78 @@ def t_counter_refuses_a_corrupt_value(L: ModuleType, tmp: Path) -> None:
         check("not a count" in err, f"[{value!r}] refused for the wrong reason: {err!r}")
 
 
+# --- the head_sha door resets THE LIVENESS COUNTERS ---------------------------
+#
+# A NEW `head_sha` is NEW evidence, so the old head's CI-liveness says nothing about it (stage-2-ci.md, "THE
+# LIVENESS COUNTERS"). That property is enforced at the WRITE DOOR — `set --head-sha` — not by prose at each
+# caller: on a genuine head move the four `LIVENESS_COUNTERS` reset to their `ROW_DEFAULTS` values in the same
+# row write, a same-value write touches nothing, and a non-sha is refused before anything is written.
+
+STALE_LIVENESS = {"ci_fingerprint": "deadbeef", "settled_strikes": "2",
+                  "unusable_refetches": "1", "ci_stalled_since": "2026-01-01T00:00:00Z"}
+
+
+def t_head_sha_change_resets_liveness(L: ModuleType, tmp: Path) -> None:
+    """A NEW head_sha through `set` RESETS every LIVENESS_COUNTERS field to its default — in the SAME write —
+    while a same-value write leaves them untouched, and a field written in the same call is preserved.
+
+    THIS IS THE MUTATION PIN: delete the reset in `apply_head_sha` and the first block below goes red — a
+    new-sha write that leaves stale counters must be impossible through `cmd_set`.
+    """
+    path = write_lines(tmp / "hs.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, ci="green", **STALE_LIVENESS))
+    # NEW head + another field (ci) in ONE call: the counters reset, and the co-written field lands.
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", SHA_B, "--ci", "red"])
+    check(code == 0, f"set exited {code}: {err!r}")
+    row = json.loads(out)
+    check(row["head_sha"] == SHA_B, f"the new head did not land: {row['head_sha']!r}")
+    check(row["ci"] == "red", f"a field written in the same call as the head move was lost: {row['ci']!r}")
+    for field in L.LIVENESS_COUNTERS:
+        check(row[field] == L.ROW_DEFAULTS[field],
+              f"a NEW head_sha left {field}={row[field]!r} — the door did not reset it to "
+              f"{L.ROW_DEFAULTS[field]!r}; a new-sha write leaving stale counters must be impossible")
+
+    # SAME head again: not a move, so nothing resets. Write a fresh strike, then re-set the SAME head.
+    cli(L, ["--file", str(path), "set", "--pr", "1", "--settled-strikes", "3"])
+    code, out, _ = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", SHA_B])
+    row = json.loads(out)
+    check(row["settled_strikes"] == "3",
+          f"a SAME-VALUE head_sha write reset a counter it must not touch: {row['settled_strikes']!r}")
+
+
+def t_head_sha_explicit_counter_wins(L: ModuleType, tmp: Path) -> None:
+    """An explicit liveness-counter flag in the SAME `set` call as a NEW head_sha WINS over the automatic
+    reset — the flag is applied AFTER the reset — while every counter NOT named still resets."""
+    path = write_lines(tmp / "hw.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, **STALE_LIVENESS))
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1",
+                             "--head-sha", SHA_B, "--settled-strikes", "5"])
+    check(code == 0, f"set exited {code}: {err!r}")
+    row = json.loads(out)
+    check(row["head_sha"] == SHA_B, f"the new head did not land: {row['head_sha']!r}")
+    check(row["settled_strikes"] == "5",
+          f"an explicit --settled-strikes did NOT win over the auto-reset: {row['settled_strikes']!r}")
+    check(row["unusable_refetches"] == L.ROW_DEFAULTS["unusable_refetches"],
+          f"a counter NOT named still had to reset on the head move: {row['unusable_refetches']!r}")
+
+
+def t_set_head_sha_refuses_a_non_sha(L: ModuleType, tmp: Path) -> None:
+    """`set --head-sha` validates the shape with SHA_RE — a value that is not 40 lowercase hex is REFUSED,
+    and NOTHING is written: no head move, no counter reset. Refusing before any mutation is the point."""
+    path = write_lines(tmp / "bad.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, **STALE_LIVENESS))
+    for bad in (SHA_A[:7], "g" * 40, SHA_A.upper(), "-"):
+        code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", bad])
+        check(code == 1, f"set --head-sha {bad!r} was ACCEPTED (exit {code}):\n{out}")
+        check("40 LOWERCASE hex" in err, f"[{bad!r}] refused for the wrong reason: {err!r}")
+    # …and the refused writes changed nothing at all — not the head, not one counter.
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    row = json.loads(out)
+    check(row["head_sha"] == SHA_A, f"a refused head_sha write still moved the head: {row['head_sha']!r}")
+    for field, want in STALE_LIVENESS.items():
+        check(row[field] == want, f"a refused head_sha write reset {field} to {row[field]!r}, not {want!r}")
+
+
 def t_write_is_atomic(L: ModuleType, tmp: Path) -> None:
     """**A LEDGER WRITE IS ALL OR NOTHING.** No crash, no full disk, may leave a store torn in half.
 
@@ -1690,6 +1762,9 @@ CASES = [
     ("verdict-head-pinned", "a verdict for a SUPERSEDED sha is refused — it describes content that is gone", t_verdict_refuses_a_moved_head),
     ("verdict-domain", "`verdict` needs a real row and one of exactly two verdicts", t_verdict_needs_a_row_and_a_known_verdict),
     ("counter-corrupt", "a counter field that is not a count is refused, never handed to int()", t_counter_refuses_a_corrupt_value),
+    ("head-sha-resets-liveness", "a NEW head_sha through `set` resets THE LIVENESS COUNTERS; a same-value write does not", t_head_sha_change_resets_liveness),
+    ("head-sha-explicit-counter-wins", "an explicit counter flag in the same call as a new head_sha wins over the auto-reset", t_head_sha_explicit_counter_wins),
+    ("head-sha-refuses-non-sha", "`set --head-sha` refuses a non-40-hex value and writes nothing", t_set_head_sha_refuses_a_non_sha),
     ("write-atomic", "a write that dies mid-way leaves the OLD ledger intact — temp + fsync + os.replace", t_write_is_atomic),
     ("skill-version", "the header records WHICH VERSION of the rules governed the run; default `unknown`", t_skill_version_is_recorded),
     ("round-cap", "at ROUND_CAP a NOT SATISFIED holds the row `repairing` and exits non-zero", t_round_cap_fires),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -154,6 +154,14 @@ ROW_DEFAULTS = {
     "pr_origin": "external", "repair_count": "0", "repair_decision": "-",
 }
 
+# THE LIVENESS COUNTERS — the SHA-bound CI-liveness fields, named ONCE here so every site that resets them on
+# a head move (this accessor's `set` door via `apply_head_sha`, and pr-adopt's refresh, which re-exports THIS
+# tuple) refers to the SET, never a retyped copy of the list. `stage-2-ci.md`, "THE LIVENESS COUNTERS", owns
+# what each member means; they describe the CI of ONE `head_sha`, so a write of a NEW head is a write of new
+# evidence and every one of them resets to its `ROW_DEFAULTS` value. Every member is a `ROW_FIELDS` field, so
+# a reset reads its fresh-head value straight from `ROW_DEFAULTS` — the values are never retyped here either.
+LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", "ci_stalled_since")
+
 # The two fields `verdict` OWNS — and the ONLY reason they are not settable through `set`/`add-row` is
 # that a door which can write them is a door that can RESET them.
 #
@@ -470,6 +478,35 @@ def cmd_add_row(path: Path, args) -> int:
     return 0
 
 
+def apply_head_sha(row: dict, new_sha: str) -> None:
+    """Write `new_sha` to `row['head_sha']`, resetting THE LIVENESS COUNTERS on a genuine head MOVE.
+
+    THE PROPERTY, enforced at the write door rather than by prose at each caller (stage-2-ci.md, "THE
+    LIVENESS COUNTERS", reset-site class 1): a NEW `head_sha` is NEW evidence, so the old head's CI-liveness
+    says nothing about it. When `new_sha != row['head_sha']` this writes the head AND resets every
+    `LIVENESS_COUNTERS` field to its `ROW_DEFAULTS` value — READ from the defaults, never retyped — mutating
+    the SAME `row` dict, so the caller's single `dump()` lands the head move and the reset in ONE atomic write.
+    A SAME-VALUE write (`new_sha == row['head_sha']`) is not a move and changes NOTHING.
+
+    The shape is validated with `SHA_RE` FIRST and REFUSED otherwise (40 lowercase hex): a value that cannot
+    be a commit id has no business becoming a row's head, and refusing before any mutation keeps a bad
+    `--head-sha` from resetting the counters.
+
+    PRECEDENCE — an explicit counter flag in the SAME `set` call WINS over the automatic reset. This helper
+    touches ONLY `head_sha` and the counters; `cmd_set` calls it and THEN applies the remaining named updates,
+    so the explicit flag is written AFTER the reset. `set --head-sha <new> --settled-strikes 5` records 5,
+    while every counter NOT named still resets to its default (pinned by `t_head_sha_explicit_counter_wins`).
+    """
+    if not SHA_RE.match(new_sha):
+        fail(f"--head-sha {new_sha!r} is not a git object id (40 LOWERCASE hex) — a value that cannot be a "
+             f"commit id has no business becoming a row's head, and a bad head must reset no counters")
+    if new_sha == row["head_sha"]:
+        return  # a same-value write is not a head MOVE — the liveness state still describes this head
+    row["head_sha"] = new_sha
+    for field in LIVENESS_COUNTERS:
+        row[field] = ROW_DEFAULTS[field]  # fresh head, fresh budget — the value comes from ROW_DEFAULTS
+
+
 def cmd_set(path: Path, args) -> int:
     header, rows = load(path)
     pr = str(args.pr)
@@ -480,6 +517,11 @@ def cmd_set(path: Path, args) -> int:
     if not updates:
         fail("set requires at least one --<field> <value>")
     check_tally(updates, row)
+    # `--head-sha` routes through the accessor, which resets THE LIVENESS COUNTERS on a genuine head move.
+    # It is applied FIRST so that an explicit counter flag in the SAME call (applied by the row.update below)
+    # WINS over the automatic reset — the precedence apply_head_sha's docstring pins.
+    if "head_sha" in updates:
+        apply_head_sha(row, updates.pop("head_sha"))
     row.update(updates)  # by NAME — never by column position
     dump(path, header, rows)
     print(json.dumps(row))

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -463,10 +463,15 @@ def t_readopt_changed_head_resets():
         check(_field(ledger, 12, "review_rounds") == "2",
               "review_rounds is MONOTONE — a re-adoption never resets the loop's memory")
         # The SHA-bound liveness counters describe the OLD head; a moved head resets every one of them to
-        # its fresh-head default (ledger.py ROW_DEFAULTS), IN THE SAME ledger update as head_sha.
+        # its fresh-head default (ledger.py ROW_DEFAULTS). pr-adopt no longer hand-resets them — the ledger
+        # `set --head-sha` DOOR does it (ledger.py's apply_head_sha), so this asserts the door's reset landed
+        # through the ordinary refresh, IN THE SAME ledger update as head_sha.
         for field in M.LIVENESS_COUNTERS:
             check(_field(ledger, 12, field) == M.L.ROW_DEFAULTS[field],
                   f"a moved head RESETS the liveness counter {field} to its fresh-head default")
+        # …and pr-adopt names the SET by re-exporting ledger's tuple — never a second copy of the list.
+        check(M.LIVENESS_COUNTERS is M.L.LIVENESS_COUNTERS,
+              "pr-adopt.LIVENESS_COUNTERS must BE ledger.LIVENESS_COUNTERS (one owner), not a duplicate")
 
 
 def t_readopt_changed_head_preserves_held_status():

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -54,12 +54,6 @@ RUN_LABEL_COLOR = "5319E7"
 # it opens). It is the ONLY thing that makes `pr_origin` = `gauntlet`; a driver cannot assert it by flag.
 GAUNTLET_AUTHORED_LABEL = "gauntlet-authored"
 
-# The SHA-bound liveness counters — stage-2-ci.md, "THE LIVENESS COUNTERS", owns the set and what each
-# member means. They describe the OLD head's CI, so a re-adoption at a moved head must reset them in the
-# same ledger update as head_sha; the reset VALUES come from ledger.py's ROW_DEFAULTS (the fresh-head
-# defaults), never a literal typed here.
-LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", "ci_stalled_since")
-
 
 def _load(name: str, filename: str):
     mod = load_module_from_path(name, _HERE / filename)
@@ -72,6 +66,12 @@ L = _load("pr_adopt_ledger", "ledger.py")
 # `required(tier)` — the review gate's SATISFIED-verdict floor — is OWNED by review-pass.py
 # (`required_reviews`); the status label mirrors that gate, so reuse the owner rather than retype the rule.
 RP = _load("pr_adopt_review_pass", "review-pass.py")
+
+# THE LIVENESS COUNTERS — RE-EXPORTED from ledger.py, never a second copy of the list. A re-adoption at a
+# moved head no longer hand-resets them: the ledger `set --head-sha` door does it (ledger.py's
+# `apply_head_sha`; stage-2-ci.md, "THE LIVENESS COUNTERS"). This name survives only for readers/tests that
+# ask pr-adopt which fields the set is.
+LIVENESS_COUNTERS = L.LIVENESS_COUNTERS
 
 
 # --- pure decision surface ----------------------------------------------------
@@ -259,11 +259,14 @@ def cmd_adopt(args) -> int:
     # must recompute and everything else survives untouched. What that is depends on whether the head moved:
     #   * NEW row: initialize the SHA-bound gate fields AND `status` (the fresh row's starting state).
     #   * MOVED head on an existing row: the new head is new evidence, so reset the SHA-bound EVIDENCE — the
-    #     review tally, ci, and the liveness counters — but PRESERVE `status`: it tracks a HUMAN decision,
-    #     not the SHA, so a head refresh must never un-hold a PR the user has not ruled on (awaiting-user,
-    #     aborted, repairing).
+    #     review tally and ci here, and THE LIVENESS COUNTERS at the accessor. The `--head-sha` write below
+    #     resets those counters itself (ledger.py's `apply_head_sha`; stage-2-ci.md, "THE LIVENESS COUNTERS")
+    #     — this refresh MUST NOT hand-reset them. `status` is PRESERVED: it tracks a HUMAN decision, not the
+    #     SHA, so a head refresh must never un-hold a PR the user has not ruled on (awaiting-user, aborted,
+    #     repairing).
     #   * UNCHANGED head on an existing row: name none of the SHA-bound fields — the accumulated verdicts,
-    #     ci and liveness state all describe content that is still there and are preserved.
+    #     ci and liveness state all describe content that is still there and are preserved (the accessor's
+    #     same-value `--head-sha` write is a no-op, so the counters are untouched).
     _, rows = L.load(Path(args.file))
     existing = L.find_row(rows, pr)
     head_changed = existing is not None and existing.get("head_sha") != planned_head
@@ -282,8 +285,6 @@ def cmd_adopt(args) -> int:
         ledger_argv += ["--tier", str(row["tier"]),
                         "--ci", str(row["ci"]),
                         "--reviews-ok", str(row["reviews_ok"])]
-        for field in LIVENESS_COUNTERS:
-            ledger_argv += [f"--{field.replace('_', '-')}", str(L.ROW_DEFAULTS[field])]
     proc = _run(ledger_argv, cwd=args.project_root)
     if proc.returncode != 0:
         return _refuse(f"ledger {verb} for PR {pr} failed: {proc.stderr.strip()}")


### PR DESCRIPTION
- `ledger.py set --head-sha` now resets THE LIVENESS COUNTERS on a genuine head move; explicit flags win
- pr-adopt re-exports the one set; every hand-reset prose site now defers to the door
