### PR TITLE
execute the clean base-only rebase as a tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,17 @@ jobs:
       - name: Format-preflight contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/format-preflight.py self-test
 
+      # The clean-rebase EXECUTOR's contract, executed. Where base-preflight only DECIDES that a rebase is
+      # due, this DOES the clean base-only case — fetch/rebase/force-with-lease push plus the ledger reset
+      # (new head_sha, ci=pending, liveness counters reset; reviews_ok carried forward per the Exception
+      # rule) — and REFUSES everything else: a conflict is aborted and a diff-changing rebase is reset, each
+      # handed back at exit 3 so the driver's judgment path owns conflict resolution. The sibling
+      # `clean-rebase-test.py` builds REAL throwaway git repos (a bare remote, a base and a PR branch, a
+      # PR-head worktree) and drives the tool end to end, asserting repo/ledger state with git plumbing, not
+      # exit codes alone; it is loaded by path and a MISSING sibling fails loudly.
+      - name: Clean-rebase contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/clean-rebase.py self-test
+
       # The merge-readiness decider's contract, executed. It is the ONE place the two GitHub merge enums
       # (`.mergeable`, `.mergeStateStatus`) are crossed with the ledger's preconditions to decide `merge`
       # vs `not-yet` — the miscross this replaces once turned a blocked merge into an infinite CI watch.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -232,6 +232,7 @@ a line the tool writes.
 | `reviewer-liveness.py` | Probe whether a dispatched reviewer's output stream is still moving; decides nothing, always exits 0 | `references/stage-2-review-gate.md` |
 | `base-preflight.py` | Decide proceed / rebase-first / recheck from a PR's live merge-state before review or fix; performs no rebase | `references/stage-2-review-gate.md` |
 | `format-preflight.py` | `check` — refuse to format any file whose formatter-write could escape the worktree (the file, or any path component, is a symlink); reads only, formats nothing | `references/stage-2-ci.md` |
+| `clean-rebase.py` | `run` — EXECUTE the clean base-only rebase (fetch/rebase/force-with-lease push + the ledger reset) and REFUSE everything else: a conflict or a diff-changing rebase is aborted/reset and handed back (exit 3), never resolved | `references/stage-2-review-gate.md` |
 | `ci-status.py` | `derive` — how `ci` is DERIVED, always, the only way — `liveness` — the recorder: writes `ci` + the liveness counters, parks at any cap — and `required-set` | `references/stage-2-ci.md` |
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/ci-derivation-spec.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -115,6 +115,10 @@
   verdicts. Clean base-only rebase with unchanged PR diff keeps `reviews_ok`, sets `ci = pending`, and
   moves `head_sha` — so writing the new head through `ledger.py … set --head-sha` makes the accessor
   **reset the liveness counters** at the door (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); never hand-reset.
+  The clean case is EXECUTED by `scripts/clean-rebase.py run` (fetch/rebase/`--force-with-lease` push +
+  that ledger reset); it **refuses anything not clean** — a conflict or a diff-changing rebase is
+  aborted/reset and handed back at **exit 3**, where the driver resolves the conflict by hand, never the
+  tool.
   Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
   on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -88,9 +88,16 @@ review gate"), and the review re-starts on the clean tip:
   UNKNOWN or unrecognized value returns `recheck` FIRST, before any rebase-first classification, so re-poll
   and re-run rather than rebase on a half-computed view (`base-preflight.py` is the owner of the full
   mapping). It is the enforced form of this rule and it is also the pre-flight gate before any fix subagent
