### PR TITLE
fix campaign session watchdog audit

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -50,8 +50,11 @@ These are **distinct modes**, not freely-composable flags; `references/run-ident
 - No argument -> discover this run's labelled PRs and continue. If none and nothing to do, show the
   idle prompt (`references/run-identity-and-lease.md`, "Resolving a heartbeat", owns its wording).
 - Non-PR arg (e.g. `auth`) -> same prompt (the old area/topic sweep arg is REMOVED).
-- `--run <id>` -> resume that run; takes no `#PR`/`--new`. Scheduled heartbeats also carry internal
+- `--run <id>` -> resume that run; takes no `#PR`/`--new`. Scheduled heartbeats carry internal
   `--token`.
+- `--run <id> --token <tok> --watchdog` -> internal, session-scoped soundness-audit wake. It requires
+  `--token`, rejects `#PR`/`--new`, and never adopts a run or recovers a dead session
+  (`references/run-identity-and-lease.md`, "Resolving a heartbeat").
 - `--new #PR...` -> force an independent new run-id for a new PR set (with carryover); requires PRs.
 
 Invalid combinations (e.g. `--new` with no PRs, or `--run` with `#PR`) are rejected / fall through to
@@ -73,8 +76,10 @@ it — no trigger means the step runs unconditionally at that point in the seque
 3. `lease.py acquire` (`refresh` on resume): take or keep the run lease; stand down if a fresh lease
    names a different owner. One active driver per run — never double-drive. **Take a run in order**
    (`references/run-identity-and-lease.md`, "Take a run"): BEFORE arming, record the run intent
-   (`ledger.py header set pending_adoption "<pr>…"`, cleared when adoption finishes), so a mid-setup
-   death is resumable — the checkpoint survives it.
+   (`ledger.py header set pending_adoption "<pr>…"`, cleared when adoption finishes) and — where the
+   host supports it — ensure the session watchdog nudge
+   (`references/runtime-adapter.md`, "Session watchdog nudge"). It audits a live session's campaign
+   soundness; it does not recover a dead session.
 4. Run start -> `ledger.py --file <state.jsonl> header set skill_version <version>`: record the
    `version` read from the **running plugin's** `plugin.json`. The harness loads this skill from the
    **installed plugin cache**, so a merged, version-bumped rule governs nothing until that cache
@@ -101,8 +106,10 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
    step 1). Then reconcile the run's PR snapshot (treat `state.jsonl` as cache) and fold completed
    review / CI / fix tasks against the SHA each ran on. When the run is **QUIET** (nudge, no meaningful
    ledger activity for its window) **OR** `ledger.py watchdog check` says the long-cadence deadline is
-   `due`/`unset`/`invalid`, run the **health pass** (one pass, then one `ledger.py watchdog arm`) before
-   rescheduling and lead the status with the diagnosis (`references/loop-control.md`, "Reschedule or exit").
+   `due`/`unset`/`invalid`, run the **health pass** (one pass, then one `ledger.py watchdog arm`)
+   before rescheduling and lead the status with the diagnosis. A `--watchdog` wake audits that the primary
+   heartbeat is armed; it runs the health pass only when one of those normal triggers applies
+   (`references/loop-control.md`, "Reschedule or exit").
 9. `ci-status.py required-set --ledger <rundir>/state.jsonl`: refresh the required set before any CI
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -52,9 +52,6 @@ These are **distinct modes**, not freely-composable flags; `references/run-ident
 - Non-PR arg (e.g. `auth`) -> same prompt (the old area/topic sweep arg is REMOVED).
 - `--run <id>` -> resume that run; takes no `#PR`/`--new`. Scheduled heartbeats also carry internal
   `--token`.
-- `--run <id> --watchdog` -> internal TOKEN-FREE resurrection poke fired by the persistent watchdog
-  entry; resolves the lease first and stands down if the primary is alive, else adopts the orphaned run
-  (`references/run-identity-and-lease.md`, "Resolving a heartbeat"). Rejected with `--token`/`--new`/`#PR`.
 - `--new #PR...` -> force an independent new run-id for a new PR set (with carryover); requires PRs.
 
 Invalid combinations (e.g. `--new` with no PRs, or `--run` with `#PR`) are rejected / fall through to
@@ -76,9 +73,8 @@ it — no trigger means the step runs unconditionally at that point in the seque
 3. `lease.py acquire` (`refresh` on resume): take or keep the run lease; stand down if a fresh lease
    names a different owner. One active driver per run — never double-drive. **Take a run in order**
    (`references/run-identity-and-lease.md`, "Take a run"): BEFORE arming, record the run intent
