### PR TITLE
feat(campaign): add quiet-run stall sweep

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -93,8 +93,12 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 
 **Heartbeat loop** (`references/loop-control.md` — read at each heartbeat before dispatch)
 
-8. Reconcile the run's PR snapshot (treat `state.jsonl` as cache) and fold completed review / CI /
-   fix tasks against the SHA each ran on.
+8. At heartbeat entry, once you own the run and load its ledger, run `nudge.py` and READ its advisory
+   reminders — computed from durable state, decides nothing, always exits 0 (`references/loop-control.md`
+   step 1). Then reconcile the run's PR snapshot (treat `state.jsonl` as cache) and fold completed
+   review / CI / fix tasks against the SHA each ran on. If the nudge reports the run **QUIET** (no
+   meaningful ledger activity for its window), run the **quiet-run sweep** before rescheduling and lead
+   the status with the diagnosis (`references/loop-control.md`, "Reschedule or exit").
 9. `ci-status.py required-set --ledger <rundir>/state.jsonl`: refresh the required set before any CI
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -90,6 +90,11 @@
   **TIME**, not derivations, because a derivation count
   tracks the run's load and would park a healthy slow build; and it does not park one, because **any**
   motion anywhere in the check set moves the fingerprint and resets the clock.
+- A run that heartbeats while **nothing moves** is not healthy: when `nudge.py` reports the run **QUIET**
+  (no meaningful ledger activity for its `QUIET_AFTER` window, read off the durable `last_activity` stamp),
+  the heartbeat **runs the quiet-run sweep before rescheduling** and **leads the status with the diagnosis**
+  — parked questions with their waiting age, stalled-review findings — ahead of the ledger table
+  (`loop-control.md`, "Reschedule or exit", owns it).
 - Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -119,7 +119,7 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4", "last_activity": "2026-07-04T09:40:00Z"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": "/srv/example-repo/.worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:9f2c\u2026", "settled_strikes": "0", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-", "review_rounds": "3", "ns_streak": "0", "intent": "stated@2026-07-04T09:15:00Z", "pr_origin": "gauntlet", "repair_count": "0", "repair_decision": "-"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": "/home/example/checkouts/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:4a71\u2026", "settled_strikes": "1", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "required check absent: integration-tests", "blocker_ruling": "-", "review_rounds": "5", "ns_streak": "2", "intent": "authored@2026-07-04T09:20:00Z", "pr_origin": "external", "repair_count": "0", "repair_decision": "-"}
 ```
@@ -142,7 +142,9 @@ once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once f
 `reviewer` (`default` (per-host cross-engine route with native fallback — see "The reviewer") | `codex` | `claude` | `<other>` — the selected reviewer; set once, see
 "The reviewer"), `required_set` (what `base_branch` **requires** — `stage-2-ci.md`, "What were we
 expecting to see?", owns the three states, the format, and the reads that produce them; re-read every
-heartbeat while it is `unknown`), `skill_version` (**which copy of the rules actually governed this run**).
+heartbeat while it is `unknown`), `skill_version` (**which copy of the rules actually governed this run**),
+`last_activity` (**when this run last did something MEANINGFUL** — a UTC ISO-8601 stamp the write doors
+maintain; the quiet-run sensor `nudge.py` reads, defined below).
 
 `skill_version` is read at startup from the **running plugin's** `plugin.json` (`SKILL.md`) and stated in
 the final report. **It is not cosmetic.** The harness loads this skill from the **installed plugin cache**,
@@ -159,6 +161,25 @@ green** (`stage-2-ci.md`), so a run that never performed the read merges **nothi
 looked" and "I looked and there are none" are different facts**, and the default is the one that claims
 nothing — a `none` that really meant "I could not see" is how a green gets recorded for a commit whose
 required check never registered.
+
+`last_activity` records **when this run last did something MEANINGFUL**, so a fresh-context heartbeat can
+tell **how long nothing has moved** without holding the history in its head — the same lesson as
+`review_rounds`. It is **maintained internally by the write doors**: any `ledger.py` mutation that changes a
+**non-exempt** field to a **new** value stamps it (UTC ISO-8601, second precision) in the **same atomic
+write**. What does **not** stamp: a **liveness-counter-only** write (a write touching only THE LIVENESS
+COUNTERS — CI-polling bookkeeping that by definition observed no PR change, which is the very "nothing
+moved" this field exists to expose), and a **no-op** (a field set to the value it already holds). **No door
+writes it directly** — `header set last_activity` is **refused**: it is a **sensor**, the same stance
+`review_rounds` takes (a door that can write a sensor is a door that can reset the clock it keeps). It
+**defaults to `-`** — the schema's "not set yet" spelling — so an old ledger written before this field
+existed reads back `-`, and every reader tolerates that: the quiet-run rule simply does not fire on it.
+
+**Boundary — `ci-status.py` writes bypass the stamp.** `ci-status.py` writes the ledger through
+`ledger.py`'s raw `dump`, not the stamping `save`, so **its writes never touch `last_activity`** — a CI
+derivation, a liveness-counter update, or a CI-park it performs leaves the field standing. This is benign:
+those CI writes are exactly the liveness-counter bookkeeping the stamp already exempts, so the only effect
+is that a run whose *only* recent motion was CI polling reads as quiet **sooner** — the quiet-run check
+fires **earlier**, which surfaces a sweep earlier and never suppresses one. It never reads falsely *fresh*.
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -18,6 +18,14 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    only on an `owned`/`adopted` verdict; on `superseded` or any refusal, **stand down**.
    This lease gate is what guarantees **no two agents drive one ledger**.
 
+   Once you own the run and have loaded its ledger, run
+   `scripts/nudge.py --file <rundir>/state.jsonl --followups .gauntlet/followups.jsonl --rundir <rundir>`
+   and **READ its output** before reconciling. It is the **advisory reminder list** — computed from durable
+   state so an amnesiac fresh-context heartbeat is HANDED its obligations rather than told to remember
+   them. It **decides nothing and always exits 0**; each reminder just points at the owner of the actual
+   check (labels, caps, the quiet-run sweep below). Act on the reminders through those owners; ignore none
+   silently.
+
    Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.jsonl`
    exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label so another run's
    PRs are never mistaken for your own (adopted PRs keep their OWN head branch, so ownership is the
@@ -464,10 +472,43 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
        heartbeat).
 
