### PR TITLE
fix(campaign): rebase behind PR at merge gate

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -40,11 +40,14 @@ yields `merge`), then confirms `origin/<base>` is an ancestor of `HEAD`. Both en
 - `not-yet <reason>` → do **NOT** merge; the reason names the block. Route on the reason's **action**
   (the phrase the tool emits), never on a hand-copied list of enum values — a value the tool newly parks
   then routes correctly with no edit here:
-  - `rebase` reasons (base moved ahead / conflicts) → refresh the PR per step 6.
+  - `rebase` reasons (base moved ahead / conflicts) → refresh the PR per step 6. A `BLOCKED` merge state
+    that is merely **behind its base** emits a `rebase` reason here (the tool probes ancestry before
+    parking), so it refreshes and re-gates rather than escalating to the user.
   - the tool's **`— park`** reasons (any `not-yet` reason that ends in `— park` / `park awaiting-user`)
     → park and name the blocker (below). This is the tool's catch-all for a merge GitHub blocks for a
-    cause campaign cannot clear itself — a draft, a `BLOCKED` merge state, **and any value neither enum
-    recognizes** — so routing on the `— park` action, not a fixed value list, keeps this bucket total.
+    cause campaign cannot clear itself — a draft, a `BLOCKED` merge state that is **up to date** (a genuine
+    human/ruleset block, not a stale base), **and any value neither enum recognizes** — so routing on the
+    `— park` action, not a fixed value list, keeps this bucket total.
   - `re-poll` reasons (merge state / mergeability not computed yet — `UNKNOWN`) → the **UNKNOWN re-poll
     bound** (below).
   - Everything else (`ci is …`, `N of M approvals`, `held`, stale head) → leave the PR; the next
@@ -69,7 +72,7 @@ the in-heartbeat cap is a fixed 3, and the coarse retry is the heartbeat loop it
 park whose exit event never comes is the same wedge it was meant to prevent. Run **`ledger.py … park --pr
 <N> --reason <the blocker>`** — the sanctioned writer of a non-CI machine-blocker park (`stage-2-ci.md`,
 "ESCALATE"). It sets `status = awaiting-user`, `ci_reason` = the blocker **named** (the draft state,
-`BLOCKED`, or the unrecognized value verbatim), and `blocker_ruling = -` in ONE atomic write (park entry
+an up-to-date `BLOCKED` merge state, or the unrecognized value verbatim), and `blocker_ruling = -` in ONE atomic write (park entry
 spends nothing and answers nothing — a ruling already on the row belongs to a **previous** park;
 `stage-2-ci.md`, "THE RULING IS CONSUMED EXACTLY ONCE"), and it refuses a blank reason, a terminal row, and
 a second park over an open question. It is then resolved through `blocker_ruling` = `retry` / `abort` — the
@@ -81,11 +84,15 @@ unparks a PR"; never invent a second mechanism here.
 
 **`BLOCKED` does NOT mean "a required check is missing or failing."** It means the merge is blocked **for
 any reason** — including a **draft** PR, or one **awaiting a human approving review**, or a ruleset
