### PR TITLE
make park entry and retry unpark atomic commands

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -318,12 +318,21 @@ Header field notes (the header fields above; per-row fields follow):
   Those two are the write sites that exist today, **not a bound on the set**: the class is the
   **property** — *campaign cannot move this PR without a human* (`status`, below, `awaiting-user` class
   2) — so **any** future park with that property writes its reason here, with no edit to this bullet.
+  Written by the park **tool**, never by hand: `ci-status.py liveness` for a CI park, `ledger.py … park
+  --pr <N> --reason <blocker>` for a non-CI one (both set it in the same atomic write as `status =
+  awaiting-user`).
 - `blocker_ruling` — durable record of the user's answer to a **machine-blocker park** (the `status`
   taxonomy below): `-` (none yet) | `retry@<iso>` | `abort@<iso>`. It is the **answer** to the question
   `ci_reason` **asks**, and it exists for the same reason `api_approval` does: a heartbeat may be a fresh
   agent instance, so an answer held only in context is an answer the user is asked for twice. `retry`
   unparks with the liveness counters cleared; `abort` goes terminal `aborted`. The unpark is
   `loop-control.md` step 3, "Only the user's answer unparks a PR".
+
+  **Who writes it:** the user's **answer** is recorded through `set --pr <N> --blocker-ruling retry@<iso>`
+  (or `abort@<iso>`); the park-ENTRY clear to `-` is the park writer's (`ledger.py … park` / `ci-status.py
+  liveness`); and the retry SPEND back to `-` is **`ledger.py … unpark`**'s, in the same write that flips
+  the status and resets the counters. `unpark` validates the shape — a bare `retry` or a malformed stamp is
+  refused, and an `abort` is routed to the terminal flow rather than consumed.
 
   **DURABLE *and* SPENT EXACTLY ONCE — one ruling answers exactly ONE park** (`stage-2-ci.md`, "THE RULING
   IS CONSUMED EXACTLY ONCE", is the owning definition: the clears at park **entry** and `retry` **consume**,
@@ -395,11 +404,12 @@ Header field notes (the header fields above; per-row fields follow):
        and "UNUSABLE — the refetch is BOUNDED"; `stage-3-merge.md`, "The merge precondition"). **This is
        the exit from `pending` — in BOTH of its shapes**, the settled one and the forever-`RUNNING` one;
        without it, a stuck PR spins forever and no one is ever told. **Answered into**
-       `blocker_ruling`: `retry@<iso>` → back to `in_review` **with the liveness counters cleared** (else
-       it re-escalates on its first derivation) **and the ruling itself SPENT back to `-`** (a ruling is
-       consumed exactly once — `stage-2-ci.md`, "THE RULING IS CONSUMED EXACTLY ONCE"; entering this park
-       clears it too, so it can never be answered by a **previous** park's ruling), `abort@<iso>` →
-       terminal `aborted` (not cleared — terminal rows are never re-parked).
+       `blocker_ruling`: `retry@<iso>` → **`ledger.py … unpark --pr <N>`**, which returns the row to
+       `in_review` **with the liveness counters cleared** (else it re-escalates on its first derivation)
+       **and the ruling itself SPENT back to `-`** (a ruling is consumed exactly once — `stage-2-ci.md`,
+       "THE RULING IS CONSUMED EXACTLY ONCE"; entering this park clears it too, so it can never be answered
+       by a **previous** park's ruling), all in one write; `abort@<iso>` → terminal `aborted` via the abort
+       procedure (`unpark` refuses it — not cleared, terminal rows are never re-parked).
 
     Same park mechanics as
     `awaiting-api` for both: `reviews_ok` stays 0, no review pass is launched for this PR, the other PRs
@@ -457,6 +467,8 @@ ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the ro
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
 ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only)
 ledger.py --file <state.jsonl> dispatch-check --pr N [--action ordinary|repair]
+ledger.py --file <state.jsonl> park --pr N --reason <blocker>     # MACHINE-BLOCKER park: status=awaiting-user, ci_reason=<blocker>, blocker_ruling=- — one write
+ledger.py --file <state.jsonl> unpark --pr N                      # retry unpark: status=in_review, ruling spent, liveness counters reset — one write
 ```
 
 **`verdict` is the ONLY sanctioned way to record a review verdict**, and it is not a convenience: it bumps
