### PR TITLE
add canonical campaign PR snapshot fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,17 +316,13 @@ jobs:
       - name: Label-mirror contract (the gate and its label move together)
         run: python3 plugins/gauntlet/skills/campaign/scripts/label-mirror.py self-test
 
-      # The reconcile detector's contract, executed. `reconcile.py detect` does the MECHANICAL half of the
-      # per-heartbeat reconcile (loop-control.md step 1): compare the batched `prs.json` snapshot against the
-      # ledger and emit the per-PR FACTS — a live row ABSENT from an `--state open` snapshot is the
-      # merged/closed-by-absence signal (a FACT, exit 0, never an error, never a `gh` fetch to "resolve" it),
-      # plus head/base/branch changes, verbatim state/merge/label observations, and unadopted candidates. It
-      # NAMES NO ACTION; routing each fact is skill prose. `self-test` runs the sibling FIXTURES
-      # (`reconcile-test.py`, loaded by path; a MISSING sibling fails loudly), which pin the exact facts
-      # object AND the fail-closed refusals (missing/null/wrong-typed canonical field, a snapshot entry
-      # outside the run's label scope, a non-array or corrupt input) at exit 2 with empty stdout. One fixture
-      # asserts the tool's canonical field set has not drifted from the command that WRITES `prs.json`.
-      - name: Reconcile detector contract (facts only; routing stays in the skill)
+      # The reconcile fetch/detect contract, executed. `fetch` owns the canonical run-scoped query,
+      # validates its raw response, refuses possible truncation, and atomically promotes `prs.json` while
+      # preserving the prior file on failure. `detect` compares that snapshot against the ledger and emits
+      # per-PR FACTS only; routing stays in skill prose. The sibling fixtures pin exact argv, hostile typed
+      # paths, byte capture, response refusals, atomic preservation, fetch-then-detect consistency, and the
+      # detector's existing fact/refusal matrix. A missing sibling fails loudly.
+      - name: Reconcile snapshot contract (fetch + facts; routing stays in the skill)
         run: python3 plugins/gauntlet/skills/campaign/scripts/reconcile.py self-test
 
       # The Bundled Scripts table in campaign's SKILL.md declares itself COMPLETE: one row per bundled

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -103,7 +103,8 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 
 8. At heartbeat entry, once you own the run and load its ledger, run `nudge.py` and READ its advisory
    reminders — computed from durable state, decides nothing, always exits 0 (`references/loop-control.md`
-   step 1). Then reconcile the run's PR snapshot (treat `state.jsonl` as cache) and fold completed
+   step 1). Then produce the run's validated PR snapshot through `reconcile.py fetch`, reconcile it
+   through `reconcile.py detect` (treat `state.jsonl` as cache), and fold completed
    review / CI / fix tasks against the SHA each ran on. When the run is **QUIET** (nudge, no meaningful
    ledger activity for its window) **OR** `ledger.py watchdog check` says the long-cadence deadline is
    `due`/`unset`/`invalid`, run the **health pass** (one pass, then one `ledger.py watchdog arm`)
