### PR TITLE
ci: derive pyright file count from the list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,50 +78,56 @@ jobs:
       - name: Pyright (the type-clean scripts)
         run: |
           set -o pipefail
-          npx --yes pyright@1.1.410 --outputjson \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/review_door.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py \
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py \
-            plugins/gauntlet/skills/campaign/scripts/ledger.py \
-            plugins/gauntlet/skills/campaign/scripts/ledger-test.py \
-            plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py \
-            plugins/gauntlet/skills/campaign/scripts/review-pass.py \
-            plugins/gauntlet/skills/campaign/scripts/review-pass-test.py \
-            plugins/gauntlet/skills/campaign/scripts/emit-finding.py \
-            plugins/gauntlet/skills/campaign/scripts/finding-audit.py \
-            plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py \
-            plugins/gauntlet/skills/campaign/scripts/repair-pass.py \
-            plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py \
-            plugins/gauntlet/skills/campaign/scripts/followups.py \
-            plugins/gauntlet/skills/campaign/scripts/followups-test.py \
-            plugins/gauntlet/skills/campaign/scripts/nudge.py \
-            plugins/gauntlet/skills/campaign/scripts/nudge-test.py \
-            plugins/gauntlet/skills/campaign/scripts/pr-adopt.py \
-            plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py \
-            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py \
-            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py \
-            plugins/gauntlet/skills/campaign/scripts/lease.py \
-            plugins/gauntlet/skills/campaign/scripts/lease-test.py \
-            plugins/gauntlet/skills/campaign/scripts/heartbeat.py \
-            plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py \
-            plugins/gauntlet/skills/campaign/scripts/run-id.py \
-            plugins/gauntlet/skills/campaign/scripts/run-id-test.py \
-            plugins/gauntlet/skills/campaign/scripts/script-table-test.py \
-            plugins/gauntlet/skills/campaign/scripts/base-preflight.py \
-            plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py \
-            plugins/gauntlet/skills/campaign/scripts/worker-prompt.py \
-            plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py \
-            plugins/gauntlet/skills/campaign/scripts/merge-check.py \
-            plugins/gauntlet/skills/campaign/scripts/merge-check-test.py | tee pyright.json
+          # The list below is the SINGLE SOURCE OF TRUTH for the type-clean set. The expected
+          # filesAnalyzed count is DERIVED from its length (`${#files[@]}`), never hardcoded — add a
+          # file here and the count updates itself, with no second edit and no literal to keep in sync.
+          files=(
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/review_door.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+            plugins/gauntlet/skills/campaign/scripts/ledger.py
+            plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+            plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
+            plugins/gauntlet/skills/campaign/scripts/review-pass.py
+            plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+            plugins/gauntlet/skills/campaign/scripts/emit-finding.py
+            plugins/gauntlet/skills/campaign/scripts/finding-audit.py
+            plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py
+            plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+            plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+            plugins/gauntlet/skills/campaign/scripts/followups.py
+            plugins/gauntlet/skills/campaign/scripts/followups-test.py
+            plugins/gauntlet/skills/campaign/scripts/nudge.py
+            plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+            plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+            plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
+            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
+            plugins/gauntlet/skills/campaign/scripts/lease.py
+            plugins/gauntlet/skills/campaign/scripts/lease-test.py
+            plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+            plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
+            plugins/gauntlet/skills/campaign/scripts/run-id.py
+            plugins/gauntlet/skills/campaign/scripts/run-id-test.py
+            plugins/gauntlet/skills/campaign/scripts/script-table-test.py
+            plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+            plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+            plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
+            plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
+            plugins/gauntlet/skills/campaign/scripts/merge-check.py
+            plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+          )
+          npx --yes pyright@1.1.410 --outputjson "${files[@]}" | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
-          echo "filesAnalyzed=${analyzed}"
-          if [ "${analyzed}" != "39" ]; then
-            echo "::error::pyright analysed ${analyzed} file(s), not the 39 it was pointed at — it checked" \
+          expected=${#files[@]}
+          echo "filesAnalyzed=${analyzed} expected=${expected}"
+          if [ "${analyzed}" != "${expected}" ]; then
+            echo "::error::pyright analysed ${analyzed} file(s), not the ${expected} it was pointed at — it checked" \
                  "nothing and said so quietly. Fix the paths above; a silent no-op is not a passing gate."
             exit 1
           fi


### PR DESCRIPTION
- pyright's hardcoded `filesAnalyzed` count was redundant with the list, bumped by hand each added script (35 → 37 → 39)
- list is now a bash array; expected count derives from `${#files[@]}`
- silent-no-op guard kept: `analyzed != expected` still fails on a listed path that matches nothing
