### PR TITLE
revalidate campaign candidates after merges

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -248,13 +248,13 @@ a line the tool writes.
 | `emit-finding.py` | Reviewer's door: record one FINDING (the only sanctioned way; findings must anchor or they do not gate) | `references/stage-2-review-gate.md` |
 | `emit-amendment.py` | Reviewer's door: raise one plan amendment (the only sanctioned way; `ts` is tool-stamped, the proposed unit is validated like a plan unit) | `references/stage-2-review-gate.md` |
 | `reviewer-liveness.py` | Probe whether a dispatched reviewer's output stream is still moving; decides nothing, always exits 0 | `references/stage-2-review-gate.md` |
-| `base-preflight.py` | Decide proceed / rebase-first / recheck from a PR's live merge-state before review or fix; performs no rebase | `references/stage-2-review-gate.md` |
+| `base-preflight.py` | Decide proceed / rebase-first / recheck from live merge-state plus fetched base ancestry before review or fix; performs no rebase | `references/stage-2-review-gate.md` |
 | `format-preflight.py` | `check` — refuse to format any file whose formatter-write could escape the worktree (the file, or any path component, is a symlink); reads only, formats nothing | `references/stage-2-ci.md` |
 | `clean-rebase.py` | `run` — EXECUTE the clean base-only rebase (fetch/rebase/force-with-lease push + the ledger reset) and REFUSE everything else: a conflict or a diff-changing rebase is aborted/reset and handed back (exit 3), never resolved | `references/stage-2-review-gate.md` |
 | `ci-status.py` | `derive` — how `ci` is DERIVED, always, the only way — `liveness` — the recorder: writes `ci` + the liveness counters, parks at any cap — and `required-set` | `references/stage-2-ci.md` |
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/ci-derivation-spec.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |
-| `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row + live PR view, crossing the ledger preconditions and both GitHub merge enums in one place | `references/stage-3-merge.md` |
+| `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row, live PR view, and fetched base ancestry | `references/stage-3-merge.md` |
 | `label-mirror.py` | `mirror` — reconcile a PR's status label with its review gate (the canonical idempotent `gauntlet-accepted`/`gauntlet-reviewing` swap), computed from the ledger row; touches only the two status labels | `references/stage-2-review-gate.md` |
 | `reconcile.py` | `detect` — compare the batched `prs.json` snapshot against the ledger and emit the per-PR reconcile FACTS (absent-by-absence, head/base/branch change, verbatim state/merge/label observations, unadopted candidates); names no action — routing is the skill's | `references/loop-control.md` |
 | `repair-pass.py` | Reassessment pass's door: `permitted` / `decide` — the closed decision enum, ownership guardrail, repair cap | `references/repair-pass.md` |

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -42,20 +42,20 @@ licence to ignore the other. A fixer that sweeps the tree to find the sites its 
 ### PRE-FLIGHT — the base must be current before ANY fix is dispatched
 
 **BEFORE dispatching ANY fix subagent (review-fix or CI-fix) for a PR, run
-`python3 scripts/base-preflight.py check --pr <N>`.** It prints ONE of three verdicts, and the action
+`python3 scripts/base-preflight.py check --pr <N> --worktree <worktree> --base <base>`.** It fetches
+`origin/<base>` and prints ONE of three verdicts, and the action
 **splits by verdict** — only `proceed` clears the dispatch, and the other two are NOT the same response:
 
 - **`proceed`** → the base is current; **dispatch the fix**.
-- **`rebase-first`** → the branch conflicts with its base or the base has moved ahead; do **NOT** dispatch.
+- **`rebase-first`** → the branch conflicts with its base or lacks the refreshed base; do **NOT** dispatch.
   **REBASE the PR onto `<base>`** (per `stage-2-review-gate.md`'s conflict-rebase), then **re-run the
   pre-flight**.
-- **`recheck`** → mergeability is not computed yet (or the view carried a value nobody has classified); do
-  **NOT** dispatch and do **NOT** rebase — **re-poll**, then **re-run the pre-flight**. Rebasing here would
-  act on a view GitHub has not finished computing.
+- **`recheck`** → mergeability is not computed yet, the view carried an unknown value, or base ancestry could
+  not be verified; do **NOT** dispatch and do **NOT** rebase — **re-poll**, then **re-run the pre-flight**.
 
 A fix authored on a stale or conflicting base is wasted work: it is re-reviewed against the rebased tip
-anyway, and its diff may not even apply. The tool DECIDES only — it performs no rebase; the driver rebases
-only on `rebase-first`, exactly as at the review-gate site.
+anyway, and its diff may not even apply. The tool fetches and decides only — it performs no rebase; the
+driver rebases only on `rebase-first`, exactly as at the review-gate site.
 
 ### SCOPE — bounds the reading
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -101,7 +101,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
        reports only THAT the head moved; deciding whether the PR **diff** changed (reset `reviews_ok`,
        relabel) or it was a **clean base-only advance** (counters only, gate kept) stays your judgement.
      - **`base_changed`** — the snapshot `baseRefName` differs from the header's `base_branch`: base-currency
-       handling (`base-preflight.md`; Stage 2a preconditions).
+       handling (`stage-2-review-gate.md`, "Base currency with `<base>`").
      - **`branch_mismatch`** — the snapshot `headRefName` differs from the row's recorded `branch`: reconcile
        the row's `branch` (adopted PRs keep their **own** head branch — the `gauntlet-run-<run-id>` label is
        the ownership marker, never a branch prefix; `files-and-ledger.md`, `branch`).
