### PR TITLE
docs(campaign): relabel on judgment-path rebase

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -165,7 +165,8 @@
   SATISFIED verdicts.** The label is a projection of `reviews_ok`, and it is the only run state a human
   sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a gauntlet it did not. So the
   **gate and the label move together, in the same step**: every action that drops `reviews_ok` to 0 (a
-  `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a conflict-resolving rebase, any other
+  `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a content-changing rebase (conflict-resolving
+  or diff-changed), any other
   content change on the head branch) MUST also reconcile the label by running `label-mirror.py mirror`
   for the PR — the ONE way that swap is applied — which restores `gauntlet-reviewing` on a PR carrying
   `gauntlet-accepted`. Never defer the swap to the next heartbeat — that leaves the label lying

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -364,7 +364,7 @@
   needs only one SATISFIED pass, so there is no second review to sequence. (Reviews for *different* PRs
   still run concurrently; only the two for the same PR serialize. See Stage 2a.)
 - Verdicts are pinned to reviewed PR content: any PR-content change (review fix / CI fix /
-  conflict-resolving rebase / bot or manual PR-branch commit) makes prior verdicts stale. Base
+  judgment-path rebase — conflict-resolving or diff-changed / bot or manual PR-branch commit) makes prior verdicts stale. Base
   advancement with no conflict and unchanged PR diff does NOT invalidate verdicts; carry `reviews_ok`
   forward, update `head_sha` through `ledger.py … set --head-sha` — which **resets the liveness counters**
   at the door (`stage-2-ci.md`, "THE LIVENESS COUNTERS") — and require fresh CI.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -120,8 +120,10 @@
   **reset the liveness counters** at the door (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); never hand-reset.
   The clean case is EXECUTED by `scripts/clean-rebase.py run` (fetch/rebase/`--force-with-lease` push +
   that ledger reset); it **refuses anything not clean** — a conflict or a diff-changing rebase is
-  aborted/reset and handed back at **exit 3**, where the driver resolves the conflict by hand, never the
-  tool.
+  aborted/reset and handed back at **exit 3**, where **both** subcases fall to the driver's JUDGMENT
+  path, never the tool: resolve the conflict by hand where there is one, OR accept/verify the reshaped
+  diff where there is none, then apply the gate reset the stage-2 owner defines — `reviews_ok = 0` **and**
+  `label-mirror.py mirror` (`stage-2-review-gate.md`, "Status labels mirror the review gate").
   Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
   on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -26,8 +26,10 @@ block. This file owns the dispatch procedure, not a second copy of prompt text.
 
 - **`proceed`** → the base is current; **dispatch the fix**.
 - **`rebase-first`** → the branch conflicts with its base or lacks the refreshed base; do **NOT** dispatch.