@@ -473,6 +485,19 @@ action that MUTATES a PR; it exits non-zero when the row is HELD (`status`, abov
 the one kind of work a `repairing` row accepts, and it is refused until the reassessment's decision is on
 the row — otherwise a driver could call its next targeted fix "the repair" and go on whacking moles under
 a new name.
+
+**`park`/`unpark` are the sanctioned writers of the machine-blocker park/unpark TRANSITIONS**, the same
+way `verdict` owns the review counters: a park (`status = awaiting-user`, `ci_reason` = the blocker,
+`blocker_ruling = -`) and a retry unpark (`status = in_review`, ruling spent, the four liveness counters
+reset) are each MULTI-FIELD writes coherent only together, so each is ONE atomic call rather than a
+hand-assembled string of `set`s. `park` is for every **non-CI** machine-blocker park (the merge-precondition
+park, `stage-3-merge.md`); the **CI** parks stay `ci-status.py liveness`'s, which writes the same three
+fields itself (`stage-2-ci.md`, "ESCALATE"). `unpark` consumes a `retry@<iso>` ruling only — it refuses a
+bare `retry`, an unanswered park, an `abort` (that goes terminal through the abort procedure), and a row
+that is not parked. **`set` still writes `status` and `blocker_ruling` and is NOT gated:** the
+review-standoff park/unpark (`finding-audit.md`) is answered into `audit-<pr>-<n>.md`, not `blocker_ruling`,
+so park/unpark cannot serve it and it stays on `set`; and `blocker_ruling` is where the user's **answer** is
+recorded (`set --blocker-ruling retry@<iso>`), which `unpark` then consumes.
 
 `table` is the user-facing status view: the end-of-heartbeat report renders it whenever the run goes back
 to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decides nothing — no gate

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -249,11 +249,14 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      answered into.** An answer that lives only in this session is an answer a fresh agent re-asks. On
      the answer: **record it**, then unpark to the `status` **THAT ANSWER** dictates — the table below is
      the authority, and it is **NOT always `in_review`**:
-     - a **RESUME** answer (`api_approval` = `approved`, a standoff ruling either way, `blocker_ruling` =
-       `retry`) → `ledger.py … set --pr <N> --status in_review`, and resume normal dispatch — including any
-       rebase or base refresh the PR has been owed while frozen — from the next heartbeat. A parked PR that has
-       fallen **behind** its base simply **stays behind** until then; it is not dropped from the run, just
-       frozen.
+     - a **RESUME** answer returns the PR to `in_review` and resumes normal dispatch — including any
+       rebase or base refresh the PR has been owed while frozen — from the next heartbeat. **The write
+       depends on the park class:** an `api_approval` = `approved` or a standoff ruling → `ledger.py … set
+       --pr <N> --status in_review` (that class carries no liveness budget and no `retry` ruling to spend);
+       a **machine-blocker** `blocker_ruling` = `retry` → **`ledger.py … unpark --pr <N>`**, which flips the
+       status, spends the ruling, and resets the liveness counters in ONE write (below — a plain `set` would
+       leave the counters standing and re-escalate). A parked PR that has fallen **behind** its base simply
+       **stays behind** until then; it is not dropped from the run, just frozen.
      - a **TERMINAL** answer (`api_approval` = `declined`, `blocker_ruling` = `abort`) → `--status aborted`
        (terminal), via `bailout-and-final-report.md`'s abort procedure. It **never** returns to
        `in_review`, and nothing is dispatched for it again.
@@ -264,16 +267,17 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      |---|---|---|
      | **`awaiting-api`** — an API-changing fix | `api_approval` = `approved@<iso>` / `declined@<iso>` | `approved` → `in_review`; `declined` → terminal `aborted` |
      | **`awaiting-user`, review standoff** — a REFUTED finding the fresh reviewer re-raised | the ruling in `<rundir>/audit-<pr>-<n>.md` | `in_review`; ruled **valid** → the finding is fixed like a CONFIRMED one, ruled **invalid** → normal flow |
-     | **`awaiting-user`, machine blocker** — campaign cannot move this PR without a human; that **property** IS the class, **never a list of cases** (one illustration: CI has SETTLED and is still not green). Do not enumerate the members here — `files-and-ledger.md`, `status`, `awaiting-user` class 2, **owns** the class, and `ci_reason` names the blocker at every one of them, present or future | `blocker_ruling` = `retry@<iso>` / `abort@<iso>` | `retry` → `in_review`, **RESET THE LIVENESS COUNTERS**, and **SPEND the ruling: `blocker_ruling` = `-`** (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "THE RULING IS CONSUMED EXACTLY ONCE"), then re-derive CI on the next heartbeat; `abort` → terminal `aborted` (the ruling **stays** — it is the record of why) |
+     | **`awaiting-user`, machine blocker** — campaign cannot move this PR without a human; that **property** IS the class, **never a list of cases** (one illustration: CI has SETTLED and is still not green). Do not enumerate the members here — `files-and-ledger.md`, `status`, `awaiting-user` class 2, **owns** the class, and `ci_reason` names the blocker at every one of them, present or future | `blocker_ruling` = `retry@<iso>` / `abort@<iso>` | `retry` → **`ledger.py … unpark --pr <N>`** — one write that sets `status = in_review`, SPENDS the ruling to `-`, and RESETS the liveness counters (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "THE RULING IS CONSUMED EXACTLY ONCE"), then re-derive CI on the next heartbeat; `abort` → terminal `aborted` via the abort procedure (`unpark` refuses it — the ruling **stays** as the record of why) |
 
      **The counter reset is part of the unpark, not an optimization**: a `retry` that clears nothing
      re-escalates on its first derivation (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "SETTLED" /
      "UNUSABLE — the refetch is BOUNDED", own why). The loop is bounded by the **human**: campaign never
      re-asks unprompted, and every park is a fresh question backed by a fresh snapshot.
 
-     **A `retry` is SPENT when it is consumed — one ruling answers exactly ONE park.** Write `status =
-     in_review`, the counter reset, and `blocker_ruling` = `-` in the **same** `ledger.py … set --pr <N>`
-     call. That re-park above is precisely the case that proves it: the PR comes back to the **same**
+     **A `retry` is SPENT when it is consumed — one ruling answers exactly ONE park.** `ledger.py … unpark
+     --pr <N>` writes `status = in_review`, the counter reset, and `blocker_ruling` = `-` in **one** call —
+     the three fields are coherent only together, so the tool does them as one write rather than leaving a
+     driver to hand-assemble them. That re-park above is precisely the case that proves it: the PR comes back to the **same**
      machine blocker, and a ruling left on the row would answer the new park with the **old** answer —
      the blocker would silently self-clear with no fresh user answer, which is the one thing the durable
      record exists to prevent. Park **entry** clears it too (`stage-2-ci.md`, ESCALATE), so a crash

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -455,9 +455,15 @@ like any other settled or stalled PR. The gate suppresses a bound only while wor
 never registered, **which check has been `RUNNING` since when without the check set moving**, which value
 was unrecognized, which read was denied), **and `blocker_ruling` = `-` in
 that same row write** ("THE RULING IS CONSUMED EXACTLY ONCE" below — a ruling already on the
-row answers the **previous** park, never this one), and tell the user. **For the three liveness bounds,
-`ci-status.py liveness` performs that row write itself** (exit `3` — "THE BOOKKEEPING IS A COMMAND",
-above); telling the user is the half that stays with the driver. It does **not**
+row answers the **previous** park, never this one), and tell the user. **The three-field row write is a
+COMMAND, split by who owns the park: for the three liveness bounds `ci-status.py liveness` performs it
+itself** (exit `3` — "THE BOOKKEEPING IS A COMMAND", above); **every OTHER machine-blocker park runs
+`ledger.py … park --pr <N> --reason <the blocker>`**, which writes `status = awaiting-user`, `ci_reason`,
+and `blocker_ruling = -` in one atomic write (`files-and-ledger.md`, "Editing the ledger" — it refuses a
+blank reason, a terminal row, and a second park over an open question). The non-CI sites are
+`stage-3-merge.md`'s merge-precondition park. **NEVER hand-assemble the three fields through `set`** — a
+park missing its `ci_reason` is a question nobody can read. Telling the user is the half that stays with
+the driver. It does **not**
 abort the run or close the PR — the run's other PRs keep going. At **this** park — a CI one — `ci_reason` is
 **the DECIDE reason for this snapshot**: the bullet that matched and the row that made it match, never a
 bare restatement of `ci`. (The field itself is **wider than CI**: it is the durable machine-blocker reason,
@@ -520,11 +526,14 @@ added to the schema tomorrow is already covered here:
 itself.** `blocker_ruling` must be **DURABLE** (it survives a context loss) **AND spent EXACTLY ONCE** (it
 answers the park it was written for, and no other). Both halves, or neither holds:
 
-- **ENTERING a machine-blocker park sets `blocker_ruling` = `-`** (ESCALATE above), in the **same**
-  `ledger.py … set` call that writes `status = awaiting-user` — one atomic row write, so no heartbeat can ever
-  observe a freshly parked row still carrying the previous park's answer.
-- **CONSUMING a `retry` sets it back to `-`** in the same call that unparks the PR (`loop-control.md`
-  step 3).
+- **ENTERING a machine-blocker park sets `blocker_ruling` = `-`** (ESCALATE above), in the **same** write
+  that sets `status = awaiting-user` — `ledger.py … park` for a non-CI park, `ci-status.py liveness` for a
+  CI one — one atomic row write, so no heartbeat can ever observe a freshly parked row still carrying the
+  previous park's answer.
+- **CONSUMING a `retry` sets it back to `-`** in the **same** `ledger.py … unpark --pr <N>` call that
+  unparks the PR (`loop-control.md` step 3): the tool spends the ruling and resets the liveness counters in
+  one write. It refuses a `blocker_ruling` that is not a well-formed `retry@<iso>` — a bare `retry` or an
+  `abort` never reaches this consume path.
 - **`abort@<iso>` is NEVER cleared.** It unparks into terminal `aborted`; a terminal row is never re-parked
   and never re-consulted, so the ruling stays as the durable record of **why** the PR stopped
   (`bailout-and-final-report.md`).

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -66,14 +66,16 @@ the in-heartbeat cap is a fixed 3, and the coarse retry is the heartbeat loop it
 `MERGEABLE`, and never let a perpetually-`UNKNOWN` PR either merge or wedge.
 
 **EVERY `awaiting-user` park a `not-yet` verdict names is a MACHINE-BLOCKER park, and it MUST declare its exit** — a
-park whose exit event never comes is the same wedge it was meant to prevent. So, in the same step: write
-`ci_reason` **naming the blocker** (the draft state, `BLOCKED`, or the unrecognized value verbatim),
-**clear `blocker_ruling` to `-`** (park entry spends nothing and answers nothing — a ruling already on the
-row belongs to a **previous** park; `stage-2-ci.md`, "THE RULING IS CONSUMED EXACTLY ONCE"), and
-resolve it through `blocker_ruling` = `retry` / `abort` — the user marks the PR ready, clears the
-protection, or gives up, and answers. The record and the unpark are defined once, in `files-and-ledger.md`
-(`status`) and `loop-control.md` step 3, "Only the user's answer unparks a PR"; never invent a second
-mechanism here.
+park whose exit event never comes is the same wedge it was meant to prevent. Run **`ledger.py … park --pr
+<N> --reason <the blocker>`** — the sanctioned writer of a non-CI machine-blocker park (`stage-2-ci.md`,
+"ESCALATE"). It sets `status = awaiting-user`, `ci_reason` = the blocker **named** (the draft state,
+`BLOCKED`, or the unrecognized value verbatim), and `blocker_ruling = -` in ONE atomic write (park entry
+spends nothing and answers nothing — a ruling already on the row belongs to a **previous** park;
+`stage-2-ci.md`, "THE RULING IS CONSUMED EXACTLY ONCE"), and it refuses a blank reason, a terminal row, and
+a second park over an open question. It is then resolved through `blocker_ruling` = `retry` / `abort` — the
+user marks the PR ready, clears the protection, or gives up, and answers. The record and the unpark are
+defined once, in `files-and-ledger.md` (`status`) and `loop-control.md` step 3, "Only the user's answer
+unparks a PR"; never invent a second mechanism here.
 
 #### `BLOCKED` and `UNSTABLE` — what each merge state means
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1726,6 +1726,206 @@ def t_stale_repair_decision_cleared_at_cap(L: ModuleType, tmp: Path) -> None:
     check(fresh in out, f"dispatch-check must name the decision to dispatch: {out!r}")
 
 
+# --- park / unpark: the machine-blocker park is a MULTI-FIELD atomic write -----
+#
+# A park (status=awaiting-user, ci_reason=<blocker>, blocker_ruling=-) and a retry unpark (status=in_review,
+# ruling spent, the four liveness counters reset) are each coherent only as ONE write. Hand-assembled from
+# `set` a field gets dropped — a park with no ci_reason is unanswerable, a retry that leaves the counters
+# re-escalates. These fixtures pin that each subcommand does the WHOLE write, refuses what it must, and
+# leaves everything it does not own untouched.
+
+PARK_ROW = dict(pr="1", head_sha=SHA_A, status="in_review", settled_strikes="2", unusable_refetches="1",
+                ci_stalled_since="2026-07-14T00:00:00Z", ci_fingerprint="sha256:zz")
+
+
+def count_dumps(L: ModuleType, fn) -> int:
+    """Run `fn` and return how many times the accessor wrote the store — a park/unpark is ONE write."""
+    calls = [0]
+    real = L.dump
+
+    def spy(*a, **k):  # noqa: ANN002,ANN003
+        calls[0] += 1
+        return real(*a, **k)
+
+    # `setattr`, not `L.dump = spy`: assigning through the ModuleType attribute is a Pyright error on the
+    # type-clean list, and this is a test seam, not a schema write.
+    setattr(L, "dump", spy)
+    try:
+        fn()
+    finally:
+        setattr(L, "dump", real)
+    return calls[0]
+
+
+def t_park_writes_all_three(L: ModuleType, tmp: Path) -> None:
+    """`park` sets status=awaiting-user, ci_reason=<blocker>, blocker_ruling=- in ONE write — and touches
+    NOTHING else, the liveness counters included (a park does not reset them; only the unpark does)."""
+    path = write_lines(tmp / "p.jsonl", header_line(L),
+                       row_line(L, blocker_ruling="retry@2026-07-01T00:00:00Z", **PARK_ROW))
+    captured: dict = {}
+
+    def run() -> None:
+        captured["r"] = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", "BLOCKED merge state — park"])
+
+    dumps = count_dumps(L, run)
+    code, out, err = captured["r"]
+    check(code == 0, f"park exited {code}: {err!r}")
+    check(dumps == 1, f"park wrote the store {dumps} times, not once — it is ONE atomic write")
+    row = json.loads(out)
+    check((row["status"], row["ci_reason"], row["blocker_ruling"])
+          == ("awaiting-user", "BLOCKED merge state — park", "-"),
+          f"park did not write the three fields atomically: {row!r}")
+    # the liveness counters and every unrelated field are UNTOUCHED — park is not the counter-reset site.
+    check((row["settled_strikes"], row["unusable_refetches"], row["ci_stalled_since"], row["ci_fingerprint"])
+          == ("2", "1", "2026-07-14T00:00:00Z", "sha256:zz"),
+          f"park reset a liveness counter — that is the UNPARK's job, not the park's: {row!r}")
+    check(row["head_sha"] == SHA_A, f"park disturbed an unrelated field: {row!r}")
+    # …and it is on DISK, not just in the printed JSON.
+    code, got, _ = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    check(json.loads(got)["status"] == "awaiting-user", f"the park did not land on disk: {got!r}")
+
+
+def t_park_refusals(L: ModuleType, tmp: Path) -> None:
+    """Every park refusal writes NOTHING, and the double-park STOPS with the OPEN question surfaced."""
+    # no row
+    code, _, err = cli(L, ["--file", str(tmp / "none.jsonl"), "park", "--pr", "9", "--reason", "x"])
+    check(code == 1 and "no row for pr 9" in err, f"park on a missing row: exit {code}, {err!r}")
+
+    # terminal rows
+    for term in ("merged", "aborted"):
+        path = write_lines(tmp / f"{term}.jsonl", header_line(L), row_line(L, pr="1", status=term))
+        code, _, err = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", "x"])
+        check(code == 1 and term in err and "terminal" in err, f"[{term}] park was allowed: exit {code}, {err!r}")
+        check("awaiting-user" not in path.read_text(), f"[{term}] a refused park still wrote the store")
+
+    # empty / `-` reason — a park that cannot NAME its blocker
+    for reason in ("", "   ", "-"):
+        path = write_lines(tmp / f"r{reason.strip() or 'blank'}.jsonl", header_line(L),
+                           row_line(L, pr="1", status="in_review"))
+        code, _, err = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", reason])
+        check(code == 1 and "name its blocker" in err, f"[{reason!r}] park with no blocker: exit {code}, {err!r}")
+        check("awaiting-user" not in path.read_text(), f"[{reason!r}] a refused park still wrote the store")
+
+    # conflicting-owner held states — each names the conflicting status, exit 1, nothing written
+    for status in ("awaiting-api", L.REPAIR_STATUS):
+        path = write_lines(tmp / f"o-{status}.jsonl", header_line(L), row_line(L, pr="1", status=status))
+        code, _, err = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", "x"])
+        check(code == 1 and status in err, f"[{status}] park did not name the conflicting owner: exit {code}, {err!r}")
+        check("awaiting-user" not in path.read_text(), f"[{status}] a refused park still wrote the store")
+
+    # DOUBLE PARK — a park is already open. STOP (EXIT_STOP), surface the OPEN ci_reason, overwrite NOTHING.
+    open_q = "SETTLED at the STRIKE CAP — nobody is coming"
+    path = write_lines(tmp / "dbl.jsonl", header_line(L),
+                       row_line(L, pr="1", status="awaiting-user", ci_reason=open_q,
+                                blocker_ruling="-"))
+    code, _, err = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", "a DIFFERENT blocker"])
+    check(code == L.EXIT_STOP, f"a second park did not STOP: exit {code}")
+    check(open_q in err, f"the double-park refusal must surface the OPEN question: {err!r}")
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "ci_reason"])
+    check(out.strip() == open_q,
+          f"a second park OVERWROTE the open question — the very thing the user is being asked to rule on: {out!r}")
+
+
+def t_unpark_spends_and_resets(L: ModuleType, tmp: Path) -> None:
+    """`unpark` flips status=in_review, SPENDS the ruling to `-`, and resets ALL FOUR liveness counters —
+    in ONE write — while every unrelated field survives."""
+    path = write_lines(tmp / "u.jsonl", header_line(L),
+                       row_line(L, blocker_ruling="retry@2026-07-14T01:00:00Z", status="awaiting-user",
+                                ci_reason="SETTLED — nobody coming", slug="keep-me", reviews_ok="1",
+                                review_rounds="5", ns_streak="0",
+                                **{k: v for k, v in PARK_ROW.items() if k not in ("status",)}))
+    captured: dict = {}
+
+    def run() -> None:
+        captured["r"] = cli(L, ["--file", str(path), "unpark", "--pr", "1"])
+
+    dumps = count_dumps(L, run)
+    code, out, err = captured["r"]
+    check(code == 0, f"unpark exited {code}: {err!r}")
+    check(dumps == 1, f"unpark wrote the store {dumps} times, not once — it is ONE atomic write")
+    row = json.loads(out)
+    check((row["status"], row["blocker_ruling"]) == ("in_review", "-"),
+          f"unpark did not flip status and SPEND the ruling: {row!r}")
+    # ALL FOUR liveness counters back to their ROW_DEFAULTS — asserted against the accessor's own defaults.
+    for f in L.LIVENESS_COUNTERS:
+        check(row[f] == L.ROW_DEFAULTS[f],
+              f"unpark left liveness counter {f}={row[f]!r}, not its default {L.ROW_DEFAULTS[f]!r} — the "
+              f"retry would re-escalate on its first derivation")
+    # …and the fields the unpark does NOT own are all still there.
+    check((row["head_sha"], row["slug"], row["reviews_ok"], row["review_rounds"], row["ci_reason"])
+          == (SHA_A, "keep-me", "1", "5", "SETTLED — nobody coming"),
+          f"unpark disturbed a field it does not own (ci_reason is overwritten by the NEXT derivation, "
+          f"never by the unpark): {row!r}")
+    code, got, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "status"])
+    check(got.strip() == "in_review", f"the unpark did not land on disk: {got!r}")
+
+
+def t_unpark_refusals(L: ModuleType, tmp: Path) -> None:
+    """Every unpark refusal writes NOTHING; the unanswered park STOPS, and abort is routed to its own flow."""
+    # no row
+    code, _, err = cli(L, ["--file", str(tmp / "none.jsonl"), "unpark", "--pr", "9"])
+    check(code == 1 and "no row for pr 9" in err, f"unpark on a missing row: exit {code}, {err!r}")
+
+    # not parked — nothing to unpark
+    for status in ("in_review", "pending", "merged", L.REPAIR_STATUS):
+        path = write_lines(tmp / f"np-{status}.jsonl", header_line(L),
+                           row_line(L, pr="1", status=status, blocker_ruling="retry@2026-07-14T00:00:00Z"))
+        code, _, err = cli(L, ["--file", str(path), "unpark", "--pr", "1"])
+        check(code == 1 and "not awaiting-user" in err, f"[{status}] unpark was allowed: exit {code}, {err!r}")
+
+    # UNANSWERED park — ruling `-`. STOP (EXIT_STOP), surface the open blocker, write nothing.
+    path = write_lines(tmp / "unans.jsonl", header_line(L),
+                       row_line(L, pr="1", status="awaiting-user", ci_reason="the OPEN question",
+                                blocker_ruling="-"))
+    code, _, err = cli(L, ["--file", str(path), "unpark", "--pr", "1"])
+    check(code == L.EXIT_STOP, f"unparking an UNANSWERED park did not STOP: exit {code}")
+    check("the OPEN question" in err, f"the unanswered-unpark refusal must surface the open blocker: {err!r}")
+    code, got, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "status"])
+    check(got.strip() == "awaiting-user", f"a refused unpark still moved the row off the park: {got!r}")
+
+    # ABORT ruling — NOT an unpark; routed to the abort flow, exit 1, nothing written
+    path = write_lines(tmp / "abort.jsonl", header_line(L),
+                       row_line(L, pr="1", status="awaiting-user", ci_reason="q",
+                                blocker_ruling="abort@2026-07-14T00:00:00Z"))
+    code, _, err = cli(L, ["--file", str(path), "unpark", "--pr", "1"])
+    check(code == 1 and "abort" in err.lower(), f"an abort ruling was treated as an unpark: exit {code}, {err!r}")
+    code, got, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "status"])
+    check(got.strip() == "awaiting-user", f"a refused (abort) unpark still moved the row: {got!r}")
+
+    # MALFORMED stamps — a bare `retry`, an empty stamp, a non-date stamp — all refused
+    for bad in ("retry", "retry@", "retry@not-a-date", "retryX@2026-07-14T00:00:00Z"):
+        path = write_lines(tmp / f"bad-{bad.strip('@') or 'x'}.jsonl", header_line(L),
+                           row_line(L, pr="1", status="awaiting-user", ci_reason="q", blocker_ruling=bad))
+        code, _, err = cli(L, ["--file", str(path), "unpark", "--pr", "1"])
+        check(code == 1 and "well-formed" in err,
+              f"[{bad!r}] a malformed ruling was accepted as a retry: exit {code}, {err!r}")
+        check("in_review" not in path.read_text(), f"[{bad!r}] a refused unpark still wrote the store")
+
+
+def t_set_status_transitions_stay_open(L: ModuleType, tmp: Path) -> None:
+    """The `set --status awaiting-user` / `set --status in_review` transitions are DELIBERATELY still
+    allowed — the design decision that keeps the REVIEW-STANDOFF park (finding-audit.md) working.
+
+    The standoff park is answered into `audit-<pr>-<n>.md`, NOT `blocker_ruling`, and its unpark carries no
+    `retry@<iso>` ruling for `unpark` to validate — so park/unpark CANNOT serve it and `set` must stay open.
+    If a future change gates these transitions to force everything through park/unpark, this fixture goes
+    red and says why: the standoff writer would break.
+    """
+    path = write_lines(tmp / "so.jsonl", header_line(L), row_line(L, pr="1", status="in_review"))
+    # standoff PARK via set — no ci_reason, no ruling; answered into the audit file
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "awaiting-user"])
+    check(code == 0, f"`set --status awaiting-user` was refused — the review-standoff park is broken: {err!r}")
+    check(json.loads(out)["status"] == "awaiting-user", f"set did not write the standoff park: {out!r}")
+    # standoff UNPARK via set — a plain return to in_review, no retry ruling involved
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+    check(code == 0, f"`set --status in_review` was refused — the standoff unpark is broken: {err!r}")
+    check(json.loads(out)["status"] == "in_review", f"set did not write the standoff unpark: {out!r}")
+    # `blocker_ruling` also stays settable via set — it is where the user's ANSWER is recorded
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--blocker-ruling", "retry@2026-07-14T00:00:00Z"])
+    check(code == 0 and json.loads(out)["blocker_ruling"] == "retry@2026-07-14T00:00:00Z",
+          f"`set --blocker-ruling` was refused — the user's answer cannot be recorded: exit {code}, {err!r}")
+
+
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
     ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
