### PR TITLE
feat(campaign): gate verdict on base-preflight

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -153,7 +153,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 16. Review verdict returned -> `ledger.py verdict`: the ONLY way to record it — NEVER hand-set
     `reviews_ok`. It bumps `review_rounds` (monotone, never reset — the loop's only memory across
     fresh-context heartbeats) and `ns_streak` atomically, and at a cap holds the PR `repairing` and
-    exits non-zero.
+    exits non-zero. It also **refuses a verdict — satisfied or not — unless a fresh base-preflight `proceed`
+    is on record for the head** (`base_ok_sha == head_sha`, written by `base-preflight.py … --file` on
+    `proceed`), so a review can never be counted over a base no pre-flight cleared.
 17. On `NOT SATISFIED`, findings are claims, not facts: a dispatched context-isolated audit subagent
     (never the orchestrator inline) verdicts each gating finding — CONFIRMED / ADJUSTED / REFUTED,
     with evidence — through `finding-audit.py`, BEFORE any fix is dispatched; **unsure -> CONFIRMED,
@@ -257,7 +259,7 @@ a line the tool writes.
 | `emit-finding.py` | Reviewer's door: record one FINDING (the only sanctioned way; findings must anchor or they do not gate) | `references/stage-2-review-gate.md` |
 | `emit-amendment.py` | Reviewer's door: raise one plan amendment (the only sanctioned way; `ts` is tool-stamped, the proposed unit is validated like a plan unit) | `references/stage-2-review-gate.md` |
 | `reviewer-liveness.py` | Probe whether a dispatched reviewer's output stream is still moving; decides nothing, always exits 0 | `references/stage-2-review-gate.md` |
