### PR TITLE
feat(campaign): add ledger row base ownership

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -126,12 +126,15 @@ shortened SHA into the store, and never reconstruct one from a display.** The ON
 shortened is `table`'s rendering (below) — that is display-only and does not exist on disk.
 
 Header-record fields: `run_id` (this run's identity — namespaces its dir/label/heartbeats; set once),
-`base_branch` (the adopted PRs' baseRefName — the branch they merge into & diffs measure against; set
-once, see "Base branch"), `api_changes` (`ask` | `allowed`, run-wide; set once from the invocation),
-`reviewer` (`default` (per-host cross-engine route with native fallback — see "The reviewer") | `codex` | `claude` | `<other>` — the selected reviewer; set once, see
-"The reviewer"), `required_set` (what `base_branch` **requires** — `stage-2-ci.md`, "What were we
-expecting to see?", owns the three states, the format, and the reads that produce them; re-read every
-heartbeat while it is `unknown`), `skill_version` (**which copy of the rules actually governed this run**),
+`base_branch` (**the LEGACY base fallback** — the base a PR merges into is now **per-row** state, and this
+header field is only what a row carrying no explicit base inherits through `effective_base`; see "Base
+branch" and the row `base_branch` field below), `api_changes` (`ask` | `allowed`, run-wide; set once from
+the invocation), `reviewer` (`default` (per-host cross-engine route with native fallback — see "The
+reviewer") | `codex` | `claude` | `<other>` — the selected reviewer; set once, see "The reviewer"),
+`required_set` (**the LEGACY required-set fallback** — the required set is now **per-row** state too, and
+this header field is only what a row carrying no explicit set inherits through `effective_required_set`;
+`stage-2-ci.md`, "What were we expecting to see?", owns the three states and the format; see the row
+`required_set` field below), `skill_version` (**which copy of the rules actually governed this run**),
 `last_activity` (**when this run last did something MEANINGFUL** — a UTC ISO-8601 stamp the write doors
 maintain; the quiet-run sensor `nudge.py` reads, defined below), `watchdog_due` (**the durable
 health-pass deadline** — a UTC ISO-8601 stamp `ledger.py watchdog` stamps and reads, defined below),
@@ -147,12 +150,14 @@ the run recorded which version it was**, so no report could say so, and the fail
 human went looking. It defaults to `unknown` for the same reason `required_set` does: *"I did not look"* is
 a different fact from any version number, and must never be spelled as one.
 
-`required_set` is a property of the **base branch**, not of a PR, which is why it lives in the header. It
-defaults to **`unknown`**, and that default is **load-bearing, not a placeholder**: `unknown` **cannot go
-green** (`stage-2-ci.md`), so a run that never performed the read merges **nothing**. **"I have not
-looked" and "I looked and there are none" are different facts**, and the default is the one that claims
-nothing — a `none` that really meant "I could not see" is how a green gets recorded for a commit whose
-required check never registered.
+The header `required_set` is a property of the **base branch** — and the base is now **per-row** state, so
+the canonical required set is a **row field** too (below). This header field is the **legacy fallback**
+`effective_required_set` reads for a row that carries no explicit set; an old single-base ledger keeps its
+header value and every one of its rows inherits it. It defaults to **`unknown`**, and that default is
+**load-bearing, not a placeholder**: `unknown` **cannot go green** (`stage-2-ci.md`), so a run that never
+performed the read merges **nothing**. **"I have not looked" and "I looked and there are none" are
+different facts**, and the default is the one that claims nothing — a `none` that really meant "I could not
+see" is how a green gets recorded for a commit whose required check never registered.
 
 `last_activity` records **when this run last did something MEANINGFUL**, so a fresh-context heartbeat can
 tell **how long nothing has moved** without holding the history in its head — the same lesson as
@@ -293,6 +298,28 @@ Header field notes (the header fields above; per-row fields follow):
   row goes **`repairing`** and the command **exits non-zero** (`repair-pass.md` owns the caps, the
   reassessment, and the repair). **This paragraph is the owner of the sensors-and-fused-reader design
   rationale** — the procedure docs point here rather than restate it.
+- `base_branch` — **the base this PR merges into**, the target `baseRefName` recorded once, at adoption,
+  from live GitHub. A run may hold rows on **different** bases, so the base is **per-row**, not per-run; the
+  header `base_branch` is only the **legacy fallback** a row with none inherits. **Resolve it through
+  `ledger.py`'s `effective_base(header, row)`** — an explicit row value, else the header — and **never read
+  either raw field directly**; that accessor is the one place the fallback lives. It is **TOOL-OWNED and
+  IMMUTABLE after creation** (`CREATE_ONLY` in `scripts/ledger.py`): `add-row` writes it and **`set` has no
+  `--base-branch` flag**, so the recorded base can never be rewritten — the campaign does not migrate a row
+  to a new base. The default is **`-`**, which is both the schema's "not set" spelling **and** its "inherit
+  the legacy header" signal, and is **DISTINCT from any explicit base name**: a `-` row inherits, an
+  explicit-base row does not — which is what lets one run mix legacy inheriting rows with new explicit-base
+  rows. An old ledger's rows read back `-` and resolve exactly as they always did, with no migration.
+- `required_set` — **the canonical required-check set for this row's effective base**. Required checks are a
+  property of the base, and the base is row state, so this is too; the header `required_set` is the **legacy
+  fallback**. **Resolve it through `effective_required_set(header, row)`** — an explicit row value, else the
+  header. Its three states (`declared:<json>` / `none` / `unknown`) are owned by `stage-2-ci.md` exactly as
+  the header field's are. Unlike `base_branch` it is **an ordinary settable field** — the grouped
+  required-set refresh writes the canonical value through `set`. The default is **`-`**, which — like
+  `base_branch` — means **inherit the header**, and is **DISTINCT from `unknown`**: `-` says "this row owns
+  no set; read the header", while `unknown` is an **explicit** row value meaning a read for THIS base was
+  attempted and failed, so it **fails closed and cannot go green** and must **never** be silently replaced
+  by the header. An old row reads back `-` and inherits; a new run writes `unknown` per row until a grouped
+  read succeeds.
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it
@@ -601,6 +628,11 @@ human*, and the formatting is lossy in four ways:
   hand-typed list of hidden fields would be **stale the next time a row field is added — by a change its
   author never sees**, and that is exactly how this paragraph broke before: it named seven hidden fields,
   a later PR added six more row fields, and neither author touched the other's work.
+
+  One default column is **not a stored field at all**: `base` is **computed** — `effective_base(header,
+  row)`, the row's resolved base (`TABLE_BASE_COLUMN` in `scripts/ledger.py`) — so a `-` row shows the
+  header base it inherits rather than a bare `-`. It is **display-only and decides nothing**; the raw stored
+  value is still `ledger.py … get --pr N --field base_branch`, and `--fields base_branch` prints it raw.
 - **It shortens the SHA.** `table` prints `head_sha` truncated to its first **8 characters**. This is a
   **display-only** truncation and applies to **`table` alone** — nothing else in campaign ever shortens a
   SHA. The stored value, and the one every other subcommand returns, stays the full 40-char `headRefOid`:

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -602,8 +602,9 @@ review-standoff park/unpark (`finding-audit.md`) is answered through `finding-au
 recorded (`set --blocker-ruling retry@<iso>`), which `unpark` then consumes.
 
 `table` is the user-facing status view: the end-of-heartbeat report renders it whenever the run goes back
-to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and decides nothing — no gate
-logic, no derived values.
+to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and makes NO gate decisions; its
+one computed value is the display-only `base` column (the `base` bullet under "It shows only SOME fields",
+below).
 
 **Read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.
 A SHA (or any value) recovered from `table`'s grid is a truncated, escaped rendering, and feeding one back

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -298,11 +298,15 @@ Header field notes (the header fields above; per-row fields follow):
   row goes **`repairing`** and the command **exits non-zero** (`repair-pass.md` owns the caps, the
   reassessment, and the repair). **This paragraph is the owner of the sensors-and-fused-reader design
   rationale** — the procedure docs point here rather than restate it.
-- `base_branch` — **the base this PR merges into**, the target `baseRefName` recorded once, at adoption,
-  from live GitHub. A run may hold rows on **different** bases, so the base is **per-row**, not per-run; the
-  header `base_branch` is only the **legacy fallback** a row with none inherits. **Resolve it through
-  `ledger.py`'s `effective_base(header, row)`** — an explicit row value, else the header — and **never read
-  either raw field directly**; that accessor is the one place the fallback lives. It is **TOOL-OWNED and
+- `base_branch` — **the base this PR merges into**, the target `baseRefName` from live GitHub, written
+  once at row creation (`add-row --base-branch`). A run may hold rows on **different** bases, so the base
+  is **per-row**, not per-run; the header `base_branch` is only the **legacy fallback** a row with none
+  inherits. `ledger.py`'s `effective_base(header, row)` — an explicit row value, else the header — is the
+  one place the fallback lives, and it is the **sanctioned door** for resolving a row's base. **This is
+  stage 1 of 3: the field and the resolver exist, and consumers are deliberately unchanged** — today only
+  `table`'s computed, display-only `base` column resolves per row; adoption does not yet record an explicit
+  row base, and every other consumer still reads the header field directly. Stages 2-3 move them through
+  the resolver. It is **TOOL-OWNED and
   IMMUTABLE after creation** (`CREATE_ONLY` in `scripts/ledger.py`): `add-row` writes it and **`set` has no
   `--base-branch` flag**, so the recorded base can never be rewritten — the campaign does not migrate a row
   to a new base. The default is **`-`**, which is both the schema's "not set" spelling **and** its "inherit
@@ -311,15 +315,17 @@ Header field notes (the header fields above; per-row fields follow):
   rows. An old ledger's rows read back `-` and resolve exactly as they always did, with no migration.
 - `required_set` — **the canonical required-check set for this row's effective base**. Required checks are a
   property of the base, and the base is row state, so this is too; the header `required_set` is the **legacy
-  fallback**. **Resolve it through `effective_required_set(header, row)`** — an explicit row value, else the
-  header. Its three states (`declared:<json>` / `none` / `unknown`) are owned by `stage-2-ci.md` exactly as
-  the header field's are. Unlike `base_branch` it is **an ordinary settable field** — the grouped
-  required-set refresh writes the canonical value through `set`. The default is **`-`**, which — like
+  fallback**. `effective_required_set(header, row)` — an explicit row value, else the header — is the
+  resolver, the same sanctioned door as `effective_base` and **staged the same way: the resolver exists
+  today, and consumers still read the header field directly until stages 2-3 move them.** Its three states
+  (`declared:<json>` / `none` / `unknown`) are owned by `stage-2-ci.md` exactly as the header field's are.
+  Unlike `base_branch` it is **an ordinary settable field** — the stage-2 grouped required-set refresh will
+  write the canonical value through `set`, so that door stays open. The default is **`-`**, which — like
   `base_branch` — means **inherit the header**, and is **DISTINCT from `unknown`**: `-` says "this row owns
   no set; read the header", while `unknown` is an **explicit** row value meaning a read for THIS base was
   attempted and failed, so it **fails closed and cannot go green** and must **never** be silently replaced
-  by the header. An old row reads back `-` and inherits; a new run writes `unknown` per row until a grouped
-  read succeeds.
+  by the header. An old row reads back `-` and inherits; once stages 2-3 land, a new run will write
+  `unknown` per row until a grouped read succeeds.
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2447,10 +2447,11 @@ def t_row_base_is_creation_only(L: ModuleType, tmp: Path) -> None:
     # …and the stored base is untouched by the refused write.
     code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "base_branch"])
     check(out == "v3\n", f"the recorded base changed despite the refusal: {out!r}")
-    # `required_set` is NOT creation-only: the grouped refresh rewrites it through `set`.
-    check("required_set" not in L.CREATE_ONLY, "required_set must stay settable via `set` — grouped refresh writes it")
+    # `required_set` is NOT creation-only: the stage-2 grouped refresh will rewrite it through `set`.
+    check("required_set" not in L.CREATE_ONLY,
+          "required_set must stay settable via `set` — the stage-2 grouped refresh will write it")
     code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--required-set", "none"])
-    check(code == 0, f"`set --required-set` must be allowed for the grouped refresh: exit {code}, {err!r}")
+    check(code == 0, f"`set --required-set` must stay open for the stage-2 grouped refresh: exit {code}, {err!r}")
 
 
 def t_required_set_dash_vs_unknown(L: ModuleType, tmp: Path) -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2369,6 +2369,156 @@ def t_pending_adoption_is_an_ordinary_field(L: ModuleType, tmp: Path) -> None:
     check(header_field(L, path, "last_activity") == FROZEN_B, "clearing pending_adoption is also activity")
 
 
+# --- row-owned base / required set, with the header as the LEGACY FALLBACK -------------------------------
+#
+# `base_branch` and `required_set` are per-ROW state now; the header fields are only what a row with no
+# explicit value inherits. These fixtures pin the schema half of static mixed-base support (the consumers
+# that resolve through the accessors are converted in a later stage): the two accessors, the immutable
+# creation-only row base, and the `-` (inherit) vs `unknown` (explicit, fail-closed) distinction.
+
+def t_old_ledger_resolves_through_the_header(L: ModuleType, tmp: Path) -> None:
+    """An old ledger — written before the row base fields existed — loads and resolves through the header.
+
+    Every row lacks `base_branch`/`required_set`, so each back-fills to `-` (the schema's "inherit the
+    header" spelling), and `effective_base`/`effective_required_set` return the header's values: the exact
+    behavior a single-base run had before these fields existed, with no migration and no file rewrite.
+    """
+    path = write_lines(
+        tmp / "old.jsonl",
+        header_line(L, run_id="r1", base_branch="main",
+                    required_set='declared:[{"context": "test"}]'),
+        json.dumps({"type": "row", "pr": "41", "slug": "old", "head_sha": SHA_A}),
+    )
+    # The row carries neither field on disk, and both read back as the `-` inherit default.
+    code, out, err = cli(L, ["--file", str(path), "get", "--pr", "41"])
+    check(code == 0, f"get on a pre-base-field row exited {code}: {err!r}")
+    row = json.loads(out)
+    check(row["base_branch"] == "-", f"an old row's base_branch must back-fill to `-`: {row['base_branch']!r}")
+    check(row["required_set"] == "-", f"an old row's required_set must back-fill to `-`: {row['required_set']!r}")
+    # …and the accessors resolve that `-` to the header — the legacy value, unchanged.
+    header, rows = L.load(path)
+    check(L.effective_base(header, rows[0]) == "main",
+          f"effective_base of a `-` row must inherit the header: {L.effective_base(header, rows[0])!r}")
+    check(L.effective_required_set(header, rows[0]) == 'declared:[{"context": "test"}]',
+          f"effective_required_set of a `-` row must inherit the header: "
+          f"{L.effective_required_set(header, rows[0])!r}")
+
+
+def t_new_row_owns_its_base(L: ModuleType, tmp: Path) -> None:
+    """A new row stores an explicit base, and the accessors return IT — never the header — for that row.
+
+    This is what lets one run mix bases: the header can say one thing (or `-`) while a row on `v3` and a row
+    on `main` each resolve to their own recorded base.
+    """
+    path = write_lines(tmp / "new.jsonl", header_line(L, run_id="r2", base_branch="-", required_set="unknown"))
+    code, _, err = cli(L, ["--file", str(path), "add-row", "--pr", "52", "--base-branch", "v3",
+                           "--required-set", 'declared:[{"context": "v3-test"}]'])
+    check(code == 0, f"add-row with an explicit base exited {code}: {err!r}")
+    code, _, err = cli(L, ["--file", str(path), "add-row", "--pr", "53", "--base-branch", "main"])
+    check(code == 0, f"add-row with an explicit base exited {code}: {err!r}")
+    header, rows = L.load(path)
+    by_pr = {r["pr"]: r for r in rows}
+    check(L.effective_base(header, by_pr["52"]) == "v3",
+          f"an explicit row base must win over the header: {L.effective_base(header, by_pr['52'])!r}")
+    check(L.effective_base(header, by_pr["53"]) == "main",
+          f"an explicit row base must win over the header: {L.effective_base(header, by_pr['53'])!r}")
+    check(L.effective_required_set(header, by_pr["52"]) == 'declared:[{"context": "v3-test"}]',
+          f"an explicit row required_set must win over the header: "
+          f"{L.effective_required_set(header, by_pr['52'])!r}")
+
+
+def t_row_base_is_creation_only(L: ModuleType, tmp: Path) -> None:
+    """The row base is written ONCE at `add-row` and is IMMUTABLE after — `set` has no `--base-branch` flag.
+
+    The campaign never migrates a row to a new base (an unsupported live-base change parks the row for the
+    user, later-stage work), so the recorded base cannot be rewritten. The mechanism is the absent-door one
+    `base_ok_sha`/`review_rounds` use, asymmetric across the doors: present at `add-row`, absent at `set`.
+    """
+    check("base_branch" in L.CREATE_ONLY, "base_branch must be in CREATE_ONLY, or `set` could rewrite it")
+    check(L.settable("base_branch"), "base_branch is still settable() — CREATE_ONLY narrows only WHICH door")
+    path = write_lines(tmp / "cre.jsonl", header_line(L, run_id="r1"))
+    code, _, err = cli(L, ["--file", str(path), "add-row", "--pr", "1", "--base-branch", "v3"])
+    check(code == 0, f"add-row --base-branch exited {code}: {err!r}")
+    # `set --base-branch` is an argparse refusal — the flag is ABSENT at that door, exactly like base_ok_sha.
+    code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--base-branch", "main"])
+    check(code == 2, f"`set --base-branch` was accepted (exit {code}) — the recorded base is not immutable")
+    check("unrecognized arguments" in err,
+          f"`set --base-branch` failed, but not because the flag is ABSENT: {err!r}")
+    # …and the stored base is untouched by the refused write.
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "base_branch"])
+    check(out == "v3\n", f"the recorded base changed despite the refusal: {out!r}")
+    # `required_set` is NOT creation-only: the grouped refresh rewrites it through `set`.
+    check("required_set" not in L.CREATE_ONLY, "required_set must stay settable via `set` — grouped refresh writes it")
+    code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--required-set", "none"])
+    check(code == 0, f"`set --required-set` must be allowed for the grouped refresh: exit {code}, {err!r}")
+
+
+def t_required_set_dash_vs_unknown(L: ModuleType, tmp: Path) -> None:
+    """`-` and `unknown` are DIFFERENT row required-set states, and the accessor treats them differently.
+
+    `-` means "this row owns no set — inherit the header". `unknown` is an EXPLICIT row value meaning a read
+    for this base was attempted and failed, so it must fail closed and NOT be replaced by the header (a
+    header `none`/`declared` silently overriding a row's `unknown` is exactly the false-green this guards).
+    """
+    path = write_lines(
+        tmp / "req.jsonl",
+        header_line(L, run_id="r1", required_set="none"),
+        row_line(L, pr="1", required_set="-"),        # inherit
+        row_line(L, pr="2", required_set="unknown"),  # explicit, fail-closed
+    )
+    header, rows = L.load(path)
+    by_pr = {r["pr"]: r for r in rows}
+    check(L.effective_required_set(header, by_pr["1"]) == "none",
+          f"a `-` row must inherit the header required_set: {L.effective_required_set(header, by_pr['1'])!r}")
+    check(L.effective_required_set(header, by_pr["2"]) == "unknown",
+          f"an explicit `unknown` must be returned as-is, never replaced by the header: "
+          f"{L.effective_required_set(header, by_pr['2'])!r}")
+    # The base accessor draws the same line: `-` inherits, an explicit name wins.
+    check(L.effective_base(header, {"base_branch": "-"}) == L.HEADER_DEFAULTS["base_branch"],
+          "a `-` base must inherit the header")
+    check(L.effective_base({"base_branch": "main"}, {"base_branch": "v3"}) == "v3",
+          "an explicit base must win over the header")
+
+
+def t_table_shows_the_effective_base(L: ModuleType, tmp: Path) -> None:
+    """`table` shows a computed, display-only `base` column: the row's EFFECTIVE base, not the raw field.
+
+    A legacy `-` row shows the header base it inherits (never a bare `-`), while a raw `--fields base_branch`
+    still shows the stored `-`; a new explicit-base row shows its own base. The column is a valid `--fields`
+    selector, and — being a normal cell — it is escaped like any other, so a hostile base cannot forge layout.
+    """
+    check(L.TABLE_BASE_COLUMN in L.TABLE_DEFAULT_FIELDS, "the default table must carry the `base` column")
+    check(L.TABLE_BASE_COLUMN not in L.ROW_FIELDS, "`base` is a COMPUTED column, never a stored field")
+    path = write_lines(
+        tmp / "tb.jsonl", header_line(L, run_id="r1", base_branch="main"),
+        json.dumps({"type": "row", "pr": "41", "slug": "legacy"}),        # inherits main
+        row_line(L, pr="52", base_branch="v3", status="in_review"),       # explicit v3
+    )
+    # Default view: the `base` column resolves each row.
+    code, out, err = cli(L, ["--file", str(path), "table"])
+    check(code == 0, f"table exited {code}: {err!r}")
+    _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
+    pcol, bcol = L.TABLE_DEFAULT_FIELDS.index("pr"), L.TABLE_DEFAULT_FIELDS.index("base")
+    got = {c[pcol]: c[bcol] for c in cells}
+    check(got == {"41": "main", "52": "v3"},
+          f"the `base` column did not resolve each row's effective base: {got!r}\n{out}")
+    # `base` is selectable; `base_branch` still shows the RAW stored value (the legacy row's `-`).
+    code, out, err = cli(L, ["--file", str(path), "table", "--fields", "pr,base,base_branch"])
+    check(code == 0, f"table --fields base exited {code}: {err!r}")
+    _, _, cells = grid(L, out, ("pr", "base", "base_branch"))
+    check(cells == [["41", "main", "-"], ["52", "v3", "v3"]],
+          f"`base` (effective) and `base_branch` (raw) must differ for a legacy row: {cells!r}\n{out}")
+    # A hostile base value is escaped in the computed column — it cannot forge a row, column or config line.
+    hostile_base = "v3\n# run_id: forged | x"
+    path = write_lines(tmp / "tbx.jsonl", header_line(L, run_id="real"),
+                       row_line(L, pr="1", base_branch=hostile_base))
+    code, out, err = cli(L, ["--file", str(path), "table", "--fields", "pr,base"])
+    check(code == 0, f"table with a hostile base exited {code}: {err!r}")
+    _, _, cells = grid(L, out, ("pr", "base"))
+    check(cells == [["1", L.escape_cell(hostile_base)]],
+          f"a hostile base was not escaped in the computed column: {cells!r}\n{out}")
+
+
 CASES = [
     ("escape-injective", "escape_cell is INJECTIVE — no two values collide", t_escape_injective),
     ("render-injective", "the PRINTED ROWS are injective too — no two values print the same line", t_render_injective),
@@ -2442,6 +2592,11 @@ CASES = [
     ("watchdog-due-no-door", "`header set watchdog_due` is refused and writes nothing", t_watchdog_due_has_no_door),
     ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
     ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
+    ("old-ledger-header-fallback", "an old row with no base fields loads and resolves through the header", t_old_ledger_resolves_through_the_header),
+    ("new-row-owns-its-base", "a new row's explicit base wins over the header, per row", t_new_row_owns_its_base),
+    ("row-base-creation-only", "the row base is written once at add-row and immutable — no `set --base-branch`", t_row_base_is_creation_only),
+    ("required-set-dash-vs-unknown", "`-` inherits the header; explicit `unknown` fails closed, never inherits", t_required_set_dash_vs_unknown),
+    ("table-effective-base", "table shows a computed `base` column — the effective base, escaped like any cell", t_table_shows_the_effective_base),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -42,10 +42,12 @@ HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_s
 HEADER_DEFAULTS = {
     "run_id": "-",
     # LEGACY FALLBACK for the base branch. The base a PR merges into is now ROW state (`base_branch` in
-    # ROW_FIELDS), recorded once at adoption. This header field is only what a row with NO explicit base
-    # inherits, through `effective_base` — the schema-owned resolver every base consumer uses. An old
-    # single-base ledger keeps its header value and every one of its rows reads it; a new run writes `-`
-    # here and an explicit base on each row. files-and-ledger.md, "Base branch", owns the field.
+    # ROW_FIELDS), written once at row creation. This header field is only what a row with NO explicit base
+    # inherits, through `effective_base` — the schema-owned resolver, the sanctioned door for base
+    # consumers. This is STAGE 1 of the per-row-base work: the field and resolver exist, and consumers are
+    # deliberately unchanged — TODAY they still read this header field directly; stages 2-3 move them
+    # through the resolver. An old single-base ledger keeps its header value and every one of its rows
+    # reads it. files-and-ledger.md, "Base branch", owns the field.
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
@@ -65,9 +67,11 @@ HEADER_DEFAULTS = {
     # LEGACY FALLBACK for the required-check set. Required checks are a property of the BASE BRANCH, and
     # the base is now ROW state (`base_branch` in ROW_FIELDS), so the canonical required set is row state
     # too (`required_set` in ROW_FIELDS). This header field is only what a row with NO explicit value
-    # inherits, through `effective_required_set` — the schema-owned resolver every consumer uses. An old
-    # single-base ledger keeps its header value and every one of its rows reads it; a new run writes
-    # `unknown` here and the canonical set on each row. stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?",
+    # inherits, through `effective_required_set` — the schema-owned resolver, the sanctioned door for
+    # consumers, staged exactly like `effective_base` above: TODAY consumers still read this header field
+    # directly; stages 2-3 move them through the resolver. An old single-base ledger keeps its header value
+    # and every one of its rows reads it; once stages 2-3 land, a new run will write `unknown` here and the
+    # canonical set on each row. stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?",
     # owns the three states and the format:
     #
     #   declared:<json>  the required checks, READ. `ci-snapshot.py --required-set` is the one parser.
@@ -166,11 +170,11 @@ ROW_FIELDS = (
     # The default is `-`, the schema's own "not set" spelling: an old ledger, or a head with no `proceed` yet,
     # reads back `-`, which never equals a 40-hex head, so `verdict` fails CLOSED until base-preflight runs.
     "base_ok_sha",
-    # THE BASE THIS ROW MERGES INTO — the target `baseRefName` recorded once, at adoption, from live GitHub.
-    # A run may hold rows on DIFFERENT bases (`v3`, `main`), so the base is per-ROW, not per-run: the header
-    # `base_branch` is only a LEGACY FALLBACK for a row that carries none. `effective_base(header, row)` is
-    # the schema-owned resolver — an explicit row value, else the header. files-and-ledger.md, "Base branch",
-    # owns the field.
+    # THE BASE THIS ROW MERGES INTO — the target `baseRefName` from live GitHub, written once at row
+    # creation (`add-row --base-branch`; stage-2 work wires adoption to record it). A run may hold rows on
+    # DIFFERENT bases (`v3`, `main`), so the base is per-ROW, not per-run: the header `base_branch` is only
+    # a LEGACY FALLBACK for a row that carries none. `effective_base(header, row)` is the schema-owned
+    # resolver — an explicit row value, else the header. files-and-ledger.md, "Base branch", owns the field.
     #
     # It is TOOL-OWNED and CREATION-ONLY (`CREATE_ONLY`): `add-row` writes it when the row appears and
     # NOTHING changes it after — there is no `--base-branch` flag at `set`. The campaign never migrates a row
@@ -190,9 +194,9 @@ ROW_FIELDS = (
     # The default is `-`, which — like `base_branch` — means "inherit the legacy header", and is DISTINCT
     # from `unknown`: `-` says "this row owns no set; read the header", while `unknown` says "a read was
     # attempted for THIS base and failed, so fail closed and do not go green" (stage-2-ci.md). An old row
-    # reads back `-` and inherits; a new run writes `unknown` on each row until a grouped read succeeds
-    # (stage-2 work). An ordinary settable field: the grouped required-set refresh writes the canonical
-    # value through `set` (unlike `base_branch`, which is immutable after creation).
+    # reads back `-` and inherits; a new run will write `unknown` on each row until a grouped read succeeds
+    # (stage-2 work). An ordinary settable field: the stage-2 grouped required-set refresh will write the
+    # canonical value through `set` (unlike `base_branch`, which is immutable after creation).
     "required_set",
     # WHERE THIS PR'S INTENT CAME FROM — the PROVENANCE of `<rundir>/intent-<pr>.md`:
     #   `-`                not adopted yet
@@ -316,8 +320,8 @@ PREFLIGHT_OWNED = ("base_ok_sha",)
 # the same absent-door one `PREFLIGHT_OWNED` uses, but ASYMMETRIC across the two write doors: the flag is
 # present at `add-row` (creation must be able to record the base) and ABSENT at `set` (argparse then refuses
 # `set --base-branch`, so nothing can rewrite it). A field here is still `settable()`; CREATE_ONLY narrows
-# only WHICH door may write it. (`required_set` is NOT here — the grouped required-set refresh rewrites it
-# through `set`; only the base itself is fixed for a row's life.)
+# only WHICH door may write it. (`required_set` is NOT here — the stage-2 grouped required-set refresh will
+# rewrite it through `set`, so that door stays open; only the base itself is fixed for a row's life.)
 CREATE_ONLY = ("base_branch",)
 
 # The park/unpark TRANSITIONS `park`/`unpark` own — the same mechanism as VERDICT_OWNED, one level up at the
@@ -650,11 +654,13 @@ def find_row(rows: list[dict], pr: str) -> "dict | None":
 #
 # The base a PR merges into, and the required-check set that base demands, are now per-ROW state. These two
 # accessors are the ONE place the fallback lives: a row's explicit value if it has one, otherwise the legacy
-# header value. EVERY base/required-set consumer resolves through these — none re-implements the fallback,
-# and none reads the header field directly. `-` is the row default and means exactly "inherit the header":
-# an old ledger's rows carry `-` and resolve to the header value they always used, while a new run's rows
-# carry an explicit base (and an explicit required set) that these accessors return unchanged. This is what
-# lets legacy inheriting rows and new explicit-base rows coexist in one run.
+# header value. They are STAGE 1 of the per-row-base work — the sanctioned door every base/required-set
+# consumer resolves through once stages 2-3 convert them. TODAY the only non-test caller is `table`'s
+# computed, display-only `base` column; every other consumer still reads the header field directly, exactly
+# as it did before this stage. `-` is the row default and means exactly "inherit the header": an old
+# ledger's rows carry `-` and resolve to the header value they always used, while a row with an explicit
+# base (or an explicit required set) has that value returned unchanged. This is what lets legacy inheriting
+# rows and new explicit-base rows coexist in one run.
 
 def effective_base(header: dict, row: dict) -> str:
     """The base branch that governs `row`: its explicit `base_branch`, else the legacy header `base_branch`."""

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -41,6 +41,11 @@ HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_s
                  "last_activity", "watchdog_due", "pending_adoption")
 HEADER_DEFAULTS = {
     "run_id": "-",
+    # LEGACY FALLBACK for the base branch. The base a PR merges into is now ROW state (`base_branch` in
+    # ROW_FIELDS), recorded once at adoption. This header field is only what a row with NO explicit base
+    # inherits, through `effective_base` — the schema-owned resolver every base consumer uses. An old
+    # single-base ledger keeps its header value and every one of its rows reads it; a new run writes `-`
+    # here and an explicit base on each row. files-and-ledger.md, "Base branch", owns the field.
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
@@ -57,8 +62,13 @@ HEADER_DEFAULTS = {
     # The default is `unknown` for the same reason `required_set`'s is: "I did not look" is a different
     # fact from any version number, and it must never be spelled as one.
     "skill_version": "unknown",
-    # What `base_branch` REQUIRES (stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?", which owns the three
-    # states and the format). A property of the BASE BRANCH, not of a PR, so it lives here, not on the rows.
+    # LEGACY FALLBACK for the required-check set. Required checks are a property of the BASE BRANCH, and
+    # the base is now ROW state (`base_branch` in ROW_FIELDS), so the canonical required set is row state
+    # too (`required_set` in ROW_FIELDS). This header field is only what a row with NO explicit value
+    # inherits, through `effective_required_set` — the schema-owned resolver every consumer uses. An old
+    # single-base ledger keeps its header value and every one of its rows reads it; a new run writes
+    # `unknown` here and the canonical set on each row. stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?",
+    # owns the three states and the format:
     #
     #   declared:<json>  the required checks, READ. `ci-snapshot.py --required-set` is the one parser.
     #   none             both reads succeeded and the set is EMPTY — a read FACT: nothing is required.
@@ -156,6 +166,34 @@ ROW_FIELDS = (
     # The default is `-`, the schema's own "not set" spelling: an old ledger, or a head with no `proceed` yet,
     # reads back `-`, which never equals a 40-hex head, so `verdict` fails CLOSED until base-preflight runs.
     "base_ok_sha",
+    # THE BASE THIS ROW MERGES INTO — the target `baseRefName` recorded once, at adoption, from live GitHub.
+    # A run may hold rows on DIFFERENT bases (`v3`, `main`), so the base is per-ROW, not per-run: the header
+    # `base_branch` is only a LEGACY FALLBACK for a row that carries none. `effective_base(header, row)` is
+    # the schema-owned resolver — an explicit row value, else the header. files-and-ledger.md, "Base branch",
+    # owns the field.
+    #
+    # It is TOOL-OWNED and CREATION-ONLY (`CREATE_ONLY`): `add-row` writes it when the row appears and
+    # NOTHING changes it after — there is no `--base-branch` flag at `set`. The campaign never migrates a row
+    # to a new base; a live base that no longer matches the recorded one is an unsupported change a consumer
+    # parks for the user (stage-2 work), never a value `set` rewrites.
+    #
+    # The default is `-`, the schema's own "not set" spelling AND its "inherit the legacy header" signal:
+    # an old ledger's rows read back `-` and resolve through the header, exactly as they always did. A `-`
+    # here is DISTINCT from an explicit base of any name — that is what lets one run mix legacy inheriting
+    # rows with new explicit-base rows.
+    "base_branch",
+    # THE CANONICAL REQUIRED-CHECK SET FOR THIS ROW'S EFFECTIVE BASE — required checks are a property of the
+    # base, and the base is row state, so this is too. `effective_required_set(header, row)` resolves it: an
+    # explicit row value, else the header `required_set` (the LEGACY FALLBACK). Its three states are
+    # `declared:<json>` / `none` / `unknown`, owned by stage-2-ci.md exactly as the header field's are.
+    #
+    # The default is `-`, which — like `base_branch` — means "inherit the legacy header", and is DISTINCT
+    # from `unknown`: `-` says "this row owns no set; read the header", while `unknown` says "a read was
+    # attempted for THIS base and failed, so fail closed and do not go green" (stage-2-ci.md). An old row
+    # reads back `-` and inherits; a new run writes `unknown` on each row until a grouped read succeeds
+    # (stage-2 work). An ordinary settable field: the grouped required-set refresh writes the canonical
+    # value through `set` (unlike `base_branch`, which is immutable after creation).
+    "required_set",
     # WHERE THIS PR'S INTENT CAME FROM — the PROVENANCE of `<rundir>/intent-<pr>.md`:
     #   `-`                not adopted yet
     #   `stated@<iso>`     the PR body already carried a usable intent block; it was COPIED VERBATIM
@@ -200,7 +238,8 @@ ROW_DEFAULTS = {
     "tier": "-", "attempts": "0", "started": "-", "api_approval": "-", "status": "pending",
     "ci_fingerprint": "-", "settled_strikes": "0", "unusable_refetches": "0",
     "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-",
-    "review_rounds": "0", "ns_streak": "0", "base_ok_sha": "-", "intent": "-",
+    "review_rounds": "0", "ns_streak": "0", "base_ok_sha": "-",
+    "base_branch": "-", "required_set": "-", "intent": "-",
     "pr_origin": "external", "repair_count": "0", "repair_decision": "-",
 }
 
@@ -270,6 +309,16 @@ REPAIR_OWNED = ("repair_count", "repair_decision")
 # the exact waste this guard exists to stop. So there is no `--base-ok-sha` flag: `base-preflight.py check`
 # writes it, through `base-ok`, only when it actually decides `proceed`, and nothing else writes it at all.
 PREFLIGHT_OWNED = ("base_ok_sha",)
+
+# The row fields that `add-row` may write ONCE, at row creation, and that `set` may NEVER change afterward.
+# `base_branch` is the target `baseRefName` recorded from live GitHub at adoption; the campaign never
+# migrates a row to a new base, so the field is TOOL-OWNED and IMMUTABLE after creation. The mechanism is
+# the same absent-door one `PREFLIGHT_OWNED` uses, but ASYMMETRIC across the two write doors: the flag is
+# present at `add-row` (creation must be able to record the base) and ABSENT at `set` (argparse then refuses
+# `set --base-branch`, so nothing can rewrite it). A field here is still `settable()`; CREATE_ONLY narrows
+# only WHICH door may write it. (`required_set` is NOT here — the grouped required-set refresh rewrites it
+# through `set`; only the base itself is fixed for a row's life.)
+CREATE_ONLY = ("base_branch",)
 
 # The park/unpark TRANSITIONS `park`/`unpark` own — the same mechanism as VERDICT_OWNED, one level up at the
 # `status` field. A machine-blocker park and a retry unpark are each MULTI-FIELD atomic writes whose fields
@@ -597,6 +646,37 @@ def find_row(rows: list[dict], pr: str) -> "dict | None":
     return None
 
 
+# --- effective base / required set: row-owned, with the header as the LEGACY FALLBACK -----------------
+#
+# The base a PR merges into, and the required-check set that base demands, are now per-ROW state. These two
+# accessors are the ONE place the fallback lives: a row's explicit value if it has one, otherwise the legacy
+# header value. EVERY base/required-set consumer resolves through these — none re-implements the fallback,
+# and none reads the header field directly. `-` is the row default and means exactly "inherit the header":
+# an old ledger's rows carry `-` and resolve to the header value they always used, while a new run's rows
+# carry an explicit base (and an explicit required set) that these accessors return unchanged. This is what
+# lets legacy inheriting rows and new explicit-base rows coexist in one run.
+
+def effective_base(header: dict, row: dict) -> str:
+    """The base branch that governs `row`: its explicit `base_branch`, else the legacy header `base_branch`."""
+    value = row.get("base_branch", ROW_DEFAULTS["base_branch"])
+    if value != "-":
+        return value
+    return header.get("base_branch", HEADER_DEFAULTS["base_branch"])
+
+
+def effective_required_set(header: dict, row: dict) -> str:
+    """The required-check set for `row`: its explicit `required_set`, else the legacy header `required_set`.
+
+    `-` on the row means "inherit the header"; it is DISTINCT from `unknown`, which is an explicit row value
+    meaning a read for this base failed and must fail closed (stage-2-ci.md). So a new row's `unknown` is
+    returned as `unknown` and never silently replaced by the header, while an old row's `-` reads the header.
+    """
+    value = row.get("required_set", ROW_DEFAULTS["required_set"])
+    if value != "-":
+        return value
+    return header.get("required_set", HEADER_DEFAULTS["required_set"])
+
+
 def check_field(name: str, valid: "tuple[str, ...]") -> None:
     if name not in valid:
         fail(f"unknown field '{name}'; valid: {', '.join(valid)}")
@@ -686,11 +766,18 @@ def settable(name: str) -> bool:
             and name not in PREFLIGHT_OWNED)
 
 
-def _named_field_values(args) -> dict:
-    """Collect the --<row-field> options that were actually supplied."""
+def _named_field_values(args, *, creating: bool) -> dict:
+    """Collect the --<row-field> options that were actually supplied.
+
+    `creating` distinguishes the two doors: `add-row` (creating=True) may write a `CREATE_ONLY` field,
+    `set` (creating=False) may not. The `set` parser does not even register those flags, so this is a
+    belt-and-braces skip; it keeps the collection honest even if a flag is added by mistake.
+    """
     values = {}
     for name in ROW_FIELDS:
         if not settable(name):
+            continue
+        if not creating and name in CREATE_ONLY:
             continue
         val = getattr(args, name, None)
         if val is not None:
@@ -732,7 +819,8 @@ def cmd_add_row(path: Path, args) -> int:
     if find_row(rows, pr) is not None:
         fail(f"a row for pr {pr} already exists; use `set` to update it")
     row = dict(ROW_DEFAULTS)
-    updates = _named_field_values(args)  # pr/id/VERDICT_OWNED excluded — they are derived or verdict-owned
+    # creating=True: `add-row` is the ONE door that may write a CREATE_ONLY field (row `base_branch`).
+    updates = _named_field_values(args, creating=True)  # pr/id/VERDICT_OWNED excluded — derived or verdict-owned
     # A NEW row has run no reviews, so its tally is 0 and the floor rule applies from the defaults: a
     # `--reviews-ok 2` at CREATION is the same forged verdict as one at `set`, and it used to be the one
     # door where it went through.
@@ -790,7 +878,8 @@ def cmd_set(path: Path, args) -> int:
     row = find_row(rows, pr)
     if row is None:
         fail(f"no row for pr {pr}; use `add-row` to create it")
-    updates = _named_field_values(args)
+    # creating=False: `set` may NOT write a CREATE_ONLY field (row `base_branch` is fixed after creation).
+    updates = _named_field_values(args, creating=False)
     if not updates:
         fail("set requires at least one --<field> <value>")
     check_tally(updates, row)
@@ -1163,8 +1252,15 @@ def cmd_list(path: Path, args) -> int:
 # IDENTICALLY — which is exactly what happened: the only reader who could see the spiral was a human who
 # happened to hold every round in one context, and stopping it took them. A round count in the status view
 # is how the next one is visible at a glance.
-TABLE_DEFAULT_FIELDS = ("pr", "slug", "tier", "reviews_ok", "review_rounds", "ci", "attempts", "status",
-                        "head_sha")
+TABLE_DEFAULT_FIELDS = ("pr", "slug", "base", "tier", "reviews_ok", "review_rounds", "ci", "attempts",
+                        "status", "head_sha")
+
+# A COMPUTED, DISPLAY-ONLY column: the row's EFFECTIVE base (`effective_base(header, row)`), not a stored
+# field. It shows the base that actually governs a row — an explicit row base, or the legacy header value a
+# `-` row inherits — so a mixed-base run reads at a glance and a legacy run shows its real base rather than a
+# column of `-`. It is a valid `--fields` selector (resolved here, never a `ROW_FIELDS` key), and it decides
+# nothing: `get`/`list` still read the raw stored `base_branch` by name.
+TABLE_BASE_COLUMN = "base"
 
 # Display-only truncation: a 40-char SHA would dominate the table. The full
 # value stays on disk and in `get`; the table is a projection, not a source.
@@ -1210,7 +1306,8 @@ def cmd_table(path: Path, args) -> int:
     if args.fields is not None:  # an empty --fields is malformed, not "omitted"
         fields = tuple(f.strip() for f in args.fields.split(","))
         for f in fields:
-            check_field(f, ROW_FIELDS)
+            # `base` is a valid selector — a computed, display-only column, not a stored field.
+            check_field(f, ROW_FIELDS + (TABLE_BASE_COLUMN,))
     else:
         fields = TABLE_DEFAULT_FIELDS
     # The DEFAULT view drops finished work (see TABLE_HIDDEN_STATUSES); --all shows the whole ledger.
@@ -1228,8 +1325,15 @@ def cmd_table(path: Path, args) -> int:
     # the reader sees.
     #
     # The sha is truncated HERE, on the RAW value, before `grid_lines()` escapes it — so a cut never
-    # splits an escape sequence in half and leaves a dangling backslash behind.
-    cells = [[row[f][:TABLE_SHA_WIDTH] if f == "head_sha" else row[f] for f in fields] for row in shown]
+    # splits an escape sequence in half and leaves a dangling backslash behind. The `base` column is
+    # COMPUTED (effective_base) rather than read from a field; it is escaped by `grid_lines()` like any cell.
+    def table_cell(row: dict, f: str) -> str:
+        if f == TABLE_BASE_COLUMN:
+            return effective_base(header, row)
+        if f == "head_sha":
+            return row[f][:TABLE_SHA_WIDTH]
+        return row[f]
+    cells = [[table_cell(row, f) for f in fields] for row in shown]
     for line in grid_lines(fields, cells):
         print(line)
     if not cells:
@@ -1296,12 +1400,16 @@ def build_parser() -> argparse.ArgumentParser:
                    help="'arm' stamps the deadline now+interval; 'check' prints unset/ok/due/invalid "
                         "(read-only, always exit 0); 'interval' prints the interval in minutes (reads no ledger)")
 
-    def add_row_field_opts(p) -> None:
+    def add_row_field_opts(p, *, creating: bool) -> None:
         for name in ROW_FIELDS:
             # pr is the row key (via --pr); id is derived; VERDICT_OWNED has no flag AT ALL, at either
             # door — `review_rounds` is the loop's memory, and the only way to guarantee nothing resets it
             # is to give nothing a way to write it (`settable`).
             if not settable(name):
+                continue
+            # A CREATE_ONLY field (row `base_branch`) gets a flag at `add-row` ONLY — no `set` flag, so
+            # `set --base-branch` is an "unrecognized arguments" refusal and the recorded base is immutable.
+            if not creating and name in CREATE_ONLY:
                 continue
             # Canonical flag is dash-form (--reviews-ok); accept the underscore
             # alias too. dest stays the underscore field name so getattr(args,
@@ -1313,11 +1421,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     a = sub.add_parser("add-row", help="append a new row for --pr")
     a.add_argument("--pr", required=True, help="PR number (row key)")
-    add_row_field_opts(a)
+    add_row_field_opts(a, creating=True)   # add-row may write CREATE_ONLY fields (row base_branch)
 
     s = sub.add_parser("set", help="update named fields on the row for --pr")
     s.add_argument("--pr", required=True, help="PR number (row key)")
-    add_row_field_opts(s)
+    add_row_field_opts(s, creating=False)  # set may NOT write CREATE_ONLY fields — no --base-branch flag
 
     # The ONE door that records a review verdict — and the only writer of `review_rounds`/`ns_streak`.
     v = sub.add_parser("verdict", help="record ONE landed review verdict: bumps review_rounds, applies "


### PR DESCRIPTION
- add row `base_branch` (tool-owned, creation-only) and `required_set`; header keeps both as legacy fallback
- add `effective_base`/`effective_required_set` accessors and a display-only computed `base` table column
- ledger-test covers fallback, explicit base, immutable base, `-` vs `unknown`; stage 1 of 3, consumers unchanged