+     **The quiet-run sweep — when the run has gone silent, LOOK before you reschedule.** A run can
+     heartbeat forever while nothing moves: every PR parked on a forgotten question, a review silently
+     stuck — and each heartbeat looks locally fine, because "nothing moved" is invisible to an agent that
+     remembers nothing. The nudge (step 1) reads that from the durable `last_activity` stamp and reports
+     the run **QUIET** when nothing meaningful has changed for **`nudge.py`'s `QUIET_AFTER` window**. When
+     it does — and open PRs remain — this heartbeat **MUST run the quiet-run sweep rather than silently
+     rescheduling into another dead interval.** The sweep is nothing new; it re-runs the checks their
+     existing owners already define, on the rows the sensor says have gone still:
+     - **any in-flight review pass** → `review-pass.py status --run <rundir> --verify`, then apply the
+       **Stage 2a launch-deadline and meaningful-progress rules** to it (`stage-2-review-gate.md`) — a
+       review that died mid-flight is exactly what a quiet streak hides.
+     - **any row that can still move** → **re-derive CI** (Stage 2b) and apply the CI watch / RUNNING-STALL
+       rules — a watch that wedged wakes no one, and only a swept heartbeat notices.
+     - **every parked PR** → **re-surface its question to the user, WITH how long it has waited.** The park
+       is not a stall to "fix" (the held-status guard still binds — step 3), but a forgotten question is
+       the single most likely reason a run went quiet, so it is what the user needs put back in front of
+       them.
+
+     **When the run is quiet, the status this heartbeat renders LEADS with that diagnosis — BEFORE the
+     ledger table:** every parked question restated with its waiting age, and every stalled-review finding,
+     first; then the mandatory table below. **When every open PR is parked, the run is not stalled — it is
+     idle BECAUSE it waits on the user**, and the status says so plainly, leading with the unanswered
+     question rather than presenting the idleness as a fault to chase. Then confirm the next heartbeat is
+     armed, exactly as always.
+
+     **The honest boundary: a quiet streak is only observable by a heartbeat that FIRES.** If the heartbeat
+     chain itself dies — no scheduled wake, no bounded wait returns — nothing in-skill notices the silence,
+     because the sensor is read only when a heartbeat runs. That failure surfaces instead as a **stale
+     lease on the next manual invocation**: adoption (`run-identity-and-lease.md`, "Resolving a heartbeat")
+     picks the orphaned run up, and the adopting driver tells the user the run had been **orphaned** — its
+     heartbeat chain had stopped — not merely resumed.
+
      ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
      both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
-     heartbeat that reschedules, never skipped, and its first and mandatory element is the ledger table
-     itself.** Run
+     heartbeat that reschedules, never skipped. Its first and mandatory element is the ledger table
+     itself** (a quiet-run diagnosis, when one fired above, leads *in front of* the table — it never
+     replaces or reorders it). Run
      `ledger.py --file <state.jsonl> table` and include its output verbatim, fenced, in the status
      message. **Verbatim means WHOLE** — including every `#` line it prints below the grid. The default
      view is a **filtered** one and those lines are what disclose the filtering

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -125,7 +125,9 @@ the verdict the tool prints.
   lease under a different token answers `superseded` — pass `--allow-takeover` only after the user has
   agreed to take over a live run. A lease the tool cannot parse is **`corrupt`, never "absent"**: it
   refuses rather than adopt. Inspect the file and remove it by hand only when the user confirms the