-   (`ledger.py header set pending_adoption "<pr>…"`, cleared when adoption finishes) and — on a
-   persistent-scheduler host — **ensure the watchdog entry** (`references/runtime-adapter.md`, "Persistent
-   watchdog capability"), so a mid-setup or later death is resumable/resurrectable.
+   (`ledger.py header set pending_adoption "<pr>…"`, cleared when adoption finishes), so a mid-setup
+   death is resumable — the checkpoint survives it.
 4. Run start -> `ledger.py --file <state.jsonl> header set skill_version <version>`: record the
    `version` read from the **running plugin's** `plugin.json`. The harness loads this skill from the
    **installed plugin cache**, so a merged, version-bumped rule governs nothing until that cache

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -91,11 +91,11 @@
   tracks the run's load and would park a healthy slow build; and it does not park one, because **any**
   motion anywhere in the check set moves the fingerprint and resets the clock.
 - A run that heartbeats while **nothing moves** is not healthy, nor is one whose heartbeats keep firing
-  but never look deeply: when the run is **QUIET** (`nudge.py`, off the durable `last_activity` stamp) **OR**
-  `ledger.py watchdog check` says the long-cadence deadline is `due`/`unset`/`invalid`, the heartbeat
-  **runs the health pass before rescheduling** (one pass, then one `watchdog arm`) and **leads the status
-  with the diagnosis** — parked questions with their waiting age, stalled-review findings — ahead of the
-  ledger table (`loop-control.md`, "Reschedule or exit", owns it).
+  but never look deeply: when the run is **QUIET** (`nudge.py`, off the durable `last_activity` stamp)
+  **OR** `ledger.py watchdog check` says the long-cadence deadline is `due`/`unset`/`invalid`, the
+  heartbeat **runs the health pass before rescheduling** (one pass, then one `watchdog arm`) and **leads
+  the status with the diagnosis** — parked questions with their waiting age, stalled-review findings —
+  ahead of the ledger table (`loop-control.md`, "Reschedule or exit", owns it).
 - Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -205,7 +205,7 @@ lived only in the invocation args — `run-identity-and-lease.md`, "Take a run",
 `watchdog_due` it is an **ORDINARY, hand-settable config field** (`header set pending_adoption "89 90"`):
 it has a real door, and **writing it IS meaningful activity** (no exemption — it is **not** a sensor and
 carries no liveness meaning). Adoption clears it back to `-` as its final step, and any later entry — the
-armed wake, a watchdog poke, a manual resume — that finds it set resumes setup idempotently from exactly
+armed wake or a manual resume — that finds it set resumes setup idempotently from exactly
 those PRs (`loop-control.md` step 1). It **defaults to `-`**: nothing is pending.
 
 Header field notes (the header fields above; per-row fields follow):

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -205,8 +205,9 @@ lived only in the invocation args — `run-identity-and-lease.md`, "Take a run",
 `watchdog_due` it is an **ORDINARY, hand-settable config field** (`header set pending_adoption "89 90"`):
 it has a real door, and **writing it IS meaningful activity** (no exemption — it is **not** a sensor and
 carries no liveness meaning). Adoption clears it back to `-` as its final step, and any later entry — the
-armed wake or a manual resume — that finds it set resumes setup idempotently from exactly
-those PRs (`loop-control.md` step 1). It **defaults to `-`**: nothing is pending.
+armed wake, a watchdog nudge after it refreshes this owner, or a manual resume — that finds it set resumes
+setup idempotently from exactly those PRs (`loop-control.md` step 1). It **defaults to `-`**: nothing is
+pending.
 
 Header field notes (the header fields above; per-row fields follow):
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -456,9 +456,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      `--run` and `--token` and never `--new`/`#PR` or `--heartbeat-id`. A scheduler-less bounded
      wait retains the current invocation and token instead of constructing a scheduled heartbeat. Both are a
      **fallback lifecycle, not a tight poll**: background completions are the primary heartbeat. A scheduled
-     heartbeat also recovers a killed/orphaned session through a later scheduled heartbeat; if a scheduler-less
-     invocation is killed, durable state permits a later explicit resume (see "Resume after a killed
-     session"). **Size the scheduled delay or bounded wait to the nearest stall it guards:**
+     heartbeat resumes another turn only while its session remains live; a dead session needs the explicit
+     resume path (see "Resume after a killed session"). **Size the scheduled delay or bounded wait to the
+     nearest stall it guards:**
      - **Run setup still owed — the lease not yet acquired, or adoption / first dispatches not yet
        run (a fresh run's arm-ended setup turn, `run-identity-and-lease.md` "Take a run") → ~60 s:**
        on a turn-ending scheduler the wakeup IS the continuation of setup, so any longer delay is
@@ -475,12 +475,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
        heartbeat).
 
-     **And whatever tier you picked, NEVER schedule past the watchdog deadline** — cap the delay at the
-     time `ledger.py watchdog check` says remains. This is what makes the watchdog a self-enqueueing job
-     on the one wakeup the host provides: the deadline is structurally guaranteed a wake, the health pass
-     runs on it, and its `watchdog arm` enqueues the next one. (The current tiers all sit inside the
-     45-min interval, so the cap binds only if a tier ever grows past it — it is the invariant, not a
-     live constraint.)
+     **And whatever tier you picked, NEVER schedule the primary heartbeat past the watchdog deadline** —
+     cap the delay at the time `ledger.py watchdog check` says remains. A host with the session-watchdog
+     capability also delivers its separate audit nudge at that deadline; this cap is the matching fallback
+     on a bounded-wait host and the guard against a later primary tier longer than 45 minutes. (The current
+     tiers all sit inside the interval, so the cap binds only if a tier grows.)
 
      **The health pass — when the run owes a deep look, LOOK before you reschedule.** A run can
      heartbeat forever while nothing moves: every PR parked on a forgotten question, a review silently
@@ -494,9 +493,14 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      ```
 
      The first is #112's quiet sensor (the durable `last_activity` stamp); the second is the durable
-     long-cadence deadline (`ledger.py watchdog`, `files-and-ledger.md`) — the sensor that catches a run
-     whose heartbeats keep FIRING but never look deeply. **When `need_health` — and open PRs remain — this heartbeat runs
-     exactly ONE health pass and then exactly ONE `ledger.py --file <state.jsonl> watchdog arm`, and
+     long-cadence deadline (`ledger.py watchdog`, `files-and-ledger.md`). The separate session watchdog
+     nudge (`runtime-adapter.md`, "Session watchdog nudge") audits both wakes during run resolution. It
+     does NOT add a deep-health trigger: a watchdog and primary heartbeat can arrive together, and the first
+     health pass re-arms the deadline for the second. Re-arm a missing primary only as this turn's final
+     normal scheduling action; re-ensure a missing watchdog nudge before that action. A bounded-wait host
+     reports that it has no separate nudge.
+     **When `need_health` — and open PRs remain — this heartbeat runs exactly ONE health pass and then exactly ONE
+     `ledger.py --file <state.jsonl> watchdog arm`, and
      completes BOTH before the status render and the turn's final scheduling action** (the last-action rule
      below). **Never two passes for two triggers**: quiet and watchdog-due firing together is still one
      pass, one arm. The pass **relies on this heartbeat's successful `refresh` verdict** (step 1) and adds
@@ -519,13 +523,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      question rather than presenting the idleness as a fault to chase. Then confirm the next heartbeat is
      armed, exactly as always.
 
-     **The honest boundary: an in-session sensor is only read by a heartbeat that FIRES.** If the heartbeat
-     chain itself dies — no scheduled wake, no bounded wait returns — nothing in-session reads either
-     sensor. Recovery is a **MANUAL RESUME on every host** (there is no persistent scheduler on either):
-     a dead chain surfaces as a **stale lease on the next manual invocation** (`--run <id>`), where
-     adoption picks the orphaned run up and tells the user the run had been **orphaned** — its chain had
-     stopped — not merely resumed (`run-identity-and-lease.md`, "Adopt only an orphaned run"). The silent
-     stall is surfaced, never absorbed.
+     **The honest boundary: the session watchdog checks a live session, not a dead one.** If the primary
+     heartbeat is missing while the session remains live, the watchdog nudge fires, audits it, and the final
+     scheduling action restores it. If the session itself dies, both in-session wakes disappear. Recovery is
+     a **MANUAL RESUME on every host**: the next `--run <id>` finds a stale lease and adoption reports the
+     run as **orphaned**, not merely resumed (`run-identity-and-lease.md`, "Adopt only an orphaned run").
 
      ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
      both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
@@ -539,7 +541,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      presented as the whole ledger. Never re-type, trim, or re-align it. Then one line per remaining
      wait naming what it waits on (review in flight, CI watch, parked on the user's answer). Render it
      after every ledger write during this heartbeat — the ledger was reconciled this heartbeat, so the table is the
-     state the next reconcile resumes from. Then take exactly one runtime branch:
+     state the next reconcile resumes from. State whether the session watchdog is armed or unavailable; never
+     imply dead-session recovery. Then take exactly one runtime branch:
      - **Scheduled-heartbeat host:** with the status above already rendered, schedule the heartbeat as
        the turn's LAST action — scheduling ends the turn on this host (`runtime-adapter.md`,
        "Scheduled-heartbeat host"), so nothing runs after it. The scheduled invocation begins again at
@@ -554,10 +557,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      non-terminal row or an existing file, so it distills exactly once; per-run files never
      contend, see "Fresh runs and carryover"), **release the run** (delete this run's
      `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, release
-     the lease — `lease.py … release --token <tok>`; the shared
-     status labels stay), emit the final report, and **do not
+     the lease — `lease.py … release --token <tok>`; then remove the session watchdog nudge
+     (`runtime-adapter.md`, "Session watchdog nudge"); the shared status labels stay), emit the final
+     report, and **do not
      reschedule**. This run's loop ends. **"Rows all terminal" alone is NOT "finished"** — finalization
