### PR TITLE
feat(campaign): add mechanical tier derivation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/nudge-test.py
             plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
             plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+            plugins/gauntlet/skills/campaign/scripts/triage.py
+            plugins/gauntlet/skills/campaign/scripts/triage-test.py
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
             plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
             plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -263,6 +265,13 @@ jobs:
       # with the suites above, the point of this step is that `py_compile` parses these files and runs neither.
       - name: Run pr-adopt contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/pr-adopt.py self-test
+
+      # Deterministic campaign tier derivation, executed over real temporary Git repositories. The suite
+      # pins human/code/sensitive classes, agent frontmatter, modes, renames, deletions, unknown and
+      # systemic inputs, hostile path bytes, stable ordering, and stale/moving-head refusal. The sibling
+      # `triage-test.py` is loaded by path and a missing or empty suite fails loudly.
+      - name: Campaign tier derivation contract
+        run: python3 plugins/gauntlet/skills/campaign/scripts/triage.py self-test
 
       # The scheduled-heartbeat callback command, pinned. The rule it protects is the resume contract:
       # the callback carries ONLY --run and --token — never --heartbeat-id (acquire-time proof) and never

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -41,9 +41,12 @@ $gauntlet:campaign --new #20
 ```
 
 Give it one or more PR numbers and it **adopts** them into a run: it labels each PR so the run owns
-it, classifies the change by the *kind* of files it touches — human-facing docs vs code vs
-agent-consumed docs vs sensitive surfaces — to pick a review tier (the change's size never enters
-into it), then starts gating. Run it **once** — it uses the host's heartbeat scheduler when available and
+it, then `triage.py` mechanically takes a per-file inventory of the stable PR-head diff by the *kind* of
+files it touches — human-facing docs vs code vs agent-consumed docs vs sensitive surfaces — and emits a
+**floor**: the lowest review tier the mechanics compel (the change's size never enters into it). The
+orchestrator then **decides the tier at or above that floor** — TRIVIAL is only ever its semantic
+"is this all human prose?" call — and starts gating. It repeats that SHA-pinned derivation each
+heartbeat. Run it **once** — it uses the host's heartbeat scheduler when available and
 keeps the current invocation alive with bounded waits otherwise. It keeps working until every adopted
 PR is merged or set aside; you don't need to re-run it.
 
@@ -162,8 +165,9 @@ flowchart TD
     B -- "no args" --> D{PRs already under this run?}
     D -- yes --> C
     D -- no --> E([prompt: run gauntlet:review<br/>or pass PR numbers])
-    C --> F[triage tier per PR head SHA]
-    F --> G{tier}
+    C --> F[triage.py: mechanical floor + inventory<br/>per stable PR head SHA]
+    F --> FT[orchestrator decides tier<br/>at or above the floor]
+    FT --> G{tier}
     G -- "TRIVIAL: human-docs only" --> H[target: 1 SATISFIED review]
     G -- "STANDARD / HIGH: any code or agent-doc" --> I[target: 2 SATISFIED reviews]
     H --> M[[event loop: gate each PR]]

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -94,7 +94,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 6. Fetch the PR; REFUSE foreign-owned and cross-repo/fork PRs. Write the PR's intent artifact
    (`intent-<pr>.md`: `## Purpose` / `## Non-goals` / `## Threat model`; local, git-ignored, never
    written back to the PR). Register the ledger row (refresh on re-adoption, never duplicate), run
-   label, status label, and worktree. Start a CI watch only if a check can still move.
+   label, status label, and worktree. Run `triage.py derive` on that resolved worktree for the mechanical
+   floor + inventory, decide the SHA-pinned tier at or above that floor, and record it before gate work.
+   Start a CI watch only if a check can still move.
 7. `review-pass.py intent-check --file <rundir>/intent-<pr>.md`: run immediately after writing an
    intent artifact and before dispatching the PR's first review — the same parser every pass later
    loads, so a malformed intent fails before review work is spent.
@@ -115,8 +117,10 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that
     mutates a PR — it exits non-zero for a HELD one.
-11. Re-derive each PR's tier from its `head_sha` (deterministic file-class triage:
-    `references/stage-2-review-gate.md`, "2a-triage"), then launch ALL due work up to caps — reviews,
+11. `triage.py derive`: re-derive each PR's tier from its `head_sha` — the tool emits the mechanical floor
+    + inventory, the orchestrator decides the tier at or above that floor and never grants TRIVIAL to a
+    diff with a non-prose file (`references/stage-2-review-gate.md`, "2a-triage") — then launch ALL due
+    work up to caps — reviews,
     CI watches/fixes, precondition clearing, base refresh — skipping HELD PRs, and stop in-flight
     reviews doomed by a content change.
 12. Before sleeping, audit: re-run the dispatch scan across both concurrency pools and confirm every
@@ -242,6 +246,7 @@ a line the tool writes.
 | `run-id.py` | Mint a run-id and ATOMICALLY create its run directory (`new`) | `references/run-identity-and-lease.md` |
 | `lease.py` | Run-lease accessor: `mint` / `acquire` / `refresh` / `release` / `read` | `references/run-identity-and-lease.md` |
 | `pr-adopt.py` | `plan` / `adopt` — mechanically adopt an existing first-party PR into a run: refuse fork/foreign/non-open, register the ledger row + ownership/status labels, discover-or-create the PR-head worktree | `references/pr-adoption.md` |
+| `triage.py` | `derive` — classify one stable, SHA-pinned PR diff and emit the per-file inventory + reasons and a mechanical FLOOR tier (SENSITIVE→HIGH, any non-prose→STANDARD, all-prose→no floor; never TRIVIAL — the orchestrator decides the tier); optional `--tier` vetoes a below-floor tier | `references/stage-2-review-gate.md` |
 | `heartbeat.py` | Emit the scheduled-heartbeat callback command the driver arms for its next wake | `references/runtime-adapter.md` |
 | `ledger.py` | Schema-owning accessor for `state.jsonl` — plus `verdict`, the ONLY verdict recorder (tally, caps, `repairing` hold), and `dispatch-check`, the held-PR guard run before any mutating action | `references/files-and-ledger.md` |
 | `review-pass.py` | Executable contract for a review pass's artifacts — plan, `pass_identity`, progress, findings, active-attempt report result, `intent-check`, and the `verify` that answers "does this pass COUNT?" | `references/stage-2-review-gate.md` |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -126,8 +126,11 @@
   `label-mirror.py mirror` (`stage-2-review-gate.md`, "Status labels mirror the review gate").
   Never spend a review over open Copilot items, a red check, or a conflicting PR (Stage 2a).
 - The review gate is **tier-dependent**: `required(tier)` fresh, context-isolated `SATISFIED` verdicts
-  on the same live PR content — **one if TRIVIAL, two otherwise** (any code / agent-doc / sensitive
-  change always requires two). Re-derive the tier from `head_sha` each heartbeat.
+  on the same live PR content — **one if TRIVIAL, two otherwise**. Re-derive the tier from `head_sha`
+  every heartbeat: `triage.py derive` supplies the mechanical inventory and **floor**, and the orchestrator
+  decides the tier at or above it (`TRIVIAL` is only ever the orchestrator's all-prose call — the tool
+  never grants it). `stage-2-review-gate.md`, "2a-triage", owns the complete invocation and policy. Never
+  classify files, modes, renames, deletions, or frontmatter by eye.
 - **The review is measured against the PR's INTENT — never against "is anything wrong with this code?"**
   The reviewer is handed `<rundir>/intent-<pr>.md` **verbatim** and answers one question: **does this PR
   achieve its stated Purpose, without breaking anything reachable by an actor named in its Threat model?**
@@ -164,14 +167,16 @@
   through 21 of them. A gate **reset** from a content change is still `set --reviews-ok 0`: **`verdict`
   records what a reviewer *decided*, `set` records what a commit *did*.**
 - **NEVER leave `gauntlet-accepted` on a PR whose live content no longer holds `required(tier)`