@@ -1775,6 +1975,11 @@ CASES = [
     ("repair-bound-no-door", "repair_count has NO flag — a budget you can zero is not a bound", t_the_repair_bound_has_no_door),
     ("repair-decision-cleared", "re-entering a cap CLEARS the stale reassessment decision — the repair budget binds", t_stale_repair_decision_cleared_at_cap),
     ("pr-origin-default", "an unknown origin is `external` — the fail-safe direction", t_pr_origin_defaults_to_external),
+    ("park-writes-three", "`park` writes status/ci_reason/blocker_ruling atomically, counters untouched", t_park_writes_all_three),
+    ("park-refusals", "park refuses no-row/terminal/blank-reason/held-owner, and a double-park STOPs", t_park_refusals),
+    ("unpark-spends-resets", "`unpark` flips status, spends the ruling, resets all four counters — one write", t_unpark_spends_and_resets),
+    ("unpark-refusals", "unpark refuses not-parked/unanswered/abort/malformed — writing nothing", t_unpark_refusals),
+    ("set-status-stays-open", "set may still write the standoff park/unpark transitions — park/unpark can't serve them", t_set_status_transitions_stay_open),
     ("replay-the-record", "the REAL #42/#43 verdict sequences: it fires, never too early, and says what it costs", t_replay_the_real_record),
 ]
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from typing import NoReturn
 