-     (carryover distilled, label deleted, lease released) may still be **owed**, so
+     (carryover distilled, label deleted, lease released, watchdog removed) may still be **owed**, so
      do these in order. **Leave
      `<rundir>` in place** (do NOT delete it here) — its terminal `state.jsonl` is what lets a later bare
      invocation detect *this* *finished* run and take the "ask the user" branch in step 1 instead of a

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -594,10 +594,10 @@ and the PR would stall forever, which is the very failure this feature exists to
 evidence answers "is this **live** process working?" and is meaningful **only** for the in-flight
 ~5-min launch check; once the task is gone, the only question is how much relaunch budget remains. It
 binds to the run via
-`--run <id>` (what every scheduled heartbeat carries, so a fresh instance adopting an orphaned run's heartbeat
-just works) or, for a bare re-invocation, by discovering live runs and adopting the sole **orphaned**
-one (asking among several). Adoption is gated on the **run lease**: an agent takes over only a run
-whose lease is absent or stale, so it can always tell whether another agent is still driving that
+`--run <id>` (which a scheduled heartbeat carries only while its session remains live; after a dead
+session, use a manual `--run <id>` resume) or, for a bare re-invocation, by discovering live runs and
+adopting the sole **orphaned** one (asking among several). Adoption is gated on the **run lease**: an agent takes
+over only a run whose lease is absent or stale, so it can always tell whether another agent is still driving that
 ledger and never double-drives an actively-held run (see "Run identity and concurrency" and Loop
 control step 1). This is how a later agent picks up exactly where a previous instance left off.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -139,14 +139,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      empty orphan run behind. **Only once the full set passes preflight**: call `create_run_directory`
      **first** — it mints the run-id and atomically creates `<rundir>` — and derive `run_id` from the
      returned directory's final path component; **then** take the run per `run-identity-and-lease.md`,
-     "Take a run" (which, BEFORE arming, records `pending_adoption` = this set's PR list and — on a
-     persistent-scheduler host — **ensures the watchdog entry**; then token, heartbeat arming,
-     `lease.py acquire` — in that order),
+     "Take a run" (which, BEFORE arming, records `pending_adoption` = this set's PR list; then token,
+     heartbeat arming, `lease.py acquire` — in that order),
      and write the `state.jsonl` header — now with `run_id` set and `base_branch` filled
-     from the agreed `baseRefName` (known from preflight). **Probe watchdog `available?` at run start and
-     REPORT the degradation when it is absent** (Codex, or `ensure` denied): long-cadence health checks
-     remain, automatic resurrection does not — a dead driver needs a manual resume
-     (`runtime-adapter.md`, "Persistent watchdog capability"). Then **adopt** each PR
+     from the agreed `baseRefName` (known from preflight). Then **adopt** each PR
      (ledger row + labels + worktree, and a CI watch **only when one is due** — `pr-adoption.md` owns what
      adoption produces and when the watch is warranted); a death mid-adoption still leaves
      a discoverable, adoptable run. **When the whole requested set is adopted, clear the checkpoint —
@@ -479,6 +475,13 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        shorter interval only re-reconciles git/gh with no new signal (and pays a fresh-context cost per
        heartbeat).
 
+     **And whatever tier you picked, NEVER schedule past the watchdog deadline** — cap the delay at the
+     time `ledger.py watchdog check` says remains. This is what makes the watchdog a self-enqueueing job
+     on the one wakeup the host provides: the deadline is structurally guaranteed a wake, the health pass
+     runs on it, and its `watchdog arm` enqueues the next one. (The current tiers all sit inside the
+     45-min interval, so the cap binds only if a tier ever grows past it — it is the invariant, not a
+     live constraint.)
+
      **The health pass — when the run owes a deep look, LOOK before you reschedule.** A run can
      heartbeat forever while nothing moves: every PR parked on a forgotten question, a review silently
      stuck — and each heartbeat looks locally fine, because "nothing moved" is invisible to an agent that
@@ -492,8 +495,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 
      The first is #112's quiet sensor (the durable `last_activity` stamp); the second is the durable
      long-cadence deadline (`ledger.py watchdog`, `files-and-ledger.md`) — the sensor that catches a run
-     whose heartbeats keep FIRING but never look deeply, and, on a persistent-scheduler host, the deadline
-     the resurrection poke enforces. **When `need_health` — and open PRs remain — this heartbeat runs
+     whose heartbeats keep FIRING but never look deeply. **When `need_health` — and open PRs remain — this heartbeat runs
      exactly ONE health pass and then exactly ONE `ledger.py --file <state.jsonl> watchdog arm`, and
      completes BOTH before the status render and the turn's final scheduling action** (the last-action rule
      below). **Never two passes for two triggers**: quiet and watchdog-due firing together is still one
@@ -509,10 +511,6 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        is not a stall to "fix" (the held-status guard still binds — step 3), but a forgotten question is
        the single most likely reason a run went quiet, so it is what the user needs put back in front of
        them.
-     - **adapter-conditional verification** (`runtime-adapter.md`): on a **scheduled-heartbeat /
-       persistent-scheduler host**, **ensure the persistent watchdog entry still exists** (`ensure` — it is
-       idempotent, so re-running it is free); on a **bounded-wait host**, verify control returns to the
-       bounded-wait loop — there is **no callback to inspect**, so do not claim one.
 
      **When the health pass ran, the status this heartbeat renders LEADS with the diagnosis — BEFORE the
      ledger table:** every parked question restated with its waiting age, and every stalled-review finding,
@@ -523,12 +521,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 
      **The honest boundary: an in-session sensor is only read by a heartbeat that FIRES.** If the heartbeat
      chain itself dies — no scheduled wake, no bounded wait returns — nothing in-session reads either
-     sensor. Recovery then depends on the host: on a **persistent-scheduler host** the **resurrection
-     poke** fires on its own cadence and adopts the orphaned run (`run-identity-and-lease.md`, "Resolving a
-     heartbeat", `--watchdog`), telling the user the run had been **orphaned** — its chain had stopped —
-     not merely resumed. Where no persistent scheduler exists (Codex — `runtime-adapter.md`), a dead chain
-     surfaces only as a **stale lease on the next manual invocation** (`--run <id>`), where adoption picks
-     the orphaned run up and reports the same. Either way the silent stall is surfaced, never absorbed.
+     sensor. Recovery is a **MANUAL RESUME on every host** (there is no persistent scheduler on either):
+     a dead chain surfaces as a **stale lease on the next manual invocation** (`--run <id>`), where
+     adoption picks the orphaned run up and tells the user the run had been **orphaned** — its chain had
+     stopped — not merely resumed (`run-identity-and-lease.md`, "Adopt only an orphaned run"). The silent
+     stall is surfaced, never absorbed.
 
      ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
      both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
@@ -557,16 +554,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      non-terminal row or an existing file, so it distills exactly once; per-run files never
      contend, see "Fresh runs and carryover"), **release the run** (delete this run's
      `gauntlet-run-<run-id>` owner label via `gh label delete gauntlet-run-<run-id> --yes`, release
-     the lease — `lease.py … release --token <tok>` — and, on a persistent-scheduler host, **remove the
-     persistent watchdog entry** (`runtime-adapter.md`, "Persistent watchdog capability"); the shared
+     the lease — `lease.py … release --token <tok>`; the shared
      status labels stay), emit the final report, and **do not
      reschedule**. This run's loop ends. **"Rows all terminal" alone is NOT "finished"** — finalization