-  is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Clean base-only rebase with the PR diff unchanged keeps `reviews_ok` but still moves `head_sha`, so it
-  sets `ci = pending`, and writing the new head through `ledger.py … set --head-sha` makes the accessor
-  **reset the liveness counters** at the door ("Status labels mirror the review gate"
+  is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Once it says `rebase-first`, **the CLEAN
+  base-only case is EXECUTED — not hand-run — by `python3 scripts/clean-rebase.py run --ledger
+  <state.jsonl> --pr <pr> --worktree <worktree> --base <base>`**: it does the fetch/rebase/`--force-with-lease`
+  push and the one ledger reset, and **refuses anything that is not clean**. **Exit 3 means it was NOT
+  clean** — a conflict, or a rebase that applied textually but changed the PR's own diff — and it has already
+  aborted/reset and left the worktree at its original head; **fall back to the JUDGMENT path**: resolve the
+  conflict by hand (the driver's call, never the tool's), then apply the gate-reset rules for a
+  content-changing rebase below. Clean base-only rebase with the PR diff unchanged keeps `reviews_ok` but still moves `head_sha`, so it
+  sets `ci = pending`, and the tool writes the new head through the accessor, which
+  **resets the liveness counters** at the door ("Status labels mirror the review gate"
   Exception, below, owns this rule; `stage-2-ci.md`, "THE LIVENESS COUNTERS");
   conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,
   exactly as the step-6 reconcile does at its own (`stage-3-merge.md`), and it therefore **relabels in the

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -206,16 +206,20 @@ subagent at a check that is merely **still running**.
 
    For each **non-parked** open PR: **base advancement alone does NOT
    invalidate gauntlet reviews.** Rebase only if GitHub flags the PR behind/conflicting:
-   - Clean rebase (no conflicts) → verify the PR's own diff/content is unchanged → keep `reviews_ok`,
-     **keep its status label as-is** (the gate did not reset, so an accepted PR stays
-     `gauntlet-accepted`), update `head_sha` to the new tip through `ledger.py … set --head-sha` (which
-     **resets the liveness counters** at the door — new commit, new evidence — `stage-2-ci.md`, "THE
-     LIVENESS COUNTERS"), set `ci = pending`, **and re-derive CI
-     from a snapshot of the new tip in the same heartbeat, launching a watch only if `liveness` then reports
-     `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched until the
-     heartbeat while its checks are running — but it must not be watched when **nothing** is running
-     either, which right after a push is the common case (no check has registered yet). CI must return
-     green before merging.
+   - Clean rebase (no conflicts, PR diff unchanged) → **EXECUTED — not hand-run — by `python3
+     scripts/clean-rebase.py run --ledger <state.jsonl> --pr <N> --worktree <worktree> --base <base>`**: it
+     does the fetch/rebase/`--force-with-lease` push, verifies the PR's own diff is unchanged, and writes the
+     one ledger reset — keep `reviews_ok`, **keep its status label as-is** (the gate did not reset, so an
+     accepted PR stays `gauntlet-accepted`), new `head_sha` written through the accessor (which **resets the
+     liveness counters** at the door — new commit, new evidence — `stage-2-ci.md`, "THE LIVENESS
+     COUNTERS"), `ci = pending`. **Exit 3 means it was NOT
+     clean** — a conflict, or a rebase that changed the PR's own diff — and it has already aborted/reset to
+     the original head; the conflict-resolution bullet below then owns it. On a clean (exit 0) rebase,
+     **re-derive CI from a snapshot of the new tip in the same heartbeat, launching a watch only if `liveness`
+     then reports `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched
+     until the heartbeat while its checks are running — but it must not be watched when **nothing** is
+     running either, which right after a push is the common case (no check has registered yet). CI must
+     return green before merging.
    - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0 AND, in that
      same step, restore `gauntlet-reviewing` if the PR carries `gauntlet-accepted`** — the gate and its
      label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate"). Update

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Fixtures for `clean-rebase.py` — driven against REAL throwaway git repos, not a mocked git.
+
+Every case builds an actual bare "remote", a base branch, a PR branch, and a PR-head worktree on disk,
+then drives the tool's REAL code (`clean-rebase.py run`, in-process via `capture_cli`) and asserts the
+resulting repo/ledger state with git plumbing — never an exit code alone. The ledger writes go through the
+REAL `ledger.py` subprocess the tool invokes, so the whole path is exercised end to end.
+
+`clean-rebase.py self-test` FAILS LOUDLY if it cannot load this file — it can never report health over a
+suite it did not run.
+
+The diff-changed case is CONSTRUCTED, not synthesized: the base edits a line INSIDE the context window of
+the PR's own hunk (line 5 vs the PR's line-3 change). The rebase applies textually — no conflict — but the
+PR's three-dot diff now carries the base's rewritten context line, so `git patch-id --stable` differs
+before and after. That is a genuine "clean textually, but the PR's diff changed" rebase, and the tool must
+refuse it exactly as it refuses a conflict.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
+
+OWNER = Path(__file__).resolve().parent / "clean-rebase.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("clean_rebase_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the clean-rebase tool at {OWNER}")
+    return mod
+
+
+M = _load_owner()
+L = M.L  # the ledger module the tool loaded
+
+
+def check(cond, msg) -> None:
+    if not cond:
+        raise M.SelfTestFailure(msg)
+
+
+# --- git / ledger helpers -----------------------------------------------------
+
+def _run(argv, cwd=None):
+    return subprocess.run(argv, capture_output=True, text=True, cwd=cwd)  # noqa: S603
+
+
+def git(cwd, *args, allow_fail=False):
+    r = _run(["git", "-C", str(cwd), *args])
+    if not allow_fail and r.returncode != 0:
+        raise M.SelfTestFailure(f"git {' '.join(args)} failed in {cwd}: {r.stderr.strip()}")
+    return r
+
+
+def _cfg(repo):
+    git(repo, "config", "user.email", "t@example.com")
+    git(repo, "config", "user.name", "Tester")
+
+
+def head(cwd, ref="HEAD") -> str:
+    return git(cwd, "rev-parse", ref).stdout.strip()
+
+
+def _ledger(*args) -> int:
+    """Run the real ledger main in-process (quietly) for test SETUP."""
+    with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+        try:
+            return L.main(list(args))
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 1
+
+
+def _field(ledger: Path, pr, name):
+    _, rows = L.load(ledger)
+    row = L.find_row(rows, str(pr))
+    return row[name] if row else None
+
+
+# 12 numbered lines — a wide file so an adjacent-context edit and a far edit are unambiguous.
+def _numbered(overrides: "dict[int, str]") -> str:
+    lines = [overrides.get(i, str(i)) for i in range(1, 13)]
+    return "\n".join(lines) + "\n"
+
+
+PR_NUMBER = "12"
+PR_BRANCH = "pr"
+
+
+class Scenario:
+    def __init__(self, tmp: Path):
+        self.tmp = tmp
+        self.remote = tmp / "remote.git"
+        self.seed = tmp / "seed"
+        self.wt = tmp / "wt"
+        self.ledger = tmp / "state.jsonl"
+        self.orig_head = ""
+
+    def build(self, *, status="in_review", reviews_ok=2):
+        _run(["git", "init", "--bare", "-b", "main", str(self.remote)])
+        _run(["git", "clone", str(self.remote), str(self.seed)])
+        _cfg(self.seed)
+        # base commit on main
+        (self.seed / "f").write_text(_numbered({}), encoding="utf-8")
+        git(self.seed, "add", "f")
+        git(self.seed, "commit", "-m", "base")
+        git(self.seed, "push", "origin", "main")
+        # PR branch: change line 3
+        git(self.seed, "checkout", "-b", PR_BRANCH)
+        (self.seed / "f").write_text(_numbered({3: "3-PR"}), encoding="utf-8")
+        git(self.seed, "commit", "-am", "pr change")
+        git(self.seed, "push", "origin", PR_BRANCH)
+        self.orig_head = head(self.seed)
+        # the PR-head worktree — a fresh clone with the PR branch checked out
+        _run(["git", "clone", str(self.remote), str(self.wt)])
+        _cfg(self.wt)
+        git(self.wt, "checkout", PR_BRANCH)
+        check(head(self.wt) == self.orig_head, "precondition: the worktree is at the PR head")
+        # ledger: header + row, with reviews_ok earned by real verdicts at the PR head
+        _ledger("--file", str(self.ledger), "header", "set", "base_branch", "main")
+        _ledger("--file", str(self.ledger), "add-row", "--pr", PR_NUMBER, "--branch", PR_BRANCH,
+                "--head-sha", self.orig_head, "--worktree", str(self.wt), "--tier", "STANDARD",
+                "--status", status)
+        for _ in range(reviews_ok):
+            _ledger("--file", str(self.ledger), "verdict", "--pr", PR_NUMBER,
+                    "--head-sha", self.orig_head, "--verdict", "satisfied")
+        return self
+
+    def advance_base(self, overrides: "dict[int, str]"):
+        """Move remote main ahead by one commit that rewrites the given lines."""
+        git(self.seed, "checkout", "main")
+        (self.seed / "f").write_text(_numbered(overrides), encoding="utf-8")
+        git(self.seed, "commit", "-am", "base advance")
+        git(self.seed, "push", "origin", "main")
+        git(self.seed, "checkout", PR_BRANCH)
+
+    def move_remote_pr(self):
+        """A concurrent push moves remote `pr` past the worktree's stale tracking ref (breaks the lease)."""
+        git(self.seed, "checkout", PR_BRANCH)
+        git(self.seed, "commit", "--allow-empty", "-m", "concurrent push")
+        git(self.seed, "push", "origin", PR_BRANCH)
+        git(self.seed, "checkout", "main")
+
+    def remote_pr_head(self) -> str:
+        return git(self.remote, "rev-parse", f"refs/heads/{PR_BRANCH}").stdout.strip()
+
+    def invoke(self, *extra):
+        argv = ["run", "--ledger", str(self.ledger), "--pr", PR_NUMBER, "--worktree", str(self.wt),
+                "--base", "main", *extra]
+        return capture_cli(M.main, argv)
+
+
+def _scenario(tmp) -> Scenario:
+    return Scenario(Path(tmp)).build()
+
+
+# --- the CLEAN case, end to end ----------------------------------------------
+
+def t_clean_rebase_end_to_end():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        s.advance_base({12: "12-BASE"})  # a FAR edit — outside the PR hunk's context, diff unchanged
+        code, _, err = s.invoke()
+        check(code == M.EXIT_OK, f"a clean base-only rebase must exit 0 (code={code}, err={err})")
+        new_head = head(s.wt)
+        check(new_head != s.orig_head, "the clean rebase moved the worktree HEAD to a new commit")
+        # the ledger recorded the new head, ci pending, and the liveness counters reset — reviews_ok kept
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == new_head, "the ledger records the new head_sha")
+        check(_field(s.ledger, PR_NUMBER, "ci") == "pending", "a head_sha change sets ci=pending")
+        for f in M.LIVENESS_COUNTERS:
+            check(_field(s.ledger, PR_NUMBER, f) == str(L.ROW_DEFAULTS[f]),
+                  f"the clean rebase resets the liveness counter {f} to its fresh-head default")
+        check(_field(s.ledger, PR_NUMBER, "reviews_ok") == "2",
+              "the clean case CARRIES reviews_ok FORWARD — the gate is not reset (the Exception rule)")
+        check(_field(s.ledger, PR_NUMBER, "review_rounds") == "2",
+              "review_rounds is monotone — a clean rebase never touches it")
+        # the remote branch was force-with-lease pushed to the new head
+        check(s.remote_pr_head() == new_head, "the remote PR branch was updated to the rebased head")
+
+
+# --- a CONFLICT: abort, restore, refuse (exit 3), touch nothing ---------------
+
+def t_conflict_aborts_and_refuses():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        s.advance_base({3: "3-BASE"})  # base rewrites the SAME line the PR changed -> conflict
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_NOT_CLEAN, f"a conflicting rebase must exit {M.EXIT_NOT_CLEAN} (code={code})")
+        check('"refused": "conflict"' in out, f"the refusal names the conflict; got {out!r}")
+        check(head(s.wt) == s.orig_head,
+              "a conflicting rebase is ABORTED and HEAD restored to the original — no partial state")
+        # a clean tree survives (rebase --abort leaves no half-applied state)
+        check(git(s.wt, "status", "--porcelain").stdout.strip() == "",
+              "the worktree is clean after the abort")
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "the ledger head_sha is untouched")
+        check(_field(s.ledger, PR_NUMBER, "reviews_ok") == "2", "the ledger reviews_ok is untouched")
+        check(s.remote_pr_head() == s.orig_head, "the remote PR branch is untouched")
+
+
+# --- diff-changed-under-rebase: clean textually, but the PR's diff moved ------
+
+def t_diff_changed_resets_and_refuses():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        # base edits line 5 — INSIDE the context window of the PR's line-3 hunk. No conflict, but the PR's
+        # three-dot diff now carries "5-BASE" as context, so its patch-id differs before/after the rebase.
+        s.advance_base({5: "5-BASE"})
+        code, out, err = s.invoke()
+        check(code == M.EXIT_NOT_CLEAN,
+              f"a rebase that changes the PR's diff must exit {M.EXIT_NOT_CLEAN} (code={code}, err={err})")
+        check('"refused": "diff-changed"' in out, f"the refusal names diff-changed; got {out!r}")
+        check(head(s.wt) == s.orig_head,
+              "diff-changed is reset --hard back to the original head — no partial state")
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "the ledger head_sha is untouched")
+        check(_field(s.ledger, PR_NUMBER, "reviews_ok") == "2", "the ledger reviews_ok is untouched")
+        check(s.remote_pr_head() == s.orig_head, "the remote PR branch is untouched")
+
+
+# --- precondition refusals (exit 2, nothing mutated) -------------------------
+
+def t_dirty_worktree_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        (s.wt / "f").write_text("dirtied\n", encoding="utf-8")  # uncommitted change
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_PRECONDITION, f"a dirty worktree is refused at exit 2 (code={code})")
+        check('"refused": "dirty"' in out, f"the refusal names the dirty tree; got {out!r}")
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "nothing mutated — head_sha untouched")
+
+
+def t_wrong_branch_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        git(s.wt, "checkout", "main")  # the row names `pr`, but `main` is checked out
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_PRECONDITION, f"a wrong-branch checkout is refused at exit 2 (code={code})")
+        check('"refused": "wrong-branch"' in out, f"the refusal names the branch mismatch; got {out!r}")
+
+
+def t_head_mismatch_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        _ledger("--file", str(s.ledger), "set", "--pr", PR_NUMBER, "--head-sha", "b" * 40)
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_PRECONDITION, f"a HEAD != ledger head_sha is refused at exit 2 (code={code})")
+        check('"refused": "stale"' in out, f"the refusal names the stale mismatch; got {out!r}")
+        check(s.orig_head in out and "b" * 40 in out,
+              "the refusal names BOTH the worktree HEAD and the ledger head_sha")
+
+
+def t_held_row_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = Scenario(Path(tmp)).build(status="awaiting-user")
+        s.advance_base({12: "12-BASE"})
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_PRECONDITION, f"a held row is refused at exit 2 (code={code})")
+        check('"refused": "held"' in out, f"the refusal names the held status; got {out!r}")
+        check(head(s.wt) == s.orig_head, "a held PR is never rebased — HEAD untouched")
+        check(s.remote_pr_head() == s.orig_head, "and the remote PR branch is untouched")
+
+
+def t_no_row_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(s.ledger), "--pr", "999",
+                                            "--worktree", str(s.wt), "--base", "main"])
+        check(code == M.EXIT_PRECONDITION, f"a missing row is refused at exit 2 (code={code})")
+        check('"refused": "no-row"' in out, f"the refusal names the missing row; got {out!r}")
+
+
+def t_absent_remote_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        # a standalone repo with a commit but NO remote configured
+        wt = tmp / "solo"
+        wt.mkdir()
+        _run(["git", "init", "-b", "pr", str(wt)])
+        _cfg(wt)
+        (wt / "f").write_text("x\n", encoding="utf-8")
+        git(wt, "add", "f")
+        git(wt, "commit", "-m", "only")
+        h = head(wt)
+        ledger = tmp / "state.jsonl"
+        _ledger("--file", str(ledger), "header", "set", "base_branch", "main")
+        _ledger("--file", str(ledger), "add-row", "--pr", PR_NUMBER, "--branch", PR_BRANCH,
+                "--head-sha", h, "--worktree", str(wt), "--tier", "STANDARD", "--status", "in_review")
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(ledger), "--pr", PR_NUMBER,
+                                            "--worktree", str(wt), "--base", "main"])
+        check(code == M.EXIT_PRECONDITION, f"an absent default remote is refused at exit 2 (code={code})")
+        check('"refused": "no-remote"' in out, f"the refusal names the absent remote; got {out!r}")
+
+
+def t_worktree_missing_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        ledger = tmp / "state.jsonl"
+        _ledger("--file", str(ledger), "header", "set", "base_branch", "main")
+        _ledger("--file", str(ledger), "add-row", "--pr", PR_NUMBER, "--branch", PR_BRANCH,
+                "--head-sha", "a" * 40, "--worktree", str(tmp / "nope"), "--tier", "STANDARD",
+                "--status", "in_review")
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(ledger), "--pr", PR_NUMBER,
+                                            "--worktree", str(tmp / "nope"), "--base", "main"])
+        check(code == M.EXIT_PRECONDITION, f"a missing worktree is refused at exit 2 (code={code})")
+        check('"refused": "worktree-missing"' in out, f"the refusal names the missing worktree; got {out!r}")
+
+
+# --- push failure: local rebase preserved, ledger NOT written (exit 1) --------
+
+def t_push_rejected_preserves_local_rebase():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        s.advance_base({12: "12-BASE"})     # a clean far edit, so the rebase itself succeeds
+        s.move_remote_pr()                   # remote pr moves past the worktree's stale tracking ref
+        remote_pr_before = s.remote_pr_head()
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_PARTIAL, f"a rejected force-with-lease exits {M.EXIT_PARTIAL} (code={code})")
+        check('"pushed": false' in out, f"the report says the push did not land; got {out!r}")
+        new_head = head(s.wt)
+        check(new_head != s.orig_head,
+              "the local rebase is PRESERVED after a push rejection — never auto-reset")
+        check(s.orig_head in out, "orig_head is printed so the driver can reset if it chooses")
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head,
+              "the ledger is NOT written after a push failure — head_sha still the original")
+        check(s.remote_pr_head() == remote_pr_before,
+              "the remote PR branch was not clobbered (force-with-lease refused it)")
+
+
+# --- --dry-run mutates nothing -----------------------------------------------
+
+def t_dry_run_mutates_nothing():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        s.advance_base({12: "12-BASE"})
+        origin_main_before = head(s.wt, "refs/remotes/origin/main")
+        code, out, _ = s.invoke("--dry-run")
+        check(code == M.EXIT_OK, f"a dry-run whose preconditions pass exits 0 (code={code})")
+        check('"dry_run": true' in out, f"the dry-run report says so; got {out!r}")
+        check(head(s.wt) == s.orig_head, "dry-run does not rebase — HEAD unchanged")
+        check(head(s.wt, "refs/remotes/origin/main") == origin_main_before,
+              "dry-run stops BEFORE the fetch — the base tracking ref is unchanged")
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "dry-run does not write the ledger")
+        check(s.remote_pr_head() == s.orig_head, "dry-run does not push")
+
+
+CASES = [
+    ("clean-rebase-e2e", "a clean base-only rebase pushes and updates the ledger, keeping reviews_ok",
+     t_clean_rebase_end_to_end),
+    ("conflict-aborts", "a conflicting rebase aborts, restores HEAD, refuses (exit 3), mutates nothing",
+     t_conflict_aborts_and_refuses),
+    ("diff-changed-resets", "a textually-clean rebase that changes the PR diff resets and refuses (exit 3)",
+     t_diff_changed_resets_and_refuses),
+    ("dirty-refused", "a dirty worktree is refused at exit 2", t_dirty_worktree_refused),
+    ("wrong-branch-refused", "a worktree on the wrong branch is refused at exit 2", t_wrong_branch_refused),
+    ("head-mismatch-refused", "HEAD != ledger head_sha is refused at exit 2, naming both values",
+     t_head_mismatch_refused),
+    ("held-refused", "a held row is refused at exit 2 and never rebased", t_held_row_refused),
+    ("no-row-refused", "a PR with no ledger row is refused at exit 2", t_no_row_refused),
+    ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),
+    ("worktree-missing-refused", "a missing/non-git worktree is refused at exit 2", t_worktree_missing_refused),
+    ("push-rejected-preserves-rebase", "a rejected push preserves the local rebase and does NOT write the "
+     "ledger (exit 1)", t_push_rejected_preserves_local_rebase),
+    ("dry-run-noop", "--dry-run mutates nothing (no fetch, rebase, push, or ledger write)",
+     t_dry_run_mutates_nothing),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""EXECUTE the campaign's CLEAN base-only rebase — and REFUSE everything else, fail-closed.
+
+`stage-2-review-gate.md`'s precondition-rebase site and `stage-3-merge.md`'s step-6 reconcile both
+describe, in prose, the same mechanical act: when `<base>` has moved and the PR does not conflict, rebase
+the PR onto the new base, and — **only if the PR's own diff is unchanged** — carry `reviews_ok` forward,
+set `ci = pending`, and reset the liveness counters (the "clean base-only rebase" Exception in
+`stage-2-review-gate.md`, "Status labels mirror the review gate", is the SEMANTIC OWNER of that reset;
+this tool CITES it and never re-decides it). That is git fetch/rebase/push plus a ledger write, transcribed
+by a model every heartbeat. This turns the CLEAN case into a command.
+
+**It does the CLEAN case and NOTHING else.** Conflict resolution is the driver's JUDGMENT and this tool
+NEVER attempts it: the moment `git rebase` reports a conflict it `--abort`s, restores HEAD, and exits
+`EXIT_NOT_CLEAN` — the driver takes over. And a rebase that applied textually but CHANGED the PR's own diff
+(a base edit near the PR's hunk re-writes the PR's effective patch) is ALSO not the clean case: the PR's
+patch identity is compared before and after, and a mismatch is `reset --hard`ed back and refused the same
+way. The only path that mutates the remote or the ledger is a rebase that was textually clean AND left the
+PR's patch identity byte-for-byte unchanged.
+
+    clean-rebase.py run --ledger <state.jsonl> --pr <N> --worktree <path> --base <base> \
+        [--remote origin] [--dry-run]
+    clean-rebase.py self-test    run every fixture (clean-rebase-test.py)
+
+Exit codes gate a caller's `$?`:
+  0  the clean rebase landed (pushed + ledger written), or a --dry-run whose preconditions all pass
+  2  a PRECONDITION refused it — nothing was mutated (no row, held/terminal, bad/dirty/stale worktree,
+     branch mismatch, absent remote). The caller fixes the stated condition and re-runs.
+  3  NOT the clean case — a conflict, or the rebase changed the PR's diff. HEAD is restored; nothing
+     pushed, ledger untouched. The driver falls back to the JUDGMENT path (resolve conflicts by hand,
+     then apply the gate-reset rules those docs own).
+  1  a PARTIAL state the driver must resolve — most importantly a push that was REJECTED after a clean
+     local rebase (the rebase is preserved locally; the ledger is NOT written, and orig_head is printed
+     so the driver can decide). Never auto-reset here — that would silently destroy a completed rebase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "clean-rebase-test.py"     # the fixture suite — this tool's executable contract
+LEDGER_PY = _HERE / "ledger.py"
+
+
+def _load_ledger():
+    mod = load_module_from_path("clean_rebase_ledger", LEDGER_PY)
+    if mod is None:
+        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER_PY}")
+    return mod
+
+
+L = _load_ledger()
+
+# TERMINAL statuses — a done PR is never rebased. `files-and-ledger.md` (`status`: "in_review -> merged,
+# or aborted; plus the HELD (non-terminal) statuses") owns the enumeration; these are the two it names as
+# terminal. HELD statuses are refused separately via `L.HELD_STATUSES` (the ledger module owns that set).
+TERMINAL_STATUSES = ("merged", "aborted")
+
+# The SHA-bound liveness counters this rebase resets. `stage-2-ci.md`, "THE LIVENESS COUNTERS", is the
+# owner of the set and of the rule that EVERY `head_sha` change resets it; a clean base-only rebase moves
+# `head_sha` (without resetting the gate), so it is one of those sites. The reset VALUES come from
+# `ledger.py`'s ROW_DEFAULTS (the fresh-head defaults), never literals typed here — same discipline as
+# `pr-adopt.py`'s re-adoption reset.
+LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", "ci_stalled_since")
+
+# Exit codes (see the module docstring for what each means to the caller).
+EXIT_OK = 0
+EXIT_PARTIAL = 1
+EXIT_PRECONDITION = 2
+EXIT_NOT_CLEAN = 3
+
+# The patch identity of an EMPTY diff — its OWN value, distinct from every real patch id (which is 40
+# lowercase hex, so this string can never collide). A PR whose diff was empty on BOTH sides compares equal
+# and is clean; empty-vs-nonempty is a change like any other.
+EMPTY_DIFF = "empty-diff"
+
+
+# --- git / ledger plumbing ----------------------------------------------------
+
+def _run(argv: list[str], *, cwd: "str | None" = None,
+         stdin: "str | None" = None) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603
+        argv, capture_output=True, text=True, check=False, cwd=cwd, input=stdin)
+
+
+def _git(worktree: str, *args: str) -> subprocess.CompletedProcess:
+    """Every git command runs against the worktree via `git -C <worktree>`."""
+    return _run(["git", "-C", worktree, *args])
+
+
+def patch_identity(worktree: str, remote: str, base: str) -> "str | None":
+    """The PR's MERGE-BASE-relative patch identity: `git diff <remote>/<base>...HEAD` piped through
+    `git patch-id --stable`. Returns the 40-hex id, `EMPTY_DIFF` for an empty diff, or None if the diff
+    itself could not be computed (a missing ref). Three-dot diff is measured from the merge base, so the
+    SAME value is produced whether the PR sits on the old or the new base — which is exactly what lets a
+    before/after comparison isolate what the REBASE did to the PR's content."""
+    diff = _git(worktree, "diff", f"{remote}/{base}...HEAD")
+    if diff.returncode != 0:
+        return None
+    pid = _run(["git", "patch-id", "--stable"], cwd=worktree, stdin=diff.stdout)
+    out = pid.stdout.strip()
+    if not out:
+        return EMPTY_DIFF
+    return out.split()[0]
+
+
+# --- output -------------------------------------------------------------------
+
+def emit(obj: dict) -> None:
+    print(json.dumps(obj))
+
+
+def refuse(kind: str, message: str, code: int) -> int:
+    """Print a structured refusal to stdout (machine-parseable) and a human line to stderr, and return the
+    gating exit code. Used for every non-success outcome so a caller can gate on `$?` OR read the reason."""
+    emit({"refused": kind, "detail": message})
+    print(f"clean-rebase: REFUSED ({kind}) — {message}", file=sys.stderr)
+    return code
+
+
+# --- the run ------------------------------------------------------------------
+
+def _is_git_worktree(worktree: str) -> bool:
+    if not Path(worktree).is_dir():
+        return False
+    r = _git(worktree, "rev-parse", "--is-inside-work-tree")
+    return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def run(args) -> int:
+    ledger_path = Path(args.ledger)
+    pr = str(args.pr)
+    worktree = args.worktree
+    base = args.base
+    remote = args.remote
+
+    # --- PRECONDITIONS: each fails CLOSED at exit 2, mutating NOTHING ----------
+
+    # 1. The ledger row must exist — there is nothing to rebase for a PR the run does not track.
+    _, rows = L.load(ledger_path)
+    row = L.find_row(rows, pr)
+    if row is None:
+        return refuse("no-row", f"no ledger row for pr {pr} — adopt it first (`pr-adopt.py adopt`)",
+                      EXIT_PRECONDITION)
+
+    # 2. A HELD PR is FROZEN — no rebase (a mutation) is dispatched on it — and a TERMINAL PR is done.
+    status = row.get("status", "-")
+    if status in L.HELD_STATUSES:
+        return refuse("held", f"pr {pr} is {status} — {L.held_reason(status)}; a held PR is never rebased",
+                      EXIT_PRECONDITION)
+    if status in TERMINAL_STATUSES:
+        return refuse("terminal", f"pr {pr} is {status} (terminal) — a done PR is never rebased",
+                      EXIT_PRECONDITION)
+
+    # 3. The worktree must exist and be a real git worktree.
+    if not _is_git_worktree(worktree):
+        return refuse("worktree-missing",
+                      f"{worktree} is missing or is not a git worktree — cannot rebase there",
+                      EXIT_PRECONDITION)
+
+    # 4. The remote must exist. `--remote` defaults to `origin`; an ABSENT remote is refused, never guessed
+    #    at (fetch/push would fail mid-flight otherwise).
+    if _git(worktree, "remote", "get-url", remote).returncode != 0:
+        return refuse("no-remote", f"remote {remote!r} is not configured in {worktree}", EXIT_PRECONDITION)
+
+    # 5. A DIRTY tree is NEVER rebased — uncommitted work would be destroyed or entangled. Nothing ignored.
+    st = _git(worktree, "status", "--porcelain")
+    if st.returncode != 0:
+        return refuse("worktree-error", f"`git status` failed in {worktree}: {st.stderr.strip()}",
+                      EXIT_PRECONDITION)
+    if st.stdout.strip():
+        return refuse("dirty", f"{worktree} has uncommitted changes — refusing to rebase a dirty tree",
+                      EXIT_PRECONDITION)
+
+    # 6. The worktree must have the ROW'S branch checked out (not detached, not a different branch).
+    br = _git(worktree, "rev-parse", "--abbrev-ref", "HEAD")
+    if br.returncode != 0:
+        return refuse("worktree-error", f"cannot read the checked-out branch in {worktree}: "
+                      f"{br.stderr.strip()}", EXIT_PRECONDITION)
+    checked_out = br.stdout.strip()
+    row_branch = row.get("branch", "-")
+    if checked_out != row_branch:
+        return refuse("wrong-branch",
+                      f"{worktree} has {checked_out!r} checked out but pr {pr}'s row branch is "
+                      f"{row_branch!r} — rebase the branch the row names, not whatever is checked out",
+                      EXIT_PRECONDITION)
+
+    # 7. The worktree HEAD must equal the row's recorded head_sha. A mismatch means the checkout or the
+    #    ledger is STALE, and rebasing either would corrupt the gate; name which value is which and send the
+    #    caller to pr-adoption's refresh to reconcile them FIRST.
+    hv = _git(worktree, "rev-parse", "HEAD")
+    if hv.returncode != 0:
+        return refuse("worktree-error", f"cannot read HEAD in {worktree}: {hv.stderr.strip()}",
+                      EXIT_PRECONDITION)
+    orig_head = hv.stdout.strip()
+    row_head = row.get("head_sha", "-")
+    if orig_head != row_head:
+        return refuse("stale",
+                      f"worktree HEAD is {orig_head} but pr {pr}'s ledger head_sha is {row_head} — the "
+                      f"checkout or the ledger is stale; reconcile them via pr-adoption's refresh "
+                      f"(`pr-adopt.py adopt`) before rebasing",
+                      EXIT_PRECONDITION)
+
+    # --- --dry-run STOPS HERE — before the first mutation (fetch moves a tracking ref) ------------------
+    if args.dry_run:
+        emit({"dry_run": True, "pr": pr, "worktree": worktree, "base": base, "remote": remote,
+              "orig_head": orig_head, "branch": row_branch,
+              "would": f"fetch {remote} {base}; rebase onto {remote}/{base}; verify the PR diff is "
+                       f"unchanged; push --force-with-lease; then set head_sha, ci=pending and reset the "
+                       f"liveness counters in the ledger"})
+        return EXIT_OK
+
+    # --- EXECUTION ------------------------------------------------------------
+
+    # Fetch the base BEFORE computing the comparison target, so both the target and the post-rebase
+    # identity are measured against the SAME (updated) base ref.
+    fetch = _git(worktree, "fetch", remote, base)
+    if fetch.returncode != 0:
+        return refuse("fetch-failed", f"`git fetch {remote} {base}` failed: {fetch.stderr.strip()}",
+                      EXIT_PRECONDITION)
+
+    # The COMPARISON TARGET — the PR's patch identity as it stands now, measured against the fetched base.
+    # (Three-dot is merge-base-relative, so this equals the PR's pre-rebase content; see patch_identity.)
+    target_id = patch_identity(worktree, remote, base)
+    if target_id is None:
+        return refuse("diff-failed",
+                      f"could not diff {remote}/{base}...HEAD in {worktree} (missing ref?) — nothing "
+                      f"rebased", EXIT_PRECONDITION)
+
+    # The rebase. ANY non-zero exit is a conflict this tool NEVER resolves: abort, restore HEAD, hand off.
+    rebase = _git(worktree, "rebase", f"{remote}/{base}")
+    if rebase.returncode != 0:
+        _git(worktree, "rebase", "--abort")
+        after = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+        if after != orig_head:
+            # `--abort` did not restore HEAD — a partial state no clean-only tool may leave silently.
+            print(f"clean-rebase: rebase --abort left HEAD at {after}, not the original {orig_head} — "
+                  f"the worktree is in a PARTIAL state; resolve it by hand", file=sys.stderr)
+            emit({"error": "abort-did-not-restore", "pr": pr, "orig_head": orig_head, "head_now": after})
+            return EXIT_PARTIAL
+        return refuse("conflict",
+                      f"rebase of pr {pr} onto {remote}/{base} conflicts — aborted, HEAD restored to "
+                      f"{orig_head}. Conflict resolution is the driver's call; this tool does the clean "
+                      f"case only", EXIT_NOT_CLEAN)
+
+    # Textually clean — but did it change the PR's OWN diff? Compare patch identities.
+    post_id = patch_identity(worktree, remote, base)
+    if post_id != target_id:
+        # NOT the clean case: the rebase re-wrote the PR's effective patch (e.g. a base edit next to the
+        # PR's hunk). Fail closed — reset to the original head and hand off to the conflict-class path.
+        _git(worktree, "reset", "--hard", orig_head)
+        restored = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+        if restored != orig_head:
+            print(f"clean-rebase: reset --hard left HEAD at {restored}, not {orig_head} — PARTIAL state",
+                  file=sys.stderr)
+            emit({"error": "reset-did-not-restore", "pr": pr, "orig_head": orig_head, "head_now": restored})
+            return EXIT_PARTIAL
+        return refuse("diff-changed",
+                      f"the rebase applied textually but CHANGED pr {pr}'s diff (patch identity "
+                      f"{target_id} -> {post_id}) — reset to {orig_head}. This is not a clean base-only "
+                      f"rebase; the driver's judgment path owns it", EXIT_NOT_CLEAN)
+
+    new_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    # Clean AND diff-preserving — the ONLY path that mutates the remote. Never `--force`, only
+    # `--force-with-lease`: a concurrent push to this branch makes the lease fail rather than clobber.
+    push = _git(worktree, "push", "--force-with-lease", remote, row_branch)
+    if push.returncode != 0:
+        # The rebase is done and correct LOCALLY; only the push was rejected. Do NOT auto-reset — that
+        # would silently destroy the completed rebase. Do NOT write the ledger — head_sha is not yet the
+        # remote truth. Report honestly and print orig_head so the driver can reset if it chooses.
+        print(f"clean-rebase: pr {pr} rebased cleanly to {new_head} but `push --force-with-lease` was "
+              f"REJECTED: {push.stderr.strip()}. The rebase is preserved locally and the ledger was NOT "
+              f"written. Driver decides (orig_head {orig_head}).", file=sys.stderr)
+        emit({"pushed": False, "pr": pr, "orig_head": orig_head, "new_head": new_head, "base": base,
+              "ledger_written": False, "reason": "push rejected — force-with-lease lease failed"})
+        return EXIT_PARTIAL
+
+    # ONE ledger write, through the ledger module: carry `reviews_ok` and the labels FORWARD (the clean
+    # case KEEPS the gate — the "clean base-only rebase" Exception in stage-2-review-gate.md, "Status labels
+    # mirror the review gate", is the owner). It IS a head_sha change, so: new head_sha, ci=pending, and
+    # reset the four liveness counters to their fresh-head ROW_DEFAULTS. `reviews_ok`/labels are NOT touched.
+    ledger_argv = ["python3", str(LEDGER_PY), "--file", str(ledger_path), "set", "--pr", pr,
+                   "--head-sha", new_head, "--ci", "pending"]
+    for field in LIVENESS_COUNTERS:
+        ledger_argv += [f"--{field.replace('_', '-')}", str(L.ROW_DEFAULTS[field])]
+    lw = _run(ledger_argv, cwd=str(ledger_path.parent))
+    if lw.returncode != 0:
+        # The push LANDED but the ledger did not update — a partial the driver must reconcile (the remote
+        # is at new_head; the ledger still says orig_head). Never silently swallow it.
+        print(f"clean-rebase: pr {pr} pushed to {new_head} but the ledger write FAILED: "
+              f"{lw.stderr.strip()}. Reconcile the row to head_sha {new_head} by hand.", file=sys.stderr)
+        emit({"pushed": True, "pr": pr, "orig_head": orig_head, "new_head": new_head, "base": base,
+              "ledger_written": False, "reason": "ledger set failed after a successful push"})
+        return EXIT_PARTIAL
+
+    emit({"pr": pr, "old_head": orig_head, "new_head": new_head, "base": base, "pushed": True,
+          "ledger": {"head_sha": new_head, "ci": "pending",
+                     **{f: str(L.ROW_DEFAULTS[f]) for f in LIVENESS_COUNTERS}}})
+    return EXIT_OK
+
+
+# --- self-test: the executable contract lives in the SIBLING module -----------
+
+class SelfTestFailure(AssertionError):
+    """A rule this file claims to enforce does not hold."""
+
+
+def sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(
+            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
+            f"health. Every rule this file enforces is now unpinned.")
+    mod = load_module_from_path("clean_rebase_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
+                              f"suite still exits 0")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
+              f"         {exc}")
+        print("\n1 check(s) FAILED — the clean-rebase tool's contract is broken.")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except SelfTestFailure as exc:
+            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
+            failures += 1
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:30} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the clean-rebase tool's contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — the clean-rebase tool's contract is intact.")
+    return 0
+
+
+# --- CLI ----------------------------------------------------------------------
+
+def main(argv: "list[str] | None" = None) -> int:
+    p = argparse.ArgumentParser(description=DESCRIPTION)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("run", help="execute the clean base-only rebase, or refuse if it is not clean")
+    r.add_argument("--ledger", required=True, help="the run ledger (<rundir>/state.jsonl)")
+    r.add_argument("--pr", required=True, help="PR number (row key)")
+    r.add_argument("--worktree", required=True, help="the PR-head worktree to rebase in")
+    r.add_argument("--base", required=True, help="the base branch to rebase onto")
+    r.add_argument("--remote", default="origin", help="the git remote (default: origin; refused if absent)")
+    r.add_argument("--dry-run", action="store_true", help="check preconditions and report; mutate nothing")
+
+    sub.add_parser("self-test", help="run every fixture (clean-rebase-test.py)")
+
+    args = p.parse_args(argv)
+    if args.cmd == "self-test":
+        return self_test()
+    return run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
- `clean-rebase.py run` does fetch/rebase/push + the ledger write for the clean case only
- any conflict or patch-id change aborts and restores; push failure preserved honestly; 12 real-git fixtures
