### PR TITLE
chore(gauntlet): bump plugin version to 0.3.3

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- bump gauntlet to 0.3.3 in both host manifests: run watchdog (#113) and sandbox write diagnostic (#114)
