### PR TITLE
add resumable campaign merge runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
             plugins/gauntlet/skills/campaign/scripts/merge-check.py
             plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+            plugins/gauntlet/skills/campaign/scripts/merge.py
+            plugins/gauntlet/skills/campaign/scripts/merge-test.py
           )
           npx --yes pyright@1.1.410 --outputjson "${files[@]}" | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
@@ -331,6 +333,11 @@ jobs:
       # no doc table to drift and no doc-check here. It NEVER performs the merge; it only decides.
       - name: Merge-check contract (the code-owned mapping, pinned by fixtures)
         run: python3 plugins/gauntlet/skills/campaign/scripts/merge-check.py self-test
+
+      # The executor imports merge-check rather than redefining readiness. Its mocked sibling fixtures pin
+      # every restart phase and ownership combination without contacting GitHub or merging a real PR.
+      - name: Resumable merge execution contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/merge.py self-test
 
       # The status-label reconciler's contract, executed. This tool is the ONE way the gate's label swap
       # (`gauntlet-accepted` <-> `gauntlet-reviewing`) is applied, so no driver hand-runs `gh pr edit` at

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -193,9 +193,8 @@ flowchart TD
     Q --> T[reset gate - verdicts and CI are SHA-pinned,<br/>re-triage tier on the new SHA]
     S --> T
     T --> M
-    R -- green --> U[merge: serialized, auto, squash<br/>no --delete-branch; repo auto-delete setting governs remote branch]
-    U --> U2[sync local base branch to remote ff-only]
-    U2 --> V[cleanup campaign-created worktree/branch only<br/>reused checkouts + branches left in place, mark merged]
+    R -- green --> U[merge.py run: resumable merge + base sync<br/>owned local cleanup + terminal ledger write]
+    U --> V[confirmed merged; reused local resources left in place<br/>no --delete-branch]
     V --> W{all PRs merged or aborted?}
     W -- no --> M
     W -- yes --> X[write carryover ledger + final report] --> X2([done])

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -196,7 +196,8 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     `ci == green`. Merge one at a time until no candidate remains immediately ready after base
     refresh. Campaign never passes `--delete-branch` — the repo's *Automatically delete head branches*
     setting governs the remote branch; local cleanup follows the per-PR `worktree_owned` /
-    `branch_owned` flags.
+    `branch_owned` flags. Execute each candidate through `merge.py run`; re-run that command after any
+    partial failure instead of hand-running its later phases.
 
 **Terminal** (`references/bailout-and-final-report.md`, `references/carryover.md`)
 
@@ -259,6 +260,7 @@ a line the tool writes.
 | `ci-snapshot.py` | Executable contract for the SHA-pinned CI snapshot artifact (used by `derive`) | `references/ci-derivation-spec.md` |
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |
 | `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row, live PR view, and fetched base ancestry | `references/stage-3-merge.md` |
+| `merge.py` | `run` — resumably execute one merge-check-approved PR merge, base sync, owned local cleanup, and terminal ledger write | `references/stage-3-merge.md` |
 | `label-mirror.py` | `mirror` — reconcile a PR's status label with its review gate (the canonical idempotent `gauntlet-accepted`/`gauntlet-reviewing` swap), computed from the ledger row; touches only the two status labels | `references/stage-2-review-gate.md` |
 | `reconcile.py` | `fetch` — construct, validate, and atomically promote the canonical run-scoped PR snapshot; `detect` — compare it against the ledger and emit per-PR FACTS. Names no action; routing is skill policy | `references/files-and-ledger.md`, `references/loop-control.md` |
 | `repair-pass.py` | Reassessment pass's door: `permitted` / `bundle` / `decide` — deterministic complete-history prompt, bundle hash binding, closed decision enum, ownership guardrail, repair cap | `references/repair-pass.md` |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -487,7 +487,7 @@
   be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
   Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN
   head branch/SHA, never off `<base>` (see `pr-adoption.md`). Re-read it each heartbeat (see "Base branch").
-- After every merge, fast-forward local `<base>` to `origin/<base>` (Stage 3 step 4) so subsequent
-  `origin/<base>...HEAD` diffs and rebases branch off the just-merged tip, not a stale base. If the
-  fast-forward fails, bail out — never force it.
+- After every merge, let `merge.py run` fast-forward local `<base>` to `origin/<base>` (Stage 3,
+  **"Resumable merge execution"**) so later diffs and rebases use the just-merged tip. If it fails,
+  re-run the command after fixing the named cause — never force the base.
 - No "Test plan" section in PR bodies.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -203,7 +203,8 @@ Header field notes (the header fields above; per-row fields follow):
   enabled, GitHub deletes the head branch on merge; otherwise it stays. Either way it is not campaign's
   action. **Local cleanup** is governed solely by the per-PR flags: the worktree is removed only when
   `worktree_owned = yes` and the local branch deleted only when `branch_owned = yes`; a reused worktree,
-  the root/main checkout, and a reused local branch are **never** removed (see "Stage 3 — Merge").
+  the root/main checkout, and a reused local branch are **never** removed. `merge.py run` owns the
+  resumable enforcement; see Stage 3, **"Resumable merge execution"**.
 
 - `id` — `pr<N>` (the adopted PR number). `slug` — slugified PR title. Together they identify the row;
   re-adoption looks up by `pr`/`id` and refreshes in place, never appends a duplicate.

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -423,9 +423,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
 ### Step 4 — Merge queued PRs as a serialized drain
 
 4. **Merge** queued PRs as a serialized drain: re-confirm one candidate against the live SHA **and
-   re-check it is not parked** (the held-status guard binds the merge too — Stage 3), revalidate that it
-   contains the fetched current base, merge it, sync `<base>`, reconcile remaining candidates, and repeat
-   while another PR is immediately mergeable (Stage 3 owns the check).
+  re-check it is not parked** (the held-status guard binds the merge too — Stage 3), then run
+  `merge.py run` for that PR. It revalidates the fetched base, merges, syncs `<base>`, cleans owned local
+  resources, and records the terminal row as one resumable sequence. Reconcile remaining candidates and
+  repeat while another PR is immediately mergeable (Stage 3 owns the check).
 ### Step 5 — Reschedule or exit
 
 5. **Reschedule or exit.**

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -427,6 +427,15 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
   `merge.py run` for that PR. It revalidates the fetched base, merges, syncs `<base>`, cleans owned local
   resources, and records the terminal row as one resumable sequence. Reconcile remaining candidates and
   repeat while another PR is immediately mergeable (Stage 3 owns the check).
+
+  **An `absent_from_snapshot` row whose ledger status is not yet terminal is also routed through
+  `merge.py run` — before the terminal routing above owns it.** Such a row is the resume case: the process
+  died after `gh pr merge` landed `MERGED` but before base-sync/cleanup/terminal write, so the PR left the
+  `--state open` snapshot while its later phases stay pending. `merge.py run` re-reads the live PR, and on
+  `MERGED` skips the merge and resumes exactly those remaining phases. Only when `merge.py run` confirms
+  the PR **closed without merging** does the separate closed-without-merge terminal path apply. (The
+  absent-fact routing itself is owned above where each reconcile fact is routed — this only names which
+  side of it, merged-not-finalized versus closed, the drain resumes versus terminates.)
 ### Step 5 — Reschedule or exit
 
 5. **Reschedule or exit.**

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -80,9 +80,12 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      names which fact triggers which:
      - **`absent_from_snapshot`** — a live row whose PR dropped out of the validated canonical snapshot:
        it merged or closed, and **that absence IS the signal** (`scripts/reconcile.py fetch` owns the
-       query contract). Handle it as a **terminal** PR (this step's finished-run cases; the Stage 3
-       drain sets `merged`). **NEVER read absence as an error, and NEVER fetch anything to "resolve" it** —
-       a past change broke adoption by "fixing" absence with `--state all` (repo `CLAUDE.md`).
+       query contract). **NEVER read absence as an error, and NEVER fetch anything to "resolve" it or widen
+       the snapshot (`--state all`) to re-open whether the row is really terminal** — a past change broke
+       adoption by "fixing" absence with `--state all` (repo `CLAUDE.md`). ROUTE it to the **Stage 3 drain**
+       (Step 4), which FINALIZES it through `merge.py run`: that single per-row live view — NOT a snapshot
+       re-widening — distinguishes **MERGED** (resume the owed base-sync/cleanup/terminal-write phases) from
+       **CLOSED without merging** (the terminal close-out, which records `aborted` and touches no local refs).
      - **`head_moved`** — the live head differs from the row's `head_sha`: this is the **gate-reset and
        liveness-counter-reset** site — the two paragraphs directly above the command block own it. The tool
        reports only THAT the head moved; deciding whether the PR **diff** changed (reset `reviews_ok`,
@@ -428,14 +431,15 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
   resources, and records the terminal row as one resumable sequence. Reconcile remaining candidates and
   repeat while another PR is immediately mergeable (Stage 3 owns the check).
 
-  **An `absent_from_snapshot` row whose ledger status is not yet terminal is also routed through
-  `merge.py run` — before the terminal routing above owns it.** Such a row is the resume case: the process
-  died after `gh pr merge` landed `MERGED` but before base-sync/cleanup/terminal write, so the PR left the
-  `--state open` snapshot while its later phases stay pending. `merge.py run` re-reads the live PR, and on
-  `MERGED` skips the merge and resumes exactly those remaining phases. Only when `merge.py run` confirms
-  the PR **closed without merging** does the separate closed-without-merge terminal path apply. (The
-  absent-fact routing itself is owned above where each reconcile fact is routed — this only names which
-  side of it, merged-not-finalized versus closed, the drain resumes versus terminates.)
+  **An `absent_from_snapshot` row (Step 1 routes it here) whose ledger status is not yet terminal is
+  FINALIZED by this drain through `merge.py run`.** Such a row is the resume case: the process died after
+  `gh pr merge` landed `MERGED` but before base-sync/cleanup/terminal write, so the PR left the
+  `--state open` snapshot while its later phases stay pending. `merge.py run` re-reads the live PR ONCE and,
+  on `MERGED`, skips the merge and resumes exactly those remaining phases. When it instead finds the PR
+  **CLOSED without merging**, the SAME command performs the terminal close-out: it records the terminal
+  `aborted` status and does **no merge and no cleanup** — the branch content never reached `<base>`, so its
+  owned worktree/branch are left untouched for the user. Either way `merge.py run` is the single finalizer;
+  Step 1 only ROUTES the absent fact here, it does not finalize it itself.
 ### Step 5 — Reschedule or exit
 
 5. **Reschedule or exit.**

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -30,8 +30,7 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label so another run's
    PRs are never mistaken for your own (adopted PRs keep their OWN head branch, so ownership is the
    LABEL only — never a branch prefix). Live work (this run) = any open PR carrying this run's label,
-   **OR** any non-terminal row in this run's `state.jsonl` (`in_review` / `awaiting-api` /
-   `awaiting-user`).
+   **OR** any non-terminal row in this run's `state.jsonl` (any status that is not terminal `merged`/`aborted`).
    Three cases:
 
    - **This run has live work → resume.** Resolve a dead review pass — no verdict, no live task — from its

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -20,9 +20,8 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 `base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
 **must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).
 
-Campaign **never** deletes the adopted PR's **remote** head branch — it never passes `--delete-branch`
-on merge; the repo's "Automatically delete head branches" setting governs remote-branch cleanup (see
-"Stage 3 — Merge").
+Campaign **never** deletes the adopted PR's **remote** head branch. Stage 3,
+**"Resumable merge execution"**, owns merge and cleanup enforcement.
 
 `worktree_owned`/`branch_owned` are tracked **per-PR** (below) and govern **local** cleanup — they alone
 decide whether the worktree/local branch is removed. A reused worktree, the root/main checkout, and a
@@ -394,9 +393,8 @@ For each `#PR` to adopt:
    via `-b`, `no` = reused a pre-existing local branch or checkout) in the row's `branch_owned` — all
    by field name through the accessor. **That `worktree` path is the source
    of truth the review and CI steps read/diff against**, and `worktree_owned`/`branch_owned` tell
-   Stage 3 cleanup what it may remove: it removes the worktree only when `worktree_owned = yes` and
-   deletes the local branch only when `branch_owned = yes` — a reused worktree or a pre-existing local
-   branch (`no`) is left in place, so campaign never deletes a ref the user owns. All fix commits for
+   `merge.py run` what it may remove; Stage 3, **"Resumable merge execution"**, owns that enforcement.
+   All fix commits for
    the PR also go here; stage only the specific
    source files changed (explicit paths, never `git add -A`). Fix commits are pushed back to the PR's
    head branch on `origin`.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -36,7 +36,7 @@ and `UNKNOWN` decide on their own, `MERGEABLE` falls through — then `.mergeSta
 yields `merge`), then confirms `origin/<base>` is an ancestor of `HEAD`. Both enums are crossed
 **TOTALLY**: a value GitHub's schema does not declare **parks**, never guesses. Act on the verdict:
 
-- `merge` → proceed to the merge steps below (step 1).
+- `merge` → run the command in **"Resumable merge execution"** below.
 - `not-yet <reason>` → do **NOT** merge; the reason names the block. Route on the reason's **action**
   (the phrase the tool emits), never on a hand-copied list of enum values — a value the tool newly parks
   then routes correctly with no edit here:
@@ -90,102 +90,28 @@ blocker instead.**
 **`UNSTABLE` means non-*passing*, which includes *pending*.** Treating it as red would dispatch a CI-fix
 subagent at a check that is merely **still running**.
 
-1. **Serialize merge operations, not heartbeats.** A heartbeat may merge multiple PRs, but only one at a time.
-   Before each merge, re-confirm the PR is still **not parked** and that both gates still hold against the live PR head SHA
-   (`gh pr view <pr> --json headRefOid --jq .headRefOid`, PR number from the ledger row) — a late push
-   may have moved the tip past the recorded `head_sha` and reset the gates —
-   **and run `merge-check.py check`** (**"The merge precondition"** above). It re-fetches
-   `origin/<base>` and verifies the candidate contains it, so a concurrent run that advanced the base cannot
-   leave an older CLEAN candidate mergeable. The tool also crosses **every** value of both enums and returns
-   the verdict.
-2. Push guard: `gh pr view <pr> --json state --jq .state` (PR number from the ledger row) must be
-   `OPEN`.
-3. Merge — always `gh pr merge <pr> --squash` (use the repo's prevailing merge method if not squash),
-   with **NO `--delete-branch`**. Campaign never deletes the adopted PR's **remote** head branch: an
-   adopted PR keeps its own branch (campaign did not create it), so campaign leaves the remote branch
-   alone. If the repo has "Automatically delete head branches" enabled, GitHub deletes it on merge;
-   otherwise it remains — either way that is the repo setting's doing, not campaign's action. Local
-   cleanup (step 5) is a separate concern, keyed only off the per-PR `worktree_owned`/`branch_owned`
-   flags.
-4. **Sync the local base branch with the remote.** The merge landed on `origin/<base>`, but local
-   `<base>` is now behind. Fast-forward it so every subsequent rebase and `origin/<base>...HEAD` diff is
-   measured against the just-merged tip, not a stale one (`<base>` = the adopted PRs' `baseRefName`,
-   not assumed `main`).
-   Local `<base>` is **shared** with any concurrent run on the same base; the fast-forward is
-   idempotent, so if another run already advanced it, a no-op "already up to date" is fine — just never
-   force it.
+### Resumable merge execution
 
-   **Run the fast-forward from wherever `<base>` is actually checked out** — don't assume it's the
-   root checkout. Use the invocation's single `RepositoryContext` and the typed process boundary from
-   `runtime-adapter.md`. A branch can be checked out in at most one working tree, so first locate that
-   tree (`git worktree list` shows the branch per path; the root package counts as one), then
-   fast-forward there. If `<base>` is checked out **nowhere**, update the ref directly instead — a plain
-   `fetch` into the local branch (this form is refused while the branch is checked out, which is why
-   it's the no-working-tree case):
+**Run the merge sequence through its command:**
 
-   ```text
-   # Always refresh origin/<base>, even with no local branch or configured upstream.
-   run_argv(
-     argv: ["git", "fetch", "origin",
-            concat("refs/heads/", base, ":refs/remotes/origin/", base)],
-     cwd: repository.project_root, stdin_file: null, stdout_file: null
-   )
+```text
+python3 <skill-dir>/scripts/merge.py run \
+  --ledger <state.jsonl> --pr <N> --project-root <repository.project_root> --repo <owner/name>
+```
 
-   # case A — <base> is checked out in discovered absolute worktree <dir>:
-   run_argv(
-     argv: ["git", "merge", "--ff-only", concat("origin/", base)],
-     cwd: dir, stdin_file: null, stdout_file: null
-   )
+`merge.py` imports `merge-check.py`; readiness policy stays owned by **"The merge precondition"** above.
+The command re-reads the live PR and exact head, checks this run's owner label, executes the established
+`gh pr merge <N> --squash` call without `--delete-branch`, confirms `MERGED`, updates local `<base>`,
+cleans only ledger-owned local resources, then records `status = merged` through the ledger accessor.
 