@@ -178,6 +179,30 @@ VERDICT_OWNED = ("review_rounds", "ns_streak")
 # forever. The tool that decides a repair is the only thing that writes what it spent.
 REPAIR_OWNED = ("repair_count", "repair_decision")
 
+# The park/unpark TRANSITIONS `park`/`unpark` own — the same mechanism as VERDICT_OWNED, one level up at the
+# `status` field. A machine-blocker park and a retry unpark are each MULTI-FIELD atomic writes whose fields
+# are coherent only TOGETHER: a park sets `status = awaiting-user`, `ci_reason` = the blocker, and
+# `blocker_ruling = -` in ONE write (a park with no `ci_reason` is a question nobody can read); a retry
+# unpark sets `status = in_review`, SPENDS the ruling back to `-`, and resets the four liveness counters in
+# ONE write (a retry that leaves the counters standing re-escalates on its first derivation). Hand-assembling
+# either from `set` is exactly how a field gets dropped, so `park`/`unpark` are the sanctioned writers of
+# those two transitions (stage-2-ci.md, "ESCALATE" / "THE RULING IS CONSUMED EXACTLY ONCE" / "THE LIVENESS
+# COUNTERS"; loop-control.md step 3; stage-3-merge.md).
+#
+# `set` is DELIBERATELY left able to write `status` and `blocker_ruling` — the guard is NOT closed, because:
+#   * the REVIEW-STANDOFF park (finding-audit.md) writes `status = awaiting-user` through `set` and is
+#     answered into `audit-<pr>-<n>.md`, NOT `blocker_ruling`; its unpark is a plain `set --status
+#     in_review` carrying no `retry@<iso>` ruling for `unpark` to validate. park/unpark cannot serve that
+#     class, so `set` stays open for it (and for `merged`/`aborted`/the api-approval resume);
+#   * `blocker_ruling` is where the USER'S ANSWER is recorded (`set --pr N --blocker-ruling retry@<iso>`);
+#     park/unpark own only the park-ENTRY clear and the retry SPEND, never the answer itself.
+# The CI-bound parks are `ci-status.py liveness`'s (it writes the same three fields itself and does NOT call
+# `park`); `park` is the writer for every OTHER machine-blocker park.
+
+# (`unpark` resets every LIVENESS_COUNTERS member — the set defined once, above — to its ROW_DEFAULTS
+# value, never a retyped literal, so a counter added to the set is reset by the retry unpark with NO edit
+# to `cmd_unpark`.)
+
 SATISFIED, NOT_SATISFIED = "satisfied", "not-satisfied"
 VERDICTS = (SATISFIED, NOT_SATISFIED)
 