@@ -256,7 +257,7 @@ a line the tool writes.
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |
 | `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row, live PR view, and fetched base ancestry | `references/stage-3-merge.md` |
 | `label-mirror.py` | `mirror` — reconcile a PR's status label with its review gate (the canonical idempotent `gauntlet-accepted`/`gauntlet-reviewing` swap), computed from the ledger row; touches only the two status labels | `references/stage-2-review-gate.md` |
-| `reconcile.py` | `detect` — compare the batched `prs.json` snapshot against the ledger and emit the per-PR reconcile FACTS (absent-by-absence, head/base/branch change, verbatim state/merge/label observations, unadopted candidates); names no action — routing is the skill's | `references/loop-control.md` |
+| `reconcile.py` | `fetch` — construct, validate, and atomically promote the canonical run-scoped PR snapshot; `detect` — compare it against the ledger and emit per-PR FACTS. Names no action; routing is skill policy | `references/files-and-ledger.md`, `references/loop-control.md` |
 | `repair-pass.py` | Reassessment pass's door: `permitted` / `decide` — the closed decision enum, ownership guardrail, repair cap | `references/repair-pass.md` |
 | `followups.py` | Schema-owning accessor for the follow-up store (`.gauntlet/followups.jsonl`) — a durable work QUEUE, not an archive: entries are deleted once recorded elsewhere, kept when nothing else would remember | `references/followups.md` |
 | `carryover.py` | `distill` — project a run's TERMINAL ledger into `.gauntlet/history/<run-id>.md` on normal exit: merged/aborted/API-declined facts, exactly once (refuses a live run and refuses to overwrite) | `references/carryover.md` |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -99,13 +99,10 @@
 - Stop a PR's in-flight review before dispatching content-changing work on it (review fix, CI fix,
   copilot-address, conflict-resolving rebase): a verdict on a doomed SHA wastes tokens and a review
   slot. Refill the slot with the next due review.
-- Reconcile from ONE batched `gh pr list` snapshot per heartbeat (`<rundir>/prs.json`), written with the
-  **canonical `prs.json` command — the single owning definition is the block "The canonical `prs.json`
-  command" in `files-and-ledger.md`**, which spells it in full, label and output path included (**ONE
-  path, ONE schema, ONE command**). Never spell a variant of it here or anywhere else, and **NEVER drop
-  `--label gauntlet-run-<run-id>` or `--limit 1000`**: without `--label` the snapshot escapes the run's
-  scope and reconcile would act on **other runs' PRs**, and without `--limit` `gh pr list` silently caps
-  at **30**. Per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth stays the
+- Reconcile from ONE batched snapshot per heartbeat (`<rundir>/prs.json`) through **`scripts/reconcile.py
+  fetch`**. `files-and-ledger.md`, **"The canonical `prs.json` command"**, owns the typed invocation;
+  the executable owns query scope, fields, result bound, validation, and atomic promotion. NEVER
+  reconstruct its GitHub query. Per-PR `gh` calls only where the snapshot falls short. Merge-gate CI truth stays the
   SHA-pinned, SHA-verified snapshot of **both** check families (Stage 2b).
 - Carryover pruning NEVER blocks a fresh-run start: keep uncertain entries, adopt the run's PRs
   immediately, ask the user asynchronously, and fold the answer in as its own heartbeat.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -9,7 +9,7 @@ resume, reuse the existing dir). Per-run dirs are what keep concurrent runs' fil
 |------|----------|
 | `state.jsonl` | Live per-PR ledger — a **cache/hint**, not the source of truth (see below) |
 | `pr-<pr>.json` | `gh pr view` snapshot captured at adoption (PR facts the ledger row is built from) |
-| `prs.json` | Batched `gh pr list` snapshot of this run's PRs — the per-heartbeat reconcile input, and the adoption/discovery input. **ONE path, ONE schema, ONE command**: the canonical command is spelled in full in **"The canonical `prs.json` command"**, the command block directly below this table, and that block is its ONLY definition. The per-heartbeat comparison of this file against the ledger is MECHANICAL and owned by **`scripts/reconcile.py detect`**, which emits the per-PR reconcile **facts** (routing them is skill policy — `loop-control.md`, step 1) |
+| `prs.json` | Batched snapshot of this run's PRs — adoption/discovery + per-heartbeat reconcile input. **`scripts/reconcile.py fetch` is the ONE executable producer**: it owns query argv, schema validation, scope validation, truncation refusal, and atomic promotion. **`scripts/reconcile.py detect` is the ONE consumer**: it emits per-PR reconcile facts. Routing remains skill policy (`loop-control.md`, "Step 1 — reconcile from ground truth") |
 | `lease.json` | This run's active-driver lease — read/written ONLY through `scripts/lease.py` (see "Run lease") |
 | `review-<pr>-<n>.prompt.txt` | The reviewer prompt for round `n`, launch attempt 1, with the verbatim intent and JSON-encoded typed transport record bound as data. Written through `runtime-adapter.md`'s `write_bytes` and passed through `dispatch_native` or `run_argv` — never embedded in shell source (`stage-2-review-gate.md`) |
 | `review-<pr>-<n>.txt` | The reviewer's PR review output, round `n` (launch attempt 1), written by the sole producer assigned in `runtime-adapter.md`'s typed review record |
@@ -23,50 +23,36 @@ resume, reuse the existing dir). Per-run dirs are what keep concurrent runs' fil
 | `repair-<pr>-<k>.md` | The **reassessment pass**'s decision record for repair `k`: the whole round-by-round history it was handed, the ONE decision it returned, and why (`repair-pass.md`). Written **before** the decision is recorded — `repair-pass.py decide` refuses a `--record` that is missing or empty, because a heartbeat is a fresh agent instance and a justification held only in a dead agent's context can never be audited |
 | `abort-<id>.md` | Detailed log for an aborted PR-task |
 
-**The canonical `prs.json` command — this block is THE definition.** Every other site defers to it, and
-**NO site may spell a variant of it** — differing spellings are how a reader of `prs.json` ends up with
-a file that is scoped wrong or missing the fields it reads. It is the typed `run_argv` operation from
-`runtime-adapter.md`: every `gh pr list` option is its own argv element, and the output path is a typed
-`Path` in `stdout_file` — never a shell redirection, so it keeps dynamic paths out of shell source and a
-`<rundir>` containing a space stays one intact path. Copy it whole, including the `--label` filter and the
-`stdout_file` path:
+**The canonical `prs.json` command — `scripts/reconcile.py fetch` is THE definition.** Every other site
+defers here and NEVER reconstructs its internal GitHub query. Resolve script from active `SKILL.md`, then
+launch this typed operation (`skill_dir` = absolute directory containing active `SKILL.md`):
 
 ```text
 run_argv(
-  argv: ["gh", "pr", "list", "--label", concat("gauntlet-run-", run_id),
-         "--state", "open", "--limit", "1000",
-         "--json", "number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels"],
+  argv: ["python3", path_join(skill_dir, "scripts", "reconcile.py"), "fetch",
+         "--project-root", repository.project_root,
+         "--run-id", run_id,
+         "--output", path_join(<rundir>, "prs.json")],
   cwd: repository.project_root,
   stdin_file: null,
-  stdout_file: path_join(<rundir>, "prs.json")
+  stdout_file: null
 )
 ```
 
-`pr-adoption.md` (discovery) and `loop-control.md`'s per-heartbeat PR scan (the `prs.json` block in step 1)
-each run this command
-inline, **identically** — same label, same flags, same `--json` field set, same path. That is intended:
-they are the same scan. What is forbidden is a **different** spelling anywhere.
+`fetch` builds the fixed `gh pr list` argv internally. It captures stdout as bytes without shell source,
+validates JSON shape + every required field + every row's run label, rejects a response at its result cap,
+then promotes the exact bytes through a same-directory atomic rename. Any command, validation, or promotion
+failure leaves the previous `prs.json` intact.
 
 Every part is load-bearing:
 
-- **Without `--label gauntlet-run-<run-id>`** the snapshot escapes the run's scope: the listing returns
-  **every PR in the repo** instead of this run's, and reconcile would then act on — adopt, relabel,
-  even merge — **other runs' PRs**. That is a **run-isolation violation**, and run isolation is the
-  property that lets concurrent runs coexist in one repo.
-- **Without `--limit`** `gh pr list` silently caps at **30** items, writing a truncated file that
-  reconcile reads as the complete run snapshot.
-- **Without `--json <the field set above>`** the reader finds no `labels`/`mergeable`/`headRefOid` —
-  two writers with different field sets silently hand the reader a file missing the fields it reads.
-- **Without the `stdout_file` `Path` (`path_join(<rundir>, "prs.json")`)** the snapshot lands somewhere
-  nobody reads, and reconcile reads a file nobody wrote. It is a typed `Path`, never a shell redirection,
-  so a `<rundir>` carrying a space stays one intact path instead of triggering a bash "ambiguous
-  redirect".
+- **Use the typed project root + output path.** `fetch` refuses relative paths and output paths outside
+  project root before it launches GitHub CLI.
+- **Use the exact run ID.** `fetch` forms the owner label as an argv value and verifies it on every row.
+- **Treat exit 0 as promotion success.** A refusal emits no replacement artifact.
 
-**`prs.json` is a BOUNDED snapshot, not a proof of completeness.** `--limit 1000` defeats the default-30
-truncation; it does **not** make the snapshot provably complete — a run with more than 1000 labelled PRs
-would still truncate. That matters because **an absent PR is indistinguishable from a PR that was never
-adopted**: a dropped row does not error, it just quietly stops being reconciled. Treat "every labelled PR
-is in `prs.json`" as an assumption bounded by that cap, never as a guarantee.
+**`fetch` refuses the query's result-cap boundary.** At that exact row count, completeness is unknown and
+absence cannot be evidence. Split campaign into smaller runs; NEVER detect against the refused response.
 
 Store ALL reviewer and `gh` output under `<rundir>` first, then Read/Grep it. NEVER `/tmp/`.
 
@@ -99,7 +85,7 @@ git-ignored driver bookkeeping, and that is the extent of campaign's on-disk foo
 ### The ledger — `state.jsonl`
 
 One row per adopted PR. It is a **cache**, not the authoritative state — **ground truth is
-GitHub via `gh`, plus local worktrees** (`gh pr list/view` for PRs and merged/open state, each PR's
+GitHub via `gh`, plus local worktrees** (`reconcile.py fetch` + per-PR `gh pr view` for PRs and state, each PR's
 `headRefOid` from `gh` — keyed by PR number — for the live head SHA, a **SHA-pinned** `check-runs` +
 commit-`status` fetch for live CI, and
 the **active launch attempt's** review output files for which verdicts exist on which SHA —

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -62,23 +62,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      that lists the set's members here is a **restatement** that goes stale the moment the set gains a
      member (this line's did, when `ci_stalled_since` joined).
 
-     Do the PR scan as
-     **one batched snapshot per heartbeat** — the **same canonical command** `pr-adoption.md` runs, writing the
-     **same path with the same schema** (they are the same scan; two spellings of it is how a reader of
-     `prs.json` ends up with fields that are not there, or a snapshot scoped to the wrong PRs). Its owning
-     definition is the block **"The canonical `prs.json` command"** in `files-and-ledger.md`; copy it
-     whole, never a variant:
-
-     ```text
-     run_argv(
-       argv: ["gh", "pr", "list", "--label", concat("gauntlet-run-", run_id),
-              "--state", "open", "--limit", "1000",
-              "--json", "number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels"],
-       cwd: repository.project_root,
-       stdin_file: null,
-       stdout_file: path_join(<rundir>, "prs.json")
-     )
-     ```
+     Produce **one batched snapshot per heartbeat** through **"The canonical `prs.json` command"** in
+     `files-and-ledger.md`. Its executable owner is `scripts/reconcile.py fetch`; NEVER reconstruct its
+     GitHub query. A refusal leaves the prior file intact, but that prior file is not current evidence →
+     stop this reconcile and handle the reported blocker.
 
      — then **compare that snapshot against the ledger by running
      `scripts/reconcile.py detect --ledger <rundir>/state.jsonl --prs <rundir>/prs.json --run-id
