### PR TITLE
docs(campaign): drop stale openssl references

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -9,7 +9,7 @@ have `ci-snapshot.py`. The lease had four reference docs and an `echo`.
 And it is not a value-write — it is a CHECK-AND-SET: take a lock, read, decide, write, read back, unlock,
 plus a stale-lock sweep and a staleness rule. Hand-rolled from prose, on every heartbeat, by a fresh agent
 instance that remembers nothing. In run `g260717-1748-d76f0acb` a driver hand-rolled it with
-`mkdir`/`openssl`/`echo`/`rmdir`, eyeballed the read-back instead of comparing tokens, and skipped the
+`mkdir`/`echo`/`rmdir`, eyeballed the read-back instead of comparing tokens, and skipped the
 stale-lock sweep entirely. It was safe only because the lease was absent and nobody else was driving.
 
 Four refusals this file exists to make, each one a thing the prose left undefined or a well-meaning driver

--- a/plugins/gauntlet/skills/campaign/scripts/run-id.py
+++ b/plugins/gauntlet/skills/campaign/scripts/run-id.py
@@ -3,7 +3,7 @@
 
 A run-id namespaces everything a run owns — its `<rundir>`, its ledger, and its `gauntlet-run-<run-id>`
 PR labels. Until now, minting one was an inline shell snippet in `run-identity-and-lease.md`
-(`run_id="g$(date +%y%m%d-%H%M)-$(openssl rand -hex 4)"`) and the "create the run dir atomically, retry on
+(a minute-resolution timestamp plus a short random hex suffix) and the "create the run dir atomically, retry on
 the rare clash" step was adapter **pseudocode** (`create_run_directory(...)`) with no bundled
 implementation. THIS script now owns both — the mint and the atomic create + retry — and the adapter's
 `create_run_directory` delegates here. That
@@ -32,8 +32,8 @@ from _gauntlet.modules import load_module_from_path
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "run-id-test.py"
 
-# `openssl rand -hex 4` in the prose = 4 bytes = 8 hex chars = 32 bits, the same width `lease.py mint`
-# uses for the agent token. Kept identical so the two random values read the same.
+# 4 bytes = 8 hex chars = 32 bits, the same width `lease.py mint` uses for the agent token.
+# Kept identical so the two random values read the same.
 RAND_BYTES = 4
 # Minute-resolution timestamps collide only for runs started in the same minute; the random suffix then
 # carries uniqueness, and the atomic mkdir + retry is the backstop. A handful of attempts is plenty — the


### PR DESCRIPTION
## Purpose

Remove the three residual `openssl` references from campaign script
comments. They are stale: run-id and agent-token minting are already
implemented in Python via the stdlib `secrets` module (`run-id.py` uses
`secrets.token_hex(RAND_BYTES)`, `lease.py mint` uses `secrets.token_hex(4)`),
and `openssl` is never executed anywhere in the tree. The comments described
an old inline-shell prose form (`openssl rand -hex 4`) that the Python code
replaced, so they read as a live dependency that no longer exists.

## Change

Comment-only, no behavior change:
- `run-id.py`: reword the two comments that quoted `openssl rand -hex 4` to
  describe the timestamp + random hex suffix and the 4-byte width directly.
- `lease.py`: drop `openssl` from the hand-rolled-shell anti-pattern list
  (`mkdir`/`echo`/`rmdir` still illustrate it).

The random-value width (4 bytes = 8 hex = 32 bits, matched between run-id and
token) and every other rationale in those comments is preserved.