@@ -359,9 +359,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      files at that `head_sha`; agent-docs = code; default STANDARD on uncertainty — see the tiers
      spec) and write it back with `ledger.py … set --pr <N> --tier <tier>`. The tier is pinned to
      `head_sha` and sets `required(tier)` = **1 if TRIVIAL else 2**.
-   - current tip has `reviews_ok < required(tier)`, its **review preconditions are clear** (no
-     unaddressed Copilot review items, CI not red, no merge conflict with `<base>` — see Stage 2a
-     preconditions), and no review running for that SHA → **first ensure the PR's INTENT
+   - current tip has `reviews_ok < required(tier)`, has no unaddressed Copilot review items, CI is not red,
+     and no review is running for that SHA → **first ensure the PR's INTENT
      (`<rundir>/intent-<pr>.md`) and PR-head worktree exist.** The dispatch substitutes the intent block
      into the review prompt **verbatim** (`review-dispatch.md`), and a reviewer with no intent is a
      reviewer asked "is anything wrong with this code?" — the question with no fixed point. **It is not an
@@ -383,8 +382,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      explicit precondition of the review launch. **Also fetch `origin/<base>` fresh before the first
      review dispatch through the typed Stage 2a pre-review operation** — the review
      diffs `origin/<base>...HEAD`, a remote-tracking ref that always exists, since adoption fetches only
-     the PR head and a local `<base>` may be absent or stale (see `pr-adoption.md` / Stage 2a). Then
-     evaluate the verdict transport through `runtime-adapter.md`'s capability/transition owner before
+     the PR head and a local `<base>` may be absent or stale (see `pr-adoption.md` / Stage 2a). Then run
+     `base-preflight.py check --pr <N> --worktree <worktree> --base <base>`; only `proceed` clears the
+     review launch. Rebase on `rebase-first` or re-poll on `recheck` per Stage 2a, then restart this
+     precondition sequence. With `proceed`, evaluate the verdict transport through
+     `runtime-adapter.md`'s capability/transition owner before
      building its record and take only the action it returns;
      missing native cwd/mount/sandbox controls alone are not a machine blocker. Then launch **one**
      review pass as a **background**
@@ -441,9 +443,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 ### Step 4 — Merge queued PRs as a serialized drain
 
 4. **Merge** queued PRs as a serialized drain: re-confirm one candidate against the live SHA **and
-   re-check it is not parked** (the held-status guard binds the merge too — Stage 3), merge
-   it, sync `<base>`, reconcile remaining candidates, and repeat while another PR is immediately
-   mergeable (Stage 3).
+   re-check it is not parked** (the held-status guard binds the merge too — Stage 3), revalidate that it
+   contains the fetched current base, merge it, sync `<base>`, reconcile remaining candidates, and repeat
+   while another PR is immediately mergeable (Stage 3 owns the check).
 ### Step 5 — Reschedule or exit
 
 5. **Reschedule or exit.**

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -428,7 +428,8 @@ invent a second one.
 missing. That, too, is a property, not a fixed list of scans: whichever rule OWNS that dispatch is the
 one that says so. For a CI fix it is `loop-control.md` step 3's dispatch scan; for a rebase it is the rule
 that owns the rebase (Stage 2a's preconditions, `stage-2-review-gate.md`; the step-6 reconcile,
-`stage-3-merge.md`) finding the PR behind/conflicting on this heartbeat. A PR frozen by a park has no
+`stage-3-merge.md`) returning `rebase-first` after it checks the PR against the refreshed base on this
+heartbeat. A PR frozen by a park has no
 machine action due — the held-status guard forbids every one of them (`loop-control.md`), so nothing is
 coming, which is why the park is the terminus and not another wait.
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -80,15 +80,14 @@ review gate"), and the review re-starts on the clean tip:
 - **CI failures.** If `ci` is red for the current tip, do NOT review — fix CI first (Stage 2b).
   Handle failures **one at a time per PR/SHA**, and **prefer a scoped subagent** per failure; different
   PRs may fix CI concurrently within the cap.
-- **Merge conflicts with `<base>`.** If GitHub flags the PR conflicting/behind
-  (`gh pr view <pr> --json mergeable,mergeStateStatus` → `CONFLICTING` / `DIRTY` / `BEHIND`), rebase
-  it onto `<base>` before reviewing. This CONFLICTING/DIRTY/BEHIND condition is now DECIDED by
-  `python3 scripts/base-preflight.py check --pr <pr>`, which prints `rebase-first` for exactly these states
-  (and `proceed` when the base is current) — but only once BOTH enum values are recognized and computed; an
-  UNKNOWN or unrecognized value returns `recheck` FIRST, before any rebase-first classification, so re-poll
-  and re-run rather than rebase on a half-computed view (`base-preflight.py` is the owner of the full
-  mapping). It is the enforced form of this rule and it is also the pre-flight gate before any fix subagent
-  is dispatched (`fix-subagent-contract.md`, PRE-FLIGHT). Once it says `rebase-first`, **the CLEAN
+- **Base currency with `<base>`.** Before reviewing or dispatching a fix, run `python3
+  scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base>`. It checks both GitHub's
+  merge states and whether fetched `origin/<base>` is an ancestor of the PR worktree's `HEAD`. A
+  `rebase-first` verdict covers a conflict, GitHub reporting behind, or a CLEAN PR whose branch lacks the
+  refreshed base. `recheck` covers an uncomputed/unrecognized GitHub value or ancestry the helper cannot
+  verify; re-poll and re-run, never dispatch or rebase from incomplete evidence. `base-preflight.py` owns
+  the decision and is the pre-flight gate for every fix subagent (`fix-subagent-contract.md`, PRE-FLIGHT).
+  Once it says `rebase-first`, **the CLEAN
   base-only case is EXECUTED — not hand-run — by `python3 scripts/clean-rebase.py run --ledger
   <state.jsonl> --pr <pr> --worktree <worktree> --base <base>`**: it does the fetch/rebase/`--force-with-lease`
   push and the one ledger reset, and **refuses anything that is not clean**. **Exit 3 means it was NOT

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -29,12 +29,12 @@ two wires is what turns a blocked merge into an infinite CI watch.
 
 **The merge-readiness decision is COMPUTED, never read by eye:**
 `python3 <skill-dir>/scripts/merge-check.py check --pr <N> --file <state.jsonl>`. It reads the ledger