-| `base-preflight.py` | Decide proceed / rebase-first / recheck from live merge-state plus fetched base ancestry before review or fix; performs no rebase | `references/stage-2-review-gate.md` |
+| `base-preflight.py` | Decide proceed / rebase-first / recheck from live merge-state plus fetched base ancestry before review or fix; performs no rebase — with `--file`, a `proceed` records `base_ok_sha` (the precondition `ledger.py verdict` enforces) | `references/stage-2-review-gate.md` |
 | `format-preflight.py` | `check` — refuse to format any file whose formatter-write could escape the worktree (the file, or any path component, is a symlink); reads only, formats nothing | `references/stage-2-ci.md` |
 | `worker-prompt.py` | `fix` — bind one complete review/CI fix prompt and logical model class, then atomically publish its exact bytes + metadata | `references/fix-subagent-contract.md` |
 | `clean-rebase.py` | `run` — EXECUTE the clean base-only rebase (fetch/rebase/force-with-lease push + the ledger write that **carries `reviews_ok` and the status label forward** on a shape-preserving rebase, resetting only `ci = pending` and the liveness counters) and REFUSE everything else: a conflict or a diff-changing rebase is aborted/reset and handed back (exit 3), never resolved | `references/stage-2-review-gate.md` |

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -237,10 +237,12 @@ Header field notes (the header fields above; per-row fields follow):
   then carry `reviews_ok` forward to the new `head_sha` (a **depth-raising tier escalation** is the one
   same-SHA event that voids `reviews_ok` without a content change — `stage-2-review-gate.md`, "Status
   labels mirror the review gate"), set `ci = pending`, and — because the head
-  **moved** — the ledger accessor **resets the liveness counters** at the `set --head-sha` write itself
-  (`stage-2-ci.md`, "THE LIVENESS COUNTERS"; ledger.py's `apply_head_sha`). A clean rebase
-  does not reset the *gate*, but it **is** a `head_sha` change, and **every** `head_sha` change resets
-  those counters at the door: the old head's strikes and stall clock measured evidence that no longer exists.
+  **moved** — the ledger accessor **resets the liveness counters AND the base-preflight stamp `base_ok_sha`**
+  at the `set --head-sha` write itself (`stage-2-ci.md`, "THE LIVENESS COUNTERS"; `base_ok_sha` below;
+  ledger.py's `apply_head_sha`). A clean rebase does not reset the *gate*, but it **is** a `head_sha` change,
+  and **every** `head_sha` change resets them at the door: the old head's strikes and stall clock measured
+  evidence that no longer exists, and a base-preflight `proceed` decided for the old head no longer describes
+  the content — so the next verdict must wait on a fresh `proceed` for the new tip.
 - `reviews_ok` — number of fresh, context-isolated SATISFIED verdicts recorded against this PR's
   current content. Target = `required(tier)`: **1 if `tier == TRIVIAL`, else 2** (Stage **2a-triage**).
   **Only `ledger.py verdict` may RAISE it** — `set --reviews-ok <n>` refuses any value above the current
@@ -264,6 +266,17 @@ Header field notes (the header fields above; per-row fields follow):
   the **review** path carried none.
 - `ns_streak` — consecutive NOT SATISFIED verdicts. Cleared **only** by a SATISFIED — never by a fix, a
   rebase or a content change. Same owner, same absent flag, same reason.
+- `base_ok_sha` — the head a base-preflight **`proceed`** was last decided for: the **MECHANICAL** form of the
+  rebase-before-review precondition. **`ledger.py verdict` refuses unless `base_ok_sha == head_sha`** — for a
+  SATISFIED **or** a NOT SATISFIED, since a counted NOT SATISFIED spends `review_rounds`/`ns_streak` toward the
+  caps just the same — so a review verdict can never be recorded over a base no fresh `proceed` cleared.
+  **Written by exactly one thing: `base-preflight.py check`**, through `ledger.py base-ok`, when — and only
+  when — it decides `proceed` for the live head. It has **no `set`/`add-row` flag** (the same absent-door
+  mechanism as `review_rounds`): a hand-written stamp would forge a `proceed` no preflight ever decided,
+  recording a verdict over a conflicting or stale base, which is the exact waste this guard exists to stop. It
+  is SHA-bound and voided on a head move exactly like the liveness counters (`head_sha` above, the reset
+  family), and stamping it is **not activity** (it records a precondition, like re-arming the watchdog). The
+  default is `-`, which no 40-char head equals, so `verdict` **fails closed** until base-preflight runs.
 
   **What READS these counters is `ledger.py verdict` itself, and at a cap it STOPS THE LOOP.** They are
   sensors, and the reader is fused into the one door that cannot be skipped — deliberately: a cap
@@ -511,7 +524,8 @@ ledger.py watchdog interval                                       # print the in
 ledger.py --file <state.jsonl> add-row --pr N [--<field> <val> …] # register a row (refuses a duplicate pr; unset fields default)
 ledger.py --file <state.jsonl> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
 ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfied|not-satisfied
-                                                                  # record ONE landed review verdict — the ONLY sanctioned path
+                                                                  # record ONE landed review verdict — the ONLY sanctioned path (refused unless base_ok_sha == head_sha)
+ledger.py --file <state.jsonl> base-ok --pr N --head-sha <sha>    # record a base-preflight `proceed` for the head (base_ok_sha) — written only by base-preflight.py, never hand-set
 ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
 ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only)

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -20,11 +20,14 @@ block. This file owns the dispatch procedure, not a second copy of prompt text.
 ### PRE-FLIGHT — the base must be current before ANY fix is dispatched
 
 **BEFORE dispatching ANY fix subagent (review-fix or CI-fix) for a PR, run
-`python3 scripts/base-preflight.py check --pr <N> --worktree <worktree> --base <base>`.** It fetches
+`python3 scripts/base-preflight.py check --pr <N> --worktree <worktree> --base <base> --file <state.jsonl>`.** It fetches
 `origin/<base>` and prints ONE of three verdicts, and the action
 **splits by verdict** — only `proceed` clears the dispatch, and the other two are NOT the same response:
 
-- **`proceed`** → the base is current; **dispatch the fix**.
+- **`proceed`** → the base is current; **dispatch the fix**. The `--file` makes the `proceed` record
+  `base_ok_sha` for the current head — the MECHANICAL precondition `ledger.py verdict` enforces
+  (`stage-2-review-gate.md`, "Recording a verdict"): a review verdict is refused for a head with no fresh
+  `proceed`.
 - **`rebase-first`** → the branch conflicts with its base or lacks the refreshed base; do **NOT** dispatch.
   **REBASE the PR onto `<base>`** through `stage-2-review-gate.md`'s base-currency handling, which runs
   `clean-rebase.py` FIRST: a clean base-only rebase (exit 0) PRESERVES the verdicts and label, and only its

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -218,7 +218,8 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
    (relaunch), and only a binary `satisfied`/`not-satisfied` ever reaches the ledger below.
    **Then record the verdict with `scripts/ledger.py verdict --pr <N> --head-sha <sha> --verdict …`** — the
    ONLY sanctioned path, and the only thing that bumps `review_rounds` (Stage 2a, "Recording a verdict");
-   never set `reviews_ok` by hand.
+   never set `reviews_ok` by hand. It refuses unless the base-preflight `proceed` above stamped `base_ok_sha`
+   for this head (the `--file` on the precondition run is what records it).
    For any completed task (review, CI watch,
    CI/review fix), record the result against the SHA it ran on and act per Stage 2.
 ### Step 3 — Dispatch due work
@@ -401,9 +402,11 @@ bounded-wait fallback returning. A completion may be a CI watch, a review, or a 
      review dispatch through the typed Stage 2a pre-review operation** — the review
      diffs `origin/<base>...HEAD`, a remote-tracking ref that always exists, since adoption fetches only
      the PR head and a local `<base>` may be absent or stale (see `pr-adoption.md` / Stage 2a). Then run
-     `base-preflight.py check --pr <N> --worktree <worktree> --base <base>`; only `proceed` clears the
-     review launch. Rebase on `rebase-first` or re-poll on `recheck` per Stage 2a, then restart this
-     precondition sequence. With `proceed`, evaluate the verdict transport through
+     `base-preflight.py check --pr <N> --worktree <worktree> --base <base> --file <state.jsonl>`; only
+     `proceed` clears the review launch, and — because a verdict follows — the `--file` is REQUIRED: on
+     `proceed` it records `base_ok_sha` for the head, without which `ledger.py verdict` refuses the verdict
+     it later records (Stage 2a, "Recording a verdict"). Rebase on `rebase-first` or re-poll on `recheck` per
+     Stage 2a, then restart this precondition sequence. With `proceed`, evaluate the verdict transport through
      `runtime-adapter.md`'s capability/transition owner before
      building its record and take only the action it returns;
      missing native cwd/mount/sandbox controls alone are not a machine blocker. Then launch **one**

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -124,12 +124,15 @@ review gate"), and the review re-starts on the clean tip:
   Handle failures **one at a time per PR/SHA**, and **prefer a scoped subagent** per failure; different
   PRs may fix CI concurrently within the cap.
 - **Base currency with `<base>`.** Before reviewing or dispatching a fix, run `python3
-  scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base>`. It checks both GitHub's
+  scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base> --file <state.jsonl>`. It checks both GitHub's
   merge states and whether fetched `origin/<base>` is an ancestor of the PR worktree's `HEAD`. A
   `rebase-first` verdict covers a conflict, GitHub reporting behind, or a CLEAN PR whose branch lacks the
   refreshed base. `recheck` covers an uncomputed/unrecognized GitHub value or ancestry the helper cannot
   verify; re-poll and re-run, never dispatch or rebase from incomplete evidence. `base-preflight.py` owns
   the decision and is the pre-flight gate for every fix subagent (`fix-subagent-contract.md`, PRE-FLIGHT).
+  **Run it with `--file <state.jsonl>`:** on `proceed` it records `base_ok_sha` for the current head — the
+  MECHANICAL precondition `ledger.py verdict` then enforces ("Recording a verdict", below), so a review verdict
+  can never be recorded for a head with no fresh `proceed`.
   Once it says `rebase-first`, **the CLEAN
   base-only case is EXECUTED — not hand-run — by `python3 scripts/clean-rebase.py run --ledger
   <state.jsonl> --pr <pr> --worktree <worktree> --base <base>`**: it does the fetch/rebase/`--force-with-lease`
@@ -718,6 +721,14 @@ As each verdict lands, record it with:
 python3 <skill-dir>/scripts/ledger.py --file <state.jsonl> verdict --pr <N> \
     --head-sha <the SHA the pass ran on> --verdict satisfied|not-satisfied
 ```
+
+**A verdict requires a fresh base-preflight `proceed` for the head, and is refused without one.** `verdict`
+checks `base_ok_sha == head_sha` — the record `base-preflight.py check … --file <state.jsonl>` writes on
+`proceed` (Preconditions, above) — and refuses a mismatch for **both** verdicts, because a counted NOT
+SATISFIED spends `review_rounds`/`ns_streak` toward the caps just the same. Skipping the pre-flight leaves the
+stamp `-`, so this door **fails closed**: run base-preflight on the current tip first. A rebase moves the head,
+which **voids** the stamp until base-preflight re-runs (`files-and-ledger.md`, the `base_ok_sha` field). Like
+the head-SHA check, this can only ever REFUSE a verdict — never manufacture a SATISFIED or merge anything.
 
 **NEVER set `reviews_ok` by hand to record a verdict.** The accessor owns the tally *and* the round
 counters, and it applies them **atomically**; hand-setting `reviews_ok` silently skips them. It is not an

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -313,6 +314,100 @@ def t_clean_view_with_current_base_proceeds():
               f"a current base must permit the candidate, got {out!r}")
 
 
+# --- `--file`: a real `proceed` RECORDS base_ok_sha on the ledger (the precondition `verdict` enforces) -----
+# base-preflight is the ONLY sanctioned writer of `base_ok_sha`: on a final `proceed`, and only when a ledger
+# is named, it resolves the worktree's HEAD and shells out to `ledger.py base-ok`. `decide()` stays pure;
+# these fixtures drive the CLI end to end (git worktree + a real sibling ledger), never `decide` directly.
+
+
+def _run_ledger(ledger: Path, *argv: str) -> subprocess.CompletedProcess:
+    proc = subprocess.run([sys.executable, str(M.LEDGER), "--file", str(ledger), *argv],
+                          capture_output=True, text=True, check=False)
+    check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
+    return proc
+
+
+def _ledger_row(ledger: Path, pr: str, head_sha: str) -> None:
+    """Build a ledger through the REAL sibling accessor with one row for `pr` at `head_sha` (base_ok_sha `-`)."""
+    _run_ledger(ledger, "header", "set", "run_id", "t")
+    _run_ledger(ledger, "add-row", "--pr", pr, "--head-sha", head_sha)
+
+
+def _base_ok_sha(ledger: Path, pr: str) -> str:
+    return _run_ledger(ledger, "get", "--pr", pr, "--field", "base_ok_sha").stdout.strip()
+
+
+def _current_base_worktree(root: Path) -> "tuple[Path, str]":
+    """A candidate clone that CONTAINS fetched main (so base-preflight reaches `proceed`). Returns (worktree,
+    HEAD sha)."""
+    remote, seed, candidate = root / "remote.git", root / "seed", root / "candidate"
+    result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                            capture_output=True, text=True, check=False)
+    check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+    result = subprocess.run(["git", "clone", str(remote), str(seed)], capture_output=True, text=True, check=False)
+    check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+    _configure_repo(seed)
+    (seed / "f").write_text("base\n", encoding="utf-8")
+    _git(seed, "add", "f")
+    _git(seed, "commit", "-m", "base")
+    _git(seed, "push", "origin", "main")
+    result = subprocess.run(["git", "clone", str(remote), str(candidate)], capture_output=True, text=True, check=False)
+    check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
+    _configure_repo(candidate)
+    head = _git(candidate, "rev-parse", "HEAD").stdout.strip()
+    return candidate, head
+
+
+def t_proceed_with_file_records_base_ok():
+    """A final `proceed` with `--file` stamps `base_ok_sha` = the worktree HEAD; the SAME check WITHOUT `--file`
+    writes nothing (the pure decider is preserved)."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        candidate, head = _current_base_worktree(root)
+        vjson = root / "clean.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+
+        # WITH --file: proceed, and the ledger row is stamped for the live head.
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", head)
+        check(_base_ok_sha(ledger, "9") == "-", "fixture setup: base_ok_sha must start `-`")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--worktree", str(candidate), "--base", "main", "--file", str(ledger)])
+        check(code == 0, f"a current base with --file must proceed (stderr: {err})")
+        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check"},
+              f"a current base must proceed, got {out!r}")
+        check(_base_ok_sha(ledger, "9") == head,
+              f"proceed with --file did not record base_ok_sha = {head!r}: {_base_ok_sha(ledger, '9')!r}")
+
+        # WITHOUT --file: still proceed, but NOTHING is written to a ledger.
+        ledger2 = root / "state2.jsonl"
+        _ledger_row(ledger2, "9", head)
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--worktree", str(candidate), "--base", "main"])
+        check(code == 0, f"the same check without --file must still proceed (stderr: {err})")
+        check(_base_ok_sha(ledger2, "9") == "-",
+              f"a proceed with NO --file wrote base_ok_sha anyway: {_base_ok_sha(ledger2, '9')!r} — the pure "
+              f"decider must write nothing")
+
+
+def t_non_proceed_with_file_leaves_base_ok():
+    """`rebase-first` and `recheck` NEVER stamp — even with `--file`. Only the proceed branch records, so a
+    non-proceed decision leaves `base_ok_sha` at `-` and a later verdict stays refused."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", "a" * 40)
+        for name, mss, want in (("rebase-first", "DIRTY", "rebase-first"), ("recheck", "UNKNOWN", "recheck")):
+            vjson = root / f"{name}.json"
+            vjson.write_text(json.dumps(view(mergeStateStatus=mss)), encoding="utf-8")
+            code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                                  "--file", str(ledger)])
+            check(code != 0, f"[{name}] a non-proceed must exit non-zero (stderr: {err})")
+            check(json.loads(out)["verdict"] == want, f"[{name}] expected {want}, got {out!r}")
+            check(_base_ok_sha(ledger, "9") == "-",
+                  f"[{name}] a non-proceed decision stamped base_ok_sha: {_base_ok_sha(ledger, '9')!r}")
+
+
 CASES = [
     ("clean-proceeds", "CLEAN passes the enum screen", t_clean_proceeds),
     ("has-hooks-proceeds", "HAS_HOOKS passes the enum screen", t_has_hooks_proceeds),
@@ -344,4 +439,8 @@ CASES = [
      t_clean_view_with_stale_base_rebases),
     ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",
      t_clean_view_with_current_base_proceeds),
