### PR TITLE
fix(campaign): unstall fresh-run setup on arm

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -108,8 +108,10 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     and a heartbeat or bounded wait is armed whenever non-terminal work remains. NEVER sleep with due
     work un-launched or no path to the next reconcile. Then follow `references/loop-control.md`,
     "Reschedule or exit", exactly: a scheduled-heartbeat host renders the status — the `ledger.py table`
-    output that block defines — after scheduling and returns; a scheduler-less host renders the same
-    status, performs one bounded wait, and returns to the reconcile step while non-terminal work remains.
+    output that block defines — and then schedules as the turn's LAST action (scheduling ends the turn
+    on that host: `references/runtime-adapter.md`, "Scheduled-heartbeat host"); a scheduler-less host
+    renders the same status, performs one bounded wait, and returns to the reconcile step while
+    non-terminal work remains.
 
 **Review gate — stage 2a** (`references/stage-2-review-gate.md`)
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -448,6 +448,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      heartbeat also recovers a killed/orphaned session through a later scheduled heartbeat; if a scheduler-less
      invocation is killed, durable state permits a later explicit resume (see "Resume after a killed
      session"). **Size the scheduled delay or bounded wait to the nearest stall it guards:**
+     - **Run setup still owed — the lease not yet acquired, or adoption / first dispatches not yet
+       run (a fresh run's arm-ended setup turn, `run-identity-and-lease.md` "Take a run") → ~60 s:**
+       on a turn-ending scheduler the wakeup IS the continuation of setup, so any longer delay is
+       dead time the user reads as a hung run.
      - **Any dispatched review pass still awaiting its first line of launch evidence → ~5 min:** its
        Stage 2a launch deadline is then the soonest thing that can fire, and a hung launch must not
        sit undetected for a full normal interval.
@@ -472,8 +476,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      wait naming what it waits on (review in flight, CI watch, parked on the user's answer). Render it
      after every ledger write during this heartbeat — the ledger was reconciled this heartbeat, so the table is the
      state the next reconcile resumes from. Then take exactly one runtime branch:
-     - **Scheduled-heartbeat host:** schedule the heartbeat, render the status above, and return. The scheduled
-       invocation begins again at step 1.
+     - **Scheduled-heartbeat host:** with the status above already rendered, schedule the heartbeat as
+       the turn's LAST action — scheduling ends the turn on this host (`runtime-adapter.md`,
+       "Scheduled-heartbeat host"), so nothing runs after it. The scheduled invocation begins again at
+       step 1.
      - **Scheduler-less bounded-wait host:** render the same status, wait only until the first task
        completion or the nearest protected deadline, then go directly back to step 1 and reconcile.
        Repeat this status/wait/reconcile cycle while non-terminal work remains. Do **not** execute the

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -92,8 +92,14 @@ the verdict the tool prints.
   acquire --token <tok> --heartbeat-id <proof>`, where the proof names the arming you ALREADY did
   (`runtime-adapter.md` says what your host's proof is). `acquire` refuses without both and never mints
   a token itself — arming comes FIRST, so a driver that dies mid-work is still resumed by its own
-  heartbeat. Keep the token in context; the heartbeat prompt already carries it, so a
-  summarized/amnesiac heartbeat recovers it from the prompt instead of guessing.
+  heartbeat. **On a host whose scheduler ends the turn (`runtime-adapter.md`, "Scheduled-heartbeat
+  host"), step 2 is the setup turn's LAST action and step 3 plus the rest of setup (header, adoption,
+  first dispatches) run on the heartbeat it armed** — the proof then names the arming that delivered
+  the very turn you are in, which is exactly "something already done". Size that first arm to the
+  setup delay (`loop-control.md`, "Reschedule or exit"): a fresh run resumes in about a minute, not a
+  full idle interval that the user reads as a hung run. Keep the token in context; the heartbeat
+  prompt already carries it, so a summarized/amnesiac heartbeat recovers it from the prompt instead of
+  guessing.
 - **You own the run iff the verdict says so.** `acquire`/`refresh` print a verdict, and the verdict —
   not your write, not an eyeballed read of the file — is the proof: `owned`/`adopted` → drive;
   `superseded`/`lost-race`/any refusal → you are NOT the driver — do not review, fix, merge, or
@@ -132,7 +138,8 @@ the verdict the tool prints.
 1. **`--run <id>` given** (every scheduled heartbeat; also a manual targeted resume). Load `<rundir>/state.jsonl`,
    then present a token to `lease.py`. **Scheduled heartbeat** (token in the prompt's `--token`) →
    `refresh`: `owned` → reconcile, continue; `superseded` → stand down; refused because the lease is
-   gone → re-arm, then `acquire`. **Manual `--run` with no token in hand** → `lease.py read` (advisory
+   gone → re-arm, then `acquire` (the turn-split in "Take a run" applies on a turn-ending scheduler:
+   the `acquire` runs on the wake the re-arm produces). **Manual `--run` with no token in hand** → `lease.py read` (advisory
    status only): `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another
    agent appears active, so **confirm takeover with the user** before `acquire --allow-takeover`;
    `corrupt` → see "Adopt only an orphaned run".

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -287,10 +287,19 @@ For the heartbeat fallback, choose exactly one lifecycle:
 1. **Scheduled-heartbeat host:** do NOT hand-assemble the callback. Run `scripts/heartbeat.py callback`
    (resolve `scripts/` from the active `SKILL.md`, per **Bundled resources** above) with the host
    invocation, run-id, and token — `heartbeat.py callback --run <run-id> --token <agent-token>
-   --invocation <campaign-invocation>` — and schedule its **stdout** (the `<campaign-invocation> --run
-   <run-id> --token <agent-token>` line the tool prints) at the delay selected by `loop-control.md`, then
-   render the status — the `ledger.py table` output `loop-control.md` "Reschedule or exit" defines — and
-   return. Letting the tool build the line is what enforces the guarantee: the callback
+   --invocation <campaign-invocation>` — render the status — the `ledger.py table` output
+   `loop-control.md` "Reschedule or exit" defines — and then, as the turn's last action, schedule the
+   tool's **stdout** (the `<campaign-invocation> --run <run-id> --token <agent-token>` line it prints)
+   at the delay selected by `loop-control.md`. **On this host, scheduling ENDS THE TURN** — the
+   scheduler answers that there is nothing more to do this turn and the harness yields until the wakeup
+   fires (verified empirically on Claude Code) — so the schedule call is ALWAYS the LAST action of a
+   turn, and everything the turn still owes (status render, ledger writes, dispatches) happens BEFORE
+   it. The same property is why fresh-run setup spans two turns: "Take a run"'s arm step ends the setup
+   turn, and `acquire` plus the rest of setup run on the heartbeat that arming produced — the acquire
+   proof is that arming, which is already done (`run-identity-and-lease.md`, "Take a run" owns the
+   sequence; `loop-control.md` "Reschedule or exit" sizes the setup delay so a fresh run resumes in
+   about a minute instead of idling a full interval looking stalled). Letting the tool build the line
+   is what enforces the guarantee: the callback
    carries **only** `--run` and `--token` and **never** `--new`/`#PR` (start-time args that would mint a
    fresh run each heartbeat) or `--heartbeat-id` (an acquire-time proof) — and the tool refuses any value
    that is empty or carries whitespace, closing the argument-injection seam. The future invocation begins


### PR DESCRIPTION
- scheduling a wakeup ends the turn on Claude Code (verified), stalling fresh-run setup ~15 min
- setup now spans two turns: arm last with a ~60s delay; acquire and adoption run on that heartbeat
- fixed render-then-schedule ordering at every site; `lease.py` unchanged