-row + the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid`) and
-prints `{"verdict":"merge"|"not-yet","reason":…}`, crossing — in ONE place — the held/open/draft/
-stale-head/ci/reviews preconditions and then **BOTH** GitHub enums (`.mergeable` first — `CONFLICTING`
+row + the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid`),
+fetches the ledger base into the PR worktree, and prints `{"verdict":"merge"|"not-yet","reason":…}`.
+It crosses — in ONE place — the held/open/draft/stale-head/ci/reviews preconditions and then **BOTH** GitHub enums (`.mergeable` first — `CONFLICTING`
 and `UNKNOWN` decide on their own, `MERGEABLE` falls through — then `.mergeStateStatus`, which alone
-yields `merge`), so the miscross above cannot recur. Both enums are crossed **TOTALLY**: a value GitHub's
-schema does not declare **parks**, never guesses. Act on the verdict:
+yields `merge`), then confirms `origin/<base>` is an ancestor of `HEAD`. Both enums are crossed
+**TOTALLY**: a value GitHub's schema does not declare **parks**, never guesses. Act on the verdict:
 
 - `merge` → proceed to the merge steps below (step 1).
 - `not-yet <reason>` → do **NOT** merge; the reason names the block. Route on the reason's **action**
@@ -94,11 +94,10 @@ subagent at a check that is merely **still running**.
    Before each merge, re-confirm the PR is still **not parked** and that both gates still hold against the live PR head SHA
    (`gh pr view <pr> --json headRefOid --jq .headRefOid`, PR number from the ledger row) — a late push
    may have moved the tip past the recorded `head_sha` and reset the gates —
