### PR TITLE
fix(campaign): self-diagnosing sandbox write failure

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
+++ b/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
@@ -45,6 +45,14 @@ isolation claim and does not create a stronger boundary:
 - `-C`, followed by `transport.review_root` as its own argv element, selects the run-artifact working
   root;
   `--skip-git-repo-check` is required because that root is deliberately not the candidate repository.
+- **`-C` MUST be `transport.review_root` because that is the reviewer's only WRITABLE root.** Every
+  artifact the reviewer writes — progress, findings, amendments, the report — lives under `review_root`,
+  and `--sandbox workspace-write` makes only the `-C` root (and its `writable_roots`) writable. A `-C`
+  pointed anywhere else (for example at the candidate worktree) leaves the run directory READ-ONLY, so
+  every `emit` fails with a read-only-filesystem error and the reviewer defers with a read-only progress
+  file. That symptom is a DISPATCH fault, not a reviewer fault: relaunching the same argv fails
+  identically. Do not widen the sandbox to "fix" it (a `writable_roots` entry for the worktree would make
+  candidate content writable); point `-C` at `review_root`.
 - `transport.worktree` is named only inside the bound prompt and is read through absolute paths (for
   example, the typed Git argv in the review prompt). Do not pass it through `-C` or `--add-dir`: either makes candidate
   content part of the writable workspace, and `-C` also enables candidate `AGENTS.md` discovery.

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -419,7 +419,9 @@ rule is sized for a reviewer working slowly, not one that never woke up. Gate ev
   too would strand a dead attempt `2` that had written a `started` line — neither relaunchable nor
   fallback-eligible — and the PR would hang forever.
 - Before re-dispatching, **re-check the command** for the known launch faults — most of all the quoted
-  prompt-file stdin redirect on every external reviewer (`review-dispatch.md`). A relaunch of the same hanging
+  prompt-file stdin redirect on every external reviewer (`review-dispatch.md`), and the external reviewer's
+  `-C` target, which must be the run-artifact root (a `-C` off that root makes the run directory read-only
+  under `workspace-write`, so every emit fails and the reviewer defers). A relaunch of the same hanging
   command hangs identically.
 - **A failed launch is a dispatch fault, not a review outcome.** It yields no verdict — it never
   counts SATISFIED or NOT SATISFIED, never touches `reviews_ok`, and never escalates the tier. It is