-  SATISFIED verdicts.** The label is a projection of `reviews_ok`, and it is the only run state a human
-  sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a gauntlet it did not. So the
-  **gate and the label move together, in the same step**: every action that drops `reviews_ok` to 0 (a
-  `NOT SATISFIED` verdict, a review/CI/copilot fix commit, a content-changing rebase (conflict-resolving
-  or diff-changed), any other
-  content change on the head branch) MUST also reconcile the label by running `label-mirror.py mirror`
-  for the PR — the ONE way that swap is applied — which restores `gauntlet-reviewing` on a PR carrying
-  `gauntlet-accepted`. Never defer the swap to the next heartbeat — that leaves the label lying
+  SATISFIED verdicts.** The label is a projection of `reviews_ok` AND `required(tier)`, and it is the
+  only run state a human sees on GitHub — a stale `gauntlet-accepted` publicly claims a PR passed a
+  gauntlet it did not. So the **gate and the label move together, in the same step**: every action that
+  changes the gate projection — dropping `reviews_ok` to 0 (a `NOT SATISFIED` verdict, a review/CI/copilot
+  fix commit, a content-changing rebase (conflict-resolving or diff-changed), any other content change on
+  the head branch, **or a depth-raising tier escalation, which voids the tally on unchanged content**), OR
+  a tier **de-escalation** that lowers `required(tier)` on unchanged content — MUST also reconcile the
+  label by running `label-mirror.py mirror` for the PR — the ONE way that swap is applied — which restores
+  `gauntlet-reviewing` on a PR carrying `gauntlet-accepted` (`stage-2-review-gate.md`, "Status labels
+  mirror the review gate", owns the two-direction split). Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
   `ci = pending` and, because it moves `head_sha`, the accessor **resets the liveness counters** at that

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -231,7 +231,9 @@ Header field notes (the header fields above; per-row fields follow):
   and `tier` describe. `ci`
   and `tier` are pinned to this exact SHA (re-triage on any content change). `reviews_ok` is pinned to
   this SHA **unless** the only change is a clean base-only rebase/merge with the PR diff unchanged;
-  then carry `reviews_ok` forward to the new `head_sha`, set `ci = pending`, and — because the head
+  then carry `reviews_ok` forward to the new `head_sha` (a **depth-raising tier escalation** is the one
+  same-SHA event that voids `reviews_ok` without a content change — `stage-2-review-gate.md`, "Status
+  labels mirror the review gate"), set `ci = pending`, and — because the head
   **moved** — the ledger accessor **resets the liveness counters** at the `set --head-sha` write itself
   (`stage-2-ci.md`, "THE LIVENESS COUNTERS"; ledger.py's `apply_head_sha`). A clean rebase
   does not reset the *gate*, but it **is** a `head_sha` change, and **every** `head_sha` change resets
@@ -241,7 +243,9 @@ Header field notes (the header fields above; per-row fields follow):
   **Only `ledger.py verdict` may RAISE it** — `set --reviews-ok <n>` refuses any value above the current
   one, because a hand-raised tally is indistinguishable from an earned one and `reviews_ok >=
   required(tier)` is a merge precondition. `set --reviews-ok 0` stays available and correct: **voiding** the
-  tally on a PR-content change is not a verdict (`stage-2-review-gate.md`, "Recording a verdict").
+  tally on a PR-content change — or on a depth-raising tier escalation, which voids it on unchanged content
+  (`stage-2-review-gate.md`, "Status labels mirror the review gate") — is not a verdict
+  (`stage-2-review-gate.md`, "Recording a verdict").
 - `review_rounds` — **landed verdicts, ever, for this PR — and it is NEVER RESET.** Not by a fix, not by a
   rebase, not by a content change, not by a re-triage. Written **only** by `ledger.py verdict`, which is why
   there is **no `--review-rounds` flag at any door**: a door that can write a counter is a door that can
@@ -296,8 +300,11 @@ Header field notes (the header fields above; per-row fields follow):
   (`ledger.py verdict` at a cap), so a decision answers exactly the cap it was recorded for and a PR that
   reaches a cap **again** must earn a fresh `decide` (which spends `repair_count`, so the bound holds).
   `abort@…` is terminal and is never cleared.
-- `tier` — the adaptive review tier derived from `head_sha`: `TRIVIAL` | `STANDARD` | `HIGH`. Re-derived
-  every heartbeat and re-triaged on any content change; drives `required(tier)` and the review depth.
+- `tier` — the adaptive review tier for `head_sha`: `TRIVIAL` | `STANDARD` | `HIGH`. Every heartbeat and on
+  any content change, `triage.py derive` supplies the mechanical `floor` + inventory and the orchestrator
+  decides the tier at or above it; `stage-2-review-gate.md`, "2a-triage", owns the complete invocation and
+  policy. This field records the orchestrator's decided tier (never below the tool's floor; `TRIVIAL` only
+  as the orchestrator's all-prose call); it drives `required(tier)` and review depth.
 - `ci` — `green` / `red` / `pending` for `head_sha`. Recorded by `ci-status.py liveness` from `derive`'s
   JSON (`stage-2-ci.md`, "THE BOOKKEEPING IS A COMMAND"). (**There is no `none`.** It was documented but
   no procedure could ever write it.)

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -180,8 +180,10 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    the wrong label, or both.
 
    This reconcile is a **backstop, not the mechanism**. The relabel is owed at the moment the gate
-   resets, in the same step that writes `reviews_ok = 0` (`stage-2-review-gate.md`, "Status labels
-   mirror the review gate"); this pass only *self-heals* a swap that was somehow missed. A PR that
+   projection changes, in the same step that writes `reviews_ok = 0` (which includes a depth-raising tier
+   escalation) or decides a de-escalation that lowers `required(tier)`
+   (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the two-direction split); this pass only
+   *self-heals* a swap that was somehow missed. A PR that
    reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
@@ -335,11 +337,44 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      (`bailout-and-final-report.md`) — leave the PR **OPEN**, drop this run's labels, write `abort-<id>.md`.
 
    Then, for each PR that is **not held at all**:
-   - any newly-adopted PR whose ledger row lacks a `tier`, or any PR whose `head_sha` changed since it
-     was last triaged → **re-triage its tier** (deterministic file-class classification of the changed
-     files at that `head_sha`; agent-docs = code; default STANDARD on uncertainty — see the tiers
-     spec) and write it back with `ledger.py … set --pr <N> --tier <tier>`. The tier is pinned to
-     `head_sha` and sets `required(tier)` = **1 if TRIVIAL else 2**.
+   - any newly-adopted PR whose ledger row lacks a `tier`, and every PR on every heartbeat → **run
+     `triage.py derive --worktree <worktree> --base origin/<base> --head-sha <head_sha>`** for the
+     mechanical inventory and `floor`. `stage-2-review-gate.md`, "2a-triage", owns the complete invocation
+     and policy. Never classify files or modes here. On success, require output `head_sha` to equal the
+     row, **decide the tier at or above `floor`** (`TRIVIAL` only when `floor` is `null` and you judge it
+     truly human prose — the tool never grants it). **VETO FIRST — BEFORE any ledger write:** re-run
+     `derive --tier <decided>` with the IDENTICAL `--worktree`/`--base`/`--head-sha` inputs so the tool
+     vetoes a below-floor mistake; require its success and an output `head_sha` still equal to the row, and
+     BLOCK gate dispatch on refusal (exit 2, no JSON). Only THEN write the tier, with **EXACTLY ONE
+     directional `ledger.py … set`** — never a preliminary generic tier write followed by a second. **A
+     same-SHA tier change is TWO events by direction, and the one write differs by direction**
+     (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the split; depth order
+     TRIVIAL < STANDARD < HIGH):
+     - **Depth-raising escalation** (the decision raises the tier to a strictly deeper one — TRIVIAL→STANDARD,
+       TRIVIAL→HIGH, STANDARD→HIGH; STANDARD→HIGH raises depth even though `required` stays 2): the standing
+       verdicts were earned at a shallower depth and do NOT satisfy the new tier, so write the deeper tier and
+       the voided tally in ONE atomic ledger write — `ledger.py … set --pr <N> --tier <deeper> --reviews-ok 0`
+       (`ledger.py set` applies every field flag in a single atomic write, so tier and reset land together and
+       no driver death can leave the deeper tier standing beside a stale tally that the next heartbeat would
+       read as no escalation). **Also stop any review pass in flight on that PR first** (the same stop the
+       content-change rule below makes): the SHA is unchanged, so an in-flight shallow-depth pass keeps a
+       matching `head_sha`, and a late SATISFIED verdict would refill the just-voided tally against the
+       deeper tier. Then require a fresh tier-sized plan before the next dispatch (the plan-copy
+       rule in `stage-2-review-gate.md` must NOT reuse the shallower plan). Do this even though the SHA is
+       unchanged.
+     - **De-escalation, unchanged, or fresh adoption** (the decision lowers the tier — STANDARD→TRIVIAL,
+       HIGH→STANDARD, HIGH→TRIVIAL — or holds it, or first-sets it on a row that lacked one): any standing
+       verdicts were earned at a DEEPER-or-equal depth (a superset), so write the tier ALONE —
+       `ledger.py … set --pr <N> --tier <decided>` — which KEEPS `reviews_ok` and the plan; only
+       `required(tier)` moves.
+     **Then, in that SAME step, run `label-mirror.py mirror` for that PR** — idempotent, a no-op when the
+     label already matches — so the tier, `required(tier)`, and the public status label move together: it
+     restores `gauntlet-reviewing` on a depth-raising escalation (the voided tally no longer meets
+     `required`) and swaps a standing tally to `gauntlet-accepted` on a de-escalation that now meets the
+     lowered `required` (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and
+     the tool). On refusal,
+     refresh the moving or mismatched input and retry; never carry a tier across content the command did
+     not classify.
    - current tip has `reviews_ok < required(tier)`, has no unaddressed Copilot review items, CI is not red,
      and no review is running for that SHA → **first ensure the PR's INTENT
      (`<rundir>/intent-<pr>.md`) and PR-head worktree exist.** The dispatch substitutes the intent block

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -42,9 +42,14 @@ gh label create gauntlet-run-<run-id> --color 5319E7 --description "gauntlet: ru
 > The MECHANICAL steps below — **1, 2, 4, 5 and the row of step 3** — are performed by
 > `scripts/pr-adopt.py adopt` (`pr-adopt.py adopt --pr <N> --run-id <id> --file <state.jsonl> --tier <T>
 > --worktrees-root <p> --project-root <p>`). The driver still supplies the two JUDGMENT calls it does not
-> make: the review **TIER** (the `--tier` argument, triaged per Stage **2a-triage**) and the PR's
-> **INTENT** (step 3a). Its decision logic is a pure `build_plan` pinned by `pr-adopt-test.py`. The steps
-> stay below as the spec the tool implements; read them as the authority.
+> make: the **tier DECISION** (choosing the review tier at or above `triage.py derive`'s mechanical floor)
+> and the PR's **INTENT** (step 3a).
+> Adoption needs a row before it has resolved the PR-head worktree, so pass `--tier STANDARD` as the
+> conservative bootstrap value. `pr-adopt.py` launches no gate work. Immediately after step 5, run
+> `triage.py derive` as required below for the floor + inventory, decide the tier at or above that floor,
+> and write it through `ledger.py`; loop control repeats
+> the command before any review. Its decision logic is a pure `build_plan` pinned by `pr-adopt-test.py`.
+> The steps stay below as the spec the tool implements; read them as the authority.
 
 For each `#PR` to adopt:
 
@@ -129,7 +134,9 @@ For each `#PR` to adopt:
      it reused a pre-existing local branch or checkout;
      `pr` = `<N>`; `head_sha` = `headRefOid`.
    - **On a NEW row only, initialize:** `reviews_ok` = `0` (no verdicts yet); `ci` = `pending`;
-     `tier` = triage per `head_sha` (Stage **2a-triage**); `attempts` = `0` (no attempt has run yet —
+     `tier` = bootstrap `STANDARD`; after step 5 the orchestrator decides the real tier at or above
+     `triage.py derive`'s floor and writes it;
+     `attempts` = `0` (no attempt has run yet —
      `attempts` counts attempts **so far**, and seeding it at `1` silently spends half the retry-once
      budget before any work is dispatched); `started` = now;
      `api_approval` = `-`; `blocker_ruling` = `-`; `status` = `in_review`;
@@ -402,6 +409,57 @@ For each `#PR` to adopt:
    head branch on `origin`.
 
 #### Step 6 — Ensure a live CI watch when — and ONLY when — a check can still move
+
+Before starting any gate work, **get the mechanical floor + inventory from the resolved PR-head worktree
+and decide the tier at or above it**:
+
+```text
+python3 <skill-dir>/scripts/triage.py derive \
+    --worktree <ledger worktree> --base origin/<base> --head-sha <headRefOid>
+```
+
+`stage-2-review-gate.md`, "2a-triage", owns the command and classification policy. Require the output
+`head_sha` to equal the adoption snapshot, decide the tier at or above the reported `floor` (`TRIVIAL`
+only as your semantic all-prose call — the tool never grants it). **Then, exactly as the heartbeat
+re-triage path does (`loop-control.md`), and BEFORE the ledger write, re-run `triage.py derive` with the
+IDENTICAL `--worktree`/`--base`/`--head-sha` inputs plus `--tier <decided>` so the tool VETOES a
+below-floor choice**; require its success and an output `head_sha` that still equals the row, and BLOCK
+gate dispatch on refusal (exit 2, no JSON). Only then replace the bootstrap — with **EXACTLY ONE
+directional `ledger.py … set`**, honouring the direction below, never a preliminary generic tier write
+followed by a second. Without this second veto derive the adoption path would
+write a below-floor tier straight through — gate work could start below the emitted floor, an
+under-reviewed stricter tier — the exact hole the heartbeat veto closes; the two paths are symmetric. A
+refusal from EITHER derive leaves the conservative bootstrap in place and blocks gate dispatch until the
+next heartbeat refreshes the worktree/head and derives successfully.
+
+**A same-SHA tier change is TWO events by direction** (`stage-2-review-gate.md`, "Status labels mirror the
+review gate", owns the split; depth order TRIVIAL < STANDARD < HIGH), and on an UNCHANGED re-adoption
+`pr-adopt.py` PRESERVES `reviews_ok` (>= 1) (it preserves it when the head did not move), so this
+decided-tier write must honour the direction before the mirror:
+- **Depth-raising escalation** (this decision raises the preserved tier to a strictly deeper one —
+  TRIVIAL→STANDARD, TRIVIAL→HIGH, STANDARD→HIGH): the preserved verdicts were earned at a shallower depth
+  and do NOT satisfy the new tier, so write the deeper tier and the voided tally in ONE atomic ledger write —
+  `ledger.py … set --pr <N> --tier <deeper> --reviews-ok 0` (`ledger.py set` applies every field flag in a
+  single atomic write, so tier and reset land together and no driver death can leave the deeper tier beside a
+  stale tally the next heartbeat would read as no escalation) — and require a fresh tier-sized plan on the
+  next dispatch.
+  Without this, a PR left `gauntlet-accepted` under a preserved STANDARD (`required` 2, `reviews_ok` 2) would
+  stay accepted when raised to HIGH — a false public label with the deep sweep never run.
+- **De-escalation, unchanged, or fresh adoption** (this decision lowers the tier, holds it, or first-sets it
+  on the bootstrap row): write the tier ALONE — `ledger.py … set --pr <N> --tier <decided>` — which KEEPS any
+  preserved verdicts; only `required(tier)` moves.
+**Then, in the SAME step, run `label-mirror.py mirror` for the PR** — idempotent, a no-op when the label
+already matches — so the tier, `required(tier)`, and the public status label move together
+(`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool). **Run it
+on an UNCHANGED re-adoption too, NOT only a fresh one:** step 4 labelled against the *preserved* tier
+before this decision, so a PR left `gauntlet-accepted` under a preserved lower tier keeps that false label
+until the mirror flips it to `gauntlet-reviewing` (the escalation reset above took the tally below
+`required`). Never skip it as a presumed no-op — a fresh adoption's `reviews_ok=0` is the ONLY case the
+mirror is a guaranteed no-op.
+
+```
+python3 <skill-dir>/scripts/label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name
+```
 
 6. **Ensure a live CI watch when — and ONLY when — a check can still move.** The warrant for a watch is a
    **still-RUNNING evidence row** in the PR's snapshot, **never the `ci` value** (Stage 2b, `stage-2-ci.md`

--- a/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
@@ -55,9 +55,10 @@ itself; the reassessment REUSES it and never reimplements it.**
    "Worker Dispatch").
 3. **One batch-fix round** for all confirmed gaps. Route every site through **ONE shared
    chokepoint/helper** so the cells can't diverge again. Add a test per cell.
-4. **Resume the gauntlet** on the batched result — the review gate's `required(tier)` fresh,
-   context-isolated SATISFIED verdicts (two: a systemic / root-cause change is HIGH tier, never
-   TRIVIAL).
+4. **Resume the gauntlet** on the batched result. Run `triage.py derive` for the floor + inventory, then
+   **decide HIGH** — a root-cause batch fix is a systemic change, an escalation the tool cannot make for
+   you — and use the review gate's `required(tier)` fresh, context-isolated SATISFIED verdicts
+   (`stage-2-review-gate.md`, "2a-triage").
 
 Caveats:
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -6,40 +6,83 @@
 > - did the pass count → "Does this pass COUNT?"
 > - the status labels look wrong → "Status labels mirror the review gate"
 
-### 2a-triage. PR triage — file class & risk tier (deterministic, per `head_sha`)
+### 2a-triage. PR triage — file class & risk tier (deterministic mechanics, orchestrator-decided tier, per `head_sha`)
 
-Before the review gauntlet, triage each PR to a **risk tier**. Triage is **deterministic** and
-**size-agnostic** — there are **NO line-count or file-count thresholds**; only *what kind* of file the
-PR touches and whether the change is systemic. Re-derive the tier **every heartbeat** from the PR's current
-`head_sha` and pin it there; record it in the ledger `tier` column via `scripts/ledger.py … set --pr
-<N> --tier <tier>` (by field name — the schema-owning accessor, `files-and-ledger.md`; never hand-edit
-the row by column position). Default to **STANDARD** whenever you are unsure. `reviews_ok` target = `required(tier)`: **1 if `tier==TRIVIAL`, else 2**.
+**The tier is a SPLIT decision.** `scripts/triage.py derive` is a mechanical INPUT with **escalate-only**
+authority: it enumerates the diff and emits the per-file inventory and a **FLOOR** — the minimum the
+mechanics compel. **You, the orchestrator, DECIDE the tier at or above that floor.** The tool can raise the
+floor and veto a below-floor tier; it can **never grant `TRIVIAL`** — that is only ever your semantic
+"is this all human prose?" call. Re-run it every heartbeat against the ledger row's current `head_sha`;
+never classify a diff by eye:
+
+```text
+python3 <skill-dir>/scripts/triage.py derive \
+    --worktree <worktree> --base origin/<base> --head-sha <head_sha> \
+    [--tier <your decided tier>]
+```
+
+The command resolves the merge-base, reads Git's NUL-delimited raw diff and modes at the expected
+40-character head, and re-reads `HEAD` after classification. A stale expected head, moving head, malformed
+diff, or failed Git read is a refusal with no partial JSON; refresh the row/worktree and retry. On success
+the output carries `head_sha`, the per-file `files` inventory (class + reasons), and the `floor`
+(`HIGH`, `STANDARD`, or `null` for no floor). **Require output `head_sha` to equal the row.** Then DECIDE
+the tier at or above `floor`. **Guard it BEFORE any ledger write:** pass the decision back as
+`--tier <decided>` on a re-run derive with the IDENTICAL inputs — the command REFUSES (exit 2, no JSON) a
+tier below the floor — and block the ledger write on refusal. Only THEN record the tier through **EXACTLY
+ONE directional `scripts/ledger.py … set`** — never a preliminary generic tier write followed by a second;
+the direction (escalation vs. de-escalation/unchanged/fresh) sets the flags, and
+`loop-control.md`/`pr-adoption.md` own that split. `TRIVIAL` is admissible **only** when `floor` is `null`
+(every changed file is human prose) **and** you judge it truly human prose.
+
+The floor computation:
+
+- any **SENSITIVE** file → floor **HIGH**;
+- any non-HUMAN-DOC file, **or** an empty/unresolved diff → floor **STANDARD**;
+- nothing but HUMAN-DOC prose → **no floor** (`null`): the tier is yours to decide, `TRIVIAL` included.
+
+Triage is **deterministic** and **size-agnostic** — there are **NO line-count or file-count thresholds**;
+only *what kind* of file the PR touches. `triage.py` is the executable owner of file classification and the
+floor. The policy it executes is the block below. Default to **STANDARD** whenever a path, status, or
+content marker is uncertain. `reviews_ok` target = `required(tier)`: **1 if `tier==TRIVIAL`, else 2**.
 
 **File classes (classify every changed file; default CODE when unsure).**
 
-- **HUMAN-DOC** — human-facing prose only: top-level `README.md`, human `docs/**`, `CHANGELOG`,
-  `LICENSE`.
+- **HUMAN-DOC** — human-facing prose only: top-level `README.md`, human prose under `docs/**`,
+  `CHANGELOG`, `LICENSE`.
 - **CODE** — source files **and agent-consumed docs**: `SKILL.md`, a skill's `references/**`,
-  `CLAUDE.md`/`AGENTS.md`, `.claude/**`, prompt / agent-instruction files, any `.md` carrying
+  `CLAUDE.md`/`AGENTS.md`, `.claude/**`, prompt / agent-instruction files, any prose file carrying
   skill/agent frontmatter. Agent-docs are CODE, never HUMAN-DOC.
 - **SENSITIVE** (a CODE subset) — CI (`.github/**`), `scripts/**`, executables (`+x`),
   `Dockerfile`/`Makefile`, dependency manifests/lockfiles, IaC, auth/crypto/secret paths.
 
+Classify **every side of the change that exists** — the base content and the head content alike — and keep
+the higher class: a rename classifies its old and new paths, a deletion its old path, and a modification or
+type-change both its base and head content (so stripping agent frontmatter cannot read as prose at HEAD).
+Treat a file whose old **or** new Git mode is executable as SENSITIVE, and any **non-regular Git object** — a
+symlink, a gitlink, or any mode that is not a regular blob — as never HUMAN-DOC (at least CODE). These are
+diff properties, so filesystem inspection of only the new checkout is not a substitute.
+
 **Tiers (no size thresholds).**
 
-- **TRIVIAL** — **ALL** changed files are HUMAN-DOC → **1** review pass, **minimal** plan.
-- **STANDARD** — any CODE / agent-doc file changed, none SENSITIVE → **2** passes, plan **covers the
-  real review dimensions**.
-- **HIGH** — any SENSITIVE file changed, OR a systemic / cross-package / root-cause change → **2**
-  passes with **mandatory cross-cutting units + a deeper sweep** (Stage 2a-deep).
+- **TRIVIAL** — an **orchestrator-only** grant: **ALL** changed files are HUMAN-DOC (`floor` is `null`)
+  **and** you judge the change truly human prose → **1** review pass, **minimal** plan. The tool never
+  emits this; a systemic change to prose is still yours to escalate.
+- **STANDARD** — the floor when any CODE / agent-doc file changed, none SENSITIVE → **2** passes, plan
+  **covers the real review dimensions**.
+- **HIGH** — the floor when any SENSITIVE file changed → **2** passes with **mandatory cross-cutting units
+  + a deeper sweep** (Stage 2a-deep). Escalate to HIGH yourself for a systemic change even when the floor
+  is lower.
 
 **Escalation guardrails.**
 
-- Agent-docs are **never** TRIVIAL. A **single** non-HUMAN-DOC byte in the diff disqualifies TRIVIAL.
-- Re-triage and **escalate** (never de-escalate below what the content warrants) when: a `NOT
-  SATISFIED` lands, a `plan_amendment_request` is raised, or a content change **adds a
+- Agent-docs are **never** TRIVIAL. A **single** non-HUMAN-DOC byte in the diff sets a STANDARD floor,
+  which the tool's `--tier` veto enforces against a mistaken TRIVIAL.
+- Re-triage and **escalate** (never de-escalate below what the content warrants, and never below the
+  floor) when: a `NOT SATISFIED` lands, a `plan_amendment_request` is raised, or a content change **adds a
   CODE/agent-doc/SENSITIVE file** to a PR that was TRIVIAL.
-- Tier is pinned to `head_sha` and re-derived every heartbeat; on any uncertainty default STANDARD.
+- Tier is pinned to `head_sha`; the floor is re-derived and the tier re-decided every heartbeat. On any
+  uncertainty default STANDARD. The tool's floor may raise a tier and never lowers it; a systemic judgment
+  is yours to add on top of the floor.
 
 ### 2a. The review gauntlet
 
@@ -124,8 +167,11 @@ continuation influenced by the first.
 flight on a PR — CI turns red, Copilot items land, a conflict appears — or any content-changing fix
 is about to be dispatched for it, **stop the in-flight review task before dispatching the fix**: its
 verdict can only describe a SHA that is about to be replaced, so letting it run wastes both the
-tokens and the review slot. The freed slot immediately refills with the next due review (Loop
-control step 3).
+tokens and the review slot. **A depth-raising tier escalation is the same call on UNCHANGED content**:
+it voids the tally, and because the SHA does not move the in-flight pass keeps a matching `head_sha`, so
+a late SATISFIED verdict — planned at the now-too-shallow depth — would refill the just-voided tally
+against the deeper tier; stop that pass too (`loop-control.md` re-triage step). The freed slot
+immediately refills with the next due review (Loop control step 3).
 
 Route every selected reviewer through `runtime-adapter.md`'s capability/transition owner and
 `reviewer.md`'s retry budget. Any resulting native-worker pass receives this same complete review
@@ -233,7 +279,18 @@ Rules:
   **no fixed unit-count band** — size to what the tier and content demand.
 - The plan describes PR content, so **reuse it across passes on unchanged content**: for pass 2 on
   the same SHA (or clean base-only rebase, diff unchanged), copy pass 1's plan to
-  `review-<pr>-2.plan.jsonl` instead of re-deriving. Re-derive only when PR content changed.
+  `review-<pr>-2.plan.jsonl` instead of re-deriving. Re-derive when PR content changed — **and, even on
+  unchanged content, when a depth-raising tier escalation invalidated the standing plan.** The plan is
+  sized to the tier (TRIVIAL minimal, STANDARD real dimensions, HIGH cross-cutting + deep sweep), and
+  the depth order is **TRIVIAL < STANDARD < HIGH**. A tier decision that raises the tier to a strictly
+  deeper one — TRIVIAL→STANDARD, TRIVIAL→HIGH, or STANDARD→HIGH (STANDARD→HIGH raises depth even though
+  `required` stays 2) — leaves the standing plan sized to the SHALLOWER tier; copying it would review
+  the deeper tier at the old, thinner depth. So a **depth-raising escalation voids the standing tally
+  and rebuilds a FRESH plan sized to the new tier** for the next pass, exactly as a content change does,
+  even though the SHA is identical (the tally-void half is owned by "Status labels mirror the review
+  gate", below). A tier DE-escalation (STANDARD→TRIVIAL, HIGH→STANDARD, HIGH→TRIVIAL) is the opposite:
+  the standing verdicts were earned at a DEEPER depth, so they and their plan STAY — only the label
+  moves.
 - Each unit MUST name concrete `target` + concrete `checks`.
 - **A unit `id` has ONE legal form — "EVERY IDENTIFIER HAS ONE LEGAL FORM" above — and `plan-add`
   refuses anything else.** `U01`, `u 01`, ` u01 ` are not other ways of spelling `u01`; they are not ids.
@@ -803,13 +860,34 @@ one adversarial pass is proportionate.
 ### Status labels mirror the review gate — relabel is part of the reset, not a later chore
 
 A PR carries `gauntlet-reviewing` until its current HEAD holds `required(tier)` SATISFIED verdicts for
-the same live PR content, then `gauntlet-accepted`. The label is a **projection of `reviews_ok`**, so it
-is only ever as true as the moment it was last written.
+the same live PR content, then `gauntlet-accepted`. The label is a **projection of `reviews_ok` AND
+`required(tier)`**, so it is only ever as true as the moment it was last written — and because the tier
+is itself a per-heartbeat DECISION (`loop-control.md` re-triage runs the judgment for every PR every
+heartbeat), a tier change moves the projection. **A same-SHA tier change is NOT one event — it is two,
+by DIRECTION**, and this is the owner of that split (the plan-rebuild half lives with the plan-copy rule,
+"Plan JSONL schema" above; `required(tier)` = 1 if TRIVIAL else 2). The tiers order by review depth
+**TRIVIAL < STANDARD < HIGH**, and a verdict is earned against a plan sized to the tier in force when it
+was cast, so it only satisfies tiers **at or below** that depth:
 
-**THE RULE — the gate and the label move together, in the same step.** Any action that takes
-`reviews_ok` to `0` (or otherwise voids the tally) MUST, in that same step, restore
-`gauntlet-reviewing` on a PR that currently carries `gauntlet-accepted` — and, symmetrically, an action
-that brings the tally UP to `required(tier)` swaps it to `gauntlet-accepted`.
+- **A depth-raising escalation** — the new tier is strictly deeper (TRIVIAL→STANDARD, TRIVIAL→HIGH, or
+  STANDARD→HIGH; STANDARD→HIGH raises depth even though `required` stays 2) — **VOIDS THE TALLY.** The
+  standing verdicts were earned at a shallower depth and do not satisfy the new tier, so the ONE directional
+  ledger write that sets the deeper tier voids `reviews_ok` in that same write (`--tier <deeper>
+  --reviews-ok 0`), and a fresh tier-sized plan is required before the next dispatch. It is therefore a
+  `reviews_ok`→0 event, and the relabel is owed exactly as for any other tally-void.
+- **A de-escalation** — the new tier is strictly shallower (STANDARD→TRIVIAL, HIGH→STANDARD, HIGH→TRIVIAL)
+  — **KEEPS the verdicts and the plan.** They were earned at a DEEPER depth, which is a superset, so the
+  single tier write carries `--tier <decided>` alone, `reviews_ok` is untouched, and only `required(tier)`
+  and the label move. This is the ONLY tier change that leaves `reviews_ok` standing.
+
+**THE RULE — the gate and the label move together, in the same step.** Any action that changes the gate
+projection — one that takes `reviews_ok` to `0` (or otherwise voids the tally, **which now includes a
+depth-raising tier escalation**), OR a **de-escalation** that lowers `required(tier)` on unchanged content
+(e.g. STANDARD→TRIVIAL flips `required` from 2 to 1) —
+MUST, in that same step, reconcile the label: restore `gauntlet-reviewing` on a PR that currently carries
+`gauntlet-accepted` when the tally no longer meets `required(tier)`
+— and, symmetrically, an action that brings `reviews_ok` up to `required(tier)` (a new verdict, or a
+de-escalation that LOWERS `required(tier)` to a tally already standing) swaps it to `gauntlet-accepted`.
 
 **`label-mirror.py mirror` is THE way that swap is applied — never a hand-run `gh pr edit`.** It reads the
 PR's ledger row, computes the desired label from `reviews_ok` and `required(tier)` exactly as the gate
@@ -833,8 +911,9 @@ passed its gauntlet** — the label is what a human reads on GitHub, and it is t
 run's state that is visible to people who will never see the ledger. Between the reset and the next
 reconcile it is simply wrong; if the session dies in that window it stays wrong indefinitely.
 
-**Every trigger that resets the gate must relabel** (this is the exhaustive list — the same events
-that drop `reviews_ok` to 0):
+**Every trigger that changes the gate projection must relabel** (this is the exhaustive list — every
+event that drops `reviews_ok` to 0, which now includes a **depth-raising tier escalation**, PLUS a
+**tier de-escalation** that lowers `required(tier)` under a standing tally):
 
 | Trigger | Where the reset happens — and therefore where the relabel is owed |
 |---|---|
@@ -845,15 +924,22 @@ that drop `reviews_ok` to 0):
 | Judgment-path rebase (conflict-resolving **or** diff-changed) — at **either** of the two sites that rebase a PR | **Stage 2a preconditions, above** (the pre-review rebase of a `CONFLICTING`/`DIRTY`/`BEHIND` PR) **and** `stage-3-merge.md`'s step-6 reconcile. Both `clean-rebase.py` exit-3 subcases reset the gate — a conflict AND a no-conflict rebase that changed the PR's own diff — so naming only the conflict one, or only one of the two sites, is how the relabel goes missing; the *event* owes the relabel, wherever it happens |
 | Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |
 | Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the heartbeat that *detects* it resets the gate, so it relabels there |
+| Tier DECISION is a **depth-raising escalation** (orchestrator re-triage raises the tier to a strictly deeper one — TRIVIAL→STANDARD, TRIVIAL→HIGH, STANDARD→HIGH — on unchanged content) | **`loop-control.md` re-triage step, the tier write** — this is a `reviews_ok`→0 event ("Status labels mirror the review gate" owns why): the same re-triage step writes the deeper tier and voids `reviews_ok` in ONE ledger write, requires a fresh tier-sized plan before the next dispatch, and runs `label-mirror.py mirror`, which restores `gauntlet-reviewing` because the voided tally no longer meets `required(tier)`. The adoption-time tier write (`pr-adoption.md` step 6) is the SAME event: an UNCHANGED re-adoption PRESERVES `reviews_ok` (>= 1) (`pr-adopt.py` preserves it when the head did not move), so a depth-raising decision there must void that preserved tally too — it is NOT a case that can be skipped |
+| Tier DECISION is a **de-escalation** that lowers `required(tier)` (STANDARD→TRIVIAL, on unchanged content, so `reviews_ok` is untouched) | **`loop-control.md` re-triage step, the tier write** — the same step runs `label-mirror.py mirror`; the verdicts STAY (they were earned at a deeper depth), and the mirror swaps a standing tally to `gauntlet-accepted` when the lowered `required(tier)` is now met. The adoption-time tier write (`pr-adoption.md` step 6) co-locates the SAME mirror; a FRESH adoption has `reviews_ok=0`, so it is a no-op there, but an UNCHANGED re-adoption whose preserved tally now meets the lowered `required` flips to `gauntlet-accepted` |
 
-**Every row names a place where `reviews_ok` is written to 0 — never "the reconcile pass".** The
+**Every row names a place where the gate PROJECTION changes — `reviews_ok` written to 0, or
+`required(tier)` changed by a tier decision — never "the reconcile pass".** The
 label-reconcile in Loop control is the backstop that *heals* a missed swap; naming it as the mechanism
-for any trigger would defeat this rule. If you add a new site that resets the gate, it goes in this
+for any trigger would defeat this rule. If you add a new site that changes the projection, it goes in this
 table with the relabel attached, and the search that proves this table complete is for **everything that
-can take `reviews_ok` to 0**, not for any particular phrasing. **That is now TWO spellings, and a search
-for only the first will miss half the sites**: `ledger.py set --reviews-ok 0` (every content-change reset —
-the rows above) and **`ledger.py verdict … --verdict not-satisfied`** (the verdict tally, which voids it).
-Search for both.
+can take `reviews_ok` to 0 OR change `required(tier)`**, not for any particular phrasing. **That is now
+THREE spellings, and a search for only the first will miss the others**: `ledger.py set --reviews-ok 0`
+(every content-change reset — the rows above — **and the depth-raising tier escalation, which resets the
+tally on unchanged content**), **`ledger.py verdict … --verdict not-satisfied`** (the
+verdict tally, which voids it), and **`ledger.py … set --pr <N> --tier`** (the tier write; a
+**de-escalation** changes `required(tier)` without touching `reviews_ok`, while a **depth-raising
+escalation** carries `--reviews-ok 0` in the SAME atomic write — one `ledger.py set` with both flags, so
+tier and voided tally move together, per `loop-control.md`/`pr-adoption.md`). Search for all three.
 
 **Exception — a clean base-only rebase** (PR diff unchanged) carries `reviews_ok` forward and therefore
 **keeps** `gauntlet-accepted`. The gate did not reset, so the label does not move. Gate and label stay in

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
@@ -99,6 +99,8 @@ def drive(led: Path, pr: str, repo: str, fake: FakeGh, *, dry_run=False) -> tupl
 REPO = "o/n"
 SWAP_TO_ACCEPTED = ["gh", "pr", "edit", "9", "--repo", REPO,
                     "--add-label", "gauntlet-accepted", "--remove-label", "gauntlet-reviewing"]
+SWAP_TO_REVIEWING = ["gh", "pr", "edit", "9", "--repo", REPO,
+                     "--add-label", "gauntlet-reviewing", "--remove-label", "gauntlet-accepted"]
 
 
 # --- the swap is applied, with the EXACT argv ---------------------------------
@@ -138,6 +140,30 @@ def t_reviewing_stays():
     check(code == 0, f"a short gate already reviewing is a no-op, got {code}")
     check(out["desired"] == "gauntlet-reviewing" and out["changed"] is False, f"expected reviewing no-op, got {out!r}")
     check(not fake.edited, "an already-reviewing label must trigger NO edit")
+
+
+# --- a re-adoption tier escalation flips a stale gauntlet-accepted back to reviewing --
+
+def t_readopt_escalation_flips_accepted_to_reviewing():
+    # An UNCHANGED re-adoption preserves reviews_ok (here 1), and pr-adopt.py's adoption-time labeling
+    # applied gauntlet-accepted under the PRESERVED TRIVIAL (required 1). The adoption-time tier DECISION
+    # then raises the tier to STANDARD (required 2), so 1/2 is short and the stale, publicly-visible
+    # gauntlet-accepted MUST flip to gauntlet-reviewing — the co-located mirror at pr-adoption.md step 6
+    # (and stage-2-review-gate.md's tier-DECISION row) is what makes that happen. It is NOT a no-op here.
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="1")   # 1/2 -> reviewing
+        fake = FakeGh(view=view_with("gauntlet-accepted", "gauntlet-run-g1"))
+        code, out, _err = drive(led, "9", REPO, fake)
+    check(code == 0, f"a short gate after escalation must reconcile and exit 0, got {code}")
+    check(out is not None and out["changed"] is True,
+          f"an accepted->reviewing swap must report changed, got {out!r}")
+    check(out["desired"] == "gauntlet-reviewing", f"desired must be reviewing after escalation, got {out!r}")
+    check(out["required"] == 2 and out["reviews_ok"] == 1, f"tier/tally must be reported, got {out!r}")
+    check(out["current"] == ["gauntlet-accepted", "gauntlet-run-g1"],
+          f"current labels must be reported, got {out!r}")
+    check(out["argv"] == SWAP_TO_REVIEWING,
+          f"the argv must be the canonical reviewing-restoring swap, got {out.get('argv')!r}")
+    check(fake.edited, "the escalation swap must actually call `gh pr edit`")
 
 
 # --- refusals: a missing row and an unset tier, both before any gh call -------
@@ -237,6 +263,7 @@ def t_required_boundary():
 
 CASES = [
     ("reviewing-to-accepted", "a met gate swaps reviewing->accepted with the exact argv", t_reviewing_to_accepted_swaps),
+    ("readopt-escalation", "a re-adoption tier escalation flips a stale accepted->reviewing with the exact argv", t_readopt_escalation_flips_accepted_to_reviewing),
     ("accepted-stays", "an already-accepted PR is a no-op — no edit call", t_accepted_stays),
     ("reviewing-stays", "an already-reviewing short gate is a no-op — no edit call", t_reviewing_stays),
     ("missing-row", "a PR with no ledger row is refused (exit 2), before any gh call", t_missing_row_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1170,6 +1170,66 @@ def t_set_cannot_raise_the_tally(L: ModuleType, tmp: Path) -> None:
     check(code == 0, f"re-writing the same tally was refused: {err!r}")
 
 
+def t_escalation_reset_is_one_atomic_write(L: ModuleType, tmp: Path) -> None:
+    """The depth-raising escalation reset — the deeper `tier` AND the voided `reviews_ok` — lands in ONE
+    `set` invocation, so the two move together (`loop-control.md`/`pr-adoption.md` re-triage steps).
+
+    Two separate writes (`set --tier HIGH` then `set --reviews-ok 0`) open a window: a driver death between
+    them leaves `tier=HIGH, reviews_ok=2`, and the next heartbeat sees no escalation (HIGH→HIGH) so never
+    re-triggers the reset — a stricter tier standing on a stale accepted tally. `set` already applies every
+    field flag in ONE atomic write, so the single-write form is available; this pins that it is.
+    """
+    path = write_lines(tmp / "e.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, tier="STANDARD"))
+    # A standing accepted tally at the shallower tier (earned, not hand-set — `set` cannot raise it).
+    cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
+    cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "reviews_ok"])
+    check(out == "2\n", f"setup: the shallow tally is {out!r}, not '2'")
+
+    # THE escalation reset: raise the tier and void the tally in ONE call.
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--tier", "HIGH", "--reviews-ok", "0"])
+    check(code == 0, f"the one-write escalation reset was refused (exit {code}): {err!r}")
+    row = json.loads(out)
+    check(row["tier"] == "HIGH", f"the deeper tier did not land in the same write: {row['tier']!r}")
+    check(row["reviews_ok"] == "0", f"the tally was not voided in the same write: {row['reviews_ok']!r}")
+
+    # And it is DURABLE — both fields are in the persisted row, not just the printed one.
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "tier"])
+    check(out == "HIGH\n", f"persisted tier is {out!r}, not 'HIGH'")
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "reviews_ok"])
+    check(out == "0\n", f"persisted reviews_ok is {out!r}, not '0' — tier and tally did not move together")
+
+
+def t_deescalation_is_a_tier_only_write(L: ModuleType, tmp: Path) -> None:
+    """A de-escalation (required-lowering flip) writes the tier ALONE and PRESERVES the tally.
+
+    The counterpart of the escalation reset: verdicts earned at a DEEPER depth are a superset that still
+    satisfies a shallower tier, so `set --tier <shallower>` with NO `--reviews-ok` flag must leave
+    `reviews_ok` standing (`loop-control.md`/`pr-adoption.md`/"Status labels mirror the review gate" — the
+    de-escalation branch keeps the verdicts; only `required(tier)` moves). This pins the tool contract the
+    prose deletion depends on: the single directional write is tier-only on a de-escalation, never a reset.
+    """
+    path = write_lines(tmp / "de.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, tier="HIGH"))
+    # A standing tally at the DEEPER tier (earned, not hand-set — `set` cannot raise it).
+    cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
+    cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "reviews_ok"])
+    check(out == "2\n", f"setup: the deep tally is {out!r}, not '2'")
+
+    # THE de-escalation: lower the tier ONLY — no --reviews-ok flag.
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--tier", "STANDARD"])
+    check(code == 0, f"the tier-only de-escalation write was refused (exit {code}): {err!r}")
+    row = json.loads(out)
+    check(row["tier"] == "STANDARD", f"the shallower tier did not land: {row['tier']!r}")
+    check(row["reviews_ok"] == "2", f"the tally was voided by a tier-only write: {row['reviews_ok']!r}")
+
+    # And it is DURABLE — the preserved tally is in the persisted row, not just the printed one.
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "tier"])
+    check(out == "STANDARD\n", f"persisted tier is {out!r}, not 'STANDARD'")
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "reviews_ok"])
+    check(out == "2\n", f"persisted reviews_ok is {out!r}, not '2' — a de-escalation must preserve verdicts")
+
+
 def t_verdict_refuses_a_moved_head(L: ModuleType, tmp: Path) -> None:
     """A verdict for a SHA that is not the row's head is REFUSED — it describes content that is gone.
 
@@ -2207,6 +2267,8 @@ CASES = [
     ("verdict-counts-rounds", "`verdict` bumps review_rounds on EVERY verdict and applies the tally atomically", t_verdict_counts_rounds),
     ("rounds-never-reset", "NOTHING resets review_rounds/ns_streak — there is no flag, at any door", t_review_rounds_never_reset),
     ("tally-floor-only", "`set` may VOID reviews_ok, NEVER raise it — only a verdict adds a verdict", t_set_cannot_raise_the_tally),
+    ("escalation-reset-atomic", "the depth-raising reset writes deeper tier + voided tally in ONE atomic set", t_escalation_reset_is_one_atomic_write),
+    ("deescalation-tier-only", "a de-escalation writes the tier ALONE and preserves the standing tally", t_deescalation_is_a_tier_only_write),
     ("verdict-head-pinned", "a verdict for a SUPERSEDED sha is refused — it describes content that is gone", t_verdict_refuses_a_moved_head),
     ("verdict-domain", "`verdict` needs a real row and one of exactly two verdicts", t_verdict_needs_a_row_and_a_known_verdict),
     ("counter-corrupt", "a counter field that is not a count is refused, never handed to int()", t_counter_refuses_a_corrupt_value),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -2,9 +2,11 @@
 """Adopt a PR into a run — the MECHANICAL half, as a command instead of a shell block in a doc.
 
 `references/pr-adoption.md` is the authority; this tool performs its steps 1, 2, 4, 5 and the row of
-step 3. It does NOT decide the review TIER (that is a triage judgment — passed in as `--tier`) and it does
-NOT author the PR's INTENT (step 3a — the driver's working note about what the PR is for). Those two are
-JUDGMENT; everything here is MECHANICS that a model transcribing a doc gets subtly wrong under load:
+step 3. It does NOT decide the review TIER: adoption passes a conservative `STANDARD` bootstrap because the
+PR-head worktree does not exist until this command resolves it, then — after step 5 — `triage.py derive`
+supplies the mechanical floor and the orchestrator decides the tier at or above it before gate work. It does
+NOT author the PR's INTENT (step 3a — the driver's working note about what the PR
+is for). Everything here is MECHANICS that a model transcribing a doc gets subtly wrong under load:
 
   * READ the PR (one `gh pr view` for the fields the ledger row needs, including the cross-repo field);
   * REFUSE fork/foreign/closed PRs — FAIL CLOSED, touching nothing when it refuses (step 2);
@@ -425,14 +427,18 @@ def main(argv: "list[str] | None" = None) -> int:
     p = sub.add_parser("plan", help="PURE: parse a `gh pr view` JSON file, print the adoption plan, exit 0")
     p.add_argument("--view-json", required=True, help="path to a parsed `gh pr view` JSON document")
     p.add_argument("--run-id", required=True, help="this run's id (the owner label is gauntlet-run-<id>)")
-    p.add_argument("--tier", required=True, help="the review tier — an INPUT; this tool never triages")
+    p.add_argument("--tier", required=True,
+                   help="bootstrap tier; adoption passes STANDARD, then the orchestrator decides the real "
+                        "tier at or above triage.py's floor before gate work")
     p.add_argument("--worktrees-root", default=".worktrees", help="root under which the head worktree sits")
 
     a = sub.add_parser("adopt", help="the real thing: read the PR, refuse/register/worktree/label")
     a.add_argument("--pr", required=True, help="PR number to adopt")
     a.add_argument("--run-id", required=True, help="this run's id")
     a.add_argument("--file", required=True, help="the run ledger (<rundir>/state.jsonl)")
-    a.add_argument("--tier", required=True, help="the review tier — an INPUT; this tool never triages")
+    a.add_argument("--tier", required=True,
+                   help="bootstrap tier; adoption passes STANDARD, then the orchestrator decides the real "
+                        "tier at or above triage.py's floor before gate work")
     a.add_argument("--worktrees-root", required=True, help="root under which the head worktree sits")
     a.add_argument("--project-root", required=True, help="the repo checkout git/ledger commands run in")
     a.add_argument("--repo", help="owner/name (default: the project-root checkout's)")

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+"""Fixtures for ``triage.py`` — the mechanical file inventory and FLOOR tier for one pinned diff.
+
+The suite uses real temporary Git repositories for the file, mode, rename, delete, modification,
+type-change, symlink, ordering and hostile path cases.  It pins that classification inspects every side
+that exists (base and head) and that a non-regular Git object (symlink, gitlink, unrecognized mode) is
+never prose.  It loads the owner by path and therefore fails loudly when the executable policy owner is
+missing.  It pins that the floor is only ever HIGH/STANDARD/None (never TRIVIAL — that is the
+orchestrator's semantic call) and that the ``--tier`` lower-bound check vetoes a below-floor tier.  That
+missing-owner failure was the pre-change reproduction: campaign previously had only prose classification,
+so no command could reject a stale head or consistently detect these classes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import capture_cli
+
+OWNER = Path(__file__).resolve().parent / "triage.py"
+
+
+def _load_owner():
+    mod = load_module_from_path("campaign_triage_owner", OWNER, register=True)
+    if mod is None:
+        raise RuntimeError(f"cannot load deterministic tier derivation at {OWNER}")
+    return mod
+
+
+M = _load_owner()
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        raise M.SelfTestFailure(message)
+
+
+def git(repo: Path, *args: str, check_result: bool = True) -> subprocess.CompletedProcess[bytes]:
+    proc = subprocess.run(["git", *args], cwd=repo, capture_output=True, check=False)  # noqa: S603
+    if check_result and proc.returncode != 0:
+        raise M.SelfTestFailure(
+            f"git {' '.join(args)} failed ({proc.returncode}): {os.fsdecode(proc.stderr)}")
+    return proc
+
+
+def write(repo: Path, name: str, content: str = "content\n", mode: int = 0o644) -> Path:
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(mode)
+    return path
+
+
+def write_bytes_name(repo: Path, name: bytes, content: bytes = b"content\n") -> None:
+    target = os.path.join(os.fsencode(repo), name)
+    fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        os.write(fd, content)
+    finally:
+        os.close(fd)
+
+
+def commit(repo: Path, message: str) -> str:
+    git(repo, "add", "--all")
+    git(repo, "commit", "-q", "-m", message)
+    return os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+
+
+@contextmanager
+def repository(base_files: dict[str, tuple[str, int]] | None = None):
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory)
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.name", "Gauntlet Test")
+        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        files = base_files or {"baseline.txt": ("base\n", 0o644)}
+        for name, (content, mode) in files.items():
+            write(repo, name, content, mode)
+        base = commit(repo, "base")
+        yield repo, base
+
+
+def derive(repo: Path, base: str, *, tier: str | None = None) -> dict:
+    head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+    return M.derive(worktree=str(repo), base=base, head_sha=head, tier=tier)
+
+
+def one_file(result: dict) -> dict:
+    check(len(result["files"]) == 1, f"expected one changed file, got {result['files']!r}")
+    return result["files"][0]
+
+
+def t_human_docs_have_no_floor() -> None:
+    with repository() as (repo, base):
+        write(repo, "docs/guide.md", "# Guide\n")
+        commit(repo, "docs")
+        result = derive(repo, base)
+    check(result["floor"] is None,
+          f"an all-prose diff must have NO floor — the tool never grants TRIVIAL: {result!r}")
+    check(one_file(result)["class"] == M.HUMAN_DOC, "docs/guide.md must be HUMAN-DOC")
+
+
+def t_top_level_human_doc_names() -> None:
+    prose = ("README.md", "CHANGELOG", "CHANGELOG.md", "CHANGELOG.txt", "CHANGELOG.rst",
+             "LICENSE", "LICENSE.md", "LICENSE.txt", "LICENSE-MIT", "LICENSE-APACHE")
+    for name in prose:
+        cls, reasons = M._path_class(name, b"plain prose\n")
+        check(cls == M.HUMAN_DOC, f"{name} must be HUMAN-DOC, got {cls}: {reasons}")
+
+
+def t_prose_named_source_is_code() -> None:
+    """A top-level name that begins with a prose word but carries a source-like or unknown suffix
+    (CHANGELOG.py, license.go, LICENSE.exe) is NOT prose: an unbounded stem prefix let it clear the
+    escalate-only floor. It must classify CODE and floor STANDARD, vetoing a decided --tier TRIVIAL."""
+    for name in ("CHANGELOG.py", "license.go", "LICENSE.exe", "changelog.sh"):
+        cls, reasons = M._path_class(name, b"import os\n")
+        check(cls == M.CODE, f"{name} must be CODE, not prose-by-prefix: {cls}: {reasons}")
+    with repository() as (repo, base):
+        write(repo, "CHANGELOG.py", "import os\nos.system('noop')\n")
+        write(repo, "license.go", "package main\n")
+        head = commit(repo, "source named like prose")
+        result = derive(repo, base)
+        check(result["floor"] == M.STANDARD,
+              f"source suffixes on prose stems must floor STANDARD: {result!r}")
+        check({row["class"] for row in result["files"]} == {M.CODE},
+              f"CHANGELOG.py and license.go must classify CODE: {result!r}")
+        code, out, err = capture_cli(M.main, [
+            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+    check(code == M.EXIT_REFUSED and out == "",
+          f"--tier TRIVIAL must be refused for source named like prose: {code}/{out!r}")
+    check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
+
+
+def t_source_and_unknown_are_standard() -> None:
+    with repository() as (repo, base):
+        write(repo, "src/widget.py", "value = 1\n")
+        write(repo, "assets/blob.weird", "x\n")
+        commit(repo, "code")
+        result = derive(repo, base)
+    check(result["floor"] == M.STANDARD,
+          f"code/unknown content must floor to STANDARD, got {result!r}")
+    check({row["class"] for row in result["files"]} == {M.CODE}, "both paths must classify CODE")
+
+
+def t_agent_frontmatter_is_code() -> None:
+    with repository() as (repo, base):
+        write(repo, "docs/operator.md", "---\nname: operator\ndescription: agent behavior\n---\nBody\n")
+        commit(repo, "agent doc")
+        result = derive(repo, base)
+    row = one_file(result)
+    check(result["floor"] == M.STANDARD and row["class"] == M.CODE,
+          f"agent-frontmatter Markdown must be CODE and floor STANDARD, got {result!r}")
+    check(any("frontmatter" in reason for reason in row["reasons"]), "reason must name frontmatter")
+
+
+def t_agent_paths_are_code() -> None:
+    cases = {
+        "AGENTS.md": "agent-consumed instruction file",
+        "plugins/x/skills/y/references/rules.md": "skill reference",
+        ".claude/commands/do.md": "Claude agent configuration path",
+        "docs/prompts/reviewer.txt": "prompt or agent-instruction path",
+    }
+    for path, expected in cases.items():
+        cls, reasons = M._path_class(path, b"plain\n")
+        check(cls == M.CODE and expected in reasons, f"{path} must be CODE because {expected}: {reasons}")
+
+
+def t_sensitive_classes_are_high() -> None:
+    cases = (
+        ".github/workflows/ci.yml",
+        "plugins/x/scripts/check.py",
+        "package-lock.json",
+        ".codex-plugin/plugin.json",
+        "infra/main.tf",
+        "deploy/helm/values.yaml",
+        "src/auth/token.py",
+        "config/secrets/app.txt",
+        "Dockerfile",
+        "Makefile",
+    )
+    for path in cases:
+        cls, reasons = M._path_class(path, b"content\n")
+        check(cls == M.SENSITIVE and reasons, f"{path} must be mechanically SENSITIVE, got {cls}: {reasons}")
+
+
+def t_mixed_content_uses_highest_class() -> None:
+    with repository() as (repo, base):
+        write(repo, "docs/guide.md", "# Guide\n")
+        write(repo, "src/main.py", "print('x')\n")
+        write(repo, ".github/workflows/ci.yml", "name: ci\n")
+        commit(repo, "mixed")
+        result = derive(repo, base)
+    check(result["floor"] == M.HIGH, f"one sensitive file must raise the mixed diff's floor to HIGH: {result!r}")
+    by_path = {row["path"]: row["class"] for row in result["files"]}
+    check(by_path == {
+        ".github/workflows/ci.yml": M.SENSITIVE,
+        "docs/guide.md": M.HUMAN_DOC,
+        "src/main.py": M.CODE,
+    }, f"mixed classes drifted: {by_path!r}")
+
+
+def t_executable_mode_add_and_remove_are_high() -> None:
+    for before, after in ((0o644, 0o755), (0o755, 0o644)):
+        with repository({"tool.txt": ("run\n", before)}) as (repo, base):
+            (repo / "tool.txt").chmod(after)
+            commit(repo, "mode")
+            result = derive(repo, base)
+        row = one_file(result)
+        check(result["floor"] == M.HIGH and row["class"] == M.SENSITIVE,
+              f"mode {oct(before)}->{oct(after)} must floor to HIGH/SENSITIVE: {result!r}")
+        check("old or new Git mode is executable" in row["reasons"], "executable reason is missing")
+
+
+def t_rename_classifies_both_paths() -> None:
+    with repository({"docs/old.md": ("# Old\n", 0o644)}) as (repo, base):
+        (repo / "src").mkdir()
+        (repo / "docs/old.md").rename(repo / "src/new.md")
+        commit(repo, "rename")
+        result = derive(repo, base)
+    row = one_file(result)
+    check(row["status"].startswith("R") and row["old_path"] == "docs/old.md" and row["path"] == "src/new.md",
+          f"rename identity is wrong: {row!r}")
+    check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+          "a rename from human docs into source must classify both paths and floor to STANDARD")
+
+
+def t_rename_from_sensitive_remains_high() -> None:
+    with repository({"scripts/tool.py": ("print('x')\n", 0o644)}) as (repo, base):
+        (repo / "docs").mkdir()
+        (repo / "scripts/tool.py").rename(repo / "docs/tool.md")
+        commit(repo, "rename sensitive")
+        result = derive(repo, base)
+    check(result["floor"] == M.HIGH and one_file(result)["class"] == M.SENSITIVE,
+          f"touching the old sensitive path must keep the floor at HIGH: {result!r}")
+
+
+def t_sensitive_deletion_is_high() -> None:
+    with repository({"scripts/obsolete.py": ("print('x')\n", 0o644)}) as (repo, base):
+        (repo / "scripts/obsolete.py").unlink()
+        commit(repo, "delete")
+        result = derive(repo, base)
+    row = one_file(result)
+    check(row["status"] == "D" and row["old_path"] == "scripts/obsolete.py",
+          f"deletion must retain its old path: {row!r}")
+    check(result["floor"] == M.HIGH, "deleting a sensitive file still floors to HIGH")
+
+
+def t_deleted_agent_frontmatter_is_code() -> None:
+    frontmatter = "---\nname: old-skill\ndescription: old agent rules\n---\nBody\n"
+    with repository({"docs/old.md": (frontmatter, 0o644)}) as (repo, base):
+        (repo / "docs/old.md").unlink()
+        commit(repo, "delete agent doc")
+        result = derive(repo, base)
+    check(result["floor"] == M.STANDARD and one_file(result)["class"] == M.CODE,
+          f"deleted Markdown must inspect base content for agent frontmatter and floor STANDARD: {result!r}")
+
+
+def t_symlink_at_human_doc_path_is_code() -> None:
+    """A symlink (Git mode 120000) added at a human-doc path is a non-regular Git object, never prose:
+    it must classify at least CODE, floor STANDARD, and refuse a decided --tier TRIVIAL."""
+    with repository({"docs/real.md": ("# Real\n", 0o644)}) as (repo, base):
+        (repo / "docs/guide.md").symlink_to("real.md")
+        head = commit(repo, "symlink at a doc path")
+        result = derive(repo, base)
+        row = one_file(result)
+        check(row["path"] == "docs/guide.md" and row["new_mode"] == "120000",
+              f"the changed file must be the symlink: {row!r}")
+        check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+              f"a symlink at a docs path must be CODE and floor STANDARD, not a prose no-floor: {result!r}")
+        code, out, err = capture_cli(M.main, [
+            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+    check(code == M.EXIT_REFUSED and out == "",
+          f"--tier TRIVIAL must be refused when a symlink clears the doc path: {code}/{out!r}")
+    check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
+
+
+def t_nonregular_modes_are_never_prose() -> None:
+    """A symlink (120000), a gitlink (160000), or any unrecognized mode at a human-doc path is a
+    non-regular Git object; the mode, not the content, forces at least CODE (fail-closed) so the
+    escalate-only floor cannot be cleared by a non-blob object wearing a prose path."""
+    def runner(argv: list[str], _worktree: str) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.CompletedProcess(argv, 0, b"plain prose\n", b"")
+
+    for mode in ("120000", "160000", "100600"):
+        change = M.Change(status="A", old_mode="000000", new_mode=mode, old_path=None, path=b"docs/guide.md")
+        row = M._classify_change(change, runner, "/nonexistent", "a" * 40, "b" * 40)
+        check(row["class"] == M.CODE,
+              f"mode {mode} at docs/guide.md must classify CODE, not prose: {row!r}")
+        check(any("non-regular" in reason for reason in row["reasons"]),
+              f"the reason must name the non-regular mode: {row!r}")
+
+
+def t_gitlink_change_survives_gitmodules_ignore_all() -> None:
+    """A commit that ADVANCES a submodule gitlink whose committed ``.gitmodules`` sets ``ignore = all`` must
+    still land in the inventory. Plain ``git diff --raw`` honors that committed ignore and OMITS the changed
+    ``160000`` row, so the remaining diff could read as all-prose and clear the escalate-only floor; the
+    ``--ignore-submodules=none`` argv forces the gitlink back in, where its mode floors it to at least CODE.
+    Uses ``git update-index --cacheinfo`` (not ``git add --all``, which would drop an on-disk-absent gitlink)."""
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory)
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.name", "Gauntlet Test")
+        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        write(repo, "docs/guide.md", "# Guide\n")
+        git(repo, "update-index", "--add", "--cacheinfo",
+            "160000,1111111111111111111111111111111111111111,vendor/sub")
+        write(repo, ".gitmodules",
+              '[submodule "vendor/sub"]\n\tpath = vendor/sub\n\turl = ./sub.git\n\tignore = all\n')
+        git(repo, "add", "docs/guide.md", ".gitmodules")
+        git(repo, "commit", "-q", "-m", "base with ignore=all submodule")
+        base = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        git(repo, "update-index", "--cacheinfo",
+            "160000,2222222222222222222222222222222222222222,vendor/sub")
+        write(repo, "docs/guide.md", "# Guide v2\n")
+        git(repo, "add", "docs/guide.md")
+        git(repo, "commit", "-q", "-m", "advance gitlink and edit prose")
+        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        result = M.derive(worktree=str(repo), base=base, head_sha=head)
+    by_path = {row["path"]: row for row in result["files"]}
+    check("vendor/sub" in by_path,
+          f"the changed gitlink must be in the inventory despite .gitmodules ignore=all: {result!r}")
+    gitlink = by_path["vendor/sub"]
+    check(gitlink["new_mode"] == "160000" and gitlink["class"] == M.CODE,
+          f"the changed gitlink must carry Git mode 160000 and classify CODE: {gitlink!r}")
+    check(M._CLASS_RANK[gitlink["class"]] >= M._CLASS_RANK[M.CODE] and result["floor"] == M.STANDARD,
+          f"a changed gitlink must floor to at least STANDARD, not read as all-prose: {result!r}")
+
+
+def t_modification_classifies_base_and_head() -> None:
+    """A single-path modification (status M) must classify BOTH its base and head content and keep the
+    higher class. Stripping agent frontmatter leaves plain prose at HEAD but changed an agent-consumed
+    document, so the base side must still classify CODE — as renames and deletions already do."""
+    frontmatter = "---\nname: operator\ndescription: agent behavior\ntools: read\n---\nBody\n"
+    with repository({"docs/operator.md": (frontmatter, 0o644)}) as (repo, base):
+        write(repo, "docs/operator.md", "# Operator\n\nPlain prose now, no frontmatter.\n")
+        head = commit(repo, "strip agent frontmatter")
+        result = derive(repo, base)
+        row = one_file(result)
+        check(row["status"] == "M", f"the change must be a modification: {row!r}")
+        check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+              f"a modification that strips frontmatter must classify the base side CODE and floor STANDARD: {result!r}")
+        code, out, err = capture_cli(M.main, [
+            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+    check(code == M.EXIT_REFUSED and out == "",
+          f"--tier TRIVIAL must be refused for a frontmatter-strip modification: {code}/{out!r}")
+    check("below the mechanical floor" in err, f"the refusal must name the floor, not a missing worktree: {err!r}")
+
+
+def t_type_change_classifies_base_and_head() -> None:
+    """A single-path type-change (status T) must classify BOTH sides. A regular prose doc that becomes a
+    symlink keeps prose at the base but a non-regular object at HEAD, so it floors to STANDARD."""
+    with repository({"docs/guide.md": ("# Guide\n", 0o644)}) as (repo, base):
+        (repo / "docs/guide.md").unlink()
+        (repo / "docs/guide.md").symlink_to("elsewhere.md")
+        commit(repo, "doc becomes a symlink")
+        result = derive(repo, base)
+    row = one_file(result)
+    check(row["status"] == "T", f"regular file -> symlink must be a type change: {row!r}")
+    check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+          f"a type change to a symlink must classify at least CODE and floor STANDARD: {result!r}")
+
+
+def t_tool_never_emits_trivial_floor() -> None:
+    """The floor is only ever HIGH, STANDARD, or None (no floor) — the tool is STRUCTURALLY INCAPABLE of
+    granting TRIVIAL. All-prose yields None (the orchestrator decides), NOT a TRIVIAL grant."""
+    scenarios = (
+        ({"docs/guide.md": "# Guide\n"}, None),
+        ({"src/main.py": "x = 1\n"}, M.STANDARD),
+        ({"scripts/tool.py": "print('x')\n"}, M.HIGH),
+    )
+    for files, expected in scenarios:
+        with repository() as (repo, base):
+            for name, content in files.items():
+                write(repo, name, content)
+            commit(repo, "scenario")
+            result = derive(repo, base)
+        check(result["floor"] == expected,
+              f"floor for {sorted(files)} must be {expected!r}, got {result['floor']!r}")
+        check(result["floor"] != M.TRIVIAL, "the tool must NEVER emit a TRIVIAL floor")
+    # An empty diff also never floors below STANDARD — never a vacuous no-floor that could read as TRIVIAL.
+    with repository() as (repo, base):
+        empty = derive(repo, base)
+    check(empty["floor"] == M.STANDARD, f"an empty diff floors to STANDARD, never TRIVIAL: {empty!r}")
+
+
+def t_tier_below_floor_is_refused() -> None:
+    """The optional --tier is a LOWER-BOUND check: a decided tier below the floor is refused (veto-downward),
+    while a tier at or above the floor — including the orchestrator's TRIVIAL on an all-prose diff — passes."""
+    # floor HIGH (sensitive): only HIGH clears it.
+    with repository() as (repo, base):
+        write(repo, "scripts/tool.py", "print('x')\n")
+        head = commit(repo, "sensitive")
+        for below in (M.TRIVIAL, M.STANDARD):
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", below])
+            check(code == M.EXIT_REFUSED and out == "",
+                  f"--tier {below} below a HIGH floor must be refused with no JSON: {code}/{out!r}")
+            check("below the mechanical floor" in err and "HIGH" in err,
+                  f"the refusal must name the floor: {err!r}")
+        check(derive(repo, base, tier=M.HIGH)["floor"] == M.HIGH,
+              "--tier HIGH clears a HIGH floor and still emits the inventory")
+    # floor STANDARD (code): TRIVIAL is refused, STANDARD/HIGH pass.
+    with repository() as (repo, base):
+        write(repo, "src/main.py", "x = 1\n")
+        commit(repo, "code")
+        try:
+            derive(repo, base, tier=M.TRIVIAL)
+        except M.TriageError as exc:
+            check("below the mechanical floor" in str(exc), f"STANDARD floor must veto TRIVIAL: {exc}")
+        else:
+            raise M.SelfTestFailure("a TRIVIAL tier below a STANDARD floor was accepted")
+        check(derive(repo, base, tier=M.STANDARD)["floor"] == M.STANDARD, "--tier STANDARD clears a STANDARD floor")
+    # floor None (all prose): the orchestrator's TRIVIAL call is ALLOWED — nothing to veto.
+    with repository() as (repo, base):
+        write(repo, "docs/guide.md", "# Guide\n")
+        commit(repo, "docs")
+        ok = derive(repo, base, tier=M.TRIVIAL)
+    check(ok["floor"] is None, "an all-prose diff has no floor, so a decided TRIVIAL is accepted")
+
+
+def t_head_mismatch_is_refused_without_output() -> None:
+    with repository() as (repo, base):
+        write(repo, "docs/guide.md", "# Guide\n")
+        head = commit(repo, "docs")
+        wrong = ("0" if head[0] != "0" else "1") + head[1:]
+        code, out, err = capture_cli(M.main, [
+            "derive", "--worktree", str(repo), "--base", base, "--head-sha", wrong,
+        ])
+    check(code == M.EXIT_REFUSED and out == "", f"stale expected head must emit no JSON, got {code}/{out!r}")
+    check("HEAD mismatch" in err and wrong in err and head in err, f"mismatch refusal must name both SHAs: {err!r}")
+
+
+def t_moving_head_is_refused() -> None:
+    sha_a = "a" * 40
+    sha_b = "b" * 40
+    head_reads = 0
+
+    def runner(argv: list[str], _worktree: str) -> subprocess.CompletedProcess[bytes]:
+        nonlocal head_reads
+        if argv == ["git", "rev-parse", "--verify", "HEAD^{commit}"]:
+            head_reads += 1
+            value = sha_a if head_reads == 1 else sha_b
+            return subprocess.CompletedProcess(argv, 0, os.fsencode(value + "\n"), b"")
+        if argv[:4] == ["git", "rev-parse", "--verify", "--end-of-options"]:
+            return subprocess.CompletedProcess(argv, 0, os.fsencode(sha_a + "\n"), b"")
+        if argv[:2] == ["git", "merge-base"]:
+            return subprocess.CompletedProcess(argv, 0, os.fsencode(sha_a + "\n"), b"")
+        if argv[:3] == ["git", "diff", "--raw"]:
+            return subprocess.CompletedProcess(argv, 0, b"", b"")
+        return subprocess.CompletedProcess(argv, 99, b"", b"unexpected argv")
+
+    with tempfile.TemporaryDirectory() as directory:
+        try:
+            M.derive(worktree=directory, base="main", head_sha=sha_a, runner=runner)
+        except M.TriageError as exc:
+            check("HEAD moved during triage" in str(exc), f"wrong moving-head refusal: {exc}")
+        else:
+            raise M.SelfTestFailure("a HEAD that moved during the read was accepted")
+
+
+def t_deterministic_order_and_bytes() -> None:
+    with repository() as (repo, base):
+        write(repo, "z-last.py", "z = 1\n")
+        write(repo, "docs/a-first.md", "# A\n")
+        write(repo, "middle.unknown", "m\n")
+        commit(repo, "unordered")
+        first = derive(repo, base)
+        second = derive(repo, base)
+    paths = [row["path"] for row in first["files"]]
+    check(paths == sorted(paths), f"per-file records must sort by path: {paths!r}")
+    encoded1 = json.dumps(first, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    encoded2 = json.dumps(second, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    check(encoded1 == encoded2, "the same pinned Git evidence must emit byte-identical JSON")
+
+
+def t_hostile_paths_are_data() -> None:
+    hostile = "--odd\n\"tick`$ name.py"
+    with repository() as (repo, base):
+        write(repo, hostile, "value = 1\n")
+        write_bytes_name(repo, b"bad-\xff-name.md", b"plain\n")
+        commit(repo, "hostile paths")
+        result = derive(repo, base)
+    paths = [row["path"] for row in result["files"]]
+    check(hostile in paths, f"whitespace/quotes/backticks/dollar/leading dash path was not preserved: {paths!r}")
+    check(any("\udcff" in path for path in paths), f"non-UTF8 filename bytes were not preserved by surrogateescape: {paths!r}")
+    json.dumps(result, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def t_empty_diff_floors_standard() -> None:
+    with repository() as (repo, base):
+        result = derive(repo, base)
+    check(result["files"] == [] and result["floor"] == M.STANDARD,
+          f"an empty/uncertain diff must floor to STANDARD, never a vacuous no-floor: {result!r}")
+
+
+def t_bad_inputs_and_git_failures_emit_no_partial_json() -> None:
+    with repository() as (repo, base):
+        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        cases = (
+            ["derive", "--worktree", str(repo), "--base", base, "--head-sha", "short"],
+            ["derive", "--worktree", str(repo), "--base=--not-a-ref", "--head-sha", head],
+            ["derive", "--worktree", str(repo / "missing"), "--base", base, "--head-sha", head],
+        )
+        for argv in cases:
+            code, out, err = capture_cli(M.main, list(argv))
+            check(code == M.EXIT_REFUSED and out == "" and "REFUSED" in err,
+                  f"bad input must fail atomically with no JSON: {argv!r} -> {code}/{out!r}/{err!r}")
+
+
+def t_raw_parser_refuses_partial_records() -> None:
+    malformed = (
+        b"not-a-header\0path\0",
+        b":100644 100644 " + b"a" * 40 + b" " + b"b" * 40 + b" M\0",
+        b":10064x 100644 " + b"a" * 40 + b" " + b"b" * 40 + b" M\0path\0",
+        b":100644 100644 short " + b"b" * 40 + b" M\0path\0",
+    )
+    for raw in malformed:
+        try:
+            M._parse_raw(raw)
+        except M.TriageError:
+            pass
+        else:
+            raise M.SelfTestFailure(f"malformed raw diff was accepted: {raw!r}")
+
+
+def t_output_head_is_full_live_sha() -> None:
+    with repository() as (repo, base):
+        write(repo, "README.md", "# Read me\n")
+        head = commit(repo, "readme")
+        result = derive(repo, base)
+    check(result["head_sha"] == head and M.SHA_RE.fullmatch(result["head_sha"]) is not None,
+          f"output must carry the exact live 40-character HEAD: {result!r}")
+    check(result["diff_base_sha"] == base, "linear fixture's diff base must be the base commit")
+
+
+def t_blob_read_failure_on_existing_side_refuses() -> None:
+    """`git show` failing for a REGULAR-file side the raw diff already named is unreadable evidence, never
+    benign absence (a blob-filtered clone with the promisor down exits 128 'bad object' while `git diff`
+    still parses at tree level). It must fail CLOSED — TriageError, exit 2, no JSON — like every other Git
+    call, not silently read as empty prose that would drop stripped agent frontmatter under the floor."""
+    base_sha = "a" * 40
+    head_sha = "b" * 40
+    # One modification of a regular-mode docs file: both sides are regular blobs, so both are read.
+    raw = b":100644 100644 " + b"c" * 40 + b" " + b"d" * 40 + b" M\0docs/operator.md\0"
+
+    def runner(argv: list[str], _worktree: str) -> subprocess.CompletedProcess[bytes]:
+        if argv == ["git", "rev-parse", "--verify", "HEAD^{commit}"]:
+            return subprocess.CompletedProcess(argv, 0, os.fsencode(head_sha + "\n"), b"")
+        if argv[:4] == ["git", "rev-parse", "--verify", "--end-of-options"]:
+            return subprocess.CompletedProcess(argv, 0, os.fsencode(base_sha + "\n"), b"")
+        if argv[:2] == ["git", "merge-base"]:
+            return subprocess.CompletedProcess(argv, 0, os.fsencode(base_sha + "\n"), b"")
+        if argv[:3] == ["git", "diff", "--raw"]:
+            return subprocess.CompletedProcess(argv, 0, raw, b"")
+        if argv[:2] == ["git", "show"]:
+            return subprocess.CompletedProcess(argv, 128, b"", b"fatal: bad object")
+        return subprocess.CompletedProcess(argv, 99, b"", b"unexpected argv")
+
+    with tempfile.TemporaryDirectory() as directory:
+        try:
+            M.derive(worktree=directory, base="main", head_sha=head_sha, runner=runner)
+        except M.TriageError as exc:
+            check("exited 128" in str(exc), f"a failed git show must fail closed with git detail: {exc}")
+        else:
+            raise M.SelfTestFailure("a failed git show on an existing regular side was read as empty prose")
+
+
+def t_nonregular_side_read_failure_is_tolerated() -> None:
+    """The mirror of the rule above: a NON-regular side (symlink/gitlink) is forced to CODE by mode and its
+    content is never read, so a `git show` failure on it must NOT abort — mode already carries the class."""
+    def runner(argv: list[str], _worktree: str) -> subprocess.CompletedProcess[bytes]:
+        if argv[:2] == ["git", "show"]:
+            return subprocess.CompletedProcess(argv, 128, b"", b"fatal: bad object")
+        return subprocess.CompletedProcess(argv, 0, b"plain prose\n", b"")
+
+    change = M.Change(status="A", old_mode="000000", new_mode="120000", old_path=None, path=b"docs/guide.md")
+    row = M._classify_change(change, runner, "/nonexistent", "a" * 40, "b" * 40)
+    check(row["class"] == M.CODE,
+          f"a symlink side must classify CODE without reading (or failing on) its blob: {row!r}")
+
+
+def t_quoted_frontmatter_keys_are_code() -> None:
+    """Agent frontmatter written with QUOTED YAML keys ("tools":, 'name':) is still agent frontmatter — a
+    bare-letter-only match dropped the key and read the block as prose. Floor STANDARD, --tier TRIVIAL vetoed."""
+    doc = '---\n"name": operator\n"tools": [read, write]\n---\nBody\n'
+    with repository() as (repo, base):
+        write(repo, "docs/operator-guide.md", doc)
+        head = commit(repo, "quoted frontmatter")
+        result = derive(repo, base)
+        row = one_file(result)
+        check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+              f"quoted-key agent frontmatter must be CODE and floor STANDARD: {result!r}")
+        code, out, err = capture_cli(M.main, [
+            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+    check(code == M.EXIT_REFUSED and out == "",
+          f"--tier TRIVIAL must be refused for quoted-key agent frontmatter: {code}/{out!r}")
+    check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
+
+
+def t_flow_style_frontmatter_is_code() -> None:
+    """Flow-style top-level frontmatter — a single ``{...}`` mapping — is valid YAML that the line-based
+    block-key scan does not match, so before the root fix it read as prose and cleared the floor. The
+    interior is now validated as a plain block mapping; a flow mapping is not one, so it fails closed to
+    CODE. Both a {name, description} and an {agent, model} flow mapping floor STANDARD end to end and veto a
+    decided --tier TRIVIAL. (The paths carry no agent token, so only the frontmatter can force CODE.)"""
+    for stem, interior in (("operator-flow", "{name: operator, description: agent behavior}"),
+                           ("model-flow", "{agent: reviewer, model: opus}")):
+        doc = f"---\n{interior}\n---\nBody\n"
+        with repository() as (repo, base):
+            write(repo, f"docs/{stem}.md", doc)
+            head = commit(repo, "flow-style frontmatter")
+            result = derive(repo, base)
+            row = one_file(result)
+            check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+                  f"flow-style agent frontmatter must be CODE and floor STANDARD: {result!r}")
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        check(code == M.EXIT_REFUSED and out == "",
+              f"--tier TRIVIAL must be refused for flow-style frontmatter: {code}/{out!r}")
+        check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
+
+
+def t_unparseable_frontmatter_fails_closed_to_code() -> None:
+    """A frontmatter interior the line-based block extractor cannot COMPLETELY account for — here a value
+    whose flow sequence is continued across lines and closes with ``]`` at column 0 — fails closed to CODE
+    regardless of its keys. Its keys (``title``, ``links``) are NOT agent keys and NOT {name, description},
+    so the ONLY thing forcing CODE is the fail-closed rule: a frontmatter that cannot be fully parsed is
+    never read as prose. Floor STANDARD end to end, --tier TRIVIAL vetoed."""
+    doc = "---\ntitle: Notes\nlinks: [\n  first,\n  second,\n]\n---\nBody\n"
+    cls, reasons = M._path_class("docs/notes.md", doc.encode("utf-8"))
+    check(cls == M.CODE and any("frontmatter" in r for r in reasons),
+          f"an unparseable frontmatter interior must fail closed to CODE: {cls}: {reasons}")
+    with repository() as (repo, base):
+        write(repo, "docs/notes.md", doc)
+        head = commit(repo, "unparseable frontmatter")
+        result = derive(repo, base)
+        check(result["floor"] == M.STANDARD and one_file(result)["class"] == M.CODE,
+              f"unparseable frontmatter must floor STANDARD: {result!r}")
+        code, out, err = capture_cli(M.main, [
+            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+    check(code == M.EXIT_REFUSED and out == "",
+          f"--tier TRIVIAL must be refused for unparseable frontmatter: {code}/{out!r}")
+    check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
+
+
+def t_frontmatter_runs_for_all_prose_extensions() -> None:
+    """The agent-frontmatter escape runs for every prose-like extension _is_human_doc accepts, not just
+    `.md`: a docs/*.txt or *.rst carrying agent frontmatter is CODE, not prose that clears the floor."""
+    doc = "---\nname: operator\ndescription: agent rules\ntools: read\n---\nBody\n"
+    for name in ("docs/operator.txt", "docs/operator.rst"):
+        with repository() as (repo, base):
+            write(repo, name, doc)
+            commit(repo, "prose doc with agent frontmatter")
+            result = derive(repo, base)
+        row = one_file(result)
+        check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
+              f"{name} carrying agent frontmatter must be CODE and floor STANDARD: {result!r}")
+
+
+def t_frontmatter_closing_past_line_100_is_code() -> None:
+    """The closing-delimiter scan must not truncate at a fixed line: agent frontmatter whose closing `---`
+    sits well past line 100 must still classify CODE, not read as prose because the scan gave up early."""
+    filler = "".join(f"note-{i}: line\n" for i in range(150))
+    doc = "---\nname: operator\ndescription: agent rules\ntools: read\n" + filler + "---\nBody\n"
+    with repository() as (repo, base):
+        write(repo, "docs/long.md", doc)
+        commit(repo, "long frontmatter")
+        result = derive(repo, base)
+    check(one_file(result)["class"] == M.CODE and result["floor"] == M.STANDARD,
+          f"agent frontmatter closing past line 100 must still be CODE: {result!r}")
+
+
+def t_unterminated_frontmatter_fails_closed_to_code() -> None:
+    """An opening `---` with NO closing delimiter anywhere is a malformed/unterminated frontmatter block:
+    fail closed to CODE rather than silently reading the whole file as prose."""
+    doc = "---\nname: operator\ntools: read\nno closing fence in this file\n"
+    cls, reasons = M._path_class("docs/broken.md", doc.encode("utf-8"))
+    check(cls == M.CODE and any("frontmatter" in r for r in reasons),
+          f"unterminated frontmatter must fail closed to CODE: {cls}: {reasons}")
+
+
+def t_pip_source_and_conda_manifests_are_sensitive() -> None:
+    """The dependency recogniser covers the pip-tools source manifest (``requirements*.in``), pip
+    ``constraints*.txt`` pins, and conda environment manifests (``environment.yml``/``.yaml``,
+    ``conda.yml``/``.yaml``) — not only the compiled ``requirements*.txt`` lockfile. Each is SENSITIVE and
+    floors HIGH, so a decided --tier STANDARD or TRIVIAL is vetoed."""
+    for path in ("requirements.in", "requirements-dev.in", "constraints.txt", "environment.yml",
+                 "environment.yaml", "conda.yml", "conda.yaml"):
+        cls, reasons = M._path_class(path, b"content\n")
+        check(cls == M.SENSITIVE and reasons, f"{path} must be mechanically SENSITIVE, got {cls}: {reasons}")
+    # requirements.in end-to-end: floor HIGH, and both below-floor tiers are refused with no JSON.
+    with repository() as (repo, base):
+        write(repo, "requirements.in", "requests\nflask\n")
+        head = commit(repo, "pip-tools source manifest")
+        result = derive(repo, base)
+        check(result["floor"] == M.HIGH and one_file(result)["class"] == M.SENSITIVE,
+              f"requirements.in is a dependency manifest and must floor HIGH: {result!r}")
+        for below in (M.TRIVIAL, M.STANDARD):
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", below])
+            check(code == M.EXIT_REFUSED and out == "",
+                  f"--tier {below} below requirements.in's HIGH floor must be refused: {code}/{out!r}")
+            check("below the mechanical floor" in err and "HIGH" in err,
+                  f"the refusal must name the HIGH floor: {err!r}")
+    # A conda environment manifest and a pip constraints file each floor HIGH end-to-end too.
+    for name in ("environment.yml", "constraints.txt"):
+        with repository() as (repo, base):
+            write(repo, name, "content\n")
+            commit(repo, name)
+            result = derive(repo, base)
+        check(result["floor"] == M.HIGH and one_file(result)["class"] == M.SENSITIVE,
+              f"{name} must floor HIGH as a dependency manifest: {result!r}")
+
+
+CASES = [
+    ("human-doc", "an all-prose diff has no floor — the tool never grants TRIVIAL", t_human_docs_have_no_floor),
+    ("human-names", "top-level README/CHANGELOG/LICENSE and prose suffixes are HUMAN-DOC", t_top_level_human_doc_names),
+    ("prose-named-source", "prose-named source suffixes (CHANGELOG.py, license.go) are CODE", t_prose_named_source_is_code),
+    ("code-unknown", "source and unknown paths are CODE and floor STANDARD", t_source_and_unknown_are_standard),
+    ("agent-frontmatter", "Markdown carrying skill/agent frontmatter is CODE", t_agent_frontmatter_is_code),
+    ("agent-paths", "agent instructions, skill references, .claude and prompts are CODE", t_agent_paths_are_code),
+    ("sensitive-classes", "CI/scripts/manifests/IaC/auth/build paths are SENSITIVE", t_sensitive_classes_are_high),
+    ("pip-conda-manifests", "requirements.in, constraints.txt and conda env manifests are SENSITIVE", t_pip_source_and_conda_manifests_are_sensitive),
+    ("mixed", "mixed files use the highest content class", t_mixed_content_uses_highest_class),
+    ("executable-mode", "adding or removing executable mode is HIGH", t_executable_mode_add_and_remove_are_high),
+    ("rename", "a rename classifies old and new paths", t_rename_classifies_both_paths),
+    ("rename-sensitive", "renaming away from a sensitive path remains HIGH", t_rename_from_sensitive_remains_high),
+    ("delete-sensitive", "deleting a sensitive file remains HIGH", t_sensitive_deletion_is_high),
+    ("delete-frontmatter", "deleted Markdown uses base content for frontmatter", t_deleted_agent_frontmatter_is_code),
+    ("symlink-doc", "a symlink at a docs path is CODE, floors STANDARD, refuses TRIVIAL", t_symlink_at_human_doc_path_is_code),
+    ("nonregular-modes", "symlink/gitlink/unrecognized modes are never prose", t_nonregular_modes_are_never_prose),
+    ("gitlink-ignore-all", "a gitlink change survives .gitmodules ignore=all in the inventory", t_gitlink_change_survives_gitmodules_ignore_all),
+    ("modify-both-sides", "a modification classifies base and head; frontmatter strip stays CODE", t_modification_classifies_base_and_head),
+    ("typechange-both-sides", "a type change classifies base and head", t_type_change_classifies_base_and_head),
+    ("no-trivial-floor", "the tool never emits a TRIVIAL floor; all-prose is no-floor", t_tool_never_emits_trivial_floor),
+    ("tier-veto", "a --tier below the floor is refused; at/above passes", t_tier_below_floor_is_refused),
+    ("head-mismatch", "a stale expected head is refused without JSON", t_head_mismatch_is_refused_without_output),
+    ("head-moving", "HEAD moving during evidence collection is refused", t_moving_head_is_refused),
+    ("deterministic", "file ordering and JSON bytes are deterministic", t_deterministic_order_and_bytes),
+    ("hostile-paths", "hostile and non-UTF8 Git paths remain inert data", t_hostile_paths_are_data),
+    ("empty-diff", "an empty diff floors to STANDARD rather than a vacuous no-floor", t_empty_diff_floors_standard),
+    ("atomic-refusal", "input and Git failures emit no partial JSON", t_bad_inputs_and_git_failures_emit_no_partial_json),
+    ("raw-partial", "malformed or partial raw Git records are refused", t_raw_parser_refuses_partial_records),
+    ("head-output", "output is pinned to the full live HEAD", t_output_head_is_full_live_sha),
+    ("blob-read-fail", "a failed git show on an existing regular side fails closed (exit 2)", t_blob_read_failure_on_existing_side_refuses),
+    ("nonregular-read-skip", "a non-regular side is CODE by mode; its blob is never read", t_nonregular_side_read_failure_is_tolerated),
+    ("quoted-frontmatter", "quoted YAML frontmatter keys still classify CODE", t_quoted_frontmatter_keys_are_code),
+    ("flow-frontmatter", "flow-style {..} agent frontmatter fails closed to CODE", t_flow_style_frontmatter_is_code),
+    ("unparseable-frontmatter", "frontmatter the extractor cannot fully parse fails closed to CODE", t_unparseable_frontmatter_fails_closed_to_code),
+    ("frontmatter-extensions", "the frontmatter check runs for .txt/.rst prose too", t_frontmatter_runs_for_all_prose_extensions),
+    ("frontmatter-long", "frontmatter closing past line 100 still classifies CODE", t_frontmatter_closing_past_line_100_is_code),
+    ("frontmatter-unterminated", "an unterminated frontmatter block fails closed to CODE", t_unterminated_frontmatter_fails_closed_to_code),
+]
+
+
+def run_cases() -> int:
+    failures = 0
+    for name, description, fn in CASES:
+        try:
+            fn()
+            print(f"PASS {name}: {description}")
+        except Exception as exc:  # noqa: BLE001 - fixture runner must report every case
+            failures += 1
+            print(f"FAIL {name}: {description}: {exc}")
+    print(f"triage fixtures: {len(CASES) - failures} passed, {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cases())

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""Emit the mechanical FLOOR and file inventory for one immutable PR-head diff.
+
+``references/stage-2-review-gate.md`` (``2a-triage``) owns the policy.  This command is a mechanical
+INPUT to that policy with ESCALATE-ONLY authority, never the tier decision.  It resolves a base, reads one
+raw Git diff pinned to the caller's expected 40-character HEAD, classifies every changed path and mode,
+then proves HEAD did not move while the evidence was read.  From that it emits a per-file inventory and a
+FLOOR tier — the minimum the mechanics compel:
+
+  * any SENSITIVE file  -> floor ``HIGH``;
+  * any non-HUMAN-DOC file (or an empty/unresolved diff) -> floor ``STANDARD``;
+  * nothing but human prose -> ``null`` floor (no floor: the orchestrator decides).
+
+It is STRUCTURALLY INCAPABLE of emitting a ``TRIVIAL`` floor: ``TRIVIAL`` is only ever the orchestrator's
+semantic "is this all human prose?" call.  The optional ``--tier`` lets a caller present the tier it
+DECIDED; the command then acts as a LOWER-BOUND check and REFUSES a tier below the floor (veto-downward).
+It never grants a tier and never lowers one.
+
+    triage.py derive --worktree <path> --base <ref> --head-sha <40-hex> [--tier TRIVIAL|STANDARD|HIGH]
+    triage.py self-test
+
+Success prints one deterministic JSON object and exits 0.  Any Git failure, malformed evidence, stale
+expected head, moving head, or a ``--tier`` below the floor prints no JSON, explains the refusal on
+stderr, and exits 2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Callable
+
+from _gauntlet.modules import load_module_from_path
+
+_HERE = Path(__file__).resolve().parent
+SIBLING = _HERE / "triage-test.py"
+
+EXIT_OK = 0
+EXIT_REFUSED = 2
+
+HUMAN_DOC = "HUMAN-DOC"
+CODE = "CODE"
+SENSITIVE = "SENSITIVE"
+
+TRIVIAL = "TRIVIAL"
+STANDARD = "STANDARD"
+HIGH = "HIGH"
+
+# Tier order, low to high. The floor is only ever STANDARD, HIGH, or None (no floor); TRIVIAL is never a
+# floor. A None floor ranks below every tier, so any DECIDED tier — including the orchestrator's TRIVIAL —
+# clears it. The --tier veto compares a driver's decided tier against the floor's rank.
+_TIER_RANK = {TRIVIAL: 0, STANDARD: 1, HIGH: 2}
+TIER_VALUES = frozenset(_TIER_RANK)
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+_HUMAN_SUFFIXES = frozenset({".md", ".mdown", ".markdown", ".rst", ".txt", ".adoc", ".asciidoc"})
+# Suffixes a top-level CHANGELOG/LICENSE stem may carry and still be prose (a bare stem has none). A stem
+# with any other suffix is source-like or unknown and classifies CODE, never HUMAN-DOC.
+_PROSE_DOC_SUFFIXES = frozenset({"", ".md", ".txt", ".rst"})
+_AGENT_DOC_BASENAMES = frozenset({"skill.md", "agents.md", "claude.md"})
+_AGENT_TOKENS = frozenset({"agent", "agents", "instruction", "instructions", "prompt", "prompts"})
+
+_DEPENDENCY_NAMES = frozenset({
+    "package.json", "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
+    "bun.lock", "bun.lockb", "deno.lock", "pyproject.toml", "poetry.lock", "pipfile",
+    "pipfile.lock", "setup.py", "setup.cfg", "uv.lock", "go.mod", "go.sum", "go.work",
+    "go.work.sum", "cargo.toml", "cargo.lock", "gemfile", "gemfile.lock", "composer.json",
+    "composer.lock", "pom.xml", "gradle.lockfile", "mix.exs", "mix.lock", "pubspec.yaml",
+    "pubspec.lock", "package.swift", "package.resolved", "nuget.config", "packages.lock.json",
+    "environment.yml", "environment.yaml", "conda.yml", "conda.yaml",
+})
+_DEPENDENCY_SUFFIXES = (".csproj", ".fsproj", ".vbproj")
+_IAC_SUFFIXES = frozenset({".tf", ".tfvars", ".hcl"})
+_IAC_PARTS = frozenset({"terraform", "pulumi", "k8s", "kubernetes", "helm", "ansible"})
+_SENSITIVE_TOKENS = frozenset({
+    "auth", "authentication", "authorization", "oauth", "oidc", "jwt", "crypto", "cryptography",
+    "secret", "secrets", "credential", "credentials", "key", "keys", "certificate", "certificates",
+})
+_FRONTMATTER_AGENT_KEYS = frozenset({"agent", "agents", "model", "tools", "skills"})
+
+# One top-level key of a plain BLOCK-style YAML mapping line: bare (``tools:``), double- or single-quoted
+# (``"tools":`` / ``'name':``), each allowed standard leading indentation. A quoted key is valid YAML that a
+# bare-letter-only match would silently drop, reading agent frontmatter as prose and clearing the floor. This
+# matches a block-mapping key line ONLY; a flow mapping (``{name: …}``) and every other non-block surface
+# form is handled by ``_frontmatter_top_level_keys``, which fails such an interior closed to CODE.
+_FRONTMATTER_KEY_RE = re.compile(
+    r"""^\s*
+        (?:"(?P<dq>[^"]+)"
+          |'(?P<sq>[^']+)'
+          |(?P<bare>[A-Za-z][A-Za-z0-9_-]*))
+        \s*:
+    """,
+    re.VERBOSE,
+)
+
+
+class TriageError(Exception):
+    """The requested tier cannot be derived from a stable, complete Git view."""
+
+
+class SelfTestFailure(AssertionError):
+    """A rule this executable claims to enforce did not hold."""
+
+
+@dataclass(frozen=True)
+class Change:
+    status: str
+    old_mode: str
+    new_mode: str
+    old_path: bytes | None
+    path: bytes
+
+
+Runner = Callable[[list[str], str], subprocess.CompletedProcess[bytes]]
+
+
+def _real_run(argv: list[str], worktree: str) -> subprocess.CompletedProcess[bytes]:
+    """Run a typed argv in the supplied worktree and preserve filename bytes with surrogateescape."""
+    return subprocess.run(argv, cwd=worktree, capture_output=True, check=False)  # noqa: S603
+
+
+def _run(runner: Runner, argv: list[str], worktree: str, operation: str) -> bytes:
+    try:
+        proc = runner(argv, worktree)
+    except OSError as exc:
+        raise TriageError(f"{operation} could not run: {exc}") from exc
+    if proc.returncode != 0:
+        detail = os.fsdecode(proc.stderr).strip()
+        suffix = f": {detail}" if detail else ""
+        raise TriageError(f"{operation} exited {proc.returncode}{suffix}")
+    return proc.stdout
+
+
+def _oid(raw: bytes, operation: str) -> str:
+    value = os.fsdecode(raw).strip()
+    if not SHA_RE.fullmatch(value):
+        raise TriageError(f"{operation} returned {value!r}, not a 40-character lowercase commit SHA")
+    return value
+
+
+def _head(runner: Runner, worktree: str) -> str:
+    return _oid(
+        _run(runner, ["git", "rev-parse", "--verify", "HEAD^{commit}"], worktree, "reading HEAD"),
+        "reading HEAD",
+    )
+
+
+def _resolve_base(runner: Runner, worktree: str, base: str) -> str:
+    if not base or "\x00" in base:
+        raise TriageError("--base must name a non-empty Git revision")
+    return _oid(
+        _run(
+            runner,
+            ["git", "rev-parse", "--verify", "--end-of-options", f"{base}^{{commit}}"],
+            worktree,
+            f"resolving base {base!r}",
+        ),
+        f"resolving base {base!r}",
+    )
+
+
+def _merge_base(runner: Runner, worktree: str, base_sha: str, head_sha: str) -> str:
+    return _oid(
+        _run(
+            runner,
+            ["git", "merge-base", base_sha, head_sha],
+            worktree,
+            "resolving the base/head merge-base",
+        ),
+        "resolving the base/head merge-base",
+    )
+
+
+def _parse_raw(raw: bytes) -> list[Change]:
+    """Parse ``git diff --raw -z`` without ever round-tripping path bytes through shell text."""
+    tokens = raw.split(b"\0")
+    if tokens and tokens[-1] == b"":
+        tokens.pop()
+    changes: list[Change] = []
+    index = 0
+    while index < len(tokens):
+        header = tokens[index]
+        index += 1
+        if not header.startswith(b":"):
+            raise TriageError("raw diff contains a record without a ':' header")
+        fields = header[1:].split(b" ")
+        if len(fields) != 5:
+            raise TriageError("raw diff header does not contain mode, object, and status fields")
+        old_mode_b, new_mode_b, old_oid, new_oid, status_b = fields
+        if not re.fullmatch(rb"[0-7]{6}", old_mode_b) or not re.fullmatch(rb"[0-7]{6}", new_mode_b):
+            raise TriageError("raw diff contains a malformed file mode")
+        if not re.fullmatch(rb"[0-9a-f]{40}", old_oid) or not re.fullmatch(rb"[0-9a-f]{40}", new_oid):
+            raise TriageError("raw diff contains an abbreviated or malformed object id")
+        if not re.fullmatch(rb"[A-Z][0-9]*", status_b):
+            raise TriageError("raw diff contains a malformed change status")
+        kind = chr(status_b[0])
+        path_count = 2 if kind in {"R", "C"} else 1
+        if index + path_count > len(tokens):
+            raise TriageError("raw diff ends before its path fields")
+        paths = tokens[index:index + path_count]
+        index += path_count
+        if any(path == b"" for path in paths):
+            raise TriageError("raw diff contains an empty path")
+        old_path = paths[0] if path_count == 2 else (paths[0] if kind == "D" else None)
+        path = paths[-1]
+        changes.append(Change(
+            status=os.fsdecode(status_b),
+            old_mode=os.fsdecode(old_mode_b),
+            new_mode=os.fsdecode(new_mode_b),
+            old_path=old_path,
+            path=path,
+        ))
+    return changes
+
+
+def _split_path(path: str) -> tuple[str, ...]:
+    """Git paths always use '/', including on Windows-hosted repositories."""
+    return tuple(part for part in PurePosixPath(path).parts if part not in {"", "."})
+
+
+def _tokens(value: str) -> set[str]:
+    return {piece for piece in re.split(r"[^a-z0-9]+", value.lower()) if piece}
+
+
+def _dependency_reason(path: str) -> str | None:
+    name = PurePosixPath(path).name.lower()
+    if name in _DEPENDENCY_NAMES:
+        return "dependency manifest or lockfile"
+    # pip requirements/constraints: the compiled ``requirements*.txt`` lockfile AND the human-authored
+    # ``requirements*.in`` source manifest pip-tools compiles from it; ``constraints*.txt`` pins alike.
+    if name.startswith("requirements") and name.endswith((".txt", ".in")):
+        return "dependency manifest or lockfile"
+    if name.startswith("constraints") and name.endswith(".txt"):
+        return "dependency manifest or lockfile"
+    if name.startswith(("build.gradle", "settings.gradle")):
+        return "dependency manifest or lockfile"
+    if name.endswith(_DEPENDENCY_SUFFIXES):
+        return "dependency manifest or lockfile"
+    if name in {"plugin.json", "marketplace.json", "manifest.json"}:
+        return "plugin or package manifest"
+    return None
+
+
+def _iac_reason(path: str) -> str | None:
+    parts = tuple(part.lower() for part in _split_path(path))
+    name = parts[-1] if parts else ""
+    suffix = PurePosixPath(name).suffix.lower()
+    if suffix in _IAC_SUFFIXES or any(part in _IAC_PARTS for part in parts):
+        return "infrastructure-as-code path"
+    if name == "chart.yaml" or re.fullmatch(r"(?:docker-)?compose(?:\.[^.]+)?\.ya?ml", name):
+        return "infrastructure-as-code manifest"
+    return None
+
+
+def _sensitive_path_reasons(path: str) -> list[str]:
+    parts = tuple(part.lower() for part in _split_path(path))
+    name = parts[-1] if parts else ""
+    reasons: list[str] = []
+    if ".github" in parts:
+        reasons.append("CI path (.github/**)")
+    if "scripts" in parts:
+        reasons.append("script path (scripts/**)")
+    if name in {"dockerfile", "makefile", "gnumakefile"} or name.startswith("dockerfile."):
+        reasons.append("build entrypoint")
+    dependency = _dependency_reason(path)
+    if dependency:
+        reasons.append(dependency)
+    iac = _iac_reason(path)
+    if iac:
+        reasons.append(iac)
+    path_tokens: set[str] = set()
+    for part in parts:
+        path_tokens.update(_tokens(part))
+    if path_tokens & _SENSITIVE_TOKENS:
+        reasons.append("auth, crypto, credential, key, or secret path")
+    return reasons
+
+
+def _agent_path_reason(path: str) -> str | None:
+    parts = tuple(part.lower() for part in _split_path(path))
+    name = parts[-1] if parts else ""
+    if name in _AGENT_DOC_BASENAMES:
+        return "agent-consumed instruction file"
+    if ".claude" in parts:
+        return "Claude agent configuration path"
+    if "skills" in parts and "references" in parts and parts.index("skills") < parts.index("references"):
+        return "skill reference"
+    if any(_tokens(part) & _AGENT_TOKENS for part in parts):
+        return "prompt or agent-instruction path"
+    return None
+
+
+def _frontmatter_top_level_keys(interior: list[str]) -> tuple[set[str], bool]:
+    """Extract a YAML frontmatter interior's top-level mapping keys, treating it as a plain BLOCK mapping.
+
+    Returns ``(keys, accountable)``. ``accountable`` is ``True`` only when every content line is one this
+    line-based extractor can COMPLETELY account for as a plain block mapping: a top-level ``key:`` entry
+    (bare or quoted), a comment, a blank, or an indented continuation of the current entry's value (a block
+    sequence item, a nested mapping, block-scalar text). It is ``False`` for any interior that is not a plain
+    block mapping — a top-level FLOW mapping (``{name: operator, description: …}``) or flow sequence, a block
+    sequence document (``- item``), a bare scalar, a ``?`` complex key, a value's flow collection continued
+    onto its own line (a ``]``/``}`` at column 0), or a continuation with no owning key.
+
+    The stdlib carries no YAML parser, so rather than parse those forms — and rather than repeat the bug of
+    misreading them as prose (each surface form was patched in turn: bare keys, then quoted keys, now flow),
+    the caller fails a non-accountable interior CLOSED to CODE. "Cannot parse completely" means CODE, never
+    prose. The failure is escalate-only and therefore safe: it can only raise a would-be HUMAN-DOC to CODE."""
+    keys: set[str] = set()
+    opened_key = False
+    for line in interior:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue  # a blank line or a comment carries no structural content
+        if line[:1] in (" ", "\t"):
+            # An indented line continues the current top-level entry's value. It is accountable only once an
+            # entry has opened it; indentation with no owning key is not a plain block mapping.
+            if not opened_key:
+                return set(), False
+            continue
+        match = _FRONTMATTER_KEY_RE.match(line)
+        if match is None:
+            # A column-0 line that is not a block ``key:`` entry: a flow mapping/sequence, a ``-`` sequence
+            # item, a bare scalar, a ``?`` complex key, or a ``]``/``}`` closing a value's flow collection
+            # that was continued across lines. None of these is a plain block mapping this extractor finishes.
+            return set(), False
+        key = match.group("dq") or match.group("sq") or match.group("bare")
+        keys.add(key.lower())
+        opened_key = True
+    return keys, True
+
+
+def _has_agent_frontmatter(content: bytes | None) -> bool:
+    if content is None:
+        return False
+    text = content.decode("utf-8", "replace")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return False
+    # Scan the WHOLE head for the closing delimiter — never a fixed-size window that would let a block
+    # closing past an arbitrary line read as prose. An opening ``---`` with no closing delimiter anywhere is
+    # a malformed/unterminated frontmatter block: fail closed (treat as agent frontmatter -> CODE).
+    closing = next((i for i, line in enumerate(lines[1:], 1) if line.strip() == "---"), None)
+    if closing is None:
+        return True
+    keys, accountable = _frontmatter_top_level_keys(lines[1:closing])
+    # An interior the block extractor cannot COMPLETELY account for — a flow mapping/sequence and every other
+    # non-block surface form — is never read as prose: fail closed to CODE. The interior is now validated as
+    # a plain block mapping rather than scanned line by line and assumed prose on any line the key regex
+    # misses, which is the class each earlier round patched one surface form at a time.
+    if not accountable:
+        return True
+    return bool(keys & _FRONTMATTER_AGENT_KEYS or {"name", "description"} <= keys)
+
+
+def _is_top_level_prose(name: str) -> bool:
+    """A top-level file whose NAME AND SUFFIX are both prose. The prose stems (``README``, ``CHANGELOG``,
+    ``LICENSE``/``LICENSE-<variant>``) are only human docs with a prose suffix or none — a source-like or
+    unknown suffix (``CHANGELOG.py``, ``license.go``) is NOT prose and falls through to CODE. Matching a
+    stem by unbounded prefix would let any ``CHANGELOG*``/``LICENSE*`` source file clear the floor."""
+    lower = name.lower()
+    if lower == "readme.md":
+        return True
+    suffix = PurePosixPath(name).suffix.lower()
+    stem = lower[: len(lower) - len(suffix)] if suffix else lower
+    if suffix not in _PROSE_DOC_SUFFIXES:
+        return False
+    return stem == "changelog" or stem == "license" or stem.startswith("license-")
+
+
+def _is_human_doc(path: str) -> bool:
+    parts = _split_path(path)
+    if not parts:
+        return False
+    name = parts[-1]
+    if len(parts) == 1 and _is_top_level_prose(name):
+        return True
+    return parts[0].lower() == "docs" and PurePosixPath(name).suffix.lower() in _HUMAN_SUFFIXES
+
+
+def _mode_executable(mode: str) -> bool:
+    return mode != "000000" and bool(int(mode, 8) & 0o111)
+
+
+_REGULAR_BLOB_MODES = frozenset({"100644", "100755"})
+
+
+def _mode_regular_blob(mode: str) -> bool:
+    """A regular file blob (``100644``) or its executable form (``100755``). A symlink (``120000``), a
+    gitlink (``160000``), or any other mode is a non-regular Git object that is never human prose, so a
+    side carrying such a mode floors to at least CODE (fail-closed)."""
+    return mode in _REGULAR_BLOB_MODES
+
+
+def _blob(runner: Runner, worktree: str, commit: str, path: bytes) -> bytes:
+    """Read a regular-file side the raw diff already proved exists at ``commit``, for frontmatter
+    classification. A failed ``git show`` here is never benign absence — the diff named this object — so it
+    is unreadable evidence (e.g. a blob-filtered clone with the promisor down) and fails CLOSED with
+    ``TriageError`` (exit 2), exactly like every other Git call. Non-regular modes never reach this: they
+    are already forced to CODE by mode, so their content is not read."""
+    spec = os.fsencode(commit) + b":" + path
+    operation = f"reading {os.fsdecode(path)!r} at {commit}"
+    try:
+        proc = runner(["git", "show", os.fsdecode(spec)], worktree)
+    except OSError as exc:
+        raise TriageError(f"{operation} could not run: {exc}") from exc
+    if proc.returncode != 0:
+        detail = os.fsdecode(proc.stderr).strip()
+        suffix = f": {detail}" if detail else ""
+        raise TriageError(f"{operation} exited {proc.returncode}{suffix}")
+    return proc.stdout
+
+
+def _path_class(path: str, content: bytes | None) -> tuple[str, list[str]]:
+    sensitive = _sensitive_path_reasons(path)
+    if sensitive:
+        return SENSITIVE, sensitive
+    agent = _agent_path_reason(path)
+    if agent:
+        return CODE, [agent]
+    if PurePosixPath(path).suffix.lower() in _HUMAN_SUFFIXES and _has_agent_frontmatter(content):
+        return CODE, ["prose file carrying skill or agent frontmatter"]
+    if _is_human_doc(path):
+        return HUMAN_DOC, ["human-facing prose"]
+    return CODE, ["unrecognized path defaults to CODE"]
+
+
+_CLASS_RANK = {HUMAN_DOC: 0, CODE: 1, SENSITIVE: 2}
+
+
+def _classify_change(change: Change, runner: Runner, worktree: str,
+                     diff_base_sha: str, head_sha: str) -> dict:
+    old_path_s = os.fsdecode(change.old_path) if change.old_path is not None else None
+    path_s = os.fsdecode(change.path)
+    status = change.status[0]
+
+    # Classify EVERY side that exists — base and head alike — and keep the higher class. The base side
+    # exists for a deletion, a modification, a type-change, and the old path of a rename/copy; the head
+    # side exists for every status but a deletion. A single-path modification or type-change (M/T) must
+    # therefore inspect its base content too — otherwise a diff that strips agent frontmatter reads as
+    # plain prose at HEAD and clears the floor. Each side carries its own Git mode; a non-regular object
+    # (symlink, gitlink, or any unrecognized mode) is never prose and floors to at least CODE.
+    sides: list[tuple[str, bytes, str, str]] = []
+    if change.old_path is not None:
+        sides.append((old_path_s or "", change.old_path, diff_base_sha, change.old_mode))
+    elif status in {"M", "T"}:
+        sides.append((path_s, change.path, diff_base_sha, change.old_mode))
+    if status != "D":
+        sides.append((path_s, change.path, head_sha, change.new_mode))
+    if not sides:  # Defensive: a deletion always has old_path, but malformed evidence must not crash.
+        sides.append((path_s, change.path, diff_base_sha, change.old_mode))
+
+    classes: list[str] = []
+    reasons: list[str] = []
+    for candidate_path, candidate_bytes, commit, mode in sides:
+        # A non-regular Git object (symlink, gitlink, unrecognized mode) is never prose and is forced to
+        # CODE by mode below, so its content is not read — and a ``git show`` on it is not required to
+        # succeed. A regular blob's content IS read, and a failed read there fails closed (see ``_blob``).
+        content = _blob(runner, worktree, commit, candidate_bytes) if _mode_regular_blob(mode) else None
+        file_class, path_reasons = _path_class(candidate_path, content)
+        if not _mode_regular_blob(mode) and _CLASS_RANK[file_class] < _CLASS_RANK[CODE]:
+            file_class = CODE
+            path_reasons = [*path_reasons, f"non-regular Git mode {mode} is never human prose"]
+        classes.append(file_class)
+        for reason in path_reasons:
+            label = f"{candidate_path}: {reason}" if len(sides) > 1 else reason
+            reasons.append(label)
+
+    if _mode_executable(change.old_mode) or _mode_executable(change.new_mode):
+        classes.append(SENSITIVE)
+        reasons.append("old or new Git mode is executable")
+    if status not in {"A", "C", "D", "M", "R", "T"}:
+        classes.append(CODE)
+        reasons.append(f"unknown Git change status {change.status!r} defaults to CODE")
+
+    file_class = max(classes, key=_CLASS_RANK.__getitem__)
+    result = {
+        "class": file_class,
+        "new_mode": change.new_mode,
+        "old_mode": change.old_mode,
+        "old_path": old_path_s,
+        "path": path_s,
+        "reasons": sorted(set(reasons)),
+        "status": change.status,
+    }
+    return result
+
+
+def _floor(files: list[dict]) -> tuple[str | None, str]:
+    """The minimum tier the mechanics compel, and why. Never ``TRIVIAL``: an all-prose diff has NO floor
+    (the orchestrator decides), and an empty/unresolved diff floors to ``STANDARD`` — never vacuously below
+    it."""
+    if any(row["class"] == SENSITIVE for row in files):
+        return HIGH, "a SENSITIVE file is present"
+    if not files:
+        return STANDARD, "no files resolved from the diff — an empty or unreadable diff never floors below STANDARD"
+    if all(row["class"] == HUMAN_DOC for row in files):
+        return None, "every changed file is human-facing prose — no mechanical floor; the orchestrator decides the tier"
+    return STANDARD, "a non-prose (CODE) file is present"
+
+
+def derive(*, worktree: str, base: str, head_sha: str, tier: str | None = None,
+           runner: Runner = _real_run) -> dict:
+    """Emit one deterministic inventory-and-floor record, or raise ``TriageError`` without partial output.
+
+    ``tier`` is the caller's DECIDED tier, if any. When supplied it is validated and checked against the
+    floor as a LOWER BOUND: a tier below the floor is refused (veto-downward). The command never grants a
+    tier and never returns ``TRIVIAL`` as a floor."""
+    if tier is not None and tier not in TIER_VALUES:
+        raise TriageError(f"--tier must be one of {sorted(TIER_VALUES)}, got {tier!r}")
+    if not SHA_RE.fullmatch(head_sha):
+        raise TriageError("--head-sha must be exactly 40 lowercase hexadecimal characters")
+    if not Path(worktree).is_dir():
+        raise TriageError(f"--worktree is not a directory: {worktree!r}")
+
+    head_before = _head(runner, worktree)
+    if head_before != head_sha:
+        raise TriageError(f"HEAD mismatch: expected {head_sha}, found {head_before}")
+    base_sha = _resolve_base(runner, worktree, base)
+    diff_base_sha = _merge_base(runner, worktree, base_sha, head_sha)
+    # ``--find-renames`` without ``-l0``: above Git's default ``diff.renameLimit`` the inexact-rename search
+    # is skipped (Git prints ``warning: … rename detection was skipped`` to stderr, exit 0). That skip is
+    # deliberately tolerated because it CANNOT lower the floor. The floor is a ``max`` over per-row classes,
+    # and an undetected rename degrades to an A row plus a D row that ``_classify_change`` classifies on BOTH
+    # sides' content — the D at the old path on the base, the A at the new path on the head — the exact two
+    # ``(path, commit, mode)`` pairs the single R record would have classified. A + D can only ADD rows, so
+    # the floor is >= the detected-rename case, never below it (verified end to end: a CODE fixture and an
+    # executable-script fixture forced through ``renameLimit=1`` floor identically detected vs. skipped, and
+    # the A+D split even re-checks the executable mode on both sides). Forcing ``-l0`` or refusing on the
+    # warning would instead make any legitimately large diff un-triageable — a fail-closed regression bought
+    # for a floor that was already correct.
+    # ``--ignore-submodules=none`` overrides any committed ``submodule.<name>.ignore=all`` in ``.gitmodules``:
+    # without it a commit that advances a gitlink whose submodule is configured ``ignore=all`` is OMITTED from
+    # ``--raw`` output, so the changed gitlink would vanish from the inventory and the diff could read as
+    # all-prose. Forcing ``none`` can only ADD a gitlink row (a ``160000`` mode that ``_classify_change`` floors
+    # to at least CODE); it never removes a row and so never lowers the floor — escalate-only, like the tool.
+    raw = _run(
+        runner,
+        ["git", "diff", "--raw", "-z", "--no-abbrev", "--find-renames", "--ignore-submodules=none",
+         diff_base_sha, head_sha, "--"],
+        worktree,
+        "reading the pinned raw diff",
+    )
+    changes = _parse_raw(raw)
+    files = [_classify_change(change, runner, worktree, diff_base_sha, head_sha) for change in changes]
+    files.sort(key=lambda row: (row["path"], row["old_path"] or "", row["status"]))
+
+    head_after = _head(runner, worktree)
+    if head_after != head_before:
+        raise TriageError(f"HEAD moved during triage: started at {head_before}, ended at {head_after}")
+
+    floor, floor_reason = _floor(files)
+    floor_rank = _TIER_RANK[floor] if floor is not None else -1
+    if tier is not None and _TIER_RANK[tier] < floor_rank:
+        raise TriageError(
+            f"decided tier {tier} is below the mechanical floor {floor} ({floor_reason}); "
+            f"the tool escalates only — decide at or above the floor")
+
+    return {
+        "base": base,
+        "diff_base_sha": diff_base_sha,
+        "files": files,
+        "floor": floor,
+        "floor_reason": floor_reason,
+        "head_sha": head_sha,
+    }
+
+
+def cmd_derive(args: argparse.Namespace) -> int:
+    try:
+        result = derive(
+            worktree=args.worktree,
+            base=args.base,
+            head_sha=args.head_sha,
+            tier=args.tier,
+        )
+    except TriageError as exc:
+        print(f"triage: REFUSED — {exc}", file=sys.stderr)
+        return EXIT_REFUSED
+    print(json.dumps(result, ensure_ascii=True, sort_keys=True, separators=(",", ":")))
+    return EXIT_OK
+
+
+def sibling_cases() -> list:
+    if not SIBLING.is_file():
+        raise SelfTestFailure(
+            f"the fixture file {SIBLING} is missing — deterministic tier derivation is untested")
+    module = load_module_from_path("campaign_triage_test", SIBLING, register=True)
+    if module is None or not hasattr(module, "CASES") or not module.CASES:
+        raise SelfTestFailure("triage sibling suite has no CASES — an empty gate checks nothing")
+    return module.CASES
+
+
+def cmd_self_test(_args: argparse.Namespace) -> int:
+    failures = 0
+    cases = sibling_cases()
+    for name, description, fn in cases:
+        try:
+            fn()
+            print(f"PASS {name}: {description}")
+        except Exception as exc:  # noqa: BLE001 - report all independent fixtures
+            failures += 1
+            print(f"FAIL {name}: {description}: {exc}")
+    print(f"triage fixtures: {len(cases) - failures} passed, {failures} failed")
+    return 1 if failures else 0
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
+    sub = root.add_subparsers(dest="command", required=True)
+    derive_parser = sub.add_parser(
+        "derive", help="emit the per-file inventory and mechanical floor for one pinned Git diff")
+    derive_parser.add_argument("--worktree", required=True)
+    derive_parser.add_argument("--base", required=True, help="base revision, commonly origin/<base>")
+    derive_parser.add_argument("--head-sha", required=True, help="expected live 40-character HEAD")
+    derive_parser.add_argument(
+        "--tier", choices=sorted(TIER_VALUES),
+        help="the caller's DECIDED tier; refused if it is below the mechanical floor (veto-downward)")
+    derive_parser.set_defaults(func=cmd_derive)
+    test_parser = sub.add_parser("self-test", help="run the sibling fixture suite")
+    test_parser.set_defaults(func=cmd_self_test)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Makes campaign review-tier derivation mechanical: a deterministic `triage.py` that classifies each PR's diff (human / code / sensitive) into a tier, with the driver's above-floor semantic judgment layered on top. Adoption and heartbeat re-triage route through the split (mechanical floor from the tool + the tier decision), and a depth-raising escalation on unchanged content voids the tally and stops any in-flight review so a shallower pass cannot count toward a deeper tier.

Supersedes #125, which exhausted the gauntlet's review-round budget; this is the same reviewed content (plus the in-flight-escalation stop-rule fix) squashed onto current `main` for a clean gauntlet run.