-   **and re-fetch `origin/<base>` and re-check
-   `gh pr view <pr> --json mergeable,mergeStateStatus,isDraft`** — a concurrent run sharing this base may
-   have advanced it since the PR was last reviewed. Feed the ledger row and that live view to
-   **`merge-check.py check`** (**"The merge precondition"** above), which crosses **every** value of both
-   enums and returns the verdict.
+   **and run `merge-check.py check`** (**"The merge precondition"** above). It re-fetches
+   `origin/<base>` and verifies the candidate contains it, so a concurrent run that advanced the base cannot
+   leave an older CLEAN candidate mergeable. The tool also crosses **every** value of both enums and returns
+   the verdict.
 2. Push guard: `gh pr view <pr> --json state --jq .state` (PR number from the ledger row) must be
    `OPEN`.
 3. Merge — always `gh pr merge <pr> --squash` (use the repo's prevailing merge method if not squash),
@@ -204,8 +203,10 @@ subagent at a check that is merely **still running**.
    either way** (observation, not mutation): the watch follows the normal policy (`stage-2-ci.md`, "WATCH
    ONLY WHAT CAN MOVE") — relaunched while a row is still RUNNING, **not** relaunched once CI has settled.
 
-   For each **non-parked** open PR: **base advancement alone does NOT
-   invalidate gauntlet reviews.** Rebase only if GitHub flags the PR behind/conflicting:
+   For each **non-parked** open PR, run `python3 scripts/base-preflight.py check --pr <pr> --worktree
+   <worktree> --base <base>`. It fetches `origin/<base>` and requires it to be an ancestor of `HEAD` even
+   when GitHub still reports CLEAN. On `recheck`, re-poll and leave the candidate alone. On
+   `rebase-first`, rebase before considering the candidate for another review or merge:
    - Clean rebase (no conflicts, PR diff unchanged) → **EXECUTED — not hand-run — by `python3
      scripts/clean-rebase.py run --ledger <state.jsonl> --pr <N> --worktree <worktree> --base <base>`**: it
      does the fetch/rebase/`--force-with-lease` push, verifies the PR's own diff is unchanged, and writes the
@@ -231,9 +232,8 @@ subagent at a check that is merely **still running**.
      that respect). Then re-derive CI for
      the new tip — watching it only if `liveness` reports `watch_warranted` ("WATCH ONLY WHAT CAN MOVE") — and re-enter
      Stage 2.
-   - Still open, **not parked**, mergeable, not behind/dirty/conflicting, same live `head_sha`,
-     `reviews_ok >= required(tier)`, and `ci == green` → still immediately mergeable; return to step 1
-     in the same heartbeat.
+   - `proceed` with the same live `head_sha`, `reviews_ok >= required(tier)`, and `ci == green` → return
+     to step 1 in the same heartbeat; `merge-check.py` repeats the ancestry check before merging.
 
 Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
 

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -12,6 +12,7 @@ the mapping is pinned TOTALLY over the enum, plus the unrecognised-value fixture
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -48,25 +49,26 @@ def expect(v: dict, verdict: str, reason: "str | None" = None) -> None:
 
 
 # --- one fixture PER mergeStateStatus value (mergeable defaults to MERGEABLE) --------------------
-# The four base-current states clear a fix; DIRTY/BEHIND demand a rebase; UNKNOWN re-polls. Together they
-# cover every value in MERGE_STATE_STATUS_VALUES, so the mapping is pinned TOTALLY over the enum.
+# The four enum-screen states advance to the graph check; DIRTY/BEHIND demand a rebase; UNKNOWN re-polls.
+# Together they cover every value in MERGE_STATE_STATUS_VALUES, so the mapping is pinned TOTALLY over the
+# enum.
 
 def t_clean_proceeds():
-    expect(view(mergeStateStatus="CLEAN"), "proceed", "branch is current with base")
+    expect(view(mergeStateStatus="CLEAN"), "proceed", "GitHub merge state permits base check")
 
 
 def t_has_hooks_proceeds():
-    expect(view(mergeStateStatus="HAS_HOOKS"), "proceed", "branch is current with base")
+    expect(view(mergeStateStatus="HAS_HOOKS"), "proceed", "GitHub merge state permits base check")
 
 
 def t_unstable_proceeds():
-    # UNSTABLE is about a non-passing/still-running CHECK, not a stale base — a fix/review may proceed.
-    expect(view(mergeStateStatus="UNSTABLE"), "proceed", "branch is current with base")
+    # UNSTABLE is about a non-passing/still-running CHECK, not Git ancestry, so it reaches the graph check.
+    expect(view(mergeStateStatus="UNSTABLE"), "proceed", "GitHub merge state permits base check")
 
 
 def t_blocked_proceeds():
-    # BLOCKED is about branch-protection/permissions, not a stale base — base-currency still clears.
-    expect(view(mergeStateStatus="BLOCKED"), "proceed", "branch is current with base")
+    # BLOCKED is about branch-protection/permissions, not Git ancestry, so it reaches the graph check.
+    expect(view(mergeStateStatus="BLOCKED"), "proceed", "GitHub merge state permits base check")
 
 
 def t_dirty_rebases():
@@ -143,14 +145,16 @@ def t_behind_with_unknown_mergeable_rechecks():
 
 # --- CLI: a recorded view makes `check` testable without gh --------------------
 
-def t_cli_proceed():
+def t_cli_missing_ancestry_rechecks():
     with tempfile.TemporaryDirectory() as d:
         vjson = Path(d) / "view.json"
         vjson.write_text(json.dumps(view()), encoding="utf-8")
         code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
-        check(code == 0, f"a `proceed` verdict must exit 0 (stderr: {err})")
-        check(json.loads(out) == {"verdict": "proceed", "reason": "branch is current with base"},
-              f"the CLI should print the proceed verdict, got {out!r}")
+        check(code != 0, f"a CLEAN view without ancestry evidence must fail closed (stderr: {err})")
+        check(json.loads(out) == {
+            "verdict": "recheck",
+            "reason": "could not verify base ancestry: base ancestry requires --worktree and --base",
+        }, f"the CLI should demand base ancestry before proceeding, got {out!r}")
 
 
 def t_cli_rebase_first():
@@ -201,11 +205,119 @@ def t_cli_bad_project_root_fails_closed():
           f"the reason must name the fetch failure, got {result['reason']!r}")
 
 
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(["git", "-C", str(cwd), *args], capture_output=True, text=True, check=False)
+    check(result.returncode == 0,
+          f"git {' '.join(args)} failed in {cwd}: {result.stderr.strip()}")
+    return result
+
+
+def _configure_repo(path: Path) -> None:
+    _git(path, "config", "user.email", "fixture@example.invalid")
+    _git(path, "config", "user.name", "Fixture")
+
+
+def t_clean_view_with_stale_base_rebases():
+    """A prior campaign merge advances main while GitHub still calls the second PR CLEAN."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        remote = root / "remote.git"
+        seed = root / "seed"
+        candidate = root / "candidate"
+
+        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+        result = subprocess.run(["git", "clone", str(remote), str(seed)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+        _configure_repo(seed)
+
+        (seed / "f").write_text("base\n", encoding="utf-8")
+        _git(seed, "add", "f")
+        _git(seed, "commit", "-m", "base")
+        _git(seed, "push", "origin", "main")
+
+        _git(seed, "checkout", "-b", "first")
+        (seed / "first").write_text("first\n", encoding="utf-8")
+        _git(seed, "add", "first")
+        _git(seed, "commit", "-m", "first candidate")
+        _git(seed, "push", "origin", "first")
+
+        _git(seed, "checkout", "main")
+        _git(seed, "checkout", "-b", "second")
+        (seed / "second").write_text("second\n", encoding="utf-8")
+        _git(seed, "add", "second")
+        _git(seed, "commit", "-m", "second candidate")
+        _git(seed, "push", "origin", "second")
+
+        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
+        _configure_repo(candidate)
+        _git(candidate, "checkout", "second")
+
+        # Simulate the first serial campaign merge advancing main after the second PR was reviewed.
+        _git(seed, "checkout", "main")
+        _git(seed, "merge", "--squash", "first")
+        _git(seed, "commit", "-m", "merge first candidate")
+        _git(seed, "push", "origin", "main")
+
+        vjson = root / "clean-view.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+        code, out, err = capture_cli(
+            M.main,
+            ["check", "--pr", "9", "--view-json", str(vjson), "--worktree", str(candidate),
+             "--base", "main"],
+        )
+        check(code != 0,
+              f"a CLEAN view whose worktree lacks the advanced base must stop for rebase (stderr: {err})")
+        check(json.loads(out) == {"verdict": "rebase-first", "reason": "base has moved ahead — rebase first"},
+              f"a stale base must rebase despite CLEAN GitHub enums, got {out!r}")
+
+
+def t_clean_view_with_current_base_proceeds():
+    """A CLEAN PR whose HEAD contains fetched main may proceed."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        remote = root / "remote.git"
+        seed = root / "seed"
+        candidate = root / "candidate"
+
+        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+        result = subprocess.run(["git", "clone", str(remote), str(seed)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+        _configure_repo(seed)
+        (seed / "f").write_text("base\n", encoding="utf-8")
+        _git(seed, "add", "f")
+        _git(seed, "commit", "-m", "base")
+        _git(seed, "push", "origin", "main")
+
+        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
+        _configure_repo(candidate)
+
+        vjson = root / "clean-view.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+        code, out, err = capture_cli(
+            M.main,
+            ["check", "--pr", "9", "--view-json", str(vjson), "--worktree", str(candidate),
+             "--base", "main"],
+        )
+        check(code == 0, f"a candidate containing the fetched base must proceed (stderr: {err})")
+        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check"},
+              f"a current base must permit the candidate, got {out!r}")
+
+
 CASES = [
-    ("clean-proceeds", "CLEAN -> proceed", t_clean_proceeds),
-    ("has-hooks-proceeds", "HAS_HOOKS -> proceed", t_has_hooks_proceeds),
-    ("unstable-proceeds", "UNSTABLE is a check signal, not a stale base -> proceed", t_unstable_proceeds),
-    ("blocked-proceeds", "BLOCKED is a permission signal, not a stale base -> proceed", t_blocked_proceeds),
+    ("clean-proceeds", "CLEAN passes the enum screen", t_clean_proceeds),
+    ("has-hooks-proceeds", "HAS_HOOKS passes the enum screen", t_has_hooks_proceeds),
+    ("unstable-proceeds", "UNSTABLE is a check signal and reaches the graph check", t_unstable_proceeds),
+    ("blocked-proceeds", "BLOCKED is a permission signal and reaches the graph check", t_blocked_proceeds),
     ("dirty-rebases", "DIRTY -> rebase-first", t_dirty_rebases),
     ("behind-rebases", "BEHIND -> rebase-first", t_behind_rebases),
     ("unknown-mergestate-rechecks", "UNKNOWN merge state -> recheck", t_unknown_mergestate_rechecks),
@@ -223,9 +335,13 @@ CASES = [
      t_dirty_with_unknown_mergeable_rechecks),
     ("behind+unknown-mergeable-rechecks", "BEHIND + UNKNOWN mergeable re-polls, never rebases",
      t_behind_with_unknown_mergeable_rechecks),
-    ("cli-proceed", "check --view-json on a CLEAN view exits 0 with proceed", t_cli_proceed),
+    ("cli-missing-ancestry", "a CLEAN view without base ancestry fails closed", t_cli_missing_ancestry_rechecks),
     ("cli-rebase-first", "check --view-json on a DIRTY view exits non-zero with rebase-first", t_cli_rebase_first),
     ("cli-malformed", "a view missing a field fails closed to recheck, never KeyError", t_cli_malformed),
     ("cli-bad-project-root", "an invalid --project-root fails closed to recheck, no traceback",
      t_cli_bad_project_root_fails_closed),
+    ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling rebases",
+     t_clean_view_with_stale_base_rebases),
+    ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",
+     t_clean_view_with_current_base_proceeds),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -2,15 +2,17 @@
 """DECIDE whether a PR's branch is current with its base BEFORE a review or a fix is authored on it.
 
 This enforces the rebase-before-review/fix precondition `stage-2-review-gate.md` states in prose: if a PR
-is CONFLICTING/DIRTY/BEHIND with `<base>`, rebase it before reviewing or fixing. That prose was a rule a
-model re-derived by eye every heartbeat, and a fix authored on a stale/conflicting base is wasted — it is
+conflicts with `<base>` or lacks its refreshed tip, rebase it before reviewing or fixing. GitHub may still
+report MERGEABLE/CLEAN after another campaign PR advances an unprotected base, so the check combines its
+merge states with fetched Git ancestry. A fix authored on a stale/conflicting base is wasted — it is
 re-reviewed against the rebased tip anyway. This turns the prose into an enforced check.
 
-It DECIDES one of `proceed` / `rebase-first` / `recheck` from the live PR view and PERFORMS NO REBASE: the
-driver rebases when told `rebase-first`, then re-runs this. Deciding and doing are two jobs and this is only
-the first — nothing here runs `git rebase`/`git merge` or edits a branch.
+It DECIDES one of `proceed` / `rebase-first` / `recheck` from the live PR view plus fetched base ancestry
+and PERFORMS NO REBASE: the driver rebases when told `rebase-first`, then re-runs this. Deciding and doing
+are two jobs and this is only the first — nothing here runs `git rebase`/`git merge` or edits a branch.
 
     base-preflight.py check --pr 31 [--repo owner/name] [--view-json <path>] [--project-root <dir>]
+        [--worktree <path> --base <branch> [--remote origin]]
     base-preflight.py self-test   run every fixture (base-preflight-test.py)
 
 The verdict is printed as JSON on stdout, and the EXIT CODE gates a caller's `$?`: 0 for `proceed`, non-zero
@@ -48,24 +50,48 @@ RECHECK = "recheck"
 
 # --- the two GitHub enums, as data so `decide` reads ONE source, mapped TOTALLY -------------------
 #
-# The AUTHORITATIVE value sets are GitHub's schema, as `stage-3-merge.md` records them. This tool judges ONLY
-# base-currency, so the two enums are crossed for exactly one question — is the branch current enough with
-# its base? — never for merge-readiness (that is `merge-check.py`'s job, downstream, over the same enums).
-# The mapping below is TOTAL over both sets: every value has a home, and a value in NEITHER set is one GitHub
-# added since — the catch-all in `decide` re-polls it rather than guessing.
+# The AUTHORITATIVE value sets are GitHub's schema, as `stage-3-merge.md` records them. The two enums are
+# crossed only as a pre-screen before the Git ancestry check, never for merge-readiness (that is
+# `merge-check.py`'s job, downstream, over the same enums). The mapping below is TOTAL over both sets: every
+# value has a home, and a value in NEITHER set is one GitHub added since — the catch-all in `decide` re-polls
+# it rather than guessing.
 MERGEABLE_VALUES = frozenset({"MERGEABLE", "CONFLICTING", "UNKNOWN"})
 MERGE_STATE_STATUS_VALUES = frozenset(
     {"DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"})
 
-# The `mergeStateStatus` values that mean the base is CURRENT ENOUGH to author a review/fix on. UNSTABLE and
-# BLOCKED are about CHECKS/PERMISSIONS, NOT a stale base — a non-passing check or a branch-protection block
-# does not make the base moved-ahead, so a fix/review may proceed; this tool judges base-currency alone.
-# DIRTY/BEHIND/UNKNOWN are deliberately ABSENT: each is handled by an earlier rule in `decide`.
+# The `mergeStateStatus` values that pass the ENUM screen. UNSTABLE and BLOCKED are about
+# CHECKS/PERMISSIONS, not a stale base. This is not proof the branch contains the refreshed base; the graph
+# check in `check` supplies that proof. DIRTY/BEHIND/UNKNOWN are deliberately ABSENT: each is handled by an
+# earlier rule in `decide`.
 BASE_CURRENT_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE", "BLOCKED"})
 
 
 def _verdict(verdict: str, reason: str) -> dict:
     return {"verdict": verdict, "reason": reason}
+
+
+def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str) -> tuple[str, str]:
+    """Return ``current``, ``stale``, or ``unverified`` for the fetched base against a PR worktree.
+
+    GitHub may keep reporting ``MERGEABLE/CLEAN`` after another campaign PR advances an unprotected base.
+    The merge-state enums alone therefore cannot prove that a candidate contains the current base. Fetch the
+    named base and ask Git's ancestry graph directly; this updates only the remote-tracking ref, never the
+    candidate branch. Callers treat ``unverified`` as fail-closed.
+    """
+    if not worktree or not base:
+        return "unverified", "base ancestry requires --worktree and --base"
+    fetch = subprocess.run(  # noqa: S603
+        ["git", "-C", worktree, "fetch", remote, base], capture_output=True, text=True, check=False)
+    if fetch.returncode != 0:
+        return "unverified", f"could not fetch {remote}/{base}: {fetch.stderr.strip()}"
+    probe = subprocess.run(  # noqa: S603
+        ["git", "-C", worktree, "merge-base", "--is-ancestor", f"{remote}/{base}", "HEAD"],
+        capture_output=True, text=True, check=False)
+    if probe.returncode == 0:
+        return "current", ""
+    if probe.returncode == 1:
+        return "stale", ""
+    return "unverified", f"could not compare HEAD with {remote}/{base}: {probe.stderr.strip()}"
 
 
 def decide(view: dict) -> dict:
@@ -78,7 +104,8 @@ def decide(view: dict) -> dict:
     `{mergeable: CONFLICTING, mergeStateStatus: UNKNOWN}` or `{..., mergeStateStatus: FROZEN}` (a value GitHub
     added since) must NOT be steered to `rebase-first` on the half of the view we DO recognise while the other
     half is uncomputed or unclassified. UNKNOWN/unrecognised WINS: re-poll and decide again on a full view,
-    never guess. Only a fully computed, recognised, non-conflicting, current view reaches `proceed`.
+    never guess. A fully computed, recognised, non-conflicting view reaches preliminary `proceed`; `check`
+    then verifies the fetched base graph before emitting final `proceed`.
     """
     mergeable = view["mergeable"]
     mss = view["mergeStateStatus"]