-campaign cannot read. Verified: `cli/cli` PR #13856 reads `BLOCKED` with `mergeable = MERGEABLE` **and a
-fully `SUCCESS` rollup**, purely because it is a draft. Mapping `BLOCKED` → `ci = pending` → "relaunch the
-CI watch" therefore **LIVELOCKS**: the CI is already green, no CI event will ever fire, campaign never
-approves PRs and never asks the user to — so it watches a settled PR forever. **Park it and name the
-blocker instead.**
+campaign cannot read, **or simply a branch that has fallen behind its base**. Verified: `cli/cli` PR #13856
+reads `BLOCKED` with `mergeable = MERGEABLE` **and a fully `SUCCESS` rollup**, purely because it is a draft.
+Mapping `BLOCKED` → `ci = pending` → "relaunch the CI watch" therefore **LIVELOCKS**: the CI is already
+green, no CI event will ever fire, campaign never approves PRs and never asks the user to — so it watches a
+settled PR forever. **Probe the base ancestry before parking: a `BLOCKED` PR that is only behind its base
+rebases (`merge-check.py` emits the `rebase` reason, verdicts carried), and only a `BLOCKED` PR proven up to
+date parks — name the blocker instead.** GitHub's merge-state enum is not a reliable "behind" signal (a
+behind PR can read `CLEAN` or `BLOCKED` under the same ruleset), so the Git ancestry check is the sound one,
+which is why `base-preflight.py` already runs it and the merge gate now matches.
 
 **`UNSTABLE` means non-*passing*, which includes *pending*.** Treating it as red would dispatch a CI-fix
 subagent at a check that is merely **still running**.

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -69,7 +69,9 @@ MERGE_STATE_STATUS_VALUES = frozenset(
 # The `mergeStateStatus` values that pass the ENUM screen. UNSTABLE and BLOCKED are about
 # CHECKS/PERMISSIONS, not a stale base. This is not proof the branch contains the refreshed base; the graph
 # check in `check` supplies that proof. DIRTY/BEHIND/UNKNOWN are deliberately ABSENT: each is handled by an
-# earlier rule in `decide`.
+# earlier rule in `decide`. NOTE: the downstream merge gate (`merge-check.py`) now runs this SAME
+# `check_base_ancestry` probe on BLOCKED before it parks — a BLOCKED PR that is only behind its base rebases
+# rather than escalating — so both gates treat BLOCKED identically (enum screen, then graph proof).
 BASE_CURRENT_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE", "BLOCKED"})
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -155,7 +155,10 @@ def t_mergestate_unstable():
 
 
 def t_mergestate_blocked():
-    expect(row(), view(mergeStateStatus="BLOCKED"), "not-yet", "GitHub says BLOCKED — park awaiting-user")
+    # BLOCKED is NO LONGER a final park at decide-level: `decide` returns the PROBE marker (it cannot tell a
+    # human/ruleset block from a merely-behind base without I/O), and `check` resolves it via the base-ancestry
+    # probe. The carried reason is the eventual park reason, used only when the probe proves the base current.
+    expect(row(), view(mergeStateStatus="BLOCKED"), M.PROBE, M.BLOCKED_PARK_REASON)
 
 
 def t_mergestate_unknown():
@@ -240,6 +243,52 @@ def t_cli_unverified_base_blocks_merge():
         "verdict": "not-yet",
         "reason": "could not verify base ancestry: could not fetch origin/main: unavailable",
     }, f"an unverified base must block merge, got {out!r}")
+
+
+def _cli_blocked(ancestry: tuple) -> "tuple[int, str, str]":
+    """Drive the real CLI over a BLOCKED view with a patched base-ancestry probe. BLOCKED routes to the PROBE
+    sentinel, so `check` resolves it HERE on `ancestry` — this exercises that resolution end to end."""
+    real_check = M.B.check_base_ancestry
+    M.B.check_base_ancestry = lambda *_args: ancestry
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1", base_branch="main"), [row()])
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view(mergeStateStatus="BLOCKED")), encoding="utf-8")
+            return capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    finally:
+        M.B.check_base_ancestry = real_check
+
+
+def t_cli_blocked_behind_rebases():
+    """THE #134 REGRESSION TEST: a BLOCKED PR that is BEHIND its base must route to REBASE, not park. Run
+    against the OLD code (BLOCKED -> final park) this parked awaiting-user; now it must emit the rebase reason
+    Stage 3 routes on to clean-rebase.py, so the verdicts carry forward and the PR merges."""
+    code, out, err = _cli_blocked(("stale", ""))
+    check(code == 0, f"a behind BLOCKED PR is a computed not-yet result (stderr: {err})")
+    check(json.loads(out) == {"verdict": "not-yet", "reason": "base moved ahead — rebase"},
+          f"a BLOCKED PR behind its base must route to rebase, not park, got {out!r}")
+
+
+def t_cli_blocked_current_parks():
+    """A BLOCKED PR proven up-to-date is a genuine human/ruleset block — it still parks awaiting-user."""
+    code, out, err = _cli_blocked(("current", ""))
+    check(code == 0, f"an up-to-date BLOCKED PR is a computed not-yet result (stderr: {err})")
+    check(json.loads(out) == {"verdict": "not-yet", "reason": "GitHub says BLOCKED — park awaiting-user"},
+          f"a BLOCKED PR that is up to date must still park, got {out!r}")
+
+
+def t_cli_blocked_unverified_leaves():
+    """A BLOCKED PR whose base ancestry cannot be read fails CLOSED: leave/re-poll (exit 1), never invent a
+    merge and never park on a transient. Mirrors the CLEAN-path unverified fixture."""
+    code, out, err = _cli_blocked(("unverified", "could not fetch origin/main: unavailable"))
+    check(code != 0, f"unverifiable ancestry on a BLOCKED PR must fail closed (stderr: {err})")
+    check(json.loads(out) == {
+        "verdict": "not-yet",
+        "reason": "could not verify base ancestry: could not fetch origin/main: unavailable",
+    }, f"an unverifiable BLOCKED PR must leave/re-poll, never merge or park, got {out!r}")
 
 
 def t_cli_no_ledger_row():