-   # case B — <base> is checked out in no working tree:
-   run_argv(
-     argv: ["git", "fetch", "origin", concat(base, ":", base)],
-     cwd: repository.project_root, stdin_file: null, stdout_file: null
-   )
-   ```
+Each phase leaves a durable or safely repeatable checkpoint. Re-run the same command after any failure:
+GitHub `MERGED` skips the merge call; base updates are fast-forward-only; absent owned worktrees/branches
+count as completed cleanup; a terminal ledger row is a no-op. The command refuses held rows, stale gates,
+uncertain GitHub facts, another run's PR, foreign refs, root/reused cleanup targets, and cleanup before
+confirmed `MERGED`. Report `reused-left` cleanup results in the final report.
 
-   Fast-forward only — never a merge commit or reset. If the fast-forward fails (local `<base>` somehow
-   diverged), do NOT force it: that's a bailout condition (stop and surface it), since rebasing PRs
-   onto a wrong base would corrupt every downstream diff.
-5. **Clean up on successful merge.** Once the merge is confirmed (`gh pr view <pr> --json state
-   --jq .state` → `MERGED`, PR number from the ledger row), tear down the local footprint. `<branch>`
-   and its worktree are the adopted PR's **own head branch** and the worktree recorded in that PR's
-   ledger row (its `branch`/`worktree` columns) — there is no `fix-<run-id>-*` branch to clean up.
-
-   **The remote head branch is not campaign's concern** — step 3 never deletes it; the repo's
-   "Automatically delete head branches" setting governs whether GitHub removes it on merge.
-
-   **Local cleanup is gated on the per-PR `worktree_owned`/`branch_owned` flags.** Adoption records the two
-   independently (campaign can create a worktree over a **pre-existing** local branch, in which case
-   `worktree_owned = yes` but `branch_owned = no`; see "PR adoption"). **Never remove a worktree or
-   delete a branch campaign didn't create:**
-   - **`worktree_owned = yes`** → campaign created the worktree, so remove it: verify the merge with
-     the `git-detect-merged` skill **against the run's `<base>`** (the ledger `base_branch` — NOT the
-     helpers' default `main`, since the base may be a release/integration branch), then `git worktree
-     remove` the **ledger-recorded worktree**. **`worktree_owned = no`** → campaign reused a
-     pre-existing checkout (the user's root/main checkout or their own worktree), so **leave the
-     worktree in place** — do NOT `git worktree remove` it.
-   - **NEVER `git worktree remove` the root/main checkout** (the repo's primary working tree) under any
-     circumstances — even were it somehow flagged owned. Removing/replacing the main checkout is
-     destructive and, for the primary working tree, impossible; `worktree_owned = yes` only ever names a
-     repository-context-derived worktree campaign itself created via `git worktree add`.
-   - **`branch_owned = yes`** → campaign created the local branch (the `-b` path), so delete it (e.g.
-     via `git-cleanup-merged` **with that same `<base>`**, or `git branch -d` the ledger-recorded
-     `branch` after the worktree is gone). **`branch_owned = no`** → campaign reused a pre-existing
-     local branch (or checkout), so **leave the local branch in place** — do NOT delete it; that branch
-     may be the user's.
-   - **Report** any reused worktree and any reused local branch that were left in place (path + branch)
-     in the final report, so the user knows their working tree/branches were untouched.
-
-   Local ref safety (`worktree_owned`/`branch_owned`, never touching the root/main checkout or any
-   reused ref) is absolute. Once cleanup is done set status `merged` (via
-   `scripts/ledger.py … set --pr <N> --status merged`, by field name — the schema-owning accessor,
-   `files-and-ledger.md`; never hand-edit the row by column position) and stop the PR's background
-   tasks.
-
-   This runs only after the merge is verified, and only ever touches PRs this run **owns** — those
-   carrying its `gauntlet-run-<run-id>` label — never another run's. Leave the worktree in place if the
-   merge cannot be confirmed — treat that as a bailout condition, not a cleanup.
+Never hand-run a later phase after this command fails. Fix the named cause, then re-run the command so its
+ownership checks and phase order remain in force.
 6. After each merge+sync+cleanup, reconcile other open PRs (write any `reviews_ok`/`head_sha`/`ci`
    change below through `scripts/ledger.py … set --pr <N> --<field> <val>` by field name, never by
    hand-editing the row by column position).
@@ -235,7 +161,8 @@ subagent at a check that is merely **still running**.
      the new tip — watching it only if `liveness` reports `watch_warranted` ("WATCH ONLY WHAT CAN MOVE") — and re-enter
      Stage 2.
    - `proceed` with the same live `head_sha`, `reviews_ok >= required(tier)`, and `ci == green` → return
-     to step 1 in the same heartbeat; `merge-check.py` repeats the ancestry check before merging.
+     to **"Resumable merge execution"** in the same heartbeat; `merge.py` imports `merge-check.py` and
+     repeats the ancestry check before merging.
 
 Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
 

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -96,13 +96,22 @@ subagent at a check that is merely **still running**.
 
 ```text
 python3 <skill-dir>/scripts/merge.py run \