@@ -241,6 +266,12 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}\Z")
 # would take `" +2 "` and CRASH on `"-"` — and `-` is this schema's own "not set" spelling, so it is a
 # value a counter field can genuinely be handed by a hand-edited store).
 COUNT_RE = re.compile(r"^(?:0|[1-9][0-9]*)\Z")
+
+# A machine-blocker ruling on disk: `retry@<iso>` | `abort@<iso>` (or `-` for none). `unpark` CONSUMES a
+# `retry`, so the shape is checked rather than trusted — the `@<iso>` is what SCOPES a ruling to the park it
+# answers (stage-2-ci.md, "THE RULING IS CONSUMED EXACTLY ONCE"), and a bare `retry` or a malformed stamp is
+# a ruling `unpark` must refuse, never act on. No DOTALL: a newline in the stamp is malformed, so it fails.
+RULING_RE = re.compile(r"^(retry|abort)@(.+)\Z")
 
 
 def fail(msg: str) -> NoReturn:
@@ -387,6 +418,25 @@ def find_row(rows: list[dict], pr: str) -> "dict | None":
 def check_field(name: str, valid: "tuple[str, ...]") -> None:
     if name not in valid:
         fail(f"unknown field '{name}'; valid: {', '.join(valid)}")
+
+
+def parse_ruling(value: str) -> "tuple[str, str] | None":
+    """A `blocker_ruling` as (kind, stamp) — or None if it is not a well-formed `retry@<iso>`/`abort@<iso>`.
+
+    The stamp is validated by actually PARSING it: a trailing `Z` is UTC, which `datetime.fromisoformat`
+    does not accept before 3.11, so it is normalised to `+00:00` first. A bare `retry`, an empty stamp, or
+    one that is not a date-time is not a ruling `unpark` may consume — refused, never guessed at.
+    """
+    m = RULING_RE.match(value)
+    if m is None:
+        return None
+    kind, stamp = m.group(1), m.group(2)
+    probe = stamp[:-1] + "+00:00" if stamp.endswith("Z") else stamp
+    try:
+        datetime.fromisoformat(probe)
+    except ValueError:
+        return None
+    return kind, stamp
 
 
 # --- subcommands --------------------------------------------------------------