-  **REBASE the PR onto `<base>`** (per `stage-2-review-gate.md`'s judgment-path rebase — conflict-resolving or diff-changed), then **re-run the
-  pre-flight**.
+  **REBASE the PR onto `<base>`** through `stage-2-review-gate.md`'s base-currency handling, which runs
+  `clean-rebase.py` FIRST: a clean base-only rebase (exit 0) PRESERVES the verdicts and label, and only its
+  **exit 3** — conflict OR diff-changed — falls back to the JUDGMENT path that resets the gate and re-mirrors
+  the label. Then **re-run the pre-flight**.
 - **`recheck`** → mergeability is not computed yet, the view carried an unknown value, or base ancestry could
   not be verified; do **NOT** dispatch and do **NOT** rebase — **re-poll**, then **re-run the pre-flight**.
 

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -26,7 +26,7 @@ block. This file owns the dispatch procedure, not a second copy of prompt text.
 
 - **`proceed`** → the base is current; **dispatch the fix**.
 - **`rebase-first`** → the branch conflicts with its base or lacks the refreshed base; do **NOT** dispatch.
-  **REBASE the PR onto `<base>`** (per `stage-2-review-gate.md`'s conflict-rebase), then **re-run the
+  **REBASE the PR onto `<base>`** (per `stage-2-review-gate.md`'s judgment-path rebase — conflict-resolving or diff-changed), then **re-run the
   pre-flight**.
 - **`recheck`** → mergeability is not computed yet, the view carried an unknown value, or base ancestry could
   not be verified; do **NOT** dispatch and do **NOT** rebase — **re-poll**, then **re-run the pre-flight**.

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -20,7 +20,7 @@ ledger.py --file <state.jsonl> verdict --pr <N> --head-sha <the live head> --ver
 
 **Hand-setting `reviews_ok` for a verdict is FORBIDDEN** — it applies the tally and silently skips the
 counters, restoring the amnesia. **But a gate RESET is not a verdict**: a content change (a fix commit, a
-CI fix, a conflict-resolving rebase, a bot push) still writes `reviews_ok = 0` through `ledger.py … set`,
+CI fix, a content-changing rebase (conflict-resolving or diff-changed), a bot push) still writes `reviews_ok = 0` through `ledger.py … set`,
 exactly as it always has. `verdict` records what a **reviewer decided**; `set` records what a **commit
 did**. Do not convert the reset sites into `verdict` calls.
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -587,8 +587,8 @@ exactly two kinds of site, and the two RESET THEMSELVES DIFFERENTLY:
    Today's sites, **illustratively and NON-EXHAUSTIVELY**: **"Any campaign commit to the PR head resets the
    gate"** (below — CI-fix, review-fix, copilot-item fix, refutation commit); **Stage 2a's precondition
    rebase** (`stage-2-review-gate.md`) and **`stage-3-merge.md`, step 6's reconcile** — for each, BOTH
-   branches: a clean base-only rebase, which does **not** reset the gate, and a conflict-resolving rebase,
-   which does; **`loop-control.md` step 1's ledger refresh** and **`pr-adoption.md` step 3's row refresh** (a
+   branches: a clean base-only rebase, which does **not** reset the gate, and a content-changing rebase
+   (conflict-resolving or diff-changed), which does; **`loop-control.md` step 1's ledger refresh** and **`pr-adoption.md` step 3's row refresh** (a
    formatter/bot commit, a manual push, any content change this run did not dispatch). Each writes the new
    `head_sha` through the accessor, so each gets the reset from the door — none hand-resets.
 2. **An unpark by `retry`** (`loop-control.md` step 3) — no new head, but the user changed something

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -49,7 +49,7 @@ the row by column position). Default to **STANDARD** whenever you are unsure. `r
 dispatch-check --pr <N>`: it exits non-zero on every **HELD** status (`files-and-ledger.md`, `status` —
 the owner; `HELD_STATUSES` in `scripts/ledger.py` is the one place they are enumerated, so **never retype
 that list**). A held PR is **FROZEN**: take no action that **MUTATES** it — no review pass, no
-precondition fix (including the conflict rebase below), no CI fix, no review fix, no merge, and nothing
+precondition fix (including the judgment-path rebase below — conflict-resolving or diff-changed), no CI fix, no review fix, no merge, and nothing
 else that changes it (`loop-control.md` step 3, "held-status guard" — the governing property; these
 are only examples). Held leaves
 `reviews_ok < required(tier)`, so the review-launch rule MUST read `status` too — otherwise the next

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -784,7 +784,7 @@ prose. Record the reviewed SHA
 continues to count after `<base>` advances if the PR is still non-conflicting and the PR diff/content
 is unchanged (e.g. clean base-only rebase); carry `reviews_ok` forward to the new `head_sha`, set
 `ci = pending` — writing the new head through the accessor **resets the liveness counters** at the door
-(`stage-2-ci.md`, "THE LIVENESS COUNTERS"). The moment PR content changes — review fix, CI fix, conflict-resolving rebase, a
+(`stage-2-ci.md`, "THE LIVENESS COUNTERS"). The moment PR content changes — review fix, CI fix, a judgment-path rebase (conflict-resolving or diff-changed), a
 formatter/bot commit on the PR branch, or manual push — earlier verdicts are stale and `reviews_ok`
 drops to 0. Pinning to SHA plus the clean-base-only exception makes the gate verifiable from git while
 not burning reviews merely because another PR merged cleanly. A `NOT SATISFIED` invalidates that

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -92,13 +92,17 @@ review gate"), and the review re-starts on the clean tip:
   <state.jsonl> --pr <pr> --worktree <worktree> --base <base>`**: it does the fetch/rebase/`--force-with-lease`
   push and the one ledger reset, and **refuses anything that is not clean**. **Exit 3 means it was NOT
   clean** — a conflict, or a rebase that applied textually but changed the PR's own diff — and it has already
-  aborted/reset and left the worktree at its original head; **fall back to the JUDGMENT path**: resolve the
-  conflict by hand (the driver's call, never the tool's), then apply the gate-reset rules for a
+  aborted/reset and left the worktree at its original head; **fall back to the JUDGMENT path**: **both**
+  exit-3 subcases land here — a conflict, AND a rebase that applied textually but changed the PR's own diff
+  — so resolve the conflict by hand where there is one, or accept the reshaped diff where there is none (the
+  driver's call, never the tool's), then apply the gate-reset rules for a
   content-changing rebase below. Clean base-only rebase with the PR diff unchanged keeps `reviews_ok` but still moves `head_sha`, so it
   sets `ci = pending`, and the tool writes the new head through the accessor, which
   **resets the liveness counters** at the door ("Status labels mirror the review gate"
   Exception, below, owns this rule; `stage-2-ci.md`, "THE LIVENESS COUNTERS");
-  conflict-resolving rebase changes PR content, so it resets the gate **as well** — here, at this site,
+  **a judgment-path rebase — conflict-resolving OR diff-changed — changes PR content**, so it resets the
+  gate **as well**, and in that same step you MUST reset `reviews_ok` to 0 **and run `label-mirror.py
+  mirror` for the PR** so the label reflects the new gate state — here, at this site,
   exactly as the step-6 reconcile does at its own (`stage-3-merge.md`), and it therefore **relabels in the
   same step** ("Status labels mirror the review gate", below).
 
@@ -838,7 +842,7 @@ that drop `reviews_ok` to 0):
 | Review-fix **or refutation** commit pushed (both are campaign commits to the PR head) | this file, verdict tally |
 | CI-fix commit pushed — economy tier **or** `session` tier | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
-| Conflict-resolving rebase — at **either** of the two sites that rebase a PR | **Stage 2a preconditions, above** (the pre-review rebase of a `CONFLICTING`/`DIRTY`/`BEHIND` PR) **and** `stage-3-merge.md`'s step-6 reconcile. Naming only one of them is how the relabel goes missing at the other; the *event* owes the relabel, wherever it happens |
+| Judgment-path rebase (conflict-resolving **or** diff-changed) — at **either** of the two sites that rebase a PR | **Stage 2a preconditions, above** (the pre-review rebase of a `CONFLICTING`/`DIRTY`/`BEHIND` PR) **and** `stage-3-merge.md`'s step-6 reconcile. Both `clean-rebase.py` exit-3 subcases reset the gate — a conflict AND a no-conflict rebase that changed the PR's own diff — so naming only the conflict one, or only one of the two sites, is how the relabel goes missing; the *event* owes the relabel, wherever it happens |
 | Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |
 | Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the heartbeat that *detects* it resets the gate, so it relabels there |
 

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -195,7 +195,8 @@ subagent at a check that is merely **still running**.
    (`loop-control.md` step 3,
    "held-status guard"): this reconcile MUTATES a PR, so it is exactly what the guard forbids. A clean
    rebase would move its `head_sha`, set `ci = pending` and — at that head write — the accessor would reset
-   its liveness counters (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); a conflict-resolving rebase would reset
+   its liveness counters (`stage-2-ci.md`, "THE LIVENESS COUNTERS"); a judgment-path rebase (conflict-resolving
+   or diff-changed) would reset
    `reviews_ok`, relabel, and relaunch work — and would **change the PR's content**, which can invalidate
    the very refutation or API change the user was parked to adjudicate. **A parked PR that has fallen
    behind simply STAYS behind** until the user answers; it is re-reconciled normally on the heartbeat after it

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -215,13 +215,14 @@ subagent at a check that is merely **still running**.
      liveness counters** at the door — new commit, new evidence — `stage-2-ci.md`, "THE LIVENESS
      COUNTERS"), `ci = pending`. **Exit 3 means it was NOT
      clean** — a conflict, or a rebase that changed the PR's own diff — and it has already aborted/reset to
-     the original head; the conflict-resolution bullet below then owns it. On a clean (exit 0) rebase,
+     the original head; the judgment-path bullet below then owns **both** exit-3 subcases. On a clean (exit 0) rebase,
      **re-derive CI from a snapshot of the new tip in the same heartbeat, launching a watch only if `liveness`
      then reports `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched
      until the heartbeat while its checks are running — but it must not be watched when **nothing** is
      running either, which right after a push is the common case (no check has registered yet). CI must
      return green before merging.
-   - Rebase requiring conflict resolution → PR content changed → **reset `reviews_ok` to 0 AND, in that
+   - Judgment-path rebase — a conflict resolved by hand, OR a no-conflict rebase that reshaped the PR's own
+     diff (both `clean-rebase.py` exit-3 subcases) → PR content changed → **reset `reviews_ok` to 0 AND, in that
      same step, reconcile the label by running `label-mirror.py mirror` for the PR** (it restores
      `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`) — the gate and its
      label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -26,8 +26,9 @@ Exit codes gate a caller's `$?`:
   2  a PRECONDITION refused it — nothing was mutated (no row, held/terminal, bad/dirty/stale worktree,
      branch mismatch, absent remote). The caller fixes the stated condition and re-runs.
   3  NOT the clean case — a conflict, or the rebase changed the PR's diff. HEAD is restored; nothing
-     pushed, ledger untouched. The driver falls back to the JUDGMENT path (resolve conflicts by hand,
-     then apply the gate-reset rules those docs own).
+     pushed, ledger untouched. The driver falls back to the JUDGMENT path for BOTH subcases (resolve a
+     conflict by hand where there is one, or accept the reshaped diff where there is none), then applies
+     the gate-reset rules those docs own.
   1  a PARTIAL state the driver must resolve — most importantly a push that was REJECTED after a clean
      local rebase (the rebase is preserved locally; the ledger is NOT written, and orig_head is printed
      so the driver can decide). Never auto-reset here — that would silently destroy a completed rebase.

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
@@ -8,8 +8,8 @@ and it is the one piece of run state a human reads on GitHub — a stale `gauntl
 PUBLIC claim that a PR passed a gauntlet it did not.
 
 WHY THIS IS A COMMAND AND NOT A `gh pr edit` A DRIVER TYPES BY HAND. The swap was a two-command idiom the
-orchestrator ran at every gate-reset site — the verdict tally, a CI/review fix push, a conflict rebase, a
-re-adoption. A step a fresh-context heartbeat must re-derive and retype at N sites is a step it forgets at
+orchestrator ran at every gate-reset site — the verdict tally, a CI/review fix push, a content-changing
+rebase (conflict-resolving or diff-changed), a re-adoption. A step a fresh-context heartbeat must re-derive and retype at N sites is a step it forgets at
 one of them, and the miss is invisible until a human reads the wrong label on GitHub. This tool reads the
 ledger row, computes the desired label the same way the gate does, and applies the canonical idempotent
 swap — so no driver hand-runs it and no driver runs it wrong.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -671,8 +671,8 @@ def check_tally(updates: dict, row: dict) -> None:
     """`set` may VOID the tally. It may NEVER RAISE it.
 
     **`reviews_ok` counts SATISFIED verdicts, and only a verdict may add one.** It stays settable because
-    voiding it is a real, frequent, correct event that is NOT a verdict — a fix commit, a rebase that
-    resolves conflicts, any PR-content change drops it to 0 (stage-2-review-gate.md, "Status labels mirror
+    voiding it is a real, frequent, correct event that is NOT a verdict — a fix commit, a judgment-path
+    rebase (conflict-resolving or diff-changed), any PR-content change drops it to 0 (stage-2-review-gate.md, "Status labels mirror
     the review gate", lists every such site). What no caller may do is write a HIGHER number: that is
     manufacturing a verdict that no review pass ever returned, and it would also skip `review_rounds` and
     `ns_streak` — the two counters that exist precisely because the tally alone cannot see a loop.


### PR DESCRIPTION
- Gap: a hand-run judgment-path rebase reset the gate but did not re-mirror the status label.
- Docs named only the "conflict-resolving" instance, omitting the no-conflict diff-changed subcase.
- Fix: name the rebase class and require `label-mirror.py mirror` at both rebase sites and two restatements.