+    ("proceed-file-records-base-ok", "a proceed with --file stamps base_ok_sha = HEAD; without --file writes nothing",
+     t_proceed_with_file_records_base_ok),
+    ("non-proceed-file-no-stamp", "rebase-first/recheck never stamp base_ok_sha, even with --file",
+     t_non_proceed_with_file_leaves_base_ok),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -12,8 +12,14 @@ and PERFORMS NO REBASE: the driver rebases when told `rebase-first`, then re-run
 are two jobs and this is only the first — nothing here runs `git rebase`/`git merge` or edits a branch.
 
     base-preflight.py check --pr 31 [--repo owner/name] [--view-json <path>] [--project-root <dir>]
-        [--worktree <path> --base <branch> [--remote origin]]
+        [--worktree <path> --base <branch> [--remote origin]] [--file <ledger>]
     base-preflight.py self-test   run every fixture (base-preflight-test.py)
+
+On a final `proceed`, and ONLY when `--file <ledger>` is given, this records that base check on the ledger row
+by shelling out to `ledger.py base-ok` — resolving the worktree's live `HEAD` and stamping it as
+`base_ok_sha`. That stamp is the MECHANICAL precondition `ledger.py verdict` enforces: a review verdict cannot
+be recorded for a head with no fresh `proceed`. Without `--file` the tool is the pure decider it always was
+(it writes nothing); `decide()` itself stays pure regardless.
 
 The verdict is printed as JSON on stdout, and the EXIT CODE gates a caller's `$?`: 0 for `proceed`, non-zero
 for `rebase-first` and `recheck` (and for a view that could not be fetched or was malformed — those fail
@@ -34,6 +40,7 @@ from _gauntlet.modules import load_module_from_path
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "base-preflight-test.py"     # the fixture suite — this tool's executable contract
+LEDGER = _HERE / "ledger.py"                   # the sibling that owns base_ok_sha; `base-ok` is its only writer
 
 
 # --- the verdicts -------------------------------------------------------------
@@ -199,10 +206,40 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None",
         raise ViewError(f"gh response is not JSON ({exc})") from exc
 
 
+def record_base_ok(ledger_file: str, pr: str, worktree: "str | None") -> "str | None":
+    """On a `proceed`, stamp the ledger's `base_ok_sha` for the worktree's CURRENT head. Returns an error
+    string on failure, else `None`. Called ONLY from `check`'s proceed branch, so it never touches `decide`.
+
+    A `proceed` clears a review or fix onto THIS head, and the stamp is what lets the later `ledger.py verdict`
+    land: that door refuses unless `base_ok_sha == head_sha`. Resolving the head HERE (never trusting a caller
+    value) and writing through `ledger.py base-ok` (the only sanctioned writer) keeps the stamp a byproduct of
+    the check actually reaching `proceed`. A `proceed` guarantees the ancestry check ran, so `worktree` is set;
+    the guard is kept anyway so a caller change cannot silently reach a `rev-parse` with no worktree.
+    """
+    if not worktree:
+        return "proceed reached with no --worktree, so the head to stamp cannot be resolved"
+    head = subprocess.run(  # noqa: S603
+        ["git", "-C", worktree, "rev-parse", "HEAD"], capture_output=True, text=True, check=False)
+    if head.returncode != 0:
+        return f"could not resolve HEAD in {worktree}: {head.stderr.strip()}"
+    sha = head.stdout.strip()
+    stamp = subprocess.run(  # noqa: S603
+        [sys.executable, str(LEDGER), "--file", ledger_file, "base-ok", "--pr", str(pr), "--head-sha", sha],
+        capture_output=True, text=True, check=False)
+    if stamp.returncode != 0:
+        return f"`ledger.py base-ok` exited {stamp.returncode}: {stamp.stderr.strip()}"
+    return None
+
+
 def check(pr: str, repo: "str | None", view_json: "str | None", project_root: "str | None",
-          worktree: "str | None", base: "str | None", remote: str) -> int:
+          worktree: "str | None", base: "str | None", remote: str, ledger_file: "str | None") -> int:
     """Fetch the live view, decide, print the verdict as JSON. EXIT 0 only on `proceed`; every other outcome
-    (rebase-first, recheck, an unfetchable or malformed view) exits non-zero so a caller can gate on `$?`."""
+    (rebase-first, recheck, an unfetchable or malformed view) exits non-zero so a caller can gate on `$?`.
+
+    When `--file` is given, a final `proceed` also records `base_ok_sha` for the live head via `ledger.py
+    base-ok` (the mechanical precondition `ledger.py verdict` enforces). A recording failure fails CLOSED to
+    `recheck` — never a bare `proceed` whose verdict the ledger would then refuse. Without `--file`, nothing
+    is written."""
     try:
         view = load_view(pr, repo, view_json, project_root)
     except ViewError as exc:
@@ -221,6 +258,12 @@ def check(pr: str, repo: "str | None", view_json: "str | None", project_root: "s
             result = _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
         elif ancestry == "unverified":
             result = _verdict(RECHECK, f"could not verify base ancestry: {detail}")
+    # ONLY on a final `proceed`, and ONLY when a ledger was named, record the proceed as `base_ok_sha` for the
+    # live head. Fail CLOSED to `recheck` on a recording failure so a `proceed` always implies the stamp landed.
+    if result["verdict"] == PROCEED and ledger_file is not None:
+        err = record_base_ok(ledger_file, pr, worktree)
+        if err is not None:
+            result = _verdict(RECHECK, f"could not record base_ok_sha: {err}")
     print(json.dumps(result))
     return 0 if result["verdict"] == PROCEED else 1
 
@@ -286,6 +329,8 @@ def main(argv: "list[str] | None" = None) -> int:
     c.add_argument("--worktree", help="the PR-head worktree used for the Git ancestry check")
     c.add_argument("--base", help="the PR base branch to fetch and compare")
     c.add_argument("--remote", default="origin", help="the worktree remote holding --base (default: origin)")
+    c.add_argument("--file", help="the ledger (state.jsonl); on `proceed`, record base_ok_sha for the live "
+                                  "head so `ledger.py verdict` can later count. Absent: the pure decider, no write")
 
     sub.add_parser("self-test", help="run every fixture (base-preflight-test.py)")
 
@@ -294,7 +339,7 @@ def main(argv: "list[str] | None" = None) -> int:
     if args.cmd == "self-test":
         return self_test()
     return check(args.pr, args.repo, args.view_json, args.project_root,
-                 args.worktree, args.base, args.remote)
+                 args.worktree, args.base, args.remote, args.file)
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -127,6 +127,10 @@ class Scenario:
         _ledger("--file", str(self.ledger), "add-row", "--pr", PR_NUMBER, "--branch", PR_BRANCH,
                 "--head-sha", self.orig_head, "--worktree", str(self.wt), "--tier", "STANDARD",
                 "--status", status)
+        # `verdict` refuses unless a base-preflight `proceed` is on record for this head
+        # (base_ok_sha == head_sha); stamp it first, as the real flow does (base-preflight.py -> base-ok).
+        if reviews_ok:
+            _ledger("--file", str(self.ledger), "base-ok", "--pr", PR_NUMBER, "--head-sha", self.orig_head)
         for _ in range(reviews_ok):
             _ledger("--file", str(self.ledger), "verdict", "--pr", PR_NUMBER,
                     "--head-sha", self.orig_head, "--verdict", "satisfied")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1073,7 +1073,7 @@ def t_verdict_counts_rounds(L: ModuleType, tmp: Path) -> None:
     gauntlet: fail, fail, pass, fail, pass, pass), and after them the row must say SIX. `reviews_ok` will
     have been voided and rebuilt twice on the way; `review_rounds` never moves but up.
     """