@@ -695,6 +745,102 @@ def cmd_dispatch_check(path: Path, args) -> int:
     return EXIT_STOP
 
 
+def cmd_park(path: Path, args) -> int:
+    """Park a PR on the USER for a MACHINE BLOCKER — the ESCALATE row write, in ONE atomic dump.
+
+    Sets `status = awaiting-user`, `ci_reason` = the blocker (NAMED), and `blocker_ruling = -` in one write.
+    The `blocker_ruling` clear is not cosmetic: park ENTRY answers nothing, so a ruling already on the row
+    belongs to a PREVIOUS park and must be voided in the SAME write that opens this one (stage-2-ci.md, "THE
+    RULING IS CONSUMED EXACTLY ONCE"). This is the sanctioned writer of the machine-blocker park transition
+    for every NON-CI park (the merge-precondition park, stage-3-merge.md; any future one). `ci-status.py
+    liveness` performs the CI-bound parks itself, on these same three fields, and does not call this.
+
+    Refusals, none of which write anything:
+      * no row, or a TERMINAL row (`merged`/`aborted`) — nothing waits on a human for it — `fail` (exit 1);
+      * an empty or `-` reason — a park that cannot name its blocker is not actionable (ESCALATE) — exit 1;
+      * `awaiting-api` / `repairing` — those held states have their OWN owners (`held_reason`) — exit 1;
+      * ALREADY `awaiting-user` — a park is open and a SECOND may not overwrite the open question. That is a
+        STOP, not an input error: `EXIT_STOP`, and the EXISTING `ci_reason` is surfaced so the driver knows
+        which question is already outstanding.
+    """
+    header, rows = load(path)
+    pr = str(args.pr)
+    row = find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}; use `add-row` to create it")
+    reason = args.reason.strip()
+    if reason in ("", "-"):
+        fail(f"park requires a --reason NAMING the blocker: a park that cannot name its blocker is not "
+             f"actionable (stage-2-ci.md, ESCALATE). `ci_reason` is the question the user is asked to rule "
+             f"on, so an empty or `-` reason parks a PR on a question nobody can read")
+    status = row["status"]
+    if status in ("merged", "aborted"):
+        fail(f"pr {pr} is {status} — a terminal row is never parked; nothing waits on a human for it")
+    if status == "awaiting-user":
+        print(f"ledger: pr {pr} is ALREADY awaiting-user — a park is open and NOT yet answered, so a second "
+              f"park may not overwrite its question. Open blocker: {row['ci_reason']}", file=sys.stderr)
+        return EXIT_STOP
+    if status in ("awaiting-api", REPAIR_STATUS):
+        fail(f"pr {pr} is {status}, not parkable as a machine blocker — that state has its own owner "
+             f"({held_reason(status)}). Resolve it through its own path, not a park")
+
+    row.update({"status": "awaiting-user", "ci_reason": reason, "blocker_ruling": "-"})
+    dump(path, header, rows)
+    print(json.dumps(row))
+    return 0
+
+
+def cmd_unpark(path: Path, args) -> int:
+    """Unpark a PR whose machine-blocker park the user answered `retry` — ONE atomic multi-field write.
+
+    The row must be `awaiting-user` AND carry a `blocker_ruling` of `retry@<iso>` (the user's answer,
+    recorded through `set`). Then, in ONE write: `status = in_review`; the ruling SPENT back to `-`
+    (consumed exactly once — stage-2-ci.md, "THE RULING IS CONSUMED EXACTLY ONCE"); and the four
+    `LIVENESS_COUNTERS` reset to their `ROW_DEFAULTS`, so the retry gets a FRESH budget instead of
+    re-escalating on its first derivation (stage-2-ci.md, "THE LIVENESS COUNTERS"). The counters are reset
+    from `ROW_DEFAULTS`, never retyped, so a member added to the set is covered with no edit here.
+
+    Refusals, none of which write anything:
+      * no row, or a row that is NOT `awaiting-user` (nothing to unpark) — `fail` (exit 1);
+      * ruling `abort@<iso>` — abort is NOT an unpark; it goes terminal through the abort procedure
+        (`bailout-and-final-report.md`), which owns it — `fail` (exit 1);
+      * a bare `retry` or a malformed stamp — not a ruling that may be consumed — `fail` (exit 1);
+      * ruling `-` — the park's question is UNANSWERED. That is a STOP, not an input error: `EXIT_STOP`,
+        and the open `ci_reason` is surfaced so the driver knows what the user still owes an answer to.
+    """
+    header, rows = load(path)
+    pr = str(args.pr)
+    row = find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}; use `add-row` to create it")
+    if row["status"] != "awaiting-user":
+        fail(f"pr {pr} is {row['status']}, not awaiting-user — there is no machine-blocker park to unpark. "
+             f"Only a parked row is unparked, and only the user's answer parks-then-unparks it")
+    ruling = row["blocker_ruling"]
+    if ruling == "-":
+        print(f"ledger: pr {pr} is awaiting-user but its blocker_ruling is `-` — the park is NOT yet "
+              f"answered. Record the user's answer first (`set --pr {pr} --blocker-ruling retry@<iso>`), "
+              f"then unpark. Open blocker: {row['ci_reason']}", file=sys.stderr)
+        return EXIT_STOP
+    parsed = parse_ruling(ruling)
+    if parsed is None:
+        fail(f"pr {pr} blocker_ruling {ruling!r} is not a well-formed ruling — expected `retry@<iso>` or "
+             f"`abort@<iso>`. A bare `retry` or a malformed timestamp is refused, never acted on")
+    kind, _ = parsed
+    if kind == "abort":
+        fail(f"pr {pr} blocker_ruling is {ruling} — `abort` is NOT an unpark. It goes to terminal `aborted` "
+             f"through the abort procedure (bailout-and-final-report.md), which owns it; `unpark` serves the "
+             f"`retry` answer only")
+
+    updates = {"status": "in_review", "blocker_ruling": "-"}
+    for f in LIVENESS_COUNTERS:
+        updates[f] = ROW_DEFAULTS[f]   # from the defaults — NEVER a retyped literal
+    row.update(updates)
+    dump(path, header, rows)
+    print(json.dumps(row))
+    return 0
+
+
 def cmd_get(path: Path, args) -> int:
     _, rows = load(path)
     row = find_row(rows, str(args.pr))