-  run is genuinely orphaned.
+  run is genuinely orphaned. **When the run you adopt still has non-terminal rows, its heartbeat chain
+  had died — tell the user the run had been orphaned, not merely resumed, so the silent stall is
+  surfaced.**
 - **Stand down if superseded.** On a scheduled heartbeat, present your `--token`: a `superseded`
   answer means a takeover while you were hung — do NOT drive; report and stop. (Carrying the token in
   the prompt removes any amnesia ambiguity — a scheduled heartbeat always knows its own token.)

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -35,6 +35,7 @@ What the fixtures are aimed at, in two families:
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
 import os
@@ -1926,6 +1927,126 @@ def t_set_status_transitions_stay_open(L: ModuleType, tmp: Path) -> None:
           f"`set --blocker-ruling` was refused — the user's answer cannot be recorded: exit {code}, {err!r}")
 
 
+# --- last_activity: the run's durable "when did anything last move?" sensor -----
+#
+# Two frozen instants, so a stamp is DETERMINISTIC and a no-op write can be PROVEN not to re-stamp (the
+# second value would differ from the first if it did). The clock is a module global that `save()` looks up
+# by name, so replacing it is the same test-injectable-clock move `lease-test.py` makes on `now`.
+FROZEN_A = "2026-01-02T03:04:05+00:00"
+FROZEN_B = "2026-06-07T08:09:10+00:00"
+
+
+@contextlib.contextmanager
+def frozen_clock(L: ModuleType, value: str):
+    """Freeze the accessor's activity clock to `value` for the duration of the block, then restore it."""
+    prev = L.now_activity
+    setattr(L, "now_activity", lambda: value)
+    try:
+        yield
+    finally:
+        setattr(L, "now_activity", prev)
+
+
+def last_activity(L: ModuleType, path: Path) -> str:
+    """Read the header's `last_activity` through the REAL CLI — the value a heartbeat would see."""
+    code, out, err = cli(L, ["--file", str(path), "header", "get", "last_activity"])
+    check(code == 0, f"header get last_activity exited {code}: {err!r}")
+    return out.rstrip("\n")
+
+
+def t_activity_stamped_on_a_real_change(L: ModuleType, tmp: Path) -> None:
+    """A value-CHANGING `set` stamps `last_activity` in the same write; a NO-OP `set` leaves it untouched.
+
+    The no-op half is what has teeth: the second write is frozen to a DIFFERENT instant, and the stamp must
+    still read the FIRST — a sensor that re-stamped on a write that changed nothing would report a stalled
+    run as alive, which is the exact reading it exists to prevent.
+    """
+    path = write_lines(tmp / "act.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1", status="pending"))
+    check(last_activity(L, path) == "-", "a fresh ledger must start with last_activity `-`")
+    with frozen_clock(L, FROZEN_A):
+        code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+        check(code == 0, f"set exited {code}: {err!r}")
+    check(last_activity(L, path) == FROZEN_A,
+          f"a value-changing set did not stamp last_activity: {last_activity(L, path)!r}")
+    with frozen_clock(L, FROZEN_B):  # a NO-OP: status is ALREADY in_review
+        code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+        check(code == 0, f"no-op set exited {code}: {err!r}")
+    check(last_activity(L, path) == FROZEN_A,
+          f"a NO-OP set re-stamped last_activity to {last_activity(L, path)!r} — a write that changes "
+          f"nothing is not activity and must leave the sensor alone")
+
+
+def t_verdict_stamps_activity(L: ModuleType, tmp: Path) -> None:
+    """A landed `verdict` stamps `last_activity` — it always moves review_rounds, so it is always activity."""
+    sha = "a" * 40
+    path = write_lines(tmp / "v.jsonl", header_line(L, run_id="r1"),
+                       row_line(L, pr="1", head_sha=sha, status="in_review"))
+    with frozen_clock(L, FROZEN_A):
+        code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", sha,
+                               "--verdict", "satisfied"])
+        check(code == 0, f"verdict exited {code}: {err!r}")
+    check(last_activity(L, path) == FROZEN_A,
+          f"a landed verdict did not stamp last_activity: {last_activity(L, path)!r}")
+
+
+def t_liveness_only_write_is_not_activity(L: ModuleType, tmp: Path) -> None:
+    """A write that moves ONLY a liveness counter does NOT stamp — polling that saw no PR change is exactly
+    the "nothing moved" last_activity exists to expose. Every member of LIVENESS_COUNTERS, one at a time.
+
+    Reading `L.LIVENESS_COUNTERS` (never a retyped list) and asserting this fixture covers it is the
+    mechanical half of "name the set": add a counter to that tuple without exempting it from activity and
+    THIS fixture goes red, instead of a new counter silently stamping the sensor on every CI poll.
+    """
+    values = {"ci_fingerprint": "abc123", "settled_strikes": "2",
+              "unusable_refetches": "3", "ci_stalled_since": "2026-05-05T05:05:05+00:00"}
+    check(set(values) == set(L.LIVENESS_COUNTERS),
+          f"this fixture does not cover every liveness counter — it tests {tuple(values)} but "
+          f"LIVENESS_COUNTERS is {L.LIVENESS_COUNTERS}; a counter it misses could stamp with no fixture red")
+    for field, value in values.items():
+        path = write_lines(tmp / f"lv-{field}.jsonl", header_line(L, run_id="r1"),
+                           row_line(L, pr="1", status="pending"))
+        with frozen_clock(L, FROZEN_A):  # a real change first, to give last_activity a known value
+            code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+            check(code == 0, f"[{field}] baseline set exited {code}: {err!r}")
+        check(last_activity(L, path) == FROZEN_A, f"[{field}] the baseline change did not stamp")
+        with frozen_clock(L, FROZEN_B):  # a liveness-counter-only write — must NOT re-stamp
+            flag = "--" + field.replace("_", "-")
+            code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", flag, value])
+            check(code == 0, f"[{field}] liveness set exited {code}: {err!r}")
+        check(last_activity(L, path) == FROZEN_A,
+              f"[{field}] a liveness-counter-only set re-stamped last_activity to "
+              f"{last_activity(L, path)!r} — a CI poll that saw no change is not meaningful activity")
+
+
+def t_last_activity_is_a_sensor_no_door(L: ModuleType, tmp: Path) -> None:
+    """`header set last_activity` is REFUSED — a sensor has no door, exactly as review_rounds has no flag —
+    and it writes NOTHING. `header get last_activity` still READS it."""
+    path = write_lines(tmp / "sensor.jsonl", header_line(L, run_id="r1"))
+    code, out, err = cli(L, ["--file", str(path), "header", "set", "last_activity",
+                             "2000-01-01T00:00:00+00:00"])
+    check(code == 1, f"header set last_activity must be REFUSED (exit 1); got {code}: {out!r}")
+    check("sensor" in err.lower(), f"the refusal must state WHY last_activity is not settable: {err!r}")
+    check(last_activity(L, path) == "-",
+          f"a REFUSED header set still wrote last_activity: {last_activity(L, path)!r} — the forged date "
+          f"reached disk")
+
+
+def t_last_activity_absent_is_tolerated(L: ModuleType, tmp: Path) -> None:
+    """An OLD ledger written before last_activity existed reads back the default `-`, `table` still renders,
+    and a mutating op on it stamps a fresh one — absence is a fresh start, never an error."""
+    old_header = json.dumps({"type": "header", "run_id": "r1", "base_branch": "main"})  # NO last_activity key
+    path = write_lines(tmp / "old.jsonl", old_header, row_line(L, pr="1", status="pending"))
+    check(last_activity(L, path) == "-",
+          f"an old ledger without last_activity must read back `-`: {last_activity(L, path)!r}")
+    code, _, err = cli(L, ["--file", str(path), "table"])
+    check(code == 0, f"table on a pre-field ledger exited {code}: {err!r}")  # readers tolerate the absence
+    with frozen_clock(L, FROZEN_A):
+        code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+        check(code == 0, f"set exited {code}: {err!r}")
+    check(last_activity(L, path) == FROZEN_A,
+          f"a mutating op on a pre-field ledger did not stamp last_activity: {last_activity(L, path)!r}")
+
+
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
     ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
