### PR TITLE
fix(campaign): rebase behind PR at merge runner

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -53,7 +53,8 @@ class Fake:
                  view_head: "str | None" = None, view_branch: "str | None" = None,
                  view_base: "str | None" = None, base: str = "main",
                  labels: "list[dict] | None" = None, local_base: str = "absent",
-                 repo_identity: str = "o/r"):
+                 repo_identity: str = "o/r", mergeable: str = "MERGEABLE",
+                 merge_state_status: str = "CLEAN"):
         self.root = root
         self.branch = "feat-pr"
         self.base = base
@@ -95,6 +96,11 @@ class Fake:
         # ("o/r"), so existing fixtures pass the cross-repo guard; overriding it models a `--repo` that does
         # NOT name the checkout's own repository (the fail-closed the guard refuses before any live view).
         self.repo_identity = repo_identity
+        # The two GitHub merge enums the live view reports. Default MERGEABLE/CLEAN yields merge-check's MERGE
+        # verdict; overriding merge_state_status to "BLOCKED" yields its PROBE sentinel, which the runner must
+        # resolve through the SAME base-ancestry probe the MERGE path runs (behind -> rebase, current -> park).
+        self.mergeable = mergeable
+        self.merge_state_status = merge_state_status
 
     def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
                run_id="g1", worktree_field: "str | None" = None) -> None:
@@ -117,8 +123,8 @@ class Fake:
             "headRefName": self.view_branch,
             "baseRefName": self.view_base,
             "labels": self.labels,
-            "mergeable": "MERGEABLE",
-            "mergeStateStatus": "CLEAN",
+            "mergeable": self.mergeable,
+            "mergeStateStatus": self.merge_state_status,
             "isDraft": False,
         }
 
@@ -324,6 +330,42 @@ def t_gate_refusals():
             check(f.merged_calls == 0, f"{kwargs} reached merge")
         finally:
             finish(td, real)
+
+
+def t_blocked_probe_rebases_when_behind_parks_when_current():
+    # merge-check.decide returns its PROBE sentinel (not MERGE) for a BLOCKED PR, because BLOCKED alone
+    # cannot tell a genuine human/ruleset block from one that is merely BEHIND its base. The runner must
+    # resolve PROBE through the SAME base-ancestry probe the MERGE path runs, mirroring merge-check.check():
+    #   * BLOCKED + behind base  -> the rebase refusal (routes to a rebase, NOT a park).
+    #   * BLOCKED + current base  -> the genuine park refusal (up-to-date human/ruleset block).
+    # RED before the fix: _require_ready refused every non-MERGE verdict with the park reason immediately,
+    # so a behind-BLOCKED PR was parked instead of rebased and the ancestry probe never ran.
+
+    # BLOCKED + behind base: fail_once="stale-base" makes the worktree ancestry probe report behind (exit 1).
+    td, root, f, led, real = scenario(merge_state_status="BLOCKED", fail_once="stale-base")
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "base moved ahead" in err,
+              f"BLOCKED-behind must route to a rebase, not a park: code={code} err={err!r}")
+        check(f.merged_calls == 0, "a BLOCKED PROBE must never reach the merge command")
+        # The probe must actually have run — the rebase verdict comes from the ancestry check, not decide.
+        check(any(argv[:5] == ["git", "-C", str(f.worktree), "merge-base", "--is-ancestor"]
+                  for argv, _ in f.calls),
+              "the runner did not run the base-ancestry probe for a BLOCKED PROBE")
+    finally:
+        finish(td, real)
+
+    # BLOCKED + current base: the ancestry probe passes, so it is a genuine block and parks.
+    td, root, f, led, real = scenario(merge_state_status="BLOCKED")
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "BLOCKED" in err,
+              f"BLOCKED-current must park as a genuine block: code={code} err={err!r}")
+        check("base moved ahead" not in err, f"an up-to-date BLOCKED PR must not be told to rebase: {err}")
+        check(f.merged_calls == 0, "a parked BLOCKED PROBE must never reach the merge command")
+        check(status(led) == "in_review", "a parked BLOCKED row must stay live, not terminate")
+    finally:
+        finish(td, real)
 
 
 def t_stale_head_and_malformed_ownership_refused():