@@ -631,6 +633,11 @@ routing verdicts as any other pass — **`amended`** (fold the amendment and re-
 (the pass stopped early — relaunch), or **`unusable`** (a spurious deferral: nothing was outstanding, so
 it owes a binary verdict). **NEVER fabricate a binary `satisfied`/`not-satisfied` for the reviewer** — if
 it did not rule, you do not rule for it.
+
+**A deferral whose reason names an UNWRITABLE progress/findings file is a DISPATCH fault, not a pass to
+route** — before any relaunch, re-check the launch argv against the canonical spelling
+(`cross-agent-reviewers.md`), above all the `-C` target, which must be the run-artifact root. Relaunching
+the same command makes the same run directory read-only and fails identically.
 
 **`--verdict` is REQUIRED, and a COMPLETE pass verified without it is `unusable` — never `ok`.** A gate
 must not depend on an agent remembering to pass something — so the input is demanded, exactly as the

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -1960,6 +1960,54 @@ def run_status_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> int:
     return failures
 
 
+def check_unwritable_target(R: types.ModuleType, T: Tables, tmp: Path) -> int:
+    """The EROFS/EACCES write-door diagnostic: an emit into an UNWRITABLE target must defer with the -C
+    diagnosis, not die with a bare `OSError` that names no cause.
+
+    **THE REAL DEFECT.** A codex reviewer launched with `-C` at the candidate worktree made the run dir
+    read-only under `workspace-write`; every `emit-progress.py` append failed with `OSError: [Errno 30]
+    Read-only file system`, the reviewer deferred with a bare "progress file is read-only", the
+    orchestrator re-dispatched the SAME wrong command, and a ~20-minute pass was lost each time. The write
+    door now translates that OS failure into a DISPATCH-fault diagnostic naming the `-C` target and the
+    `VERDICT: DEFERRED` recovery.
+
+    We cannot mount a read-only filesystem in a unit test, so we reproduce the same errno family the door
+    treats identically: appending to a `0o444` file raises `EACCES`, the sibling of the real `EROFS`.
+    `chmod` does not restrict root, so under euid 0 (or a platform without `geteuid`) the condition cannot
+    be created and the case skips cleanly — the diagnostic is behavioral, not a gate rule, so a skipped
+    probe is honest rather than a false green.
+    """
+    if not hasattr(os, "geteuid") or os.geteuid() == 0:
+        print("skip     [unwritable] chmod does not restrict root — the EROFS/EACCES write door "
+              "cannot be probed here")
+        return 0
+    d = tmp / "unwritable"
+    d.mkdir(parents=True, exist_ok=True)
+    progress = d / PROGRESS_FILE
+    # A validly dispatched-but-empty pass: pass_identity as the first line, a one-unit plan, and a sound
+    # intent beside it — so emit clears every READ-side check and reaches the write door, which is the one
+    # thing under test here.
+    progress.write_text(T.ident() + "\n", encoding="utf-8")
+    (d / PLAN_FILE).write_text(T.unit("u01") + "\n", encoding="utf-8")
+    write_intent(d)
+    progress.chmod(0o444)
+    try:
+        code, text = run_cli(R, ["emit", "--file", str(progress), "--unit", "u01", "--status", "started"])
+    finally:
+        progress.chmod(0o644)  # restore so the TemporaryDirectory cleanup can remove it
+    if code == 0:
+        print("FAIL     [unwritable] emit into a read-only progress file EXITED 0 — the write door "
+              "swallowed the OSError instead of deferring")
+        return 1
+    if "-C" not in text or "DEFERRED" not in text:
+        print(f"FAIL     [unwritable] emit refused (exit {code}) but its message names neither the `-C` "
+              f"target nor the DEFERRED recovery:\n         {text.strip()}")
+        return 1
+    print(f"ok       [unwritable] emit into a read-only target -> exit {code}, DISPATCH-fault diagnostic "
+          f"names -C and VERDICT: DEFERRED")
+    return 0
+
+
 def run(R: types.ModuleType, tmp: Path) -> int:
     """Every family, then the mutation matrix. Non-zero on any failure.
 
@@ -2010,6 +2058,8 @@ def run(R: types.ModuleType, tmp: Path) -> int:
     failures += check_amendment_door(R, tmp)
     print()
     failures += run_status_cases(R, T, tmp)
+    print()
+    failures += check_unwritable_target(R, T, tmp)
     print()
     if failures:
         print(f"{failures} check(s) FAILED — the review-pass contract is broken.")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -107,6 +107,7 @@ so. Absent that, the guard fires: the DEFAULT is that nothing has been ruled on.
 from __future__ import annotations
 
 import argparse
+import errno
 import importlib.util
 import json
 import os
@@ -1527,10 +1528,43 @@ def write_line(path: Path, before: str, rec: "dict[str, object]",
     line = json.dumps(rec, separators=(",", ":")) + "\n"
     # MUTATE:write-verifies-result:pass
     readable_back(before + line)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as out:
-        out.write(line)
+    _append_line(path, line)
     return line
+
+
+def _append_line(path: Path, line: str) -> None:
+    """The actual disk write — isolated so an UNWRITABLE target says WHY, not a bare traceback.
+
+    Every artifact this tool produces is appended here. The append can fail because the target's
+    filesystem cannot be written from this process — `EROFS` (the filesystem itself is read-only) or
+    `EACCES` (the path is not writable). The bare `OSError` those raise says nothing about the cause the
+    real run hit: a codex reviewer launched with `-C` pointed at the candidate worktree instead of the
+    run-artifact root, so its `workspace-write` sandbox made the RUN directory read-only and EVERY emit
+    failed with `Read-only file system`. This is NOT a rule about the artifact's contents — the bytes are
+    fine; the door they were headed for is shut — so it lives OUTSIDE the read-side rule functions and is
+    not one the round-trip/mutation machinery pins. It only translates the OS failure into a diagnosis a
+    driver can act on, and keeps the existing exit path (a `Defect` -> exit 1, non-zero).
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as out:
+            out.write(line)
+    except OSError as exc:
+        if exc.errno in (errno.EROFS, errno.EACCES):
+            raise Defect(
+                f"{path.name} cannot be written ({exc}) — its filesystem is READ-ONLY, or the path is not "
+                f"writable from this process. When this process is a sandboxed reviewer (codex "
+                f"`workspace-write`), that means the launch's `-C` root does NOT cover the run directory: "
+                f"every artifact a reviewer writes (progress, findings, amendments, report) lives under the "
+                f"run-artifact root, so `-C` MUST be that root — `cross-agent-reviewers.md` (\"Claude Code "
+                f"orchestrator -> Codex reviewer\") owns the exact argv, and a `-C` pointed at the candidate "
+                f"worktree makes the run directory read-only and every emit fail like this. This is a "
+                f"DISPATCH fault, not a reviewer fault, and retrying into the SAME sandbox fails "
+                f"identically. Do NOT create the file yourself and do NOT retry: make the report's terminal "
+                f"line `VERDICT: DEFERRED — {path.name} is on a read-only/unwritable filesystem (check the "
+                f"launch's -C target)` and stop"
+            ) from exc
+        raise
 
 
 def cmd_emit(args) -> int:


### PR DESCRIPTION
- a codex reviewer launched with `-C <worktree>` gets a read-only run dir, losing a full pass
- emit doors now name the sandbox `-C` cause on EROFS/EACCES: defer, do not retry
- docs add the writability rationale at the canonical argv; `writable_roots` widening refuted