@@ -896,6 +1042,17 @@ def build_parser() -> argparse.ArgumentParser:
                         "rebase, relabel. 'repair' = the reassessment's decided repair, the only work a "
                         "`repairing` row accepts (and only once its decision is recorded)")
 
+    pk = sub.add_parser("park", help="park a PR on the user for a MACHINE BLOCKER: status=awaiting-user, "
+                                     "ci_reason=<blocker>, blocker_ruling=- — atomically")
+    pk.add_argument("--pr", required=True, help="PR number (row key)")
+    pk.add_argument("--reason", required=True,
+                    help="the machine blocker, NAMED — the question the user is asked to rule on; becomes "
+                         "ci_reason. Empty or `-` is refused")
+
+    up = sub.add_parser("unpark", help="unpark a PR whose machine-blocker park the user answered `retry`: "
+                                       "status=in_review, ruling spent, liveness counters reset — atomically")
+    up.add_argument("--pr", required=True, help="PR number (row key)")
+
     g = sub.add_parser("get", help="print the row for --pr as JSON, or one field")
     g.add_argument("--pr", required=True, help="PR number (row key)")
     g.add_argument("--field", help="print only this field")
@@ -926,7 +1083,7 @@ def main(argv: list[str]) -> int:
     handlers = {
         "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set, "verdict": cmd_verdict,
         "get": cmd_get, "list": cmd_list, "table": cmd_table,
-        "dispatch-check": cmd_dispatch_check,
+        "dispatch-check": cmd_dispatch_check, "park": cmd_park, "unpark": cmd_unpark,
     }
     return handlers[args.cmd](path, args)
 


### PR DESCRIPTION
- `ledger.py park` writes the ESCALATE triple atomically; refuses double-parks surfacing the open question
- `ledger.py unpark` consumes a validated `retry@<iso>`, spends it, resets the liveness counters in one write