@@ -1981,6 +2102,11 @@ CASES = [
     ("unpark-refusals", "unpark refuses not-parked/unanswered/abort/malformed — writing nothing", t_unpark_refusals),
     ("set-status-stays-open", "set may still write the standoff park/unpark transitions — park/unpark can't serve them", t_set_status_transitions_stay_open),
     ("replay-the-record", "the REAL #42/#43 verdict sequences: it fires, never too early, and says what it costs", t_replay_the_real_record),
+    ("activity-stamped-on-change", "a value-changing set stamps last_activity; a no-op set does not", t_activity_stamped_on_a_real_change),
+    ("verdict-stamps-activity", "a landed verdict stamps last_activity — it always moves review_rounds", t_verdict_stamps_activity),
+    ("liveness-not-activity", "a liveness-counter-only write does NOT stamp — polling that saw no change is not activity", t_liveness_only_write_is_not_activity),
+    ("last-activity-sensor", "last_activity has NO door — `header set last_activity` is refused and writes nothing", t_last_activity_is_a_sensor_no_door),
+    ("last-activity-absent-ok", "an old ledger without last_activity reads `-` and mutating it stamps fresh", t_last_activity_absent_is_tolerated),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -18,7 +18,7 @@ import os
 import re
 import sys
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
@@ -37,7 +37,8 @@ TEST_PY = HERE / "ledger-test.py"     # the fixture suite — this accessor's ex
 
 # --- schema (owned here, once) ------------------------------------------------
 
-HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_set", "skill_version")
+HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_set", "skill_version",
+                 "last_activity")
 HEADER_DEFAULTS = {
     "run_id": "-",
     "base_branch": "-",
@@ -69,6 +70,17 @@ HEADER_DEFAULTS = {
     # a `none` that really meant "I could not see" is how a green is recorded for a commit whose required
     # check never registered.
     "required_set": "unknown",
+    # WHEN THIS RUN LAST DID SOMETHING MEANINGFUL — a UTC ISO-8601 stamp (second precision), maintained
+    # INTERNALLY by the write doors, never hand-set (`header set last_activity` is refused; a sensor has no
+    # door). Every heartbeat is a fresh agent instance, so "how long has nothing moved?" cannot live in the
+    # driver's head — it lives here, the same lesson as `review_rounds`. `nudge.py` reads it to fire the
+    # quiet-run sweep when a run has gone silent for too long.
+    #
+    # The default is `-`, the schema's own "not set" spelling — the same one `ci_stalled_since` (this run's
+    # other on-disk ISO timestamp) uses. An old ledger written before this field existed reads back `-`, and
+    # every reader MUST tolerate that absence: `-` means "nothing has been stamped yet", which is a fact, not
+    # a date, and the quiet-run rule simply does not fire on it.
+    "last_activity": "-",
 }
 
 ROW_FIELDS = (
@@ -162,6 +174,16 @@ ROW_DEFAULTS = {
 # evidence and every one of them resets to its `ROW_DEFAULTS` value. Every member is a `ROW_FIELDS` field, so
 # a reset reads its fresh-head value straight from `ROW_DEFAULTS` — the values are never retyped here either.
 LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", "ci_stalled_since")
+
+# THE FIELDS WHOSE WRITE IS NOT "MEANINGFUL ACTIVITY" — so a write that touches ONLY these does NOT stamp
+# `last_activity`. Two members, both load-bearing, and the set is NAMED (never retyped) so it cannot drift:
+#   * `last_activity` itself — a sensor never counts its own write as the thing it senses; letting it would
+#     reset the very clock it keeps (the same "no door hand-writes a sensor" stance `review_rounds` takes).
+#   * THE LIVENESS COUNTERS (the whole set, `LIVENESS_COUNTERS`) — CI polling bookkeeping. A derivation that
+#     moved only these observed NO change in the PR, which is PRECISELY the "nothing moved" `last_activity`
+#     exists to expose; stamping on it would hide a stalled run behind its own polling. A counter added to
+#     `LIVENESS_COUNTERS` is exempt here with no edit, because this reads that set rather than a copy of it.
+ACTIVITY_EXEMPT = frozenset(LIVENESS_COUNTERS + ("last_activity",))
 
 # The two fields `verdict` OWNS — and the ONLY reason they are not settable through `set`/`add-row` is
 # that a door which can write them is a door that can RESET them.
@@ -408,6 +430,42 @@ def dump(path: Path, header: dict, rows: list[dict]) -> None:
     )
 
 
+def now_activity() -> str:
+    """The current UTC time as an ISO-8601 stamp to the SECOND — what `last_activity` records.
+
+    A MODULE-LEVEL function on purpose: a fixture freezes the clock by replacing it (`setattr(L,
+    'now_activity', ...)`), the same test-injectable-clock convention `lease.py`'s `now()` uses. The form is
+    UTC-aware, second precision — byte-for-byte the shape `ci-status.py` writes `ci_stalled_since` in, so the
+    run's two on-disk ISO timestamps read back the same way.
+    """
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def is_activity(updates: dict, current: dict) -> bool:
+    """Does this write record MEANINGFUL activity — i.e. does it change a NON-EXEMPT field to a NEW value?
+
+    Two things make a write NOT activity, and both are handled here: a field in `ACTIVITY_EXEMPT` (a liveness
+    counter, or `last_activity` itself) never counts, and a NO-OP — a field set to the value it already holds
+    — never counts either. So `set --settled-strikes 5` (liveness only) and `set --status merged` where the
+    row is ALREADY `merged` both return False, while `set --status merged` on an in-flight row returns True.
+    """
+    return any(name not in ACTIVITY_EXEMPT and current.get(name) != value
+               for name, value in updates.items())
+
+
+def save(path: Path, header: dict, rows: list[dict], *, activity: bool) -> None:
+    """Write the store, stamping `last_activity` in the SAME atomic write iff this write is real activity.
+
+    Every mutating door routes its write through here rather than calling `dump()` directly, so the stamp and
+    the change it marks are one `os.replace()` — a heartbeat can never see the new row without the timestamp
+    that dates it, nor the reverse. When `activity` is False (a no-op `set`, or a liveness-counter-only
+    write) the stamp is left exactly as it was: that untouched-ness is the signal the quiet-run rule reads.
+    """
+    if activity:
+        header["last_activity"] = now_activity()
+    dump(path, header, rows)
+
+
 def find_row(rows: list[dict], pr: str) -> "dict | None":
     for row in rows:
         if row.get("pr") == pr:
@@ -451,8 +509,17 @@ def cmd_header(path: Path, args) -> int:
         return 0
     if args.value is None:
         fail("header set requires a value")
+    # `last_activity` is a SENSOR — no door hand-writes it, exactly as no flag at any door writes
+    # `review_rounds`. It is stamped by `save()` as a side effect of a REAL change, never typed in, so a
+    # driver cannot forge "this run is alive" (nor, by writing an old date, forge "it is stalled").
+    if args.field == "last_activity":
+        fail("`last_activity` is a SENSOR, not a settable field — it is stamped automatically on a real "
+             "change and there is no door to hand-write it, the same stance `review_rounds` takes. A value "
+             "typed in here would be a forged liveness reading, which is the one thing this field must never "
+             "carry")
+    activity = header.get(args.field) != args.value
     header[args.field] = args.value
-    dump(path, header, rows)
+    save(path, header, rows, activity=activity)
     return 0
 
 
@@ -523,7 +590,7 @@ def cmd_add_row(path: Path, args) -> int:
     row["pr"] = pr  # --pr is the row key
     row["id"] = f"pr{pr}"  # id is always derived from pr, never caller-set
     rows.append(row)
-    dump(path, header, rows)
+    save(path, header, rows, activity=True)  # adopting a PR is always activity — a row appeared
     print(json.dumps(row))
     return 0
 
@@ -567,13 +634,17 @@ def cmd_set(path: Path, args) -> int:
     if not updates:
         fail("set requires at least one --<field> <value>")
     check_tally(updates, row)
+    # Decide activity from the updates against the row AS LOADED — before `apply_head_sha`/`row.update`
+    # mutate it. A head MOVE counts (head_sha is non-exempt and changes), and the liveness counters that
+    # move resets do NOT (they are in ACTIVITY_EXEMPT); a liveness-counter-only `set`, or a no-op, does not.
+    activity = is_activity(updates, row)
     # `--head-sha` routes through the accessor, which resets THE LIVENESS COUNTERS on a genuine head move.
     # It is applied FIRST so that an explicit counter flag in the SAME call (applied by the row.update below)
     # WINS over the automatic reset — the precedence apply_head_sha's docstring pins.
     if "head_sha" in updates:
         apply_head_sha(row, updates.pop("head_sha"))
     row.update(updates)  # by NAME — never by column position
-    dump(path, header, rows)
+    save(path, header, rows, activity=activity)
     print(json.dumps(row))
     return 0
 
@@ -651,7 +722,7 @@ def cmd_verdict(path: Path, args) -> int:
         # `in_review`) row, so the decision it clears is always a spent one. The next repair here MUST be
         # earned by a fresh `decide`, which bumps `repair_count` — the bound the mechanism exists to hold.
         row["repair_decision"] = "-"
-    dump(path, header, rows)
+    save(path, header, rows, activity=True)  # a landed verdict always moves review_rounds — always activity
     print(json.dumps(row))
     if not at_cap:
         return 0
@@ -785,7 +856,7 @@ def cmd_park(path: Path, args) -> int:
              f"({held_reason(status)}). Resolve it through its own path, not a park")
 
     row.update({"status": "awaiting-user", "ci_reason": reason, "blocker_ruling": "-"})
-    dump(path, header, rows)
+    save(path, header, rows, activity=True)  # a park changes `status` — a non-exempt field, so it is activity
     print(json.dumps(row))
     return 0
 
@@ -836,7 +907,7 @@ def cmd_unpark(path: Path, args) -> int:
     for f in LIVENESS_COUNTERS:
         updates[f] = ROW_DEFAULTS[f]   # from the defaults — NEVER a retyped literal
     row.update(updates)
-    dump(path, header, rows)
+    save(path, header, rows, activity=True)  # unpark flips `status` back to in_review — a non-exempt change
     print(json.dumps(row))
     return 0
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -11,6 +11,7 @@ that emits every line unconditionally — which is no printer at all.
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
@@ -40,8 +41,18 @@ def row(pr, status, **kw) -> dict:
     return r
 
 
-def fire(rows, *, hdr=None, n_followups=0, rundir=None) -> list:
-    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir)
+def fire(rows, *, hdr=None, n_followups=0, rundir=None, now=None) -> list:
+    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, now)
+
+
+# A fixed "now" and two stamps around it, so the quiet-run rule is DETERMINISTIC: one older than
+# QUIET_AFTER (fires) and one comfortably inside it (silent).
+NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def stamp(minutes_ago: int) -> str:
+    """A last_activity value `minutes_ago` before NOW, in the ledger's UTC ISO-8601 second-precision form."""
+    return (NOW - timedelta(minutes=minutes_ago)).isoformat(timespec="seconds")
 
 
 def has(lines, substr) -> bool:
@@ -174,6 +185,57 @@ def t_terminal_pr_fires_no_per_pr_line():
           "a terminal PR must produce NO per-PR reminder")
 
 
+# --- quiet-run sweep ----------------------------------------------------------
+# Boundary stamps are derived FROM N.QUIET_AFTER, not hard-coded minutes, so a re-tuned constant still
+# leaves one stamp comfortably over the threshold and one comfortably under it.
+_QUIET_MIN = int(N.QUIET_AFTER.total_seconds() // 60)
+
+
+def t_quiet_run_fires_when_stale():
+    """A ledger quiet longer than QUIET_AFTER with an open PR fires the whole sweep — and a FRESH ledger
+    fires none of it (the teeth: an always-on sweep would be no sweep)."""
+    stale = fire([row(1, "in_review", ci="green")], hdr=header(run_id="g1", last_activity=stamp(_QUIET_MIN + 5)), now=NOW)
+    check(has(stale, "QUIET"), "a run quiet past QUIET_AFTER must fire the sweep")
+    check(has(stale, "review-pass.py status --run <rundir> --verify"),
+          "the sweep must remind to run the review-pass status check with --verify")
+    check(has(stale, "re-derive CI"), "the sweep must remind to re-derive CI for rows that can move")
+    check(has(stale, "confirm the next heartbeat is armed before you sleep"),
+          "the sweep must remind to arm the next heartbeat before sleeping")
+    fresh = fire([row(1, "in_review", ci="green")], hdr=header(run_id="g1", last_activity=stamp(_QUIET_MIN - 5)), now=NOW)
+    check(not has(fresh, "QUIET"), "a run with recent activity must NOT fire the quiet sweep")
+
+
+def t_quiet_run_silent_when_absent():
+    """An absent/`-` last_activity (an old ledger that predates the sensor) is NOT a stall — stay silent."""
+    check(not has(fire([row(1, "in_review")], hdr=header(run_id="g1"), now=NOW), "QUIET"),
+          "a default `-` last_activity must NOT fire the quiet sweep")
+    check(not has(fire([row(1, "in_review")], hdr=header(run_id="g1", last_activity=""), now=NOW), "QUIET"),
+          "an empty last_activity must NOT fire the quiet sweep")
+    check(not has(fire([row(1, "in_review")], hdr=header(run_id="g1", last_activity="not-a-date"), now=NOW), "QUIET"),
+          "an unparseable last_activity must NOT fire the quiet sweep — advisory, never a crash")
+
+
+def t_quiet_run_needs_an_open_pr():
+    """A quiet ledger with NOTHING open has nothing to sweep — the rule stays silent."""
+    check(not has(fire([row(1, "merged")], hdr=header(run_id="g1", last_activity=stamp(_QUIET_MIN + 5)), now=NOW), "QUIET"),
+          "a quiet run whose only rows are terminal must NOT fire the sweep")
+
+
+def t_quiet_run_names_the_park():
+    """When PARKED rows are the ONLY open rows, the sweep says the run is waiting on the USER and surfaces
+    the unanswered question — the park is the thing to act on, not a stall to chase."""
+    lines = fire([row(7, "awaiting-user", ci_reason="needs your approval")],
+                 hdr=header(run_id="g1", last_activity=stamp(_QUIET_MIN + 5)), now=NOW)
+    check(has(lines, "waiting on YOU"), "a parked-only quiet run must say it is waiting on the user")
+    check(has(lines, "PR 7: parked — LEAD") and has(lines, "needs your approval"),
+          "the sweep must surface the parked PR's question, led with how long it has waited")
+    # a MIXED run (an in-flight row alongside the parked one) is NOT parked-only — it must not claim so.
+    mixed = fire([row(7, "awaiting-user", ci_reason="needs your approval"), row(8, "in_review")],
+                 hdr=header(run_id="g1", last_activity=stamp(_QUIET_MIN + 5)), now=NOW)
+    check(has(mixed, "QUIET") and not has(mixed, "waiting on YOU"),
+          "a run with an in-flight PR is not idle-on-user — it must not claim every open PR is parked")
+
+
 def t_a_nudge_never_blocks():
     # main() over a real ledger file exits 0 no matter what it prints.
     with tempfile.TemporaryDirectory() as d:
@@ -197,5 +259,9 @@ CASES = [
     ("work-due", "the work-due nudge fires whenever review is due (fu25)", t_work_due_fires_whenever_review_is_due),
     ("mergeable", "mergeable nudge respects required(tier)", t_mergeable_fires_when_counters_are_met),
     ("terminal-quiet", "a terminal PR fires no per-PR line", t_terminal_pr_fires_no_per_pr_line),
+    ("quiet-fires-when-stale", "a run quiet past QUIET_AFTER with an open PR fires the sweep; fresh does not", t_quiet_run_fires_when_stale),
+    ("quiet-silent-when-absent", "an absent/`-`/unparseable last_activity never fires the sweep", t_quiet_run_silent_when_absent),
+    ("quiet-needs-open-pr", "a quiet run with nothing open has nothing to sweep", t_quiet_run_needs_an_open_pr),
+    ("quiet-names-the-park", "a parked-only quiet run says it waits on the user and surfaces the question", t_quiet_run_names_the_park),
     ("never-blocks", "a nudge always exits 0", t_a_nudge_never_blocks),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
@@ -48,6 +49,33 @@ REPAIRING = L.REPAIR_STATUS
 TERMINAL = ("merged", "aborted")
 OPEN_FOLLOWUP_HIDDEN = F.TABLE_HIDDEN_STATES  # a follow-up in one of these is closed, not open work
 
+# The PARKED-on-a-human statuses — HELD minus `repairing` (which waits on the reassessment pass, not the
+# user). DERIVED from HELD so a new held status cannot silently join or miss this set. The quiet-run rule
+# treats these specially: a run idle only because every open PR is parked is idle BECAUSE it waits on YOU.
+PARKED = tuple(s for s in HELD if s != REPAIRING)
+
+# How long a run may show NO ledger activity before the quiet-run sweep fires. Derived, not guessed: two
+# normal ~15-min heartbeat intervals (so a single slow heartbeat never trips it) plus ~5 min of slack.
+QUIET_AFTER = timedelta(minutes=35)
+
+
+def _activity_age(last_activity: str, now: datetime) -> "timedelta | None":
+    """How long since the run last did something — or None if that is UNKNOWABLE, in which case the
+    quiet-run rule stays silent. This is advisory and NEVER raises: a `-` (an old ledger that predates the
+    sensor), an empty value, an unparseable stamp, or a naive one all read as "cannot tell" and skip the
+    rule rather than fabricate an age. A stamp is UTC ISO-8601 (ledger.py writes `now_activity()`); a naive
+    value cannot be subtracted from an aware `now`, so it is refused here rather than crashing the printer.
+    """
+    if not last_activity or last_activity == "-":
+        return None
+    try:
+        ts = datetime.fromisoformat(last_activity)
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        return None
+    return now - ts
+
 
 def required(tier: str) -> int:
     """1 if TRIVIAL, else 2. Untriaged ('-'/'') counts as needs-review (target 2) — never under-remind."""
@@ -65,8 +93,15 @@ def rundir_has(rundir: "Path | None", name: str) -> bool:
     return rundir is not None and (rundir / name).exists()
 
 
-def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None") -> list:
-    """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings."""
+def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
+              now: "datetime | None" = None) -> list:
+    """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings.
+
+    `now` is the current UTC time, injectable so the quiet-run rule is testable; it defaults to
+    `datetime.now(timezone.utc)` when a caller (main) does not pass one.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
     out: list = []
     active = [r for r in rows if r["status"] not in TERMINAL]
 
@@ -83,6 +118,33 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None")
         out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
     if n_followups:
         out.append(f"{n_followups} open follow-up(s) — start any you can.")
+
+    # --- quiet-run sweep -------------------------------------------------------
+    # A run whose ledger has not moved for QUIET_AFTER is not necessarily healthy — a review may have died,
+    # a poll may be stuck, or the user may be sitting on a parked question. Every heartbeat is a fresh
+    # context, so "how long has nothing moved?" is read from the durable `last_activity` stamp, not memory.
+    # The rule reminds the orchestrator to SWEEP before rescheduling into another silent interval; it decides
+    # nothing. It stays silent unless there is BOTH a readable stamp that old AND at least one open PR — an
+    # idle run with nothing open has nothing to sweep, and a `-`/absent stamp is an old ledger, not a stall.
+    age = _activity_age(header.get("last_activity", "-"), now)
+    if age is not None and age >= QUIET_AFTER and active:
+        quiet_min = int(age.total_seconds() // 60)
+        parked = [r for r in active if r["status"] in PARKED]
+        out.append(f"run has been QUIET for ~{quiet_min}m (no ledger activity) — SWEEP before rescheduling.")
+        if len(parked) == len(active):
+            # The run is not stalled — it is WAITING ON THE USER. The unanswered question is the thing to
+            # surface, not a stall to chase; say so explicitly so the sweep is not misread as a fault.
+            out.append("every open PR is parked — the run is idle BECAUSE it is waiting on YOU; the "
+                       "unanswered question below is the thing to surface, not a stall to fix.")
+        out.append("run `review-pass.py status --run <rundir> --verify` — apply the launch-deadline and "
+                   "meaningful-progress rules to any in-flight pass.")
+        out.append("re-derive CI for every row that can still move.")
+        for r in parked:
+            why = r.get("ci_reason", "-")
+            tail = f": {why}" if why and why != "-" else ""
+            out.append(f"PR {r['pr']}: parked — LEAD your next status to the user with this question and how "
+                       f"long it has waited (≥ ~{quiet_min}m quiet){tail}.")
+        out.append("confirm the next heartbeat is armed before you sleep.")
 
     # --- per-PR reminders ------------------------------------------------------
     # A HELD PR (parked or repairing) fires ONLY its held reminder. That exclusion is enforced by the
@@ -122,8 +184,9 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None")
     return out
 
 
-def render(header: dict, rows: list, n_followups: int, rundir: "Path | None") -> str:
-    lines = reminders(header, rows, n_followups, rundir)
+def render(header: dict, rows: list, n_followups: int, rundir: "Path | None",
+           now: "datetime | None" = None) -> str:
+    lines = reminders(header, rows, n_followups, rundir, now)
     run_id = header.get("run_id", "-")
     head = f"NUDGE (run {run_id}) — {len(lines)} reminder(s):"
     body = "\n".join(f"  - {line}" for line in lines)


### PR DESCRIPTION
- ledger header gains `last_activity`: stamped by meaningful mutations, never by liveness-only writes; no door sets it
- nudge.py reports a quiet run (no change for ~35 min) and lists the stall sweep to run
- heartbeat docs wire nudge in at entry; a quiet heartbeat must sweep and lead its status with the diagnosis
