### PR TITLE
feat(campaign): add run watchdog

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -52,6 +52,9 @@ These are **distinct modes**, not freely-composable flags; `references/run-ident
 - Non-PR arg (e.g. `auth`) -> same prompt (the old area/topic sweep arg is REMOVED).
 - `--run <id>` -> resume that run; takes no `#PR`/`--new`. Scheduled heartbeats also carry internal
   `--token`.
+- `--run <id> --watchdog` -> internal TOKEN-FREE resurrection poke fired by the persistent watchdog
+  entry; resolves the lease first and stands down if the primary is alive, else adopts the orphaned run
+  (`references/run-identity-and-lease.md`, "Resolving a heartbeat"). Rejected with `--token`/`--new`/`#PR`.
 - `--new #PR...` -> force an independent new run-id for a new PR set (with carryover); requires PRs.
 
 Invalid combinations (e.g. `--new` with no PRs, or `--run` with `#PR`) are rejected / fall through to
@@ -71,7 +74,11 @@ it — no trigger means the step runs unconditionally at that point in the seque
 2. Fresh run -> `run-id.py new`: mint the run-id and ATOMICALLY create its run directory, then apply
    carryover from earlier runs (`references/carryover.md`).
 3. `lease.py acquire` (`refresh` on resume): take or keep the run lease; stand down if a fresh lease
-   names a different owner. One active driver per run — never double-drive.
+   names a different owner. One active driver per run — never double-drive. **Take a run in order**
+   (`references/run-identity-and-lease.md`, "Take a run"): BEFORE arming, record the run intent
+   (`ledger.py header set pending_adoption "<pr>…"`, cleared when adoption finishes) and — on a
+   persistent-scheduler host — **ensure the watchdog entry** (`references/runtime-adapter.md`, "Persistent
+   watchdog capability"), so a mid-setup or later death is resumable/resurrectable.
 4. Run start -> `ledger.py --file <state.jsonl> header set skill_version <version>`: record the
    `version` read from the **running plugin's** `plugin.json`. The harness loads this skill from the
    **installed plugin cache**, so a merged, version-bumped rule governs nothing until that cache
@@ -96,9 +103,10 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 8. At heartbeat entry, once you own the run and load its ledger, run `nudge.py` and READ its advisory
    reminders — computed from durable state, decides nothing, always exits 0 (`references/loop-control.md`
    step 1). Then reconcile the run's PR snapshot (treat `state.jsonl` as cache) and fold completed
-   review / CI / fix tasks against the SHA each ran on. If the nudge reports the run **QUIET** (no
-   meaningful ledger activity for its window), run the **quiet-run sweep** before rescheduling and lead
-   the status with the diagnosis (`references/loop-control.md`, "Reschedule or exit").
+   review / CI / fix tasks against the SHA each ran on. When the run is **QUIET** (nudge, no meaningful
+   ledger activity for its window) **OR** `ledger.py watchdog check` says the long-cadence deadline is
+   `due`/`unset`/`invalid`, run the **health pass** (one pass, then one `ledger.py watchdog arm`) before
+   rescheduling and lead the status with the diagnosis (`references/loop-control.md`, "Reschedule or exit").
 9. `ci-status.py required-set --ledger <rundir>/state.jsonl`: refresh the required set before any CI
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -90,11 +90,12 @@
   **TIME**, not derivations, because a derivation count
   tracks the run's load and would park a healthy slow build; and it does not park one, because **any**
   motion anywhere in the check set moves the fingerprint and resets the clock.
-- A run that heartbeats while **nothing moves** is not healthy: when `nudge.py` reports the run **QUIET**
-  (no meaningful ledger activity for its `QUIET_AFTER` window, read off the durable `last_activity` stamp),
-  the heartbeat **runs the quiet-run sweep before rescheduling** and **leads the status with the diagnosis**
-  — parked questions with their waiting age, stalled-review findings — ahead of the ledger table
-  (`loop-control.md`, "Reschedule or exit", owns it).
+- A run that heartbeats while **nothing moves** is not healthy, nor is one whose heartbeats keep firing
+  but never look deeply: when the run is **QUIET** (`nudge.py`, off the durable `last_activity` stamp) **OR**
+  `ledger.py watchdog check` says the long-cadence deadline is `due`/`unset`/`invalid`, the heartbeat
+  **runs the health pass before rescheduling** (one pass, then one `watchdog arm`) and **leads the status
+  with the diagnosis** — parked questions with their waiting age, stalled-review findings — ahead of the
+  ledger table (`loop-control.md`, "Reschedule or exit", owns it).
 - Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -119,7 +119,7 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4", "last_activity": "2026-07-04T09:40:00Z"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4", "last_activity": "2026-07-04T09:40:00Z", "watchdog_due": "2026-07-04T10:25:00Z", "pending_adoption": "-"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": "/srv/example-repo/.worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:9f2c\u2026", "settled_strikes": "0", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-", "review_rounds": "3", "ns_streak": "0", "intent": "stated@2026-07-04T09:15:00Z", "pr_origin": "gauntlet", "repair_count": "0", "repair_decision": "-"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": "/home/example/checkouts/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:4a71\u2026", "settled_strikes": "1", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "required check absent: integration-tests", "blocker_ruling": "-", "review_rounds": "5", "ns_streak": "2", "intent": "authored@2026-07-04T09:20:00Z", "pr_origin": "external", "repair_count": "0", "repair_decision": "-"}
 ```
@@ -144,7 +144,10 @@ once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once f
 expecting to see?", owns the three states, the format, and the reads that produce them; re-read every
 heartbeat while it is `unknown`), `skill_version` (**which copy of the rules actually governed this run**),
 `last_activity` (**when this run last did something MEANINGFUL** — a UTC ISO-8601 stamp the write doors
-maintain; the quiet-run sensor `nudge.py` reads, defined below).
+maintain; the quiet-run sensor `nudge.py` reads, defined below), `watchdog_due` (**the durable
+health-pass deadline** — a UTC ISO-8601 stamp `ledger.py watchdog` stamps and reads, defined below),
+`pending_adoption` (**the run-intent checkpoint** — the requested PR list recorded at setup, defined
+below).
 
 `skill_version` is read at startup from the **running plugin's** `plugin.json` (`SKILL.md`) and stated in
 the final report. **It is not cosmetic.** The harness loads this skill from the **installed plugin cache**,
@@ -180,6 +183,30 @@ derivation, a liveness-counter update, or a CI-park it performs leaves the field
 those CI writes are exactly the liveness-counter bookkeeping the stamp already exempts, so the only effect
 is that a run whose *only* recent motion was CI polling reads as quiet **sooner** — the quiet-run check
 fires **earlier**, which surfaces a sweep earlier and never suppresses one. It never reads falsely *fresh*.
+
+`watchdog_due` records **the durable HEALTH-PASS DEADLINE** — a UTC ISO-8601 stamp (second precision)
+naming the instant by which the run owes its next deep **health pass** (`loop-control.md`, "Reschedule or
+exit", owns the pass). It is stamped **only** by `ledger.py watchdog arm` (`now + WATCHDOG_INTERVAL`);
+`ledger.py watchdog check` reads it back — read-only, always exit 0 — printing exactly one of `unset` /
+`ok <remaining>` / `due <age>` / `invalid — re-arm`, and **`ledger.py` OWNS that parse** (nudge reuses it,
+never a second copy): a malformed or naive stamp reads as `invalid`, whose advisory fix is a re-arm, never
+a crash — the same treatment the quiet-run rule gives an unreadable `last_activity`. It is a
+**TOOL-STAMPED** field, the exact stance `last_activity` takes: **`header set watchdog_due` is refused**
+(there is no door to hand-write it — a typed-in deadline would be a **forged** one), and its writes are
+**activity-EXEMPT** (it joins `ACTIVITY_EXEMPT`) — re-arming the watchdog is not "the run did something
+meaningful", so a bare `watchdog arm` must **never** stamp `last_activity`, else the watchdog would defeat
+the very quiet sensor it backs. It **defaults to `-`** — the schema's "not set yet" spelling — and
+`watchdog check` reads `-` as `unset`; an old ledger predating the field reads back `-` and every reader
+tolerates that.
+
+`pending_adoption` records **the RUN-INTENT CHECKPOINT** — a space-separated list of PR numbers written at
+setup, **BEFORE `acquire`**, so a death mid-setup does not lose the requested PR list (which otherwise
+lived only in the invocation args — `run-identity-and-lease.md`, "Take a run", owns the sequence). Unlike
+`watchdog_due` it is an **ORDINARY, hand-settable config field** (`header set pending_adoption "89 90"`):
+it has a real door, and **writing it IS meaningful activity** (no exemption — it is **not** a sensor and
+carries no liveness meaning). Adoption clears it back to `-` as its final step, and any later entry — the
+armed wake, a watchdog poke, a manual resume — that finds it set resumes setup idempotently from exactly
+those PRs (`loop-control.md` step 1). It **defaults to `-`**: nothing is pending.
 
 Header field notes (the header fields above; per-row fields follow):
 
@@ -479,7 +506,10 @@ and pass that path to subtasks, exactly as with `emit-progress.py`. Subcommands
 # Run: python3 <skill-dir>/scripts/ledger.py --file <state.jsonl> <subcommand> …
 # The synopsis abbreviates that `python3 <skill-dir>/scripts/ledger.py` prefix to `ledger.py`.
 ledger.py --file <state.jsonl> header get <field>                 # read a run-config header field
-ledger.py --file <state.jsonl> header set <field> <value>         # set a run-config header field
+ledger.py --file <state.jsonl> header set <field> <value>         # set a run-config header field (refused for a TOOL-STAMPED field: last_activity, watchdog_due)
+ledger.py --file <state.jsonl> watchdog arm                       # stamp watchdog_due = now + WATCHDOG_INTERVAL (activity-EXEMPT)
+ledger.py --file <state.jsonl> watchdog check                     # print unset|ok <rem>|due <age>|invalid — re-arm (read-only, always exit 0)
+ledger.py watchdog interval                                       # print the interval in minutes (reads NO ledger; scheduler adapter consumes THIS)
 ledger.py --file <state.jsonl> add-row --pr N [--<field> <val> …] # register a row (refuses a duplicate pr; unset fields default)
 ledger.py --file <state.jsonl> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
 ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfied|not-satisfied

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -23,8 +23,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    and **READ its output** before reconciling. It is the **advisory reminder list** — computed from durable
    state so an amnesiac fresh-context heartbeat is HANDED its obligations rather than told to remember
    them. It **decides nothing and always exits 0**; each reminder just points at the owner of the actual
-   check (labels, caps, the quiet-run sweep below). Act on the reminders through those owners; ignore none
-   silently.
+   check (labels, caps, the health pass below — including its `watchdog due` reminder). Act on the
+   reminders through those owners; ignore none silently.
 
    Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.jsonl`
    exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label so another run's
@@ -139,12 +139,19 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      empty orphan run behind. **Only once the full set passes preflight**: call `create_run_directory`
      **first** — it mints the run-id and atomically creates `<rundir>` — and derive `run_id` from the
      returned directory's final path component; **then** take the run per `run-identity-and-lease.md`,
-     "Take a run" (token, heartbeat arming, `lease.py acquire` — in that order),
+     "Take a run" (which, BEFORE arming, records `pending_adoption` = this set's PR list and — on a
+     persistent-scheduler host — **ensures the watchdog entry**; then token, heartbeat arming,
+     `lease.py acquire` — in that order),
      and write the `state.jsonl` header — now with `run_id` set and `base_branch` filled
-     from the agreed `baseRefName` (known from preflight). Then **adopt** each PR
+     from the agreed `baseRefName` (known from preflight). **Probe watchdog `available?` at run start and
+     REPORT the degradation when it is absent** (Codex, or `ensure` denied): long-cadence health checks
+     remain, automatic resurrection does not — a dead driver needs a manual resume
+     (`runtime-adapter.md`, "Persistent watchdog capability"). Then **adopt** each PR
      (ledger row + labels + worktree, and a CI watch **only when one is due** — `pr-adoption.md` owns what
      adoption produces and when the watch is warranted); a death mid-adoption still leaves
-     a discoverable, adoptable run. Then fall through to dispatch/reschedule.
+     a discoverable, adoptable run. **When the whole requested set is adopted, clear the checkpoint —
+     `ledger.py … header set pending_adoption -`** (this is adoption's final step; a later entry that
+     still sees it set knows setup did not finish and resumes it). Then fall through to dispatch/reschedule.
    - **This run's `state.jsonl` is fully terminal — every row `merged`/`aborted`, no open PR carrying this
      run's label → the run is finished.** Do **not** silently exit "all fixed" (the old bug) and do **not**
      silently restart. **Ask the user** whether to gate more PRs — e.g. "gauntlet run
@@ -472,14 +479,27 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
        heartbeat).
 