@@ -103,9 +130,9 @@ def decide(view: dict) -> dict:
     if mss == "BEHIND":
         return _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
 
-    # 5. CURRENT WITH BASE — mergeable AND a base-current merge state. The one verdict that clears a fix.
+    # 5. ENUM SCREEN PASSES — the graph check in `check` decides whether this becomes final `proceed`.
     if mergeable == "MERGEABLE" and mss in BASE_CURRENT_STATES:
-        return _verdict(PROCEED, "branch is current with base")
+        return _verdict(PROCEED, "GitHub merge state permits base check")
 
     # 6. DEFENSIVE CATCH-ALL — unreachable after step 1 pinned both enums to their schema sets and steps 2-5
     #    covered every recognised combination. Fail closed rather than fall off the end of the function.
@@ -172,8 +199,8 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None",
         raise ViewError(f"gh response is not JSON ({exc})") from exc
 
 
-def check(pr: str, repo: "str | None", view_json: "str | None",
-          project_root: "str | None") -> int:
+def check(pr: str, repo: "str | None", view_json: "str | None", project_root: "str | None",
+          worktree: "str | None", base: "str | None", remote: str) -> int:
     """Fetch the live view, decide, print the verdict as JSON. EXIT 0 only on `proceed`; every other outcome
     (rebase-first, recheck, an unfetchable or malformed view) exits non-zero so a caller can gate on `$?`."""
     try:
@@ -188,6 +215,12 @@ def check(pr: str, repo: "str | None", view_json: "str | None",
         print(json.dumps(_verdict(RECHECK, f"malformed PR view: {problem}")))
         return 1
     result = decide(view)
+    if result["verdict"] == PROCEED:
+        ancestry, detail = check_base_ancestry(worktree, base, remote)
+        if ancestry == "stale":
+            result = _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
+        elif ancestry == "unverified":
+            result = _verdict(RECHECK, f"could not verify base ancestry: {detail}")
     print(json.dumps(result))
     return 0 if result["verdict"] == PROCEED else 1
 
@@ -250,6 +283,9 @@ def main(argv: "list[str] | None" = None) -> int:
     c.add_argument("--repo", help="owner/name (default: the current checkout's)")
     c.add_argument("--view-json", help="a recorded `gh pr view` JSON — decide without calling gh")
     c.add_argument("--project-root", help="run `gh pr view` with this as its working directory")
+    c.add_argument("--worktree", help="the PR-head worktree used for the Git ancestry check")
+    c.add_argument("--base", help="the PR base branch to fetch and compare")
+    c.add_argument("--remote", default="origin", help="the worktree remote holding --base (default: origin)")
 
     sub.add_parser("self-test", help="run every fixture (base-preflight-test.py)")
 
@@ -257,7 +293,8 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.cmd == "self-test":
         return self_test()
-    return check(args.pr, args.repo, args.view_json, args.project_root)
+    return check(args.pr, args.repo, args.view_json, args.project_root,
+                 args.worktree, args.base, args.remote)
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -185,16 +185,61 @@ def t_unknown_mergeable_value_parks():
 # --- CLI: a recorded view makes `check` testable without gh --------------------
 
 def t_cli_injected_view():
-    with tempfile.TemporaryDirectory() as d:
-        led = Path(d) / "state.jsonl"
-        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
-        vjson = Path(d) / "view.json"
-        vjson.write_text(json.dumps(view()), encoding="utf-8")
-        code, out, err = capture_cli(
-            M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
-        check(code == 0, f"the CLI must exit 0 on a computed verdict (stderr: {err})")
-        check(json.loads(out) == {"verdict": "merge", "reason": ""},
-              f"the CLI should print the merge verdict, got {out!r}")
+    real_check = M.B.check_base_ancestry
+    M.B.check_base_ancestry = lambda *_args: ("current", "")
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1", base_branch="main"), [row()])
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view()), encoding="utf-8")
+            code, out, err = capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    finally:
+        M.B.check_base_ancestry = real_check
+    check(code == 0, f"the CLI must exit 0 on a computed verdict (stderr: {err})")
+    check(json.loads(out) == {"verdict": "merge", "reason": ""},
+          f"the CLI should print the merge verdict, got {out!r}")
+
+
+def t_cli_stale_base_blocks_merge():
+    """The final gate repeats base ancestry before it turns a CLEAN candidate into a merge."""
+    real_check = M.B.check_base_ancestry
+    M.B.check_base_ancestry = lambda *_args: ("stale", "")
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1", base_branch="main"), [row()])
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view()), encoding="utf-8")
+            code, out, err = capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    finally:
+        M.B.check_base_ancestry = real_check
+    check(code == 0, f"a stale base is a computed not-yet result (stderr: {err})")
+    check(json.loads(out) == {"verdict": "not-yet", "reason": "base moved ahead — rebase"},
+          f"a CLEAN candidate behind the base must not merge, got {out!r}")
+
+
+def t_cli_unverified_base_blocks_merge():
+    """The final gate fails closed when it cannot read the candidate's base ancestry."""
+    real_check = M.B.check_base_ancestry
+    M.B.check_base_ancestry = lambda *_args: ("unverified", "could not fetch origin/main: unavailable")
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1", base_branch="main"), [row()])
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view()), encoding="utf-8")
+            code, out, err = capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    finally:
+        M.B.check_base_ancestry = real_check
+    check(code != 0, f"unverified base ancestry must fail closed (stderr: {err})")
+    check(json.loads(out) == {
+        "verdict": "not-yet",
+        "reason": "could not verify base ancestry: could not fetch origin/main: unavailable",
+    }, f"an unverified base must block merge, got {out!r}")
 
 
 def t_cli_no_ledger_row():