-    path = write_lines(tmp / "v.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
+    path = write_lines(tmp / "v.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
 
     def verdict(v: str) -> dict:
         code, out, err = cli(L, ["--file", str(path), "verdict", "--pr", "1",
@@ -1109,7 +1109,7 @@ def t_review_rounds_never_reset(L: ModuleType, tmp: Path) -> None:
     A rule that says "never reset it" is an exhortation, and the loop it guards ran for eight hours under
     three of those. Removing the door is a mechanism.
     """
-    path = write_lines(tmp / "nr.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
+    path = write_lines(tmp / "nr.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "not-satisfied"])
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "not-satisfied"])
 
@@ -1146,7 +1146,7 @@ def t_set_cannot_raise_the_tally(L: ModuleType, tmp: Path) -> None:
     importantly, it stays OPEN downward, because voiding the tally on a content change is a real and
     frequent event that is NOT a verdict (a fix commit, a conflict rebase, a formatter's push).
     """
-    path = write_lines(tmp / "t.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
+    path = write_lines(tmp / "t.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
 
     code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--reviews-ok", "2"])
@@ -1179,7 +1179,8 @@ def t_escalation_reset_is_one_atomic_write(L: ModuleType, tmp: Path) -> None:
     re-triggers the reset — a stricter tier standing on a stale accepted tally. `set` already applies every
     field flag in ONE atomic write, so the single-write form is available; this pins that it is.
     """
-    path = write_lines(tmp / "e.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, tier="STANDARD"))
+    path = write_lines(tmp / "e.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A, tier="STANDARD"))
     # A standing accepted tally at the shallower tier (earned, not hand-set — `set` cannot raise it).
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
@@ -1209,7 +1210,8 @@ def t_deescalation_is_a_tier_only_write(L: ModuleType, tmp: Path) -> None:
     de-escalation branch keeps the verdicts; only `required(tier)` moves). This pins the tool contract the
     prose deletion depends on: the single directional write is tier-only on a de-escalation, never a reset.
     """
-    path = write_lines(tmp / "de.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A, tier="HIGH"))
+    path = write_lines(tmp / "de.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A, tier="HIGH"))
     # A standing tally at the DEEPER tier (earned, not hand-set — `set` cannot raise it).
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
     cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
@@ -1277,7 +1279,8 @@ def t_counter_refuses_a_corrupt_value(L: ModuleType, tmp: Path) -> None:
     """
     for value in ("-", "two", "-1", "01", " 2"):
         path = write_lines(tmp / f"c-{value.strip() or 'blank'}.jsonl", header_line(L),
-                           json.dumps({"type": "row", "pr": "1", "head_sha": SHA_A, "review_rounds": value}))
+                           json.dumps({"type": "row", "pr": "1", "head_sha": SHA_A, "base_ok_sha": SHA_A,
+                                       "review_rounds": value}))
         code, out, err = cli(L, ["--file", str(path), "verdict", "--pr", "1",
                                  "--head-sha", SHA_A, "--verdict", "satisfied"])
         check(code == 1, f"review_rounds={value!r} was accepted as a number (exit {code}):\n{out}")
@@ -1356,6 +1359,130 @@ def t_set_head_sha_refuses_a_non_sha(L: ModuleType, tmp: Path) -> None:
         check(row[field] == want, f"a refused head_sha write reset {field} to {row[field]!r}, not {want!r}")
 
 
+# --- base_ok_sha: the MECHANICAL base-preflight precondition on `verdict` ------
+#
+# `verdict` refuses unless a base-preflight `proceed` is on record for THIS head (`base_ok_sha == head_sha`).
+# `base-ok` is the ONLY writer; a genuine head move voids the stamp; there is no `set` door (PREFLIGHT_OWNED);
+# and stamping is not activity. Together these make "run base-preflight before you record a verdict" a
+# mechanism, not a prose rule a fresh-context heartbeat is trusted to remember.
+
+def t_verdict_refused_without_base_ok(L: ModuleType, tmp: Path) -> None:
+    """A verdict is REFUSED unless `base_ok_sha == head_sha` — for BOTH verdicts — and ALLOWED once it is.
+
+    Skipping base-preflight leaves the stamp `-`, which no 40-hex head equals, so the door fails CLOSED: a
+    review verdict cannot be recorded over a base no `proceed` cleared. A counted NOT SATISFIED spends the loop
+    budget, so the guard covers not-satisfied exactly as it covers satisfied. A tool that can only REFUSE a
+    verdict can never merge anything.
+    """
+    for verdict in ("satisfied", "not-satisfied"):
+        path = write_lines(tmp / f"nobase-{verdict}.jsonl", header_line(L),
+                           row_line(L, pr="1", head_sha=SHA_A))  # base_ok_sha defaults to `-`
+        code, out, err = cli(L, ["--file", str(path), "verdict", "--pr", "1",
+                                 "--head-sha", SHA_A, "--verdict", verdict])
+        check(code == 1, f"[{verdict}] a verdict with no base-preflight proceed was recorded (exit {code}):\n{out}")
+        check("no fresh base-preflight `proceed`" in err, f"[{verdict}] refused for the wrong reason: {err!r}")
+        code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "review_rounds"])
+        check(out == "0\n", f"[{verdict}] the refused verdict still bumped review_rounds: {out!r}")
+
+    # A proceed on record for a DIFFERENT (earlier) head does not authorize a verdict on THIS content.
+    path = write_lines(tmp / "stale-base.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_B))
+    code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
+    check(code == 1, "a verdict authorized by a proceed for a DIFFERENT head was recorded")
+    check("no fresh base-preflight `proceed`" in err, f"refused for the wrong reason: {err!r}")
+
+    # …and with the proceed on record for THIS head, the same verdict LANDS.
+    path = write_lines(tmp / "withbase.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
+    code, out, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_A, "--verdict", "satisfied"])
+    check(code == 0, f"a verdict WITH a fresh proceed on record was refused (exit {code}): {err!r}")
+    check(json.loads(out)["review_rounds"] == "1", f"the allowed verdict did not land: {out!r}")
+
+
+def t_head_move_voids_base_ok(L: ModuleType, tmp: Path) -> None:
+    """A genuine head MOVE through `set --head-sha` voids `base_ok_sha` to `-`; a SAME-VALUE write leaves it.
+
+    A new head is UNVERIFIED until a fresh proceed — so the verdict allowed on the old head is now refused, and
+    only re-running base-preflight (here, `base-ok`) on the new head clears it again. THE MUTATION PIN: delete
+    the `base_ok_sha` reset in `apply_head_sha` and the first block goes red.
+    """
+    path = write_lines(tmp / "void.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
+    code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", SHA_B])
+    check(code == 0, f"set exited {code}: {err!r}")
+    check(json.loads(out)["base_ok_sha"] == L.ROW_DEFAULTS["base_ok_sha"],
+          f"a head MOVE left base_ok_sha standing: {json.loads(out)['base_ok_sha']!r} — the proceed for the "
+          f"old head must not authorize the new content")
+    code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_B, "--verdict", "satisfied"])
+    check(code == 1, "a verdict landed on a moved head whose proceed was voided")
+
+    # …and a SAME-VALUE head write is not a move: a stamp for that head is left standing.
+    cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_B])
+    code, out, _ = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", SHA_B])
+    check(json.loads(out)["base_ok_sha"] == SHA_B,
+          f"a SAME-VALUE head write voided a stamp it must not touch: {json.loads(out)['base_ok_sha']!r}")
+
+
+def t_base_ok_writes_and_refuses(L: ModuleType, tmp: Path) -> None:
+    """`base-ok` records `base_ok_sha` for the row's CURRENT head, and REFUSES a non-40-hex value, a head
+    mismatch, or a missing row — writing NOTHING on any refusal."""
+    path = write_lines(tmp / "bok.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
+    code, out, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A])
+    check(code == 0, f"base-ok on the current head exited {code}: {err!r}")
+    check(json.loads(out)["base_ok_sha"] == SHA_A, f"base-ok did not stamp base_ok_sha: {out!r}")
+
+    for bad in (SHA_A[:7], "g" * 40, SHA_A.upper()):
+        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", bad])
+        check(code == 1, f"base-ok --head-sha {bad!r} was accepted (exit {code})")
+        check("40 LOWERCASE hex" in err, f"[{bad!r}] refused for the wrong reason: {err!r}")
+
+    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_B])
+    check(code == 1, "base-ok stamped a head that is not the row's current one")
+    check("does not match" in err, f"refused for the wrong reason: {err!r}")
+
+    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "9", "--head-sha", SHA_A])
+    check(code == 1, "base-ok wrote a stamp for a PR with no row")
+    check("no row for pr 9" in err, f"refused for the wrong reason: {err!r}")
+
+    # …and the stamp for the current head is still exactly SHA_A after every refusal.
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "base_ok_sha"])
+    check(out == SHA_A + "\n", f"a refused base-ok changed base_ok_sha: {out!r}")
+
+
+def t_base_ok_sha_has_no_set_door(L: ModuleType, tmp: Path) -> None:
+    """`base_ok_sha` cannot be written through `set`/`add-row` — the same mechanism as review_rounds and
+    repair_count (PREFLIGHT_OWNED). A door that can hand-write the proceed stamp is a door that can FORGE a
+    proceed no base-preflight ever decided, recording a verdict over a base that never passed. So there is no
+    `--base-ok-sha` flag: argparse refuses it, and only `base-ok` writes the field."""
+    check("base_ok_sha" in L.PREFLIGHT_OWNED, "base_ok_sha must be in PREFLIGHT_OWNED, or a set door can forge it")
+    check(not L.settable("base_ok_sha"), "settable() must refuse base_ok_sha — PREFLIGHT_OWNED")
+    path = write_lines(tmp / "bnodoor.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
+    for door in (["set", "--pr", "1"], ["add-row", "--pr", "77"]):
+        code, _, err = cli(L, ["--file", str(path), *door, "--base-ok-sha", SHA_A])
+        check(code == 2, f"`{door[0]} --base-ok-sha` was accepted (exit {code}) — a hand-write door can forge a proceed")
+        check("unrecognized arguments" in err,
+              f"`{door[0]} --base-ok-sha` failed, but not because the flag is ABSENT: {err!r}")
+
+
+def t_base_ok_is_not_activity(L: ModuleType, tmp: Path) -> None:
+    """`base-ok` writes with `activity=False` — recording a precondition is not the run doing meaningful work,
+    exactly as re-arming the watchdog is not. Also asserts base_ok_sha IS in ACTIVITY_EXEMPT (name the set)."""
+    check("base_ok_sha" in L.ACTIVITY_EXEMPT,
+          "base_ok_sha must be in ACTIVITY_EXEMPT — stamping a precondition must not reset the quiet sensor")
+    path = write_lines(tmp / "boa.jsonl", header_line(L, run_id="r1"),
+                       row_line(L, pr="1", head_sha=SHA_A, status="in_review"))
+    with frozen_clock(L, FROZEN_A):  # a real change first, to give last_activity a known value
+        code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--slug", "x"])
+        check(code == 0, f"baseline set exited {code}: {err!r}")
+    check(last_activity(L, path) == FROZEN_A, "the baseline change did not stamp last_activity")
+    with frozen_clock(L, FROZEN_B):  # a base-ok write — must NOT re-stamp
+        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A])
+        check(code == 0, f"base-ok exited {code}: {err!r}")
+    check(last_activity(L, path) == FROZEN_A,
+          f"base-ok re-stamped last_activity to {last_activity(L, path)!r} — stamping a precondition is not "
+          f"meaningful activity and must leave the quiet sensor alone")
+
+
 def t_write_is_atomic(L: ModuleType, tmp: Path) -> None:
     """**A LEDGER WRITE IS ALL OR NOTHING.** No crash, no full disk, may leave a store torn in half.
 
@@ -1371,7 +1498,8 @@ def t_write_is_atomic(L: ModuleType, tmp: Path) -> None:
     filesystems is a copy, and a copy tears exactly like the truncate did), the bytes were `fsync`ed
     before anything pointed at them, and nothing was left behind.
     """
-    path = write_lines(tmp / "atomic.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
+    path = write_lines(tmp / "atomic.jsonl", header_line(L),
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
     before = path.read_bytes()
 
     fsyncs = 0
@@ -1465,7 +1593,11 @@ def verdicts(L: ModuleType, path: Path, seq: str, pr: str = "1", move_head: bool
 
     `move_head` replays what really happens between rounds: a NOT SATISFIED sends a fix, the fix pushes,
     the head moves. That is what makes this a test of "`review_rounds` survives a fix" and not a rehearsal
-    on static content.
+    on static content. The head move voids `base_ok_sha`, so — exactly as the real flow re-runs
+    base-preflight on the rebased tip — this re-stamps `base-ok` for the new head before the next verdict.
+
+    The CALLER's row must start with `base_ok_sha == SHA_A` (a `proceed` on record for the first head), or
+    the very first verdict is refused; the verdict-driving fixtures set it beside `head_sha`.
     """
     sha = SHA_A
     for i, v in enumerate(seq, start=1):
@@ -1476,11 +1608,13 @@ def verdicts(L: ModuleType, path: Path, seq: str, pr: str = "1", move_head: bool
         if move_head and v == "N":
             sha = f"{i:040x}"
             cli(L, ["--file", str(path), "set", "--pr", pr, "--head-sha", sha])
+            cli(L, ["--file", str(path), "base-ok", "--pr", pr, "--head-sha", sha])  # re-preflight the new head
     return len(seq), 0
 
 
 def capped_row(L: ModuleType, tmp: Path, name: str, **over: str) -> Path:
-    fields = {"pr": "1", "head_sha": SHA_A, "status": "in_review", **over}
+    # base_ok_sha == head_sha: a base-preflight `proceed` on record for the head, so `verdict` may count.
+    fields = {"pr": "1", "head_sha": SHA_A, "base_ok_sha": SHA_A, "status": "in_review", **over}
     return write_lines(tmp / name, header_line(L), row_line(L, **fields))
 
 
@@ -1665,7 +1799,7 @@ def replay(L: ModuleType, tmp: Path, pr: str, stop_after: "int | None" = None) -
     assert isinstance(seq, str) and isinstance(passes, list)
     check(len(seq) == len(passes), f"[#{pr}] the fixture's own record is inconsistent")
     path = write_lines(tmp / f"replay-{pr}-{stop_after}.jsonl", header_line(L),
-                       row_line(L, pr=pr, head_sha=SHA_A, status="in_review"))
+                       row_line(L, pr=pr, head_sha=SHA_A, base_ok_sha=SHA_A, status="in_review"))
     sha = SHA_A
     for i, (v, npass) in enumerate(zip(seq, passes), start=1):
         if stop_after is not None and npass > stop_after:
@@ -1677,9 +1811,10 @@ def replay(L: ModuleType, tmp: Path, pr: str, stop_after: "int | None" = None) -
             check(out.strip() == L.REPAIR_STATUS, f"[#{pr}] the trigger left the row live")
             return npass
         check(code == 0, f"[#{pr}] verdict {i} (pass r{npass}) exited {code}")
-        if v == "N":  # a fix was dispatched and pushed: the head MOVED
+        if v == "N":  # a fix was dispatched and pushed: the head MOVED, and base-preflight re-ran on the new tip
             sha = f"{i:040x}"
             cli(L, ["--file", str(path), "set", "--pr", pr, "--head-sha", sha])
+            cli(L, ["--file", str(path), "base-ok", "--pr", pr, "--head-sha", sha])
     return None
 
 
@@ -1747,7 +1882,7 @@ def t_stale_repair_decision_cleared_at_cap(L: ModuleType, tmp: Path) -> None:
     # `repair_count`/`repair_decision` have NO `set` flag by design (t_the_repair_bound_has_no_door).
     stale = "rescope@2026-07-14T00:00:00Z"
     path = write_lines(tmp / "stale.jsonl", header_line(L),
-                       row_line(L, pr="1", head_sha=SHA_A, status="in_review",
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A, status="in_review",
                                 pr_origin="gauntlet", repair_count="1", repair_decision=stale))
     code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "repair_decision"])
     check(out.strip() == stale, f"fixture setup is wrong — the row does not carry the stale decision: {out!r}")
@@ -2041,7 +2176,7 @@ def t_verdict_stamps_activity(L: ModuleType, tmp: Path) -> None:
     """A landed `verdict` stamps `last_activity` — it always moves review_rounds, so it is always activity."""
     sha = "a" * 40
     path = write_lines(tmp / "v.jsonl", header_line(L, run_id="r1"),
-                       row_line(L, pr="1", head_sha=sha, status="in_review"))
+                       row_line(L, pr="1", head_sha=sha, base_ok_sha=sha, status="in_review"))
     with frozen_clock(L, FROZEN_A):
         code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", sha,
                                "--verdict", "satisfied"])
@@ -2275,6 +2410,11 @@ CASES = [
     ("head-sha-resets-liveness", "a NEW head_sha through `set` resets THE LIVENESS COUNTERS; a same-value write does not", t_head_sha_change_resets_liveness),
     ("head-sha-explicit-counter-wins", "an explicit counter flag in the same call as a new head_sha wins over the auto-reset", t_head_sha_explicit_counter_wins),
     ("head-sha-refuses-non-sha", "`set --head-sha` refuses a non-40-hex value and writes nothing", t_set_head_sha_refuses_a_non_sha),
+    ("verdict-needs-base-ok", "a verdict is refused unless base_ok_sha == head_sha — both verdicts; allowed once stamped", t_verdict_refused_without_base_ok),
+    ("head-move-voids-base-ok", "a head MOVE voids base_ok_sha to `-`; a same-value write leaves it", t_head_move_voids_base_ok),
+    ("base-ok-writes-refuses", "`base-ok` stamps the current head; refuses non-40-hex, head-mismatch, no-row", t_base_ok_writes_and_refuses),
+    ("base-ok-sha-no-door", "base_ok_sha has NO set/add-row flag (PREFLIGHT_OWNED) — a hand-write door forges a proceed", t_base_ok_sha_has_no_set_door),
+    ("base-ok-not-activity", "a base-ok write does NOT stamp last_activity — stamping a precondition is not activity", t_base_ok_is_not_activity),
     ("write-atomic", "a write that dies mid-way leaves the OLD ledger intact — temp + fsync + os.replace", t_write_is_atomic),
     ("skill-version", "the header records WHICH VERSION of the rules governed the run; default `unknown`", t_skill_version_is_recorded),
     ("round-cap", "at ROUND_CAP a NOT SATISFIED holds the row `repairing` and exits non-zero", t_round_cap_fires),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -139,6 +139,23 @@ ROW_FIELDS = (
     # A heartbeat is a fresh agent instance. A counter that lives in the driver's head does not exist.
     "review_rounds",   # landed verdicts, ever, for this PR. MONOTONE — NEVER reset, by anything.
     "ns_streak",       # consecutive NOT SATISFIED. Reset ONLY by a SATISFIED.
+    # THE HEAD A BASE-PREFLIGHT `proceed` WAS LAST DECIDED FOR — the MECHANICAL form of the
+    # rebase-before-review precondition (stage-2-review-gate.md, "Recording a verdict"). `base-preflight.py
+    # check` writes it (through `base-ok`, the ONLY sanctioned writer) when — and only when — it decides
+    # `proceed` for the live head; `cmd_verdict` then REFUSES unless `base_ok_sha == head_sha`, so a review
+    # verdict can never be recorded — satisfied OR not-satisfied — over a base no fresh `proceed` cleared. A
+    # counted NOT SATISFIED spends `review_rounds`/`ns_streak` toward the caps, so the guard covers both.
+    #
+    # It is SHA-bound like THE LIVENESS COUNTERS and voided the same way: `apply_head_sha` resets it to its
+    # `ROW_DEFAULTS` value on a genuine head MOVE — a new head is unverified until a fresh `proceed` — and it
+    # has NO `set` door (`PREFLIGHT_OWNED`): a hand-written stamp would forge the precondition it exists to
+    # enforce, the same "remove the door" stance `review_rounds` takes. Its writes are activity-EXEMPT, because
+    # stamping a precondition is not "the run did something meaningful" (the same stance the liveness counters
+    # and `watchdog_due` take).
+    #
+    # The default is `-`, the schema's own "not set" spelling: an old ledger, or a head with no `proceed` yet,
+    # reads back `-`, which never equals a 40-hex head, so `verdict` fails CLOSED until base-preflight runs.
+    "base_ok_sha",
     # WHERE THIS PR'S INTENT CAME FROM — the PROVENANCE of `<rundir>/intent-<pr>.md`:
     #   `-`                not adopted yet
     #   `stated@<iso>`     the PR body already carried a usable intent block; it was COPIED VERBATIM
@@ -183,7 +200,7 @@ ROW_DEFAULTS = {
     "tier": "-", "attempts": "0", "started": "-", "api_approval": "-", "status": "pending",
     "ci_fingerprint": "-", "settled_strikes": "0", "unusable_refetches": "0",
     "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-",
-    "review_rounds": "0", "ns_streak": "0", "intent": "-",
+    "review_rounds": "0", "ns_streak": "0", "base_ok_sha": "-", "intent": "-",
     "pr_origin": "external", "repair_count": "0", "repair_decision": "-",
 }
 
@@ -207,7 +224,10 @@ LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", 
 #     "the run did something meaningful": it is the run promising to look again later. Stamping `last_activity`
 #     on it would let a bare `watchdog arm` masquerade as activity and reset the very quiet sensor the watchdog
 #     exists to back — so `watchdog arm` must NOT stamp, and this exemption is how that is guaranteed.
-ACTIVITY_EXEMPT = frozenset(LIVENESS_COUNTERS + ("last_activity", "watchdog_due"))
+#   * `base_ok_sha` — the base-preflight `proceed` stamp. Recording that the base is current for a head is a
+#     PRECONDITION being met, not the run advancing: `base-ok` writes it with `activity=False`, and this
+#     exemption is what guarantees a bare stamp cannot masquerade as activity and reset the quiet sensor.
+ACTIVITY_EXEMPT = frozenset(LIVENESS_COUNTERS + ("last_activity", "watchdog_due", "base_ok_sha"))
 
 # THE HEADER FIELDS WITH NO HAND-WRITE DOOR — `header set <field>` is REFUSED for each, mapped to the exact
 # refusal message. Both are TOOL-STAMPED: `last_activity` by `save()`'s side effect on a real change,
@@ -242,6 +262,14 @@ VERDICT_OWNED = ("review_rounds", "ns_streak")
 # write it is a door that can zero it, and a driver that could zero its own repair budget could repair
 # forever. The tool that decides a repair is the only thing that writes what it spent.
 REPAIR_OWNED = ("repair_count", "repair_decision")
+
+# The base-preflight stamp `base-ok` OWNS — settable through NO flag, the same mechanism as VERDICT_OWNED and
+# REPAIR_OWNED, for the same reason. `base_ok_sha` is the MECHANICAL base-currency precondition `verdict`
+# enforces (it refuses unless the stamp equals the row's head). A door that can hand-write it is a door that
+# can FORGE a `proceed` no base-preflight ever decided — recording a verdict over a conflicting or stale base,
+# the exact waste this guard exists to stop. So there is no `--base-ok-sha` flag: `base-preflight.py check`
+# writes it, through `base-ok`, only when it actually decides `proceed`, and nothing else writes it at all.
+PREFLIGHT_OWNED = ("base_ok_sha",)
 
 # The park/unpark TRANSITIONS `park`/`unpark` own — the same mechanism as VERDICT_OWNED, one level up at the
 # `status` field. A machine-blocker park and a retry unpark are each MULTI-FIELD atomic writes whose fields
@@ -650,9 +678,12 @@ def settable(name: str) -> bool:
     exclusion, and it is the mechanism behind "`review_rounds` is NEVER reset": a door that can write a
     counter is a door that can zero it, so those two fields simply have NO flag. `verdict` writes them.
     `REPAIR_OWNED` is the same mechanism for the repair's bound: a driver that could zero `repair_count`
-    could repair forever, so only `repair-pass.py decide` writes what a PR has spent.
+    could repair forever, so only `repair-pass.py decide` writes what a PR has spent. `PREFLIGHT_OWNED` is
+    the same mechanism for the base-currency precondition: a door that can hand-write `base_ok_sha` could
+    forge a `proceed` no base-preflight decided, so only `base-preflight.py` writes it, through `base-ok`.
     """
-    return name not in ("pr", "id") and name not in VERDICT_OWNED and name not in REPAIR_OWNED
+    return (name not in ("pr", "id") and name not in VERDICT_OWNED and name not in REPAIR_OWNED
+            and name not in PREFLIGHT_OWNED)
 
 
 def _named_field_values(args) -> dict:
@@ -716,14 +747,16 @@ def cmd_add_row(path: Path, args) -> int:
 
 
 def apply_head_sha(row: dict, new_sha: str) -> None:
-    """Write `new_sha` to `row['head_sha']`, resetting THE LIVENESS COUNTERS on a genuine head MOVE.
+    """Write `new_sha` to `row['head_sha']`, resetting THE LIVENESS COUNTERS and the base-preflight stamp
+    `base_ok_sha` on a genuine head MOVE.
 
     THE PROPERTY, enforced at the write door rather than by prose at each caller (stage-2-ci.md, "THE
     LIVENESS COUNTERS", reset-site class 1): a NEW `head_sha` is NEW evidence, so the old head's CI-liveness
-    says nothing about it. When `new_sha != row['head_sha']` this writes the head AND resets every
-    `LIVENESS_COUNTERS` field to its `ROW_DEFAULTS` value — READ from the defaults, never retyped — mutating
-    the SAME `row` dict, so the caller's single `dump()` lands the head move and the reset in ONE atomic write.
-    A SAME-VALUE write (`new_sha == row['head_sha']`) is not a move and changes NOTHING.
+    says nothing about it — and neither does a `proceed` decided for the old head. When `new_sha !=
+    row['head_sha']` this writes the head AND resets every `LIVENESS_COUNTERS` field, AND `base_ok_sha`, to its
+    `ROW_DEFAULTS` value — READ from the defaults, never retyped — mutating the SAME `row` dict, so the
+    caller's single `dump()` lands the head move and the reset in ONE atomic write. A SAME-VALUE write
+    (`new_sha == row['head_sha']`) is not a move and changes NOTHING.
 
     The shape is validated with `SHA_RE` FIRST and REFUSED otherwise (40 lowercase hex): a value that cannot
     be a commit id has no business becoming a row's head, and refusing before any mutation keeps a bad
@@ -742,6 +775,11 @@ def apply_head_sha(row: dict, new_sha: str) -> None:
     row["head_sha"] = new_sha
     for field in LIVENESS_COUNTERS:
         row[field] = ROW_DEFAULTS[field]  # fresh head, fresh budget — the value comes from ROW_DEFAULTS
+    # A new head is UNVERIFIED until a fresh base-preflight `proceed`: void the recorded proceed here too, so a
+    # `proceed` decided for the OLD head can never authorize a `verdict` on new content (the `base_ok_sha`
+    # field definition; `cmd_verdict`). Read from `ROW_DEFAULTS`, never a retyped literal, exactly like the
+    # counters above — a fresh-head `base_ok_sha` is its default `-`, which no 40-hex head equals.
+    row["base_ok_sha"] = ROW_DEFAULTS["base_ok_sha"]
 
 
 def cmd_set(path: Path, args) -> int:
@@ -790,6 +828,13 @@ def cmd_verdict(path: Path, args) -> int:
     door, so a late verdict from a superseded attempt can never reach the tally through a driver that
     skipped the check.
 
+    **The base-currency precondition is checked too, and refused if not met.** A `proceed` must be on record
+    for this head (`base_ok_sha == head_sha`), or the review ran over a base a fresh base-preflight never
+    cleared. This is the MECHANICAL form of the rebase-before-review rule the prose (stage-2-review-gate.md)
+    only asked for: `base-preflight.py` stamps `base_ok_sha` on a real `proceed`, and skipping it leaves the
+    stamp `-` (or a stale head), so this door refuses — satisfied OR not-satisfied, since a counted NOT
+    SATISFIED spends the loop budget just the same. Like the head check, this can only ever REFUSE a verdict.
+
     **The counters are SENSORS, and this door NEVER WRITES THEM BACKWARDS — but it does READ them, and at
     a cap it STOPS THE LOOP.** The hazard in fusing a reader into a sensor is that the reader comes to
     reset the counter it consumes; that hazard is structurally absent here, because the cap path writes
@@ -823,6 +868,18 @@ def cmd_verdict(path: Path, args) -> int:
         fail(f"this verdict ran on {args.head_sha} but pr {pr}'s head is {row['head_sha']} — it describes "
              f"content that is no longer there. A verdict for a superseded SHA never counts: reconcile the "
              f"row against `gh` first, and re-review the live tip")
+    # THE BASE-CURRENCY PRECONDITION, MECHANICAL. A `proceed` must be on record for THIS head, or the review
+    # ran over a base a fresh base-preflight never cleared and the verdict is refused — satisfied OR
+    # not-satisfied, since a counted NOT SATISFIED spends the loop budget just the same. Because the head
+    # check above already pinned `args.head_sha == row['head_sha']`, this transitively requires `base_ok_sha
+    # == row['head_sha']`: a `proceed` stamped for an EARLIER head (voided to `-` on the move) cannot
+    # authorize a review of new content.
+    if row["base_ok_sha"] != args.head_sha:
+        fail(f"pr {pr}'s head {args.head_sha} has no fresh base-preflight `proceed` on record (base_ok_sha is "
+             f"{row['base_ok_sha']!r}) — a review verdict is refused, satisfied or not, until the base is "
+             f"confirmed current for THIS head. Run `base-preflight.py check --pr {pr} --worktree <worktree> "
+             f"--base <base> --file <ledger>`; it records `base_ok_sha` only when it decides `proceed`, and a "
+             f"rebase moves the head, which voids the stamp until it is re-run")
 
     rounds = counter(row, "review_rounds") + 1   # MONOTONE. Bumped before anything can go wrong below.
     if args.verdict == SATISFIED:
@@ -865,6 +922,46 @@ def cmd_verdict(path: Path, args) -> int:
         file=sys.stderr,
     )
     return EXIT_STOP
+
+
+def cmd_base_ok(path: Path, args) -> int:
+    """Record a base-preflight `proceed` for the row's CURRENT head — the ONLY sanctioned writer of
+    `base_ok_sha`, and the MECHANICAL half of the rebase-before-review precondition.
+
+    `cmd_verdict` refuses unless `base_ok_sha == head_sha`; this is what makes that pass. It is written by
+    `base-preflight.py check` when — and ONLY when — the decider reaches `proceed` for the live head, so the
+    stamp is a BYPRODUCT of the check actually running, never a value a driver types in (there is no `set`
+    flag: `PREFLIGHT_OWNED`). A forged stamp would authorize a verdict over a base no `proceed` ever cleared,
+    which is the waste this guard exists to stop.
+
+    Refusals, none of which write anything:
+      * no row — `fail` (exit 1);
+      * a `--head-sha` that is not a git object id (40 LOWERCASE hex) — a stamp bound to a non-commit makes
+        the `verdict` comparison unfalsifiable, refused before any write (the SHA discipline `verdict` and
+        `apply_head_sha` hold);
+      * a `--head-sha` that is not the row's current head — a `proceed` is meaningful for the LIVE head only,
+        so a stamp for any other SHA is refused (the same coherence rule `verdict` enforces).
+
+    The write is activity-EXEMPT (`base_ok_sha` is in `ACTIVITY_EXEMPT`): stamping a precondition is not the
+    run doing meaningful work, exactly as re-arming the watchdog is not.
+    """
+    header, rows = load(path)
+    pr = str(args.pr)
+    row = find_row(rows, pr)
+    if row is None:
+        fail(f"no row for pr {pr}; use `add-row` to create it")
+    if not SHA_RE.match(args.head_sha):
+        fail(f"--head-sha {args.head_sha!r} is not a git object id (40 LOWERCASE hex) — a base-preflight "
+             f"`proceed` is recorded AGAINST a commit, and a value that cannot be one makes the `verdict` "
+             f"base-currency check unfalsifiable")
+    if row["head_sha"] != args.head_sha:
+        fail(f"a `proceed` for {args.head_sha} does not match pr {pr}'s head {row['head_sha']} — a preflight "
+             f"clears the LIVE head only, so a stamp for any other SHA is refused. Reconcile the row against "
+             f"`gh` and re-run base-preflight on the current tip")
+    row["base_ok_sha"] = args.head_sha
+    save(path, header, rows, activity=False)  # exempt: stamping a precondition is not meaningful activity
+    print(json.dumps(row))
+    return 0
 
 
 def held_reason(status: str) -> str:
@@ -1230,6 +1327,16 @@ def build_parser() -> argparse.ArgumentParser:
     v.add_argument("--verdict", required=True, choices=VERDICTS,
                    help="the reviewer's VERDICT line, as the orchestrator read it")
 
+    # The ONLY sanctioned writer of `base_ok_sha` — there is no `--base-ok-sha` flag at `set`/`add-row`
+    # (PREFLIGHT_OWNED). `base-preflight.py check` calls this on a real `proceed`; nothing else records it.
+    b = sub.add_parser("base-ok", help="record a base-preflight `proceed` for the row's current head "
+                                       "(base_ok_sha) — the precondition `verdict` enforces; written only by "
+                                       "base-preflight.py on a real proceed, never hand-set")
+    b.add_argument("--pr", required=True, help="PR number (row key)")
+    b.add_argument("--head-sha", dest="head_sha", required=True,
+                   help="the head the `proceed` was decided for — must equal the row's head_sha, or the "
+                        "stamp describes a base check for content that is not the live tip and is refused")
+
     d = sub.add_parser("dispatch-check", help="may campaign ACT on this PR? run before every action that "
                                               f"MUTATES a PR; exits {EXIT_STOP} when the row is HELD")
     d.add_argument("--pr", required=True, help="PR number (row key)")
@@ -1284,6 +1391,7 @@ def main(argv: list[str]) -> int:
     path = Path(args.file)
     handlers = {
         "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set, "verdict": cmd_verdict,
+        "base-ok": cmd_base_ok,
         "get": cmd_get, "list": cmd_list, "table": cmd_table,
         "dispatch-check": cmd_dispatch_check, "park": cmd_park, "unpark": cmd_unpark,
         "watchdog": cmd_watchdog,

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -250,6 +250,9 @@ def _set_row(ledger: Path, pr, **fields) -> None:
 
 
 def _record_verdict(ledger: Path, pr, head_sha, verdict="satisfied") -> None:
+    # `verdict` refuses unless a base-preflight `proceed` is on record for THIS head
+    # (base_ok_sha == head_sha); stamp it first, exactly as the real flow does (base-preflight.py -> base-ok).
+    _ledger("--file", str(ledger), "base-ok", "--pr", str(pr), "--head-sha", head_sha)
     _ledger("--file", str(ledger), "verdict", "--pr", str(pr), "--head-sha", head_sha, "--verdict", verdict)
 
 


### PR DESCRIPTION
Makes the base-preflight `proceed` precondition MECHANICAL instead of advisory prose: a review verdict can no longer be recorded for a head that has no fresh `proceed`, so review rounds are never spent over a conflicting or stale base.

- New non-settable ledger field `base_ok_sha`, stamped only by `base-preflight.py` on a real `proceed` (via a new `ledger.py base-ok` door), bound to the exact head it verified.
- `ledger.py verdict` refuses (for both satisfied and not-satisfied) unless `base_ok_sha == head_sha`.
- `apply_head_sha` voids `base_ok_sha` on any head move, so a rebase/fix auto-invalidates a stale `proceed`.

Gate-safe by construction: the change can only ever REFUSE a verdict (never manufacture a SATISFIED or merge), and `ledger.py`/`base-preflight.py` run from the installed cache, so this branch's new rule is inert during its own review. `review-pass.py verify` stays offline/untouched. Implements follow-up fu46.