-  --ledger <state.jsonl> --pr <N> --project-root <repository.project_root> --repo <owner/name>
+  --ledger <state.jsonl> --pr <N> --project-root <repository.project_root> --repo <owner/name> \
+  [--merge-method squash|merge|rebase]
 ```
 
 `merge.py` imports `merge-check.py`; readiness policy stays owned by **"The merge precondition"** above.
 The command re-reads the live PR and exact head, checks this run's owner label, executes the established
-`gh pr merge <N> --squash` call without `--delete-branch`, confirms `MERGED`, updates local `<base>`,
-cleans only ledger-owned local resources, then records `status = merged` through the ledger accessor.
+`gh pr merge <N> --<merge-method> --match-head-commit <head_sha>` call without `--delete-branch`, confirms
+`MERGED`, updates local `<base>`, cleans only ledger-owned local resources, then records `status = merged`
+through the ledger accessor.
+
+`--match-head-commit` pins the merge to the exact reviewed head SHA: a push that advanced the live tip
+between the readiness view and the merge call makes GitHub refuse fail-closed, rather than squashing the
+unreviewed head. `--merge-method` defaults to `squash`; **use the repo's prevailing merge method if squash
+is disabled** (a squash-only-disabled repository otherwise fails loudly on every restart). The
+no-`--delete-branch` rule holds for every method: campaign never deletes the adopted PR's remote head
+branch — the repo's "Automatically delete head branches" setting alone governs that.
 
 Each phase leaves a durable or safely repeatable checkpoint. Re-run the same command after any failure:
 GitHub `MERGED` skips the merge call; base updates are fast-forward-only; absent owned worktrees/branches

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -115,7 +115,8 @@ branch — the repo's "Automatically delete head branches" setting alone governs
 
 Each phase leaves a durable or safely repeatable checkpoint. Re-run the same command after any failure:
 GitHub `MERGED` skips the merge call; base updates are fast-forward-only; absent owned worktrees/branches
-count as completed cleanup; a terminal ledger row is a no-op. The command refuses held rows, stale gates,
+count as completed cleanup; a terminal ledger row is a no-op. The command refuses held rows whose PR is not
+CLOSED (a CLOSED held row is closed out to `aborted`, not refused — `loop-control.md` Step 4), stale gates,
 uncertain GitHub facts, another run's PR, foreign refs, root/reused cleanup targets, and cleanup before
 confirmed `MERGED`. Report `reused-left` cleanup results in the final report.
 

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -115,8 +115,9 @@ branch — the repo's "Automatically delete head branches" setting alone governs
 
 Each phase leaves a durable or safely repeatable checkpoint. Re-run the same command after any failure:
 GitHub `MERGED` skips the merge call; base updates are fast-forward-only; absent owned worktrees/branches
-count as completed cleanup; a terminal ledger row is a no-op. The command refuses held rows whose PR is not
-CLOSED (a CLOSED held row is closed out to `aborted`, not refused — `loop-control.md` Step 4), stale gates,
+count as completed cleanup; a terminal ledger row is a no-op. The command refuses held rows whose live PR is
+OPEN (a CLOSED held row is closed out to `aborted` — `loop-control.md` Step 4 — and a `MERGED` held row is an
+external merge, resumed to finalize base-sync/owned-cleanup/terminal write; neither is refused), stale gates,
 uncertain GitHub facts, another run's PR, foreign refs, root/reused cleanup targets, and cleanup before
 confirmed `MERGED`. Report `reused-left` cleanup results in the final report.
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -49,7 +49,9 @@ class Fake:
     def __init__(self, root: Path, *, worktree_owned="yes", branch_owned="yes",
                  state="OPEN", ci="green", reviews="2", status="in_review",
                  base_checked=True, fail_once: "str | None" = None,
-                 live_head: str = SHA, reject_method: "str | None" = None):
+                 live_head: str = SHA, reject_method: "str | None" = None,
+                 view_head: "str | None" = None, view_branch: "str | None" = None,
+                 view_base: "str | None" = None):
         self.root = root
         self.branch = "feat-pr"
         self.base = "main"
@@ -72,6 +74,12 @@ class Fake:
         # model, respectively, a head-race (--match-head-commit must refuse) and a disabled method.
         self.live_head = live_head
         self.reject_method = reject_method
+        # The live view's head/base/branch, each defaulting to the pinned ledger value. Overriding one
+        # models a push that advanced the head, or a base/branch rename, BEFORE the reported live state —
+        # the input the strict merge pins refuse but the ledger-only CLOSED close-out must tolerate.
+        self.view_head = view_head or SHA
+        self.view_branch = view_branch or self.branch
+        self.view_base = view_base or self.base
 
     def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
                run_id="g1") -> None:
@@ -86,9 +94,9 @@ class Fake:
     def view(self) -> dict:
         return {
             "state": self.state,
-            "headRefOid": SHA,
-            "headRefName": self.branch,
-            "baseRefName": self.base,
+            "headRefOid": self.view_head,
+            "headRefName": self.view_branch,
+            "baseRefName": self.view_base,
             "labels": [{"name": "gauntlet-run-g1"}],
             "mergeable": "MERGEABLE",
             "mergeStateStatus": "CLEAN",
@@ -524,6 +532,34 @@ def t_absent_snapshot_closed_row_terminates():
         finish(td, real)
 
 
+def t_closed_out_terminates_despite_moved_head_base_or_branch():
+    # The CLOSED close-out is LEDGER-ONLY (records `aborted`, merges nothing, cleans nothing), so the strict
+    # live head/base/branch pins that gate a MERGE do not apply to it. Their trigger is ordinary same-repo
+    # author behavior: a push advances the head, or a base/branch is renamed, and THEN the PR is closed.
+    # A CLOSED PR never re-enters the open snapshot, so reconcile can never refresh the row's head_sha —
+    # if the close-out refused on the pin the row would wedge at in_review forever. All three variants must
+    # still terminate as `aborted` with no merge and no cleanup. (The pins stay in force on OPEN and MERGED:
+    # t_stale_head_and_malformed_ownership_refused and t_root_and_foreign_targets_refused cover that.)
+    for label, knob in (
+        ("moved head", {"view_head": "b" * 40}),
+        ("changed base", {"view_base": "release"}),
+        ("changed branch", {"view_branch": "renamed"}),
+    ):
+        td, root, f, led, real = scenario(state="CLOSED", **knob)
+        try:
+            code, result, err = invoke(f, led, root)
+            check(code == 0, f"{label}: close-out refused instead of terminating: {err}")
+            check(status(led) == "aborted",
+                  f"{label}: closed-without-merge row must terminate as aborted, got {status(led)!r}")
+            check(result is not None and result["status"] == "closed-unmerged" and result["cleanup"] == {},
+                  f"{label}: expected closed-unmerged with no cleanup, got {result}")
+            check(f.merged_calls == 0, f"{label}: the close-out issued a merge command")
+            check(f.worktree_present and f.branch_present,
+                  f"{label}: the close-out deleted owned resources holding unmerged work")
+        finally:
+            finish(td, real)
+
+
 def t_absent_routing_decision():
     # The ROUTING DECISION itself (loop-control.md Step 1 -> Step 4), exercised end to end rather than by a
     # bare execute() call. reconcile.py observes the absent fact; `merge.py run` is the single finalizer BOTH
@@ -575,5 +611,6 @@ CASES = [
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),
     ("absent-closed", "an absent-but-unfinalized CLOSED-without-merge row terminates as aborted with no cleanup", t_absent_snapshot_closed_row_terminates),
+    ("closed-out-moved-refs", "the CLOSED close-out terminates as aborted despite a moved head, base, or branch", t_closed_out_terminates_despite_moved_head_base_or_branch),
     ("absent-routing", "the absent fact routes reconcile -> merge.py run, which finalizes MERGED and CLOSED sides", t_absent_routing_decision),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -51,10 +51,10 @@ class Fake:
                  base_checked=True, fail_once: "str | None" = None,
                  live_head: str = SHA, reject_method: "str | None" = None,
                  view_head: "str | None" = None, view_branch: "str | None" = None,
-                 view_base: "str | None" = None):
+                 view_base: "str | None" = None, base: str = "main"):
         self.root = root
         self.branch = "feat-pr"
-        self.base = "main"
+        self.base = base
         self.worktree = root / ".worktrees" / self.branch
         self.worktree_owned = worktree_owned
         self.branch_owned = branch_owned
@@ -336,7 +336,10 @@ def t_owner_label_and_uncertain_view_refused():
 
 
 def t_base_checked_out_and_absent():
-    for checked, expected in ((True, ["merge", "--ff-only"]), (False, ["fetch", "origin", "main:main"])):
+    # The absent-base path fetches with a FULLY-QUALIFIED refspec (`refs/heads/<base>:refs/heads/<base>`, no
+    # leading `+`), never the bare `<base>:<base>` that git would option-parse from a dash-leading base name.
+    for checked, expected in ((True, ["merge", "--ff-only"]),
+                              (False, ["fetch", "origin", "refs/heads/main:refs/heads/main"])):
         td, root, f, led, real = scenario(base_checked=checked)
         try:
             code, _, err = invoke(f, led, root)
@@ -346,6 +349,47 @@ def t_base_checked_out_and_absent():
                   f"base checked={checked} did not use {expected}: {suffixes}")
         finally:
             finish(td, real)
+
+
+def t_dash_leading_base_is_never_option_parseable():
+    # A network-supplied base name (gh baseRefName) that begins with a dash is LEGAL git but would be
+    # option-parsed by `git fetch` if passed as a bare argv element. Both fetch sites must qualify it into
+    # a `refs/heads/...` refspec so a hostile base can never inject an option or a command path.
+
+    # F1 (_base_is_current, the merge-check ancestry refresh, on the worktree): tracking-ref form.
+    base = "--upload-pack=/bin/false"
+    td, root, f, led, real = scenario(base=base)
+    try:
+        code, _, err = invoke(f, led, root)
+        check(code == 0, f"dash-leading base broke the ancestry refresh: {err}")
+        worktree = str(f.worktree)
+        tracking = f"refs/heads/{base}:refs/remotes/origin/{base}"
+        wt_fetches = [argv for argv, _ in f.calls
+                      if argv[:5] == ["git", "-C", worktree, "fetch", "origin"]]
+        check(wt_fetches == [["git", "-C", worktree, "fetch", "origin", tracking]],
+              f"ancestry refresh did not use the safe tracking refspec: {wt_fetches}")
+        check(not any(argv[-1] == base for argv, _ in f.calls if "fetch" in argv),
+              "a fetch passed the dash-leading base as a bare option-parseable positional")
+    finally:
+        finish(td, real)
+
+    # F2 (_sync_base, the no-checked-out-base fast-forward): local-ref form, no leading `+`. The sync must
+    # SUCCEED so cleanup and the terminal write run — the bare `--prune:--prune` form wedged them forever.
+    base = "--prune"
+    td, root, f, led, real = scenario(base=base, base_checked=False)
+    try:
+        code, _, err = invoke(f, led, root)
+        check(code == 0, f"dash-leading base wedged the base-sync: {err}")
+        check(status(led) == "merged", "base-sync failure blocked the terminal write")
+        local = f"refs/heads/{base}:refs/heads/{base}"
+        root_fetches = [argv for argv, _ in f.calls
+                        if argv[:5] == ["git", "-C", str(root), "fetch", "origin"]]
+        check(["git", "-C", str(root), "fetch", "origin", local] in root_fetches,
+              f"absent-base sync did not use the safe local refspec: {root_fetches}")
+        check(not any(token == f"{base}:{base}" for argv, _ in f.calls for token in argv),
+              "the option-parseable bare `<base>:<base>` refspec is still assembled")
+    finally:
+        finish(td, real)
 
 
 def t_merge_and_confirmation_failures_resume():
@@ -602,6 +646,7 @@ CASES = [
     ("stale-malformed", "stale live SHA and malformed ownership fail closed", t_stale_head_and_malformed_ownership_refused),
     ("owner-and-view", "another run and uncertain GitHub state fail closed", t_owner_label_and_uncertain_view_refused),
     ("base-location", "checked-out and absent local base use their documented update paths", t_base_checked_out_and_absent),
+    ("dash-base-safe", "a dash-leading base name is fully-qualified at both fetch sites, never option-parseable", t_dash_leading_base_is_never_option_parseable),
     ("merge-resume", "merge and confirmation failures resume safely", t_merge_and_confirmation_failures_resume),
     ("postmerge-resume", "every post-merge phase resumes without another merge", t_postmerge_phase_failures_resume),
     ("merge-accepted", "MERGED confirmation outranks a lost merge response", t_merge_transport_failure_after_acceptance_continues),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -82,11 +82,15 @@ class Fake:
         self.view_base = view_base or self.base
 
     def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
-               run_id="g1") -> None:
+               run_id="g1", worktree_field: "str | None" = None) -> None:
         header = dict(L.HEADER_DEFAULTS, run_id=run_id, base_branch=self.base)
         row = dict(L.ROW_DEFAULTS)
+        # `worktree_field` writes the row's worktree column VERBATIM — passing the ROW_DEFAULTS "-" models a
+        # HALF-ADOPTION (pr-adopt.py registered the row before it resolved the worktree). Otherwise the
+        # column is the absolute worktree path, resolved like an adopted row.
+        wt = worktree_field if worktree_field is not None else str(worktree or self.worktree)
         row.update(pr="9", id="pr9", branch=branch or self.branch,
-                   worktree=str(worktree or self.worktree), worktree_owned=self.worktree_owned,
+                   worktree=wt, worktree_owned=self.worktree_owned,
                    branch_owned=self.branch_owned, head_sha=SHA, reviews_ok=self.reviews,
                    ci=self.ci, tier="HIGH", status=self.status)
         L.dump(path, header, [row])
@@ -630,6 +634,34 @@ def t_absent_snapshot_closed_row_terminates():
         finish(td, real)
 
 
+def t_half_adopted_closed_row_closes_out_without_cleanup_fields():
+    # A HALF-ADOPTION: pr-adopt.py registers the ledger row (step 4) BEFORE it resolves the worktree
+    # (step 5), and its documented git-failure path returns with worktree/worktree_owned/branch_owned left
+    # at their ROW_DEFAULTS "-". If that PR is then CLOSED on GitHub, the close-out records `aborted` and
+    # performs NO local cleanup, so it must NOT require those three fields — validating them (the old
+    # over-strict path) refused on the unresolved worktree_owned, leaving status=in_review. Because a CLOSED
+    # PR is absent from the open snapshot, the heartbeat re-routes it to this same finalizer forever (a wedge
+    # loop). The close-out must terminate as `aborted`, clean NOTHING, and never touch the unresolved fields.
+    td, root, f, led, real = scenario(state="CLOSED", worktree_owned="-", branch_owned="-")
+    try:
+        f.ledger(led, worktree_field="-")  # the half-adoption defaults: all three cleanup fields unresolved
+        code, result, err = invoke(f, led, root)
+        check(code == 0, f"half-adopted CLOSED row did not close out (over-strict validation?): {err}")
+        check(status(led) == "aborted",
+              f"half-adopted CLOSED row must terminate as aborted, got {status(led)!r}")
+        check(result is not None and result["status"] == "closed-unmerged" and result["cleanup"] == {},
+              f"the close-out must report closed-unmerged with no cleanup: {result}")
+        check(f.merged_calls == 0, "the half-adopted close-out issued a merge command")
+        check(not any(argv[:3] == ["gh", "pr", "merge"] for argv, _ in f.calls),
+              "the half-adopted close-out issued a merge command")
+        check(not any("worktree" in argv and "remove" in argv for argv, _ in f.calls),
+              "the half-adopted close-out performed a local cleanup operation")
+        check(f.worktree_present and f.branch_present,
+              "the half-adopted close-out destroyed local resources")
+    finally:
+        finish(td, real)
+
+
 def t_closed_out_terminates_despite_moved_head_base_or_branch():
     # The CLOSED close-out is LEDGER-ONLY (records `aborted`, merges nothing, cleans nothing), so the strict
     # live head/base/branch pins that gate a MERGE do not apply to it. Their trigger is ordinary same-repo
@@ -745,6 +777,7 @@ CASES = [
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),
     ("absent-closed", "an absent-but-unfinalized CLOSED-without-merge row terminates as aborted with no cleanup", t_absent_snapshot_closed_row_terminates),
+    ("half-adopted-closed", "a half-adopted CLOSED row closes out to aborted without requiring the cleanup-ownership fields", t_half_adopted_closed_row_closes_out_without_cleanup_fields),
     ("closed-out-moved-refs", "the CLOSED close-out terminates as aborted despite a moved head, base, or branch", t_closed_out_terminates_despite_moved_head_base_or_branch),
     ("closed-out-held-statuses", "a CLOSED PR closes out every held status to aborted; merged+CLOSED stays refused", t_closed_out_terminates_every_held_status),
     ("absent-routing", "the absent fact routes reconcile -> merge.py run, which finalizes MERGED and CLOSED sides", t_absent_routing_decision),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -51,7 +51,8 @@ class Fake:
                  base_checked=True, fail_once: "str | None" = None,
                  live_head: str = SHA, reject_method: "str | None" = None,
                  view_head: "str | None" = None, view_branch: "str | None" = None,
-                 view_base: "str | None" = None, base: str = "main"):
+                 view_base: "str | None" = None, base: str = "main",
+                 labels: "list[dict] | None" = None):
         self.root = root
         self.branch = "feat-pr"
         self.base = base
@@ -80,6 +81,9 @@ class Fake:
         self.view_head = view_head or SHA
         self.view_branch = view_branch or self.branch
         self.view_base = view_base or self.base
+        # The live PR's labels. Default carries THIS run's owner label; passing [] models a HALF-ADOPTION
+        # whose PR never got `gh pr edit`-attached its label, and a foreign entry models another run's PR.
+        self.labels = labels if labels is not None else [{"name": "gauntlet-run-g1"}]
 
     def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
                run_id="g1", worktree_field: "str | None" = None) -> None:
@@ -101,7 +105,7 @@ class Fake:
             "headRefOid": self.view_head,
             "headRefName": self.view_branch,
             "baseRefName": self.view_base,
-            "labels": [{"name": "gauntlet-run-g1"}],
+            "labels": self.labels,
             "mergeable": "MERGEABLE",
             "mergeStateStatus": "CLEAN",
             "isDraft": False,
@@ -757,6 +761,98 @@ def t_absent_routing_decision():
             finish(td, real)
 
 
+def t_label_free_half_adopted_closed_out():
+    # A HALF-ADOPTION can fail even EARLIER than the worktree step: pr-adopt.py persists the ledger row and
+    # then, during its step-5 Git work, dies BEFORE `gh pr edit` attaches the run label. GitHub then reports
+    # the PR as CLOSED with labels=[]. The close-out is ledger-only (records `aborted`, merges and cleans
+    # NOTHING), so it must not require THIS run's own label to be present — over-strict validation refused
+    # the missing label and left status=in_review, and because a CLOSED PR is absent from the open snapshot
+    # the heartbeat re-routes it to this same finalizer forever (a wedge loop). The FOREIGN-label refusal is
+    # NOT relaxed, though: a `gauntlet-run-*` label belonging to ANOTHER run still fails closed.
+    td, root, f, led, real = scenario(state="CLOSED", worktree_owned="-", branch_owned="-", labels=[])
+    try:
+        f.ledger(led, worktree_field="-")  # half-adoption: cleanup fields unresolved AND no own label yet
+        code, result, err = invoke(f, led, root)
+        check(code == 0, f"label-free half-adopted CLOSED row did not close out (over-strict label?): {err}")
+        check(status(led) == "aborted",
+              f"label-free half-adopted CLOSED row must terminate as aborted, got {status(led)!r}")
+        check(result is not None and result["status"] == "closed-unmerged" and result["cleanup"] == {},
+              f"the close-out must report closed-unmerged with no cleanup: {result}")
+        check(f.merged_calls == 0, "the label-free close-out issued a merge command")
+        check(not any("worktree" in argv and "remove" in argv for argv, _ in f.calls),
+              "the label-free close-out performed a local cleanup operation")
+        check(f.worktree_present and f.branch_present, "the label-free close-out destroyed local resources")
+    finally:
+        finish(td, real)
+
+    # The FOREIGN-label variant of the SAME half-adopted CLOSED row must still REFUSE — run isolation is not
+    # relaxed just because own-label presence is.
+    td, root, f, led, real = scenario(state="CLOSED", worktree_owned="-", branch_owned="-",
+                                      labels=[{"name": "gauntlet-run-other"}])
+    try:
+        f.ledger(led, worktree_field="-")
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "another run's owner label" in err,
+              f"a foreign-labelled half-adopted CLOSED row was not refused: code={code} err={err!r}")
+        check(f.merged_calls == 0, "the foreign-label refusal must precede any merge")
+    finally:
+        finish(td, real)
+
+
+def t_external_merge_while_held_resumes():
+    # A fully-adopted, still-HELD row (status in `L.HELD_STATUSES`) whose exact reviewed head a maintainer
+    # merges out-of-band: GitHub reports MERGED. The work LANDED, so the finalizer must RESUME the owed
+    # base-sync / owned cleanup / terminal write — not refuse "held" before ever reaching the MERGED-resume
+    # branch (the old order rejected the held status first, wedging every absent-row heartbeat). Iterate the
+    # enum so a new held status is covered with no edit.
+    for held in L.HELD_STATUSES:
+        td, root, f, led, real = scenario(state="MERGED", status=held)
+        try:
+            code, result, err = invoke(f, led, root)
+            check(code == 0, f"{held}: external MERGE of a held row did not resume: {err}")
+            check(f.merged_calls == 0, f"{held}: an externally-merged PR must not be re-merged")
+            check(status(led) == "merged", f"{held}: resume must finalize the terminal ledger row")
+            check(not f.worktree_present and not f.branch_present,
+                  f"{held}: resume must complete owned base-sync/cleanup per ownership")
+            check(result is not None and result["status"] == "merged", f"{held}: unexpected result: {result}")
+        finally:
+            finish(td, real)
+
+    # Guardrail: a live OPEN held row is STILL refused — the campaign must never INITIATE a merge on a held
+    # PR. Only an already-landed external MERGE resumes; OPEN keeps waiting on the human.
+    for held in L.HELD_STATUSES:
+        td, root, f, led, real = scenario(state="OPEN", status=held)
+        try:
+            code, _result, err = invoke(f, led, root)
+            check(code != 0 and f"held ({held})" in err,
+                  f"OPEN+{held} must stay refused as held, got code={code} err={err!r}")
+            check(f.merged_calls == 0, f"OPEN+{held} must never reach the merge command")
+        finally:
+            finish(td, real)
+
+
+def t_absent_held_row_external_merge_routes_to_resume():
+    # The ROUTING DECISION for the new resume: an absent-from-snapshot HELD row (held statuses are NON-terminal,
+    # so reconcile reports the absent fact exactly as it does for in_review) that GitHub has externally MERGED.
+    # The one `absent_from_snapshot` fact routes to `merge.py run`, which resumes the held row to `merged`.
+    td, root, f, led, real = scenario(state="MERGED", status="awaiting-user")
+    try:
+        prs = root / "prs.json"
+        prs.write_text("[]", encoding="utf-8")
+        facts = RECON.detect(led, prs, "g1")
+        row_fact = facts["rows"]["9"]
+        check(row_fact.get("absent_from_snapshot") is True,
+              f"reconcile did not report the held row absent: {row_fact}")
+        check("terminal" not in row_fact, f"a held row must not be pre-classified terminal: {row_fact}")
+        code, result, err = invoke(f, led, root)
+        check(code == 0, f"absent held+MERGED row did not resume through run: {err}")
+        check(status(led) == "merged", f"absent held row finalized to {status(led)!r}, expected merged")
+        check(f.merged_calls == 0, "an already-merged held PR must not be re-merged on resume")
+        check(result is not None and result["status"] == "merged", f"unexpected result: {result}")
+    finally:
+        finish(td, real)
+
+
 CASES = [
     ("happy-owned", "exact merge argv, owned cleanup, terminal write", t_happy_owned_cleanup_and_command),
     ("merged-live-row", "MERGED with live ledger resumes without another merge", t_merge_landed_ledger_live_resumes),
@@ -781,4 +877,7 @@ CASES = [
     ("closed-out-moved-refs", "the CLOSED close-out terminates as aborted despite a moved head, base, or branch", t_closed_out_terminates_despite_moved_head_base_or_branch),
     ("closed-out-held-statuses", "a CLOSED PR closes out every held status to aborted; merged+CLOSED stays refused", t_closed_out_terminates_every_held_status),
     ("absent-routing", "the absent fact routes reconcile -> merge.py run, which finalizes MERGED and CLOSED sides", t_absent_routing_decision),
+    ("label-free-half-adopted-closed", "a half-adopted CLOSED row with no own label closes out to aborted; a foreign label still refuses", t_label_free_half_adopted_closed_out),
+    ("external-merge-held-resume", "an external MERGE of a held row resumes to merged for every held status; OPEN+held stays refused", t_external_merge_while_held_resumes),
+    ("absent-held-merge-routing", "an absent held row externally MERGED routes reconcile -> merge.py run, which resumes it to merged", t_absent_held_row_external_merge_routes_to_resume),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -478,6 +478,60 @@ def t_repeat_after_terminal_is_noop():
         finish(td, real)
 
 
+def t_repeat_after_closed_terminal_is_noop():
+    # Symmetric with t_repeat_after_terminal_is_noop, for the `aborted` terminal side. The close-out records
+    # `aborted`; a SECOND run on that terminal row must be the SAME already-complete no-op the `merged` repeat
+    # is — no merge, no cleanup, no ledger write, and NEVER destroying the unmerged work the abort preserved.
+    td, root, f, led, real = scenario(state="CLOSED")
+    try:
+        first, _, err = invoke(f, led, root)
+        check(first == 0 and status(led) == "aborted", f"close-out did not record aborted: {err}")
+        before = len(f.calls)
+        second, result, err = invoke(f, led, root)
+        check(second == 0 and result is not None and result["status"] == "already-complete",
+              f"aborted terminal rerun was not an already-complete no-op: {err}")
+        check(status(led) == "aborted", "aborted terminal rerun changed the ledger")
+        new = [argv for argv, _ in f.calls[before:]]
+        check(not any(argv[:3] == ["gh", "pr", "merge"] for argv in new), "aborted terminal rerun issued a merge")
+        check(not any("worktree" in argv and "remove" in argv for argv in new),
+              "aborted terminal rerun cleaned resources")
+        check(f.worktree_present and f.branch_present, "aborted terminal rerun destroyed unmerged work")
+    finally:
+        finish(td, real)
+
+    # The repeat is ledger-only, so — exactly as the fresh close-out tolerates them
+    # (t_closed_out_terminates_despite_moved_head_base_or_branch) — a head/base/branch that moved before the
+    # close still yields the no-op, never a spurious live-ref refusal on a settled terminal row.
+    for label, knob in (
+        ("moved head", {"view_head": "b" * 40}),
+        ("changed base", {"view_base": "release"}),
+        ("changed branch", {"view_branch": "renamed"}),
+    ):
+        td, root, f, led, real = scenario(state="CLOSED", status="aborted", **knob)
+        try:
+            code, result, err = invoke(f, led, root)
+            check(code == 0 and result is not None and result["status"] == "already-complete",
+                  f"{label}: aborted+CLOSED repeat refused instead of no-op: {err}")
+            check(status(led) == "aborted", f"{label}: the repeat changed the ledger")
+            check(f.merged_calls == 0, f"{label}: the repeat issued a merge")
+            check(f.worktree_present and f.branch_present, f"{label}: the repeat destroyed unmerged work")
+        finally:
+            finish(td, real)
+
+    # Guardrail: an `aborted` row whose live PR is OPEN or MERGED is a CONTRADICTION, not a no-op — the PR is
+    # no longer closed-without-merge. It must REFUSE naming the mismatch (not the generic "not in_review"),
+    # mirroring the merged+non-MERGED guard.
+    for live_state in ("OPEN", "MERGED"):
+        td, root, f, led, real = scenario(state=live_state, status="aborted")
+        try:
+            code, _result, err = invoke(f, led, root)
+            check(code != 0 and "aborted but GitHub state is" in err,
+                  f"aborted+{live_state} must refuse as a contradiction, got code={code} err={err!r}")
+            check(f.merged_calls == 0, f"aborted+{live_state} contradiction must not merge")
+        finally:
+            finish(td, real)
+
+
 def t_head_race_between_view_and_merge_refuses_before_landing():
     # A push advances the live tip to a DIFFERENT SHA in the window between the pre-merge view (which
     # still reports the reviewed head) and the merge call. --match-head-commit pins the reviewed SHA, so
@@ -686,6 +740,7 @@ CASES = [
     ("merge-accepted", "MERGED confirmation outranks a lost merge response", t_merge_transport_failure_after_acceptance_continues),
     ("terminal-write-resume", "a failed terminal write resumes after already-completed cleanup", t_terminal_write_failure_resumes_after_cleanup),
     ("terminal-repeat", "repeated invocation after terminal state is a no-op", t_repeat_after_terminal_is_noop),
+    ("aborted-terminal-repeat", "repeating after a CLOSED close-out is an already-complete no-op (moved refs tolerated); aborted+OPEN/MERGED refuses as a contradiction", t_repeat_after_closed_terminal_is_noop),
     ("head-race", "--match-head-commit refuses a tip that advanced before the merge landed", t_head_race_between_view_and_merge_refuses_before_landing),
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -34,7 +34,8 @@ def check(cond: bool, msg: str) -> None:
 class Fake:
     def __init__(self, root: Path, *, worktree_owned="yes", branch_owned="yes",
                  state="OPEN", ci="green", reviews="2", status="in_review",
-                 base_checked=True, fail_once: "str | None" = None):
+                 base_checked=True, fail_once: "str | None" = None,
+                 live_head: str = SHA, reject_method: "str | None" = None):
         self.root = root
         self.branch = "feat-pr"
         self.base = "main"
@@ -53,6 +54,10 @@ class Fake:
         self.failed: set[str] = set()
         self.view_error_once = fail_once == "confirm-view"
         self.merged_calls = 0
+        # The live tip GitHub would merge, and a merge method the repo rejects — the two knobs that
+        # model, respectively, a head-race (--match-head-commit must refuse) and a disabled method.
+        self.live_head = live_head
+        self.reject_method = reject_method
 
     def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
                run_id="g1") -> None:
@@ -107,6 +112,12 @@ class Fake:
             return ok(json.dumps(self.view()))
         if argv[:3] == ["gh", "pr", "merge"]:
             self.merged_calls += 1
+            if "--match-head-commit" in argv:
+                pinned = argv[argv.index("--match-head-commit") + 1]
+                if pinned != self.live_head:
+                    return bad("Head branch was modified. Review and try the merge again.")
+            if self.reject_method is not None and f"--{self.reject_method}" in argv:
+                return bad(f"{self.reject_method.capitalize()} merges are not allowed on this repository")
             if self._fail("merge-before"):
                 return bad("merge rejected")
             self.state = "MERGED"
@@ -155,9 +166,10 @@ def scenario(**kwargs):
     return td, root, fake, ledger, real
 
 
-def invoke(fake: Fake, ledger: Path, root: Path) -> tuple[int, "dict | None", str]:
+def invoke(fake: Fake, ledger: Path, root: Path,
+           merge_method: str = "squash") -> tuple[int, "dict | None", str]:
     try:
-        result = M.execute(ledger, "9", root, "o/r")
+        result = M.execute(ledger, "9", root, "o/r", merge_method=merge_method)
         return 0, result, ""
     except M.Refusal as exc:
         return 1, None, str(exc)
@@ -183,7 +195,8 @@ def t_happy_owned_cleanup_and_command():
         check(status(led) == "merged", "terminal ledger state must land last")
         check(not f.worktree_present and not f.branch_present, "both owned resources must be removed")
         merge = [argv for argv, _ in f.calls if argv[:3] == ["gh", "pr", "merge"]]
-        check(merge == [["gh", "pr", "merge", "9", "--repo", "o/r", "--squash"]],
+        check(merge == [["gh", "pr", "merge", "9", "--repo", "o/r", "--squash",
+                         "--match-head-commit", SHA]],
               f"wrong merge argv: {merge}")
         check(all("--delete-branch" not in argv for argv, _ in f.calls),
               "campaign must never request remote branch deletion")
@@ -399,6 +412,80 @@ def t_repeat_after_terminal_is_noop():
         finish(td, real)
 
 
+def t_head_race_between_view_and_merge_refuses_before_landing():
+    # A push advances the live tip to a DIFFERENT SHA in the window between the pre-merge view (which
+    # still reports the reviewed head) and the merge call. --match-head-commit pins the reviewed SHA, so
+    # GitHub refuses; the unreviewed head is never squashed and the row stays live for a clean re-gate.
+    td, root, f, led, real = scenario(live_head="c" * 40)
+    try:
+        code, _result, _err = invoke(f, led, root)
+        check(code != 0, "head-race merge was not refused")
+        merge = [argv for argv, _ in f.calls if argv[:3] == ["gh", "pr", "merge"]]
+        check(merge == [["gh", "pr", "merge", "9", "--repo", "o/r", "--squash",
+                         "--match-head-commit", SHA]],
+              f"merge argv did not pin the reviewed head: {merge}")
+        check(f.state == "OPEN", "the unreviewed head was merged despite the pin")
+        check(status(led) == "in_review", "a refused head-race must leave the row live to re-gate")
+        check(f.worktree_present and f.branch_present,
+              "a refused merge must not clean owned resources")
+    finally:
+        finish(td, real)
+
+
+def t_merge_method_input_validated_and_applied():
+    # The merge method is an explicit, validated runner input defaulting to squash. A squash-disabled
+    # repo fails LOUDLY on the default; the documented recourse is to pass the repo's prevailing method.
+    td, root, f, led, real = scenario(reject_method="squash")
+    try:
+        code, _result, err = invoke(f, led, root)  # default --squash on a squash-disabled repo
+        check(code != 0 and "not allowed" in err, f"squash-disabled repo did not fail loudly: {err}")
+        check(f.state == "OPEN", "a rejected squash must not merge")
+        check(status(led) == "in_review", "a rejected merge must leave the row live")
+    finally:
+        finish(td, real)
+
+    td, root, f, led, real = scenario(reject_method="squash")
+    try:
+        code, _result, err = invoke(f, led, root, merge_method="merge")  # prevailing method recourse
+        check(code == 0, f"prevailing merge method was not honored: {err}")
+        merge = [argv for argv, _ in f.calls if argv[:3] == ["gh", "pr", "merge"]]
+        check(merge == [["gh", "pr", "merge", "9", "--repo", "o/r", "--merge",
+                         "--match-head-commit", SHA]],
+              f"merge argv did not carry the chosen method: {merge}")
+        check(all("--delete-branch" not in argv for argv, _ in f.calls),
+              "a non-squash method must still never request remote branch deletion")
+        check(status(led) == "merged", "the prevailing-method merge did not complete")
+    finally:
+        finish(td, real)
+
+    td, root, f, led, real = scenario()
+    try:
+        code, _result, err = invoke(f, led, root, merge_method="octopus")
+        check(code != 0 and "merge method" in err, f"an invalid merge method was accepted: {err}")
+        check(f.merged_calls == 0, "an invalid merge method reached the merge call")
+    finally:
+        finish(td, real)
+
+
+def t_absent_snapshot_merged_row_resumes_via_run():
+    # Heartbeat routing (loop-control.md Step 4): an absent-from-snapshot row whose ledger status is not
+    # yet terminal is routed through `merge.py run`. GitHub already MERGED it, but the process died before
+    # base-sync/cleanup/terminal write, so those later phases are still pending. run resumes them here —
+    # no second merge, cleanup completes, terminal row lands — which is what the doc delegates to it.
+    td, root, f, led, real = scenario(state="MERGED")
+    try:
+        check(f.worktree_present and f.branch_present, "precondition: later phases still pending")
+        code, result, err = invoke(f, led, root)
+        check(code == 0, err)
+        check(f.merged_calls == 0, "a MERGED PR must not be re-merged when the heartbeat resumes it")
+        check(status(led) == "merged", "resume must finalize the terminal ledger row")
+        check(not f.worktree_present and not f.branch_present,
+              "resume must complete the pending base-sync/cleanup phases")
+        check(result is not None and result["status"] == "merged", f"unexpected result: {result}")
+    finally:
+        finish(td, real)
+
+
 CASES = [
     ("happy-owned", "exact merge argv, owned cleanup, terminal write", t_happy_owned_cleanup_and_command),
     ("merged-live-row", "MERGED with live ledger resumes without another merge", t_merge_landed_ledger_live_resumes),
@@ -413,4 +500,7 @@ CASES = [
     ("merge-accepted", "MERGED confirmation outranks a lost merge response", t_merge_transport_failure_after_acceptance_continues),
     ("terminal-write-resume", "a failed terminal write resumes after already-completed cleanup", t_terminal_write_failure_resumes_after_cleanup),
     ("terminal-repeat", "repeated invocation after terminal state is a no-op", t_repeat_after_terminal_is_noop),
+    ("head-race", "--match-head-commit refuses a tip that advanced before the merge landed", t_head_race_between_view_and_merge_refuses_before_landing),
+    ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
+    ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Mocked fixtures for `merge.py`; no fixture contacts GitHub or merges a real PR."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+OWNER = Path(__file__).resolve().parent / "merge.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("merge_runner_owner", OWNER)
+    if mod is None:
+        raise RuntimeError(f"cannot load {OWNER}")
+    return mod
+
+
+M = _load_owner()
+L = M.L
+
+SHA = "a" * 40
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise M.SelfTestFailure(msg)
+
+
+class Fake:
+    def __init__(self, root: Path, *, worktree_owned="yes", branch_owned="yes",
+                 state="OPEN", ci="green", reviews="2", status="in_review",
+                 base_checked=True, fail_once: "str | None" = None):
+        self.root = root
+        self.branch = "feat-pr"
+        self.base = "main"
+        self.worktree = root / ".worktrees" / self.branch
+        self.worktree_owned = worktree_owned
+        self.branch_owned = branch_owned
+        self.state = state
+        self.ci = ci
+        self.reviews = reviews
+        self.status = status
+        self.base_checked = base_checked
+        self.worktree_present = True
+        self.branch_present = True
+        self.calls: list[tuple[list[str], str | None]] = []
+        self.fail_once = fail_once
+        self.failed: set[str] = set()
+        self.view_error_once = fail_once == "confirm-view"
+        self.merged_calls = 0
+
+    def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
+               run_id="g1") -> None:
+        header = dict(L.HEADER_DEFAULTS, run_id=run_id, base_branch=self.base)
+        row = dict(L.ROW_DEFAULTS)
+        row.update(pr="9", id="pr9", branch=branch or self.branch,
+                   worktree=str(worktree or self.worktree), worktree_owned=self.worktree_owned,
+                   branch_owned=self.branch_owned, head_sha=SHA, reviews_ok=self.reviews,
+                   ci=self.ci, tier="HIGH", status=self.status)
+        L.dump(path, header, [row])
+
+    def view(self) -> dict:
+        return {
+            "state": self.state,
+            "headRefOid": SHA,
+            "headRefName": self.branch,
+            "baseRefName": self.base,
+            "labels": [{"name": "gauntlet-run-g1"}],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "isDraft": False,
+        }
+
+    def _fail(self, phase: str) -> bool:
+        if self.fail_once == phase and phase not in self.failed:
+            self.failed.add(phase)
+            return True
+        return False
+
+    def _worktrees(self) -> str:
+        entries = []
+        if self.base_checked:
+            entries.append(f"worktree {self.root}\0HEAD {'b' * 40}\0branch refs/heads/{self.base}\0\0")
+        if self.worktree_present:
+            entries.append(
+                f"worktree {self.worktree}\0HEAD {SHA}\0branch refs/heads/{self.branch}\0\0")
+        return "".join(entries)
+
+    def run(self, argv: list[str], *, cwd: "str | None" = None) -> subprocess.CompletedProcess:
+        self.calls.append((list(argv), cwd))
+        ok = lambda out="": subprocess.CompletedProcess(argv, 0, out, "")
+        bad = lambda why: subprocess.CompletedProcess(argv, 1, "", why)
+
+        if argv[:5] == ["git", "-C", str(self.root), "rev-parse", "--show-toplevel"]:
+            return ok(f"{self.root}\n")
+        if "check-ref-format" in argv:
+            return ok()
+        if argv[:3] == ["gh", "pr", "view"]:
+            if self.view_error_once and self.merged_calls:
+                self.view_error_once = False
+                return bad("temporary view failure")
+            return ok(json.dumps(self.view()))
+        if argv[:3] == ["gh", "pr", "merge"]:
+            self.merged_calls += 1
+            if self._fail("merge-before"):
+                return bad("merge rejected")
+            self.state = "MERGED"
+            if self._fail("merge-after"):
+                return bad("connection lost after acceptance")
+            return ok()
+        if argv[:4] == ["git", "-C", str(self.worktree), "fetch"]:
+            return bad("ancestry fetch failed") if self._fail("entry-fetch") else ok()
+        if argv[:5] == ["git", "-C", str(self.worktree), "merge-base", "--is-ancestor"]:
+            return bad("stale") if self._fail("stale-base") else ok()
+        if len(argv) >= 6 and argv[:4] == ["git", "-C", str(self.root), "fetch"] and ":refs/remotes/" in argv[-1]:
+            return bad("tracking fetch failed") if self._fail("sync-tracking") else ok()
+        if argv[:6] == ["git", "-C", str(self.root), "worktree", "list", "--porcelain"]:
+            return ok(self._worktrees())
+        if len(argv) >= 6 and argv[:3] == ["git", "-C", str(self.root)] and argv[3:5] == ["fetch", "origin"]:
+            return bad("base ref fetch failed") if self._fail("sync-base") else ok()
+        if len(argv) >= 6 and argv[:3] == ["git", "-C", str(self.root)] and argv[3:5] == ["merge", "--ff-only"]:
+            return bad("base ff failed") if self._fail("sync-base") else ok()
+        if argv[:4] == ["git", "-C", str(self.worktree), "status"]:
+            return ok("dirty\n") if self._fail("dirty") else ok()
+        if argv[:5] == ["git", "-C", str(self.root), "worktree", "remove"]:
+            if self._fail("worktree-remove"):
+                return bad("remove failed")
+            self.worktree_present = False
+            return ok()
+        if len(argv) >= 7 and argv[:4] == ["git", "-C", str(self.root), "show-ref"]:
+            return ok() if self.branch_present else bad("absent")
+        if len(argv) >= 5 and argv[:4] == ["git", "-C", str(self.root), "rev-parse"]:
+            return ok(f"{SHA}\n")
+        if len(argv) >= 7 and argv[:4] == ["git", "-C", str(self.root), "branch"]:
+            if self._fail("branch-remove"):
+                return bad("branch delete failed")
+            self.branch_present = False
+            return ok()
+        return bad(f"unexpected command: {argv!r}")
+
+
+def scenario(**kwargs):
+    td = tempfile.TemporaryDirectory()
+    root = Path(td.name).resolve()
+    fake = Fake(root, **kwargs)
+    ledger = root / "state.jsonl"
+    fake.ledger(ledger)
+    real = getattr(M, "_run")
+    setattr(M, "_run", fake.run)
+    return td, root, fake, ledger, real
+
+
+def invoke(fake: Fake, ledger: Path, root: Path) -> tuple[int, "dict | None", str]:
+    try:
+        result = M.execute(ledger, "9", root, "o/r")
+        return 0, result, ""
+    except M.Refusal as exc:
+        return 1, None, str(exc)
+
+
+def finish(td, real) -> None:
+    setattr(M, "_run", real)
+    td.cleanup()
+
+
+def status(ledger: Path) -> str:
+    row = L.find_row(L.load(ledger)[1], "9")
+    if row is None:
+        raise M.SelfTestFailure("fixture ledger lost PR 9")
+    return row["status"]
+
+
+def t_happy_owned_cleanup_and_command():
+    td, root, f, led, real = scenario()
+    try:
+        code, result, err = invoke(f, led, root)
+        check(code == 0, err)
+        check(status(led) == "merged", "terminal ledger state must land last")
+        check(not f.worktree_present and not f.branch_present, "both owned resources must be removed")
+        merge = [argv for argv, _ in f.calls if argv[:3] == ["gh", "pr", "merge"]]
+        check(merge == [["gh", "pr", "merge", "9", "--repo", "o/r", "--squash"]],
+              f"wrong merge argv: {merge}")
+        check(all("--delete-branch" not in argv for argv, _ in f.calls),
+              "campaign must never request remote branch deletion")
+        check(result is not None and
+              result["cleanup"] == {"worktree": "removed", "branch": "removed"},
+              f"cleanup result is incomplete: {result}")
+    finally:
+        finish(td, real)
+
+
+def t_merge_landed_ledger_live_resumes():
+    td, root, f, led, real = scenario(state="MERGED")
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code == 0, err)
+        check(f.merged_calls == 0, "a durable MERGED state must skip the merge command")
+        check(status(led) == "merged", "resume must finish the live ledger row")
+    finally:
+        finish(td, real)
+
+
+def t_reused_resources_are_left():
+    for wt_owned, br_owned in (("no", "no"), ("yes", "no"), ("no", "yes"), ("yes", "yes")):
+        td, root, f, led, real = scenario(worktree_owned=wt_owned, branch_owned=br_owned)
+        try:
+            code, _result, err = invoke(f, led, root)
+            if (wt_owned, br_owned) == ("no", "yes"):
+                check(code != 0 and "not an adoption-produced" in err,
+                      f"{wt_owned}/{br_owned}: impossible ownership state was accepted")
+                continue
+            check(code == 0, f"{wt_owned}/{br_owned}: {err}")
+            check(f.worktree_present == (wt_owned == "no"),
+                  f"{wt_owned}/{br_owned}: wrong worktree cleanup")
+            check(f.branch_present == (br_owned == "no"),
+                  f"{wt_owned}/{br_owned}: wrong branch cleanup")
+        finally:
+            finish(td, real)
+
+
+def t_root_and_foreign_targets_refused():
+    td, root, f, led, real = scenario()
+    try:
+        f.ledger(led, worktree=root)
+        code, _, err = invoke(f, led, root)
+        check(code != 0 and "repository-derived campaign path" in err,
+              f"owned root target was not refused: {err}")
+        check(f.merged_calls == 0, "ownership refusal must happen before merge")
+        f.ledger(led, branch="other")
+        code, _, err = invoke(f, led, root)
+        check(code != 0 and "live head branch" in err, f"foreign branch was not refused: {err}")
+    finally:
+        finish(td, real)
+
+
+def t_gate_refusals():
+    for kwargs, needle in (
+        ({"ci": "red"}, "ci is red"),
+        ({"ci": "pending"}, "ci is pending"),
+        ({"reviews": "1"}, "1 of 2 approvals"),
+        ({"status": "awaiting-user"}, "held"),
+        ({"fail_once": "stale-base"}, "base moved ahead"),
+    ):
+        td, root, f, led, real = scenario(**kwargs)
+        try:
+            code, _, err = invoke(f, led, root)
+            check(code != 0 and needle in err, f"{kwargs} did not fail closed: {err}")
+            check(f.merged_calls == 0, f"{kwargs} reached merge")
+        finally:
+            finish(td, real)
+
+
+def t_stale_head_and_malformed_ownership_refused():
+    td, root, f, led, real = scenario()
+    original_view = f.view
+    try:
+        def moved():
+            v = original_view()
+            v["headRefOid"] = "c" * 40
+            return v
+        f.view = moved
+        code, _, err = invoke(f, led, root)
+        check(code != 0 and "differs from ledger head" in err, f"stale SHA was accepted: {err}")
+        check(f.merged_calls == 0, "stale SHA reached merge")
+
+        f.view = original_view
+        f.worktree_owned = "-"
+        f.ledger(led)
+        code, _, err = invoke(f, led, root)
+        check(code != 0 and "worktree_owned" in err, f"malformed ownership was accepted: {err}")
+    finally:
+        finish(td, real)
+
+
+def t_owner_label_and_uncertain_view_refused():
+    td, root, f, led, real = scenario()
+    original_view = f.view
+    try:
+        def foreign():
+            v = original_view()
+            v["labels"] = [{"name": "gauntlet-run-other"}]
+            return v
+        f.view = foreign
+        code, _, err = invoke(f, led, root)
+        check(code != 0 and "owner label" in err, f"another run was not refused: {err}")
+
+        def malformed():
+            v = original_view()
+            del v["mergeStateStatus"]
+            return v
+        f.view = malformed
+        code, _, err = invoke(f, led, root)
+        check(code != 0 and "mergeStateStatus" in err, f"malformed GitHub state was not refused: {err}")
+    finally:
+        finish(td, real)
+
+
+def t_base_checked_out_and_absent():
+    for checked, expected in ((True, ["merge", "--ff-only"]), (False, ["fetch", "origin", "main:main"])):
+        td, root, f, led, real = scenario(base_checked=checked)
+        try:
+            code, _, err = invoke(f, led, root)
+            check(code == 0, err)
+            suffixes = [argv[3:] for argv, _ in f.calls if argv[:3] == ["git", "-C", str(root)]]
+            check(any(parts[:len(expected)] == expected for parts in suffixes),
+                  f"base checked={checked} did not use {expected}: {suffixes}")
+        finally:
+            finish(td, real)
+
+
+def t_merge_and_confirmation_failures_resume():
+    for phase in ("merge-before", "confirm-view"):
+        td, root, f, led, real = scenario(fail_once=phase)
+        try:
+            first, _, _ = invoke(f, led, root)
+            check(first != 0 and status(led) == "in_review", f"{phase} must leave ledger live")
+            if phase == "confirm-view":
+                check(f.worktree_present and f.branch_present,
+                      "confirmation failure cleaned resources before MERGED was observed")
+            second, _, err = invoke(f, led, root)
+            check(second == 0, f"{phase} did not resume: {err}")
+            expected_merges = 2 if phase == "merge-before" else 1
+            check(f.merged_calls == expected_merges,
+                  f"{phase}: expected {expected_merges} merge command(s), got {f.merged_calls}")
+        finally:
+            finish(td, real)
+
+
+def t_postmerge_phase_failures_resume():
+    for phase in ("sync-tracking", "sync-base", "worktree-remove", "branch-remove"):
+        td, root, f, led, real = scenario(fail_once=phase)
+        try:
+            first, _, _ = invoke(f, led, root)
+            check(first != 0 and f.state == "MERGED" and status(led) == "in_review",
+                  f"{phase}: partial state must be durable and ledger live")
+            second, _, err = invoke(f, led, root)
+            check(second == 0 and status(led) == "merged", f"{phase} did not resume: {err}")
+            check(f.merged_calls == 1, f"{phase}: resume repeated merge")
+        finally:
+            finish(td, real)
+
+
+def t_merge_transport_failure_after_acceptance_continues():
+    td, root, f, led, real = scenario(fail_once="merge-after")
+    try:
+        code, _, err = invoke(f, led, root)
+        check(code == 0, f"confirmed MERGED must outrank merge transport failure: {err}")
+        check(status(led) == "merged", "confirmed merge did not complete")
+    finally:
+        finish(td, real)
+
+
+def t_terminal_write_failure_resumes_after_cleanup():
+    td, root, f, led, real = scenario()
+    real_save = L.save
+    fired = False
+
+    def fail_once(path, header, rows, *, activity):
+        nonlocal fired
+        if not fired:
+            fired = True
+            raise OSError("simulated atomic replace failure")
+        return real_save(path, header, rows, activity=activity)
+
+    L.save = fail_once
+    try:
+        first, _, err = invoke(f, led, root)
+        check(first != 0 and "terminal ledger write failed" in err, f"write failure was not controlled: {err}")
+        check(f.state == "MERGED" and not f.worktree_present and not f.branch_present,
+              "write failure did not leave safely re-derived completed phases")
+        check(status(led) == "in_review", "failed atomic terminal write changed the ledger")
+        second, _, err = invoke(f, led, root)
+        check(second == 0 and status(led) == "merged", f"terminal write did not resume: {err}")
+        check(f.merged_calls == 1, "terminal-write resume repeated merge")
+    finally:
+        L.save = real_save
+        finish(td, real)
+
+
+def t_repeat_after_terminal_is_noop():
+    td, root, f, led, real = scenario()
+    try:
+        first, _, err = invoke(f, led, root)
+        check(first == 0, err)
+        before = len(f.calls)
+        second, result, err = invoke(f, led, root)
+        check(second == 0 and result is not None and result["status"] == "already-complete", err)
+        new = [argv for argv, _ in f.calls[before:]]
+        check(not any(argv[:3] == ["gh", "pr", "merge"] for argv in new),
+              "terminal rerun repeated merge")
+        check(not any("worktree" in argv and "remove" in argv for argv in new),
+              "terminal rerun repeated cleanup")
+    finally:
+        finish(td, real)
+
+
+CASES = [
+    ("happy-owned", "exact merge argv, owned cleanup, terminal write", t_happy_owned_cleanup_and_command),
+    ("merged-live-row", "MERGED with live ledger resumes without another merge", t_merge_landed_ledger_live_resumes),
+    ("ownership-matrix", "all worktree/branch ownership combinations clean only owned resources", t_reused_resources_are_left),
+    ("root-foreign", "root cleanup and foreign branch are refused before merge", t_root_and_foreign_targets_refused),
+    ("gate-refusals", "held, stale, red, pending, and short-tally rows never merge", t_gate_refusals),
+    ("stale-malformed", "stale live SHA and malformed ownership fail closed", t_stale_head_and_malformed_ownership_refused),
+    ("owner-and-view", "another run and uncertain GitHub state fail closed", t_owner_label_and_uncertain_view_refused),
+    ("base-location", "checked-out and absent local base use their documented update paths", t_base_checked_out_and_absent),
+    ("merge-resume", "merge and confirmation failures resume safely", t_merge_and_confirmation_failures_resume),
+    ("postmerge-resume", "every post-merge phase resumes without another merge", t_postmerge_phase_failures_resume),
+    ("merge-accepted", "MERGED confirmation outranks a lost merge response", t_merge_transport_failure_after_acceptance_continues),
+    ("terminal-write-resume", "a failed terminal write resumes after already-completed cleanup", t_terminal_write_failure_resumes_after_cleanup),
+    ("terminal-repeat", "repeated invocation after terminal state is a no-op", t_repeat_after_terminal_is_noop),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -604,6 +604,40 @@ def t_closed_out_terminates_despite_moved_head_base_or_branch():
             finish(td, real)
 
 
+def t_closed_out_terminates_every_held_status():
+    # The close-out fires for ANY non-terminal status, not just `in_review`. A CLOSED PR moots every HELD
+    # reason (`L.HELD_STATUSES` — awaiting-api/awaiting-user/repairing): nothing is left to merge, approve,
+    # adjudicate, or repair, and a human closing a parked PR IS the resolution. So every held status must
+    # terminate as `aborted` with NO merge and NO cleanup, exactly like the in_review close-out
+    # (t_absent_snapshot_closed_row_terminates). This is the counterpart of the OPEN+held REFUSAL that
+    # t_gate_refusals still pins: OPEN keeps waiting on the human, CLOSED closes out.
+    for held in L.HELD_STATUSES:
+        td, root, f, led, real = scenario(state="CLOSED", status=held)
+        try:
+            code, result, err = invoke(f, led, root)
+            check(code == 0, f"{held}: CLOSED held row refused instead of terminating: {err}")
+            check(status(led) == "aborted",
+                  f"{held}: CLOSED held row must terminate as aborted, got {status(led)!r}")
+            check(result is not None and result["status"] == "closed-unmerged" and result["cleanup"] == {},
+                  f"{held}: expected closed-unmerged with no cleanup, got {result}")
+            check(f.merged_calls == 0, f"{held}: the close-out issued a merge command")
+            check(f.worktree_present and f.branch_present,
+                  f"{held}: the close-out deleted owned resources holding unmerged work")
+        finally:
+            finish(td, real)
+
+    # Guardrail: a `merged` row with a CLOSED live state stays a REFUSED contradiction (a merged PR reports
+    # MERGED, not CLOSED). `merged` is excluded from the close-out, so it falls to the terminal status gate.
+    td, root, f, led, real = scenario(state="CLOSED", status="merged")
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "merged but GitHub state is" in err,
+              f"merged+CLOSED must stay a refused contradiction, got code={code} err={err!r}")
+        check(f.merged_calls == 0, "the merged/CLOSED contradiction must not merge")
+    finally:
+        finish(td, real)
+
+
 def t_absent_routing_decision():
     # The ROUTING DECISION itself (loop-control.md Step 1 -> Step 4), exercised end to end rather than by a
     # bare execute() call. reconcile.py observes the absent fact; `merge.py run` is the single finalizer BOTH
@@ -657,5 +691,6 @@ CASES = [
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),
     ("absent-closed", "an absent-but-unfinalized CLOSED-without-merge row terminates as aborted with no cleanup", t_absent_snapshot_closed_row_terminates),
     ("closed-out-moved-refs", "the CLOSED close-out terminates as aborted despite a moved head, base, or branch", t_closed_out_terminates_despite_moved_head_base_or_branch),
+    ("closed-out-held-statuses", "a CLOSED PR closes out every held status to aborted; merged+CLOSED stays refused", t_closed_out_terminates_every_held_status),
     ("absent-routing", "the absent fact routes reconcile -> merge.py run, which finalizes MERGED and CLOSED sides", t_absent_routing_decision),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -20,8 +20,22 @@ def _load_owner():
     return mod
 
 
+def _load_reconcile():
+    # Loaded by path (never a static import — reconcile.py is outside the pyright type-clean set, and
+    # `merge.py` already loads its siblings this way). The helper raises rather than returning None, so the
+    # module binding is non-optional at every use.
+    path = OWNER.parent / "reconcile.py"
+    mod = load_module_from_path("merge_test_reconcile", path)
+    if mod is None:
+        raise RuntimeError(f"cannot load {path}")
+    return mod
+
+
 M = _load_owner()
 L = M.L
+# The reconcile detector. The routing-decision fixture drives BOTH tools: the fact reconcile emits, and the
+# `merge.py run` finalizer that fact routes to.
+RECON = _load_reconcile()
 
 SHA = "a" * 40
 
@@ -486,6 +500,63 @@ def t_absent_snapshot_merged_row_resumes_via_run():
         finish(td, real)
 
 
+def t_absent_snapshot_closed_row_terminates():
+    # Heartbeat routing (loop-control.md Step 4), the CLOSED side of the absent-row finalizer: an
+    # absent-from-snapshot NON-TERMINAL row whose live PR is CLOSED WITHOUT merging (a human closed it, or the
+    # driver died after `gh pr close`). `merge.py run` performs the terminal close-out — records `aborted`,
+    # runs NO merge, and cleans NOTHING: the branch content never reached <base>, so removing an owned
+    # worktree/branch would destroy unmerged work.
+    td, root, f, led, real = scenario(state="CLOSED")
+    try:
+        code, result, err = invoke(f, led, root)
+        check(code == 0, err)
+        check(f.merged_calls == 0, "a CLOSED-without-merge PR must never be merged")
+        check(status(led) == "aborted", f"a closed-without-merge row must terminate as aborted, got {status(led)!r}")
+        check(result is not None and result["status"] == "closed-unmerged" and result["cleanup"] == {},
+              f"the close-out must report closed-unmerged with no cleanup: {result}")
+        check(f.worktree_present and f.branch_present,
+              "the close-out must NOT delete owned resources holding unmerged work")
+        check(not any(argv[:3] == ["gh", "pr", "merge"] for argv, _ in f.calls),
+              "the close-out issued a merge command")
+        check(not any("worktree" in argv and "remove" in argv for argv, _ in f.calls),
+              "the close-out removed a worktree")
+    finally:
+        finish(td, real)
+
+
+def t_absent_routing_decision():
+    # The ROUTING DECISION itself (loop-control.md Step 1 -> Step 4), exercised end to end rather than by a
+    # bare execute() call. reconcile.py observes the absent fact; `merge.py run` is the single finalizer BOTH
+    # sides of the routing lead to. reconcile emits `absent_from_snapshot: True` for a NON-TERMINAL row missing
+    # from the snapshot, and that one fact routes to `merge.py run`, which distinguishes MERGED (resume) from
+    # CLOSED-without-merge (terminate). Both branches are driven from the same reconcile fact here.
+    for live_state, want_status, want_result in (
+        ("MERGED", "merged", "merged"),
+        ("CLOSED", "aborted", "closed-unmerged"),
+    ):
+        td, root, f, led, real = scenario(state=live_state)
+        try:
+            # Routing INPUT: reconcile sees PR 9 (in_review) absent from an empty snapshot and reports the fact.
+            prs = root / "prs.json"
+            prs.write_text("[]", encoding="utf-8")
+            facts = RECON.detect(led, prs, "g1")
+            row_fact = facts["rows"]["9"]
+            check(row_fact.get("absent_from_snapshot") is True,
+                  f"{live_state}: reconcile did not report the absent fact: {row_fact}")
+            check("terminal" not in row_fact,
+                  f"{live_state}: a non-terminal absent row must not be pre-classified terminal: {row_fact}")
+            # Routing OUTPUT: the fact routes to `merge.py run`, which finalizes the correct side.
+            code, result, err = invoke(f, led, root)
+            check(code == 0, f"{live_state}: {err}")
+            check(status(led) == want_status,
+                  f"{live_state}: absent row finalized to {status(led)!r}, expected {want_status!r}")
+            check(result is not None and result["status"] == want_result,
+                  f"{live_state}: run reported {result}, expected result status {want_result!r}")
+            check(f.merged_calls == 0, f"{live_state}: an already-terminal live PR must not be re-merged")
+        finally:
+            finish(td, real)
+
+
 CASES = [
     ("happy-owned", "exact merge argv, owned cleanup, terminal write", t_happy_owned_cleanup_and_command),
     ("merged-live-row", "MERGED with live ledger resumes without another merge", t_merge_landed_ledger_live_resumes),
@@ -503,4 +574,6 @@ CASES = [
     ("head-race", "--match-head-commit refuses a tip that advanced before the merge landed", t_head_race_between_view_and_merge_refuses_before_landing),
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),
+    ("absent-closed", "an absent-but-unfinalized CLOSED-without-merge row terminates as aborted with no cleanup", t_absent_snapshot_closed_row_terminates),
+    ("absent-routing", "the absent fact routes reconcile -> merge.py run, which finalizes MERGED and CLOSED sides", t_absent_routing_decision),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -138,21 +138,34 @@ def _validate_ref(root: Path, value: str, role: str) -> None:
 
 
 def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
-                    *, check_live_refs: bool = True, check_cleanup_ownership: bool = True) -> None:
-    # Two INDEPENDENT relaxations, both defaulting to the FULL validation every cleanup-performing caller
-    # needs. A caller drops a relaxation ONLY when the path it guards does not use what that relaxation
-    # checks; the ledger-only CLOSED close-out and its aborted-repeat drop BOTH (they merge nothing and
-    # clean nothing), every other caller keeps both.
-    #   * `check_live_refs=False` drops the live head/base/branch equality pins below — the checks a MERGE
-    #     needs to land on the exact reviewed tip. A head push or base/branch rename before a CLOSED
-    #     close-out is irrelevant to a row that only records terminal `aborted`.
-    #   * `check_cleanup_ownership=False` drops the cleanup-ownership fields (`worktree`, `worktree_owned`,
-    #     `branch_owned`). The close-out performs NO local cleanup, so it must not require them resolved: a
-    #     HALF-ADOPTED row (pr-adopt.py registers the ledger row BEFORE it resolves the worktree, so its
-    #     documented git-failure path leaves those three at their ROW_DEFAULTS "-") that is then CLOSED on
-    #     GitHub must still TERMINATE, not wedge non-terminal forever — a CLOSED PR never re-enters the
-    #     open snapshot to be re-gated, so a refusal here re-routes the finalizer to the same failing
-    #     call every heartbeat. Every cleanup-performing caller keeps these (the default).
+                    *, check_live_refs: bool = True, require_resolved_ownership: bool = True,
+                    require_own_label: bool = True) -> None:
+    # Validation is SCOPED BY PATH, because the finalize reaches this from paths that do very different
+    # things. The three relaxations below default to the FULL validation the ONE merge-INITIATING path needs
+    # (a live OPEN state on an in_review row: it starts a merge, then cleans up its owned resources). Every
+    # OTHER path only FINALIZES an already-decided outcome — an external MERGE, a CLOSE, or a terminal repeat
+    # — so it merges nothing and requires only what its terminal write / owned cleanup actually touches. A
+    # relaxation is dropped ONLY on a path that does not use what it checks. The DESTRUCTIVE-OP guard below
+    # (an owned resource's identity) is NOT one of these relaxations: it runs on EVERY path whenever a
+    # resource is owned (`_owned=="yes"`), because that is exactly when `_cleanup` removes it — the guard
+    # between a bug and a destroyed worktree is never relaxed.
+    #   * `check_live_refs=False` drops the live head/base/branch equality pins — the checks a MERGE needs to
+    #     land on the exact reviewed tip, and the head pin a MERGED-resume keeps to confirm OUR reviewed head
+    #     is what landed. Only the CLOSED terminal paths drop it: a push or a base/branch rename before a
+    #     CLOSE is irrelevant to a row that only records terminal `aborted`, and a CLOSED PR never re-enters
+    #     the open snapshot to have its head_sha refreshed, so pinning it there would wedge the row forever.
+    #   * `require_resolved_ownership=False` drops the fail-closed that BOTH ownership fields are RESOLVED
+    #     (∈{yes,no}). That fail-closed is a MERGE-INITIATING sanity gate: a HALF-ADOPTION (pr-adopt.py
+    #     registers the ledger row BEFORE it resolves the worktree, so its documented git-failure path leaves
+    #     `worktree`/`worktree_owned`/`branch_owned` at their ROW_DEFAULTS "-") must never MERGE. A
+    #     finalize-only path merges nothing; an unresolved field there just means this run owns NOTHING to
+    #     clean, so the row must still TERMINATE, not wedge — the destructive guard already protects every
+    #     owned removal, so a half-adopted PR that is later CLOSED or externally MERGED still finalizes.
+    #   * `require_own_label=False` drops the requirement that the PR still carries THIS run's own label. A
+    #     half-adoption fails before `gh pr edit` attaches it, so a half-adopted PR that is later CLOSED or
+    #     externally MERGED carries no run label; requiring it on those finalize-only paths would wedge the
+    #     row forever. The FOREIGN-label refusal below is NEVER relaxed on any path — it is the real
+    #     run-isolation guard — so dropping own-label presence never lets a finalize act on another run's PR.
     if row.get("pr") != pr:
         raise Refusal(f"ledger row belongs to PR {row.get('pr')}, not PR {pr}")
     if not pr.isdecimal() or int(pr) < 1:
@@ -172,15 +185,13 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
         raise Refusal(f"ledger reviews_ok {row.get('reviews_ok')!r} is malformed")
     if row.get("ci") not in ("green", "red", "pending"):
         raise Refusal(f"ledger ci {row.get('ci')!r} is malformed")
-    if check_cleanup_ownership:
+    if require_resolved_ownership:
         if row.get("worktree_owned") not in ("yes", "no"):
             raise Refusal(f"ledger worktree_owned {row.get('worktree_owned')!r} is unresolved")
         if row.get("branch_owned") not in ("yes", "no"):
             raise Refusal(f"ledger branch_owned {row.get('branch_owned')!r} is unresolved")
-        if row["branch_owned"] == "yes" and row["worktree_owned"] != "yes":
-            raise Refusal("branch_owned=yes with worktree_owned=no is not an adoption-produced ownership state")
-        if not Path(row.get("worktree", "")).is_absolute():
-            raise Refusal("ledger worktree must be an absolute path")
+    if row.get("branch_owned") == "yes" and row.get("worktree_owned") != "yes":
+        raise Refusal("branch_owned=yes with worktree_owned=no is not an adoption-produced ownership state")
     if check_live_refs:
         if view["headRefOid"] != row["head_sha"]:
             raise Refusal(
@@ -194,13 +205,22 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
     labels = _labels(view)
     ours = f"{RUN_LABEL_PREFIX}{run_id}"
     run_labels = [name for name in labels if name.startswith(RUN_LABEL_PREFIX)]
-    if ours not in run_labels:
-        raise Refusal(f"PR {pr} does not carry this run's owner label {ours}")
+    # The FOREIGN-label refusal comes FIRST and is never relaxed — it is the run-isolation guard, and must
+    # fire even on a path where this run's OWN label presence is not required.
     foreign = [name for name in run_labels if name != ours]
     if foreign:
         raise Refusal(f"PR {pr} also carries another run's owner label {foreign[0]}")
-    if check_cleanup_ownership and row["worktree_owned"] == "yes":
-        worktree = Path(row["worktree"])
+    if require_own_label and ours not in run_labels:
+        raise Refusal(f"PR {pr} does not carry this run's owner label {ours}")
+    # DESTRUCTIVE-OP guard — UNCONDITIONAL, never gated on a relaxation flag. Whenever a resource is OWNED,
+    # `_cleanup` will remove it, so its identity must be exactly the repository-derived campaign resource. A
+    # half-adoption leaves `worktree_owned` at "-" (this guard skips it — nothing is owned to remove); an
+    # adopted row that owns the worktree must have it resolved to `<root>/.worktrees/<branch>`, never the
+    # repository root.
+    if row.get("worktree_owned") == "yes":
+        worktree = Path(row.get("worktree", ""))
+        if not worktree.is_absolute():
+            raise Refusal("owned worktree must be an absolute path")
         expected = root / ".worktrees" / branch
         if os.path.normpath(str(worktree)) != os.path.normpath(str(expected)):
             raise Refusal(
@@ -385,32 +405,32 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
         raise Refusal(f"no ledger row for PR {pr}")
     view = _view(pr, repo, root)
 
-    # CLOSED WITHOUT MERGING — the terminal close-out, the CLOSED side of the absent-row finalizer
-    # loop-control.md Step 4 routes here (a human closed the PR, or the driver died after `gh pr close`).
-    # There is NOTHING to merge and NOTHING to clean up: the branch content never reached `<base>`, so an
-    # owned worktree/branch holds UNMERGED work that removing it would destroy. This close-out is
-    # ledger-only, so NEITHER the live head/base/branch pins (`check_live_refs=False`) NOR the
-    # cleanup-ownership fields (`check_cleanup_ownership=False`) apply to it: a push that advanced the head
-    # before the close, a base/branch rename, OR a HALF-ADOPTED row whose worktree/ownership fields never
-    # resolved must still TERMINATE the row, not wedge it non-terminal forever (a CLOSED PR never re-enters
-    # the open snapshot to be re-gated, so a refusal here re-routes the finalizer to the same failure). ANY
-    # non-terminal row — `in_review` OR any held status (`L.HELD_STATUSES`) — is a real close-out: a CLOSED
-    # PR moots every held reason (nothing left to merge, approve, adjudicate, or repair), and a human
-    # closing a parked PR IS the resolution. Only a `merged` row with a CLOSED live state is a contradiction
-    # (a merged PR reports MERGED, not CLOSED), left to the fully-validated status gate below. Record the
-    # terminal `aborted` status (files-and-ledger.md, `status` taxonomy: any non-terminal status -> `aborted`)
-    # and stop.
+    # Classify the finalize PATH before validating — the tier the validation runs at depends on it.
+    #   * close_out: the CLOSED side of the absent-row finalizer (loop-control.md Step 4) — a human closed
+    #     the PR, or the driver died after `gh pr close`. There is NOTHING to merge and NOTHING to clean up:
+    #     the branch content never reached `<base>`, so an owned worktree/branch holds UNMERGED work that
+    #     removing it would destroy. ANY non-terminal row — `in_review` OR any held status
+    #     (`L.HELD_STATUSES`) — is a real close-out: a CLOSED PR moots every held reason, and a human closing
+    #     a parked PR IS the resolution. Only a `merged` row with a CLOSED live state is a contradiction (a
+    #     merged PR reports MERGED, not CLOSED), left to the terminal status gate below.
+    #   * aborted_repeat: an already-`aborted` row whose PR is still CLOSED — the terminal-repeat no-op,
+    #     symmetric with the `merged`-repeat below.
+    #   Both are LEDGER-ONLY (record `aborted`/no-op, merge and clean nothing), so both drop the live
+    #   head/base/branch pins (`check_live_refs=False`): a push or base/branch rename before the CLOSE must
+    #   not wedge a settled row, and a CLOSED PR never re-enters the open snapshot to be re-gated.
     close_out = view["state"] == "CLOSED" and row["status"] not in ("merged", "aborted")
-    # An already-`aborted` row whose PR is still CLOSED is the aborted TERMINAL-REPEAT, symmetric with the
-    # `merged`-repeat no-op below: like the fresh close-out it is ledger-only (nothing to merge or clean up),
-    # so it too drops BOTH the live head/base/branch pins and the cleanup-ownership fields — a push or
-    # base/branch rename that landed before the close, or an unresolved half-adoption worktree, must not
-    # turn a settled no-op into a spurious refusal. The `aborted` block below is its CLOSED-only guard; a
-    # live OPEN/MERGED keeps the full validation (its refusal is a contradiction, not a no-op).
     aborted_repeat = row["status"] == "aborted" and view["state"] == "CLOSED"
-    relaxed = close_out or aborted_repeat
+    ledger_only = close_out or aborted_repeat
+    # merge_initiating is the ONE path that STARTS a merge — a live OPEN state on an in_review row. It is the
+    # only path that requires the full merge-tip pins, RESOLVED ownership, and this run's OWN-label presence:
+    # a half-adoption (unresolved ownership, no own label yet) must never be merged. Every other path only
+    # finalizes an already-decided outcome (an external MERGE, a CLOSE, or a terminal repeat), so it merges
+    # nothing and tolerates a half-adoption (which then owns nothing to clean) rather than wedging it.
+    merge_initiating = view["state"] == "OPEN" and row["status"] == "in_review"
     _validate_state(header, row, pr, root, view,
-                    check_live_refs=not relaxed, check_cleanup_ownership=not relaxed)
+                    check_live_refs=not ledger_only,
+                    require_resolved_ownership=merge_initiating,
+                    require_own_label=merge_initiating)
     if close_out:
         _mark_terminal(ledger, pr, "aborted")
         return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}
@@ -430,12 +450,24 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
             raise Refusal(
                 f"terminal ledger row says merged but GitHub state is {view['state']!r}")
         return {"status": "already-complete", "pr": pr, "cleanup": {}}
-    if row["status"] != "in_review":
+
+    # Only NONTERMINAL rows (in_review or a held status) remain. Classify by the LIVE state, not the row
+    # status, so an EXTERNAL merge finalizes the landed work regardless of a held row.
+    if view["state"] == "MERGED":
+        # A maintainer merged the exact reviewed head while this row was still nonterminal — in_review OR
+        # held (`L.HELD_STATUSES`). The full ownership validation above confirmed our reviewed head/base/
+        # branch on our owned resources, so the work LANDED: fall through to resume the owed base-sync /
+        # owned cleanup / terminal write. This is the ONLY way a held row proceeds; the campaign still never
+        # INITIATES a merge on a held (or OPEN) PR — that stays refused just below.
+        pass
+    elif row["status"] != "in_review":
+        # A nonterminal, non-MERGED row that is not in_review is HELD (or malformed). The campaign must
+        # never INITIATE a merge on it. (CLOSED already closed out above; a live-MERGED held row already
+        # resumed above — only a live OPEN held row reaches here.)
         if row["status"] in L.HELD_STATUSES:
             raise Refusal(f"PR {pr} is held ({row['status']})")
         raise Refusal(f"PR {pr} row status is {row['status']!r}, not in_review")
-
-    if view["state"] == "OPEN":
+    elif view["state"] == "OPEN":
         _require_ready(row, header, view)
         # --match-head-commit pins the merge to the exact reviewed SHA. If a push advanced the live tip
         # in the window between the pre-merge view and this call, GitHub refuses fail-closed rather than
@@ -453,8 +485,8 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
             raise Refusal(
                 f"merge command returned success but PR {pr} state is {confirmed['state']!r}, not MERGED")
         view = confirmed
-    elif view["state"] != "MERGED":
-        # CLOSED was already finalized by the close-out above; only OPEN and MERGED remain live here.
+    else:
+        # in_review but the live state is neither OPEN nor MERGED (CLOSED already finalized above).
         raise Refusal(f"PR {pr} state is {view['state']!r}; expected OPEN, MERGED, or CLOSED")
 
     # MERGED is confirmed before any local ref or worktree is changed. Each following phase is idempotent.

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -6,7 +6,8 @@ against the live PR and fetched base, then performs the established merge sequen
 is either durable outside this process (GitHub MERGED, updated refs, absent owned resources, terminal
 ledger row) or safe to repeat. A rerun therefore resumes after interruption without repeating the merge.
 
-    merge.py run --ledger <state.jsonl> --pr <N> --project-root <dir> --repo <owner/name>
+    merge.py run --ledger <state.jsonl> --pr <N> --project-root <dir> --repo <owner/name> \
+        [--merge-method squash|merge|rebase]
     merge.py self-test
 
 The sibling `merge-test.py` is the executable contract. Tests replace the process boundary; they never
@@ -42,6 +43,7 @@ MC = _load("merge_runner_check", "merge-check.py")
 SHA_RE = re.compile(r"^[0-9a-f]{40}\Z")
 COUNT_RE = re.compile(r"^(?:0|[1-9][0-9]*)\Z")
 RUN_LABEL_PREFIX = "gauntlet-run-"
+MERGE_METHODS = ("squash", "merge", "rebase")
 VIEW_FIELDS = (
     "state,headRefOid,headRefName,baseRefName,labels,"
     "mergeable,mergeStateStatus,isDraft"
@@ -336,7 +338,11 @@ def _mark_merged(ledger: Path, pr: str) -> None:
             raise Refusal(f"terminal ledger write failed: {exc}") from exc
 
 
-def execute(ledger: Path, pr: str, project_root: Path, repo: str) -> dict:
+def execute(ledger: Path, pr: str, project_root: Path, repo: str,
+            merge_method: str = "squash") -> dict:
+    if merge_method not in MERGE_METHODS:
+        raise Refusal(
+            f"merge method {merge_method!r} is not one of {', '.join(MERGE_METHODS)}")
     root = resolve_project_root(project_root)
     header, rows = L.load(ledger)
     row = L.find_row(rows, pr)
@@ -357,7 +363,11 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str) -> dict:
 
     if view["state"] == "OPEN":
         _require_ready(row, header, view)
-        merge_argv = ["gh", "pr", "merge", pr, "--repo", repo, "--squash"]
+        # --match-head-commit pins the merge to the exact reviewed SHA. If a push advanced the live tip
+        # in the window between the pre-merge view and this call, GitHub refuses fail-closed rather than
+        # squashing the unreviewed head; the post-merge re-validation would only detect that after landing.
+        merge_argv = ["gh", "pr", "merge", pr, "--repo", repo, f"--{merge_method}",
+                      "--match-head-commit", row["head_sha"]]
         merge_proc = _run(merge_argv, cwd=str(root))
         # A transport failure can happen after GitHub accepted the merge. Re-read state before deciding
         # whether this phase failed; MERGED is the durable checkpoint and prevents a second merge attempt.
@@ -425,12 +435,15 @@ def main(argv: "list[str] | None" = None) -> int:
     run.add_argument("--pr", required=True)
     run.add_argument("--project-root", required=True, type=Path)
     run.add_argument("--repo", required=True)
+    run.add_argument("--merge-method", default="squash", choices=MERGE_METHODS,
+                     help="merge method (default: squash; use the repo's prevailing method if squash is disabled)")
     sub.add_parser("self-test", help="run every fixture in merge-test.py")
     args = parser.parse_args(argv)
     if args.cmd == "self-test":
         return self_test()
     try:
-        result = execute(args.ledger, str(args.pr), args.project_root, args.repo)
+        result = execute(args.ledger, str(args.pr), args.project_root, args.repo,
+                         merge_method=args.merge_method)
     except (Refusal, SystemExit) as exc:
         detail = exc if isinstance(exc, Refusal) else "ledger rejected malformed state"
         print(f"merge: REFUSED — {detail}", file=sys.stderr)

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Execute one already-approved campaign merge and its owned local cleanup.
+
+`merge-check.py` remains the owner of merge readiness. This command imports that gate, re-evaluates it
+against the live PR and fetched base, then performs the established merge sequence. Each completed phase
+is either durable outside this process (GitHub MERGED, updated refs, absent owned resources, terminal
+ledger row) or safe to repeat. A rerun therefore resumes after interruption without repeating the merge.
+
+    merge.py run --ledger <state.jsonl> --pr <N> --project-root <dir> --repo <owner/name>
+    merge.py self-test
+
+The sibling `merge-test.py` is the executable contract. Tests replace the process boundary; they never
+contact GitHub and never merge a real PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE / "merge-test.py"
+
+
+def _load(name: str, filename: str):
+    mod = load_module_from_path(name, HERE / filename)
+    if mod is None:
+        raise RuntimeError(f"cannot load {filename}")
+    return mod
+
+
+L = _load("merge_runner_ledger", "ledger.py")
+MC = _load("merge_runner_check", "merge-check.py")
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}\Z")
+COUNT_RE = re.compile(r"^(?:0|[1-9][0-9]*)\Z")
+RUN_LABEL_PREFIX = "gauntlet-run-"
+VIEW_FIELDS = (
+    "state,headRefOid,headRefName,baseRefName,labels,"
+    "mergeable,mergeStateStatus,isDraft"
+)
+
+
+class Refusal(RuntimeError):
+    """A fail-closed boundary or phase failure."""
+
+
+def _run(argv: list[str], *, cwd: "str | None" = None) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(argv, cwd=cwd, capture_output=True, text=True, check=False)  # noqa: S603
+    except OSError as exc:
+        return subprocess.CompletedProcess(argv, 127, "", str(exc))
+
+
+def _require(proc: subprocess.CompletedProcess, what: str) -> str:
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "no diagnostic").strip()
+        raise Refusal(f"{what} failed (exit {proc.returncode}): {detail}")
+    return proc.stdout
+
+
+def _one_lf(value: str) -> str:
+    return value[:-1] if value.endswith("\n") else value
+
+
+def resolve_project_root(checkout: Path) -> Path:
+    """Resolve the typed repository root once, following runtime-adapter.md's boundary."""
+    if not checkout.is_absolute():
+        raise Refusal("--project-root must be absolute")
+    out = _require(
+        _run(["git", "-C", str(checkout), "rev-parse", "--show-toplevel"]),
+        "repository resolution",
+    )
+    raw = _one_lf(out)
+    if not raw or not os.path.isabs(raw):
+        raise Refusal("repository resolution returned an empty or non-absolute path")
+    resolved = Path(raw)
+    if os.path.normpath(str(resolved)) != os.path.normpath(str(checkout)):
+        raise Refusal(f"--project-root {checkout} resolves to a different repository root {resolved}")
+    return resolved
+
+
+def _labels(view: dict) -> list[str]:
+    raw = view.get("labels")
+    if not isinstance(raw, list):
+        raise Refusal("live PR field 'labels' must be a list")
+    names: list[str] = []
+    for item in raw:
+        name = item.get("name") if isinstance(item, dict) else item
+        if not isinstance(name, str):
+            raise Refusal("live PR labels must contain string names")
+        names.append(name)
+    return names
+
+
+def _validate_view(view: object) -> dict:
+    if not isinstance(view, dict):
+        raise Refusal("live PR view is not a JSON object")
+    for field in ("state", "headRefOid", "headRefName", "baseRefName", "mergeable",
+                  "mergeStateStatus"):
+        if not isinstance(view.get(field), str):
+            raise Refusal(f"live PR field {field!r} must be a string")
+    if not isinstance(view.get("isDraft"), bool):
+        raise Refusal("live PR field 'isDraft' must be a bool")
+    _labels(view)
+    return view
+
+
+def _view(pr: str, repo: str, root: Path) -> dict:
+    argv = ["gh", "pr", "view", pr, "--repo", repo, "--json", VIEW_FIELDS]
+    out = _require(_run(argv, cwd=str(root)), f"live view for PR {pr}")
+    try:
+        parsed = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise Refusal(f"live view for PR {pr} is not JSON: {exc}") from exc
+    return _validate_view(parsed)
+
+
+def _validate_ref(root: Path, value: str, role: str) -> None:
+    if not value or value == "-":
+        raise Refusal(f"{role} is unresolved")
+    proc = _run(["git", "-C", str(root), "check-ref-format", f"refs/heads/{value}"])
+    _require(proc, f"validation of {role} {value!r}")
+
+
+def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict) -> None:
+    if row.get("pr") != pr:
+        raise Refusal(f"ledger row belongs to PR {row.get('pr')}, not PR {pr}")
+    if not pr.isdecimal() or int(pr) < 1:
+        raise Refusal(f"PR number {pr!r} is not a positive integer")
+    run_id = header.get("run_id", "-")
+    if not run_id or run_id == "-":
+        raise Refusal("ledger run_id is unresolved")
+    base = header.get("base_branch", "-")
+    branch = row.get("branch", "-")
+    _validate_ref(root, base, "base_branch")
+    _validate_ref(root, branch, "row branch")
+    if row.get("head_sha") is None or not SHA_RE.match(row["head_sha"]):
+        raise Refusal("ledger head_sha must be a full lowercase 40-character object id")
+    if row.get("tier") not in ("TRIVIAL", "STANDARD", "HIGH"):
+        raise Refusal(f"ledger tier {row.get('tier')!r} is malformed")
+    if not COUNT_RE.match(row.get("reviews_ok", "")):
+        raise Refusal(f"ledger reviews_ok {row.get('reviews_ok')!r} is malformed")
+    if row.get("ci") not in ("green", "red", "pending"):
+        raise Refusal(f"ledger ci {row.get('ci')!r} is malformed")
+    if row.get("worktree_owned") not in ("yes", "no"):
+        raise Refusal(f"ledger worktree_owned {row.get('worktree_owned')!r} is unresolved")
+    if row.get("branch_owned") not in ("yes", "no"):
+        raise Refusal(f"ledger branch_owned {row.get('branch_owned')!r} is unresolved")
+    if row["branch_owned"] == "yes" and row["worktree_owned"] != "yes":
+        raise Refusal("branch_owned=yes with worktree_owned=no is not an adoption-produced ownership state")
+    worktree = Path(row.get("worktree", ""))
+    if not worktree.is_absolute():
+        raise Refusal("ledger worktree must be an absolute path")
+    if view["headRefOid"] != row["head_sha"]:
+        raise Refusal(
+            f"live head {view['headRefOid']} differs from ledger head {row['head_sha']} — re-gate")
+    if view["headRefName"] != branch:
+        raise Refusal(
+            f"live head branch {view['headRefName']!r} differs from ledger branch {branch!r}")
+    if view["baseRefName"] != base:
+        raise Refusal(
+            f"live base {view['baseRefName']!r} differs from ledger base {base!r}")
+    labels = _labels(view)
+    ours = f"{RUN_LABEL_PREFIX}{run_id}"
+    run_labels = [name for name in labels if name.startswith(RUN_LABEL_PREFIX)]
+    if ours not in run_labels:
+        raise Refusal(f"PR {pr} does not carry this run's owner label {ours}")
+    foreign = [name for name in run_labels if name != ours]
+    if foreign:
+        raise Refusal(f"PR {pr} also carries another run's owner label {foreign[0]}")
+    if row["worktree_owned"] == "yes":
+        expected = root / ".worktrees" / branch
+        if os.path.normpath(str(worktree)) != os.path.normpath(str(expected)):
+            raise Refusal(
+                f"owned worktree {worktree} is not the repository-derived campaign path {expected}")
+        if os.path.normpath(str(worktree)) == os.path.normpath(str(root)):
+            raise Refusal("the repository root can never be an owned cleanup target")
+
+
+def _base_is_current(row: dict, header: dict) -> None:
+    worktree = row["worktree"]
+    base = header["base_branch"]
+    _require(
+        _run(["git", "-C", worktree, "fetch", "origin", base]),
+        f"refresh of origin/{base} for merge-check",
+    )
+    probe = _run(
+        ["git", "-C", worktree, "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"])
+    if probe.returncode == 1:
+        raise Refusal("merge-check: base moved ahead — rebase")
+    _require(probe, f"merge-check ancestry against origin/{base}")
+
+
+def _require_ready(row: dict, header: dict, view: dict) -> None:
+    """Delegate policy to merge-check.py, then supply its fetched-base ancestry phase."""
+    result = MC.decide(row, view, required=MC.REQUIRED)
+    if result.get("verdict") != MC.MERGE:
+        raise Refusal(f"merge-check: {result.get('reason', 'not ready')}")
+    _base_is_current(row, header)
+
+
+def _parse_worktrees(data: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for token in data.split("\0"):
+        if token == "":
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        key, sep, value = token.partition(" ")
+        current[key] = value if sep else ""
+    if current:
+        entries.append(current)
+    return entries
+
+
+def _worktree_listing(root: Path) -> list[dict[str, str]]:
+    out = _require(
+        _run(["git", "-C", str(root), "worktree", "list", "--porcelain", "-z"]),
+        "worktree discovery",
+    )
+    return _parse_worktrees(out)
+
+
+def _sync_base(root: Path, base: str) -> None:
+    remote_ref = f"refs/heads/{base}:refs/remotes/origin/{base}"
+    _require(
+        _run(["git", "-C", str(root), "fetch", "origin", remote_ref]),
+        f"refresh of origin/{base}",
+    )
+    branch_ref = f"refs/heads/{base}"
+    checked: list[str] = []
+    for entry in _worktree_listing(root):
+        path = entry.get("worktree")
+        if entry.get("branch") == branch_ref and path is not None:
+            checked.append(path)
+    if len(checked) > 1:
+        raise Refusal(f"base branch {base!r} is checked out in more than one worktree")
+    if checked:
+        _require(
+            _run(["git", "-C", checked[0], "merge", "--ff-only", f"origin/{base}"]),
+            f"fast-forward of checked-out base {base}",
+        )
+    else:
+        _require(
+            _run(["git", "-C", str(root), "fetch", "origin", f"{base}:{base}"]),
+            f"fast-forward of local base ref {base}",
+        )
+
+
+def _entry_at(entries: list[dict[str, str]], path: str) -> "dict[str, str] | None":
+    target = os.path.normpath(path)
+    for entry in entries:
+        if os.path.normpath(entry.get("worktree", "")) == target:
+            return entry
+    return None
+
+
+def _cleanup(root: Path, row: dict) -> dict:
+    branch = row["branch"]
+    branch_ref = f"refs/heads/{branch}"
+    worktree = row["worktree"]
+    removed_worktree = False
+    removed_branch = False
+
+    entries = _worktree_listing(root)
+    entry = _entry_at(entries, worktree)
+    if row["worktree_owned"] == "yes":
+        if entry is not None:
+            if entry.get("branch") != branch_ref:
+                raise Refusal(
+                    f"owned worktree path {worktree} now holds a foreign or detached checkout")
+            status = _require(
+                _run(["git", "-C", worktree, "status", "--porcelain", "--untracked-files=all"]),
+                f"cleanliness check for owned worktree {worktree}",
+            )
+            if status:
+                raise Refusal(f"owned worktree {worktree} is dirty; refusing cleanup")
+            _require(
+                _run(["git", "-C", str(root), "worktree", "remove", worktree]),
+                f"removal of owned worktree {worktree}",
+            )
+            removed_worktree = True
+    elif entry is not None and entry.get("branch") not in (branch_ref, None):
+        raise Refusal(f"reused worktree path {worktree} now holds a foreign branch")
+
+    if row["branch_owned"] == "yes":
+        entries = _worktree_listing(root)
+        checked = [entry.get("worktree") for entry in entries if entry.get("branch") == branch_ref]
+        if checked:
+            raise Refusal(f"owned branch {branch!r} is still checked out at {checked[0]}")
+        exists = _run(["git", "-C", str(root), "show-ref", "--verify", "--quiet", branch_ref])
+        if exists.returncode == 0:
+            actual = _one_lf(_require(
+                _run(["git", "-C", str(root), "rev-parse", branch_ref]),
+                f"identity check for owned branch {branch}",
+            ))
+            if actual != row["head_sha"]:
+                raise Refusal(
+                    f"owned branch {branch!r} moved to {actual}; expected {row['head_sha']}")
+            _require(
+                _run(["git", "-C", str(root), "branch", "-D", "--", branch]),
+                f"removal of owned branch {branch}",
+            )
+            removed_branch = True
+        elif exists.returncode != 1:
+            _require(exists, f"lookup of owned branch {branch}")
+
+    return {
+        "worktree": "removed" if removed_worktree else
+                    ("already-absent" if row["worktree_owned"] == "yes" else "reused-left"),
+        "branch": "removed" if removed_branch else
+                  ("already-absent" if row["branch_owned"] == "yes" else "reused-left"),
+    }
+
+
+def _mark_merged(ledger: Path, pr: str) -> None:
+    header, rows = L.load(ledger)
+    row = L.find_row(rows, pr)
+    if row is None:
+        raise Refusal(f"ledger row for PR {pr} disappeared before terminal write")
+    if row["status"] != "merged":
+        row["status"] = "merged"
+        try:
+            L.save(ledger, header, rows, activity=True)
+        except OSError as exc:
+            raise Refusal(f"terminal ledger write failed: {exc}") from exc
+
+
+def execute(ledger: Path, pr: str, project_root: Path, repo: str) -> dict:
+    root = resolve_project_root(project_root)
+    header, rows = L.load(ledger)
+    row = L.find_row(rows, pr)
+    if row is None:
+        raise Refusal(f"no ledger row for PR {pr}")
+    view = _view(pr, repo, root)
+    _validate_state(header, row, pr, root, view)
+
+    if row["status"] == "merged":
+        if view["state"] != "MERGED":
+            raise Refusal(
+                f"terminal ledger row says merged but GitHub state is {view['state']!r}")
+        return {"status": "already-complete", "pr": pr, "cleanup": {}}
+    if row["status"] != "in_review":
+        if row["status"] in L.HELD_STATUSES:
+            raise Refusal(f"PR {pr} is held ({row['status']})")
+        raise Refusal(f"PR {pr} row status is {row['status']!r}, not in_review")
+
+    if view["state"] == "OPEN":
+        _require_ready(row, header, view)
+        merge_argv = ["gh", "pr", "merge", pr, "--repo", repo, "--squash"]
+        merge_proc = _run(merge_argv, cwd=str(root))
+        # A transport failure can happen after GitHub accepted the merge. Re-read state before deciding
+        # whether this phase failed; MERGED is the durable checkpoint and prevents a second merge attempt.
+        confirmed = _view(pr, repo, root)
+        _validate_state(header, row, pr, root, confirmed)
+        if confirmed["state"] != "MERGED":
+            if merge_proc.returncode != 0:
+                _require(merge_proc, f"merge of PR {pr}")
+            raise Refusal(
+                f"merge command returned success but PR {pr} state is {confirmed['state']!r}, not MERGED")
+        view = confirmed
+    elif view["state"] != "MERGED":
+        raise Refusal(f"PR {pr} state is {view['state']!r}; expected OPEN or MERGED")
+
+    # MERGED is confirmed before any local ref or worktree is changed. Each following phase is idempotent.
+    _sync_base(root, header["base_branch"])
+    cleanup = _cleanup(root, row)
+    _mark_merged(ledger, pr)
+    return {"status": "merged", "pr": pr, "cleanup": cleanup}
+
+
+class SelfTestFailure(AssertionError):
+    """A claimed merge-runner rule did not hold."""
+
+
+def _sibling_cases() -> list:
+    if not SIBLING.exists():
+        raise SelfTestFailure(f"fixture suite is missing at {SIBLING}")
+    mod = load_module_from_path("merge_runner_test", SIBLING, register=True)
+    if mod is None:
+        raise SelfTestFailure(f"cannot load fixture suite at {SIBLING}")
+    cases = getattr(mod, "CASES", None)
+    if not cases:
+        raise SelfTestFailure(f"{SIBLING.name} exports no CASES")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = _sibling_cases()
+    except SelfTestFailure as exc:
+        print(f"FAIL sibling-fixtures: {exc}")
+        return 1
+    for name, rule, fn in cases:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL {name}: {rule}\n     {type(exc).__name__}: {exc}")
+        else:
+            print(f"ok   {name}: {rule}")
+    if failures:
+        print(f"{failures} merge-runner fixture(s) failed")
+        return 1
+    print(f"all {len(cases)} merge-runner fixtures hold")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    run = sub.add_parser("run", help="resume or execute one proven-ready merge")
+    run.add_argument("--ledger", required=True, type=Path)
+    run.add_argument("--pr", required=True)
+    run.add_argument("--project-root", required=True, type=Path)
+    run.add_argument("--repo", required=True)
+    sub.add_parser("self-test", help="run every fixture in merge-test.py")
+    args = parser.parse_args(argv)
+    if args.cmd == "self-test":
+        return self_test()
+    try:
+        result = execute(args.ledger, str(args.pr), args.project_root, args.repo)
+    except (Refusal, SystemExit) as exc:
+        detail = exc if isinstance(exc, Refusal) else "ledger rejected malformed state"
+        print(f"merge: REFUSED — {detail}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -137,7 +137,12 @@ def _validate_ref(root: Path, value: str, role: str) -> None:
     _require(proc, f"validation of {role} {value!r}")
 
 
-def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict) -> None:
+def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
+                    *, check_live_refs: bool = True) -> None:
+    # `check_live_refs=False` drops ONLY the live head/base/branch equality pins below — the checks a
+    # MERGE needs to land on the exact reviewed tip. The ledger-only CLOSED close-out (execute()) passes
+    # it: it records terminal `aborted` and touches nothing else, so a head push or base/branch rename
+    # before the close is irrelevant to it. Every non-close-out caller keeps the pins (the default).
     if row.get("pr") != pr:
         raise Refusal(f"ledger row belongs to PR {row.get('pr')}, not PR {pr}")
     if not pr.isdecimal() or int(pr) < 1:
@@ -166,15 +171,16 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict) ->
     worktree = Path(row.get("worktree", ""))
     if not worktree.is_absolute():
         raise Refusal("ledger worktree must be an absolute path")
-    if view["headRefOid"] != row["head_sha"]:
-        raise Refusal(
-            f"live head {view['headRefOid']} differs from ledger head {row['head_sha']} — re-gate")
-    if view["headRefName"] != branch:
-        raise Refusal(
-            f"live head branch {view['headRefName']!r} differs from ledger branch {branch!r}")
-    if view["baseRefName"] != base:
-        raise Refusal(
-            f"live base {view['baseRefName']!r} differs from ledger base {base!r}")
+    if check_live_refs:
+        if view["headRefOid"] != row["head_sha"]:
+            raise Refusal(
+                f"live head {view['headRefOid']} differs from ledger head {row['head_sha']} — re-gate")
+        if view["headRefName"] != branch:
+            raise Refusal(
+                f"live head branch {view['headRefName']!r} differs from ledger branch {branch!r}")
+        if view["baseRefName"] != base:
+            raise Refusal(
+                f"live base {view['baseRefName']!r} differs from ledger base {base!r}")
     labels = _labels(view)
     ours = f"{RUN_LABEL_PREFIX}{run_id}"
     run_labels = [name for name in labels if name.startswith(RUN_LABEL_PREFIX)]
@@ -356,7 +362,22 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
     if row is None:
         raise Refusal(f"no ledger row for PR {pr}")
     view = _view(pr, repo, root)
-    _validate_state(header, row, pr, root, view)
+
+    # CLOSED WITHOUT MERGING — the terminal close-out, the CLOSED side of the absent-row finalizer
+    # loop-control.md Step 4 routes here (a human closed the PR, or the driver died after `gh pr close`).
+    # There is NOTHING to merge and NOTHING to clean up: the branch content never reached `<base>`, so an
+    # owned worktree/branch holds UNMERGED work that removing it would destroy. This close-out is
+    # ledger-only, so the live head/base/branch pins do NOT apply to it (`check_live_refs=False`): a push
+    # that advanced the head before the close, or a base/branch rename, must still TERMINATE the row, not
+    # wedge it at in_review forever (a CLOSED PR never re-enters the open snapshot to be re-gated). Only an
+    # in_review row is a real close-out; a `merged`/held row with a CLOSED live state is a contradiction
+    # left to the fully-validated status gate below. Record the terminal `aborted` status
+    # (files-and-ledger.md, `status` taxonomy: `in_review` -> `aborted`) and stop.
+    close_out = view["state"] == "CLOSED" and row["status"] == "in_review"
+    _validate_state(header, row, pr, root, view, check_live_refs=not close_out)
+    if close_out:
+        _mark_terminal(ledger, pr, "aborted")
+        return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}
 
     if row["status"] == "merged":
         if view["state"] != "MERGED":
@@ -386,15 +407,8 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
             raise Refusal(
                 f"merge command returned success but PR {pr} state is {confirmed['state']!r}, not MERGED")
         view = confirmed
-    elif view["state"] == "CLOSED":
-        # CLOSED WITHOUT MERGING — the terminal close-out, the CLOSED side of the absent-row finalizer
-        # loop-control.md Step 4 routes here (a human closed the PR, or the driver died after `gh pr close`).
-        # There is NOTHING to merge and NOTHING to clean up: the branch content never reached `<base>`, so an
-        # owned worktree/branch holds UNMERGED work that removing it would destroy. Record the terminal
-        # `aborted` status (files-and-ledger.md, `status` taxonomy: `in_review` -> `aborted`) and stop.
-        _mark_terminal(ledger, pr, "aborted")
-        return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}
     elif view["state"] != "MERGED":
+        # CLOSED was already finalized by the close-out above; only OPEN and MERGED remain live here.
         raise Refusal(f"PR {pr} state is {view['state']!r}; expected OPEN, MERGED, or CLOSED")
 
     # MERGED is confirmed before any local ref or worktree is changed. Each following phase is idempotent.

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -384,10 +384,26 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
     # terminal `aborted` status (files-and-ledger.md, `status` taxonomy: any non-terminal status -> `aborted`)
     # and stop.
     close_out = view["state"] == "CLOSED" and row["status"] not in ("merged", "aborted")
-    _validate_state(header, row, pr, root, view, check_live_refs=not close_out)
+    # An already-`aborted` row whose PR is still CLOSED is the aborted TERMINAL-REPEAT, symmetric with the
+    # `merged`-repeat no-op below: like the fresh close-out it is ledger-only (nothing to merge or clean up),
+    # so it too drops the live head/base/branch pins — a push or base/branch rename that landed before the
+    # close must not turn a settled no-op into a spurious refusal. The `aborted` block below is its
+    # CLOSED-only guard; a live OPEN/MERGED keeps the pins (its refusal is a contradiction, not a no-op).
+    aborted_repeat = row["status"] == "aborted" and view["state"] == "CLOSED"
+    _validate_state(header, row, pr, root, view, check_live_refs=not (close_out or aborted_repeat))
     if close_out:
         _mark_terminal(ledger, pr, "aborted")
         return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}
+
+    if row["status"] == "aborted":
+        # Terminal-repeat, symmetric with the `merged` no-op below (both terminal statuses are safe to
+        # repeat). A CLOSED live state confirms the recorded abort still holds -> the same already-complete
+        # no-op, no ledger write. A live OPEN or MERGED state CONTRADICTS the terminal `aborted` row (the PR
+        # is no longer closed-without-merge); refuse naming the mismatch, never a silent no-op.
+        if view["state"] != "CLOSED":
+            raise Refusal(
+                f"terminal ledger row says aborted but GitHub state is {view['state']!r}, not CLOSED")
+        return {"status": "already-complete", "pr": pr, "cleanup": {}}
 
     if row["status"] == "merged":
         if view["state"] != "MERGED":

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -263,6 +263,10 @@ def _sync_base(root: Path, base: str) -> None:
     if len(checked) > 1:
         raise Refusal(f"base branch {base!r} is checked out in more than one worktree")
     if checked:
+        # ff-only intentionally accepts a local-ahead base (git reports "Already up to date", exit 0).
+        # Downstream diffs/rebases read origin/<base> (freshly fetched above), not this local branch, so a
+        # local-ahead checkout poisons nothing; local-ahead means origin is an ancestor of local, i.e. local
+        # already contains the merged tip. The dangerous diverged case still fails ff-only and refuses below.
         _require(
             _run(["git", "-C", checked[0], "merge", "--ff-only", f"origin/{base}"]),
             f"fast-forward of checked-out base {base}",

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -376,11 +376,14 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
     # owned worktree/branch holds UNMERGED work that removing it would destroy. This close-out is
     # ledger-only, so the live head/base/branch pins do NOT apply to it (`check_live_refs=False`): a push
     # that advanced the head before the close, or a base/branch rename, must still TERMINATE the row, not
-    # wedge it at in_review forever (a CLOSED PR never re-enters the open snapshot to be re-gated). Only an
-    # in_review row is a real close-out; a `merged`/held row with a CLOSED live state is a contradiction
-    # left to the fully-validated status gate below. Record the terminal `aborted` status
-    # (files-and-ledger.md, `status` taxonomy: `in_review` -> `aborted`) and stop.
-    close_out = view["state"] == "CLOSED" and row["status"] == "in_review"
+    # wedge it non-terminal forever (a CLOSED PR never re-enters the open snapshot to be re-gated). ANY
+    # non-terminal row — `in_review` OR any held status (`L.HELD_STATUSES`) — is a real close-out: a CLOSED
+    # PR moots every held reason (nothing left to merge, approve, adjudicate, or repair), and a human
+    # closing a parked PR IS the resolution. Only a `merged` row with a CLOSED live state is a contradiction
+    # (a merged PR reports MERGED, not CLOSED), left to the fully-validated status gate below. Record the
+    # terminal `aborted` status (files-and-ledger.md, `status` taxonomy: any non-terminal status -> `aborted`)
+    # and stop.
+    close_out = view["state"] == "CLOSED" and row["status"] not in ("merged", "aborted")
     _validate_state(header, row, pr, root, view, check_live_refs=not close_out)
     if close_out:
         _mark_terminal(ledger, pr, "aborted")

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -6,6 +6,11 @@ against the live PR and fetched base, then performs the established merge sequen
 is either durable outside this process (GitHub MERGED, updated refs, absent owned resources, terminal
 ledger row) or safe to repeat. A rerun therefore resumes after interruption without repeating the merge.
 
+It is also the FINALIZER for an absent-from-snapshot row loop-control.md Step 4 routes here after a merge
+that landed but never finished: the single live view distinguishes MERGED (resume the owed base-sync /
+cleanup / terminal-write phases) from CLOSED-without-merge (the terminal close-out — record `aborted`, no
+merge, no cleanup, because unmerged branch content must never be destroyed).
+
     merge.py run --ledger <state.jsonl> --pr <N> --project-root <dir> --repo <owner/name> \
         [--merge-method squash|merge|rebase]
     merge.py self-test
@@ -325,13 +330,15 @@ def _cleanup(root: Path, row: dict) -> dict:
     }
 
 
-def _mark_merged(ledger: Path, pr: str) -> None:
+def _mark_terminal(ledger: Path, pr: str, status: str) -> None:
+    """Write a TERMINAL ledger status (`merged` after a landed merge, `aborted` after a closed-without-merge
+    close-out) as the last, resumable phase. A same-value write is a no-op, so a re-run finalizes idempotently."""
     header, rows = L.load(ledger)
     row = L.find_row(rows, pr)
     if row is None:
         raise Refusal(f"ledger row for PR {pr} disappeared before terminal write")
-    if row["status"] != "merged":
-        row["status"] = "merged"
+    if row["status"] != status:
+        row["status"] = status
         try:
             L.save(ledger, header, rows, activity=True)
         except OSError as exc:
@@ -379,13 +386,21 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
             raise Refusal(
                 f"merge command returned success but PR {pr} state is {confirmed['state']!r}, not MERGED")
         view = confirmed
+    elif view["state"] == "CLOSED":
+        # CLOSED WITHOUT MERGING — the terminal close-out, the CLOSED side of the absent-row finalizer
+        # loop-control.md Step 4 routes here (a human closed the PR, or the driver died after `gh pr close`).
+        # There is NOTHING to merge and NOTHING to clean up: the branch content never reached `<base>`, so an
+        # owned worktree/branch holds UNMERGED work that removing it would destroy. Record the terminal
+        # `aborted` status (files-and-ledger.md, `status` taxonomy: `in_review` -> `aborted`) and stop.
+        _mark_terminal(ledger, pr, "aborted")
+        return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}
     elif view["state"] != "MERGED":
-        raise Refusal(f"PR {pr} state is {view['state']!r}; expected OPEN or MERGED")
+        raise Refusal(f"PR {pr} state is {view['state']!r}; expected OPEN, MERGED, or CLOSED")
 
     # MERGED is confirmed before any local ref or worktree is changed. Each following phase is idempotent.
     _sync_base(root, header["base_branch"])
     cleanup = _cleanup(root, row)
-    _mark_merged(ledger, pr)
+    _mark_terminal(ledger, pr, "merged")
     return {"status": "merged", "pr": pr, "cleanup": cleanup}
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -138,11 +138,21 @@ def _validate_ref(root: Path, value: str, role: str) -> None:
 
 
 def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
-                    *, check_live_refs: bool = True) -> None:
-    # `check_live_refs=False` drops ONLY the live head/base/branch equality pins below — the checks a
-    # MERGE needs to land on the exact reviewed tip. The ledger-only CLOSED close-out (execute()) passes
-    # it: it records terminal `aborted` and touches nothing else, so a head push or base/branch rename
-    # before the close is irrelevant to it. Every non-close-out caller keeps the pins (the default).
+                    *, check_live_refs: bool = True, check_cleanup_ownership: bool = True) -> None:
+    # Two INDEPENDENT relaxations, both defaulting to the FULL validation every cleanup-performing caller
+    # needs. A caller drops a relaxation ONLY when the path it guards does not use what that relaxation
+    # checks; the ledger-only CLOSED close-out and its aborted-repeat drop BOTH (they merge nothing and
+    # clean nothing), every other caller keeps both.
+    #   * `check_live_refs=False` drops the live head/base/branch equality pins below — the checks a MERGE
+    #     needs to land on the exact reviewed tip. A head push or base/branch rename before a CLOSED
+    #     close-out is irrelevant to a row that only records terminal `aborted`.
+    #   * `check_cleanup_ownership=False` drops the cleanup-ownership fields (`worktree`, `worktree_owned`,
+    #     `branch_owned`). The close-out performs NO local cleanup, so it must not require them resolved: a
+    #     HALF-ADOPTED row (pr-adopt.py registers the ledger row BEFORE it resolves the worktree, so its
+    #     documented git-failure path leaves those three at their ROW_DEFAULTS "-") that is then CLOSED on
+    #     GitHub must still TERMINATE, not wedge non-terminal forever — a CLOSED PR never re-enters the
+    #     open snapshot to be re-gated, so a refusal here re-routes the finalizer to the same failing
+    #     call every heartbeat. Every cleanup-performing caller keeps these (the default).
     if row.get("pr") != pr:
         raise Refusal(f"ledger row belongs to PR {row.get('pr')}, not PR {pr}")
     if not pr.isdecimal() or int(pr) < 1:
@@ -162,15 +172,15 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
         raise Refusal(f"ledger reviews_ok {row.get('reviews_ok')!r} is malformed")
     if row.get("ci") not in ("green", "red", "pending"):
         raise Refusal(f"ledger ci {row.get('ci')!r} is malformed")
-    if row.get("worktree_owned") not in ("yes", "no"):
-        raise Refusal(f"ledger worktree_owned {row.get('worktree_owned')!r} is unresolved")
-    if row.get("branch_owned") not in ("yes", "no"):
-        raise Refusal(f"ledger branch_owned {row.get('branch_owned')!r} is unresolved")
-    if row["branch_owned"] == "yes" and row["worktree_owned"] != "yes":
-        raise Refusal("branch_owned=yes with worktree_owned=no is not an adoption-produced ownership state")
-    worktree = Path(row.get("worktree", ""))
-    if not worktree.is_absolute():
-        raise Refusal("ledger worktree must be an absolute path")
+    if check_cleanup_ownership:
+        if row.get("worktree_owned") not in ("yes", "no"):
+            raise Refusal(f"ledger worktree_owned {row.get('worktree_owned')!r} is unresolved")
+        if row.get("branch_owned") not in ("yes", "no"):
+            raise Refusal(f"ledger branch_owned {row.get('branch_owned')!r} is unresolved")
+        if row["branch_owned"] == "yes" and row["worktree_owned"] != "yes":
+            raise Refusal("branch_owned=yes with worktree_owned=no is not an adoption-produced ownership state")
+        if not Path(row.get("worktree", "")).is_absolute():
+            raise Refusal("ledger worktree must be an absolute path")
     if check_live_refs:
         if view["headRefOid"] != row["head_sha"]:
             raise Refusal(
@@ -189,7 +199,8 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
     foreign = [name for name in run_labels if name != ours]
     if foreign:
         raise Refusal(f"PR {pr} also carries another run's owner label {foreign[0]}")
-    if row["worktree_owned"] == "yes":
+    if check_cleanup_ownership and row["worktree_owned"] == "yes":
+        worktree = Path(row["worktree"])
         expected = root / ".worktrees" / branch
         if os.path.normpath(str(worktree)) != os.path.normpath(str(expected)):
             raise Refusal(
@@ -378,9 +389,11 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
     # loop-control.md Step 4 routes here (a human closed the PR, or the driver died after `gh pr close`).
     # There is NOTHING to merge and NOTHING to clean up: the branch content never reached `<base>`, so an
     # owned worktree/branch holds UNMERGED work that removing it would destroy. This close-out is
-    # ledger-only, so the live head/base/branch pins do NOT apply to it (`check_live_refs=False`): a push
-    # that advanced the head before the close, or a base/branch rename, must still TERMINATE the row, not
-    # wedge it non-terminal forever (a CLOSED PR never re-enters the open snapshot to be re-gated). ANY
+    # ledger-only, so NEITHER the live head/base/branch pins (`check_live_refs=False`) NOR the
+    # cleanup-ownership fields (`check_cleanup_ownership=False`) apply to it: a push that advanced the head
+    # before the close, a base/branch rename, OR a HALF-ADOPTED row whose worktree/ownership fields never
+    # resolved must still TERMINATE the row, not wedge it non-terminal forever (a CLOSED PR never re-enters
+    # the open snapshot to be re-gated, so a refusal here re-routes the finalizer to the same failure). ANY
     # non-terminal row — `in_review` OR any held status (`L.HELD_STATUSES`) — is a real close-out: a CLOSED
     # PR moots every held reason (nothing left to merge, approve, adjudicate, or repair), and a human
     # closing a parked PR IS the resolution. Only a `merged` row with a CLOSED live state is a contradiction
@@ -390,11 +403,14 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
     close_out = view["state"] == "CLOSED" and row["status"] not in ("merged", "aborted")
     # An already-`aborted` row whose PR is still CLOSED is the aborted TERMINAL-REPEAT, symmetric with the
     # `merged`-repeat no-op below: like the fresh close-out it is ledger-only (nothing to merge or clean up),
-    # so it too drops the live head/base/branch pins — a push or base/branch rename that landed before the
-    # close must not turn a settled no-op into a spurious refusal. The `aborted` block below is its
-    # CLOSED-only guard; a live OPEN/MERGED keeps the pins (its refusal is a contradiction, not a no-op).
+    # so it too drops BOTH the live head/base/branch pins and the cleanup-ownership fields — a push or
+    # base/branch rename that landed before the close, or an unresolved half-adoption worktree, must not
+    # turn a settled no-op into a spurious refusal. The `aborted` block below is its CLOSED-only guard; a
+    # live OPEN/MERGED keeps the full validation (its refusal is a contradiction, not a no-op).
     aborted_repeat = row["status"] == "aborted" and view["state"] == "CLOSED"
-    _validate_state(header, row, pr, root, view, check_live_refs=not (close_out or aborted_repeat))
+    relaxed = close_out or aborted_repeat
+    _validate_state(header, row, pr, root, view,
+                    check_live_refs=not relaxed, check_cleanup_ownership=not relaxed)
     if close_out:
         _mark_terminal(ledger, pr, "aborted")
         return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -201,8 +201,12 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
 def _base_is_current(row: dict, header: dict) -> None:
     worktree = row["worktree"]
     base = header["base_branch"]
+    # Fully-qualified refspec so a dash-leading base name (network-supplied via baseRefName) can never be
+    # parsed by git as an option; the same safety idiom as _sync_base and pr-adopt.py. This updates the very
+    # origin/<base> remote-tracking ref the ancestry probe below reads.
+    tracking_ref = f"refs/heads/{base}:refs/remotes/origin/{base}"
     _require(
-        _run(["git", "-C", worktree, "fetch", "origin", base]),
+        _run(["git", "-C", worktree, "fetch", "origin", tracking_ref]),
         f"refresh of origin/{base} for merge-check",
     )
     probe = _run(
@@ -264,8 +268,11 @@ def _sync_base(root: Path, base: str) -> None:
             f"fast-forward of checked-out base {base}",
         )
     else:
+        # Fully-qualified refspec (no leading `+`, preserving fast-forward-only semantics) so a dash-leading
+        # base name can never be parsed by git as an option — the same safety idiom used just above.
+        local_ref = f"refs/heads/{base}:refs/heads/{base}"
         _require(
-            _run(["git", "-C", str(root), "fetch", "origin", f"{base}:{base}"]),
+            _run(["git", "-C", str(root), "fetch", "origin", local_ref]),
             f"fast-forward of local base ref {base}",
         )
 

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -50,6 +50,7 @@ def check_document_contract() -> None:
     adoption = read("pr-adoption.md")
     run_identity = read("run-identity-and-lease.md")
     merge = read("stage-3-merge.md")
+    merge_runner = (ROOT / "scripts" / "merge.py").read_text(encoding="utf-8")
     root_cause = read("root-cause-pass.md")
     files_ledger = read("files-and-ledger.md")
     loop_control = read("loop-control.md")
@@ -169,8 +170,10 @@ def check_document_contract() -> None:
             "adoption restored an unresolved project_root consumer")
     require("create_run_directory(repository)" in run_identity,
             "fresh-run creation bypasses the repository context owner")
-    require('cwd: repository.project_root' in merge and "argv: [\"git\", \"fetch\"" in merge,
-            "merge fetches bypass the typed repository context")
+    require("root = resolve_project_root(project_root)" in merge_runner and
+            '["git", "-C", str(root), "fetch"' in merge_runner and
+            "shell=True" not in merge_runner,
+            "merge runner bypasses the typed repository context/argv boundary")
     require("git -C $" not in merge and "cwd: project_root" not in stage
             and "cwd: project_root" not in dispatch,
             "merge/pre-review restored an ambient or unresolved Git cwd")

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -431,10 +431,13 @@ def run_repository_context_fixtures() -> None:
             require((scratch_root / sibling).parent == scratch_root,
                     f"Copilot scratch sibling escaped its owner: {sibling}")
 
+        # Both fetch sites qualify a hostile, dash-leading base into a `refs/heads/...` refspec so git can
+        # never option-parse it (adoption: tracking ref; merge base-sync: local ref, no leading `+`).
         base = "--base with spaces\nand-newline"
         refresh_ref = f"refs/heads/{base}:refs/remotes/origin/{base}"
         adoption_fetch = ["git", "fetch", "origin", refresh_ref]
-        merge_direct_fetch = ["git", "fetch", "origin", f"{base}:{base}"]
+        merge_direct_ref = f"refs/heads/{base}:refs/heads/{base}"
+        merge_direct_fetch = ["git", "fetch", "origin", merge_direct_ref]
         map_a_git = {
             "A05 copilot process cwd": (copilot_argv, repository["project_root"]),
             "A15 adoption/pre-review Git cwd": (adoption_fetch, repository["project_root"]),
@@ -444,7 +447,7 @@ def run_repository_context_fixtures() -> None:
             require(len(argv) >= 4 and cwd == repository_root and cwd.is_absolute(),
                     f"{cell} shifted argv or lost the resolved absolute cwd")
         require(adoption_fetch == ["git", "fetch", "origin", refresh_ref] and
-                merge_direct_fetch == ["git", "fetch", "origin", f"{base}:{base}"],
+                merge_direct_fetch == ["git", "fetch", "origin", merge_direct_ref],
                 "repository Git argv shifted a hostile ref")
 
 


### PR DESCRIPTION
- execute approved merges through restart-safe, ownership-checked phases
- cover merge, base-sync, cleanup, and terminal-write resumes with mocked fixtures