-     (carryover distilled, label deleted, lease released, watchdog entry removed) may still be **owed**, so
-     do these in order and only remove the watchdog entry once the rest is done; a resurrection poke that
-     arrives with finalization still owed **resumes the terminal step** rather than deleting the entry from
-     under it (`run-identity-and-lease.md`, "Resolving a heartbeat", `--watchdog`). The poke's own
-     self-cleanup — it removes the entry when it finds the run finished AND finalized — is the **backstop**
-     for a terminal step that died before removing it. **Leave
+     (carryover distilled, label deleted, lease released) may still be **owed**, so
+     do these in order. **Leave
      `<rundir>` in place** (do NOT delete it here) — its terminal `state.jsonl` is what lets a later bare
      invocation detect *this* *finished* run and take the "ask the user" branch in step 1 instead of a
      silent exit. (A stale heartbeat firing after exit harmlessly re-hits the finished-run branch via

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -93,13 +93,19 @@ the verdict the tool prints.
   ledger + header if missing — so a death before `acquire` does not lose the requested PR list (it
   otherwise lived only in the invocation args), and any later entry that finds `pending_adoption` set
   resumes setup idempotently from adoption of exactly those PRs (`files-and-ledger.md`; adoption clears it
-  back to `-` as its final step, `loop-control.md` step 1). Then (2) arm the scheduled heartbeat carrying the token (`--token <tok>`, via `heartbeat.py
-  callback` — `runtime-adapter.md` owns the host mechanism); (3) `lease.py --file <rundir>/lease.json
+  back to `-` as its final step, `loop-control.md` step 1). Then (2) call the session watchdog's
+  `available?` operation. When available, ensure its recurring nudge using `heartbeat.py watchdog --run
+  <run-id> --token <tok> --invocation <campaign-invocation>` (`runtime-adapter.md`, "Session watchdog
+  nudge"). When unavailable or when `ensure` fails, report that the run has no separate audit wake and
+  continue. The nudge does not end this turn and exists only while this session lives. Then (3) arm the
+  scheduled heartbeat carrying
+  the token (`--token <tok>`, via `heartbeat.py callback` — `runtime-adapter.md` owns the host
+  mechanism); (4) `lease.py --file <rundir>/lease.json
   acquire --token <tok> --heartbeat-id <proof>`, where the proof names the arming you ALREADY did
   (`runtime-adapter.md` says what your host's proof is). `acquire` refuses without both and never mints
-  a token itself — arming comes FIRST, so a driver that dies mid-work is still resumed by its own
-  heartbeat. **On a host whose scheduler ends the turn (`runtime-adapter.md`, "Scheduled-heartbeat
-  host"), step 2 is the setup turn's LAST action and step 3 plus the rest of setup (header, adoption,
+  a token itself — arming comes FIRST, so a live session can resume after a turn ends mid-work. **On a host
+  whose scheduler ends the turn (`runtime-adapter.md`, "Scheduled-heartbeat
+  host"), step 3 is the setup turn's LAST action and step 4 plus the rest of setup (header, adoption,
   first dispatches) run on the heartbeat it armed** — the proof then names the arming that delivered
   the very turn you are in, which is exactly "something already done". Size that first arm to the
   setup delay (`loop-control.md`, "Reschedule or exit"): a fresh run resumes in about a minute, not a
@@ -143,14 +149,20 @@ the verdict the tool prints.
 
 ### Resolving a heartbeat (Loop control step 1 applies this)
 
-1. **`--run <id>` given** (every scheduled heartbeat; also a manual targeted resume). Load `<rundir>/state.jsonl`,
-   then present a token to `lease.py`. **Scheduled heartbeat** (token in the prompt's `--token`) →
-   `refresh`: `owned` → reconcile, continue; `superseded` → stand down; refused because the lease is
-   gone → re-arm, then `acquire` (the turn-split in "Take a run" applies on a turn-ending scheduler:
-   the `acquire` runs on the wake the re-arm produces). **Manual `--run` with no token in hand** → `lease.py read` (advisory
-   status only): `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another
-   agent appears active, so **confirm takeover with the user** before `acquire --allow-takeover`;
-   `corrupt` → see "Adopt only an orphaned run".
+1. **`--run <id>` given** (every scheduled heartbeat, session watchdog nudge, or manual targeted resume).
+   Load `<rundir>/state.jsonl`, then present a token to `lease.py`. **Scheduled heartbeat** (token in
+   the prompt's `--token`, without `--watchdog`) → `refresh`: `owned` → reconcile, continue;
+   `superseded` → stand down; refused because the lease is gone → re-arm, then `acquire` (the turn-split
+   in "Take a run" applies on a turn-ending scheduler: the `acquire` runs on the wake the re-arm
+   produces). **Session watchdog** (`--run <id> --token <tok> --watchdog`) → first run the runtime
+   adapter's read-only primary and watchdog inspections, then take the same `refresh`: `owned` → run
+   the soundness audit before normal reconciliation (`loop-control.md`, "Reschedule or exit"); any refusal
+   or `superseded` → report the inspections and stop. It NEVER calls `acquire`,
+   `--allow-takeover`, or adoption: it is a live-session audit, not a recovery path.
+   **Manual `--run` with no token in hand** → `lease.py read` (advisory status only):
+   `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another agent
+   appears active, so **confirm takeover with the user** before `acquire --allow-takeover`; `corrupt` →
+   see "Adopt only an orphaned run".
 
 2. **Bare invocation** → the arg decides intent:
    - **`#PR` args are given** (`<campaign-invocation> #12 #15`, no `--run`) → **start a NEW run** that

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -88,15 +88,12 @@ the verdict the tool prints.
 
 - **Take a run** — at fresh-run start or on adoption — **in this order**: (1) `lease.py mint` prints
   your agent token; **then, BEFORE arming (the arm ends the setup turn on a turn-ending scheduler), do
-  the two durable-setup steps that must survive a mid-setup death:** **(a)** record the run intent —
+  the durable-setup step that must survive a mid-setup death:** record the run intent —
   `ledger.py --file <rundir>/state.jsonl header set pending_adoption "<pr> <pr> …"`, which creates the
   ledger + header if missing — so a death before `acquire` does not lose the requested PR list (it
   otherwise lived only in the invocation args), and any later entry that finds `pending_adoption` set
   resumes setup idempotently from adoption of exactly those PRs (`files-and-ledger.md`; adoption clears it
-  back to `-` as its final step, `loop-control.md` step 1); **(b)** on a persistent-scheduler host,
-  **ensure the watchdog entry** (`runtime-adapter.md`, "Persistent watchdog capability" — `ensure` is
-  idempotent and does NOT end the turn), so a heartbeat chain that dies during or after setup can still be
-  resurrected. Then (2) arm the scheduled heartbeat carrying the token (`--token <tok>`, via `heartbeat.py
+  back to `-` as its final step, `loop-control.md` step 1). Then (2) arm the scheduled heartbeat carrying the token (`--token <tok>`, via `heartbeat.py
   callback` — `runtime-adapter.md` owns the host mechanism); (3) `lease.py --file <rundir>/lease.json
   acquire --token <tok> --heartbeat-id <proof>`, where the proof names the arming you ALREADY did
   (`runtime-adapter.md` says what your host's proof is). `acquire` refuses without both and never mints
@@ -154,22 +151,6 @@ the verdict the tool prints.
    status only): `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another
    agent appears active, so **confirm takeover with the user** before `acquire --allow-takeover`;
    `corrupt` → see "Adopt only an orphaned run".
-
-   **`--run <id> --watchdog` — the resurrection poke** (fired by the persistent watchdog entry —
-   `runtime-adapter.md`, "Persistent watchdog capability"; the poke line is `heartbeat.py watchdog`'s, and
-   is **TOKEN-FREE**). **Arg grammar:** `--watchdog` **requires `--run`** and is **rejected** in
-   combination with `--token`, `--new`, or `#PR` args — a token-bearing poke beside a live chain could
-   double-drive, and `--new`/`#PR` are start-time args that would mint a fresh run. Because it carries no
-   token it resolves the lease **first** and stands down when the primary is alive. Load
-   `<rundir>/state.jsonl`, `lease.py read`, and act on the verdict — **reusing existing verdicts only**:
-
-   | `lease.py` read / state | action |
-   |---|---|
-   | `held` | the primary driver is alive: report **one** stand-down line and **EXIT**. Never prompt, never `--allow-takeover`. |
-   | `stale`/`absent`, run **not finalized** — a non-terminal row remains, **OR** `pending_adoption` is set, **OR** every row is terminal but finalization is still owed (carryover not distilled / label not deleted / lease not released — the lease file is still present and the run label still exists) | the heartbeat chain is **dead**: adopt per "Take a run" — mint, arm the SHORT chain (setup delay), and on a turn-terminal host the arm **ends the poke's turn** so `acquire` runs on the armed wake (exactly the setup turn-split above). Then resume from **what durable state says**: `pending_adoption` set → finish setup (adopt those PRs); non-terminal rows → the normal loop; finalization owed → run the **terminal step** (`loop-control.md`, "Reschedule or exit"). **Report that the watchdog resurrected an orphaned run**, not merely resumed it. |
-   | `stale`/`absent`, run **finished AND finalized** — every row terminal, carryover distilled, label deleted, lease released | nothing to drive: **remove the watchdog entry** (the self-cleaning backstop for a terminal step that never got to remove it) and **EXIT**. |
-   | `corrupt` | report and **EXIT** — never adopt a corrupt lease (the existing rule; see "Adopt only an orphaned run"). |
-   | post-acquire `superseded` / `lost-race` | a driver took the run while you were acquiring: **stand down** (the existing rule) — report and stop. |
 
 2. **Bare invocation** → the arg decides intent:
    - **`#PR` args are given** (`<campaign-invocation> #12 #15`, no `--run`) → **start a NEW run** that

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -314,46 +314,12 @@ The second path is how Codex CLI sessions operate when no scheduled-heartbeat ca
 the process is killed, durable run state and the lease takeover rules allow a later invocation to resume;
 the skill does not pretend a heartbeat was scheduled when none was.
 
-### Persistent watchdog capability
-
-The heartbeat mechanisms above are the run's SHORT cadence. `ledger.py watchdog` (`files-and-ledger.md`)
-adds a LONG durable deadline both hosts honor at loop entry. On a host that has a **persistent scheduler**
-— one that survives the death of the driving process — that deadline is backed by a **resurrection poke**:
-a low-frequency wake that re-checks a run whose heartbeat chain may have died. This capability owns the
-scheduler entry; the deadline itself is host-neutral and lives in `ledger.py`.
-
-The capability is **four idempotent operations**, keyed **deterministically** by run id so a re-run never
-creates a duplicate entry — the entry name is `gauntlet-watchdog-<run-id>`:
-
-- `available?` — probe whether this host has a persistent scheduler. Unavailability is a **documented,
-  NON-blocking degradation** (below), never an error that stops the run.
-- `ensure` — create the entry if it is missing; **safe to repeat** (an existing entry is left as-is). Its
-  recurrence is the number `ledger.py watchdog interval` prints — **read it from the tool, never copy a
-  literal**, so a re-tuned interval reaches the scheduler with no edit here. The command the entry fires is
-  built **only** by `heartbeat.py watchdog --run <run-id> --invocation <campaign-invocation>` (it prints
-  `<campaign-invocation> --run <run-id> --watchdog`) — the **same no-hand-assembly stance** the callback
-  takes: never splice that line together yourself, so the poke can never carry a `--token`, `--new`, `#PR`,
-  or `--heartbeat-id` it must not (`run-identity-and-lease.md`, "Resolving a heartbeat", owns the poke's
-  resolution).
-- `inspect` — does the entry exist?
-- `remove` — delete the entry.
-
-**None of `ensure`/`inspect`/`remove` ends the turn** — only wakeup **scheduling** does (the
-scheduled-heartbeat lifecycle above). Managing the watchdog entry is ordinary work the turn does before its
-final scheduling action, exactly like a ledger write or a dispatch.
-
-Host mappings:
-
-| Host | `persistent watchdog` |
-|---|---|
-| Claude Code | the **harness cron facility** — a persistent scheduler that outlives the session, so `ensure`/`inspect`/`remove` map to its create/list/delete and the poke fires even after a dead heartbeat chain. |
-| Codex | **ABSENT.** There is no persistent scheduler. The loop-entry `watchdog check` still delivers the **full health cadence** whenever a heartbeat or bounded wait runs; what is missing is only automatic resurrection — if the driving process itself dies, recovery is a **manual resume** (`--run <id>`), stated plainly to the user. |
-
-**Unavailability is a NON-blocking, REPORTED degradation.** When `available?` is false (Codex always), or
-`ensure` fails or is denied, the run does **not** stop and does **not** park: it proceeds on the §1
-deadline path alone, and the setup report and every status render state the boundary — long-cadence health
-checks remain, **automatic resurrection does not**, so a dead driver needs a manual resume
-(`loop-control.md`, run start and "Reschedule or exit", own the report).
+The watchdog deadline (`ledger.py watchdog`, `files-and-ledger.md`; owner: `loop-control.md`'s health
+pass) is a LONG durable deadline that needs **NO host mechanism**. Every host's loop entry checks it on
+the existing heartbeat or bounded-wait chain, so it is **identical on Claude Code and Codex** — there is
+no scheduler entry, no resurrection poke, nothing host-specific. A dead heartbeat chain or a dead session
+is recovered by **MANUAL RESUME on every host**: the next manual `--run <id>` invocation finds a stale
+lease and adopts the orphaned run (`run-identity-and-lease.md` owns adoption).
 
 ## Reviewer selection and diversity
 

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -314,12 +314,36 @@ The second path is how Codex CLI sessions operate when no scheduled-heartbeat ca
 the process is killed, durable run state and the lease takeover rules allow a later invocation to resume;
 the skill does not pretend a heartbeat was scheduled when none was.
 
-The watchdog deadline (`ledger.py watchdog`, `files-and-ledger.md`; owner: `loop-control.md`'s health
-pass) is a LONG durable deadline that needs **NO host mechanism**. Every host's loop entry checks it on
-the existing heartbeat or bounded-wait chain, so it is **identical on Claude Code and Codex** — there is
-no scheduler entry, no resurrection poke, nothing host-specific. A dead heartbeat chain or a dead session
-is recovered by **MANUAL RESUME on every host**: the next manual `--run <id>` invocation finds a stale
-lease and adopts the orphaned run (`run-identity-and-lease.md` owns adoption).
+### Session watchdog nudge
+
+The watchdog is a SECOND, long-cadence wake that asks the current session's orchestrator to audit campaign
+soundness. It is not a durable recovery system: it exists only while that session exists and a dead session
+still needs a manual `--run <id>` resume. `ledger.py watchdog` owns the 45-minute cadence and
+`loop-control.md`, "Reschedule or exit", owns the audit.
+
+On a host with a session-watchdog capability, use these idempotent operations, keyed by
+`gauntlet-watchdog-<run-id>`:
+
+- `available?` — report whether the host can schedule an additional wake into this live session.
+- `ensure` — create the recurring nudge if missing. Use `ledger.py watchdog interval` for its cadence
+  and schedule only `heartbeat.py watchdog`'s stdout, built with run id, owner token, and campaign
+  invocation. The nudge reaches the same session; it never launches an independent driver.
+- `inspect` — report whether the nudge remains armed for this session.
+- `remove` — delete the nudge during normal finalization.
+- `primary inspect` — on a scheduled-heartbeat host, report whether the next primary callback names this
+  run and owner token. A missing callback is repaired by this turn's final normal scheduling action; a
+  bounded-wait host reports that no callback exists to inspect.
+
+None of these operations ends the turn. The primary heartbeat's final scheduling action still ends it.
+
+| Host | Session watchdog |
+|---|---|
+| Claude Code | Harness cron, scoped to this session. Its entry must deliver the watchdog command into this session, not create a new worker. |
+| Codex | Absent. The bounded-wait loop still honors `watchdog_due`, but has no separate audit wake. |
+
+An absent capability or failed `ensure` is non-blocking. State the boundary in the run-start and status
+reports: normal heartbeat health checks remain, but no separate session watchdog is armed. Do not claim
+that either host recovers a dead session automatically.
 
 ## Reviewer selection and diversity
 

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
@@ -126,72 +126,6 @@ def t_smuggled_args_cannot_reach_stdout():
                       f"a refused callback must not leak {forbidden!r} to stdout, got {out!r}")
 
 
-# --- the token-free watchdog poke contract ------------------------------------
-
-def t_watchdog_line_shape():
-    got = H.watchdog_command("/gauntlet:campaign", "g260704-0915-a3f29c1b")
-    check(got == "/gauntlet:campaign --run g260704-0915-a3f29c1b --watchdog",
-          f"the poke must be exactly `<invocation> --run <id> --watchdog`, got {got!r}")
-
-
-def t_watchdog_carries_run_and_watchdog_and_nothing_forbidden():
-    """The poke's WHOLE contract: it carries `--run` and `--watchdog`, and NONE of `--token`, `--new`, `#PR`,
-    or `--heartbeat-id`. A token-bearing poke beside a live chain could be adopted as a second driver and
-    double-drive the run; the start-time/acquire-time args would mint a fresh run or replay a stale proof."""
-    got = H.watchdog_command("/gauntlet:campaign", "g260704-0915-a3f29c1b")
-    check("--run" in got, "the poke must carry --run — it names the run to check on")
-    check("--watchdog" in got, "the poke must carry --watchdog — the flavor that resolves the lease first")
-    for forbidden in ("--token", "--new", "#", "--heartbeat-id"):
-        check(forbidden not in got,
-              f"the poke must NOT carry {forbidden!r} — a token could double-drive; --new/#PR would mint a "
-              f"fresh run; --heartbeat-id is an acquire-time proof a lease-resolving poke never presents")
-
-
-def t_watchdog_host_neutral():
-    got = H.watchdog_command("$gauntlet:campaign", "g1")
-    check(got.startswith("$gauntlet:campaign "),
-          "the poke must assume NO host form — the Codex `$` invocation must survive verbatim")
-
-
-def t_cli_watchdog_prints_command():
-    r, inv = "g260704-0915-a3f29c1b", "$gauntlet:campaign"
-    code, out, err = capture_cli(H.main, ["watchdog", "--run", r, "--invocation", inv])
-    check(code == 0, f"a well-formed poke invocation must exit 0, got {code}")
-    check(out.strip() == f"{inv} --run {r} --watchdog",
-          f"the CLI must print the exact poke command, got {out.strip()!r}")
-    check(err == "", f"a successful poke must write nothing to stderr, got {err!r}")
-
-
-def _assert_watchdog_refused(argv, what):
-    code, out, err = capture_cli(H.main, ["watchdog", *argv])
-    check(code != 0, f"a {what} must fail closed with a non-zero exit, got {code}")
-    check(out.strip() == "", f"a refused poke ({what}) must print NOTHING on stdout, got {out.strip()!r}")
-    check("REFUSED" in err, f"the refusal ({what}) must say REFUSED on stderr, got {err!r}")
-    return out
-
-
-def t_cli_watchdog_fails_closed_on_blank_and_whitespace():
-    _assert_watchdog_refused(["--run", "", "--invocation", "/x"], "blank --run")
-    _assert_watchdog_refused(["--run", "g1", "--invocation", ""], "blank --invocation")
-    _assert_watchdog_refused(["--run", "g1 --new #9", "--invocation", "/gauntlet:campaign"],
-                             "whitespace-containing --run")
-    _assert_watchdog_refused(["--run", "g1\ttok", "--invocation", "/gauntlet:campaign"], "tab --run")
-    _assert_watchdog_refused(["--run", "g1", "--invocation", "/gauntlet:campaign --new"],
-                             "whitespace-containing --invocation")
-
-
-def t_watchdog_smuggled_token_cannot_reach_stdout():
-    # The point of the token-free design: a `--token`/`--new`/`#PR`/`--heartbeat-id` hidden behind whitespace
-    # in --run must NEVER survive to stdout, where a scheduler would re-split it into a double-driving argv.
-    for smuggle in ("g1 --token deadbeef", "g1 --new #99", "g1 #12", "g1 --heartbeat-id deadbeef"):
-        out = _assert_watchdog_refused(["--run", smuggle, "--invocation", "/gauntlet:campaign"],
-                                       f"smuggled {smuggle!r}")
-        for forbidden in ("--token", "--new", "#", "--heartbeat-id"):
-            if forbidden in smuggle:
-                check(forbidden not in out,
-                      f"a refused poke must not leak {forbidden!r} to stdout, got {out!r}")
-
-
 CASES = [
     ("callback-two-flags", "the callback is exactly `<invocation> --run <id> --token <tok>`",
      t_callback_is_two_flags),
@@ -215,16 +149,4 @@ CASES = [
      t_cli_refuses_tab_and_newline),
     ("smuggle-blocked", "--new/#PR/--heartbeat-id hidden behind whitespace never reach stdout",
      t_smuggled_args_cannot_reach_stdout),
-    ("watchdog-line-shape", "the poke is exactly `<invocation> --run <id> --watchdog`",
-     t_watchdog_line_shape),
-    ("watchdog-run-and-watchdog-only", "the poke carries --run/--watchdog and none of --token/--new/#PR/--heartbeat-id",
-     t_watchdog_carries_run_and_watchdog_and_nothing_forbidden),
-    ("watchdog-host-neutral", "the poke's invocation is passed in — no `/` host form is hardcoded",
-     t_watchdog_host_neutral),
-    ("watchdog-cli-prints", "the watchdog subcommand prints the exact poke and nothing else",
-     t_cli_watchdog_prints_command),
-    ("watchdog-fails-closed", "a blank or whitespace value fails closed, prints nothing, says REFUSED",
-     t_cli_watchdog_fails_closed_on_blank_and_whitespace),
-    ("watchdog-smuggle-blocked", "a smuggled --token/--new/#PR/--heartbeat-id never reaches stdout",
-     t_watchdog_smuggled_token_cannot_reach_stdout),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Fixtures for `heartbeat.py` — the scheduled-heartbeat callback command.
+"""Fixtures for `heartbeat.py` — the scheduled heartbeat and session-watchdog commands.
 
 They live in a SIBLING file, and `heartbeat.py self-test` FAILS LOUDLY if it cannot load them.
 
-EVERY FIXTURE MUST PIN A RULE with TEETH. The rules worth the most here are the ones that keep the callback
-a RESUME and nothing else: it carries exactly `--run` and `--token`, it never carries `--heartbeat-id`
-(an acquire-time proof), and it never carries `--new`/`#PR` (start-time args that would mint a fresh run
-every heartbeat). Each of those, if it regressed, would silently break the resume contract.
+EVERY FIXTURE MUST PIN A RULE with TEETH. The rules worth the most here are the ones that keep both wakes
+on the current run: the heartbeat carries exactly `--run` and `--token`; the watchdog adds only
+`--watchdog`; neither carries `--heartbeat-id` (an acquire-time proof) or `--new`/`#PR` (start-time
+args that would mint a fresh run every wake).
 """
 
 from __future__ import annotations
@@ -126,6 +126,51 @@ def t_smuggled_args_cannot_reach_stdout():
                       f"a refused callback must not leak {forbidden!r} to stdout, got {out!r}")
 
 
+# --- session watchdog wake -----------------------------------------------------
+
+def t_watchdog_is_owner_callback_plus_flag():
+    got = H.watchdog_command("/gauntlet:campaign", "g260704-0915-a3f29c1b", "aabbccdd")
+    check(got == "/gauntlet:campaign --run g260704-0915-a3f29c1b --token aabbccdd --watchdog",
+          f"the watchdog must be the owner callback plus --watchdog, got {got!r}")
+    check("--heartbeat-id" not in got and "--new" not in got and "#" not in got,
+          "the watchdog must carry no acquire-time proof or start-time args")
+
+
+def t_watchdog_host_neutral():
+    got = H.watchdog_command("$gauntlet:campaign", "g1", "t1")
+    check(got.startswith("$gauntlet:campaign "),
+          "the watchdog must preserve the supplied Codex invocation; no host form is hardcoded")
+
+
+def t_cli_watchdog_prints_command():
+    r, t, inv = "g260704-0915-a3f29c1b", "aabbccdd", "$gauntlet:campaign"
+    code, out, err = capture_cli(H.main, ["watchdog", "--run", r, "--token", t, "--invocation", inv])
+    check(code == 0, f"a well-formed watchdog wake must exit 0, got {code}")
+    check(out.strip() == f"{inv} --run {r} --token {t} --watchdog",
+          f"the watchdog CLI must print the exact command, got {out.strip()!r}")
+    check(err == "", f"a successful watchdog wake must write nothing to stderr, got {err!r}")
+
+
+def _assert_watchdog_refused(argv, what):
+    code, out, err = capture_cli(H.main, ["watchdog", *argv])
+    check(code != 0, f"a {what} must fail closed with a non-zero exit, got {code}")
+    check(out.strip() == "", f"a refused watchdog ({what}) must print NOTHING on stdout, got {out.strip()!r}")
+    check("REFUSED" in err, f"the watchdog refusal ({what}) must say REFUSED on stderr, got {err!r}")
+    return out
+
+
+def t_watchdog_refuses_unusable_values():
+    _assert_watchdog_refused(["--run", "", "--token", "tok", "--invocation", "/gauntlet:campaign"],
+                             "blank watchdog run")
+    _assert_watchdog_refused(["--run", "g1", "--token", "aa bb", "--invocation", "/gauntlet:campaign"],
+                             "whitespace-containing watchdog token")
+    out = _assert_watchdog_refused(
+        ["--run", "g1 --new #9", "--token", "tok", "--invocation", "/gauntlet:campaign"],
+        "watchdog run containing start-time args")
+    check("--new" not in out and "#" not in out,
+          f"a refused watchdog must not leak smuggled args to stdout, got {out!r}")
+
+
 CASES = [
     ("callback-two-flags", "the callback is exactly `<invocation> --run <id> --token <tok>`",
      t_callback_is_two_flags),
@@ -149,4 +194,12 @@ CASES = [
      t_cli_refuses_tab_and_newline),
     ("smuggle-blocked", "--new/#PR/--heartbeat-id hidden behind whitespace never reach stdout",
      t_smuggled_args_cannot_reach_stdout),
+    ("watchdog-owner-callback", "the watchdog is the owner callback plus --watchdog only",
+     t_watchdog_is_owner_callback_plus_flag),
+    ("watchdog-host-neutral", "the watchdog preserves the supplied host invocation",
+     t_watchdog_host_neutral),
+    ("watchdog-cli-prints", "the watchdog subcommand prints the exact command and nothing else",
+     t_cli_watchdog_prints_command),
+    ("watchdog-refuses-unusable", "a malformed watchdog command prints nothing and refuses",
+     t_watchdog_refuses_unusable_values),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -48,20 +48,6 @@ def callback_command(invocation: str, run_id: str, token: str) -> str:
     return f"{invocation} --run {run_id} --token {token}"
 
 
-def watchdog_command(invocation: str, run_id: str) -> str:
-    """Assemble the watchdog resurrection poke: `<invocation> --run <run-id> --watchdog`, and NOTHING else.
-
-    A poke is fired by a persistent scheduler to check on a run whose heartbeat chain may have died. It is
-    TOKEN-FREE BY DESIGN: unlike the `callback` (a resume by the SAME owner, which carries `--token`), a poke
-    might land BESIDE a still-live heartbeat chain. A token-bearing poke could then be adopted as a second
-    driver and DOUBLE-DRIVE the one run, so the poke carries no token — it resolves the lease first and stands
-    down when the primary is alive. It likewise carries no `--new`/`#PR` (start-time args that would mint a
-    fresh run) and no `--heartbeat-id` (an acquire-time proof). The host form is passed in, so this stays
-    host-neutral, exactly like `callback_command`.
-    """
-    return f"{invocation} --run {run_id} --watchdog"
-
-
 # --- cli ----------------------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
@@ -75,18 +61,13 @@ def build_parser() -> argparse.ArgumentParser:
                     help="the host campaign invocation (Claude Code `/gauntlet:campaign`, "
                          "Codex `$gauntlet:campaign`) — passed in so this tool hardcodes no host form")
 
-    wd = sub.add_parser("watchdog", help="print the TOKEN-FREE watchdog resurrection poke command")
-    wd.add_argument("--run", required=True, help="the run id the poke checks on (never mints a new run)")
-    wd.add_argument("--invocation", required=True,
-                    help="the host campaign invocation — passed in so this tool hardcodes no host form")
-
     sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
     return parser
 
 
 def _reject_unusable(fields: "list[tuple[str, str]]") -> bool:
-    """Fail closed on any required value that is empty OR contains ANY whitespace. Shared by `callback` and
-    `watchdog`: whitespace is the argument-injection seam — a `--run "g1 --new #99"` would smuggle extra
+    """Fail closed on any required value that is empty OR contains ANY whitespace for the `callback`:
+    whitespace is the argument-injection seam — a `--run "g1 --new #99"` would smuggle extra
     tokens past the fixed-shape guarantee once the printed line is re-split into argv. No legitimate value (a
     `g<date>-<rand>` run-id, a hex token, a `/gauntlet:campaign` invocation) carries whitespace. On a bad
     value: print the refusal on stderr, print NOTHING on stdout, return True so the caller returns non-zero.
@@ -115,16 +96,7 @@ def main(argv: "list[str] | None" = None) -> int:
         print(callback_command(args.invocation, args.run, args.token))
         return 0
 
-    if args.cmd == "watchdog":
-        # The poke is TOKEN-FREE by design, so it validates only `--run` and `--invocation` — the same
-        # empty/whitespace fail-closed the callback applies, so a smuggled `--token`/`--new`/`#PR` hidden
-        # behind whitespace can never survive to stdout and be re-split into a double-driving argv.
-        if _reject_unusable([("--run", args.run), ("--invocation", args.invocation)]):
-            return 1
-        print(watchdog_command(args.invocation, args.run))
-        return 0
-
-    parser.error("a subcommand is required (callback | watchdog | self-test)")
+    parser.error("a subcommand is required (callback | self-test)")
 
 
 # --- self-test ----------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Emit the scheduled-heartbeat callback command — the exact line an agent schedules for its next wake.
+"""Emit the scheduled heartbeat and session-watchdog commands.
 
 A scheduled heartbeat is the SAME owner resuming its own run, so when that callback runs it goes through
 `lease.py`'s REFRESH path, not `acquire`. Per the single-user policy (`AGENTS.md`), an owner's refresh needs
@@ -18,9 +18,13 @@ and nothing else. In particular:
 - It hardcodes NO host form. The invocation string (`/gauntlet:campaign` on Claude Code,
   `$gauntlet:campaign` on Codex) is PASSED IN via `--invocation`, so this tool is host-neutral.
 
-This tool does NOT arm the heartbeat. Arming is the host's own `ScheduleWakeup`/cron call, which is an
-agent-only action that cannot be scripted — `runtime-adapter.md` owns that mechanism. This tool only PRINTS
-the command the agent then schedules through it.
+The watchdog is a SECOND, session-scoped wake at a longer cadence. It carries the current owner's token and
+adds `--watchdog`, which makes the campaign audit its soundness before rescheduling. It is not an orphan
+recovery path and never claims to survive a dead session.
+
+This tool does NOT arm either wake. Arming is the host's own scheduler call, which is an agent-only action
+that cannot be scripted — `runtime-adapter.md` owns that mechanism. This tool only PRINTS the command the
+agent then schedules through it.
 """
 
 from __future__ import annotations
@@ -31,7 +35,7 @@ from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
 
-DESCRIPTION = "Print the scheduled-heartbeat callback command (two flags only: --run and --token)."
+DESCRIPTION = "Print a scheduled heartbeat or session-watchdog campaign command."
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "heartbeat-test.py"
@@ -48,6 +52,11 @@ def callback_command(invocation: str, run_id: str, token: str) -> str:
     return f"{invocation} --run {run_id} --token {token}"
 
 
+def watchdog_command(invocation: str, run_id: str, token: str) -> str:
+    """Build a session-scoped soundness-audit wake for the current owner."""
+    return f"{invocation} --run {run_id} --token {token} --watchdog"
+
+
 # --- cli ----------------------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
@@ -61,12 +70,18 @@ def build_parser() -> argparse.ArgumentParser:
                     help="the host campaign invocation (Claude Code `/gauntlet:campaign`, "
                          "Codex `$gauntlet:campaign`) — passed in so this tool hardcodes no host form")
 
+    wd = sub.add_parser("watchdog", help="print the session-watchdog soundness-audit wake command")
+    wd.add_argument("--run", required=True, help="the existing run id the watchdog audits")
+    wd.add_argument("--token", required=True, help="the current owner token")
+    wd.add_argument("--invocation", required=True,
+                    help="the host campaign invocation — passed in so this tool hardcodes no host form")
+
     sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
     return parser
 
 
 def _reject_unusable(fields: "list[tuple[str, str]]") -> bool:
-    """Fail closed on any required value that is empty OR contains ANY whitespace for the `callback`:
+    """Fail closed on any required value that is empty OR contains ANY whitespace:
     whitespace is the argument-injection seam — a `--run "g1 --new #99"` would smuggle extra
     tokens past the fixed-shape guarantee once the printed line is re-split into argv. No legitimate value (a
     `g<date>-<rand>` run-id, a hex token, a `/gauntlet:campaign` invocation) carries whitespace. On a bad
@@ -96,7 +111,14 @@ def main(argv: "list[str] | None" = None) -> int:
         print(callback_command(args.invocation, args.run, args.token))
         return 0
 
-    parser.error("a subcommand is required (callback | self-test)")
+    if args.cmd == "watchdog":
+        if _reject_unusable([("--run", args.run), ("--token", args.token),
+                             ("--invocation", args.invocation)]):
+            return 1
+        print(watchdog_command(args.invocation, args.run, args.token))
+        return 0
+
+    parser.error("a subcommand is required (callback | watchdog | self-test)")
 
 
 # --- self-test ----------------------------------------------------------------
@@ -131,7 +153,7 @@ def self_test() -> int:
     except SelfTestFailure as exc:
         print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
               f"         {exc}")