@@ -942,6 +984,7 @@ CASES = [
     ("ownership-matrix", "all worktree/branch ownership combinations clean only owned resources", t_reused_resources_are_left),
     ("root-foreign", "root cleanup and foreign branch are refused before merge", t_root_and_foreign_targets_refused),
     ("gate-refusals", "held, stale, red, pending, and short-tally rows never merge", t_gate_refusals),
+    ("blocked-probe-ancestry", "a BLOCKED PROBE resolves via the base-ancestry probe: behind rebases, up-to-date parks; neither merges", t_blocked_probe_rebases_when_behind_parks_when_current),
     ("stale-malformed", "stale live SHA and malformed ownership fail closed", t_stale_head_and_malformed_ownership_refused),
     ("owner-and-view", "another run and uncertain GitHub state fail closed", t_owner_label_and_uncertain_view_refused),
     ("base-location", "checked-out and absent local base use their documented update paths", t_base_checked_out_and_absent),

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -248,11 +248,22 @@ def _base_is_current(row: dict, header: dict) -> None:
 
 
 def _require_ready(row: dict, header: dict, view: dict) -> None:
-    """Delegate policy to merge-check.py, then supply its fetched-base ancestry phase."""
+    """Delegate policy to merge-check.py, then supply its fetched-base ancestry phase.
+
+    merge-check.decide returns MERGE only for CLEAN/HAS_HOOKS; a BLOCKED PR is left as the PROBE sentinel
+    because `decide` alone cannot tell a genuine block from one that is merely BEHIND its base. Mirror
+    merge-check.check(): the ancestry probe runs for BOTH the MERGE and PROBE verdicts. `_base_is_current`
+    raises the rebase Refusal when the PR is behind its base, so a BLOCKED-behind PR is routed to a rebase
+    exactly as the gate does — NOT parked. A PROBE that survives the probe is BLOCKED-but-current: a genuine
+    human/ruleset block that parks. PROBE never reaches an actual merge; it can only refuse (rebase or park).
+    """
     result = MC.decide(row, view, required=MC.REQUIRED)
-    if result.get("verdict") != MC.MERGE:
+    verdict = result.get("verdict")
+    if verdict not in (MC.MERGE, MC.PROBE):
         raise Refusal(f"merge-check: {result.get('reason', 'not ready')}")
     _base_is_current(row, header)
+    if verdict == MC.PROBE:
+        raise Refusal(f"merge-check: {MC.BLOCKED_PARK_REASON}")
 
 
 def _parse_worktrees(data: str) -> list[dict[str, str]]:


### PR DESCRIPTION
## Purpose

Make the merge RUNNER (`merge.py`) handle a `BLOCKED` PR consistently with the
stage-3 gate (`merge-check.py`). Found by a whole-codebase coherence review.

## The incoherence

`merge-check.py` (updated in #137) routes a `BLOCKED` `mergeStateStatus` to an
internal `PROBE` outcome and resolves it by base-ancestry: **behind base →
rebase**, up-to-date-but-`BLOCKED` → park. But `merge.py`'s `_require_ready`
calls `MC.decide` (the pure decision), gets `PROBE` for `BLOCKED`, and its old
`!= MC.MERGE` guard refused with the **park** reason immediately — never
running its own base-ancestry probe (`_base_is_current`, which only ran on the
`MERGE` path). So a behind-`BLOCKED` PR reaching the runner was **parked
instead of rebased** — the exact behavior #137 fixed at the gate, still wrong
one layer down. Fail-closed (never a wrong merge), but incoherent: #134 added
the runner and #137 taught the gate the new behavior; the runner never learned
`PROBE`.

## Change

`_require_ready` now runs the ancestry probe for both `MERGE` and `PROBE`,
mirroring `merge-check.check()`: behind → rebase Refusal; up-to-date `BLOCKED`
→ park Refusal (`MC.BLOCKED_PARK_REASON`). `PROBE` still never reaches an
actual merge — only refuse-with-rebase or refuse-with-park. The `MERGE` path
and every other non-MERGE verdict are unchanged; no new route to a merge.

Regression fixture `blocked-probe-ancestry`: behind-`BLOCKED` → rebase (and the
probe ran); current-`BLOCKED` → park; neither merges. Verified RED without the
fix. 29 runner fixtures + 30 merge-check fixtures + pyright + validate-plugins
all green.