-     **The quiet-run sweep — when the run has gone silent, LOOK before you reschedule.** A run can
+     **The health pass — when the run owes a deep look, LOOK before you reschedule.** A run can
      heartbeat forever while nothing moves: every PR parked on a forgotten question, a review silently
      stuck — and each heartbeat looks locally fine, because "nothing moved" is invisible to an agent that
-     remembers nothing. The nudge (step 1) reads that from the durable `last_activity` stamp and reports
-     the run **QUIET** when nothing meaningful has changed for **`nudge.py`'s `QUIET_AFTER` window**. When
-     it does — and open PRs remain — this heartbeat **MUST run the quiet-run sweep rather than silently
-     rescheduling into another dead interval.** The sweep is nothing new; it re-runs the checks their
-     existing owners already define, on the rows the sensor says have gone still:
+     remembers nothing. Two sensors trigger the same deep look, and **you compute the trigger AFTER
+     ownership is established (step 1's lease verdict) and AFTER the nudge read**:
+
+     ```text
+     need_health = run is QUIET (nudge, step 1 — no meaningful ledger activity for QUIET_AFTER)
+                   OR  ledger.py watchdog check says `due` / `unset` / `invalid`
+     ```
+
+     The first is #112's quiet sensor (the durable `last_activity` stamp); the second is the durable
+     long-cadence deadline (`ledger.py watchdog`, `files-and-ledger.md`) — the sensor that catches a run
+     whose heartbeats keep FIRING but never look deeply, and, on a persistent-scheduler host, the deadline
+     the resurrection poke enforces. **When `need_health` — and open PRs remain — this heartbeat runs
+     exactly ONE health pass and then exactly ONE `ledger.py --file <state.jsonl> watchdog arm`, and
+     completes BOTH before the status render and the turn's final scheduling action** (the last-action rule
+     below). **Never two passes for two triggers**: quiet and watchdog-due firing together is still one
+     pass, one arm. The pass **relies on this heartbeat's successful `refresh` verdict** (step 1) and adds
+     **no lease machinery** of its own. Its contents are nothing new — it re-runs the checks their existing
+     owners already define, on the rows that have gone still:
      - **any in-flight review pass** → `review-pass.py status --run <rundir> --verify`, then apply the
        **Stage 2a launch-deadline and meaningful-progress rules** to it (`stage-2-review-gate.md`) — a
        review that died mid-flight is exactly what a quiet streak hides.
@@ -489,25 +509,31 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        is not a stall to "fix" (the held-status guard still binds — step 3), but a forgotten question is
        the single most likely reason a run went quiet, so it is what the user needs put back in front of
        them.
+     - **adapter-conditional verification** (`runtime-adapter.md`): on a **scheduled-heartbeat /
+       persistent-scheduler host**, **ensure the persistent watchdog entry still exists** (`ensure` — it is
+       idempotent, so re-running it is free); on a **bounded-wait host**, verify control returns to the
+       bounded-wait loop — there is **no callback to inspect**, so do not claim one.
 
-     **When the run is quiet, the status this heartbeat renders LEADS with that diagnosis — BEFORE the
+     **When the health pass ran, the status this heartbeat renders LEADS with the diagnosis — BEFORE the
      ledger table:** every parked question restated with its waiting age, and every stalled-review finding,
      first; then the mandatory table below. **When every open PR is parked, the run is not stalled — it is
      idle BECAUSE it waits on the user**, and the status says so plainly, leading with the unanswered
      question rather than presenting the idleness as a fault to chase. Then confirm the next heartbeat is
      armed, exactly as always.
 
