### PR TITLE
emit the watch decision from liveness

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -781,8 +781,9 @@ ever re-ordered again.
   - **An unknown value parks the PR AS SOON AS no `FAIL` outranks it** — on this derivation if there is
     no `FAIL`, otherwise on the next one, once the CI fix has cleared the failure. **It is deferred, never
     dropped**, and it outranks `pending`: a still-running row does **not** postpone the park.
-- **pending** → any evidence row classifies `RUNNING` → leave `ci = pending`. **This is the ONLY outcome
-  that warrants a watch** (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"): a row can still move on its own, so if the
+- **pending** → any evidence row classifies `RUNNING` → leave `ci = pending`. **This outcome warrants a
+  watch** (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE", owns the whole policy — a `red` verdict with a
+  still-`RUNNING` row is watched too): a row can still move on its own, so if the
   watch task has exited, **relaunch it in this same heartbeat** — a PR with a still-RUNNING row must never sit
   unwatched waiting for the fallback heartbeat. **It is also BOUNDED**: "a row can still move" is a claim the row
   makes, not a promise it keeps, so if the whole check set then sits unchanged for the CI STALL CAP, the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -69,11 +69,13 @@
 - Work-conserving dispatch is mandatory: every heartbeat scans all PRs and launches every due
   action that fits a free slot before returning. Waiting is allowed only when no useful action is
   launchable anywhere in the run.
-- A PR with a **still-RUNNING** check must ALWAYS have a live watch: if **`derive`'s `buckets.RUNNING`
-  is > 0** (the CLASSIFY tally — `ci-derivation-spec.md`, "CLASSIFY every row" — an EXPLICIT membership test, and
+- A PR whose snapshot can still move must ALWAYS have a live watch: if **`liveness` reports
+  `watch_warranted`** — its mechanical reduction of "WATCH ONLY WHAT CAN MOVE": `verified AND verdict !=
+  UNCLASSIFIED AND buckets.RUNNING > 0`, where `buckets.RUNNING` is the CLASSIFY tally
+  (`ci-derivation-spec.md`, "CLASSIFY every row"), an EXPLICIT membership test and
   **NEVER** "any row is not yet terminal" / `.status != COMPLETED`, which is a negated test: it sweeps up
   every value GitHub adds tomorrow and silently watches it instead of letting it fall to the
-  `UNKNOWN_VALUE` escalation) and the watch task has exited (including after any rebase/push), relaunch
+  `UNKNOWN_VALUE` escalation — and the watch task has exited (including after any rebase/push), relaunch
   the watch in this same heartbeat — never wait for the next heartbeat.
 - **But NEVER relaunch a watch merely because `ci == pending`.** Once CI has **SETTLED** (no row can
   still move) there is nothing to block on: `gh pr checks --watch` returns in about **a second**, and a
@@ -207,8 +209,8 @@
   Write the refutation as an **inline comment at the site** (plus `<rundir>/audit-<pr>-<n>.md`) and
   **commit it**. A refutation is a COMMIT, a commit is PR CONTENT, and PR content **RESETS THE GATE** and
   is **REVIEWED** — route it through the same "any campaign commit resets the gate" rule (`reviews_ok` →
-  0, restore `gauntlet-reviewing`, re-derive CI for the new tip and watch it only if a row can still move,
-  re-enter Stage 2a); never invent a second mechanism. Nothing is slipped past the reviewer: the argument is IN the diff, so a bogus refutation is
+  0, restore `gauntlet-reviewing`, re-derive CI for the new tip and watch it only if `liveness` reports
+  `watch_warranted`, re-enter Stage 2a); never invent a second mechanism. Nothing is slipped past the reviewer: the argument is IN the diff, so a bogus refutation is
   a defect the next reviewer flags. The comment MUST be a **falsifiable claim with evidence** ("git has
   no hardlink mode — a PR cannot create one; verified: checkout recreates separate inodes"), NEVER an
   instruction to the reviewer ("ignore this", "do not re-raise", "already dismissed") — argue why the
@@ -395,9 +397,9 @@
   `reviews_ok` to 0 AND restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`; the new commit
   moves `head_sha`, so writing it through the accessor **resets the liveness counters** at the door
   (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); re-derive CI
-  for the new tip and watch it **only if a row can still move** (`stage-2-ci.md`, "WATCH ONLY WHAT CAN
-  MOVE" — a watch launched on a tip whose checks have not registered yet has nothing to block on and
-  exits in about a second), and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
+  for the new tip and watch it **only if `liveness` reports `watch_warranted`** (`stage-2-ci.md`, "WATCH
+  ONLY WHAT CAN MOVE" — a watch launched on a tip whose checks have not registered yet has nothing to
+  block on and exits in about a second), and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
 - **THE LIVENESS COUNTERS reset on EVERY `head_sha` change — gate reset or not, and the ledger accessor
   enforces it at the head write** (`stage-2-ci.md`, "THE LIVENESS COUNTERS", which names every site): write
   the new `head_sha` through `ledger.py … set --head-sha` and its door resets the set — no site hand-resets.

--- a/plugins/gauntlet/skills/campaign/references/finding-audit.md
+++ b/plugins/gauntlet/skills/campaign/references/finding-audit.md
@@ -111,7 +111,7 @@ On REFUTED:
 - **Commit it.** The refutation commit is a **PR-content change**, so it **RESETS THE GATE** exactly like
   any other campaign commit: route it through the existing "any campaign commit to the PR head resets the
   gate" rule (`reviews_ok` → 0, restore `gauntlet-reviewing` — "Status labels mirror the review gate" —
-  re-derive CI for the new tip and watch it only if a row can still move, re-enter Stage 2a on the new
+  re-derive CI for the new tip and watch it only if `liveness` reports `watch_warranted`, re-enter Stage 2a on the new
   tip). Do **NOT** invent a second mechanism.
 - CONFIRMED / ADJUSTED findings from the same round still go to the scoped fix subagent; the refutation
   comment rides along in the same round's work.

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -365,9 +365,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      resulting commit **resets the gate** (Stage 2b, "Any campaign commit to the PR head resets the gate").
      The worker's job order, the no-weakening prohibition, and the denylist live in `stage-2-ci.md` —
      follow them there; do NOT restate them here. Different PRs may fix CI concurrently within the cap.
-   - CI snapshot holds a **still-RUNNING** evidence row (an evidence row that classifies `RUNNING` under
-     Stage 2b CLASSIFY — never "a row that is not terminal") for a PR whose watch task has already exited →
-     **relaunch the watch in this same heartbeat**. A PR with a row that can still move must never sit
+   - `liveness` reports **`watch_warranted`** (its reduction of "WATCH ONLY WHAT CAN MOVE" — a verified
+     snapshot with a still-`RUNNING` evidence row that is not an `UNKNOWN_VALUE` park; the `RUNNING` is an
+     evidence row that classifies `RUNNING` under Stage 2b CLASSIFY, never "a row that is not terminal") for
+     a PR whose watch task has already exited →
+     **relaunch the watch in this same heartbeat**. A PR whose watch is warranted must never sit
      unwatched until the fallback heartbeat; the fallback lifecycle is not the mechanism. **But NEVER relaunch
      it merely because `ci == pending`** — once CI has SETTLED nothing can move, `gh pr checks --watch`
      exits in about a second, and its completion is itself a heartbeat: that is a heartbeat per second, forever

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -32,8 +32,9 @@ VERIFY (via `scripts/ci-snapshot.py`, which it calls), and DECIDE, all defined i
 value to write to the ledger, the `reason` (**which rule fired, and which row made it fire** — this is what
 `ci_reason` is built from), the evidence counts, `head_moved` + `head_sha_now`, the `required_set` state the
 verdict was decided under, the `fingerprint` of the verified snapshot's evidence rows, the `buckets`
-CLASSIFY tally (`PASS`/`RUNNING`/`FAIL`/`UNKNOWN_VALUE` — `buckets.RUNNING > 0` is the one fact the
-watch policy reads; both `null` when the snapshot never verified), and the path to the snapshot it left
+CLASSIFY tally (`PASS`/`RUNNING`/`FAIL`/`UNKNOWN_VALUE`; both `null` when the snapshot never verified —
+`liveness` reduces `buckets.RUNNING` to the `watch_warranted` fact the watch policy acts on, and reads it
+directly for its SETTLED/RUNNING-STALL split), and the path to the snapshot it left
 behind. It exits `0` **only** on green.
 **Write `ci` from that JSON; never from an impression of some command's output** — and then hand that
 same JSON to `ci-status.py liveness` ("THE BOOKKEEPING IS A COMMAND", below), which records it and does
@@ -116,9 +117,9 @@ wins") and is never re-evaluated by hand.
 | `verdict` | `ci` | The driver's move |
 |---|---|---|
 | `green` | `green` | Nothing here — Stage 3's merge preconditions take over. No watch. |
-| `red` | `red` | **If the row is HELD (`liveness` reports it), dispatch nothing** — a held PR dispatches nothing until its question is answered (`loop-control.md` step 3, "held-status guard"); the watch still follows "WATCH ONLY WHAT CAN MOVE" below. Otherwise: **stop any review pass in flight on this PR** (the fix will replace its SHA — `loop-control.md` step 3; free the slot), **CLASSIFY the failure from the check logs** ("Classify, then set the model class", below) **before dispatching anything**, and dispatch a **scoped CI-fix subagent** into `<worktree>` — the row's ledger `worktree` value, the single source of truth for this PR's checkout path (`pr-adoption.md`). Its fix commits + pushes to the PR's **own head branch** → apply the gate reset ("Any campaign commit to the PR head resets the gate", below). Watch only while `buckets.RUNNING > 0`. |
+| `red` | `red` | **If the row is HELD (`liveness` reports it), dispatch nothing** — a held PR dispatches nothing until its question is answered (`loop-control.md` step 3, "held-status guard"); the watch still follows "WATCH ONLY WHAT CAN MOVE" below. Otherwise: **stop any review pass in flight on this PR** (the fix will replace its SHA — `loop-control.md` step 3; free the slot), **CLASSIFY the failure from the check logs** ("Classify, then set the model class", below) **before dispatching anything**, and dispatch a **scoped CI-fix subagent** into `<worktree>` — the row's ledger `worktree` value, the single source of truth for this PR's checkout path (`pr-adoption.md`). Its fix commits + pushes to the PR's **own head branch** → apply the gate reset ("Any campaign commit to the PR head resets the gate", below). Watch only while `liveness` reports `watch_warranted` (a still-RUNNING row — "WATCH ONLY WHAT CAN MOVE", below). |
 | `unclassified` | `pending` | `liveness` has parked the PR (`status = awaiting-user`). **Prompt the user** per ESCALATE ("THE PARK MUST DECLARE ITS OWN EXIT", below), naming the offending value from `reason`. Never guess a bucket for it. No watch — the park is the resolution. |
-| `pending` | `pending` | `buckets.RUNNING > 0` → ensure a live watch ("WATCH ONLY WHAT CAN MOVE", below). Otherwise nothing can move — no watch; the liveness bounds own the wait and `liveness` escalates at a cap. The `pending` sub-cases that waiting can never green (`nothing registered`, `required set unreadable`, `required check missing` — each named in `reason`) resolve through those same bounds; while `required_set` is `unknown`, keep running `required-set` each heartbeat ("WHAT WERE WE EXPECTING TO SEE?", below). |
+| `pending` | `pending` | `liveness` reports `watch_warranted` → ensure a live watch ("WATCH ONLY WHAT CAN MOVE", below). Otherwise nothing can move — no watch; the liveness bounds own the wait and `liveness` escalates at a cap. The `pending` sub-cases that waiting can never green (`nothing registered`, `required set unreadable`, `required check missing` — each named in `reason`) resolve through those same bounds; while `required_set` is `unknown`, keep running `required-set` each heartbeat ("WHAT WERE WE EXPECTING TO SEE?", below). |
 | `unusable` / `unverifiable` | `pending` | **Refetch on the next heartbeat** — the heartbeat is the backoff ("UNUSABLE — the refetch is BOUNDED", below); `liveness` counted the attempt and escalates at the REFETCH CAP. `head_moved: true` → refresh the row's `head_sha` (`pr-adoption.md`) and re-derive pinned to it. No watch. |
 
 #### WHAT WERE WE EXPECTING TO SEE? — the required-check set
@@ -724,9 +725,17 @@ unusable_refetches >= 3                 -> ESCALATE (above)  # 3 == THE REFETCH 
 
 #### WATCH ONLY WHAT CAN MOVE — the relaunch is not free
 
-The watch is warranted by **a row that can still move**, never by the `ci` value — and "a row can still
-move" is read off **`derive`'s JSON: `buckets.RUNNING > 0`**, never off a hand classification of the
-snapshot:
+The watch decision is **`liveness`'s `watch_warranted` field** — the driver ACTS on it and NEVER reads
+this table by hand. When it is **true and no watch task is alive**, ensure one (relaunch it in this same
+heartbeat if it has exited); when it is **false**, never launch or relaunch. The field is the mechanical
+reduction `watch_warranted = verified AND verdict != UNCLASSIFIED AND buckets.RUNNING > 0`: a watch is
+warranted by **a row that can still move**, never by the `ci` value.
+
+**The table below is the SPEC that field implements** — each row is one case of the predicate, kept so a
+reader can audit the field against the policy. **The `UNKNOWN_VALUE` row is the one a naive
+`buckets.RUNNING > 0` reading gets wrong**: an unclassified verdict can still carry a running row (DECIDE
+ranks `UNKNOWN_VALUE` above plain `pending`), yet the park — not a check finishing — is its exit, so
+`watch_warranted` excludes it.
 
 | DECIDE outcome | Watch? |
 |---|---|
@@ -756,11 +765,11 @@ Every one of them MUST, in the same step:
   the gate and its label move together, never one without the other (`stage-2-review-gate.md`, "Status
   labels mirror the review gate");
 - **re-derive `ci` from a fresh snapshot for the NEW `head_sha`, and launch a watch if — and only if —
-  that snapshot holds a row that can still move** ("WATCH ONLY WHAT CAN MOVE" above). Writing the new
+  `liveness` then reports `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE" above). Writing the new
   `head_sha` through the accessor **resets the liveness counters** at the door ("THE LIVENESS COUNTERS"
   above), so the PR gets a clean budget.
   **NEVER launch the watch unconditionally on the push**: at that instant the checks may not have
-  registered yet, so watch only if the fresh snapshot holds a row that can still move ("WATCH ONLY WHAT
+  registered yet, so watch only if `liveness` reports `watch_warranted` ("WATCH ONLY WHAT
   CAN MOVE" above);
 - **re-enter Stage 2a.**
 

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -211,8 +211,8 @@ subagent at a check that is merely **still running**.
      `gauntlet-accepted`), update `head_sha` to the new tip through `ledger.py … set --head-sha` (which
      **resets the liveness counters** at the door — new commit, new evidence — `stage-2-ci.md`, "THE
      LIVENESS COUNTERS"), set `ci = pending`, **and re-derive CI
-     from a snapshot of the new tip in the same heartbeat, launching a watch only if that snapshot holds a
-     still-RUNNING row** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched until the
+     from a snapshot of the new tip in the same heartbeat, launching a watch only if `liveness` then reports
+     `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched until the
      heartbeat while its checks are running — but it must not be watched when **nothing** is running
      either, which right after a push is the common case (no check has registered yet). CI must return
      green before merging.
@@ -223,7 +223,7 @@ subagent at a check that is merely **still running**.
      new tip through the accessor, which **resets the liveness counters** (a new head is new evidence — `stage-2-ci.md`, "THE
      LIVENESS COUNTERS"; the clean-rebase branch above does the same, and this branch is no different in
      that respect). Then re-derive CI for
-     the new tip — watching it only if a row can still move ("WATCH ONLY WHAT CAN MOVE") — and re-enter
+     the new tip — watching it only if `liveness` reports `watch_warranted` ("WATCH ONLY WHAT CAN MOVE") — and re-enter
      Stage 2.
    - Still open, **not parked**, mergeable, not behind/dirty/conflicting, same live `head_sha`,
      `reviews_ok >= required(tier)`, and `ci == green` → still immediately mergeable; return to step 1

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -427,12 +427,12 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
         return rows[0]
 
     def derived(verdict: str = "pending", ci_value: str = "pending", running: int = 1,
-                head_sha: str = sha) -> dict:
+                head_sha: str = sha, fail: int = 0, unknown: int = 0) -> dict:
         verified = verdict not in ("unusable", "unverifiable")
         return ci.derive_output({
             "head_sha": head_sha, "verdict": verdict, "ci": ci_value, "reason": "row X made it fire",
             "fingerprint": fp1 if verified else None,
-            "buckets": ({"PASS": 1, "RUNNING": running, "FAIL": 0, "UNKNOWN_VALUE": 0}
+            "buckets": ({"PASS": 1, "RUNNING": running, "FAIL": fail, "UNKNOWN_VALUE": unknown}
                         if verified else None),
         })
 
@@ -539,6 +539,38 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
          (out["state"], out["escalated"], r["status"], r["blocker_ruling"],
           "UNKNOWN VALUE" in r["ci_reason"]))
 
+    # WATCH WARRANTED — the mechanical reduction of "WATCH ONLY WHAT CAN MOVE", emitted so the driver never
+    # reads that table by hand: verified AND verdict != unclassified AND buckets.RUNNING > 0. Each case is
+    # one row of the WATCH table, asserted against `watch_warranted` and the fact `watch_reason` names.
+    def watch(name: str, warranted: bool, needle: str, derv: dict, **reset_fields: str) -> None:
+        reset(**reset_fields)
+        out = ci.liveness(ledger, "35", derv, "none", now)
+        case(name, (warranted, True), (out["watch_warranted"], needle in out["watch_reason"]))
+
+    watch("pending with RUNNING rows warrants a watch", True, "still RUNNING",
+          derived(running=2), ci_fingerprint=fp1)
+    watch("settled red warrants no watch — nothing can move", False, "nothing can move",
+          derived(verdict="red", ci_value="red", running=0), ci_fingerprint=fp1, ci="red")
+    # red with a still-RUNNING row (a FAIL row AND a RUNNING row in buckets): the fix moves it, but the
+    # RUNNING row can still move, so the watch IS warranted — the WATCH table's red split, verbatim.
+    watch("red with a still-RUNNING row warrants a watch", True, "still RUNNING",
+          derived(verdict="red", ci_value="red", running=1, fail=1), ci_fingerprint=fp1, ci="red")
+    watch("green warrants no watch", False, "nothing can move",
+          derived(verdict="green", ci_value="green", running=0), ci_fingerprint=fp1)
+    watch("an unusable derivation warrants no watch — no verified snapshot", False, "no verified snapshot",
+          derived(verdict="unusable"))
+    # THE COUNTEREXAMPLE the exclusion exists for: `decide()` ranks UNKNOWN_VALUE above plain `pending`,
+    # so an UNCLASSIFIED verdict can carry a still-RUNNING row (buckets RUNNING>0 AND UNKNOWN_VALUE>0). A
+    # bare RUNNING>0 reading would warrant a watch; the park is the resolution, so watch_warranted is
+    # FALSE. Delete the `verdict != unclassified` term and this case goes red.
+    watch("unclassified with a RUNNING row warrants NO watch — the park is the resolution",
+          False, "park is the resolution",
+          derived(verdict="unclassified", ci_value="pending", running=1, unknown=1))
+    # A HELD row does not change the watch decision — parking never stops a warranted watch nor starts an
+    # unwarranted one. Same RUNNING>0 pending derivation, on a parked row -> still warranted.
+    watch("a held row with a RUNNING row still warrants a watch", True, "still RUNNING",
+          derived(running=1), status="awaiting-user", ci_reason="the open question", ci_fingerprint=fp1)
+
     return problems
 
 
@@ -588,7 +620,7 @@ def run(ci, tmp: Path) -> int:
     if not liveness_problems:
         print(f"ok       {'liveness bookkeeping':32} -> every transition of the derivation block: strikes "
               f"to the cap, the stall clock, the refetch cap, machine-action stop, held observation, "
-              f"stale-head refusal")
+              f"stale-head refusal, and the watch_warranted reduction (incl. the UNCLASSIFIED exclusion)")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -101,10 +101,14 @@ also reads the PR's CURRENT head, LAST (after both evidence families), and if it
 red would be a claim about the wrong commit too. `ci = pending`, and the reason NAMES the new head so the
 driver re-derives against it rather than guessing. See `derive()`.
 
-WHAT IT DOES NOT DECIDE, ON PURPOSE. It answers **what the evidence says**, and **whether that evidence is
-about this PR at all**. It does NOT answer **what the driver should do about it** — whether to launch a
-watch, dispatch a CI fix, or park the PR. Those rules live in `stage-2-ci.md`. Encoding them here would
-create a SECOND owner of a rule that is moving under it.
+WHAT IT DOES NOT DECIDE, ON PURPOSE. `derive` answers **what the evidence says**, and **whether that
+evidence is about this PR at all**. It does NOT answer **what the driver should DO** — dispatch a CI fix,
+or prompt the user when a PR parks. Those ACTIONS live in `stage-2-ci.md`. ONE ROW OF THAT BOUNDARY MOVED
+DELIBERATELY, and only that row: the watch policy ("WATCH ONLY WHAT CAN MOVE") reduces mechanically to a
+single fact — IS A WATCH WARRANTED? — so `liveness` now EMITS that fact as `watch_warranted` instead of
+leaving the driver to read the table by hand. What stays the driver's is the ACTION it triggers: LAUNCHING
+the watch task, ensuring one is alive, relaunching an exited one. Encoding those actions here would create
+a SECOND owner of a rule that is moving under it.
 
 THE DOC AND THIS TOOL CANNOT SILENTLY DISAGREE — `doc-check` is what makes that true.
 The enums, the CLASSIFY buckets and the DECIDE order are stated in `ci-derivation-spec.md` as prose AND encoded in
@@ -1618,6 +1622,48 @@ def liveness(ledger_path: Path, pr: str, derived: dict, machine_action: str, now
         put("blocker_ruling", "-")
 
     LEDGER.dump(ledger_path, header, rows)
+
+    # --- watch_warranted: the WHOLE of "WATCH ONLY WHAT CAN MOVE", reduced to one fact ---------------
+    #
+    # The watch policy's table (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE") collapses to ONE predicate,
+    # EMITTED here so the driver ACTS on a field instead of reading the table by eye — the same by-eye
+    # judgment the whole tool exists to remove. What stays the driver's is the ACTION: LAUNCHING the watch
+    # task, ensuring one is alive, relaunching an exited one. Deciding WHETHER a watch is warranted is this:
+    #
+    #     watch_warranted = VERIFIED  AND  verdict != UNCLASSIFIED  AND  buckets["RUNNING"] > 0
+    #
+    # It reads ONLY `derived` — NEVER the row's `status` — so it is UNAFFECTED by held/parked status: a
+    # park neither stops a warranted watch nor starts an unwarranted one (`stage-2-ci.md`, "WATCH ONLY WHAT
+    # CAN MOVE"; the CI-watch park exception in `loop-control.md` step 3 and `critical-rules.md`).
+    #
+    # THE COLLAPSE, one WATCH-table row at a time — this is the proof, not a summary of it:
+    #   * green                    -> every evidence row PASS, so RUNNING == 0 -> false.
+    #   * pending (a row RUNNING)  -> RUNNING > 0 -> TRUE.
+    #   * pending (nothing registered) -> zero evidence rows -> RUNNING == 0 -> false.
+    #   * pending (required set unreadable) / (required check missing) -> NO row is RUNNING BY DECIDE
+    #     CONSTRUCTION: plain `pending` (a RUNNING row) OUTRANKS both required-set bullets, so had a row
+    #     been RUNNING the verdict would be plain `pending`, not either of these -> RUNNING == 0 -> false.
+    #   * red + a row still RUNNING -> RUNNING > 0 -> TRUE.   red, every row terminal -> RUNNING == 0 -> false.
+    #   * unusable / unverifiable  -> NOT verified (no trusted rows to tally) -> false.
+    #   * UNKNOWN_VALUE            -> false, AND THIS IS THE ONE ROW A BARE `RUNNING > 0` GETS WRONG.
+    #     `ci-snapshot.decide()` ranks UNCLASSIFIED ABOVE plain `pending`, so an unclassified verdict CAN
+    #     carry a still-RUNNING row (buckets == {RUNNING: 1, UNKNOWN_VALUE: 1} is reachable, and pinned by
+    #     a fixture). The table says NO watch anyway: `liveness` has ALREADY PARKED the PR, and the human
+    #     ruling — not a check finishing — is the exit; a running check completing cannot answer the open
+    #     question the unknown value raised. So the predicate EXCLUDES UNCLASSIFIED explicitly. Drop that
+    #     term and it would warrant a pointless watch on a parked PR — the counterexample this field exists
+    #     to get right.
+    running = derived["buckets"]["RUNNING"] if derived["verified"] else 0
+    if not derived["verified"]:
+        watch_warranted, watch_reason = False, "no verified snapshot"
+    elif derived["verdict"] == SNAP.UNCLASSIFIED:
+        watch_warranted, watch_reason = False, "unknown value parked — the park is the resolution, not a watch"
+    elif running > 0:
+        watch_warranted = True
+        watch_reason = f"{running} row{'s' if running != 1 else ''} still RUNNING"
+    else:
+        watch_warranted, watch_reason = False, "nothing can move"
+
     return {
         "pr": pr,
         "head_sha": row["head_sha"],
@@ -1632,6 +1678,11 @@ def liveness(ledger_path: Path, pr: str, derived: dict, machine_action: str, now
         "settled_strikes": row["settled_strikes"],
         "unusable_refetches": row["unusable_refetches"],
         "ci_stalled_since": row["ci_stalled_since"],
+        # WHETHER A WATCH IS WARRANTED — the whole of "WATCH ONLY WHAT CAN MOVE", decided above so the
+        # driver never reads that table by hand. The driver ACTS on it: watch_warranted AND no live watch
+        # -> ensure/relaunch one; false -> never launch or relaunch. `watch_reason` names the deciding fact.
+        "watch_warranted": watch_warranted,
+        "watch_reason": watch_reason,
     }
 
 


### PR DESCRIPTION
- `liveness` emits `watch_warranted`/`watch_reason`; the WATCH table is the spec it implements
- the UNKNOWN_VALUE row is the case a bare RUNNING>0 misses — pinned by the counterexample fixture
- fixes the spec line claiming pending is the only watched outcome (red-with-RUNNING is too)