@@ -293,6 +338,8 @@ CASES = [
     ("mss-unknown-value-parks", "an unrecognised merge state parks (totality)", t_unknown_mergestate_value_parks),
     ("mergeable-unknown-value-parks", "an unrecognised mergeable value parks", t_unknown_mergeable_value_parks),
     ("cli-injected-view", "check --view-json decides without gh and exits 0", t_cli_injected_view),
+    ("cli-stale-base", "a CLEAN candidate behind refreshed base cannot merge", t_cli_stale_base_blocks_merge),
+    ("cli-unverified-base", "an unreadable base ancestry fails closed", t_cli_unverified_base_blocks_merge),
     ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
     ("cli-view-missing-field", "a view missing a field fails closed, never KeyError", t_cli_view_missing_field),
     ("cli-view-wrong-type", "a view field of the wrong JSON type fails closed", t_cli_view_wrong_type_field),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""DECIDE whether a PR may merge — from its ledger row plus its live GitHub view. GATE MACHINERY.
+"""DECIDE whether a PR may merge — from its ledger row, live GitHub view, and fetched base ancestry. GATE MACHINERY.
 
 It prints ONE verdict: `merge` (every precondition met) or `not-yet` with a concrete `reason`. It NEVER
 merges anything, and it wires into no merge step — deciding and doing are two jobs, and this is only the
 first. `gh pr merge` lives in `stage-3-merge.md`, downstream of a `merge` verdict; nothing here runs it.
 
-WHY THIS IS A COMMAND AND NOT A TABLE A DRIVER READS BY EYE. The merge decision crosses FIVE ledger
-preconditions (held, open, draft, live head == reviewed head, ci, reviews) and then TWO GitHub enums
+WHY THIS IS A COMMAND AND NOT A TABLE A DRIVER READS BY EYE. The merge decision crosses the ledger
+preconditions (held, open, draft, live head == reviewed head, ci, reviews, current base) and then TWO GitHub enums
 (`.mergeable` and `.mergeStateStatus`) that answer DIFFERENT questions — `.mergeable` says the branches
 CAN be combined, `.mergeStateStatus` says the merge is PERMITTED RIGHT NOW. Reading one for the other is
 the miscross that once turned a BLOCKED merge into an infinite CI watch (`stage-3-merge.md`): a PR that was
@@ -15,8 +15,10 @@ the miscross that once turned a BLOCKED merge into an infinite CI watch (`stage-
 two enums are crossed, so nobody does it by hand and nobody does it wrong.
 
 `.mergeable = MERGEABLE` is NECESSARY BUT NOT SUFFICIENT: it falls THROUGH to `.mergeStateStatus`, which is
-the only field that yields `merge`. Both enums are mapped TOTALLY — every value GitHub's schema declares has
-its own row, and a value with NO row is a WEDGE, so the catch-all PARKS it rather than guessing. This mapping
+the only field that yields a preliminary `merge`. Before emitting `merge`, the shared preflight helper
+fetches the ledger base and proves it is an ancestor of the candidate `HEAD`. Both enums are mapped TOTALLY
+— every value GitHub's schema declares has its own row, and a value with NO row is a WEDGE, so the catch-all
+PARKS it rather than guessing. This mapping
 is the OWNER of the merge-readiness decision; `references/stage-3-merge.md` now DELEGATES that decision to a
 single `merge-check.py check` call rather than restating it as a by-eye table, and the sibling fixtures pin
 every value's verdict.
@@ -56,6 +58,7 @@ def _load(name: str, filename: str):
 # status — or any other non-`in_review` status — is frozen by that allow-list with no edit here.
 L = _load("merge_check_ledger", "ledger.py")
 HELD_STATUSES = L.HELD_STATUSES
+B = _load("merge_check_base_preflight", "base-preflight.py")
 
 # `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped. The rule already lives in `nudge.py`
 # (and `review-pass.py`); a third copy here would be the drift this repo keeps killing. So merge-check
@@ -235,7 +238,7 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
 def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None") -> int:
     """Read the ledger row + the live view, decide, print the verdict as JSON. Exit 0 on a computed verdict;
     a view that could not be fetched is a fail-closed not-yet, and a non-zero exit is fine there."""
-    _header, rows = L.load(ledger_path)
+    header, rows = L.load(ledger_path)
     row = next((r for r in rows if r["pr"] == str(pr)), None)
     if row is None:
         print(json.dumps(_not_yet("no ledger row")))
@@ -251,7 +254,22 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
     if problem is not None:
         print(json.dumps(_not_yet(f"malformed PR view: {problem}")))
         return 1
-    print(json.dumps(decide(row, view, required=REQUIRED)))
+    result = decide(row, view, required=REQUIRED)
+    if result["verdict"] != MERGE:
+        print(json.dumps(result))
+        return 0
+
+    # GitHub may still call the PR MERGEABLE/CLEAN after an earlier campaign merge advances an unprotected
+    # base. Re-fetch and compare actual ancestry before the final merge decision; the shared preflight helper
+    # owns the graph check so review dispatch and Stage 3 cannot disagree about what "current base" means.
+    ancestry, detail = B.check_base_ancestry(row.get("worktree"), header.get("base_branch"), "origin")
+    if ancestry == "stale":
+        print(json.dumps(_not_yet("base moved ahead — rebase")))
+        return 0
+    if ancestry == "unverified":
+        print(json.dumps(_not_yet(f"could not verify base ancestry: {detail}")))
+        return 1
+    print(json.dumps(result))
     return 0
 
 


### PR DESCRIPTION
- Revalidate CLEAN candidates against refreshed base ancestry after each campaign merge.
- Block final merges until the candidate contains the current base.
- Fixes #118.