-     **The honest boundary: a quiet streak is only observable by a heartbeat that FIRES.** If the heartbeat
-     chain itself dies — no scheduled wake, no bounded wait returns — nothing in-skill notices the silence,
-     because the sensor is read only when a heartbeat runs. That failure surfaces instead as a **stale
-     lease on the next manual invocation**: adoption (`run-identity-and-lease.md`, "Resolving a heartbeat")
-     picks the orphaned run up, and the adopting driver tells the user the run had been **orphaned** — its
-     heartbeat chain had stopped — not merely resumed.
+     **The honest boundary: an in-session sensor is only read by a heartbeat that FIRES.** If the heartbeat
+     chain itself dies — no scheduled wake, no bounded wait returns — nothing in-session reads either
+     sensor. Recovery then depends on the host: on a **persistent-scheduler host** the **resurrection
+     poke** fires on its own cadence and adopts the orphaned run (`run-identity-and-lease.md`, "Resolving a
+     heartbeat", `--watchdog`), telling the user the run had been **orphaned** — its chain had stopped —
+     not merely resumed. Where no persistent scheduler exists (Codex — `runtime-adapter.md`), a dead chain
+     surfaces only as a **stale lease on the next manual invocation** (`--run <id>`), where adoption picks
+     the orphaned run up and reports the same. Either way the silent stall is surfaced, never absorbed.
 
      ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
      both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
      heartbeat that reschedules, never skipped. Its first and mandatory element is the ledger table
-     itself** (a quiet-run diagnosis, when one fired above, leads *in front of* the table — it never
+     itself** (a health-pass diagnosis, when one fired above, leads *in front of* the table — it never
      replaces or reorders it). Run
      `ledger.py --file <state.jsonl> table` and include its output verbatim, fenced, in the status
      message. **Verbatim means WHOLE** — including every `#` line it prints below the grid. The default
@@ -530,9 +556,17 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      terminal ledger — merged PRs, aborted PRs + why, and declined-API facts — and REFUSES a run with any
      non-terminal row or an existing file, so it distills exactly once; per-run files never
      contend, see "Fresh runs and carryover"), **release the run** (delete this run's
-     `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, and release
-     the lease — `lease.py … release --token <tok>`; the shared status labels stay), emit the final report, and **do not
-     reschedule**. This run's loop ends. **Leave
+     `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, release
+     the lease — `lease.py … release --token <tok>` — and, on a persistent-scheduler host, **remove the
+     persistent watchdog entry** (`runtime-adapter.md`, "Persistent watchdog capability"); the shared
+     status labels stay), emit the final report, and **do not
+     reschedule**. This run's loop ends. **"Rows all terminal" alone is NOT "finished"** — finalization
+     (carryover distilled, label deleted, lease released, watchdog entry removed) may still be **owed**, so
+     do these in order and only remove the watchdog entry once the rest is done; a resurrection poke that
+     arrives with finalization still owed **resumes the terminal step** rather than deleting the entry from
+     under it (`run-identity-and-lease.md`, "Resolving a heartbeat", `--watchdog`). The poke's own
+     self-cleanup — it removes the entry when it finds the run finished AND finalized — is the **backstop**
+     for a terminal step that died before removing it. **Leave
      `<rundir>` in place** (do NOT delete it here) — its terminal `state.jsonl` is what lets a later bare
      invocation detect *this* *finished* run and take the "ask the user" branch in step 1 instead of a
      silent exit. (A stale heartbeat firing after exit harmlessly re-hits the finished-run branch via

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -87,7 +87,16 @@ corrupt-lease refusal, and the read-back. Do not unpack those mechanics here: pr
 the verdict the tool prints.
 
 - **Take a run** — at fresh-run start or on adoption — **in this order**: (1) `lease.py mint` prints
-  your agent token; (2) arm the scheduled heartbeat carrying it (`--token <tok>`, via `heartbeat.py
+  your agent token; **then, BEFORE arming (the arm ends the setup turn on a turn-ending scheduler), do
+  the two durable-setup steps that must survive a mid-setup death:** **(a)** record the run intent —
+  `ledger.py --file <rundir>/state.jsonl header set pending_adoption "<pr> <pr> …"`, which creates the
+  ledger + header if missing — so a death before `acquire` does not lose the requested PR list (it
+  otherwise lived only in the invocation args), and any later entry that finds `pending_adoption` set
+  resumes setup idempotently from adoption of exactly those PRs (`files-and-ledger.md`; adoption clears it
+  back to `-` as its final step, `loop-control.md` step 1); **(b)** on a persistent-scheduler host,
+  **ensure the watchdog entry** (`runtime-adapter.md`, "Persistent watchdog capability" — `ensure` is
+  idempotent and does NOT end the turn), so a heartbeat chain that dies during or after setup can still be
+  resurrected. Then (2) arm the scheduled heartbeat carrying the token (`--token <tok>`, via `heartbeat.py
   callback` — `runtime-adapter.md` owns the host mechanism); (3) `lease.py --file <rundir>/lease.json
   acquire --token <tok> --heartbeat-id <proof>`, where the proof names the arming you ALREADY did
   (`runtime-adapter.md` says what your host's proof is). `acquire` refuses without both and never mints
@@ -145,6 +154,23 @@ the verdict the tool prints.
    status only): `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another
    agent appears active, so **confirm takeover with the user** before `acquire --allow-takeover`;
    `corrupt` → see "Adopt only an orphaned run".
+
+   **`--run <id> --watchdog` — the resurrection poke** (fired by the persistent watchdog entry —
+   `runtime-adapter.md`, "Persistent watchdog capability"; the poke line is `heartbeat.py watchdog`'s, and
+   is **TOKEN-FREE**). **Arg grammar:** `--watchdog` **requires `--run`** and is **rejected** in
+   combination with `--token`, `--new`, or `#PR` args — a token-bearing poke beside a live chain could
+   double-drive, and `--new`/`#PR` are start-time args that would mint a fresh run. Because it carries no
+   token it resolves the lease **first** and stands down when the primary is alive. Load
+   `<rundir>/state.jsonl`, `lease.py read`, and act on the verdict — **reusing existing verdicts only**:
+
+   | `lease.py` read / state | action |
+   |---|---|
+   | `held` | the primary driver is alive: report **one** stand-down line and **EXIT**. Never prompt, never `--allow-takeover`. |
+   | `stale`/`absent`, run **not finalized** — a non-terminal row remains, **OR** `pending_adoption` is set, **OR** every row is terminal but finalization is still owed (carryover not distilled / label not deleted / lease not released — the lease file is still present and the run label still exists) | the heartbeat chain is **dead**: adopt per "Take a run" — mint, arm the SHORT chain (setup delay), and on a turn-terminal host the arm **ends the poke's turn** so `acquire` runs on the armed wake (exactly the setup turn-split above). Then resume from **what durable state says**: `pending_adoption` set → finish setup (adopt those PRs); non-terminal rows → the normal loop; finalization owed → run the **terminal step** (`loop-control.md`, "Reschedule or exit"). **Report that the watchdog resurrected an orphaned run**, not merely resumed it. |
+   | `stale`/`absent`, run **finished AND finalized** — every row terminal, carryover distilled, label deleted, lease released | nothing to drive: **remove the watchdog entry** (the self-cleaning backstop for a terminal step that never got to remove it) and **EXIT**. |
+   | `corrupt` | report and **EXIT** — never adopt a corrupt lease (the existing rule; see "Adopt only an orphaned run"). |
+   | post-acquire `superseded` / `lost-race` | a driver took the run while you were acquiring: **stand down** (the existing rule) — report and stop. |
+
 2. **Bare invocation** → the arg decides intent:
    - **`#PR` args are given** (`<campaign-invocation> #12 #15`, no `--run`) → **start a NEW run** that
      **adopts those PRs** (see "PR adoption"). Passing PRs is an explicit "gate these now", so it never

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -314,6 +314,47 @@ The second path is how Codex CLI sessions operate when no scheduled-heartbeat ca
 the process is killed, durable run state and the lease takeover rules allow a later invocation to resume;
 the skill does not pretend a heartbeat was scheduled when none was.
 
+### Persistent watchdog capability
+
+The heartbeat mechanisms above are the run's SHORT cadence. `ledger.py watchdog` (`files-and-ledger.md`)
+adds a LONG durable deadline both hosts honor at loop entry. On a host that has a **persistent scheduler**
+— one that survives the death of the driving process — that deadline is backed by a **resurrection poke**:
+a low-frequency wake that re-checks a run whose heartbeat chain may have died. This capability owns the
+scheduler entry; the deadline itself is host-neutral and lives in `ledger.py`.
+
+The capability is **four idempotent operations**, keyed **deterministically** by run id so a re-run never
+creates a duplicate entry — the entry name is `gauntlet-watchdog-<run-id>`:
+
+- `available?` — probe whether this host has a persistent scheduler. Unavailability is a **documented,
+  NON-blocking degradation** (below), never an error that stops the run.
+- `ensure` — create the entry if it is missing; **safe to repeat** (an existing entry is left as-is). Its
+  recurrence is the number `ledger.py watchdog interval` prints — **read it from the tool, never copy a
+  literal**, so a re-tuned interval reaches the scheduler with no edit here. The command the entry fires is
+  built **only** by `heartbeat.py watchdog --run <run-id> --invocation <campaign-invocation>` (it prints
+  `<campaign-invocation> --run <run-id> --watchdog`) — the **same no-hand-assembly stance** the callback
+  takes: never splice that line together yourself, so the poke can never carry a `--token`, `--new`, `#PR`,
+  or `--heartbeat-id` it must not (`run-identity-and-lease.md`, "Resolving a heartbeat", owns the poke's
+  resolution).
+- `inspect` — does the entry exist?
+- `remove` — delete the entry.
+
+**None of `ensure`/`inspect`/`remove` ends the turn** — only wakeup **scheduling** does (the
+scheduled-heartbeat lifecycle above). Managing the watchdog entry is ordinary work the turn does before its
+final scheduling action, exactly like a ledger write or a dispatch.
+
+Host mappings:
+
+| Host | `persistent watchdog` |
+|---|---|
+| Claude Code | the **harness cron facility** — a persistent scheduler that outlives the session, so `ensure`/`inspect`/`remove` map to its create/list/delete and the poke fires even after a dead heartbeat chain. |
+| Codex | **ABSENT.** There is no persistent scheduler. The loop-entry `watchdog check` still delivers the **full health cadence** whenever a heartbeat or bounded wait runs; what is missing is only automatic resurrection — if the driving process itself dies, recovery is a **manual resume** (`--run <id>`), stated plainly to the user. |
+
+**Unavailability is a NON-blocking, REPORTED degradation.** When `available?` is false (Codex always), or
+`ensure` fails or is denied, the run does **not** stop and does **not** park: it proceeds on the §1
+deadline path alone, and the setup report and every status render state the boundary — long-cadence health
+checks remain, **automatic resurrection does not**, so a dead driver needs a manual resume
+(`loop-control.md`, run start and "Reschedule or exit", own the report).
+
 ## Reviewer selection and diversity
 
 **`reviewer.md`, "Selecting the reviewer", OWNS reviewer selection** — the priority order, the diversity

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
@@ -126,6 +126,72 @@ def t_smuggled_args_cannot_reach_stdout():
                       f"a refused callback must not leak {forbidden!r} to stdout, got {out!r}")
 
 
+# --- the token-free watchdog poke contract ------------------------------------
+
+def t_watchdog_line_shape():
+    got = H.watchdog_command("/gauntlet:campaign", "g260704-0915-a3f29c1b")
+    check(got == "/gauntlet:campaign --run g260704-0915-a3f29c1b --watchdog",
+          f"the poke must be exactly `<invocation> --run <id> --watchdog`, got {got!r}")
+
+
+def t_watchdog_carries_run_and_watchdog_and_nothing_forbidden():
+    """The poke's WHOLE contract: it carries `--run` and `--watchdog`, and NONE of `--token`, `--new`, `#PR`,
+    or `--heartbeat-id`. A token-bearing poke beside a live chain could be adopted as a second driver and
+    double-drive the run; the start-time/acquire-time args would mint a fresh run or replay a stale proof."""
+    got = H.watchdog_command("/gauntlet:campaign", "g260704-0915-a3f29c1b")
+    check("--run" in got, "the poke must carry --run — it names the run to check on")
+    check("--watchdog" in got, "the poke must carry --watchdog — the flavor that resolves the lease first")
+    for forbidden in ("--token", "--new", "#", "--heartbeat-id"):
+        check(forbidden not in got,
+              f"the poke must NOT carry {forbidden!r} — a token could double-drive; --new/#PR would mint a "
+              f"fresh run; --heartbeat-id is an acquire-time proof a lease-resolving poke never presents")
+
+
+def t_watchdog_host_neutral():
+    got = H.watchdog_command("$gauntlet:campaign", "g1")
+    check(got.startswith("$gauntlet:campaign "),
+          "the poke must assume NO host form — the Codex `$` invocation must survive verbatim")
+
+
+def t_cli_watchdog_prints_command():
+    r, inv = "g260704-0915-a3f29c1b", "$gauntlet:campaign"
+    code, out, err = capture_cli(H.main, ["watchdog", "--run", r, "--invocation", inv])
+    check(code == 0, f"a well-formed poke invocation must exit 0, got {code}")
+    check(out.strip() == f"{inv} --run {r} --watchdog",
+          f"the CLI must print the exact poke command, got {out.strip()!r}")
+    check(err == "", f"a successful poke must write nothing to stderr, got {err!r}")
+
+
+def _assert_watchdog_refused(argv, what):
+    code, out, err = capture_cli(H.main, ["watchdog", *argv])
+    check(code != 0, f"a {what} must fail closed with a non-zero exit, got {code}")
+    check(out.strip() == "", f"a refused poke ({what}) must print NOTHING on stdout, got {out.strip()!r}")
+    check("REFUSED" in err, f"the refusal ({what}) must say REFUSED on stderr, got {err!r}")
+    return out
+
+
+def t_cli_watchdog_fails_closed_on_blank_and_whitespace():
+    _assert_watchdog_refused(["--run", "", "--invocation", "/x"], "blank --run")
+    _assert_watchdog_refused(["--run", "g1", "--invocation", ""], "blank --invocation")
+    _assert_watchdog_refused(["--run", "g1 --new #9", "--invocation", "/gauntlet:campaign"],
+                             "whitespace-containing --run")
+    _assert_watchdog_refused(["--run", "g1\ttok", "--invocation", "/gauntlet:campaign"], "tab --run")
+    _assert_watchdog_refused(["--run", "g1", "--invocation", "/gauntlet:campaign --new"],
+                             "whitespace-containing --invocation")
+
+
+def t_watchdog_smuggled_token_cannot_reach_stdout():
+    # The point of the token-free design: a `--token`/`--new`/`#PR`/`--heartbeat-id` hidden behind whitespace
+    # in --run must NEVER survive to stdout, where a scheduler would re-split it into a double-driving argv.
+    for smuggle in ("g1 --token deadbeef", "g1 --new #99", "g1 #12", "g1 --heartbeat-id deadbeef"):
+        out = _assert_watchdog_refused(["--run", smuggle, "--invocation", "/gauntlet:campaign"],
+                                       f"smuggled {smuggle!r}")
+        for forbidden in ("--token", "--new", "#", "--heartbeat-id"):
+            if forbidden in smuggle:
+                check(forbidden not in out,
+                      f"a refused poke must not leak {forbidden!r} to stdout, got {out!r}")
+
+
 CASES = [
     ("callback-two-flags", "the callback is exactly `<invocation> --run <id> --token <tok>`",
      t_callback_is_two_flags),
@@ -149,4 +215,16 @@ CASES = [
      t_cli_refuses_tab_and_newline),
     ("smuggle-blocked", "--new/#PR/--heartbeat-id hidden behind whitespace never reach stdout",
      t_smuggled_args_cannot_reach_stdout),
+    ("watchdog-line-shape", "the poke is exactly `<invocation> --run <id> --watchdog`",
+     t_watchdog_line_shape),
+    ("watchdog-run-and-watchdog-only", "the poke carries --run/--watchdog and none of --token/--new/#PR/--heartbeat-id",
+     t_watchdog_carries_run_and_watchdog_and_nothing_forbidden),
+    ("watchdog-host-neutral", "the poke's invocation is passed in — no `/` host form is hardcoded",
+     t_watchdog_host_neutral),
+    ("watchdog-cli-prints", "the watchdog subcommand prints the exact poke and nothing else",
+     t_cli_watchdog_prints_command),
+    ("watchdog-fails-closed", "a blank or whitespace value fails closed, prints nothing, says REFUSED",
+     t_cli_watchdog_fails_closed_on_blank_and_whitespace),
+    ("watchdog-smuggle-blocked", "a smuggled --token/--new/#PR/--heartbeat-id never reaches stdout",
+     t_watchdog_smuggled_token_cannot_reach_stdout),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -48,6 +48,20 @@ def callback_command(invocation: str, run_id: str, token: str) -> str:
     return f"{invocation} --run {run_id} --token {token}"
 
 
+def watchdog_command(invocation: str, run_id: str) -> str:
+    """Assemble the watchdog resurrection poke: `<invocation> --run <run-id> --watchdog`, and NOTHING else.
+
+    A poke is fired by a persistent scheduler to check on a run whose heartbeat chain may have died. It is
+    TOKEN-FREE BY DESIGN: unlike the `callback` (a resume by the SAME owner, which carries `--token`), a poke
+    might land BESIDE a still-live heartbeat chain. A token-bearing poke could then be adopted as a second
+    driver and DOUBLE-DRIVE the one run, so the poke carries no token — it resolves the lease first and stands
+    down when the primary is alive. It likewise carries no `--new`/`#PR` (start-time args that would mint a
+    fresh run) and no `--heartbeat-id` (an acquire-time proof). The host form is passed in, so this stays
+    host-neutral, exactly like `callback_command`.
+    """
+    return f"{invocation} --run {run_id} --watchdog"
+
+
 # --- cli ----------------------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
@@ -61,8 +75,30 @@ def build_parser() -> argparse.ArgumentParser:
                     help="the host campaign invocation (Claude Code `/gauntlet:campaign`, "
                          "Codex `$gauntlet:campaign`) — passed in so this tool hardcodes no host form")
 
+    wd = sub.add_parser("watchdog", help="print the TOKEN-FREE watchdog resurrection poke command")
+    wd.add_argument("--run", required=True, help="the run id the poke checks on (never mints a new run)")
+    wd.add_argument("--invocation", required=True,
+                    help="the host campaign invocation — passed in so this tool hardcodes no host form")
+
     sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
     return parser
+
+
+def _reject_unusable(fields: "list[tuple[str, str]]") -> bool:
+    """Fail closed on any required value that is empty OR contains ANY whitespace. Shared by `callback` and
+    `watchdog`: whitespace is the argument-injection seam — a `--run "g1 --new #99"` would smuggle extra
+    tokens past the fixed-shape guarantee once the printed line is re-split into argv. No legitimate value (a
+    `g<date>-<rand>` run-id, a hex token, a `/gauntlet:campaign` invocation) carries whitespace. On a bad
+    value: print the refusal on stderr, print NOTHING on stdout, return True so the caller returns non-zero.
+    """
+    for flag, val in fields:
+        if not val or any(ch.isspace() for ch in val):
+            print(f"heartbeat: REFUSED — {flag} must not be empty or contain whitespace. A value that is "
+                  f"blank or carries any whitespace character (space, tab, newline) cannot go into the "
+                  f"scheduled command: whitespace would smuggle extra argv tokens past the fixed-shape "
+                  f"guarantee. Nothing was printed.", file=sys.stderr)
+            return True
+    return False
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -73,24 +109,22 @@ def main(argv: "list[str] | None" = None) -> int:
         return self_test()
 
     if args.cmd == "callback":
-        # Fail closed: a required value that is empty OR contains ANY whitespace must never be assembled
-        # into the callback. Whitespace is the argument-injection seam — a `--run "g1 --new #99"` would
-        # smuggle extra tokens (`--new`, `#PR`, `--heartbeat-id`) past the two-flag guarantee once the
-        # printed line is re-split into argv. No legitimate value (a `g<date>-<rand>` run-id, a hex token,
-        # a `/gauntlet:campaign` invocation) contains whitespace. Refuse loudly on stderr, print NOTHING on
-        # stdout, and return non-zero so a caller cannot schedule a broken or injected command.
-        for flag, val in (("--run", args.run), ("--token", args.token), ("--invocation", args.invocation)):
-            if not val or any(ch.isspace() for ch in val):
-                print(f"heartbeat: REFUSED — {flag} must not be empty or contain whitespace. A value that "
-                      f"is blank or carries any whitespace character (space, tab, newline) cannot go into "
-                      f"the scheduled-heartbeat callback: whitespace would smuggle extra argv tokens past "
-                      f"the two-flag guarantee. Nothing was printed.",
-                      file=sys.stderr)
-                return 1
+        if _reject_unusable([("--run", args.run), ("--token", args.token),
+                             ("--invocation", args.invocation)]):
+            return 1
         print(callback_command(args.invocation, args.run, args.token))
         return 0
 
-    parser.error("a subcommand is required (callback | self-test)")
+    if args.cmd == "watchdog":
+        # The poke is TOKEN-FREE by design, so it validates only `--run` and `--invocation` — the same
+        # empty/whitespace fail-closed the callback applies, so a smuggled `--token`/`--new`/`#PR` hidden
+        # behind whitespace can never survive to stdout and be re-split into a double-driving argv.
+        if _reject_unusable([("--run", args.run), ("--invocation", args.invocation)]):
+            return 1
+        print(watchdog_command(args.invocation, args.run))
+        return 0
+
+    parser.error("a subcommand is required (callback | watchdog | self-test)")
 
 
 # --- self-test ----------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -41,6 +41,7 @@ import json
 import os
 import sys
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import ModuleType
 
@@ -2047,6 +2048,132 @@ def t_last_activity_absent_is_tolerated(L: ModuleType, tmp: Path) -> None:
           f"a mutating op on a pre-field ledger did not stamp last_activity: {last_activity(L, path)!r}")
 
 
+# --- watchdog: the durable long-cadence health-pass deadline ------------------
+#
+# A single frozen instant so `arm` stamps a DETERMINISTIC deadline and `check` classifies it against a known
+# `now`. `now_watchdog()` is the module clock `arm`/`check` both look up by name, so replacing it is the same
+# test-injectable-clock move `frozen_clock` makes on `now_activity`.
+WD_NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@contextlib.contextmanager
+def frozen_watchdog(L: ModuleType, value: datetime):
+    """Freeze the accessor's watchdog clock to `value` for the block, then restore it."""
+    prev = L.now_watchdog
+    setattr(L, "now_watchdog", lambda: value)
+    try:
+        yield
+    finally:
+        setattr(L, "now_watchdog", prev)
+
+
+def header_field(L: ModuleType, path: Path, field: str) -> str:
+    """Read one header field through the REAL CLI — the value a heartbeat would see."""
+    code, out, err = cli(L, ["--file", str(path), "header", "get", field])
+    check(code == 0, f"header get {field} exited {code}: {err!r}")
+    return out.rstrip("\n")
+
+
+def t_watchdog_arm_stamps_a_future_deadline(L: ModuleType, tmp: Path) -> None:
+    """`watchdog arm` stamps `watchdog_due = now + WATCHDOG_INTERVAL` — a FUTURE aware ISO stamp — and does
+    so through the real CLI. The teeth: the stamped value is EXACTLY the frozen now plus the module interval,
+    so a drifted interval or a wrong sign is caught, not waved through."""
+    path = write_lines(tmp / "wd.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1", status="in_review"))
+    check(header_field(L, path, "watchdog_due") == "-", "a fresh ledger must start with watchdog_due `-`")
+    with frozen_watchdog(L, WD_NOW):
+        code, _, err = cli(L, ["--file", str(path), "watchdog", "arm"])
+        check(code == 0, f"watchdog arm exited {code}: {err!r}")
+    expected = (WD_NOW + L.WATCHDOG_INTERVAL).isoformat()
+    check(header_field(L, path, "watchdog_due") == expected,
+          f"arm did not stamp now+WATCHDOG_INTERVAL: {header_field(L, path, 'watchdog_due')!r} != {expected!r}")
+
+
+def t_watchdog_check_states(L: ModuleType, tmp: Path) -> None:
+    """`watchdog check` prints EXACTLY one of unset/ok <rem>/due <age>/invalid — re-arm, always exit 0, and a
+    malformed OR naive stored stamp is the `invalid` state, never a crash. Every branch, one fixture."""
+    def check_line(due: "str | None") -> str:
+        over = {} if due is None else {"watchdog_due": due}
+        path = write_lines(tmp / "chk.jsonl", header_line(L, run_id="r1", **over))
+        with frozen_watchdog(L, WD_NOW):
+            code, out, err = cli(L, ["--file", str(path), "watchdog", "check"])
+        check(code == 0, f"watchdog check must ALWAYS exit 0 (due={due!r}); got {code}: {err!r}")
+        return out.rstrip("\n")
+
+    check(check_line("-") == "unset", "a `-` deadline reads `unset`")
+    check(check_line(None) == "unset", "an absent watchdog_due (old ledger) reads `unset`")
+    future = (WD_NOW + timedelta(minutes=30)).isoformat()
+    check(check_line(future) == "ok 30m", f"a future deadline reads `ok <remaining>`: {check_line(future)!r}")
+    past = (WD_NOW - timedelta(minutes=7)).isoformat()
+    check(check_line(past) == "due 7m", f"a past deadline reads `due <age>`: {check_line(past)!r}")
+    check(check_line("2020-01-01T00:00:00") == "invalid — re-arm",
+          "a NAIVE stamp (no tzinfo) is the invalid state — it cannot be compared to an aware now")
+    check(check_line("not-a-date") == "invalid — re-arm",
+          "a MALFORMED stamp is the invalid state — advisory repair-by-re-arm, never a crash")
+
+
+def t_watchdog_arm_is_not_activity(L: ModuleType, tmp: Path) -> None:
+    """`watchdog arm` must NOT stamp `last_activity` — `watchdog_due` is in ACTIVITY_EXEMPT, so re-arming the
+    watchdog cannot masquerade as the run doing meaningful work and reset the quiet sensor it backs.
+
+    The teeth: give last_activity a known value, then arm under a DIFFERENT frozen watchdog instant; the
+    sensor must still read the first value. Also asserts watchdog_due IS in ACTIVITY_EXEMPT (name the set)."""
+    check("watchdog_due" in L.ACTIVITY_EXEMPT,
+          "watchdog_due must be in ACTIVITY_EXEMPT — a re-arm that stamped last_activity would defeat the "
+          "quiet sensor the watchdog exists to back")
+    path = write_lines(tmp / "arm-act.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1", status="pending"))
+    with frozen_clock(L, FROZEN_A):  # a real change first, to give last_activity a known value
+        code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "in_review"])
+        check(code == 0, f"baseline set exited {code}: {err!r}")
+    check(header_field(L, path, "last_activity") == FROZEN_A, "the baseline change did not stamp last_activity")
+    with frozen_watchdog(L, WD_NOW):
+        code, _, err = cli(L, ["--file", str(path), "watchdog", "arm"])
+        check(code == 0, f"watchdog arm exited {code}: {err!r}")
+    check(header_field(L, path, "last_activity") == FROZEN_A,
+          f"watchdog arm stamped last_activity to {header_field(L, path, 'last_activity')!r} — a re-arm is "
+          f"not meaningful activity and must leave the quiet sensor alone")
+
+
+def t_watchdog_due_has_no_door(L: ModuleType, tmp: Path) -> None:
+    """`header set watchdog_due` is REFUSED — a tool-stamped deadline has no hand-write door, exactly as
+    `last_activity` has none — and it writes NOTHING. `header get watchdog_due` still READS it."""
+    path = write_lines(tmp / "nodoor.jsonl", header_line(L, run_id="r1"))
+    code, out, err = cli(L, ["--file", str(path), "header", "set", "watchdog_due", "2020-01-01T00:00:00+00:00"])
+    check(code == 1, f"header set watchdog_due must be REFUSED (exit 1); got {code}: {out!r}")
+    check("watchdog_due" in err, f"the refusal must name the field: {err!r}")
+    check(header_field(L, path, "watchdog_due") == "-",
+          f"a REFUSED header set still wrote watchdog_due: {header_field(L, path, 'watchdog_due')!r} — the "
+          f"forged deadline reached disk")
+
+
+def t_watchdog_interval_prints_the_constant(L: ModuleType, tmp: Path) -> None:
+    """`watchdog interval` prints WATCHDOG_INTERVAL in whole minutes, reads NO ledger (needs no --file), and
+    the printed number is DERIVED from the constant — never a hard-coded literal that could drift from it."""
+    code, out, err = cli(L, ["watchdog", "interval"])
+    check(code == 0, f"watchdog interval must exit 0 with no --file; got {code}: {err!r}")
+    expected = int(L.WATCHDOG_INTERVAL.total_seconds() // 60)
+    check(out.rstrip("\n") == str(expected),
+          f"watchdog interval printed {out.rstrip(chr(10))!r}, not the constant's {expected} minutes")
+
+
+def t_pending_adoption_is_an_ordinary_field(L: ModuleType, tmp: Path) -> None:
+    """`pending_adoption` is a NORMAL settable config field: `header set` writes it, it round-trips, clears
+    back to `-`, and — unlike watchdog_due — setting it IS meaningful activity (it stamps last_activity)."""
+    path = write_lines(tmp / "pend.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1", status="pending"))
+    check(header_field(L, path, "pending_adoption") == "-", "pending_adoption must default to `-`")
+    with frozen_clock(L, FROZEN_A):
+        code, _, err = cli(L, ["--file", str(path), "header", "set", "pending_adoption", "89 90"])
+        check(code == 0, f"header set pending_adoption exited {code}: {err!r}")
+    check(header_field(L, path, "pending_adoption") == "89 90",
+          f"pending_adoption did not round-trip: {header_field(L, path, 'pending_adoption')!r}")
+    check(header_field(L, path, "last_activity") == FROZEN_A,
+          "setting pending_adoption IS meaningful activity — it must stamp last_activity (no exemption)")
+    with frozen_clock(L, FROZEN_B):  # clearing it back to `-` is a real value change → still activity
+        code, _, err = cli(L, ["--file", str(path), "header", "set", "pending_adoption", "-"])
+        check(code == 0, f"clearing pending_adoption exited {code}: {err!r}")
+    check(header_field(L, path, "pending_adoption") == "-", "pending_adoption must clear back to `-`")
+    check(header_field(L, path, "last_activity") == FROZEN_B, "clearing pending_adoption is also activity")
+
+
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
     ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