-        print("\n1 check(s) FAILED — the heartbeat callback tool's contract is broken.")
+        print("\n1 check(s) FAILED — the campaign wake-command tool's contract is broken.")
         return 1
     for name, rule, fn in cases:
         try:
@@ -146,9 +168,9 @@ def self_test() -> int:
             print(f"ok       {name:30} -> {rule}")
     print()
     if failures:
-        print(f"{failures} check(s) FAILED — the heartbeat callback tool's contract is broken.")
+        print(f"{failures} check(s) FAILED — the campaign wake-command tool's contract is broken.")
         return 1
-    print(f"all {len(cases)} fixtures hold — the heartbeat callback tool's contract is intact.")
+    print(f"all {len(cases)} fixtures hold — the campaign wake-command tool's contract is intact.")
     return 0
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -83,8 +83,9 @@ HEADER_DEFAULTS = {
     "last_activity": "-",
     # THE DURABLE HEALTH-PASS DEADLINE — a UTC ISO-8601 stamp (second precision) naming the instant by which
     # the run owes its next deep "health pass". `ledger.py watchdog arm` stamps it to `now + WATCHDOG_INTERVAL`;
-    # `watchdog check` reads it back; both hosts honor it at loop entry so a run that has gone quiet (a dead
-    # heartbeat chain, or heartbeats firing but never doing the deep look) still gets a periodic forced sweep.
+    # `watchdog check` reads it back; every live loop honors it at entry. The session watchdog audits
+    # scheduling separately, so the first wake that sees this deadline due performs the sweep. It does not
+    # revive a dead session.
     # A TOOL-STAMPED field, exactly like `last_activity`: there is NO `header set watchdog_due` door (a
     # hand-written deadline would be a forged one), and its writes are activity-EXEMPT (re-arming the watchdog
     # is not "the run did something meaningful"; letting it stamp would defeat the very quiet sensor it backs).


### PR DESCRIPTION
- add a session-scoped watchdog nudge at the 45-minute health deadline
- audit primary-heartbeat arming and campaign soundness while the session is live
- retain the 15-minute primary heartbeat and manual resume after a session ends