@@ -91,9 +78,9 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      not a tool failure, so `detect` exits 0 on it; it fails closed only on a snapshot that is not
      evidence). Route each fact to the rule that already governs it — the rules are unchanged, this only
      names which fact triggers which:
-     - **`absent_from_snapshot`** — a live row whose PR **dropped out of the `--state open` snapshot**: it
-       merged or closed, and **that absence IS the signal** (`files-and-ledger.md`, the `prs.json`
-       bounded-snapshot caveat). Handle it as a **terminal** PR (this step's finished-run cases; the Stage 3
+     - **`absent_from_snapshot`** — a live row whose PR dropped out of the validated canonical snapshot:
+       it merged or closed, and **that absence IS the signal** (`scripts/reconcile.py fetch` owns the
+       query contract). Handle it as a **terminal** PR (this step's finished-run cases; the Stage 3
        drain sets `merged`). **NEVER read absence as an error, and NEVER fetch anything to "resolve" it** —
        a past change broke adoption by "fixing" absence with `--state all` (repo `CLAUDE.md`).
      - **`head_moved`** — the live head differs from the row's `head_sha`: this is the **gate-reset and

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -6,29 +6,16 @@ them into the run and start their gate work.
 
 Two entry paths feed it (see "Run identity and concurrency" for the full grammar):
 - **explicit `#PR` args** (`<campaign-invocation> #12 #15`) — adopt exactly those PRs.
-- **no-arg discovery** (`<campaign-invocation>`, resume) — reconcile the PRs already labelled for this run:
+- **no-arg discovery** (`<campaign-invocation>`, resume) — run **"The canonical `prs.json` command"**
+  from `files-and-ledger.md`, then reconcile PRs already labelled for this run. The executable owner is
+  `scripts/reconcile.py fetch`; NEVER reconstruct its GitHub query in prose.
 
-  ```text
-  # THE canonical run snapshot — the SAME command loop-control's per-heartbeat PR scan (the `prs.json`
-  # block in step 1) runs. ONE path, ONE schema.
-  # Owning definition: "The canonical `prs.json` command" in files-and-ledger.md. Copy it whole;
-  # never spell a variant.
-  run_argv(
-    argv: ["gh", "pr", "list", "--label", concat("gauntlet-run-", run_id),
-           "--state", "open", "--limit", "1000",
-           "--json", "number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels"],
-    cwd: repository.project_root,
-    stdin_file: null,
-    stdout_file: path_join(<rundir>, "prs.json")
-  )
-  ```
-
-  Every open PR carrying this run's owner label is already ours — refresh its row from that snapshot.
+  Every PR returned by the canonical snapshot is already ours — refresh its row from that snapshot.
   A PR with the label but no row is a re-adoption after an amnesiac heartbeat; a row whose PR is gone
   (merged/closed) reconciles to its terminal status.
 
-  **`--limit` is NOT optional** — `gh pr list` silently caps at **30** items without it, and a truncated
-  snapshot loses rows silently (`files-and-ledger.md`, `prs.json`).
+  A fetch refusal produces no discovery input. Keep the previous snapshot untouched and resolve the
+  reported blocker before adoption.
 
 `base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
 **must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fixtures for `reconcile.py` — the ledger-vs-snapshot FACT detector.
+"""Fixtures for `reconcile.py` — canonical snapshot fetch + ledger FACT detection.
 
 They live in a SIBLING file, and `reconcile.py self-test` FAILS LOUDLY if it cannot load them.
 
@@ -20,7 +20,7 @@ Two decisions this suite PINS, because they are the ones a reader would otherwis
 from __future__ import annotations
 
 import json
-import re
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -28,7 +28,6 @@ from _gauntlet.modules import load_module_from_path
 from _gauntlet.testing import capture_cli
 
 OWNER = Path(__file__).resolve().parent / "reconcile.py"
-REFERENCES = Path(__file__).resolve().parent.parent / "references"
 
 
 def _load_owner():
@@ -107,6 +106,173 @@ def scenario(rows, entries, *, base_branch="main", run_id=RUN_ID):
         ledger = build_ledger(d, rows, base_branch=base_branch)
         prs = build_prs(d, entries)
         return run(ledger, prs, run_id=run_id)
+
+
+def fetch_paths(tmp: str, *, hostile: bool = False) -> "tuple[Path, Path]":
+    root_name = "project with space\nand newline" if hostile else "project"
+    output_name = "prs ; $(never-executed).json" if hostile else "prs.json"
+    project_root = Path(tmp) / root_name
+    output = project_root / ".gauntlet" / "tmp" / "run dir" / output_name
+    output.parent.mkdir(parents=True)
+    return project_root, output
+
+
+def response_bytes(entries) -> bytes:
+    return (json.dumps(entries, ensure_ascii=False, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+class RecordedRunner:
+    def __init__(self, stdout: bytes, returncode: int, stderr: bytes) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+        self.calls: list[tuple[list[str], dict]] = []
+
+    def __call__(self, argv: list[str], **kwargs) -> "subprocess.CompletedProcess[bytes]":
+        self.calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(
+            argv, self.returncode, stdout=self.stdout, stderr=self.stderr)
+
+
+def completed(stdout: bytes, *, returncode: int = 0, stderr: bytes = b"") -> RecordedRunner:
+    return RecordedRunner(stdout, returncode, stderr)
+
+
+def expect_fetch_refusal(project_root: Path, output: Path, run_id: str, runner, needle: str) -> None:
+    try:
+        M.fetch_snapshot(project_root, output, run_id, runner=runner)
+    except M.Refusal as exc:
+        check(needle in str(exc), f"refusal did not name {needle!r}: {exc}")
+    else:
+        raise M.SelfTestFailure(f"fetch unexpectedly accepted response; wanted refusal naming {needle!r}")
+
+
+# --- canonical fetch ---------------------------------------------------------
+
+def t_fetch_exact_argv_and_raw_bytes():
+    hostile_run_id = "run with space;$(never-executed)\nand newline"
+    hostile_label = M.RUN_LABEL_PREFIX + hostile_run_id
+    item = entry(41, title="snowman ☃", label_names=[hostile_label, REVIEWING])
+    payload = response_bytes([item])
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d, hostile=True)
+        runner = completed(payload)
+        count = M.fetch_snapshot(project_root, output, hostile_run_id, runner=runner)
+
+        expected = [
+            "gh", "pr", "list",
+            "--label", hostile_label,
+            "--state", "open",
+            "--limit", "1000",
+            "--json", "number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels",
+        ]
+        check(runner.calls == [(expected, {
+            "cwd": project_root, "capture_output": True, "check": False,
+        })], f"fetch argv/cwd drifted or passed through a shell: {runner.calls!r}")
+        check(count == 1, f"one response row must yield count 1, got {count}")
+        check(output.read_bytes() == payload,
+              "fetch did not promote the exact captured stdout bytes (Unicode or whitespace changed)")
+        check(not (project_root / "never-executed").exists(),
+              "hostile argv/path text was interpreted instead of passed as data")
+
+
+def t_fetch_malformed_and_missing_field_preserve_old():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        old = b"previous snapshot\n"
+        output.write_bytes(old)
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(b"not json\n"), "not valid JSON")
+        check(output.read_bytes() == old, "malformed JSON replaced the previous snapshot")
+
+        missing = entry(41)
+        del missing["headRefOid"]
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes([missing])),
+                             "headRefOid")
+        check(output.read_bytes() == old, "missing-field response replaced the previous snapshot")
+
+
+def t_fetch_non_utf8_preserves_old():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(b"\xff\xfe"), "not UTF-8")
+        check(output.read_bytes() == b"old", "non-UTF-8 response replaced the previous snapshot")
+
+
+def t_fetch_wrong_label_preserves_old():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        foreign = entry(41, label_names=["gauntlet-run-other", REVIEWING])
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes([foreign])), RUN_LABEL)
+        check(output.read_bytes() == b"old", "wrong-label response replaced the previous snapshot")
+
+
+def t_fetch_limit_boundary_refused():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        rows = [entry(n) for n in range(M.SNAPSHOT_LIMIT)]
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes(rows)), "may be truncated")
+        check(output.read_bytes() == b"old", "limit-boundary response replaced the previous snapshot")
+
+
+def t_fetch_command_failures_preserve_old():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        expect_fetch_refusal(project_root, output, RUN_ID,
+                             completed(b"partial", returncode=7, stderr=b"network failed"), "exited 7")
+        check(output.read_bytes() == b"old", "non-zero gh response replaced the previous snapshot")
+
+        def cannot_spawn(argv, **kwargs):
+            raise FileNotFoundError("gh missing")
+
+        expect_fetch_refusal(project_root, output, RUN_ID, cannot_spawn, "could not run")
+        check(output.read_bytes() == b"old", "spawn failure replaced the previous snapshot")
+
+
+def t_fetch_replace_failure_preserves_old_and_cleans_temp():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        real_replace = M.os.replace
+
+        def fail_replace(source, target):
+            raise OSError("simulated replace failure")
+
+        M.os.replace = fail_replace
+        try:
+            expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes([entry(41)])),
+                                 "atomically promote")
+        finally:
+            M.os.replace = real_replace
+        check(output.read_bytes() == b"old", "failed atomic replace damaged the previous snapshot")
+        leftovers = list(output.parent.glob(f".{output.name}.*.tmp"))
+        check(leftovers == [], f"failed atomic replace left temp artifacts: {leftovers!r}")
+
+
+def t_fetch_rejects_untyped_or_escaping_paths():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        runner = completed(response_bytes([]))
+        expect_fetch_refusal(Path("relative-root"), output, RUN_ID, runner, "absolute")
+        expect_fetch_refusal(project_root, Path("relative-output"), RUN_ID, runner, "absolute")
+        outside = Path(d) / "outside.json"
+        expect_fetch_refusal(project_root, outside, RUN_ID, runner, "stay under")
+        check(runner.calls == [], "invalid typed paths reached gh instead of failing before the fetch")
+
+
+def t_fetch_then_detect_consistent():
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        ledger = build_ledger(output.parent, [row(41)])
+        count = M.fetch_snapshot(project_root, output, RUN_ID, runner=completed(response_bytes([entry(41)])))
+        facts = M.detect(ledger, output, RUN_ID)
+        check(count == 1 and facts["counts"]["snapshot_entries"] == 1,
+              f"fetch and detect disagree about snapshot size: {count}, {facts!r}")
+        check(facts["rows"]["41"]["absent_from_snapshot"] is False,
+              f"detect did not consume the fetched row: {facts!r}")
 
 
 # --- happy-path facts ---------------------------------------------------------
@@ -287,7 +453,7 @@ def t_missing_canonical_field_refused():
     check(code == 2, f"a missing canonical field must exit 2 (fail closed), got {code}")
     check(out.strip() == "", f"a refusal must print NO facts to stdout, got {out!r}")
     check("headRefOid" in err, f"the refusal must NAME the missing field, got {err!r}")
-    check("files-and-ledger.md" in err, f"the refusal must point at the canonical block, got {err!r}")
+    check("reconcile.py fetch" in err, f"the refusal must point at the executable owner, got {err!r}")
 
 
 def t_null_canonical_field_refused():
@@ -389,22 +555,24 @@ def t_corrupt_ledger_refused():
     check("schema owner" in err, f"the refusal must attribute it to the ledger owner, got {err!r}")
 
 
-# --- anti-drift: the canonical field set matches the doc that OWNS the command --
-
-def t_canonical_fields_match_the_doc():
-    doc = (REFERENCES / "files-and-ledger.md").read_text(encoding="utf-8")
-    matches = re.findall(r'"--json",\s*"([^"]+)"', doc)
-    check(len(matches) == 1,
-          f"expected exactly one `--json` field list in files-and-ledger.md's canonical block, "
-          f"found {len(matches)} — the anchor this check reads moved")
-    doc_fields = tuple(matches[0].split(","))
-    check(doc_fields == M.CANONICAL_FIELDS,
-          f"reconcile.CANONICAL_FIELDS {M.CANONICAL_FIELDS!r} has DRIFTED from the canonical command's "
-          f"field set {doc_fields!r} — a field added to the command must be added to the detector, or a "
-          f"fact silently goes unread")
-
-
 CASES = [
+    ("fetch-exact-argv", "fetch owns exact label/state/limit/fields argv and captures raw bytes",
+     t_fetch_exact_argv_and_raw_bytes),
+    ("fetch-refuse-malformed", "malformed/missing-field output preserves the old snapshot",
+     t_fetch_malformed_and_missing_field_preserve_old),
+    ("fetch-refuse-non-utf8", "non-UTF-8 output preserves the old snapshot", t_fetch_non_utf8_preserves_old),
+    ("fetch-refuse-wrong-label", "every fetched row must carry this run's label",
+     t_fetch_wrong_label_preserves_old),
+    ("fetch-refuse-limit", "a response at the limit boundary may be truncated and is refused",
+     t_fetch_limit_boundary_refused),
+    ("fetch-command-failures", "non-zero and spawn failures preserve the old snapshot",
+     t_fetch_command_failures_preserve_old),
+    ("fetch-atomic-preserve", "failed atomic promotion preserves old bytes and cleans its temp",
+     t_fetch_replace_failure_preserves_old_and_cleans_temp),
+    ("fetch-typed-paths", "relative or escaping paths refuse before gh runs",
+     t_fetch_rejects_untyped_or_escaping_paths),
+    ("fetch-then-detect", "detect consumes exactly the snapshot fetch validated and promoted",
+     t_fetch_then_detect_consistent),
     ("all-quiet", "a present, unchanged live row -> only neutral observations", t_all_quiet),
     ("merged-by-absence", "an absent live row -> absent_from_snapshot:true, exit 0, NOT an error",
      t_merged_by_absence),
@@ -442,6 +610,4 @@ CASES = [
     ("refuse-missing-ledger", "a missing ledger -> exit 2", t_missing_ledger_refused),
     ("refuse-corrupt-ledger", "a corrupt ledger -> exit 2, attributed to the schema owner",
      t_corrupt_ledger_refused),
-    ("canonical-fields-match-doc", "reconcile.CANONICAL_FIELDS == the canonical command's field set",
-     t_canonical_fields_match_the_doc),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -1,34 +1,38 @@
 #!/usr/bin/env python3
-"""COMPARE the batched `prs.json` snapshot against the ledger and emit the per-PR FACTS — nothing else.
+"""FETCH the canonical `prs.json` snapshot, then compare it against the ledger as FACTS.
 
-This tool does the MECHANICAL half of the per-heartbeat reconcile (`references/loop-control.md`, step 1):
-line up each ledger row against the run's `prs.json` snapshot and report, per PR, what is OBSERVABLY
-different. It NAMES NO ACTION. Whether a fact means "refresh the row", "reset the gate", "adopt a
-candidate", "handle a terminal PR" — that routing is CAMPAIGN POLICY and stays in the skill prose. The
-tool observes; loop-control.md step 1 routes. That split is the whole point: detection is deterministic
-and testable, routing is judgement, and mixing them is how a routing bug hides inside a comparison.
+This tool owns both MECHANICAL halves of the per-heartbeat reconcile (`references/loop-control.md`,
+"Step 1 — reconcile from ground truth"):
 
+* `fetch` constructs the ONE canonical `gh pr list` argv internally, captures stdout as bytes, validates
+  the complete snapshot contract, and atomically promotes it to `prs.json`.
+* `detect` lines up each ledger row against that file and reports what is OBSERVABLY different.
+
+Neither command names an action. Whether a fact means "refresh the row", "reset the gate", "adopt a
+candidate", or "handle a terminal PR" is CAMPAIGN POLICY and stays in the skill prose. The tool observes;
+loop-control.md routes. That split keeps detection deterministic without asking each driver to reconstruct
+the query whose bytes detection consumes.
+
+    reconcile.py fetch --project-root <project-root> --run-id <id> --output <rundir>/prs.json
     reconcile.py detect --ledger <state.jsonl> --prs <rundir>/prs.json --run-id <id>
 
-`--run-id` is used ONLY to validate label scope: every snapshot entry MUST carry this run's
-`gauntlet-run-<run-id>` label, because the canonical command that WRITES `prs.json` scopes the listing to
-exactly that label (`references/files-and-ledger.md`, "The canonical `prs.json` command"). A snapshot that
-escaped that scope is the run-isolation violation the label exists to prevent, so the whole file is
-refused — never silently reconciled against another run's PRs.
+`--run-id` selects the label for `fetch` and validates label scope for both commands: every snapshot entry
+MUST carry this run's `gauntlet-run-<run-id>` label. A snapshot that escaped that scope is the run-isolation
+violation the label exists to prevent, so the whole file is refused — never silently reconciled against
+another run's PRs.
 
 FACTS ONLY, and NEUTRAL. The headline signal — a live row that is ABSENT from the snapshot — is the
 MERGED/CLOSED-BY-ABSENCE fact: the canonical command lists `--state open`, so a merged or closed PR simply
 DROPS OUT of the snapshot, and that absence IS the signal (`references/loop-control.md`, step 1). This tool
 reports it as the plain boolean `absent_from_snapshot`; it is NEVER an error, the tool NEVER fetches
-anything to "resolve" it, and routing it (terminal handling) is the skill's job. (A past change broke
+anything per-PR to "resolve" it, and routing it (terminal handling) is the skill's job. (A past change broke
 adoption by "fixing" absence-based merged-detection with `--state all`, which resurrected merged PRs as
 active work — see the repo's CLAUDE.md. Absence is a FACT to report, not a bug to fix.)
 
-NO NETWORK, NO gh, NO WRITES. `detect` is a pure function of two files to one JSON object on stdout. It
-exits 0 whenever the inputs were READABLE — a moved head or a vanished PR is a fact, not a tool failure —
-and exits 2 (fail closed) only when an input is not evidence: a file it cannot read, a `prs.json` that is
-not a JSON array, an entry missing a canonical field or carrying the wrong run label, or a ledger the
-schema owner rejects.
+`detect` performs NO NETWORK or writes. It is a pure function of two files to one JSON object on stdout.
+`fetch` performs one fixed `gh` read and one atomic local promotion. Both fail closed with exit 2 when an
+input or response is not evidence. A failed command, malformed response, wrong-label row, possible
+limit-boundary truncation, or failed promotion leaves any previous `prs.json` byte-for-byte intact.
 
 The fixture suite is the SIBLING `reconcile-test.py`, this tool's executable contract; `self-test` loads
 it by a `__file__`-relative path and FAILS LOUDLY if it is missing — a self-test that passes because it
@@ -39,8 +43,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+from typing import Callable
 
 from _gauntlet.modules import load_module_from_path
 
@@ -59,20 +67,18 @@ def _load(name: str, filename: str):
 # restated — the ledger has exactly one reader, and reconcile is one of its consumers.
 L = _load("reconcile_ledger", "ledger.py")
 
-# The block in `references/files-and-ledger.md` that OWNS the `prs.json` `--json` field set and the run
-# label. Every refusal about a snapshot points a reader there — the command has one definition, and a
-# drifted snapshot is diagnosed against it.
-CANONICAL_BLOCK = '"The canonical `prs.json` command" in references/files-and-ledger.md'
+# This module is the executable owner of the snapshot query and validation contract. Prose points to the
+# `fetch` command instead of restating its argv.
+CANONICAL_BLOCK = '`reconcile.py fetch` (the executable `prs.json` contract)'
 
-# The canonical `--json` field set, as data. This is the set reconcile READS off each snapshot entry, so
-# it must match the field set the canonical command WRITES; `transport-contract-test.py` pins the copies
-# of that command that live in the docs, and `reconcile-test.py` pins this tuple against the doc block, so
-# a field added to the command and not here (or vice versa) fails a test rather than silently dropping a
-# fact. Owner of the command: CANONICAL_BLOCK.
+# The canonical `--json` field set, as data. `fetch_argv` writes exactly this set and the validators read
+# exactly this set, so one tuple binds producer and consumer without a prose copy.
 CANONICAL_FIELDS: tuple[str, ...] = (
     "number", "headRefName", "headRefOid", "title", "baseRefName",
     "state", "mergeable", "mergeStateStatus", "labels",
 )
+SNAPSHOT_LIMIT = 1000
+SNAPSHOT_STATE = "open"
 
 # The run-owner label prefix (`gauntlet-run-<run-id>`) and the two mutually-exclusive status labels whose
 # presence reconcile REPORTS (never judges). These mirror `pr-adopt.py`/loop-control.md; the labels are a
@@ -105,8 +111,18 @@ _SHAPE_NAME = {str: "a string", int: "an integer", list: "a list", dict: "an obj
 
 
 class Refusal(Exception):
-    """The inputs are not evidence. `detect` fails CLOSED (exit 2) — it NEVER emits facts derived from a
-    snapshot it could not trust, and it never guesses a value a drifted command failed to write."""
+    """The input or response is not evidence. Commands fail closed without promoting or emitting it."""
+
+
+def fetch_argv(run_id: str) -> list[str]:
+    """Return the ONE canonical PR snapshot argv. Dynamic values stay separate typed argv elements."""
+    return [
+        "gh", "pr", "list",
+        "--label", RUN_LABEL_PREFIX + run_id,
+        "--state", SNAPSHOT_STATE,
+        "--limit", str(SNAPSHOT_LIMIT),
+        "--json", ",".join(CANONICAL_FIELDS),
+    ]
 
 
 def sfield(entry: object, key: str, index: int) -> object:
@@ -170,29 +186,18 @@ def label_names(entry: object, index: int) -> list[str]:
     return names
 
 
-def read_snapshot(prs_path: Path, run_id: str) -> "list[dict]":
-    """Read `prs.json`, validate every entry against the canonical contract, and return the entries as
-    typed fact dicts. Any failure raises `Refusal` — this is the fail-closed boundary; nothing downstream
-    reads a raw snapshot value.
+def _validated_entries(data: object, run_id: str, source: str) -> "list[dict]":
+    """Validate decoded snapshot JSON and return typed fact dictionaries.
 
     Each returned dict carries ONLY the canonical fields, at their validated shapes, plus the extracted
     `label_names`. The run-label scope check runs here: an entry that does not carry `gauntlet-run-<run-id>`
-    refuses the WHOLE file (a snapshot that escaped the run's scope cannot be partly trusted)."""
-    run_label = RUN_LABEL_PREFIX + run_id
-    try:
-        raw = prs_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise Refusal(f"cannot read the snapshot at {prs_path}: {exc}")
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise Refusal(f"{prs_path} is not valid JSON ({exc}) — the canonical command writes a JSON array "
-                      f"({CANONICAL_BLOCK}).")
+    refuses the WHOLE response because a snapshot that escaped the run's scope cannot be partly trusted.
+    """
     if not isinstance(data, list):
         raise Refusal(
-            f"{prs_path} is {_SHAPE_NAME.get(type(data), type(data).__name__)}, not a JSON array — the "
-            f"canonical `gh pr list --json …` command writes an ARRAY of PR objects ({CANONICAL_BLOCK}).")
-
+            f"{source} is {_SHAPE_NAME.get(type(data), type(data).__name__)}, not a JSON array — "
+            f"the canonical `gh pr list --json …` response is an ARRAY of PR objects ({CANONICAL_BLOCK}).")
+    run_label = RUN_LABEL_PREFIX + run_id
     entries: list[dict] = []
     seen: dict[str, int] = {}
     for index, entry in enumerate(data):
@@ -201,8 +206,8 @@ def read_snapshot(prs_path: Path, run_id: str) -> "list[dict]":
             raise Refusal(
                 f"prs.json entry #{index} does not carry this run's label {run_label!r} (it has "
                 f"{names!r}) — the snapshot escaped the run's label scope, which is the run-isolation "
-                f"violation the canonical command's `--label` exists to prevent ({CANONICAL_BLOCK}). "
-                f"Refusing the whole file; a snapshot scoped to the wrong PRs is not evidence.")
+                f"violation the canonical fetch's `--label` exists to prevent ({CANONICAL_BLOCK}). "
+                f"Refusing the whole response; a snapshot scoped to the wrong PRs is not evidence.")
         fact = {k: sfield(entry, k, index) for k in CANONICAL_FIELDS if k != "labels"}
         fact["label_names"] = names
         number_key = str(fact["number"])
@@ -210,10 +215,94 @@ def read_snapshot(prs_path: Path, run_id: str) -> "list[dict]":
             raise Refusal(
                 f"prs.json lists PR #{number_key} at both entry #{seen[number_key]} and #{index} — a "
                 f"snapshot that names one PR twice cannot be reconciled deterministically. Refusing the "
-                f"whole file.")
+                f"whole response.")
         seen[number_key] = index
         entries.append(fact)
     return entries
+
+
+def validate_snapshot_bytes(payload: bytes, run_id: str, source: str = "gh response") -> "list[dict]":
+    """Decode and validate raw fetch bytes. No write happens until this returns successfully."""
+    try:
+        raw = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise Refusal(f"{source} is not UTF-8 ({exc}) — undecodable bytes are not snapshot evidence.") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise Refusal(f"{source} is not valid JSON ({exc}) — the canonical fetch must return a JSON array "
+                      f"({CANONICAL_BLOCK}).") from exc
+    return _validated_entries(data, run_id, source)
+
+
+def read_snapshot(prs_path: Path, run_id: str) -> "list[dict]":
+    """Read and validate `prs.json`; any failure raises `Refusal`."""
+    try:
+        payload = prs_path.read_bytes()
+    except OSError as exc:
+        raise Refusal(f"cannot read the snapshot at {prs_path}: {exc}")
+    return validate_snapshot_bytes(payload, run_id, str(prs_path))
+
+
+def _validate_fetch_paths(project_root: Path, output: Path) -> None:
+    """Enforce the runtime adapter's absolute project-root and project-owned output contract."""
+    if not project_root.is_absolute():
+        raise Refusal(f"--project-root must be an absolute typed RepositoryContext path, got {project_root}")
+    if not output.is_absolute():
+        raise Refusal(f"--output must be an absolute typed Path, got {output}")
+    try:
+        root_real = project_root.resolve(strict=True)
+        parent_real = output.parent.resolve(strict=True)
+    except OSError as exc:
+        raise Refusal(f"cannot resolve fetch paths: {exc}") from exc
+    if not root_real.is_dir():
+        raise Refusal(f"--project-root is not a directory: {project_root}")
+    if parent_real != root_real and root_real not in parent_real.parents:
+        raise Refusal(f"--output must stay under --project-root: {output}")
+
+
+def _replace_bytes(path: Path, payload: bytes) -> None:
+    """Atomically promote bytes through a same-directory temp, preserving the prior target on failure."""
+    fd, temp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    temp = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp, path)
+    except BaseException:
+        temp.unlink(missing_ok=True)
+        raise
+
+
+def fetch_snapshot(
+    project_root: Path,
+    output: Path,
+    run_id: str,
+    *,
+    runner: "Callable[..., subprocess.CompletedProcess[bytes]]" = subprocess.run,
+) -> int:
+    """Fetch, validate, and atomically promote one canonical snapshot. Return validated row count."""
+    _validate_fetch_paths(project_root, output)
+    argv = fetch_argv(run_id)
+    try:
+        proc = runner(argv, cwd=project_root, capture_output=True, check=False)
+    except OSError as exc:
+        raise Refusal(f"could not run canonical `gh pr list`: {exc}") from exc
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+        raise Refusal(f"canonical `gh pr list` exited {proc.returncode}: {stderr}")
+    entries = validate_snapshot_bytes(proc.stdout, run_id)
+    if len(entries) >= SNAPSHOT_LIMIT:
+        raise Refusal(
+            f"canonical `gh pr list` returned {len(entries)} rows at its --limit {SNAPSHOT_LIMIT} boundary; "
+            "the response may be truncated, so absence is not evidence and no snapshot was promoted.")
+    try:
+        _replace_bytes(output, proc.stdout)
+    except OSError as exc:
+        raise Refusal(f"could not atomically promote the validated snapshot to {output}: {exc}") from exc
+    return len(entries)
 
 
 def _facts_for_present_row(row: dict, base_branch: str, entry: dict) -> dict:
@@ -328,6 +417,21 @@ def cmd_detect(ledger_path: Path, prs_path: Path, run_id: str) -> int:
     return 0
 
 
+def cmd_fetch(project_root: Path, output: Path, run_id: str) -> int:
+    """Run the canonical fetch and print its result. A refusal emits no stdout and preserves `output`."""
+    try:
+        entries = fetch_snapshot(project_root, output, run_id)
+    except Refusal as exc:
+        print(f"reconcile: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps({
+        "entries": entries,
+        "output": str(output),
+        "run_id": run_id,
+    }, sort_keys=True))
+    return 0
+
+
 # --- self-test: the executable contract lives in the SIBLING module ------------
 
 class SelfTestFailure(AssertionError):
@@ -357,7 +461,7 @@ def self_test() -> int:
     except SelfTestFailure as exc:
         print(f"FAIL     {'sibling-fixtures':34} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
               f"         {exc}")
-        print("\n1 check(s) FAILED — the reconcile detector's contract is broken.")
+        print("\n1 check(s) FAILED — the reconcile fetch/detect contract is broken.")
         return 1
     for name, rule, fn in cases:
         try:
@@ -372,15 +476,21 @@ def self_test() -> int:
             print(f"ok       {name:34} -> {rule}")
     print()
     if failures:
-        print(f"{failures} fixture(s) failed — the reconcile detector's contract is broken.")
+        print(f"{failures} fixture(s) failed — the reconcile fetch/detect contract is broken.")
         return 1
-    print(f"all {len(cases)} fixtures hold — the detector's contract is intact.")
+    print(f"all {len(cases)} fixtures hold — the fetch/detect contract is intact.")
     return 0
 
 
 def main(argv: "list[str] | None" = None) -> int:
     p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
     sub = p.add_subparsers(dest="cmd", required=True)
+
+    f = sub.add_parser("fetch", help="fetch, validate, and atomically promote the canonical prs.json")
+    f.add_argument("--project-root", required=True, type=Path,
+                   help="absolute repository.project_root from the typed RepositoryContext")
+    f.add_argument("--run-id", required=True, help="this run's id — selects and validates its owner label")
+    f.add_argument("--output", required=True, type=Path, help="absolute output path (<rundir>/prs.json)")
 
     d = sub.add_parser("detect", help="emit the per-PR reconcile FACTS (ledger vs prs.json); routes nothing")
     d.add_argument("--ledger", required=True, type=Path, help="the run ledger (<rundir>/state.jsonl)")
@@ -393,6 +503,8 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.cmd == "self-test":
         return self_test()
+    if args.cmd == "fetch":
+        return cmd_fetch(args.project_root, args.output, args.run_id)
     return cmd_detect(args.ledger, args.prs, args.run_id)
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -41,26 +41,28 @@ def check_document_contract() -> None:
     loop_control = read("loop-control.md")
     copilot = (COPILOT / "SKILL.md").read_text(encoding="utf-8")
 
-    # The canonical prs.json snapshot command is the typed run_argv operation, spelled IDENTICALLY at all
-    # three sites — the owning block plus the two mandated copies. The output path is a typed Path in
-    # stdout_file, never a shell redirection (`> <rundir>/prs.json`), so dynamic paths stay out of shell
-    # source and a run directory containing a space stays one intact Path. Compare on whitespace-collapsed
-    # text so the sites' differing code-fence indentation does not read as a variant spelling.
-    prs_json_argv = (
-        'argv: ["gh", "pr", "list", "--label", concat("gauntlet-run-", run_id), '
-        '"--state", "open", "--limit", "1000", '
-        '"--json", "number,headRefName,headRefOid,title,baseRefName,state,mergeable,mergeStateStatus,labels"],'
-    )
-    prs_json_stdout = 'stdout_file: path_join(<rundir>, "prs.json")'
-    prs_json_argv_flat = " ".join(prs_json_argv.split())
-    for name, text in (("files-and-ledger.md", files_ledger),
+    # The canonical prs.json producer is now one executable owner. Only files-and-ledger.md spells the
+    # typed invocation; adoption and heartbeat prose point to it and never reconstruct the internal gh
+    # argv. The output remains a typed Path argument and never enters shell source or stdout redirection.
+    prs_fetch_argv = " ".join(" ".join((
+        'argv: ["python3", path_join(skill_dir, "scripts", "reconcile.py"), "fetch",',
+        '"--project-root", repository.project_root,',
+        '"--run-id", run_id,',
+        '"--output", path_join(<rundir>, "prs.json")],',
+    )).split())
+    require(prs_fetch_argv in " ".join(files_ledger.split()),
+            "files-and-ledger.md lost the typed reconcile.py fetch invocation")
+    require("stdout_file: null" in files_ledger,
+            "files-and-ledger.md routed fetch output through a second writer")
+    for name, body in (("pr-adoption.md", adoption), ("loop-control.md", loop_control)):
+        require("The canonical `prs.json` command" in body and "reconcile.py fetch" in body,
+                f"{name} lost its pointer to the executable snapshot owner")
+        require('argv: ["gh", "pr", "list"' not in body,
+                f"{name} reconstructed the internal gh query instead of using reconcile.py fetch")
+    for name, body in (("files-and-ledger.md", files_ledger),
                        ("pr-adoption.md", adoption),
                        ("loop-control.md", loop_control)):
-        require(prs_json_argv_flat in " ".join(text.split()),
-                f"{name} lost the typed prs.json argv (--label concat / --state / --limit / --json)")
-        require(prs_json_stdout in text,
-                f"{name} lost the typed prs.json stdout_file Path")
-        require("> <rundir>/prs.json" not in text,
+        require("> <rundir>/prs.json" not in body,
                 f"{name} restored the prs.json shell redirection")
 
     # The per-PR `gh pr view` adoption snapshot is the same class: typed run_argv, its output path a
@@ -353,8 +355,8 @@ def run_repository_context_fixtures() -> None:
         require(scratch_root != Path("/.gauntlet/tmp"),
                 "absent PROJECT regressed to the root-level scratch path")
 
-        # The canonical prs.json snapshot path is produced via stdout_file/path_join, a typed Path — never
-        # a shell redirection. With the repository root carrying a space and a newline, path_join keeps the
+        # The canonical prs.json snapshot path is passed to reconcile.py fetch as a typed Path — never a
+        # shell redirection. With the repository root carrying a space and a newline, path_join keeps the
         # snapshot ONE intact Path under <rundir>; it is never shell-split and never triggers a bash
         # "ambiguous redirect".
         prs_json_path = rundir / "prs.json"
@@ -365,14 +367,14 @@ def run_repository_context_fixtures() -> None:
         require(prs_json_path.is_absolute() and
                 (prs_json_path == repository_root or repository_root in prs_json_path.parents),
                 f"prs.json snapshot path escaped the repository: {prs_json_path!s}")
-        # As one stdout_file argv element into a shell-only adapter, the space/newline-bearing path stays a
-        # single token — exactly one Path, never split by the shell.
+        # As one argv element into a shell-only adapter, the space/newline-bearing path stays one token —
+        # exactly one Path, never split by the shell.
         prs_json_probe = [sys.executable, "-c",
                           "import json,sys; print(json.dumps(sys.argv[1:]))", os.fspath(prs_json_path)]
         prs_json_done = subprocess.run(["sh", "-c", shlex.join(prs_json_probe)],
                                        text=True, capture_output=True, check=True)
         require(json.loads(prs_json_done.stdout) == [os.fspath(prs_json_path)],
-                "prs.json stdout_file path was shell-split by the mechanical encoder")
+                "prs.json fetch output path was shell-split by the mechanical encoder")
 
         mkdir_parent = ["mkdir", "-p", "--", os.fspath(scratch_root)]
         mkdir_run = ["mkdir", "--", os.fspath(rundir)]


### PR DESCRIPTION
- own the run-scoped `gh pr list` query in `reconcile.py fetch`
- validate and atomically preserve `prs.json` before fact detection
- replace prose query copies with executable-owner pointers