@@ -2107,6 +2234,12 @@ CASES = [
     ("liveness-not-activity", "a liveness-counter-only write does NOT stamp — polling that saw no change is not activity", t_liveness_only_write_is_not_activity),
     ("last-activity-sensor", "last_activity has NO door — `header set last_activity` is refused and writes nothing", t_last_activity_is_a_sensor_no_door),
     ("last-activity-absent-ok", "an old ledger without last_activity reads `-` and mutating it stamps fresh", t_last_activity_absent_is_tolerated),
+    ("watchdog-arm-future", "watchdog arm stamps watchdog_due = now + WATCHDOG_INTERVAL (a future stamp)", t_watchdog_arm_stamps_a_future_deadline),
+    ("watchdog-check-states", "watchdog check prints unset/ok/due/invalid, always exit 0, naive+malformed → invalid", t_watchdog_check_states),
+    ("watchdog-arm-not-activity", "watchdog arm does NOT stamp last_activity — watchdog_due is ACTIVITY_EXEMPT", t_watchdog_arm_is_not_activity),
+    ("watchdog-due-no-door", "`header set watchdog_due` is refused and writes nothing", t_watchdog_due_has_no_door),
+    ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
+    ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -18,7 +18,7 @@ import os
 import re
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import NoReturn
 
@@ -38,7 +38,7 @@ TEST_PY = HERE / "ledger-test.py"     # the fixture suite — this accessor's ex
 # --- schema (owned here, once) ------------------------------------------------
 
 HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_set", "skill_version",
-                 "last_activity")
+                 "last_activity", "watchdog_due", "pending_adoption")
 HEADER_DEFAULTS = {
     "run_id": "-",
     "base_branch": "-",
@@ -81,6 +81,25 @@ HEADER_DEFAULTS = {
     # every reader MUST tolerate that absence: `-` means "nothing has been stamped yet", which is a fact, not
     # a date, and the quiet-run rule simply does not fire on it.
     "last_activity": "-",
+    # THE DURABLE HEALTH-PASS DEADLINE — a UTC ISO-8601 stamp (second precision) naming the instant by which
+    # the run owes its next deep "health pass". `ledger.py watchdog arm` stamps it to `now + WATCHDOG_INTERVAL`;
+    # `watchdog check` reads it back; both hosts honor it at loop entry so a run that has gone quiet (a dead
+    # heartbeat chain, or heartbeats firing but never doing the deep look) still gets a periodic forced sweep.
+    # A TOOL-STAMPED field, exactly like `last_activity`: there is NO `header set watchdog_due` door (a
+    # hand-written deadline would be a forged one), and its writes are activity-EXEMPT (re-arming the watchdog
+    # is not "the run did something meaningful"; letting it stamp would defeat the very quiet sensor it backs).
+    #
+    # The default is `-`, the schema's own "not set" spelling. An old ledger written before this field existed
+    # reads back `-`, and every reader tolerates that: `watchdog check` reads `-` as `unset`.
+    "watchdog_due": "-",
+    # THE RUN-INTENT CHECKPOINT — a space-separated list of PR numbers recorded at setup, BEFORE acquire, so a
+    # death mid-setup does not lose the requested PR list (which otherwise lived only in the invocation args).
+    # An ORDINARY, hand-settable config field (`header set pending_adoption "89 90"`), unlike `watchdog_due`:
+    # it has a real door, and writing it IS meaningful activity (no exemption). Adoption clears it back to `-`
+    # as its final step; any later entry that finds it set resumes setup idempotently from those PRs.
+    #
+    # The default is `-`: nothing is pending. This is not a sensor and carries no liveness meaning.
+    "pending_adoption": "-",
 }
 
 ROW_FIELDS = (
@@ -183,7 +202,29 @@ LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", 
 #     moved only these observed NO change in the PR, which is PRECISELY the "nothing moved" `last_activity`
 #     exists to expose; stamping on it would hide a stalled run behind its own polling. A counter added to
 #     `LIVENESS_COUNTERS` is exempt here with no edit, because this reads that set rather than a copy of it.
-ACTIVITY_EXEMPT = frozenset(LIVENESS_COUNTERS + ("last_activity",))
+#   * `watchdog_due` — the health-pass deadline. A write whose ONLY change is re-arming the watchdog is not
+#     "the run did something meaningful": it is the run promising to look again later. Stamping `last_activity`
+#     on it would let a bare `watchdog arm` masquerade as activity and reset the very quiet sensor the watchdog
+#     exists to back — so `watchdog arm` must NOT stamp, and this exemption is how that is guaranteed.
+ACTIVITY_EXEMPT = frozenset(LIVENESS_COUNTERS + ("last_activity", "watchdog_due"))
+
+# THE HEADER FIELDS WITH NO HAND-WRITE DOOR — `header set <field>` is REFUSED for each, mapped to the exact
+# refusal message. Both are TOOL-STAMPED: `last_activity` by `save()`'s side effect on a real change,
+# `watchdog_due` by `watchdog arm`. A value typed in either would be a FORGED reading (a fake liveness stamp,
+# a fake deadline), the one thing these fields must never carry — the same "remove the door" mechanism
+# `review_rounds` uses against a reset. Named as a set so a third such field refuses with one edit here.
+NO_SET_HEADER = {
+    "last_activity":
+        "`last_activity` is a SENSOR, not a settable field — it is stamped automatically on a real "
+        "change and there is no door to hand-write it, the same stance `review_rounds` takes. A value "
+        "typed in here would be a forged liveness reading, which is the one thing this field must never "
+        "carry",
+    "watchdog_due":
+        "`watchdog_due` is a TOOL-STAMPED deadline, not a settable field — it is written only by "
+        "`ledger.py watchdog arm` and there is no door to hand-write it, the same stance `last_activity` "
+        "takes. A value typed in here would be a forged deadline, which is the one thing this field must "
+        "never carry",
+}
 
 # The two fields `verdict` OWNS — and the ONLY reason they are not settable through `set`/`add-row` is
 # that a door which can write them is a door that can RESET them.
@@ -441,6 +482,60 @@ def now_activity() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
+# HOW LONG A `watchdog arm` PUSHES THE DEADLINE OUT. Derived, not guessed: ~3 normal ~15-min heartbeat
+# beats, so the watchdog is a LONG cadence that a healthy short-beat run re-arms well before it fires, and
+# only a run that has actually gone quiet (or whose heartbeat chain died) lets it lapse. "Short checks long,
+# long checks short": the 15-min heartbeat backstops this deadline, and this deadline backstops the heartbeat.
+WATCHDOG_INTERVAL = timedelta(minutes=45)
+
+
+def now_watchdog() -> datetime:
+    """The current UTC time as an AWARE datetime, second precision — the instant `watchdog arm` measures the
+    deadline from and `watchdog check` compares against.
+
+    MODULE-LEVEL for the same reason `now_activity()` is: a fixture freezes it by replacing it (`setattr(L,
+    'now_watchdog', ...)`). It returns a datetime rather than a string because both arm (now + interval) and
+    check (now vs the stored deadline) do arithmetic on it; second precision matches the on-disk ISO shape.
+    """
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def watchdog_state(value: str, now: datetime) -> "tuple[str, timedelta | None]":
+    """Classify the stored `watchdog_due` against `now`. Returns (state, delta):
+
+      ("unset",   None)       `-`/empty — the watchdog was never armed.
+      ("ok",      remaining)  a FUTURE aware deadline — time left until the health pass is owed.
+      ("due",     age)        a PAST (or exactly-now) aware deadline — how long the pass is overdue.
+      ("invalid", None)       unparseable OR naive — the advisory repair-by-re-arm state.
+
+    This OWNS the `watchdog_due` parse (nudge.py reuses it), and it NEVER raises: a malformed stamp, or a
+    naive one that cannot be compared to an aware `now`, reads as `invalid` rather than crashing a read-only
+    check — the same treatment nudge gives an unreadable `last_activity`. The advisory fix for `invalid` is a
+    re-arm, so it is a state, not an error.
+    """
+    if not value or value == "-":
+        return ("unset", None)
+    try:
+        ts = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return ("invalid", None)
+    if ts.tzinfo is None:  # a naive stamp cannot be subtracted from an aware `now` — refuse it, do not crash
+        return ("invalid", None)
+    if now >= ts:
+        return ("due", now - ts)
+    return ("ok", ts - now)
+
+
+def watchdog_check_line(value: str, now: datetime) -> str:
+    """The EXACT one line `watchdog check` prints: one of `unset` / `ok <remaining>` / `due <age>` /
+    `invalid — re-arm`. Durations render in whole minutes (`45m`), the same unit the quiet-run sweep uses."""
+    state, delta = watchdog_state(value, now)
+    if delta is None:  # exactly the two duration-less states
+        return "unset" if state == "unset" else "invalid — re-arm"
+    minutes = int(delta.total_seconds() // 60)
+    return f"{state} {minutes}m"
+
+
 def is_activity(updates: dict, current: dict) -> bool:
     """Does this write record MEANINGFUL activity — i.e. does it change a NON-EXEMPT field to a NEW value?
 
@@ -509,17 +604,41 @@ def cmd_header(path: Path, args) -> int:
         return 0
     if args.value is None:
         fail("header set requires a value")
-    # `last_activity` is a SENSOR — no door hand-writes it, exactly as no flag at any door writes
-    # `review_rounds`. It is stamped by `save()` as a side effect of a REAL change, never typed in, so a
-    # driver cannot forge "this run is alive" (nor, by writing an old date, forge "it is stalled").
-    if args.field == "last_activity":
-        fail("`last_activity` is a SENSOR, not a settable field — it is stamped automatically on a real "
-             "change and there is no door to hand-write it, the same stance `review_rounds` takes. A value "
-             "typed in here would be a forged liveness reading, which is the one thing this field must never "
-             "carry")
+    # A tool-stamped field (`last_activity`, `watchdog_due`) has NO hand-write door — no flag at any door
+    # writes `review_rounds` for the same reason. Each is stamped only by its own tool-path (a sensor's
+    # `save()` side effect, or `watchdog arm`), never typed in, so a driver cannot forge "this run is alive"
+    # (nor, by writing an old date, forge "it is stalled" or "the deadline already passed").
+    if args.field in NO_SET_HEADER:
+        fail(NO_SET_HEADER[args.field])
     activity = header.get(args.field) != args.value
     header[args.field] = args.value
     save(path, header, rows, activity=activity)
+    return 0
+
+
+def watchdog_interval_minutes() -> int:
+    """`WATCHDOG_INTERVAL` in whole minutes — the number `watchdog interval` prints. The scheduler adapter
+    consumes THIS (never a copied literal), so a re-tuned constant reaches every consumer with no edit there."""
+    return int(WATCHDOG_INTERVAL.total_seconds() // 60)
+
+
+def cmd_watchdog(path: Path, args) -> int:
+    """`watchdog arm | check | interval` — the durable health-pass deadline. `interval` is handled in main()
+    before the ledger is touched (it reads a constant, not the store); this owns `arm` and `check`.
+
+    `arm` stamps `watchdog_due = now + WATCHDOG_INTERVAL` and saves with `activity=False`: `watchdog_due` is
+    in `ACTIVITY_EXEMPT`, so a re-arm must NEVER stamp `last_activity` (that would let the watchdog defeat the
+    quiet sensor it backs). `check` is READ-ONLY and ALWAYS exits 0 — a malformed or naive stored deadline
+    prints the `invalid — re-arm` state rather than crashing, since a read that gates nothing must never fail.
+    """
+    header, rows = load(path)
+    if args.action == "arm":
+        due = now_watchdog() + WATCHDOG_INTERVAL
+        header["watchdog_due"] = due.isoformat()
+        save(path, header, rows, activity=False)  # exempt: re-arming is not meaningful activity
+        return 0
+    # check
+    print(watchdog_check_line(header.get("watchdog_due", HEADER_DEFAULTS["watchdog_due"]), now_watchdog()))
     return 0
 
 
@@ -1072,6 +1191,11 @@ def build_parser() -> argparse.ArgumentParser:
     h.add_argument("field")
     h.add_argument("value", nargs="?")
 
+    w = sub.add_parser("watchdog", help="arm/check/print the durable health-pass deadline (watchdog_due)")
+    w.add_argument("action", choices=("arm", "check", "interval"),
+                   help="'arm' stamps the deadline now+interval; 'check' prints unset/ok/due/invalid "
+                        "(read-only, always exit 0); 'interval' prints the interval in minutes (reads no ledger)")
+
     def add_row_field_opts(p) -> None:
         for name in ROW_FIELDS:
             # pr is the row key (via --pr); id is derived; VERDICT_OWNED has no flag AT ALL, at either
@@ -1148,6 +1272,12 @@ def main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
     if args.cmd == "self-test":  # stdlib only, no ledger, no repo checkout, no network
         return self_test()
+    if args.cmd == "watchdog" and args.action == "interval":
+        # `interval` prints a module constant and reads NO ledger — so, like self-test, it needs no --file.
+        # The scheduler adapter reads this number; forcing it to name a ledger just to learn the cadence would
+        # be a false dependency. `arm`/`check` DO read the store and fall through to the --file guard below.
+        print(watchdog_interval_minutes())
+        return 0
     if args.file is None:
         parser.error("the following arguments are required: --file")
     path = Path(args.file)
@@ -1155,6 +1285,7 @@ def main(argv: list[str]) -> int:
         "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set, "verdict": cmd_verdict,
         "get": cmd_get, "list": cmd_list, "table": cmd_table,
         "dispatch-check": cmd_dispatch_check, "park": cmd_park, "unpark": cmd_unpark,
+        "watchdog": cmd_watchdog,
     }
     return handlers[args.cmd](path, args)
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -236,6 +236,45 @@ def t_quiet_run_names_the_park():
           "a run with an in-flight PR is not idle-on-user — it must not claim every open PR is parked")
 
 
+# --- watchdog-due reminder ----------------------------------------------------
+# Stamps built around NOW so the rule is DETERMINISTIC: a future deadline (ok → silent) and a past one
+# (due → fires), plus the `-`/malformed/naive spellings that read unset/invalid.
+
+def _future(minutes: int) -> str:
+    return (NOW + timedelta(minutes=minutes)).isoformat(timespec="seconds")
+
+
+def _past(minutes: int) -> str:
+    return (NOW - timedelta(minutes=minutes)).isoformat(timespec="seconds")
+
+
+def t_watchdog_due_fires_on_unset_overdue_invalid_with_open_work():
+    """With an OPEN PR, the reminder fires when watchdog_due is unset (`-`), overdue (a past deadline), or
+    invalid (malformed or naive) — and stays SILENT when it is `ok` (a future deadline). The teeth: an
+    always-on reminder would be no sensor, so the `ok` case must be silent."""
+    open_row = [row(1, "in_review")]
+    for label, wd in (("unset (`-`)", "-"),
+                      ("overdue", _past(10)),
+                      ("malformed", "not-a-date"),
+                      ("naive", "2026-07-19T11:00:00")):  # no tzinfo
+        lines = fire(open_row, hdr=header(run_id="g1", watchdog_due=wd), now=NOW)
+        check(has(lines, "watchdog due — run the health pass"),
+              f"a {label} watchdog_due with open work must fire the watchdog-due reminder")
+    ok = fire(open_row, hdr=header(run_id="g1", watchdog_due=_future(30)), now=NOW)
+    check(not has(ok, "watchdog due"),
+          "a future (ok) watchdog deadline must NOT fire the reminder — the run does not owe a health pass yet")
+
+
+def t_watchdog_due_silent_without_open_work():
+    """No non-terminal row → nothing to health-check, so the reminder stays silent even when unset/overdue —
+    both an empty ledger and a terminal-only one."""
+    for rows in ([], [row(1, "merged"), row(2, "aborted")]):
+        for wd in ("-", _past(10), "not-a-date"):
+            lines = fire(rows, hdr=header(run_id="g1", watchdog_due=wd), now=NOW)
+            check(not has(lines, "watchdog due"),
+                  f"a run with no open work must NOT fire the watchdog-due reminder (rows={rows}, wd={wd!r})")
+
+
 def t_a_nudge_never_blocks():
     # main() over a real ledger file exits 0 no matter what it prints.
     with tempfile.TemporaryDirectory() as d:
@@ -263,5 +302,7 @@ CASES = [
     ("quiet-silent-when-absent", "an absent/`-`/unparseable last_activity never fires the sweep", t_quiet_run_silent_when_absent),
     ("quiet-needs-open-pr", "a quiet run with nothing open has nothing to sweep", t_quiet_run_needs_an_open_pr),
     ("quiet-names-the-park", "a parked-only quiet run says it waits on the user and surfaces the question", t_quiet_run_names_the_park),
+    ("watchdog-due-fires", "watchdog-due reminder fires on unset/overdue/invalid with open work, silent when ok", t_watchdog_due_fires_on_unset_overdue_invalid_with_open_work),
+    ("watchdog-due-needs-open-work", "watchdog-due reminder is silent with no open/terminal-only rows", t_watchdog_due_silent_without_open_work),
     ("never-blocks", "a nudge always exits 0", t_a_nudge_never_blocks),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -119,6 +119,18 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
     if n_followups:
         out.append(f"{n_followups} open follow-up(s) — start any you can.")
 
+    # --- watchdog-due reminder -------------------------------------------------
+    # The durable long-cadence health-pass deadline (ledger.py's `watchdog_due`). When it is due, never armed,
+    # or unreadable AND there is open work, the run owes a deep health pass — the long sensor that catches a
+    # run heartbeats keep firing on but never look deeply at. The parse is ledger.py's own `watchdog_state`
+    # (never a second copy of it), and like every nudge rule it is a CHEAP read that never raises: a malformed
+    # or naive deadline reads `invalid`, which fires the same "re-arm it" reminder rather than crashing. Nudge
+    # knows NOTHING about scheduler entries — that is the health pass's adapter business, not a reminder's.
+    if active:
+        wd_state, _ = L.watchdog_state(header.get("watchdog_due", "-"), now)
+        if wd_state in ("due", "unset", "invalid"):
+            out.append("watchdog due — run the health pass, then `ledger.py watchdog arm`.")
+
     # --- quiet-run sweep -------------------------------------------------------
     # A run whose ledger has not moved for QUIET_AFTER is not necessarily healthy — a review may have died,
     # a poll may be stuck, or the user may be sitting on a parked question. Every heartbeat is a fresh


### PR DESCRIPTION
- durable `watchdog_due` deadline (45 min): every loop entry checks it; due/unset triggers the health pass
- persistent-scheduler poke `--run <id> --watchdog` resurrects a dead chain on Claude Code; Codex absence documented
- setup checkpoint `pending_adoption` makes a mid-setup death resumable; design reviewed by codex, 11 findings folded