@@ -331,7 +380,7 @@ CASES = [
     ("mss-behind", "BEHIND -> rebase", t_mergestate_behind),
     ("mss-dirty", "DIRTY -> rebase", t_mergestate_dirty),
     ("mss-unstable", "UNSTABLE -> non-passing, not campaign's ci", t_mergestate_unstable),
-    ("mss-blocked", "BLOCKED -> park awaiting-user", t_mergestate_blocked),
+    ("mss-blocked", "BLOCKED -> probe base ancestry (rebase if behind, else park)", t_mergestate_blocked),
     ("mss-unknown", "UNKNOWN merge state -> re-poll", t_mergestate_unknown),
     ("mergeable-conflicting", "CONFLICTING decided on .mergeable alone", t_conflicting_mergeable),
     ("mergeable-unknown", "UNKNOWN mergeability -> re-poll", t_unknown_mergeable),
@@ -340,6 +389,10 @@ CASES = [
     ("cli-injected-view", "check --view-json decides without gh and exits 0", t_cli_injected_view),
     ("cli-stale-base", "a CLEAN candidate behind refreshed base cannot merge", t_cli_stale_base_blocks_merge),
     ("cli-unverified-base", "an unreadable base ancestry fails closed", t_cli_unverified_base_blocks_merge),
+    ("cli-blocked-behind", "a BLOCKED PR behind its base routes to rebase (the #134 fix)",
+     t_cli_blocked_behind_rebases),
+    ("cli-blocked-current", "a BLOCKED PR up to date still parks awaiting-user", t_cli_blocked_current_parks),
+    ("cli-blocked-unverified", "a BLOCKED PR with unreadable ancestry fails closed", t_cli_blocked_unverified_leaves),
     ("cli-no-row", "a PR absent from the ledger decides `no ledger row`", t_cli_no_ledger_row),
     ("cli-view-missing-field", "a view missing a field fails closed, never KeyError", t_cli_view_missing_field),
     ("cli-view-wrong-type", "a view field of the wrong JSON type fails closed", t_cli_view_wrong_type_field),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -16,7 +16,10 @@ two enums are crossed, so nobody does it by hand and nobody does it wrong.
 
 `.mergeable = MERGEABLE` is NECESSARY BUT NOT SUFFICIENT: it falls THROUGH to `.mergeStateStatus`, which is
 the only field that yields a preliminary `merge`. Before emitting `merge`, the shared preflight helper
-fetches the ledger base and proves it is an ancestor of the candidate `HEAD`. Both enums are mapped TOTALLY
+fetches the ledger base and proves it is an ancestor of the candidate `HEAD`. `BLOCKED` runs that SAME
+ancestry probe before it parks: a BLOCKED PR that is merely BEHIND its base is routed to a rebase (which the
+gate carries forward), not parked on the user; only a BLOCKED PR proven up-to-date is a genuine human/ruleset
+block and parks. The probe NEVER yields a new merge — it can only turn a park into a rebase. Both enums are mapped TOTALLY
 — every value GitHub's schema declares has its own row, and a value with NO row is a WEDGE, so the catch-all
 PARKS it rather than guessing. This mapping
 is the OWNER of the merge-readiness decision; `references/stage-3-merge.md` now DELEGATES that decision to a
@@ -79,19 +82,24 @@ MERGEABLE = {
     "UNKNOWN": "mergeability not computed yet — re-poll",
 }
 
-# `.mergeStateStatus` — CLEAN and HAS_HOOKS are the ONLY two that clear the merge; every other value is a
-# terminal not-yet. This mapping is the OWNER of the merge-readiness decision; `stage-3-merge.md` DELEGATES
-# to it. A value with no row here parks via the catch-all in `decide`, never guesses; the sibling fixtures
-# pin every value's verdict.
+# `.mergeStateStatus` — CLEAN and HAS_HOOKS are the ONLY two that can clear the merge; BLOCKED cannot be
+# decided by `decide` alone (it might merely be BEHIND its base, which a rebase fixes), so it routes to the
+# PROBE sentinel and `check` resolves it with the base-ancestry probe it already runs for the merge path;
+# every other value is a terminal not-yet. This mapping is the OWNER of the merge-readiness decision;
+# `stage-3-merge.md` DELEGATES to it. A value with no row here parks via the catch-all in `decide`, never
+# guesses; the sibling fixtures pin every value's verdict.
 MERGE = "merge"
 NOT_YET = "not-yet"
+PROBE = "probe-base"                              # BLOCKED: decide can't finish; check() resolves via ancestry
+REBASE_REASON = "base moved ahead — rebase"       # Stage 3 routes on the `rebase` phrase to clean-rebase.py
+BLOCKED_PARK_REASON = "GitHub says BLOCKED — park awaiting-user"
 MERGE_STATE_STATUS = {
     "CLEAN": (MERGE, ""),
     "HAS_HOOKS": (MERGE, ""),
-    "BEHIND": (NOT_YET, "base moved ahead — rebase"),
+    "BEHIND": (NOT_YET, REBASE_REASON),
     "DIRTY": (NOT_YET, "conflicts — rebase"),
     "UNSTABLE": (NOT_YET, "a check is non-passing (may still be running) — not campaign's ci signal"),
-    "BLOCKED": (NOT_YET, "GitHub says BLOCKED — park awaiting-user"),
+    "BLOCKED": (PROBE, BLOCKED_PARK_REASON),
     "UNKNOWN": (NOT_YET, "merge state not computed yet — re-poll"),
 }
 
@@ -102,6 +110,12 @@ def _merge() -> dict:
 
 def _not_yet(reason: str) -> dict:
     return {"verdict": NOT_YET, "reason": reason}
+
+
+def _probe(reason: str) -> dict:
+    """A BLOCKED verdict `decide` cannot finish: `check` runs the base-ancestry probe and resolves it to
+    rebase (behind) / park (up-to-date, the carried `reason`) / leave (unverifiable). NEVER printed."""
+    return {"verdict": PROBE, "reason": reason}
 
 
 def _short(sha: str) -> str:
@@ -169,7 +183,11 @@ def decide(row: dict, view: dict, *, required) -> dict:
     if row_mss is None:
         return _not_yet(f"unknown merge state {mss} — park, never guess")
     verdict, reason = row_mss
-    return _merge() if verdict == MERGE else _not_yet(reason)
+    if verdict == MERGE:
+        return _merge()
+    if verdict == PROBE:
+        return _probe(reason)
+    return _not_yet(reason)
 
 
 # --- obtain the live PR view ---------------------------------------------------
@@ -255,21 +273,28 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
         print(json.dumps(_not_yet(f"malformed PR view: {problem}")))
         return 1
     result = decide(row, view, required=REQUIRED)
-    if result["verdict"] != MERGE:
+    verdict = result["verdict"]
+    if verdict == NOT_YET:
         print(json.dumps(result))
         return 0
 
-    # GitHub may still call the PR MERGEABLE/CLEAN after an earlier campaign merge advances an unprotected
-    # base. Re-fetch and compare actual ancestry before the final merge decision; the shared preflight helper
-    # owns the graph check so review dispatch and Stage 3 cannot disagree about what "current base" means.
+    # MERGE and PROBE (BLOCKED) BOTH resolve here on the same base-ancestry probe; they differ ONLY in the
+    # `current` outcome. GitHub may still call a PR MERGEABLE/CLEAN after an earlier campaign merge advances an
+    # unprotected base, and a BLOCKED PR may merely be BEHIND its base — a rebase fixes both. So re-fetch and
+    # compare actual ancestry before the final decision; the shared preflight helper owns the graph check so
+    # review dispatch and Stage 3 cannot disagree about what "current base" means.
     ancestry, detail = B.check_base_ancestry(row.get("worktree"), header.get("base_branch"), "origin")
-    if ancestry == "stale":
-        print(json.dumps(_not_yet("base moved ahead — rebase")))
+    if ancestry == "stale":                       # behind base -> rebase (BOTH paths; never a merge)
+        print(json.dumps(_not_yet(REBASE_REASON)))
         return 0
-    if ancestry == "unverified":
+    if ancestry == "unverified":                  # fail closed -> leave/re-poll (BOTH paths)
         print(json.dumps(_not_yet(f"could not verify base ancestry: {detail}")))
         return 1
-    print(json.dumps(result))
+    # ancestry == current: MERGE clears; PROBE (BLOCKED but up-to-date) is a genuine human/ruleset block -> park.
+    if verdict == MERGE:
+        print(json.dumps(_merge()))
+        return 0
+    print(json.dumps(_not_yet(result["reason"])))
     return 0
 
 


### PR DESCRIPTION
## Purpose

Make the stage-3 merge gate consistent with base-preflight: a PR whose
GitHub `mergeStateStatus` is `BLOCKED` is no longer parked blindly. The gate
now probes base ancestry and, when the PR is merely **behind** its base,
routes it to a clean rebase instead of parking for a human.

## Why

A fully-gated merge candidate (2 SATISFIED verdicts, green CI) can still be
refused by GitHub with "the base branch policy prohibits the merge" purely
because its branch is behind `main`. `base-preflight.py` already handles this
at review/reconcile time (probe `git merge-base --is-ancestor`; behind →
rebase-first), but `merge-check.py` was the one gate that parked a `BLOCKED`
PR without that probe — sending a rebase-fixable PR to `awaiting-user`.

Deriving an "up-to-date required" signal from the ruleset was investigated and
rejected: the only ruleset on `main` is `deletion` + `non_fast_forward`, and
the merge-state enum is an unreliable proxy (a behind PR can report `CLEAN`;
another reports `BLOCKED` under the identical ruleset). The sound signal is the
ancestry probe the campaign already owns.

## Change (PROBE shape)

- `merge-check.py`: `BLOCKED` routes to an internal `PROBE` outcome, parallel
  to the existing `MERGEABLE → FALL_THROUGH` deferral. `check()` runs the
  shared `base-preflight` ancestry probe for both `MERGE` and `PROBE`: behind →
  `not-yet` with a `rebase` reason (stage 3 routes on that phrase to
  `clean-rebase.py`, verdicts carried); up-to-date → park unchanged;
  ancestry unverifiable → fail closed. No new route yields a `merge` verdict —
  strictly more conservative.
- Restatement sweep across `stage-3-merge.md`, the table/comments/docstring,
  and `base-preflight.py`'s cross-reference note.
- Regression + unit fixtures: `blocked_behind_rebases` (the reproduced #134
  case), `blocked_current_parks`, `blocked_unverified_leaves`.