### PR TITLE
feat(campaign): carryover v2 and per-base reports

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -183,7 +183,8 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 
 20. `ci-status.py derive`: how `ci` is DERIVED — always, the only way ("THE DERIVATION IS A COMMAND"
     owns the exact invocation): a SHA-pinned snapshot of BOTH check families, verified before parsing,
-    decided against the header's required set. NEVER from `gh pr checks` (its output carries no SHA),
+    decided against the selected row's `effective_required_set` that `--ledger` resolves ("THE REQUIRED
+    SET IS NAMED, AND IT HAS NO DEFAULT" owns it). NEVER from `gh pr checks` (its output carries no SHA),
     NEVER by reading command output and judging it by eye. `ci-status.py liveness` then RECORDS that
     JSON — `ci`, the fingerprint, the strike/stall/refetch counters, and any cap park ("THE BOOKKEEPING
     IS A COMMAND" owns the invocation): the arithmetic is never applied by hand.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -86,8 +86,10 @@ it — no trigger means the step runs unconditionally at that point in the seque
    **installed plugin cache**, so a merged, version-bumped rule governs nothing until that cache
    refreshes; record what is actually running.
 5. Run start -> set `reviewer` in the ledger header (`references/reviewer.md`) — once, never
-   re-derived from memory. Header fields are DATA: re-read `base_branch` and `reviewer` from the
-   ledger every heartbeat, never assume `main`, never trust memory.
+   re-derived from memory. Header fields are DATA: re-read `reviewer` from the ledger every heartbeat,
+   never trust memory. The base a PR merges into is **per-row** now (`effective_base` — the row's
+   recorded base, else the header's legacy `base_branch` fallback), so **re-resolve each active PR's
+   effective base every heartbeat**, never assume `main`.
 
 **Adoption** (`references/pr-adoption.md`) — for each explicit `#PR` arg, and on every heartbeat for
 every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snapshot):

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -143,17 +143,19 @@ When the loop exits, summarize:
   than `stated@…`. **An `authored` intent is the DRIVER'S CLAIM about what the PR is for**, not the
   author's, and a wrong one silently **narrows** a review. It is a real cost and it is disclosed here rather
   than buried; a `stated@…` intent came from the PR body and needs no flag.
-- **Merged** — PR number + slug, one-line description, and tier.
+- **Merged** — PR number + slug, one-line description, tier, and the **base it merged into** (its
+  `effective_base`), so a mixed-base run shows which release line each PR shipped to.
 - **Residual risk** — for each merged PR, each accepting SATISFIED pass's `RESIDUAL-RISK` line (the
   least-certain area it named — `required(tier)` lines, so two for a STANDARD/HIGH PR and one for a
   TRIVIAL PR), and a flag when two accepting passes name the same area. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
-- **What the base branch REQUIRED** — the ledger's `required_set` (`stage-2-ci.md` owns its states). Report
-  **which state the run was in**, because it is what every `green` in this report rests on: `declared:…` —
-  name the checks that had to pass; `none` — the base branch required nothing, **read and confirmed**, not
-  merely unobserved. **NEVER report `unknown` as "no required checks"**: it means campaign **could not
-  read** them, nothing merged on it, and any PR that reached it **escalated** — say which read failed, so
-  the user can fix the access rather than wonder why the run stalled.
+- **What each base REQUIRED** — the required-check set, now **per base** (`effective_required_set`;
+  `stage-2-ci.md` owns its states). A run may span several bases (`v3`, `main`), so report **each distinct
+  base and which state it was in**, because it is what every `green` on that base rests on: `declared:…` —
+  name the checks that had to pass; `none` — that base required nothing, **read and confirmed**, not merely
+  unobserved. **NEVER report `unknown` as "no required checks"**: it means campaign **could not read** them
+  **for that base**, nothing merged on it, and any PR that reached it **escalated** — say which base's read
+  failed, so the user can fix the access rather than wonder why those PRs stalled.
 - **Repaired** — every PR that reached a review-loop cap: its `review_rounds`, the decision the
   reassessment pass returned, and a pointer to `repair-<pr>-<k>.md` (`repair-pass.md`). **Report a DEMOTE's
   demoted findings explicitly** — they are true findings that were deliberately **not fixed**, and burying

--- a/plugins/gauntlet/skills/campaign/references/carryover.md
+++ b/plugins/gauntlet/skills/campaign/references/carryover.md
@@ -30,11 +30,48 @@ actively-driven run owns — so there is still no write contention with a live w
 `history.md`, if present from before this split, is still read as read-only history; leave it in
 place.)
 
+### The carryover file format — v2, with a v1 fallback
+
+`carryover.py distill` always writes **format v2**, single-base runs included. A run may hold PRs on
+**different bases** (`v3`, `main`), so the base is per **PR**, not per run:
+
+- Each projected object carries its own **`base_branch`** — the row's **effective base** at distillation
+  (its recorded base, else the run's legacy header base).
+- The metadata carries a **`base_branches`** array: the sorted, deduplicated set of those bases. It
+  replaces v1's single `base_branch:` line.
+
+```text
+run_id: g260722-0900-acde1234
+base_branches: ["main", "v3"]
+distilled_at: 2026-07-22T18:00:00Z
+
+## merged
+{"pr": "41", "slug": "fix-v3-parser", ..., "base_branch": "v3"}
+{"pr": "52", "slug": "fix-main-parser", ..., "base_branch": "main"}
+```
+
+**A v1 file stays readable.** A pre-v2 file has a single top-level `base_branch:` line and its objects
+carry **no** `base_branch`. In that file, that one base is the **effective base of every object** — read
+it that way and prune each object against it:
+
+```text
+run_id: g260601-1000-01020304
+base_branch: main
+distilled_at: 2026-06-01T12:00:00Z
+
+## merged
+{"pr": "12", "slug": "fix-typo", ...}
+```
+
+Existing history is never rewritten; a v1 file remains v1 on disk.
+
 ### Pruning the ledger
 
-The store grows one file per run, so **prune it regularly** — early in every fresh run, once that
-run's PRs are adopted and its `base_branch` is resolved (pruning keys off the base), and any time the
-user asks. The goal is to drop entries that **no longer apply to the current code**:
+The store grows one file per run, so **prune it regularly** — early in every fresh run, once that run's
+PRs are adopted, and any time the user asks. Pruning keys off the base, and the base is **per entry**:
+prune each object against **its own** `base_branch` (a v1 object against that file's single base). History
+for one base never prunes against another. The goal is to drop entries that **no longer apply to the
+current code**:
 
 - **aborted** whose cited `file:line` no longer exists, or whose PR has since merged/closed by other
   means — the recorded blocker can't still hold.
@@ -73,10 +110,11 @@ above); it never reads or duplicates the follow-up store.
 1. **Start the run per `loop-control.md` step 1's fresh-run path** — preflight the `#PR` set read-only
    first, and only then create run state and adopt. That step owns the ordering and the refusal
    behavior; never restate it here.
-2. **Read every file in `.gauntlet/history/`, then prune against the resolved `base_branch`** (drop
-   entries no longer applicable to that base; uncertain deletions are asked about **without blocking**
-   — keep the entries and proceed, see "Pruning the ledger"). Pruning only ever edits **finished**
-   runs' own files (no live writer), so there's nothing to race.
+2. **Read every file in `.gauntlet/history/`, then prune each entry against its OWN recorded base**
+   (a v2 object's `base_branch`, a v1 object against that file's single base; drop entries no longer
+   applicable to that base; uncertain deletions are asked about **without blocking** — keep the entries
+   and proceed, see "Pruning the ledger"). Pruning only ever edits **finished** runs' own files (no live
+   writer), so there's nothing to race.
 3. Enter the loop as normal, on the clean `<rundir>`. Carryover is advisory historical context only —
    it de-dups against already-merged/aborted work and reminds the user of parked API-declined changes;
    it never auto-adopts or auto-skips a PR.

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -557,8 +557,9 @@ nothing was looking. Three checks close that, and **none is optional**:
 - **`ci-status.py doc-check` checks every `gh` INVOCATION in this file against the argv the code really
   issues** — *every copy of them*, not just the spec block (a recap that drops `,headRefOid` reconstructs a
   fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It sweeps
-  **every copy of the `ci-status.py derive` command across every skill doc** for `--required-set`, too — the
-  flag that decides a merge must not be droppable by a recap.
+  **every copy of the `ci-status.py derive` command across every skill doc** for a named required set
+  (`--ledger`, which resolves the row's `effective_required_set`, or an explicit `--required-set`), too — the
+  set that decides a merge must not be droppable by a recap.
 
 **TWO refusals are CROSS-SOURCE and no single-fetch filter can state them** — the rollup's `StatusContext`
 **coverage**, and the **AGREEMENT** of the two sources about a check they both report. One `jq` filter sees

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -387,9 +387,11 @@
 - A fresh run carries over prior knowledge from `.gauntlet/history/` (merged/aborted PR record, to
   dedup and inform) but still judges every adopted PR fresh — carryover is advisory, never
   auto-accept/reject.
-- Prune `.gauntlet/history/` at every fresh run: drop only entries unambiguously moot against
-  current `<base>`; for anything uncertain, list it and ask the user before deleting. Never silently
-  prune an entry you're unsure about.
+- Prune `.gauntlet/history/` at every fresh run: drop only entries unambiguously moot against **their
+  own recorded base** — each object prunes against its OWN `base_branch` (a v1 object against that
+  file's single base); history for one base never prunes against another (`carryover.md`, "Pruning the
+  ledger", owns the rule). For anything uncertain, list it and ask the user before deleting. Never
+  silently prune an entry you're unsure about.
 
 ### Fix dispatch and worker models
 
@@ -489,10 +491,12 @@
 
 ### Merge and base hygiene
 
-- The run targets a **base branch** (`base_branch` in the ledger header), which is **not assumed to
-  be `main`** — it is the `baseRefName` of the adopted PRs (must agree across them, else prompt).
-  Reviews diff `origin/<base>...HEAD` and PRs merge into `<base>`; a fix worktree branches off the PR's OWN
-  head branch/SHA, never off `<base>` (see `pr-adoption.md`). Re-read it each heartbeat (see "Base branch").
+- The run targets a **base branch**, **not assumed to be `main`** — it is the `baseRefName` of the
+  adopted PRs (must agree across them, else prompt). The base is **per-row** state, resolved through
+  `ledger.py`'s `effective_base` (a row's explicit `base_branch`, else the legacy header fallback), never
+  re-read from the one header field (see "Base branch"). Reviews diff `origin/<base>...HEAD` and PRs merge
+  into `<base>`; a fix worktree branches off the PR's OWN head branch/SHA, never off `<base>` (see
+  `pr-adoption.md`).
 - After every merge, let `merge.py run` fast-forward local `<base>` to `origin/<base>` (Stage 3,
   **"Resumable merge execution"**) so later diffs and rebases use the just-merged tip. If it fails,
   re-run the command after fixing the named cause — never force the base.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -450,13 +450,14 @@
   The gate is unchanged; record the selected route and resulting reviewer in the report. See "The
   reviewer".
 - **RUN `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before CI derivation on every
-  heartbeat.** It owns both base-branch declaration reads, their strict parse and union, and the atomic ledger
-  write. A settled value is reused; only `unknown` is retried. See `stage-2-ci.md`, "WHAT WERE WE EXPECTING
-  TO SEE?".
+  heartbeat.** It groups nonterminal rows by `effective_base`, owns both declaration reads per **distinct
+  base**, their strict parse and union, and the atomic per-row ledger write. A settled group is reused; only
+  an `unknown` group is retried. See `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?".
 - **DERIVE `ci` BY RUNNING `scripts/ci-status.py derive --pr <N> --head-sha <the ledger's> --rundir
-  <rundir> --required-set <the ledger header's>`, and by NOTHING ELSE.** It fetches, promotes, verifies and
+  <rundir> --ledger <rundir>/state.jsonl`, and by NOTHING ELSE.** It fetches, promotes, verifies and
   decides, and prints the verdict, the `ci` value and the liveness `fingerprint` as JSON (`stage-2-ci.md`,
-  "THE DERIVATION IS A COMMAND", which owns the exact invocation — **`--required-set` is MANDATORY**: the evidence says what
+  "THE DERIVATION IS A COMMAND", which owns the exact invocation — **the required set is NAMED, never
+  defaulted**: `--ledger` resolves the row's `effective_required_set`; the evidence says what
   showed up, and only the base branch's declared set says what was SUPPOSED to).  **NEVER derive `ci` by
   READING the output of a command and judging it.** That is not a style preference: every rule below was already
   correct when a driver ran `gh pr checks`, saw that no checks were reported, and wrote **`ci = green`** —

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -302,11 +302,13 @@ Header field notes (the header fields above; per-row fields follow):
   once at row creation (`add-row --base-branch`). A run may hold rows on **different** bases, so the base
   is **per-row**, not per-run; the header `base_branch` is only the **legacy fallback** a row with none
   inherits. `ledger.py`'s `effective_base(header, row)` — an explicit row value, else the header — is the
-  one place the fallback lives, and it is the **sanctioned door** for resolving a row's base. **This is
-  stage 1 of 3: the field and the resolver exist, and consumers are deliberately unchanged** — today only
-  `table`'s computed, display-only `base` column resolves per row; adoption does not yet record an explicit
-  row base, and every other consumer still reads the header field directly. Stages 2-3 move them through
-  the resolver. It is **TOOL-OWNED and
+  one place the fallback lives, and it is the **sanctioned door** for resolving a row's base;
+  `require_effective_base` is the fail-closed form the resolved-base consumers route through. **Per-row
+  base resolution is LIVE:** adoption records each new row's base at creation (`add-row --base-branch`),
+  and every consumer resolves a row's base through those accessors, never the one header base. What
+  REMAINS is mixed-base **admission** — surfacing PRs on DIFFERENT bases into one run; adoption still
+  admits only the run's one agreed base (the mixed-base rollout's final PR —
+  `docs/designs/campaign-mixed-base-branches.md`, "Staged implementation plan"). It is **TOOL-OWNED and
   IMMUTABLE after creation** (`CREATE_ONLY` in `scripts/ledger.py`): `add-row` writes it and **`set` has no
   `--base-branch` flag**, so the recorded base can never be rewritten — the campaign does not migrate a row
   to a new base. The default is **`-`**, which is both the schema's "not set" spelling **and** its "inherit
@@ -316,19 +318,19 @@ Header field notes (the header fields above; per-row fields follow):
 - `required_set` — **the canonical required-check set for this row's effective base**. Required checks are a
   property of the base, and the base is row state, so this is too; the header `required_set` is the **legacy
   fallback**. `effective_required_set(header, row)` — an explicit row value, else the header — is the
-  resolver, the same sanctioned door as `effective_base` and **staged the same way: the resolver exists
-  today, and consumers still read the header field directly until stages 2-3 move them.** Its three states
+  resolver, the same sanctioned door as `effective_base`, and **resolves per row LIVE, exactly like it.**
+  Its three states
   (`declared:<json>` / `none` / `unknown`) are owned by `stage-2-ci.md` exactly as the header field's are.
-  Unlike `base_branch` it is **an ordinary settable field** — the stage-2 grouped required-set refresh will
-  write the canonical value through `set`, so that door stays open. The default is **`-`**, which — like
+  Unlike `base_branch` it is **an ordinary settable field** — the grouped required-set refresh writes the
+  canonical per-base value through `set`, so that door stays open. The default is **`-`**, which — like
   `base_branch` — means **inherit the header**, and is **DISTINCT from `unknown`**: `-` says "this row owns
   no set; inherit the header — but only for the header's OWN base", which `effective_required_set` enforces:
   it returns the header value only when this row's effective base IS the header base, and otherwise stays
   `unknown` (a row on a different base has no set here until its base is read — the header never describes
   another base's set). `unknown` is an **explicit** row value meaning a read for THIS base was
   attempted and failed, so it **fails closed and cannot go green** and must **never** be silently replaced
-  by the header. An old single-base row reads back `-` and inherits (its base IS the header base); once
-  stages 2-3 land, a new run will write `unknown` per row until a grouped read succeeds.
+  by the header. An old single-base row reads back `-` and inherits (its base IS the header base); a new
+  run writes `unknown` per row until a grouped read succeeds.
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -322,10 +322,13 @@ Header field notes (the header fields above; per-row fields follow):
   Unlike `base_branch` it is **an ordinary settable field** — the stage-2 grouped required-set refresh will
   write the canonical value through `set`, so that door stays open. The default is **`-`**, which — like
   `base_branch` — means **inherit the header**, and is **DISTINCT from `unknown`**: `-` says "this row owns
-  no set; read the header", while `unknown` is an **explicit** row value meaning a read for THIS base was
+  no set; inherit the header — but only for the header's OWN base", which `effective_required_set` enforces:
+  it returns the header value only when this row's effective base IS the header base, and otherwise stays
+  `unknown` (a row on a different base has no set here until its base is read — the header never describes
+  another base's set). `unknown` is an **explicit** row value meaning a read for THIS base was
   attempted and failed, so it **fails closed and cannot go green** and must **never** be silently replaced
-  by the header. An old row reads back `-` and inherits; once stages 2-3 land, a new run will write
-  `unknown` per row until a grouped read succeeds.
+  by the header. An old single-base row reads back `-` and inherits (its base IS the header base); once
+  stages 2-3 land, a new run will write `unknown` per row until a grouped read succeeds.
 - `intent` — the PROVENANCE of `<rundir>/intent-<pr>.md` (the file itself is markdown, so it lives in the
   run dir, not in this one-object-per-line store): `-` (not adopted yet) | `stated@<iso>` (the PR body
   already carried a usable intent block, copied verbatim) | `authored@<iso>` (the driver **inferred** it

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -20,8 +20,11 @@ block. This file owns the dispatch procedure, not a second copy of prompt text.
 ### PRE-FLIGHT — the base must be current before ANY fix is dispatched
 
 **BEFORE dispatching ANY fix subagent (review-fix or CI-fix) for a PR, run
-`python3 scripts/base-preflight.py check --pr <N> --worktree <worktree> --base <base> --file <state.jsonl>`.** It fetches
-`origin/<base>` and prints ONE of three verdicts, and the action
+`python3 scripts/base-preflight.py check --pr <N> --worktree <worktree> --base <base> --file <state.jsonl>`.**
+`<base>` is **this PR row's effective base** — its explicit `base_branch`, else the legacy header fallback
+(`ledger.py`'s `effective_base`), never the one header base. With `--file`, the ROW owns the base: `--base`
+is an **assertion** that must equal the row's effective base, and the helper also compares the PR's live
+`baseRefName` against it. It fetches `origin/<base>` and prints ONE of three verdicts, and the action
 **splits by verdict** — only `proceed` clears the dispatch, and the other two are NOT the same response:
 
 - **`proceed`** → the base is current; **dispatch the fix**. The `--file` makes the `proceed` record
@@ -33,8 +36,13 @@ block. This file owns the dispatch procedure, not a second copy of prompt text.
   `clean-rebase.py` FIRST: a clean base-only rebase (exit 0) PRESERVES the verdicts and label, and only its
   **exit 3** — conflict OR diff-changed — falls back to the JUDGMENT path that resets the gate and re-mirrors
   the label. Then **re-run the pre-flight**.
-- **`recheck`** → mergeability is not computed yet, the view carried an unknown value, or base ancestry could
-  not be verified; do **NOT** dispatch and do **NOT** rebase — **re-poll**, then **re-run the pre-flight**.
+- **`recheck`** → mergeability is not computed yet, the view carried an unknown value, base ancestry could
+  not be verified, **or the PR was retargeted** — its live `baseRefName` no longer equals the row's effective
+  base (a different branch NAME, not a mere ADVANCE of the same branch). A retarget is an unsupported mid-run
+  change: the reason is the machine-blocker wording a reconcile/re-adoption park records (`base changed from
+  <recorded> to <live>; not supported mid-run`); **park the row** on the user through that path rather than
+  dispatch. For the other recheck causes, do **NOT** dispatch and do **NOT** rebase — **re-poll**, then
+  **re-run the pre-flight**.
 
 A fix authored on a stale or conflicting base is wasted work: it is re-reviewed against the rebased tip
 anyway, and its diff may not even apply. The tool fetches and decides only — it performs no rebase; the
@@ -53,13 +61,17 @@ argv: ["python3", path_join(skill_dir, "scripts", "worker-prompt.py"), "fix",
        "--worktree", worktree,
        "--pr", pr,
        "--base", base,
+       "--file", state_jsonl,
        "--preflight-verdict", "proceed",
        "--issues-file", issues_file,
        optional_ci("--logs-file", logs_file),
        "--output-dir", attempt_prompt_bundle]
 ```
 
-`role` is exactly `review`, `ci-session`, or `ci-economy`. The output directory must not exist. Use
+`role` is exactly `review`, `ci-session`, or `ci-economy`. `base` is this PR row's effective base (as in the
+pre-flight above); `--file <state.jsonl>` makes `worker-prompt.py` assert `--base` equals the `--pr` row's
+effective base and refuse a disagreement, so the base baked into the fix prompt can never be a branch the row
+does not track. The output directory must not exist. Use
 `prompt.txt` as the worker's complete prompt bytes. Read `metadata.json` and dispatch with its `role` and
 logical `model_class`; the runtime adapter maps that class to the active host. Never map a host model name
 inside this tool or add prompt text after materialization.

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -197,18 +197,24 @@ about and one whose partial rejection strands the rest.
    (`fix-subagent-contract.md`) that authors the fix **and opens a PR** for it. The driver hands the fixer
    a **worktree branched from the base the follow-up targets**, and the fixer branches, commits, pushes,
    and opens the PR against that base — its worktree and scope requirements are owned by
-   `fix-subagent-contract.md`, not restated here. **The target is per follow-up, not per run** (a run may
-   hold PRs on different bases): a follow-up **derived from one PR** takes **that PR's recorded base**
-   (`effective_base` of its ledger row) as the proposed target; a **run-level** follow-up has **no
-   implicit target**, so the **user chooses** it. The user may override the proposed target before the PR
-   is opened. Either way the resulting PR then enters through **normal adoption**, which records its live
-   `baseRefName` once (`pr-adoption.md`). That PR is opened
+   `fix-subagent-contract.md`, not restated here. **The target is per follow-up**: a follow-up **derived
+   from one PR** takes **that PR's recorded base** (`effective_base` of its ledger row) as the proposed
+   target; a **run-level** follow-up has **no implicit target**, so the **user chooses** it. The user may
+   override the proposed target before the PR is opened. The resulting PR then enters through **normal
+   adoption**, which records its live `baseRefName` once (`pr-adoption.md`). **Adoption still admits only
+   the run's one agreed base** (`pr-adoption.md`, "PR adoption") — mixed bases in one run are a later
+   stage (stage 3, PR #148). So the follow-up folds into THIS run (step 4) **only when its target equals
+   the run's agreed base**; a follow-up targeting a **different** base is NOT adopted here — surface it
+   (step 5) for its own run and leave the entry open. In a single-base run a PR-derived follow-up always
+   shares that base, so this only diverts a user-chosen different-base target. When the target is the
+   run's base, that PR is opened
    **`gauntlet-authored`** and adopted into the current run so `pr-adoption.md` reads it as
    `pr_origin=gauntlet` — without the label it defaults to `external`, which then blocks campaign's own
    later autonomous repair of the very PR it authored. Record the PR with `followups.py open-pr --id fuN
    --pr <ref>`; the entry stays `in-pr` and names which PR is addressing it.
 
-4. **FOLD THE PR INTO THE CURRENT CAMPAIGN.** The follow-up's PR is **adopted into this run** like any other
+4. **FOLD THE PR INTO THE CURRENT CAMPAIGN.** The follow-up's PR — which step 3 admitted only on the run's
+   agreed base — is **adopted into this run** like any other
    (`pr-adoption.md` — the `gauntlet-authored` label, ledger row, intent, CI) and **gated by the same
    review gauntlet**. This is the
    whole point of "self-accepted, not accepted": the driver may take a follow-up up on its own, but the PR

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -195,9 +195,14 @@ about and one whose partial rejection strands the rest.
    `behavior-preserved`, `reversible` — `take-up` refuses without them), the driver takes it up
    (→ `self-accepted`) and dispatches a **scoped fix subagent under the fix-subagent contract**
    (`fix-subagent-contract.md`) that authors the fix **and opens a PR** for it. The driver hands the fixer
-   a **worktree from the current run's base branch**, and the fixer branches, commits, pushes, and opens
-   the PR against that base — its worktree and scope requirements are owned by `fix-subagent-contract.md`,
-   not restated here. That PR is opened
+   a **worktree branched from the base the follow-up targets**, and the fixer branches, commits, pushes,
+   and opens the PR against that base — its worktree and scope requirements are owned by
+   `fix-subagent-contract.md`, not restated here. **The target is per follow-up, not per run** (a run may
+   hold PRs on different bases): a follow-up **derived from one PR** takes **that PR's recorded base**
+   (`effective_base` of its ledger row) as the proposed target; a **run-level** follow-up has **no
+   implicit target**, so the **user chooses** it. The user may override the proposed target before the PR
+   is opened. Either way the resulting PR then enters through **normal adoption**, which records its live
+   `baseRefName` once (`pr-adoption.md`). That PR is opened
    **`gauntlet-authored`** and adopted into the current run so `pr-adoption.md` reads it as
    `pr_origin=gauntlet` — without the label it defaults to `external`, which then blocks campaign's own
    later autonomous repair of the very PR it authored. Record the PR with `followups.py open-pr --id fuN

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -96,8 +96,21 @@ the worker returns, and what never moves into it. The steps below are unchanged 
        relabel) or it was a **clean base-only advance** — which fires the head-move reset at the door
        (`files-and-ledger.md`, the `head_sha` field, "What a genuine head move resets"), gate kept — stays
        your judgement.
-     - **`base_changed`** — the snapshot `baseRefName` differs from the header's `base_branch`: base-currency
-       handling (`stage-2-review-gate.md`, "Base currency with `<base>`").
+     - **`base_changed`** — the snapshot `baseRefName` differs from this row's **`effective_base`** (its
+       explicit row `base_branch`, else the legacy header fallback; `detect` resolves it per row through
+       `ledger.py`'s `effective_base`, never against the one header base). The PR's TARGET moved, and the
+       campaign does **not** migrate a row to a new base — **PARK the row** on the user through the existing
+       machine-blocker path and do **NOT** act on `head_moved`/dispatch/CI/merge for it this pass (base
+       currency is decided FIRST): run **`ledger.py … park --pr <N> --reason "base changed from <ledger> to
+       <snapshot>; not supported mid-run"`** with the `base_changed` fact's own `ledger` (recorded) and
+       `snapshot` (live) values — the EXACT durable reason, recorded in `ci_reason`; the park sets
+       `status = awaiting-user` and clears `blocker_ruling`, and the label reconcile below mirrors it. An
+       **already-held** row keeps its open question — `park` returns `EXIT_STOP` and leaves the existing
+       `ci_reason` intact; report the mismatch, do not overwrite. The user resolves it through the ordinary
+       machine-blocker ruling path (`retry` after restoring the base / `abort`) at "PARKED" below. (This is
+       the PR being **retargeted** — a different base branch NAME. A base branch that merely ADVANCED, same
+       name, is not this fact; it is caught by base-preflight ancestry — `stage-2-review-gate.md`, "Base
+       currency with `<base>`".)
      - **`branch_mismatch`** — the snapshot `headRefName` differs from the row's recorded `branch`: reconcile
        the row's `branch` (adopted PRs keep their **own** head branch — the `gauntlet-run-<run-id>` label is
        the ownership marker, never a branch prefix; `files-and-ledger.md`, `branch`).

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -17,8 +17,13 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   A fetch refusal produces no discovery input. Keep the previous snapshot untouched and resolve the
   reported blocker before adoption.
 
-`base_branch` for the run = the adopted PR's `baseRefName`. When several PRs are adopted at once they
-**must agree** on `baseRefName`; if they disagree, stop and prompt the user (one run targets one base).
+Each adopted PR **records its own live `baseRefName`** on its ledger row — the row's `base_branch`, written
+**once at creation** by `pr-adopt.py` (`add-row --base-branch`) and **immutable** afterward (`files-and-ledger.md`,
+the row `base_branch` field). Resolve a row's base through `ledger.py`'s `effective_base` (an explicit row
+value, else the legacy header fallback), never the raw header field. **For now, when several PRs are adopted
+at once they still must agree on `baseRefName`** — mixed bases in one run are a later stage; if they disagree,
+stop and prompt the user. The header `base_branch` is only the legacy fallback a row with no explicit base
+inherits.
 
 Campaign **never** deletes the adopted PR's **remote** head branch. Stage 3,
 **"Resumable merge execution"**, owns merge and cleanup enforcement.
@@ -123,6 +128,14 @@ For each `#PR` to adopt:
    one: the schema lives in the script, and a copy of it retyped here would be stale the next time a row
    field is added.
 
+   **Re-adoption base gate — BEFORE any refresh write.** The recorded row `base_branch` is immutable, and
+   the campaign never migrates a row to a new base. On a re-adoption, `pr-adopt.py` first compares the PR's
+   live `baseRefName` with the row's `effective_base`; **if they differ it PARKS the row** (machine-blocker,
+   `status = awaiting-user`, `ci_reason` = `base changed from <recorded> to <live>; not supported mid-run`,
+   `blocker_ruling` cleared — the same reason and park the reconcile `base_changed` route uses) and STOPS,
+   refreshing no evidence, rewriting no base, and applying no label. An already-held row keeps its open
+   question. Only a matching (or brand-new) base proceeds to the refresh below.
+
    - `id` = `pr<N>`; `slug` = slugified PR title; `branch` = the PR's **own** `headRefName` (adopted PRs
      keep their branch — do NOT mint a `fix-<run-id>-...` branch); `worktree` = `-`,
      `worktree_owned` = `-`, and `branch_owned` = `-` until the head worktree is resolved in step 5
@@ -132,7 +145,9 @@ For each `#PR` to adopt:
      `branch_owned` = `yes` **only** when campaign created the local branch (the `-b` path) / `no` when
      it reused a pre-existing local branch or checkout;
      `pr` = `<N>`; `head_sha` = `headRefOid`.
-   - **On a NEW row only, initialize:** `reviews_ok` = `0` (no verdicts yet); `ci` = `pending`;
+   - **On a NEW row only, initialize:** `base_branch` = the PR's live `baseRefName` (recorded ONCE through
+     `add-row --base-branch`, immutable after — this is the per-row base every later action resolves through
+     `effective_base`); `reviews_ok` = `0` (no verdicts yet); `ci` = `pending`;
      `tier` = bootstrap `STANDARD`; after step 5 the orchestrator decides the real tier at or above
      `triage.py derive`'s floor and writes it;
      `attempts` = `0` (no attempt has run yet —

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -94,9 +94,12 @@ refused with the mismatch and recovery named.
 The command writes the prompt and `<output>.manifest.json`, then prints the manifest location and hashes.
 It refuses missing or duplicate active artifacts, an incomplete pass, a report whose framing `review-pass.py`
 rejects (no terminal `VERDICT:` line, or a verdict incoherent with the round's findings), a stale
-latest-review/ledger/worktree SHA, or a failed Git read. It resolves `origin/<base>` to one immutable commit
-SHA before any read and binds it, so every diff is measured against a single base and `decide` can detect a
-base that moved. **Re-running it while the decision is still unrecorded is safe and idempotent:**
+latest-review/ledger/worktree SHA, or a failed Git read. `<base>` is **this PR row's effective base** — its
+explicit `base_branch`, else the legacy header fallback (`ledger.py`'s `effective_base`), never the one
+header base — so a mixed-base run bundles each PR against its own release line. It resolves `origin/<base>`
+to one immutable commit SHA before any read and binds it, so every diff is measured against a single base and
+`decide` can detect a base that moved (`decide` re-derives that same effective base from the row, so a
+manifest bound to a different base is refused). **Re-running it while the decision is still unrecorded is safe and idempotent:**
 because the bundle is deterministic, an existing prompt/manifest pair whose bytes match the freshly rebuilt
 bundle is REUSED — so a heartbeat that built the bundle and died before `decide` simply resumes — a partial
 pair left by a crash mid-write is regenerated, and a non-matching or symlinked output is refused rather than

--- a/plugins/gauntlet/skills/campaign/references/review-dispatch.md
+++ b/plugins/gauntlet/skills/campaign/references/review-dispatch.md
@@ -14,7 +14,7 @@ result = run_argv(
   argv: ["python3", review_dispatch_script, "prepare",
          "--run-dir", review_root,
          "--pr", pr, "--pass", review_pass, "--launch-attempt", launch_attempt,
-         "--worktree", worktree, "--base", base,
+         "--worktree", worktree, "--base", base, "--file", ledger,
          "--route", route, "--report-producer", report_producer,
          "--head-sha", head_sha, "--dispatched-at", dispatched_at,
          "--intent-file", intent_file],
@@ -31,9 +31,14 @@ Inputs have these owners:
 - `route`, `report_producer`, and `launch_attempt` come from `runtime-adapter.md`, **Review preparation
   mapping**. `prepare` never selects, probes, or changes them.
 - `review_root`, `worktree`, and `base` come from the invocation's typed `RepositoryContext` and ledger.
-  `review_root` and `worktree` must be different directories with neither nested inside the other; the
-  command refuses an identical or either-way-nested pair before staging any artifact, so preparation never
-  writes launch files into the candidate worktree. This is a fail-closed input check, not an OS boundary.
+  `base` is **this PR row's effective base** — its explicit `base_branch`, else the legacy header fallback
+  (`ledger.py`'s `effective_base`), never the one header base. It rides the typed transport as data (the
+  reviewer diffs `origin/<base>...HEAD`); `--file <review_root>/state.jsonl` makes `--base` an **assertion**
+  that must equal the selected `--pr` row's effective base, and `prepare` refuses a disagreement — the row is
+  the source of truth, the flag is not. `review_root` and `worktree` must be different directories with
+  neither nested inside the other; the command refuses an identical or either-way-nested pair before staging
+  any artifact, so preparation never writes launch files into the candidate worktree. This is a fail-closed
+  input check, not an OS boundary.
 - `pr`, `review_pass`, `head_sha`, and `dispatched_at` name this launch attempt.
 - `intent_file` is the absolute derived `<rundir>/intent-<pr>.md` path. The command refuses another path.
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -45,7 +45,9 @@ needs no OS sandbox. A same-engine process (Codex → another `codex exec`, Clau
 -p`) provides fresh context only and must not be reported as diversity. A fresh native worker on the
 active host is the complete, valid **fallback** when the paired CLI is absent or the cross-engine process
 fails after its retry. The cost benefit compounds the diversity one: review passes dominate campaign's
-native-worker spend — each re-reads the **whole** `origin/<base>...HEAD` diff, runs `required(tier)` times
+native-worker spend — each re-reads the **whole** `origin/<base>...HEAD` diff (where `<base>` is the
+selected PR row's **effective base** — its explicit `base_branch`, else the legacy header fallback,
+resolved through `ledger.py`'s `effective_base`, never the one header base), runs `required(tier)` times
 per SHA, and re-runs **from scratch** on every gate reset (a content change voids the tally), so a PR that
 takes several fix rounds can spend many full-diff passes — and the default cross-engine route moves all of
 that off the native-worker pool, while a native-worker fallback (paired CLI absent) does not. Both are

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -1,11 +1,17 @@
 ## Base branch
 
-The run targets a **base branch** — the branch every adopted PR merges into and every review diff is
-measured against. It is **not assumed to be `main`**: it is the **adopted PRs' `baseRefName`** (from
-`gh pr view`), which may be a release or integration branch. When several PRs are adopted at once they
-must **agree** on `baseRefName`; if they disagree, stop and prompt (one run targets one base). Resolve
-it **once** at the start of a run and record it in the ledger header as `base_branch`; re-read it from
-the ledger every heartbeat, never from memory.
+The run targets a **base branch** — the branch a PR merges into and its review diff is measured
+against. It is **not assumed to be `main`**: it is a PR's **`baseRefName`** (from `gh pr view`), which
+may be a release or integration branch. PRs adopted together must **agree** on `baseRefName`; if they
+disagree, stop and prompt — **adoption admits only one base per run today** (mixed-base admission is the
+rollout's final, not-yet-shipped stage).
+
+The base is **per-row** state, recorded on each row at adoption (`pr-adopt.py` → `add-row
+--base-branch`); the ledger **header** `base_branch` is only the **legacy fallback** a row carrying none
+inherits. Every consumer resolves a row's base through `ledger.py`'s `effective_base(header, row)` (and
+`require_effective_base`, its fail-closed form, before acting on it) — never by re-reading the one header
+field. The field, its accessors, and the `CREATE_ONLY` rule are owned by the `base_branch` field in
+`files-and-ledger.md`.
 
 Throughout this doc, `<base>` means that branch and `origin/<base>` its remote-tracking branch.
 Concretely: adopted PRs already target `<base>` (their `baseRefName`), every review diffs
@@ -44,7 +50,7 @@ host-specific `repository.scratch_root` and owns that invocation. The atomic cre
 retry live in `run-id.py`; the caller no longer mints an id or retries. Do not unpack that operation here.
 
 Record it in the ledger header field `run_id` (`ledger.py --file <state.jsonl> header set run_id
-<run-id>`) and re-read it every heartbeat (`ledger.py … header get run_id`, like `base_branch`); never trust
+<run-id>`) and re-read it every heartbeat (`ledger.py … header get run_id`); never trust
 in-context memory for it — a heartbeat may be a fresh agent instance. It flows into:
 
 | Owned by the run | Namespaced form |

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -154,8 +154,12 @@ one repository, reads both declaration sources, validates every response field, 
 declarations, validates the result through `ci-snapshot.py`'s strict parser, and writes the canonical value
 to that base's rows **still needing one** through `ledger.py`'s atomic store (legacy `-` rows inherit the
 header, which the same command settles as their fallback channel — no inherited row value is materialized).
-A row whose stored value is already settled is **never overwritten** — by a failed read or a fresh one; an
-unsettled row joining a base with a settled sibling adopts that settled value with no new GitHub read. It
+A value already settled for a base is **never overwritten** — not by a failed read, not by a fresh one — and
+an unsettled row on that base ADOPTS it with no new GitHub read. That settled value may come from EITHER
+channel that holds base B's set: a group **sibling** row's own settled value, **or the header's** when B **is
+the header base** (the header describes base B for that base alone — never a different one, which would
+settle a base off another base's set). So a `-`/`unknown` row on the header base heals from the header's
+settled value with no read, and a failed read cannot knock it back to `unknown`. It
 exits 0 when every group is settled (`declared:…` or `none`), 1 while any group is still `unknown`, and 2
 for a caller or ledger error. A settled group is returned without another GitHub read, and a read that
 fails for one base leaves only that base's unsettled rows `unknown` while the others settle — so the same

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -152,12 +152,14 @@ The command GROUPS the nonterminal rows by `effective_base` and reads each **dis
 resolves each base through `ledger.py`, URL-encodes it as an API path segment, scopes every GitHub call to
 one repository, reads both declaration sources, validates every response field, unions and sorts the
 declarations, validates the result through `ci-snapshot.py`'s strict parser, and writes the canonical value
-to that base's rows through `ledger.py`'s atomic store (legacy `-` rows inherit the header, which the same
-command settles as their fallback channel — no inherited row value is materialized). It exits 0 when every
-group is settled (`declared:…` or `none`), 1 while any group is still `unknown`, and 2 for a caller or ledger
-error. A settled group is returned without another GitHub read, and a read that fails for one base leaves
-only that group `unknown` while the others settle — so the same command is safe to run on every heartbeat
-and retries only the `unknown` groups.
+to that base's rows **still needing one** through `ledger.py`'s atomic store (legacy `-` rows inherit the
+header, which the same command settles as their fallback channel — no inherited row value is materialized).
+A row whose stored value is already settled is **never overwritten** — by a failed read or a fresh one; an
+unsettled row joining a base with a settled sibling adopts that settled value with no new GitHub read. It
+exits 0 when every group is settled (`declared:…` or `none`), 1 while any group is still `unknown`, and 2
+for a caller or ledger error. A settled group is returned without another GitHub read, and a read that
+fails for one base leaves only that base's unsettled rows `unknown` while the others settle — so the same
+command is safe to run on every heartbeat and retries only the `unknown` groups.
 
 The command owns two mandatory reads. They do **not** need the same permission: **`GET
 /repos/{o}/{r}/branches/{b}` needs `Contents: read`**, while **`GET

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -23,7 +23,7 @@ campaign commit to the PR head resets the gate", below, through `scripts/ledger.
 
 ```sh
 python3 <skill>/scripts/ci-status.py derive --pr <N> --head-sha <the LEDGER's head_sha> --rundir <rundir> \
-  --required-set "$(python3 <skill>/scripts/ledger.py --file <rundir>/state.jsonl header get required_set)"
+  --ledger <rundir>/state.jsonl
 ```
 
 It performs every step of the spec — FETCH (SHA-pinned, paginated, **both** families), PROMOTE (atomic),
@@ -40,14 +40,17 @@ behind. It exits `0` **only** on green.
 same JSON to `ci-status.py liveness` ("THE BOOKKEEPING IS A COMMAND", below), which records it and does
 the counter arithmetic.
 
-**`--required-set` IS MANDATORY, AND IT HAS NO DEFAULT.** It is the ledger header's `required_set`, passed
-straight through (`declared:<json>` | `none` | `unknown` — "WHAT WERE WE EXPECTING TO SEE?", below). The
-evidence can only ever say what **showed up**; what was **supposed** to show up is a property of the base
-branch, and **a required check that never registered is NO ROW AT ALL** — invisible to the counts, to
-containment, and to the rollup cross-check alike. So the tool refuses to guess it: a caller who omits the
-flag gets an error, and a spec it cannot parse is **exit 2**, never a quiet `none`. `unknown` is a legal
-value and **can never go green** — which is what makes a run that never performed the read merge **nothing**
-rather than merge everything with a footnote.
+**THE REQUIRED SET IS NAMED, AND IT HAS NO DEFAULT.** `--ledger` resolves the selected **row's**
+`effective_required_set` — its explicit `required_set`, else the legacy header value — because the required
+set is a property of the base and the base is now per-row state (`declared:<json>` | `none` | `unknown` —
+"WHAT WERE WE EXPECTING TO SEE?", below). (`--required-set <spec>` still passes a set straight through for a
+pure/out-of-run derivation; alongside `--ledger` it is an **assertion** that must equal the row's effective
+set, never a second source.) The evidence can only ever say what **showed up**; what was **supposed** to show
+up is a property of the base branch, and **a required check that never registered is NO ROW AT ALL** —
+invisible to the counts, to containment, and to the rollup cross-check alike. So the tool refuses to guess
+it: a derive with neither `--ledger` nor `--required-set` gets an error, and a spec it cannot parse is
+**exit 2**, never a quiet `none`. `unknown` is a legal value and **can never go green** — which is what makes
+a run that never performed the read merge **nothing** rather than merge everything with a footnote.
 
 **A MOVED HEAD FAILS CLOSED — `head_moved: true` is NEVER a green, and never a red either.** The fetch is
 pinned to the `head_sha` **the ledger holds**, and a push can land at any moment — including *while the tool
@@ -145,12 +148,16 @@ Run the required-set command before CI derivation on every heartbeat:
 python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl [--repo <owner>/<repo>]
 ```
 
-The command reads `base_branch` through `ledger.py`, URL-encodes it as an API path segment, scopes every
-GitHub call to one repository, reads both declaration sources, validates every response field, unions and
-sorts the declarations, validates the result through `ci-snapshot.py`'s strict parser, and writes the
-canonical value through `ledger.py`'s atomic store. It exits 0 for a settled `declared:…` or `none`, 1 for
-`unknown`, and 2 for a caller or ledger error. A settled value is returned without another GitHub read, so
-the same command is safe to run on every heartbeat and retries only an `unknown` value.
+The command GROUPS the nonterminal rows by `effective_base` and reads each **distinct** base once: it
+resolves each base through `ledger.py`, URL-encodes it as an API path segment, scopes every GitHub call to
+one repository, reads both declaration sources, validates every response field, unions and sorts the
+declarations, validates the result through `ci-snapshot.py`'s strict parser, and writes the canonical value
+to that base's rows through `ledger.py`'s atomic store (legacy `-` rows inherit the header, which the same
+command settles as their fallback channel — no inherited row value is materialized). It exits 0 when every
+group is settled (`declared:…` or `none`), 1 while any group is still `unknown`, and 2 for a caller or ledger
+error. A settled group is returned without another GitHub read, and a read that fails for one base leaves
+only that group `unknown` while the others settle — so the same command is safe to run on every heartbeat
+and retries only the `unknown` groups.
 
 The command owns two mandatory reads. They do **not** need the same permission: **`GET
 /repos/{o}/{r}/branches/{b}` needs `Contents: read`**, while **`GET
@@ -178,19 +185,20 @@ it is not optional.
 
 ##### THREE states, NEVER two — "I CANNOT SEE ANY" IS NOT "THERE ARE NONE"
 
-The command persists the outcome in the ledger header as `required_set` — **a state it cannot persist is a
-state it does not have** (`files-and-ledger.md` owns the field; this block owns its meaning and format).
+The command persists the outcome **per row** as `required_set` — **a state it cannot persist is a
+state it does not have** (`files-and-ledger.md` owns the field; this block owns its meaning and format). The
+header `required_set` is the legacy fallback for a row carrying no explicit set.
 
 **WHEN: run the COMMAND every heartbeat, and let IT decide whether GitHub is read** — that split is the
 whole policy, and it is why the two sentences that follow do not conflict. The GitHub **read** happens once
-per run, before the first CI derivation — the set is a property of `base_branch`, which is itself set once
-(`files-and-ledger.md`, "Base branch"), so one read serves every PR in the run — **and is retried, every
-heartbeat, for as long as the value is `unknown`**: that is the whole of its retry policy, and it is what
-keeps a transient failure (a network blip, a rate limit) from parking PRs that were never really blocked —
-a read that recovers before the STRIKE CAP costs the run nothing at all. **Once it is `declared:…` or
-`none`, it is SETTLED — the command returns the ledger's value without touching GitHub**, and never
+per **distinct base**, before the first CI derivation — the set is a property of the base, and every row on
+the same base shares one read (`files-and-ledger.md`, "Base branch") — **and is retried, every heartbeat,
+for as long as that base's value is `unknown`**: that is the whole of its retry policy, and it is what keeps
+a transient failure (a network blip, a rate limit) from parking PRs that were never really blocked — a read
+that recovers before the STRIKE CAP costs the run nothing at all. **Once a base's set is `declared:…` or
+`none`, it is SETTLED — the command returns that group's value without touching GitHub**, and never
 overwrites a successful read with a later failure. So there is no "should I run it this time?" question:
-always run it; a settled value makes it a cheap local no-op.
+always run it; a settled group makes it a cheap local no-op.
 
 | State | `required_set` | When | What `green` may claim |
 |---|---|---|---|

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -18,8 +18,13 @@ never classify a diff by eye:
 ```text
 python3 <skill-dir>/scripts/triage.py derive \
     --worktree <worktree> --base origin/<base> --head-sha <head_sha> \
-    [--tier <your decided tier>]
+    --file <state.jsonl> --pr <pr> [--tier <your decided tier>]
 ```
+
+Here `<base>` is **this PR row's effective base** — its explicit `base_branch`, else the legacy header
+fallback (`ledger.py`'s `effective_base`), never the one header base. Passing `--file <state.jsonl> --pr
+<pr>` makes `--base` an **assertion**: `triage.py` refuses (exit 2, no JSON) if `origin/<base>` does not
+name that row's effective base, so the diff can never be measured against a branch the row does not track.
 
 The command resolves the merge-base, reads Git's NUL-delimited raw diff and modes at the expected
 40-character head, and re-reads `HEAD` after classification. A stale expected head, moving head, malformed
@@ -123,20 +128,29 @@ review gate"), and the review re-starts on the clean tip:
 - **CI failures.** If `ci` is red for the current tip, do NOT review — fix CI first (Stage 2b).
   Handle failures **one at a time per PR/SHA**, and **prefer a scoped subagent** per failure; different
   PRs may fix CI concurrently within the cap.
-- **Base currency with `<base>`.** Before reviewing or dispatching a fix, run `python3
-  scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base> --file <state.jsonl>`. It checks both GitHub's
-  merge states and whether fetched `origin/<base>` is an ancestor of the PR worktree's `HEAD`. A
-  `rebase-first` verdict covers a conflict, GitHub reporting behind, or a CLEAN PR whose branch lacks the
-  refreshed base. `recheck` covers an uncomputed/unrecognized GitHub value or ancestry the helper cannot
-  verify; re-poll and re-run, never dispatch or rebase from incomplete evidence. `base-preflight.py` owns
-  the decision and is the pre-flight gate for every fix subagent (`fix-subagent-contract.md`, PRE-FLIGHT).
-  **Run it with `--file <state.jsonl>`:** on `proceed` it records `base_ok_sha` for the current head — the
-  MECHANICAL precondition `ledger.py verdict` then enforces ("Recording a verdict", below), so a review verdict
-  can never be recorded for a head with no fresh `proceed`.
+- **Base currency with `<base>`.** Throughout Stage 2, `<base>` is **this PR row's effective base** — its
+  explicit `base_branch`, else the legacy header fallback (`ledger.py`'s `effective_base`), never the one
+  header base; a mixed-base run resolves it per row. Before reviewing or dispatching a fix, run `python3
+  scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base> --file <state.jsonl>`. With
+  `--file`, the ROW owns the base: `--base` is an **assertion** that must equal the row's effective base, and
+  the helper also compares the PR's **live** `baseRefName` against it. It checks GitHub's merge states and
+  whether fetched `origin/<base>` is an ancestor of the PR worktree's `HEAD`. A `rebase-first` verdict covers
+  a conflict, GitHub reporting behind, or a CLEAN PR whose branch lacks the refreshed base — a base that
+  merely **ADVANCED** (same branch NAME, new commits). `recheck` covers an uncomputed/unrecognized GitHub
+  value, ancestry the helper cannot verify, **or a live retarget** — the PR now targets a different branch
+  NAME, an unsupported mid-run change the helper refuses with the same machine-blocker reason a
+  reconcile/re-adoption park records (`base changed from <recorded> to <live>; not supported mid-run`); park
+  the row through that path and do not proceed. Re-poll and re-run, never dispatch or rebase from incomplete
+  evidence. `base-preflight.py` owns the decision and is the pre-flight gate for every fix subagent
+  (`fix-subagent-contract.md`, PRE-FLIGHT). **Run it with `--file <state.jsonl>`:** on `proceed` it records
+  `base_ok_sha` for the current head — the MECHANICAL precondition `ledger.py verdict` then enforces
+  ("Recording a verdict", below), so a review verdict can never be recorded for a head with no fresh
+  `proceed`.
   Once it says `rebase-first`, **the CLEAN
   base-only case is EXECUTED — not hand-run — by `python3 scripts/clean-rebase.py run --ledger
   <state.jsonl> --pr <pr> --worktree <worktree> --base <base>`**: it does the fetch/rebase/`--force-with-lease`
-  push and the one ledger reset, and **refuses anything that is not clean**. **Exit 3 means it was NOT
+  push and the one ledger reset, and **refuses anything that is not clean**. Its `--base` is an assertion too
+  — it refuses (exit 2, no mutation) before any fetch if `--base` disagrees with the row's effective base. **Exit 3 means it was NOT
   clean** — a conflict, or a rebase that applied textually but changed the PR's own diff — and it has already
   aborted/reset and left the worktree at its original head; **fall back to the JUDGMENT path**: **both**
   exit-3 subcases land here — a conflict, AND a rebase that applied textually but changed the PR's own diff

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -29,12 +29,16 @@ two wires is what turns a blocked merge into an infinite CI watch.
 
 **The merge-readiness decision is COMPUTED, never read by eye:**
 `python3 <skill-dir>/scripts/merge-check.py check --pr <N> --file <state.jsonl>`. It reads the ledger
-row + the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid`),
-fetches the ledger base into the PR worktree, and prints `{"verdict":"merge"|"not-yet","reason":…}`.
-It crosses — in ONE place — the held/open/draft/stale-head/ci/reviews preconditions and then **BOTH** GitHub enums (`.mergeable` first — `CONFLICTING`
+row + the live PR view (`gh pr view <pr> --json mergeable,mergeStateStatus,isDraft,state,headRefOid,baseRefName`),
+resolves the row's **effective base** (its explicit `base_branch`, else the legacy header) and fetches THAT
+base into the PR worktree, and prints `{"verdict":"merge"|"not-yet","reason":…}`.
+It crosses — in ONE place — the held/open/draft/**base-retarget**/stale-head/ci/reviews preconditions and then **BOTH** GitHub enums (`.mergeable` first — `CONFLICTING`
 and `UNKNOWN` decide on their own, `MERGEABLE` falls through — then `.mergeStateStatus`, which alone
-yields `merge`), then confirms `origin/<base>` is an ancestor of `HEAD`. Both enums are crossed
-**TOTALLY**: a value GitHub's schema does not declare **parks**, never guesses. Act on the verdict:
+yields `merge`), then confirms `origin/<effective-base>` is an ancestor of `HEAD`. Both enums are crossed
+**TOTALLY**: a value GitHub's schema does not declare **parks**, never guesses. A live `baseRefName` that no
+longer matches the row's recorded base is an unsupported retarget: it fails closed with the shared
+machine-blocker reason (`base changed from <recorded> to <live>; not supported mid-run`), and the next
+reconcile parks the row. Act on the verdict:
 
 - `merge` → run the command in **"Resumable merge execution"** below.
 - `not-yet <reason>` → do **NOT** merge; the reason names the block. Route on the reason's **action**
@@ -50,6 +54,8 @@ yields `merge`), then confirms `origin/<base>` is an ancestor of `HEAD`. Both en
     `— park` action, not a fixed value list, keeps this bucket total.
   - `re-poll` reasons (merge state / mergeability not computed yet — `UNKNOWN`) → the **UNKNOWN re-poll
     bound** (below).
+  - the **`not supported mid-run`** reason (a live base retarget) → leave the PR; the next reconcile detects
+    the base change and parks the row on the user (the merge door only refuses — reconcile owns the park).
   - Everything else (`ci is …`, `N of M approvals`, `held`, stale head) → leave the PR; the next
     heartbeat re-evaluates once that precondition changes.
 
@@ -110,8 +116,11 @@ python3 <skill-dir>/scripts/merge.py run \
 `merge.py` imports `merge-check.py`; readiness policy stays owned by **"The merge precondition"** above.
 The command re-reads the live PR and exact head, checks this run's owner label, executes the established
 `gh pr merge <N> --<merge-method> --match-head-commit <head_sha>` call without `--delete-branch`, confirms
-`MERGED`, updates local `<base>`, cleans only ledger-owned local resources, then records `status = merged`
-through the ledger accessor.
+`MERGED`, updates the local **row base** (`effective_base` — after a `v3` PR, local `v3`; after a `main` PR,
+local `main`), cleans only ledger-owned local resources, then records `status = merged`
+through the ledger accessor. Every base door in the command — the pre-merge validation, the merge-check
+ancestry, and this post-merge sync — targets the row's base, and refuses a live retarget with the shared
+`base changed … not supported mid-run` reason.
 
 `--match-head-commit` pins the merge to the exact reviewed head SHA: a push that advanced the live tip
 between the readiness view and the merge call makes GitHub refuse fail-closed, rather than squashing the
@@ -149,8 +158,10 @@ ownership checks and phase order remain in force.
    ONLY WHAT CAN MOVE") — relaunched while a row is still RUNNING, **not** relaunched once CI has settled.
 
    For each **non-parked** open PR, run `python3 scripts/base-preflight.py check --pr <pr> --worktree
-   <worktree> --base <base>`. It fetches `origin/<base>` and requires it to be an ancestor of `HEAD` even
-   when GitHub still reports CLEAN. On `recheck`, re-poll and leave the candidate alone. On
+   <worktree> --base <base> --file <state.jsonl>`, where `<base>` is that row's **effective base** (its
+   explicit `base_branch`, else the legacy header — a run may hold PRs on different bases, so it is resolved
+   per PR, and `--base` is asserted against it). It fetches `origin/<base>` and requires it to be an ancestor
+   of `HEAD` even when GitHub still reports CLEAN. On `recheck`, re-poll and leave the candidate alone. On
    `rebase-first`, rebase before considering the candidate for another review or merge:
    - Clean rebase (no conflicts, PR diff unchanged) → **EXECUTED — not hand-run — by `python3
      scripts/clean-rebase.py run --ledger <state.jsonl> --pr <N> --worktree <worktree> --base <base>`**: it
@@ -182,6 +193,9 @@ ownership checks and phase order remain in force.
      to **"Resumable merge execution"** in the same heartbeat; `merge.py` imports `merge-check.py` and
      repeats the ancestry check before merging.
 
-Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
+The drain stays **serialized — one PR at a time across the whole run**, even when PRs target different bases
+(`v3`, `main`). There is no run-wide checkout pinned to one branch: each merge resolves, validates, and syncs
+its own row's base, so a mixed-base run drains in one serial order and each merge updates only its base's
+local ref. Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
 
 ---

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -33,8 +33,10 @@ def _load_owner():
 M = _load_owner()
 
 
-def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN") -> dict:
-    return {"mergeable": mergeable, "mergeStateStatus": mergeStateStatus}
+def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN", baseRefName="main") -> dict:
+    # `baseRefName` is the PR's LIVE base: `check --file` compares it with the row's effective base and refuses
+    # a retarget. `decide()` ignores it, so the pure-decide fixtures below are unaffected by its presence.
+    return {"mergeable": mergeable, "mergeStateStatus": mergeStateStatus, "baseRefName": baseRefName}
 
 
 def check(cond: bool, msg: str) -> None:
@@ -327,9 +329,18 @@ def _run_ledger(ledger: Path, *argv: str) -> subprocess.CompletedProcess:
     return proc
 
 
-def _ledger_row(ledger: Path, pr: str, head_sha: str) -> None:
-    """Build a ledger through the REAL sibling accessor with one row for `pr` at `head_sha` (base_ok_sha `-`)."""
+def _ledger_row(ledger: Path, pr: str, head_sha: str, base: str = "main") -> None:
+    """Build a ledger through the REAL sibling accessor with one row for `pr` at `head_sha` (base_ok_sha `-`),
+    carrying an EXPLICIT row base — the shape `pr-adopt.py` writes for every new row (`--base-branch`)."""
     _run_ledger(ledger, "header", "set", "run_id", "t")
+    _run_ledger(ledger, "add-row", "--pr", pr, "--head-sha", head_sha, "--base-branch", base)
+
+
+def _legacy_ledger_row(ledger: Path, pr: str, head_sha: str, header_base: str = "main") -> None:
+    """An OLD-shape ledger: the row carries NO explicit base (`base_branch` stays `-`), so its effective base
+    INHERITS the legacy header `base_branch`. Proves `check --file` resolves through the accessor's fallback."""
+    _run_ledger(ledger, "header", "set", "run_id", "t")
+    _run_ledger(ledger, "header", "set", "base_branch", header_base)
     _run_ledger(ledger, "add-row", "--pr", pr, "--head-sha", head_sha)
 
 
@@ -408,6 +419,97 @@ def t_non_proceed_with_file_leaves_base_ok():
                   f"[{name}] a non-proceed decision stamped base_ok_sha: {_base_ok_sha(ledger, '9')!r}")
 
 
+# --- `--file`: the ROW owns the base — `--base` is an assertion, a live retarget refuses --------------------
+# These drive the CLI with `--view-json` so no gh/git worktree is needed: the base checks all run BEFORE the
+# ancestry probe, so a refusal is reached without a real base to fetch.
+
+
+def t_file_base_assertion_mismatch_rechecks():
+    """`--base` disagreeing with the row's effective base is REFUSED — the flag is an assertion, not a source."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", "a" * 40, base="main")
+        vjson = root / "v.json"
+        vjson.write_text(json.dumps(view(baseRefName="main")), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--base", "v3", "--file", str(ledger)])
+        check(code != 0, f"a --base disagreeing with the row must fail closed (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "recheck", f"a --base mismatch must recheck, never proceed, got {result!r}")
+        check("disagrees" in result["reason"] and "effective base" in result["reason"],
+              f"the reason must name the --base disagreement, got {result['reason']!r}")
+
+
+def t_file_origin_prefixed_base_matches():
+    """An `origin/<base>` form of `--base` matches the row's bare effective base (the prefix is stripped)."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", "a" * 40, base="main")
+        vjson = root / "v.json"
+        # DIRTY so the run stops at the (post-assertion) decide step, not the ancestry probe — proving the
+        # `origin/main` assertion PASSED (a refusal there would name the disagreement instead).
+        vjson.write_text(json.dumps(view(mergeStateStatus="DIRTY", baseRefName="main")), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--base", "origin/main", "--file", str(ledger)])
+        check(code != 0, f"a DIRTY view still rebases (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "rebase-first",
+              f"origin/main must satisfy the assertion and fall through to decide, got {result!r}")
+
+
+def t_file_live_retarget_rechecks():
+    """The PR's live `baseRefName` differs from the row's effective base -> the retarget refusal, with the
+    EXACT machine-blocker wording a re-adoption/reconcile park records (never proceed, never rebase-first)."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", "a" * 40, base="main")
+        vjson = root / "v.json"
+        vjson.write_text(json.dumps(view(baseRefName="v9")), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--base", "main", "--file", str(ledger)])
+        check(code != 0, f"a live retarget must fail closed (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "recheck", f"a retarget must recheck, never proceed, got {result!r}")
+        check(result["reason"] == "base changed from main to v9; not supported mid-run",
+              f"the retarget reason must be the exact machine-blocker wording, got {result['reason']!r}")
+
+
+def t_file_legacy_row_inherits_header_base():
+    """An OLD row (no explicit base) resolves through the legacy header, and the live comparison uses THAT
+    inherited base: a live `baseRefName` differing from the header base refuses with the header value named."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _legacy_ledger_row(ledger, "9", "a" * 40, header_base="main")
+        vjson = root / "v.json"
+        vjson.write_text(json.dumps(view(baseRefName="v9")), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--file", str(ledger)])
+        check(code != 0, f"a legacy row whose live base moved must fail closed (stderr: {err})")
+        result = json.loads(out)
+        check(result["reason"] == "base changed from main to v9; not supported mid-run",
+              f"the inherited header base must drive the comparison, got {result['reason']!r}")
+
+
+def t_file_missing_row_rechecks():
+    """`--file` naming a PR with no ledger row fails closed — the base cannot be resolved, never proceed."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", "a" * 40, base="main")
+        vjson = root / "v.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "77", "--view-json", str(vjson),
+                                              "--file", str(ledger)])
+        check(code != 0, f"an unknown PR row must fail closed (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "recheck" and "no ledger row for pr 77" in result["reason"],
+              f"a missing row must recheck and name the PR, got {result!r}")
+
+
 CASES = [
     ("clean-proceeds", "CLEAN passes the enum screen", t_clean_proceeds),
     ("has-hooks-proceeds", "HAS_HOOKS passes the enum screen", t_has_hooks_proceeds),
@@ -443,4 +545,13 @@ CASES = [
      t_proceed_with_file_records_base_ok),
     ("non-proceed-file-no-stamp", "rebase-first/recheck never stamp base_ok_sha, even with --file",
      t_non_proceed_with_file_leaves_base_ok),
+    ("file-base-assertion-mismatch", "--file: --base disagreeing with the row's effective base rechecks",
+     t_file_base_assertion_mismatch_rechecks),
+    ("file-origin-prefixed-base", "--file: an origin/<base> --base satisfies the assertion",
+     t_file_origin_prefixed_base_matches),
+    ("file-live-retarget", "--file: a live baseRefName retarget rechecks with the machine-blocker wording",
+     t_file_live_retarget_rechecks),
+    ("file-legacy-row-header-base", "--file: an old row inherits the header base for the live comparison",
+     t_file_legacy_row_inherits_header_base),
+    ("file-missing-row", "--file: an unknown PR row fails closed to recheck", t_file_missing_row_rechecks),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -459,6 +459,36 @@ def t_file_origin_prefixed_base_matches():
               f"origin/main must satisfy the assertion and fall through to decide, got {result!r}")
 
 
+def t_file_origin_named_base_matches_itself():
+    """A base LITERALLY named `origin/<x>` (a legal branch name) matches itself: `--base origin/release`
+    against a stored `origin/release` must pass the assertion, never be read as a disagreement because one
+    side was stripped (`ledger.py base_agrees` — identical strings always agree). A bare `--base release`
+    still disagrees: the STORED base is never stripped."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", "a" * 40, base="origin/release")
+        vjson = root / "v.json"
+        # DIRTY so the run stops at the (post-assertion) decide step, not the ancestry probe — proving the
+        # identical-string assertion PASSED (a refusal there would name the disagreement instead).
+        vjson.write_text(json.dumps(view(mergeStateStatus="DIRTY", baseRefName="origin/release")),
+                         encoding="utf-8")
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--base", "origin/release", "--file", str(ledger)])
+        check(code != 0, f"a DIRTY view still rebases (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "rebase-first",
+              f"identical origin/release strings must agree and fall through to decide, got {result!r}")
+        # The bare form does NOT assert a base literally named origin/release — the stored base is never
+        # stripped, so this refuses as a disagreement.
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--base", "release", "--file", str(ledger)])
+        check(code != 0, f"a bare --base against an origin/-named stored base must fail closed (stderr: {err})")
+        result = json.loads(out)
+        check(result["verdict"] == "recheck" and "disagrees" in result["reason"],
+              f"a bare --base must disagree with a stored origin/-named base, got {result!r}")
+
+
 def t_file_live_retarget_rechecks():
     """The PR's live `baseRefName` differs from the row's effective base -> the retarget refusal, with the
     EXACT machine-blocker wording a re-adoption/reconcile park records (never proceed, never rebase-first)."""
@@ -549,6 +579,8 @@ CASES = [
      t_file_base_assertion_mismatch_rechecks),
     ("file-origin-prefixed-base", "--file: an origin/<base> --base satisfies the assertion",
      t_file_origin_prefixed_base_matches),
+    ("file-origin-named-base", "--file: a base literally named origin/<x> matches itself; a bare form disagrees",
+     t_file_origin_named_base_matches_itself),
     ("file-live-retarget", "--file: a live baseRefName retarget rechecks with the machine-blocker wording",
      t_file_live_retarget_rechecks),
     ("file-legacy-row-header-base", "--file: an old row inherits the header base for the live comparison",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -15,11 +15,20 @@ are two jobs and this is only the first — nothing here runs `git rebase`/`git 
         [--worktree <path> --base <branch> [--remote origin]] [--file <ledger>]
     base-preflight.py self-test   run every fixture (base-preflight-test.py)
 
+When `--file <ledger>` is given, the ledger ROW owns the base: this resolves the selected PR row's
+`effective_base` (its explicit `base_branch`, else the legacy header fallback, through `ledger.py`), and any
+`--base` argument becomes an ASSERTION that must equal it — not an independent base source. It also compares
+the live PR view's `baseRefName` with that effective base and REFUSES `proceed` when they differ: the PR was
+retargeted to a different branch NAME, an unsupported mid-run change, so it fails closed to `recheck` with the
+same `BASE_CHANGE_PARK_REASON` wording a re-adoption/reconcile park records and the driver parks the row. (A
+base that merely ADVANCED — same branch, new commits — is NOT a retarget; that stays the ancestry
+`rebase-first` below.)
+
 On a final `proceed`, and ONLY when `--file <ledger>` is given, this records that base check on the ledger row
 by shelling out to `ledger.py base-ok` — resolving the worktree's live `HEAD` and stamping it as
 `base_ok_sha`. That stamp is the MECHANICAL precondition `ledger.py verdict` enforces: a review verdict cannot
 be recorded for a head with no fresh `proceed`. Without `--file` the tool is the pure decider it always was
-(it writes nothing); `decide()` itself stays pure regardless.
+(it writes nothing, and `--base` is the base it fetches); `decide()` itself stays pure regardless.
 
 The verdict is printed as JSON on stdout, and the EXIT CODE gates a caller's `$?`: 0 for `proceed`, non-zero
 for `rebase-first` and `recheck` (and for a view that could not be fetched or was malformed — those fail
@@ -41,6 +50,38 @@ from _gauntlet.modules import load_module_from_path
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "base-preflight-test.py"     # the fixture suite — this tool's executable contract
 LEDGER = _HERE / "ledger.py"                   # the sibling that owns base_ok_sha; `base-ok` is its only writer
+PR_ADOPT = _HERE / "pr-adopt.py"               # owns BASE_CHANGE_PARK_REASON — reused, never re-spelt here
+
+
+def _load_ledger():
+    mod = load_module_from_path("base_preflight_ledger", LEDGER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER}")
+    return mod
+
+
+L = _load_ledger()
+
+# Loaded LAZILY (only when a live retarget is found) so the pure decider and self-test never pull the
+# adoption module chain: pr-adopt.py OWNS `BASE_CHANGE_PARK_REASON`, the EXACT machine-blocker wording a
+# re-adoption/reconcile park records. A preflight retarget-refusal reuses that one owner so the reason reads
+# identically everywhere — never a second copy of the string here.
+_PA = None
+
+
+def _base_change_reason(recorded: str, live: str) -> str:
+    global _PA
+    if _PA is None:
+        _PA = load_module_from_path("base_preflight_pr_adopt", PR_ADOPT)
+        if _PA is None:
+            raise RuntimeError(f"cannot load pr-adopt.py for the base-change reason at {PR_ADOPT}")
+    return _PA.BASE_CHANGE_PARK_REASON.format(recorded=recorded, live=live)
+
+
+def _strip_remote(ref: str) -> str:
+    """`origin/main` -> `main`; anything without that prefix is returned unchanged. Lets a `--base` passed as
+    `origin/<base>` (the review-diff form) be compared against the row's bare `effective_base`."""
+    return ref[len("origin/"):] if ref.startswith("origin/") else ref
 
 
 # --- the verdicts -------------------------------------------------------------
@@ -150,7 +191,7 @@ def decide(view: dict) -> dict:
 
 # --- obtain the live PR view ---------------------------------------------------
 
-VIEW_FIELDS = "mergeable,mergeStateStatus"
+VIEW_FIELDS = "mergeable,mergeStateStatus,baseRefName"
 
 # Every field `decide` reads off the view, each a string. `validate_view` pins this at the boundary so
 # `decide` may assume a shaped view and never raises `KeyError`/`TypeError` on a value the caller handed in.
@@ -233,6 +274,40 @@ def record_base_ok(ledger_file: str, pr: str, worktree: "str | None") -> "str | 
     return None
 
 
+def resolve_ledger_base(ledger_file: str, pr: str, base_arg: "str | None",
+                        view: dict) -> "tuple[str | None, dict | None]":
+    """When a ledger is named the ROW owns the base — `--base` is only an assertion, never a base source.
+
+    Load the row for `pr`, resolve its `effective_base` (its explicit `base_branch`, else the legacy header
+    fallback, through `ledger.py`'s accessor — never a second copy of that rule), then fail CLOSED unless:
+    the row exists and has a usable base; any `--base` given equals it (an `origin/<base>` form is stripped
+    first); and the PR's LIVE `baseRefName` still equals it. A live mismatch is an unsupported retarget: it
+    routes the SAME `BASE_CHANGE_PARK_REASON` wording a re-adoption/reconcile park records, so the driver
+    parks the row through the existing machine-blocker path. (A base that merely ADVANCED — same branch NAME,
+    new commits — is NOT this: it is the ancestry `rebase-first` in `check`.) Returns `(effective_base, None)`
+    to continue with that base, or `(None, verdict)` — always a `recheck`, never `proceed` — to refuse."""
+    try:
+        header, rows = L.load(Path(ledger_file))
+    except SystemExit as exc:
+        return None, _verdict(RECHECK, f"could not read ledger {ledger_file}: {exc}")
+    row = L.find_row(rows, str(pr))
+    if row is None:
+        return None, _verdict(RECHECK, f"no ledger row for pr {pr} — its base cannot be resolved")
+    effective_base = L.effective_base(header, row)
+    if not effective_base or effective_base == "-":
+        return None, _verdict(RECHECK, f"pr {pr} has no usable effective base in the ledger")
+    if base_arg is not None and _strip_remote(base_arg) != effective_base:
+        return None, _verdict(
+            RECHECK, f"--base {base_arg!r} disagrees with pr {pr}'s ledger effective base "
+                     f"{effective_base!r} — --base is an assertion, not a base source")
+    live = view.get("baseRefName")
+    if not isinstance(live, str) or not live:
+        return None, _verdict(RECHECK, "malformed PR view: missing baseRefName, so the live base is unknown")
+    if live != effective_base:
+        return None, _verdict(RECHECK, _base_change_reason(effective_base, live))
+    return effective_base, None
+
+
 def check(pr: str, repo: "str | None", view_json: "str | None", project_root: "str | None",
           worktree: "str | None", base: "str | None", remote: str, ledger_file: "str | None") -> int:
     """Fetch the live view, decide, print the verdict as JSON. EXIT 0 only on `proceed`; every other outcome
@@ -253,6 +328,15 @@ def check(pr: str, repo: "str | None", view_json: "str | None", project_root: "s
     if problem is not None:
         print(json.dumps(_verdict(RECHECK, f"malformed PR view: {problem}")))
         return 1
+    # When a ledger is named, the ROW owns the base: resolve `effective_base`, assert any `--base` matches it,
+    # and refuse (fail CLOSED to `recheck`) if the PR's live target no longer equals it. On success `base` is
+    # the row's effective base, so the ancestry fetch below measures against the base the row actually tracks
+    # — never a `--base` a caller could have handed in disagreeing with the ledger.
+    if ledger_file is not None:
+        base, refusal = resolve_ledger_base(ledger_file, pr, base, view)
+        if refusal is not None:
+            print(json.dumps(refusal))
+            return 1
     result = decide(view)
     if result["verdict"] == PROCEED:
         ancestry, detail = check_base_ancestry(worktree, base, remote)
@@ -329,10 +413,13 @@ def main(argv: "list[str] | None" = None) -> int:
     c.add_argument("--view-json", help="a recorded `gh pr view` JSON — decide without calling gh")
     c.add_argument("--project-root", help="run `gh pr view` with this as its working directory")
     c.add_argument("--worktree", help="the PR-head worktree used for the Git ancestry check")
-    c.add_argument("--base", help="the PR base branch to fetch and compare")
-    c.add_argument("--remote", default="origin", help="the worktree remote holding --base (default: origin)")
-    c.add_argument("--file", help="the ledger (state.jsonl); on `proceed`, record base_ok_sha for the live "
-                                  "head so `ledger.py verdict` can later count. Absent: the pure decider, no write")
+    c.add_argument("--base", help="the PR base branch to fetch and compare; with --file it is an ASSERTION "
+                                  "that must equal the row's effective base, not an independent base source")
+    c.add_argument("--remote", default="origin", help="the worktree remote holding the base (default: origin)")
+    c.add_argument("--file", help="the ledger (state.jsonl); resolves the row's effective base (asserting "
+                                  "--base and refusing a live retarget), and on `proceed` records base_ok_sha "
+                                  "for the live head so `ledger.py verdict` can later count. Absent: the pure "
+                                  "decider, no write, --base is the base it fetches")
 
     sub.add_parser("self-test", help="run every fixture (base-preflight-test.py)")
 

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -287,9 +287,9 @@ def resolve_ledger_base(ledger_file: str, pr: str, base_arg: "str | None",
     row = L.find_row(rows, str(pr))
     if row is None:
         return None, _verdict(RECHECK, f"no ledger row for pr {pr} — its base cannot be resolved")
-    effective_base = L.effective_base(header, row)
-    if not effective_base or effective_base == "-":
-        return None, _verdict(RECHECK, f"pr {pr} has no usable effective base in the ledger")
+    effective_base, base_problem = L.require_effective_base(header, row, pr)
+    if base_problem is not None:
+        return None, _verdict(RECHECK, base_problem)
     if base_arg is not None and not L.base_agrees(base_arg, effective_base):
         return None, _verdict(
             RECHECK, f"--base {base_arg!r} disagrees with pr {pr}'s ledger effective base "

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -78,12 +78,6 @@ def _base_change_reason(recorded: str, live: str) -> str:
     return _PA.BASE_CHANGE_PARK_REASON.format(recorded=recorded, live=live)
 
 
-def _strip_remote(ref: str) -> str:
-    """`origin/main` -> `main`; anything without that prefix is returned unchanged. Lets a `--base` passed as
-    `origin/<base>` (the review-diff form) be compared against the row's bare `effective_base`."""
-    return ref[len("origin/"):] if ref.startswith("origin/") else ref
-
-
 # --- the verdicts -------------------------------------------------------------
 #
 # `proceed` is the ONLY verdict that clears a review/fix onto this branch; `rebase-first` says the base is
@@ -280,8 +274,8 @@ def resolve_ledger_base(ledger_file: str, pr: str, base_arg: "str | None",
 
     Load the row for `pr`, resolve its `effective_base` (its explicit `base_branch`, else the legacy header
     fallback, through `ledger.py`'s accessor — never a second copy of that rule), then fail CLOSED unless:
-    the row exists and has a usable base; any `--base` given equals it (an `origin/<base>` form is stripped
-    first); and the PR's LIVE `baseRefName` still equals it. A live mismatch is an unsupported retarget: it
+    the row exists and has a usable base; any `--base` given agrees with it (`ledger.py`'s `base_agrees` —
+    the one owner of that comparison); and the PR's LIVE `baseRefName` still equals it. A live mismatch is an unsupported retarget: it
     routes the SAME `BASE_CHANGE_PARK_REASON` wording a re-adoption/reconcile park records, so the driver
     parks the row through the existing machine-blocker path. (A base that merely ADVANCED — same branch NAME,
     new commits — is NOT this: it is the ancestry `rebase-first` in `check`.) Returns `(effective_base, None)`
@@ -296,7 +290,7 @@ def resolve_ledger_base(ledger_file: str, pr: str, base_arg: "str | None",
     effective_base = L.effective_base(header, row)
     if not effective_base or effective_base == "-":
         return None, _verdict(RECHECK, f"pr {pr} has no usable effective base in the ledger")
-    if base_arg is not None and _strip_remote(base_arg) != effective_base:
+    if base_arg is not None and not L.base_agrees(base_arg, effective_base):
         return None, _verdict(
             RECHECK, f"--base {base_arg!r} disagrees with pr {pr}'s ledger effective base "
                      f"{effective_base!r} — --base is an assertion, not a base source")

--- a/plugins/gauntlet/skills/campaign/scripts/carryover-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover-test.py
@@ -210,6 +210,27 @@ def t_header_base_dash_is_accepted() -> None:
 
 # --- refusal: a live (non-terminal) run is never distilled --------------------
 
+def t_unresolved_effective_base_is_refused() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        # BOTH the header base and the row base are `-` (the ROW_DEFAULTS default): `effective_base` resolves
+        # to `-`, an UNRESOLVED base. distill must REFUSE rather than stamp `-` into the durable history,
+        # where it would poison future per-base prunes (`ledger.py require_effective_base`, the one owner). If
+        # that guard is deleted, distill writes `base_branches: ["-"]` and a per-object `base_branch: "-"` —
+        # so this fixture FAILS.
+        header = _header(base_branch="-")
+        rows = [_row("41", slug="done", status="merged", head_sha=SHA_A, tier="STANDARD", review_rounds="2")]
+        code, out, err, out_dir = _distill(tmp, header, rows)
+        check(code == C.EXIT_STOP,
+              f"an unresolved (`-`) base is refused with EXIT_STOP ({C.EXIT_STOP}); got {code}")
+        check("41" in err and "no usable effective base" in err,
+              f"the refusal NAMES the offending PR and the unresolved base: {err!r}")
+        check(out.strip() == "", "a refused distill prints no summary on stdout")
+        check(not (out_dir / "g260704-0915-a3f29c1b.md").exists(),
+              "a refused distill writes NO history file")
+        check(_temp_files(out_dir) == [], "a refused distill leaves NO temp file behind")
+
+
 def t_non_terminal_row_is_refused_naming_the_pr() -> None:
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
@@ -344,6 +365,8 @@ CASES = [
      t_mixed_bases_per_object_and_sorted_array),
     ("header-base-dash", "a `-` header base is accepted (base is per-row); bases come from the rows",
      t_header_base_dash_is_accepted),
+    ("unresolved-base-refused", "a both-`-` ledger (row and header base unset) is refused, writing no `-` into history",
+     t_unresolved_effective_base_is_refused),
     ("non-terminal-refused", "a live run is refused, naming the offending PR, writing nothing",
      t_non_terminal_row_is_refused_naming_the_pr),
     ("once-only", "an existing file is not overwritten without --force; --force overwrites",

--- a/plugins/gauntlet/skills/campaign/scripts/carryover-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover-test.py
@@ -128,21 +128,26 @@ def t_terminal_ledger_is_distilled() -> None:
         check(len(parsed["api-declined"]) == 1, "one api-declined row in the file")
 
         merged = parsed["merged"][0]
+        # v2: every object also carries its effective base. These legacy-inheriting rows (base_branch `-`)
+        # resolve to the header base `main`.
         check(merged == {"pr": "41", "slug": "fix-null-deref", "head_sha": SHA_A, "tier": "STANDARD",
-                         "review_rounds": "3"},
-              f"the merged row projects exactly its documented fields (full 40-char SHA): {merged}")
+                         "review_rounds": "3", "base_branch": "main"},
+              f"the merged row projects exactly its documented fields plus effective base: {merged}")
 
         declined = parsed["api-declined"][0]
         check(declined == {"pr": "60", "slug": "change-signature",
-                           "api_approval": "declined@2026-07-04T16:00:00Z"},
-              f"the api-declined row carries pr/slug/api_approval: {declined}")
+                           "api_approval": "declined@2026-07-04T16:00:00Z", "base_branch": "main"},
+              f"the api-declined row carries pr/slug/api_approval/base_branch: {declined}")
         # The declined PR is ALSO aborted — it appears in BOTH sections (a reminder projection).
         check(any(r["pr"] == "60" for r in parsed["aborted"]),
               "a declined-API PR is terminal-aborted and appears in the aborted section too")
 
         meta = out_path.read_text(encoding="utf-8")
         check(f"distilled_at: {NOW}" in meta, "the distilled-at stamp is the --now value, verbatim")
-        check("base_branch: main" in meta, "the header records base_branch")
+        check('base_branches: ["main"]' in meta,
+              "v2 metadata is a sorted, deduplicated base_branches array (here just the header base)")
+        check("format v2" in meta, "the file declares carryover format v2")
+        check(summary["base_branches"] == ["main"], f"the summary carries the base set: {summary}")
 
 
 def t_head_sha_is_never_shortened() -> None:
@@ -154,6 +159,53 @@ def t_head_sha_is_never_shortened() -> None:
         parsed = _parse_sections((out_dir / "g260704-0915-a3f29c1b.md").read_text(encoding="utf-8"))
         check(parsed["merged"][0]["head_sha"] == SHA_A,
               "the carryover file stores the FULL 40-char SHA — never a display truncation")
+
+
+# --- v2: mixed bases, per-object base, and the sorted/deduplicated array -------
+
+def t_mixed_bases_per_object_and_sorted_array() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        # One run, THREE rows on TWO bases — plus a legacy-inheriting row (base `-`) that resolves to the
+        # header base. This exercises both channels of `effective_base` in one file.
+        header = _header(base_branch="main")
+        rows = [
+            _row("41", slug="fix-v3", status="merged", head_sha=SHA_A, tier="STANDARD",
+                 review_rounds="2", base_branch="v3"),
+            _row("52", slug="fix-main", status="merged", head_sha=SHA_B, tier="TRIVIAL",
+                 review_rounds="1"),  # base_branch `-` → inherits header `main`
+            _row("60", slug="also-v3", status="aborted", head_sha=SHA_C, base_branch="v3",
+                 ci_reason="required check absent", blocker_ruling="abort@2026-07-04T16:30:00Z"),
+        ]
+        code, out, err, out_dir = _distill(tmp, header, rows)
+        check(code == 0, f"a mixed-base terminal ledger distills; stderr={err!r}")
+
+        summary = json.loads(out)
+        check(summary["base_branches"] == ["main", "v3"],
+              f"base_branches is sorted and deduplicated across every row: {summary}")
+
+        text = (out_dir / "g260704-0915-a3f29c1b.md").read_text(encoding="utf-8")
+        check('base_branches: ["main", "v3"]' in text,
+              "the metadata array is sorted and deduplicated, one entry per distinct base")
+        parsed = _parse_sections(text)
+        bases = {r["pr"]: r["base_branch"] for sec in parsed.values() for r in sec}
+        check(bases == {"41": "v3", "52": "main", "60": "v3"},
+              f"each object carries ITS OWN effective base (explicit, else inherited): {bases}")
+
+
+def t_header_base_dash_is_accepted() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        # A new run writes header base `-` (the legacy fallback is unset) and an explicit base per row.
+        header = _header(base_branch="-")
+        rows = [_row("41", slug="s", status="merged", head_sha=SHA_A, tier="TRIVIAL",
+                     review_rounds="1", base_branch="main")]
+        code, out, err, out_dir = _distill(tmp, header, rows)
+        check(code == 0, f"a `-` header base is NO LONGER refused — base is per-row now; stderr={err!r}")
+        summary = json.loads(out)
+        check(summary["base_branches"] == ["main"], f"bases come from the rows, not the header: {summary}")
+        parsed = _parse_sections((out_dir / "g260704-0915-a3f29c1b.md").read_text(encoding="utf-8"))
+        check(parsed["merged"][0]["base_branch"] == "main", "the row's explicit base is projected")
 
 
 # --- refusal: a live (non-terminal) run is never distilled --------------------
@@ -225,8 +277,8 @@ def t_malformed_ledger_is_refused() -> None:
 def t_header_without_run_id_is_refused() -> None:
     with tempfile.TemporaryDirectory() as d:
         tmp = Path(d)
-        # A header whose run_id/base_branch are unset (`-`) is not a run's ledger.
-        header = dict(L.HEADER_DEFAULTS)  # run_id and base_branch default to "-"
+        # A header whose run_id is unset (`-`) is not a run's ledger. (The base is no longer gated here.)
+        header = dict(L.HEADER_DEFAULTS)  # run_id defaults to "-"
         rows = [_row("41", slug="s", status="merged", head_sha=SHA_A, tier="TRIVIAL", review_rounds="1")]
         code, out, err, out_dir = _distill(tmp, header, rows)
         check(code == C.EXIT_OPERATOR,
@@ -288,6 +340,10 @@ CASES = [
      t_terminal_ledger_is_distilled),
     ("full-sha", "the carryover file stores the full 40-char SHA, never a truncation",
      t_head_sha_is_never_shortened),
+    ("mixed-bases", "v2 stamps each object's effective base and a sorted, deduplicated base_branches array",
+     t_mixed_bases_per_object_and_sorted_array),
+    ("header-base-dash", "a `-` header base is accepted (base is per-row); bases come from the rows",
+     t_header_base_dash_is_accepted),
     ("non-terminal-refused", "a live run is refused, naming the offending PR, writing nothing",
      t_non_terminal_row_is_refused_naming_the_pr),
     ("once-only", "an existing file is not overwritten without --force; --force overwrites",

--- a/plugins/gauntlet/skills/campaign/scripts/carryover.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover.py
@@ -199,10 +199,17 @@ def distill(ledger, ledger_path: Path, out_dir: Path, now: str, *, force: bool) 
                                  f"died mid-write")
 
     # Each row's EFFECTIVE base resolves through the schema owner (its own recorded base, else the legacy
-    # header) — never a second copy of that fallback. `base_branches` is the sorted, deduplicated set for
-    # the v2 metadata; `base_of` stamps each object so history prunes per PR/base pair.
+    # header) — never a second copy of that fallback. An UNRESOLVED base (blank or the `-` sentinel) is
+    # REFUSED before it can be stamped into the durable history: `ledger.require_effective_base` is the one
+    # owner of that fail-closed rule, and history that recorded `-` as a branch name would poison every
+    # future prune ("prune each entry against ITS OWN base"). `base_branches` is the sorted, deduplicated set
+    # for the v2 metadata; `base_of` stamps each object so history prunes per PR/base pair.
     def base_of(row: dict) -> str:
-        return ledger.effective_base(header, row)
+        base, base_problem = ledger.require_effective_base(header, row, row.get("pr", "-"))
+        if base_problem is not None:
+            raise Refusal(EXIT_STOP, f"{base_problem} — refusing to distill an unresolved base into the durable "
+                                     f"history, where it would poison future per-base prunes")
+        return base
 
     base_branches = sorted({base_of(r) for r in rows})
     projected = sections(rows)

--- a/plugins/gauntlet/skills/campaign/scripts/carryover.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover.py
@@ -29,6 +29,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import Callable
 
 from _gauntlet.atomic import replace_text
 from _gauntlet.modules import load_module_from_path
@@ -39,7 +40,7 @@ HERE = Path(__file__).resolve().parent
 LEDGER_PY = HERE / "ledger.py"          # the schema owner — its loader's strictness is reused, never re-rolled
 TEST_PY = HERE / "carryover-test.py"    # the fixture suite — this tool's executable contract, a SIBLING
 
-FORMAT_VERSION = "1"
+FORMAT_VERSION = "2"
 
 # Exit codes, per the house split (mirrors ledger.py's `fail`=1 / EXIT_STOP=3 shape, one tier up):
 #   2  OPERATOR ERROR — the tool was pointed at something that is not a distillable ledger: bad args
@@ -62,6 +63,10 @@ TERMINAL_STATUSES = ("merged", "aborted")
 #   aborted       — the durable WHY a PR could not clear the bar: `ci_reason` (the machine blocker) and
 #                   `blocker_ruling` (the user's answer, e.g. abort@<iso>).
 #   api-declined  — the parked API fact to remind the user about: the PR and its `api_approval` verdict.
+# EVERY projected object ALSO carries `base_branch` (v2): the row's EFFECTIVE base at distillation
+# (`ledger.effective_base` — its own recorded base, else the run's legacy header base). It is added by
+# `render`, not listed here, because it is a COMPUTED value, not a raw field read. Pruning uses each
+# PR/base pair, so history for one base never prunes against another (`carryover.md`).
 MERGED_FIELDS = ("pr", "slug", "head_sha", "tier", "review_rounds")
 ABORTED_FIELDS = ("pr", "slug", "ci_reason", "blocker_ruling")
 API_DECLINED_FIELDS = ("pr", "slug", "api_approval")
@@ -100,10 +105,15 @@ def sections(rows: list[dict]) -> "list[tuple[str, tuple[str, ...], list[dict]]]
     ]
 
 
-def render(run_id: str, base_branch: str, now: str,
-           projected: "list[tuple[str, tuple[str, ...], list[dict]]]") -> str:
+def render(run_id: str, base_branches: "list[str]", now: str,
+           projected: "list[tuple[str, tuple[str, ...], list[dict]]]",
+           base_of: "Callable[[dict], str]") -> str:
     """The history file as text — a self-describing artifact. The leading comment DOCUMENTS the format so
     the file explains itself; the data is one JSON object per PR (fields, never sentences).
+
+    `base_branches` is the sorted, deduplicated set of every projected row's effective base — the v2
+    metadata that replaces v1's single `base_branch:` line. `base_of` resolves one row's effective base
+    (`ledger.effective_base`), stamped onto every object so history prunes per PR/base pair.
     """
     out: list[str] = []
     out.append(f"<!-- gauntlet carryover history — format v{FORMAT_VERSION}")
@@ -112,22 +122,29 @@ def render(run_id: str, base_branch: str, now: str,
     out.append("DO NOT hand-edit, and it is never re-distilled (an existing file means a previous exit")
     out.append("already wrote it). Object keys are ledger field names (scripts/ledger.py ROW_FIELDS).")
     out.append("Each `## <section>` heading is followed by zero or more rows, one JSON object per PR:")
-    out.append("  merged        pr, slug, head_sha (at merge), tier, review_rounds")
-    out.append("  aborted       pr, slug, ci_reason, blocker_ruling  (the durable why it stopped)")
-    out.append("  api-declined  pr, slug, api_approval. A declined PR is ALSO aborted, so it appears in")
-    out.append("                BOTH sections — this is a reminder projection, not double-counting.")
+    out.append("  merged        pr, slug, head_sha (at merge), tier, review_rounds, base_branch")
+    out.append("  aborted       pr, slug, ci_reason, blocker_ruling, base_branch  (the durable why it stopped)")
+    out.append("  api-declined  pr, slug, api_approval, base_branch. A declined PR is ALSO aborted, so it")
+    out.append("                appears in BOTH sections — this is a reminder projection, not double-counting.")
+    out.append("Each object's `base_branch` is the row's EFFECTIVE base at distillation (its own recorded")
+    out.append("base, else the run's legacy header base). `base_branches` below is the sorted, deduplicated")
+    out.append("set of those bases; prune each entry against ITS OWN base, never the run's (carryover.md).")
+    out.append("A v1 file instead carries a single `base_branch:` metadata line and NO per-object base — in")
+    out.append("that file, that one base is the effective base of every object (carryover.md owns the read).")
     out.append("Follow-ups are NOT here: they live in .gauntlet/followups.jsonl (followups.md).")
     out.append("-->")
     out.append(f"# carryover {run_id}")
     out.append("")
     out.append(f"run_id: {run_id}")
-    out.append(f"base_branch: {base_branch}")
+    out.append(f"base_branches: {json.dumps(base_branches)}")
     out.append(f"distilled_at: {now}")
     for name, fields, rows in projected:
         out.append("")
         out.append(f"## {name}")
         for row in rows:
-            out.append(json.dumps({f: row[f] for f in fields}))
+            obj = {f: row[f] for f in fields}
+            obj["base_branch"] = base_of(row)
+            out.append(json.dumps(obj))
     return "\n".join(out) + "\n"
 
 
@@ -141,18 +158,19 @@ def check_now(now: str) -> str:
     return now
 
 
-def check_run_identity(header: dict) -> "tuple[str, str]":
-    """A distillable ledger names its run. `run_id`/`base_branch` default to `-` (unset) when absent, so a
-    `-` here means the header carries no run identity — not a distill source.
+def check_run_id(header: dict) -> str:
+    """A distillable ledger names its run. `run_id` defaults to `-` (unset) when absent, so a `-` here
+    means the header carries no run identity — not a distill source.
+
+    The base branch is NO LONGER a header-level gate (v2): the base a PR merges into is per-ROW state
+    (`ledger.effective_base`), so a new run's header base is `-` and each row carries its own explicit
+    base. A run's bases are read from its rows, not this one header field, so a `-` header base is normal.
     """
-    run_id, base_branch = header.get("run_id", "-"), header.get("base_branch", "-")
+    run_id = header.get("run_id", "-")
     if not run_id.strip() or run_id == "-":
         raise Refusal(EXIT_OPERATOR, "the ledger header has no run_id — this is not a run's ledger, so there "
                                      "is nothing to distill")
-    if not base_branch.strip() or base_branch == "-":
-        raise Refusal(EXIT_OPERATOR, f"the ledger header for run {run_id} has no base_branch — a distillable "
-                                     f"run records the branch its PRs merged into")
-    return run_id, base_branch
+    return run_id
 
 
 def check_terminal(rows: list[dict]) -> None:
@@ -171,7 +189,7 @@ def distill(ledger, ledger_path: Path, out_dir: Path, now: str, *, force: bool) 
     """
     now = check_now(now)
     header, rows = ledger.load(ledger_path)  # the schema owner's loader — its strictness IS the validation
-    run_id, base_branch = check_run_identity(header)
+    run_id = check_run_id(header)
     check_terminal(rows)
 
     out_path = out_dir / f"{run_id}.md"
@@ -180,8 +198,15 @@ def distill(ledger, ledger_path: Path, out_dir: Path, now: str, *, force: bool) 
                                  f"distilled exactly once). Pass --force ONLY to re-run after a crash that "
                                  f"died mid-write")
 
+    # Each row's EFFECTIVE base resolves through the schema owner (its own recorded base, else the legacy
+    # header) — never a second copy of that fallback. `base_branches` is the sorted, deduplicated set for
+    # the v2 metadata; `base_of` stamps each object so history prunes per PR/base pair.
+    def base_of(row: dict) -> str:
+        return ledger.effective_base(header, row)
+
+    base_branches = sorted({base_of(r) for r in rows})
     projected = sections(rows)
-    text = render(run_id, base_branch, now, projected)
+    text = render(run_id, base_branches, now, projected, base_of)
     out_dir.mkdir(parents=True, exist_ok=True)
     # Same-directory temp + os.replace: a reader sees the whole old file or the whole new one, never a torn
     # write, and a failure leaves the ORIGINAL untouched and takes the temp with it (the house pattern).
@@ -190,6 +215,7 @@ def distill(ledger, ledger_path: Path, out_dir: Path, now: str, *, force: bool) 
     return {
         "run_id": run_id,
         "path": str(out_path),
+        "base_branches": base_branches,
         **{name.replace("-", "_"): len(rows) for name, _fields, rows in projected},
     }
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -187,8 +187,9 @@ UNCLASSIFIED = "unclassified"  # a value NO rule maps — escalate to a human; N
 # statement about what SHOWED UP; `green` is supposed to be a statement about what was REQUIRED.
 #
 # That was the REGISTRATION GAP, and it is what this section closes: the expected set is READ from the base
-# branch (branch protection AND rulesets — stage-2-ci.md owns the two reads), carried in the ledger header's
-# `required_set`, and passed in here. `green` now requires every declared check to be PRESENT and PASSING.
+# branch (branch protection AND rulesets — stage-2-ci.md owns the two reads), stored PER ROW as `required_set`
+# (the base is per-row state, so its required set is too; the ledger header value is only the legacy
+# fallback), and passed in here. `green` now requires every declared check to be PRESENT and PASSING.
 #
 # THREE STATES, NEVER TWO. "I could not see any" is NOT "there are none":
 DECLARED = "declared"  # both reads succeeded, the union is non-empty — these checks must be present+passing
@@ -201,7 +202,7 @@ CANNOT_READ = "unknown"  # a read FAILED. We do not know what was required — s
 # PENDING outcome that escalates (stage-2-ci.md, SETTLED) — and it is `ledger.py`'s DEFAULT, which makes a
 # run that never performed the read merge NOTHING instead of merging everything with a footnote.
 
-# The spec, as it is written in the ledger header: `declared:<json>` | `none` | `unknown`.
+# The spec, as it is written in the ledger row's `required_set` (header is the legacy fallback): `declared:<json>` | `none` | `unknown`.
 #
 # The `declared:` payload is a JSON ARRAY, not a comma-separated list, and that is not fussiness: A REQUIRED
 # CHECK'S NAME MAY CONTAIN A COMMA. A matrix job is named `job (a, b)` — 40 of the 100 check runs on
@@ -1387,7 +1388,8 @@ def main() -> int:
         "--required-set",
         required=True,
         help=(
-            "what the BASE BRANCH requires — the ledger header's `required_set`, VERBATIM: "
+            "what the BASE BRANCH requires — the row's `effective_required_set` (the ledger header value is "
+            "only its legacy fallback), VERBATIM: "
             "`declared:<json>` | `none` | `unknown` (stage-2-ci.md, 'WHAT WERE WE EXPECTING TO SEE?'). "
             "REQUIRED, with no default: a snapshot can be nonempty and all-passing while a REQUIRED check "
             "has not registered at all — that is no row, not a failing one, and no rule that reads only "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -571,6 +571,37 @@ def grouped_required_set_cases(ci, tmp: Path) -> list[str]:
     except SystemExit:
         pass
 
+    # 5. SINGLE-BASE TOP-LEVEL CONTRACT (regression guard). A new single-base run (one explicit-base row,
+    #    header still `unknown`) that settles to `none` must report the PRE-PR top-level summary: the
+    #    top-level base_branch/required_set/state describe that ONE settled base — NEVER a stale header
+    #    `unknown` sitting beside settled=true, and the `state` key must be PRESENT. (Mixed-base runs keep
+    #    `groups` as the signal and are covered above; there the top-level summary intentionally has no
+    #    single base to report.)
+    single = tmp / "single-base-toplevel.jsonl"
+    sheader = dict(ci.LEDGER.HEADER_DEFAULTS)
+    sheader.update({"run_id": "single", "base_branch": "main", "required_set": "unknown"})
+    ci.LEDGER.dump(single, sheader, [mrow("147", "main")])
+
+    def none_fetch(source: str, _argv: list[str]):
+        return {"protection": {"enabled": False}} if source.endswith("classic") else [[]]
+
+    sout = ci.refresh_required_set(none_fetch, single, "o/r")
+    for key in ("base_branch", "repo", "required_set", "state", "settled", "reason"):
+        if key not in sout:
+            problems.append(f"[single-base] top-level key {key!r} dropped from the return: {sorted(sout)!r}")
+    none_state = ci.SNAP.parse_required_set(ci.SNAP.NONE_DECLARED).state
+    if sout.get("required_set") != ci.SNAP.NONE_DECLARED:
+        problems.append(f"[single-base] top-level required_set must be the settled `none`, not a stale "
+                        f"header `unknown`: {sout.get('required_set')!r}")
+    if sout.get("state") != none_state:
+        problems.append(f"[single-base] top-level state must report the settled base's state, not be absent: "
+                        f"{sout.get('state')!r}")
+    if sout.get("base_branch") != "main":
+        problems.append(f"[single-base] top-level base_branch must be the single base: "
+                        f"{sout.get('base_branch')!r}")
+    if not sout.get("settled"):
+        problems.append(f"[single-base] a single-base run that read `none` must be settled: {sout!r}")
+
     return problems
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -518,6 +518,40 @@ def grouped_required_set_cases(ci, tmp: Path) -> list[str]:
     if mlseen != ["v3"] or not mlout["settled"]:
         problems.append(f"[grouped] settled main header must not be re-read; only v3: seen={mlseen!r}")
 
+    # 3c. A SETTLED ROW IS NEVER CLOBBERED — AND ITS VALUE IS ADOPTED. pr 1 holds a settled `none`; pr 2 just
+    #    joined the same base with `-`. The refresh must not touch GitHub at all (a transient FetchError here
+    #    used to write `unknown` over pr 1's settled `none`, and a successful read would have overwritten it
+    #    too — the same class): pr 2 ADOPTS the group's settled value, pr 1 keeps it.
+    adopt = tmp / "adopt-settled.jsonl"
+    ci.LEDGER.dump(adopt, dict(mheader), [mrow("1", "main", required_set="none"), mrow("2", "main")])
+    aout = ci.refresh_required_set(must_not_fetch, adopt, "o/r")
+    _ah, arows = ci.LEDGER.load(adopt)
+    agot = {r["pr"]: r["required_set"] for r in arows}
+    if agot.get("1") != "none":
+        problems.append(f"[grouped] a settled row was clobbered by a group refresh: {agot!r}")
+    if agot.get("2") != "none":
+        problems.append(f"[grouped] a fresh row must adopt its base's settled value with no read: {agot!r}")
+    if not aout["settled"]:
+        problems.append(f"[grouped] the adopting group must report settled: {aout!r}")
+
+    # 3d. DISAGREEING settled values (a hand-edit this never papers over) force a fresh read — which lands
+    #    ONLY on the rows that needed it: both settled rows keep their values even though the read succeeded
+    #    with a third value.
+    dis = tmp / "disagree-settled.jsonl"
+    ci.LEDGER.dump(dis, dict(mheader), [mrow("1", "main", required_set="none"),
+                                        mrow("2", "main", required_set=v3_set),
+                                        mrow("3", "main")])
+    df, dseen = mk_fetch({"main": "main-test"})
+    ci.refresh_required_set(df, dis, "o/r")
+    _dh, drows = ci.LEDGER.load(dis)
+    dgot = {r["pr"]: r["required_set"] for r in drows}
+    if dgot.get("1") != "none" or dgot.get("2") != v3_set:
+        problems.append(f"[grouped] a successful fresh read overwrote a settled row: {dgot!r}")
+    if dgot.get("3") != main_set:
+        problems.append(f"[grouped] the unsettled row must take the fresh read: {dgot!r}")
+    if dseen != ["main"]:
+        problems.append(f"[grouped] disagreeing settled values must force exactly one read: {dseen!r}")
+
     # 4. `derive` resolves the ROW's effective required set from --ledger; --required-set is an ASSERTION.
     parsed = ci.resolve_required_for_derive(str(mixed), "1", None)
     if parsed.state != ci.SNAP.parse_required_set(v3_set).state:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -399,6 +399,7 @@ def required_set_cases(ci, tmp: Path) -> list[str]:
         problems.append(f"[required-set] producer-to-verifier chain returned {verdict}: {verdict_reason}")
 
     problems += grouped_required_set_cases(ci, tmp)
+    problems += required_set_matrix_cases(ci, tmp)
     return problems
 
 
@@ -601,6 +602,130 @@ def grouped_required_set_cases(ci, tmp: Path) -> list[str]:
                         f"{sout.get('base_branch')!r}")
     if not sout.get("settled"):
         problems.append(f"[single-base] a single-base run that read `none` must be settled: {sout!r}")
+
+    return problems
+
+
+def required_set_matrix_cases(ci, tmp: Path) -> list[str]:
+    """The EXHAUSTIVE state matrix for "the settled required set for a base B".
+
+    B lives in TWO storage channels — the ledger HEADER (only when B IS the header base) and the explicit-base
+    GROUP rows — and three review rounds each clipped one cell where they were not treated as ONE fact. This
+    table pins the DECIDED value for every reachable cell of
+        (base relation: row base == header base | != | legacy `-` inherits header base)
+      x (row required_set: `-` | `none` | `declared:` | `unknown`)
+      x (header required_set: `unknown` | `none` | `declared:`)
+      x (read outcome: not-needed | success | failed).
+    Delete either half of the fix and a NAMED cell below fails: the header-fold in
+    `ci-status.refresh_required_set` (a `-`/`unknown` row on the header base adopts a settled header value with
+    NO read, and a FAILED read never clobbers it), or the base-agreement gate in
+    `ledger.effective_required_set` (a `-` row on a DIFFERENT base than the header stays `unknown`, never
+    reads as the header base's set). No cell is a false green: every unread base fails closed as `unknown`.
+    """
+    L = ci.LEDGER
+    problems: list[str] = []
+    UNKNOWN = L.HEADER_DEFAULTS["required_set"]  # the fail-closed `unknown` default, from its owner
+
+    def declared(base: str) -> str:
+        return ci.canonical_required_set([(f"{base}-req", ci.SNAP.ANY_APP)])
+
+    def run_cell(name: str, header_base: str, header_req: str, row_base: str, row_req: str, read: str) -> dict:
+        """One single-row ledger driven once through `refresh_required_set`.
+
+        `read`: `none` = assert NO GitHub read happens; `ok` = the (single) base's read succeeds with its own
+        distinct declared set; `fail` = that read raises. The fetch records every base it is asked for, so
+        `seen == []` mechanically proves adoption/skip rather than a read.
+        """
+        path = tmp / f"matrix-{name}.jsonl"
+        header = dict(L.HEADER_DEFAULTS)
+        header.update({"run_id": name, "base_branch": header_base, "required_set": header_req})
+        row = dict(L.ROW_DEFAULTS)
+        row.update({"pr": "1", "branch": "b1", "base_branch": row_base,
+                    "required_set": row_req, "status": "in_review"})
+        L.dump(path, header, [row])
+        hb, rb0 = L.load(path)
+        eff_before = L.effective_required_set(hb, rb0[0])
+        target = L.effective_base(hb, rb0[0])
+        seen: list[str] = []
+
+        def fetch(source: str, _argv: list[str]):
+            if source.endswith("classic"):
+                seen.append(target)
+            if read == "fail":
+                raise ci.FetchError(f"simulated outage on {target}")
+            if source.endswith("classic"):
+                return {"protection": {"enabled": True, "required_status_checks":
+                        {"checks": [{"context": f"{target}-req", "app_id": None}]}}}
+            return [[]]
+
+        out = ci.refresh_required_set(fetch, path, "o/r")
+        ha, ra = L.load(path)
+        return {"row": ra[0]["required_set"], "header": ha["required_set"], "settled": out["settled"],
+                "seen": seen, "eff_before": eff_before, "eff_after": L.effective_required_set(ha, ra[0])}
+
+    MAIN, V3 = declared("main"), declared("v3")
+
+    # name, HB, HR, RB, RR, read -> expected row, header, settled, seen, eff_before, eff_after
+    cells = [
+        # --- A. ROW BASE == HEADER BASE ("main"): the header is base B's OTHER settled channel (round 3) ---
+        # A `-` row adopts the settled header with NO read; a FAILED read can never clobber it (the round-3 repro).
+        ("A1-adopt-none-noread",    "main", "none",         "main", "-",       "none", "none", "none",         True,  [],       "none",         "none"),
+        ("A2-adopt-none-underfail", "main", "none",         "main", "-",       "fail", "none", "none",         True,  [],       "none",         "none"),
+        ("A3-adopt-declared",       "main", MAIN,           "main", "-",       "none", MAIN,   MAIN,           True,  [],       MAIN,           MAIN),
+        # An explicit `unknown` row on the header base HEALS from the header's settled read, no re-read.
+        ("A4-unknown-adopts",       "main", "none",         "main", "unknown", "fail", "none", "none",         True,  [],       "unknown",      "none"),
+        # An already-settled row with an `unknown` header needs nothing — no read, value kept.
+        ("A5-settled-hdr-unknown",  "main", UNKNOWN,        "main", "none",    "none", "none", UNKNOWN,        True,  [],       "none",         "none"),
+        ("A6-declared-row-kept",    "main", UNKNOWN,        "main", MAIN,      "none", MAIN,   UNKNOWN,        True,  [],       MAIN,           MAIN),
+        # --- B. ROW BASE != HEADER BASE ("v3" vs "main"), MIXED (stage-3 non-goal): header NEVER leaks ---
+        # A different base is read for its OWN set; before the read the `-` row is `unknown`, NOT the header's `none`.
+        ("B1-mixed-reads-own",      "main", "none",         "v3",   "-",       "ok",   V3,     "none",         True,  ["v3"],   "unknown",      V3),
+        ("B2-mixed-fail-closed",    "main", "none",         "v3",   "-",       "fail", UNKNOWN,"none",         False, ["v3"],   "unknown",      "unknown"),
+        ("B3-mixed-declared-noleak","main", MAIN,           "v3",   "-",       "ok",   V3,     MAIN,           True,  ["v3"],   "unknown",      V3),
+        # --- C. LEGACY `-` BASE ROW (inherits header base "main"): the HEADER channel, row never materialized ---
+        ("C1-legacy-settles-hdr",   "main", UNKNOWN,        "-",    "-",       "ok",   "-",    MAIN,           True,  ["main"], "unknown",      MAIN),
+        ("C2-legacy-hdr-settled",   "main", "none",         "-",    "-",       "none", "-",    "none",         True,  [],       "none",         "none"),
+        # --- D. NEW-RUN SHAPE (header base "-", header `unknown`): explicit-base row owns the read ---
+        ("D1-newrun-reads",         "-",    UNKNOWN,        "main", "-",       "ok",   MAIN,   UNKNOWN,        True,  ["main"], "unknown",      MAIN),
+        ("D2-newrun-fail-closed",   "-",    UNKNOWN,        "main", "-",       "fail", UNKNOWN,UNKNOWN,        False, ["main"], "unknown",      "unknown"),
+    ]
+    for (name, hb, hr, rb, rr, read, e_row, e_hdr, e_settled, e_seen, e_eff_b, e_eff_a) in cells:
+        got = run_cell(name, hb, hr, rb, rr, read)
+        want = {"row": e_row, "header": e_hdr, "settled": e_settled, "seen": e_seen,
+                "eff_before": e_eff_b, "eff_after": e_eff_a}
+        for key, wanted in want.items():
+            if got[key] != wanted:
+                problems.append(f"[matrix {name}] {key} = {got[key]!r}, expected {wanted!r} (full: {got!r})")
+
+    # A header value that DISAGREES with a settled ROW on the same base is a hand-edit, never papered over:
+    # the header is folded in as one more settled SOURCE, so two distinct values force EXACTLY one read, which
+    # lands ONLY on the unsettled `-` row; the settled row and the header both keep their values.
+    dis = tmp / "matrix-header-row-disagree.jsonl"
+    dh = dict(L.HEADER_DEFAULTS)
+    dh.update({"run_id": "hdr-disagree", "base_branch": "main", "required_set": "none"})
+    mk_row = lambda pr, rs: {**dict(L.ROW_DEFAULTS), "pr": pr, "branch": f"b{pr}",
+                             "base_branch": "main", "required_set": rs, "status": "in_review"}
+    L.dump(dis, dh, [mk_row("1", MAIN), mk_row("2", "-")])
+    dseen: list[str] = []
+
+    def dfetch(source: str, _argv: list[str]):
+        if source.endswith("classic"):
+            dseen.append("main")
+            return {"protection": {"enabled": True, "required_status_checks":
+                    {"checks": [{"context": "main-req", "app_id": None}]}}}
+        return [[]]
+
+    dout = ci.refresh_required_set(dfetch, dis, "o/r")
+    _dh2, drows = L.load(dis)
+    dgot = {r["pr"]: r["required_set"] for r in drows}
+    if dgot.get("1") != MAIN:
+        problems.append(f"[matrix disagree] a settled row must survive the forced read: {dgot!r}")
+    if dgot.get("2") != MAIN:
+        problems.append(f"[matrix disagree] the unsettled `-` row must take the fresh read: {dgot!r}")
+    if dseen != ["main"]:
+        problems.append(f"[matrix disagree] header-vs-row disagreement forces EXACTLY one read: {dseen!r}")
+    if not dout["settled"]:
+        problems.append(f"[matrix disagree] the group must settle after the read: {dout!r}")
 
     return problems
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -398,6 +398,145 @@ def required_set_cases(ci, tmp: Path) -> list[str]:
     if verdict != ci.SNAP.GREEN or "required set satisfied" not in verdict_reason:
         problems.append(f"[required-set] producer-to-verifier chain returned {verdict}: {verdict_reason}")
 
+    problems += grouped_required_set_cases(ci, tmp)
+    return problems
+
+
+def grouped_required_set_cases(ci, tmp: Path) -> list[str]:
+    """The GROUPED, per-base refresh (mixed bases), and `derive`'s row-based required-set resolution."""
+    problems: list[str] = []
+
+    def base_payload(context: str):
+        return {"protection": {"enabled": True,
+                               "required_status_checks": {"checks": [{"context": context, "app_id": None}]}}}
+
+    def mk_fetch(context_by_base: dict):
+        """A fetch keyed on the base in the argv endpoint. Records each DISTINCT base's classic read so a test
+        can assert one GitHub read per base."""
+        seen: list[str] = []
+
+        def _fetch(source: str, argv: list[str]):
+            endpoint = argv[-1]
+            base = next((b for b in context_by_base if endpoint.endswith(ci.quote(b, safe=""))), None)
+            if base is None:
+                raise ci.FetchError(f"unexpected endpoint {endpoint!r}")
+            if source.endswith("classic"):
+                seen.append(base)
+                return base_payload(context_by_base[base])
+            return [[]]   # ruleset: one empty page
+
+        return _fetch, seen
+
+    v3_set = ci.canonical_required_set([("v3-test", ci.SNAP.ANY_APP)])
+    main_set = ci.canonical_required_set([("main-test", ci.SNAP.ANY_APP)])
+
+    def mrow(pr: str, base: str, required_set: str = "-", status: str = "in_review") -> dict:
+        # required_set defaults to "-" — exactly what pr-adopt.py writes for a new explicit-base row (it sets
+        # base_branch only). The grouped refresh must still read THIS base for it (never inherit the header).
+        row = dict(ci.LEDGER.ROW_DEFAULTS)
+        row.update({"pr": pr, "branch": f"b{pr}", "base_branch": base,
+                    "required_set": required_set, "status": status})
+        return row
+
+    # 1. MIXED BASES: two explicit-base rows settle from ONE read per distinct base; the header is untouched.
+    mixed = tmp / "mixed-base-state.jsonl"
+    mheader = dict(ci.LEDGER.HEADER_DEFAULTS)
+    mheader.update({"run_id": "mixed", "base_branch": "-", "required_set": "unknown"})
+    ci.LEDGER.dump(mixed, mheader, [mrow("1", "v3"), mrow("2", "main")])
+    fetch, seen = mk_fetch({"v3": "v3-test", "main": "main-test"})
+    out = ci.refresh_required_set(fetch, mixed, "o/r")
+    header_after, rows_after = ci.LEDGER.load(mixed)
+    got = {r["pr"]: r["required_set"] for r in rows_after}
+    if got.get("1") != v3_set or got.get("2") != main_set:
+        problems.append(f"[grouped] per-base write wrong: {got!r}")
+    if not out["settled"]:
+        problems.append(f"[grouped] mixed-base groups not settled: {out!r}")
+    if sorted(seen) != ["main", "v3"]:
+        problems.append(f"[grouped] each distinct base must be read EXACTLY once: {seen!r}")
+    if header_after["required_set"] != "unknown":
+        problems.append(f"[grouped] a new-run header must stay unknown, never materialized: "
+                        f"{header_after['required_set']!r}")
+
+    # a second refresh reads NOTHING — every group is settled.
+    def must_not_fetch(_source, _argv):
+        raise AssertionError("a settled group was re-read")
+    reused = ci.refresh_required_set(must_not_fetch, mixed, "o/r")
+    if not reused["settled"] or reused["groups"]:
+        problems.append(f"[grouped] settled groups must not be re-read: {reused!r}")
+
+    # 2. A FAILED read for ONE base isolates: the other base still settles, the failed base stays unknown.
+    mixed2 = tmp / "mixed-base-fail.jsonl"
+    ci.LEDGER.dump(mixed2, dict(mheader), [mrow("1", "v3"), mrow("2", "deny")])
+
+    def fetch_fail(source: str, argv: list[str]):
+        if argv[-1].endswith("deny"):
+            raise ci.FetchError("denied")
+        return base_payload("v3-test") if source.endswith("classic") else [[]]
+
+    out2 = ci.refresh_required_set(fetch_fail, mixed2, "o/r")
+    _h2, rows2 = ci.LEDGER.load(mixed2)
+    got2 = {r["pr"]: r["required_set"] for r in rows2}
+    if got2.get("1") != v3_set:
+        problems.append(f"[grouped] a settled group must persist despite a sibling's failure: {got2!r}")
+    if got2.get("2") != ci.SNAP.CANNOT_READ:
+        problems.append(f"[grouped] a failed base must stay unknown, never `none`: {got2!r}")
+    if out2["settled"]:
+        problems.append(f"[grouped] a run with an unknown group is NOT settled: {out2!r}")
+
+    # 3. LEGACY ledger: `-` rows inherit the HEADER, which the same command settles — the row is NOT materialized.
+    legacy = tmp / "legacy-grouped-state.jsonl"
+    lheader = dict(ci.LEDGER.HEADER_DEFAULTS)
+    lheader.update({"run_id": "legacy", "base_branch": "main", "required_set": "unknown"})
+    lrow = dict(ci.LEDGER.ROW_DEFAULTS)
+    lrow.update({"pr": "9", "branch": "b9", "status": "in_review"})   # base_branch/required_set stay "-"
+    ci.LEDGER.dump(legacy, lheader, [lrow])
+    lf, lseen = mk_fetch({"main": "main-test"})
+    lout = ci.refresh_required_set(lf, legacy, "o/r")
+    lh, lrows = ci.LEDGER.load(legacy)
+    if lh["required_set"] != main_set:
+        problems.append(f"[grouped] a legacy header must settle for its `-` rows: {lh['required_set']!r}")
+    if lrows[0]["required_set"] != "-":
+        problems.append(f"[grouped] a legacy `-` row must NOT be materialized: {lrows[0]['required_set']!r}")
+    if lseen != ["main"] or not lout["settled"]:
+        problems.append(f"[grouped] legacy refresh read/settle wrong: seen={lseen!r} out={lout!r}")
+
+    # 3b. A SETTLED HEADER MUST NOT LEAK into a new explicit-base row on a DIFFERENT base. A legacy `main` run
+    #     (header already `declared:[main]`) adopts a new `v3` PR (base_branch=v3, required_set="-"). The v3
+    #     group must READ v3's own requirements, never inherit the settled main header.
+    mixedleg = tmp / "mixed-legacy-header.jsonl"
+    mlheader = dict(ci.LEDGER.HEADER_DEFAULTS)
+    mlheader.update({"run_id": "mixedleg", "base_branch": "main", "required_set": main_set})
+    ci.LEDGER.dump(mixedleg, mlheader, [mrow("1", "-"), mrow("7", "v3")])  # pr1 legacy inherit, pr7 explicit v3
+    mlf, mlseen = mk_fetch({"v3": "v3-test"})   # only v3 is unsettled; main header is already settled
+    mlout = ci.refresh_required_set(mlf, mixedleg, "o/r")
+    _mlh, mlrows = ci.LEDGER.load(mixedleg)
+    mlgot = {r["pr"]: r["required_set"] for r in mlrows}
+    if mlgot.get("7") != v3_set:
+        problems.append(f"[grouped] a new explicit v3 row must read v3, not inherit the main header: {mlgot!r}")
+    if mlgot.get("1") != "-":
+        problems.append(f"[grouped] the legacy `-` row must stay inheriting, not materialized: {mlgot!r}")
+    if mlseen != ["v3"] or not mlout["settled"]:
+        problems.append(f"[grouped] settled main header must not be re-read; only v3: seen={mlseen!r}")
+
+    # 4. `derive` resolves the ROW's effective required set from --ledger; --required-set is an ASSERTION.
+    parsed = ci.resolve_required_for_derive(str(mixed), "1", None)
+    if parsed.state != ci.SNAP.parse_required_set(v3_set).state:
+        problems.append(f"[derive] --ledger did not resolve pr 1's effective required set: {parsed!r}")
+    ci.resolve_required_for_derive(str(mixed), "1", v3_set)   # a matching assertion passes
+    try:
+        ci.resolve_required_for_derive(str(mixed), "1", main_set)
+        problems.append("[derive] a --required-set disagreeing with the row must fail closed")
+    except SystemExit:
+        pass
+    legacy_parsed = ci.resolve_required_for_derive(str(legacy), "9", None)
+    if legacy_parsed.state != ci.SNAP.parse_required_set(main_set).state:
+        problems.append(f"[derive] a legacy `-` row must resolve through the header fallback: {legacy_parsed!r}")
+    try:
+        ci.resolve_required_for_derive(str(mixed), "404", None)
+        problems.append("[derive] a missing row must fail closed, never default the set")
+    except SystemExit:
+        pass
+
     return problems
 
 
@@ -611,7 +750,8 @@ def run(ci, tmp: Path) -> int:
         failures += 1
         print(f"FAIL     {problem}")
     if not required_problems:
-        print(f"ok       {'required-set producer':32} -> 10 cases: both APIs, strict shapes, canonical ledger state")
+        print(f"ok       {'required-set producer':32} -> both APIs, strict shapes, canonical ledger state, "
+              f"grouped per-base refresh, and derive's row-based resolution")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -624,7 +624,7 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
         LEDGER.dump(ledger_path, header, rows)
 
     settled = all(g["settled"] for g in groups_out)
-    return {
+    result = {
         "repo": state["repo"],
         "base_branch": header_base,
         "required_set": header["required_set"],
@@ -634,6 +634,31 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
                    if not groups_out
                    else f"settled {sum(g['settled'] for g in groups_out)} of {len(groups_out)} base group(s)"),
     }
+
+    # SINGLE-BASE TOP-LEVEL CONTRACT. When the whole run resolves to ONE effective base, restore the pre-PR
+    # top-level summary: `base_branch`/`required_set`/`state` describe that one base (the settled value, not the
+    # header's stale `unknown`), and the `state` key is present. This is the promise "single-base runs stay
+    # behaviorally unchanged" — it must hold for a NEW explicit-base row too, not only legacy `-` rows. A
+    # MIXED-base run has no single base to summarize, so it keeps `groups` as the signal and omits `state`.
+    effective_bases = set(explicit_groups)
+    if has_legacy or not nonterminal:
+        effective_bases.add(header_base)
+    if len(effective_bases) == 1:
+        base = next(iter(effective_bases))
+        acted = next((g for g in groups_out if g["base"] == base), None)
+        if acted is not None:
+            value, base_state = acted["required_set"], acted["state"]
+        else:
+            # Fully settled already (no read this call): read the settled value from its storage — the explicit
+            # rows' own value, or the header for a legacy / row-less ledger.
+            group_rows = explicit_groups.get(base)
+            value = group_rows[0]["required_set"] if group_rows else header["required_set"]
+            base_state = SNAP.parse_required_set(value).state
+        result["base_branch"] = base
+        result["required_set"] = value
+        result["state"] = base_state
+
+    return result
 
 
 # --- FETCH ---------------------------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -516,9 +516,11 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
 
     Required checks are a property of the base, and the base is per-ROW state, so the required set is too.
     This GROUPS the nonterminal rows by `effective_base`, reads each DISTINCT base's requirements ONCE from
-    GitHub, and writes the canonical result to that base's rows (`ledger.py`'s writer, never a second copy of
-    the file format). A read that fails leaves ONLY that base's group `unknown` (fail-closed, never `none`);
-    other groups settle independently. Legacy `-` rows carry no explicit base or set: they inherit the HEADER
+    GitHub, and writes the canonical result to that base's rows STILL NEEDING one (`ledger.py`'s writer,
+    never a second copy of the file format). A row whose stored value is already settled is NEVER
+    overwritten — by a failed read or a fresh one; an unsettled row joining a settled base adopts the
+    group's settled value with no new read. A read that fails leaves ONLY that base's unsettled rows
+    `unknown` (fail-closed, never `none`); other groups settle independently. Legacy `-` rows carry no explicit base or set: they inherit the HEADER
     through `effective_required_set`, which this settles as its own (legacy) channel — so an old single-base
     ledger, down to a zero-row one, keeps working exactly as before and NO inherited row value is materialized.
     """
@@ -578,14 +580,26 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
                            "state": parsed.state, "settled": parsed.state != SNAP.CANNOT_READ,
                            "reason": reason})
 
-    # EXPLICIT-BASE ROW GROUPS. Read a group when any row's OWN stored `required_set` is unsettled — the row
-    # STORES its base's set, and its base may differ from the header base, so the header fallback must NOT
-    # settle it here (an explicit `-` row has simply not had ITS base read yet: `_read_needed("-")` is True).
-    # Write the canonical value to EVERY row in the group so a base's rows always agree. A base that is
-    # unusable (blank/`-`) cannot be read — leave the group `unknown` rather than fabricate a permissive answer.
+    # EXPLICIT-BASE ROW GROUPS. Act on a group when any row's OWN stored `required_set` is unsettled — the
+    # row STORES its base's set, and its base may differ from the header base, so the header fallback must
+    # NOT settle it here (an explicit `-` row has simply not had ITS base read yet: `_read_needed("-")` is
+    # True). A SETTLED row's value (`declared:<json>`/`none`) is NEVER overwritten — not by a failed read
+    # (which would clobber it with `unknown`) and not by a fresh read (settled reads are never re-read:
+    # `_read_needed`). So when the group already holds exactly one settled value, the unsettled rows ADOPT it
+    # with no GitHub read; only a group with no settled value (or with disagreeing settled values — a
+    # hand-edit this never papers over) reads GitHub, and the result lands ONLY on the rows that needed it.
+    # A base that is unusable (blank/`-`) cannot be read — leave the group `unknown` rather than fabricate a
+    # permissive answer.
     for base, group_rows in explicit_groups.items():
-        if not any(_read_needed(r.get("required_set", LEDGER.ROW_DEFAULTS["required_set"]))
-                   for r in group_rows):
+        unsettled = []
+        settled_values = set()
+        for r in group_rows:
+            spec = r.get("required_set", LEDGER.ROW_DEFAULTS["required_set"])
+            if _read_needed(spec):
+                unsettled.append(r)
+            else:
+                settled_values.add(spec)
+        if not unsettled:
             continue
         prs = [r["pr"] for r in group_rows]
         if not base or base == "-":
@@ -593,8 +607,12 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
                                "required_set": SNAP.CANNOT_READ, "state": SNAP.CANNOT_READ,
                                "settled": False, "reason": f"pr(s) {prs} have no usable base to read"})
             continue
-        value, reason = read_base(base)
-        for r in group_rows:
+        if len(settled_values) == 1:
+            value = next(iter(settled_values))
+            reason = "adopted the group's settled value; settled reads are never re-read"
+        else:
+            value, reason = read_base(base)
+        for r in unsettled:
             r["required_set"] = value
         dirty = True
         parsed = SNAP.parse_required_set(value)

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -24,9 +24,9 @@ WHAT WAS SUPPOSED TO BE THERE IS NOT A QUESTION THE EVIDENCE CAN ANSWER — SO I
 Every rule below quantifies over the rows we GOT. A REQUIRED CHECK THAT HAS NOT REGISTERED IS NO ROW AT ALL,
 so no count, no marker and no cross-check can see it: they all agree, correctly, about a set that is missing
 the one member that matters. The base branch's REQUIRED SET is the other half of the question, it is read
-from branch protection AND rulesets (`stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?"), it is carried in the
-ledger header, and it is passed in here — MANDATORY, with NO DEFAULT, because a caller who forgot must never
-be handed the permissive answer. `unknown` (the read FAILED) is a PENDING outcome that escalates; it can
+from branch protection AND rulesets (`stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?"), it is stored per ROW
+(its base is per-row, so its required set is too — the header value is only the legacy fallback), and it is
+passed in here — NAMED, with NO DEFAULT, because a caller who forgot must never be handed the permissive answer. `unknown` (the read FAILED) is a PENDING outcome that escalates; it can
 NEVER go green. `ci-snapshot.py` owns the rule, this tool's job is to HAND IT THE SET — see `derive()`.
 
 SCOPE — WHY THIS IS A SEPARATE FILE FROM `ci-snapshot.py`, AND NOT A SUBCOMMAND OF IT.
@@ -391,10 +391,33 @@ def check_required_set(spec: str):
     except SNAP.SpecError as exc:
         fail(
             f"--required-set {spec!r} cannot be read ({exc}) — and a spec we cannot read is NOT `none`. "
-            f"It is the ledger header's `required_set` (`ledger.py … header get required_set`), and "
-            f"guessing at it would say 'the base branch requires nothing' on the strength of a value we "
-            f"failed to parse."
+            f"It is the row's `effective_required_set` (its explicit `required_set`, else the legacy header "
+            f"value), and guessing at it would say 'the base branch requires nothing' on the strength of a "
+            f"value we failed to parse."
         )
+
+
+def resolve_required_for_derive(ledger_file: str, pr: str, required_set_arg: "str | None"):
+    """Resolve the required set `derive` decides under from the ledger ROW, not the header.
+
+    The set is a property of the base, and the base is per-ROW state, so the value is the selected row's
+    `effective_required_set` — its explicit `required_set`, else the legacy header value, through the ONE
+    schema-owned accessor (never a second copy of that fallback). Any `--required-set` given ALONGSIDE
+    `--ledger` becomes an ASSERTION that must equal it — the same "argument is an assertion, not a second
+    source of truth" contract base-preflight uses for `--base`. Fails CLOSED on a missing row or a malformed
+    value; `unknown` parses through as its fail-closed self (it can NEVER green — a `pending` bullet in DECIDE).
+    """
+    header, rows = LEDGER.load(Path(ledger_file))
+    row = LEDGER.find_row(rows, str(pr))
+    if row is None:
+        fail(f"derive: no ledger row for pr {pr} — its required set cannot be resolved")
+    spec = LEDGER.effective_required_set(header, row)
+    if required_set_arg is not None and required_set_arg != spec:
+        fail(
+            f"derive: --required-set {required_set_arg!r} disagrees with pr {pr}'s effective required set "
+            f"{spec!r} — with --ledger, --required-set is an ASSERTION, not a second source of truth"
+        )
+    return check_required_set(spec)
 
 
 # --- REQUIRED SET -------------------------------------------------------------------------------
@@ -471,45 +494,127 @@ def fetch_required_set(fetch: Fetch, repo: str, base_branch: str) -> tuple[str, 
         return SNAP.CANNOT_READ, str(exc)
 
 
-def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = None) -> dict:
-    """Settle the ledger header once, retrying only while its value is `unknown`."""
-    header, rows = LEDGER.load(ledger_path)
-    current_spec = header["required_set"]
+# The two TERMINAL row statuses — ledger.py's park guard names them (`merged`/`aborted`). A terminal row's
+# required set is frozen with its campaign record and is never re-read; the grouped refresh below quantifies
+# over NONTERMINAL rows only.
+TERMINAL_STATUSES = ("merged", "aborted")
+
+
+def _read_needed(spec: str) -> bool:
+    """Does this required-set spec still need a (re)read? `unknown` does, and so does a value we cannot even
+    parse (forced to re-read rather than trusted — the same fail-closed stance the header path always took).
+    `declared:<json>` and `none` are SETTLED reads and are never re-read: the head-SHA liveness checks are
+    the freshness boundary, NOT a policy-revision field (stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?")."""
     try:
-        current = SNAP.parse_required_set(current_spec)
+        return SNAP.parse_required_set(spec).state == SNAP.CANNOT_READ
+    except SNAP.SpecError:
+        return True
+
+
+def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = None) -> dict:
+    """Settle the required-check set PER BASE, retrying only the groups whose value is still `unknown`.
+
+    Required checks are a property of the base, and the base is per-ROW state, so the required set is too.
+    This GROUPS the nonterminal rows by `effective_base`, reads each DISTINCT base's requirements ONCE from
+    GitHub, and writes the canonical result to that base's rows (`ledger.py`'s writer, never a second copy of
+    the file format). A read that fails leaves ONLY that base's group `unknown` (fail-closed, never `none`);
+    other groups settle independently. Legacy `-` rows carry no explicit base or set: they inherit the HEADER
+    through `effective_required_set`, which this settles as its own (legacy) channel — so an old single-base
+    ledger, down to a zero-row one, keeps working exactly as before and NO inherited row value is materialized.
+    """
+    header, rows = LEDGER.load(ledger_path)
+    nonterminal = [r for r in rows if r.get("status") not in TERMINAL_STATUSES]
+
+    # The header MUST parse before anything overwrites it — a malformed value is a hand-edit to fail on, not
+    # to clobber (preserves the old header-path refusal).
+    header_spec = header["required_set"]
+    try:
+        SNAP.parse_required_set(header_spec)
     except SNAP.SpecError as exc:
-        fail(f"ledger required_set {current_spec!r} is malformed ({exc}); refusing to overwrite it")
+        fail(f"ledger required_set {header_spec!r} is malformed ({exc}); refusing to overwrite it")
 
-    if current.state != SNAP.CANNOT_READ:
-        return {
-            "base_branch": header["base_branch"],
-            "repo": repo,
-            "required_set": current_spec,
-            "state": current.state,
-            "settled": True,
-            "reason": "the ledger already holds a settled required set; no GitHub read was made",
-        }
+    # Explicit-base rows STORE their own `required_set`; group them by that base. Legacy `-` rows inherit the
+    # header, so they are NOT grouped here — the header channel below is their storage.
+    explicit_groups: "dict[str, list[dict]]" = {}
+    has_legacy = False
+    for row in nonterminal:
+        if row.get("base_branch", LEDGER.ROW_DEFAULTS["base_branch"]) == "-":
+            has_legacy = True
+            continue
+        explicit_groups.setdefault(LEDGER.effective_base(header, row), []).append(row)
 
-    base_branch = header["base_branch"]
-    if not base_branch or base_branch == "-":
-        fail("ledger base_branch is not set; required checks cannot be read without it")
-    if repo is None:
-        try:
-            repo = resolve_repo(fetch)
-        except FetchError as exc:
-            fail(f"cannot determine the repo ({exc}) — pass --repo owner/name")
+    # One GitHub read per DISTINCT base, memoized so a base shared by the header channel and an explicit group
+    # is read at most once. Repo is resolved LAZILY — only if some group actually needs a read.
+    reads: "dict[str, tuple[str, str]]" = {}
+    state: dict = {"repo": repo}
 
-    value, reason = fetch_required_set(fetch, repo, base_branch)
-    header["required_set"] = value
-    LEDGER.dump(ledger_path, header, rows)
-    parsed = SNAP.parse_required_set(value)
+    def read_base(base: str) -> "tuple[str, str]":
+        if base in reads:
+            return reads[base]
+        if state["repo"] is None:
+            try:
+                state["repo"] = resolve_repo(fetch)
+            except FetchError as exc:
+                fail(f"cannot determine the repo ({exc}) — pass --repo owner/name")
+        value = fetch_required_set(fetch, state["repo"], base)
+        reads[base] = value
+        return value
+
+    groups_out: list[dict] = []
+    dirty = False
+    header_base = header.get("base_branch", LEDGER.HEADER_DEFAULTS["base_branch"])
+
+    # THE HEADER / LEGACY CHANNEL. Settle the header when a legacy `-` row inherits it (or there are no rows at
+    # all — the compatibility case of a header-only ledger) and its value is still `unknown`. A new run's
+    # header base is `-`, so this is skipped and the row groups own the read.
+    if (has_legacy or not nonterminal) and _read_needed(header_spec):
+        if not header_base or header_base == "-":
+            fail("ledger base_branch is not set; required checks cannot be read without it")
+        value, reason = read_base(header_base)
+        header["required_set"] = value
+        dirty = True
+        parsed = SNAP.parse_required_set(value)
+        groups_out.append({"base": header_base, "storage": "header", "required_set": value,
+                           "state": parsed.state, "settled": parsed.state != SNAP.CANNOT_READ,
+                           "reason": reason})
+
+    # EXPLICIT-BASE ROW GROUPS. Read a group when any row's OWN stored `required_set` is unsettled — the row
+    # STORES its base's set, and its base may differ from the header base, so the header fallback must NOT
+    # settle it here (an explicit `-` row has simply not had ITS base read yet: `_read_needed("-")` is True).
+    # Write the canonical value to EVERY row in the group so a base's rows always agree. A base that is
+    # unusable (blank/`-`) cannot be read — leave the group `unknown` rather than fabricate a permissive answer.
+    for base, group_rows in explicit_groups.items():
+        if not any(_read_needed(r.get("required_set", LEDGER.ROW_DEFAULTS["required_set"]))
+                   for r in group_rows):
+            continue
+        prs = [r["pr"] for r in group_rows]
+        if not base or base == "-":
+            groups_out.append({"base": base, "storage": "rows", "prs": prs,
+                               "required_set": SNAP.CANNOT_READ, "state": SNAP.CANNOT_READ,
+                               "settled": False, "reason": f"pr(s) {prs} have no usable base to read"})
+            continue
+        value, reason = read_base(base)
+        for r in group_rows:
+            r["required_set"] = value
+        dirty = True
+        parsed = SNAP.parse_required_set(value)
+        groups_out.append({"base": base, "storage": "rows", "prs": prs, "required_set": value,
+                           "state": parsed.state, "settled": parsed.state != SNAP.CANNOT_READ,
+                           "reason": reason})
+
+    if dirty:
+        LEDGER.dump(ledger_path, header, rows)
+
+    settled = all(g["settled"] for g in groups_out)
     return {
-        "base_branch": base_branch,
-        "repo": repo,
-        "required_set": value,
-        "state": parsed.state,
-        "settled": parsed.state != SNAP.CANNOT_READ,
-        "reason": reason,
+        "repo": state["repo"],
+        "base_branch": header_base,
+        "required_set": header["required_set"],
+        "groups": groups_out,
+        "settled": settled,
+        "reason": ("no group needed a read; every nonterminal row's required set is already settled"
+                   if not groups_out
+                   else f"settled {sum(g['settled'] for g in groups_out)} of {len(groups_out)} base group(s)"),
     }
 
 
@@ -1349,7 +1454,7 @@ def derive(fetch: Fetch, repo: str, pr: str, head_sha: str, rundir: Path, requir
     about the WRONG THING, and merging on it merges code whose checks never ran.
 
     AND ONE QUESTION THE EVIDENCE CANNOT ANSWER EITHER, WHICH IS WHY IT ARRIVES AS AN ARGUMENT. `required` is
-    what the BASE BRANCH declared (`--required-set`, from the ledger header). Every rule that reads the
+    what the BASE BRANCH declared (the row's `effective_required_set`, resolved from `--ledger`). Every rule that reads the
     artifact quantifies over the rows that ARE in it, and a required check that has not registered is NO ROW:
     invisible to the counts, to containment, and to the rollup cross-check alike — all three agree, correctly,
     about a set that is missing the one member that decides the merge. Only a DECLARED set can see it,
@@ -1445,8 +1550,8 @@ def result(pr: str, head_sha: str, verdict: str, reason: str, path: Path | None,
         # arrive on the old one.
         "head_sha_now": head_now,
         "head_moved": head_moved(head_sha, head_now),
-        # THE SET THIS VERDICT WAS DECIDED UNDER — `declared` / `none` / `unknown`, exactly as the ledger
-        # header holds it. It is an INPUT, recorded so the answer can be reproduced, and it is NOT a caveat
+        # THE SET THIS VERDICT WAS DECIDED UNDER — `declared` / `none` / `unknown`, the row's
+        # `effective_required_set`. It is an INPUT, recorded so the answer can be reproduced, and it is NOT a caveat
         # channel: `unknown` NEVER accompanies a green (it is a `pending` bullet in `decide()`), so this can
         # never become "green, but note that we could not read what was required".
         "required_set": required.state,
@@ -1984,11 +2089,12 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
     """EVERY COPY OF THE DERIVE COMMAND, IN EVERY SKILL DOC — not just the one in the doc under test.
 
-    THE FLAG THAT DECIDES A MERGE MUST NOT BE DROPPABLE BY A RECAP. `--required-set` is what makes `green`
-    mean *the required set passed*; a copy of the command that omits it is a reader reconstructing an
-    invocation the tool REFUSES (it is a required argument). This repo has already paid for the class TWICE:
-    a fourth copy of a canonical command that had gone stale, and a doc recap that dropped `,headRefOid`
-    from the rollup fetch.
+    THE FLAG THAT NAMES THE REQUIRED SET MUST NOT BE DROPPABLE BY A RECAP. The required set is what makes
+    `green` mean *the required set passed*, and it is now the ROW's `effective_required_set`: a copy names it
+    with `--ledger` (resolve the row's set — the production form) OR with an explicit `--required-set`. A copy
+    carrying NEITHER is a reader reconstructing an invocation the tool REFUSES. This repo has already paid for
+    the class TWICE: a fourth copy of a canonical command that had gone stale, and a doc recap that dropped
+    `,headRefOid` from the rollup fetch.
 
     A copy is any occurrence that RUNS the command (`ci-status.py derive` carrying `--pr`) — prose that
     merely NAMES the command is not a copy, and is not checked. **THE UNIT IS THE COMMAND, NOT THE LINE**:
@@ -2008,12 +2114,12 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
                 continue  # prose that NAMES the command, not a copy of it
             n = text.count("\n", 0, m.start()) + 1
             copies.append(f"{md.name}:{n}")
-            if "--required-set" not in command:
+            if "--ledger" not in command and "--required-set" not in command:
                 problems.append(
-                    f"{md.name}:{n} runs `ci-status.py derive` WITHOUT `--required-set` — the flag that "
-                    f"makes `green` mean the REQUIRED SET passed. A reader following this copy issues a "
-                    f"command the tool refuses; a reader who 'fixes' it by dropping the flag gets a verdict "
-                    f"about the rows that showed up, which is the registration gap, reopened by a recap."
+                    f"{md.name}:{n} runs `ci-status.py derive` WITHOUT `--ledger` OR `--required-set` — the "
+                    f"flag that makes `green` mean the REQUIRED SET passed. A reader following this copy "
+                    f"issues a command the tool refuses; a reader who 'fixes' it by dropping the set gets a "
+                    f"verdict about the rows that showed up, which is the registration gap, reopened by a recap."
                 )
     if not copies:
         problems.append(
@@ -2058,7 +2164,7 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
 
 
 def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every runnable required-set copy names the ledger whose header the command owns."""
+    """Every runnable required-set copy names the ledger whose per-row required sets the command persists."""
     problems, copies = [], []
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = md.read_text(encoding="utf-8")
@@ -2197,7 +2303,7 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
     problems += derive_problems
     if not derive_problems:
         held.append(f"{'the derive invocations':32} {len(derive_copies)} copies across the skill's docs, "
-                    f"every one of them passing --required-set")
+                    f"every one naming the required set (--ledger or --required-set)")
     required_problems, required_copies = check_required_set_copies()
     problems += required_problems
     if not required_problems:
@@ -2303,18 +2409,25 @@ def main() -> int:
     d.add_argument("--head-sha", required=True, help="the LEDGER's head_sha — the commit to pin the fetch to")
     d.add_argument("--rundir", required=True, type=Path, help="where the snapshot is promoted")
     d.add_argument("--repo", help="owner/name (default: the current checkout's, via `gh repo view`)")
-    # MANDATORY, AND WITH NO DEFAULT — the same rule `ci-snapshot.evaluate()` enforces on ITS callers, and
-    # for the same reason: a caller who forgot to say what the base branch requires must not be handed the
-    # permissive answer. It is the ledger header's value, verbatim:
-    #   --required-set "$(python3 <skill>/scripts/ledger.py --file <rundir>/state.jsonl header get required_set)"
-    # `unknown` is a legal value and it can NEVER go green (it is a `pending` bullet in DECIDE) — which is
+    # THE REQUIRED SET IS NAMED, NEVER DEFAULTED — the same rule `ci-snapshot.evaluate()` enforces on ITS
+    # callers, and for the same reason: a caller who forgot to say what the base branch requires must not be
+    # handed the permissive answer. It is now the selected ROW's `effective_required_set` (the base is
+    # per-row, so its required set is too), resolved from the ledger:
+    #   --ledger <rundir>/state.jsonl
+    # `--required-set` remains for the pure/explicit path (tests, an out-of-run spec): with `--ledger` it is
+    # an ASSERTION that must equal the row's effective set; without `--ledger` it IS the set, verbatim. One of
+    # the two is REQUIRED. `unknown` is a legal value that can NEVER go green (a `pending` bullet in DECIDE) —
     # exactly what makes a run that never performed the read merge NOTHING, instead of merging everything.
-    d.add_argument("--required-set", required=True,
-                   help="the ledger header's `required_set`: `declared:<json>` | `none` | `unknown`")
+    d.add_argument("--ledger", type=Path,
+                   help="the run's state.jsonl — resolve the row's `effective_required_set` (its explicit "
+                        "`required_set`, else the legacy header value). The canonical production form")
+    d.add_argument("--required-set",
+                   help="an explicit required set (`declared:<json>` | `none` | `unknown`); with --ledger it "
+                        "is an ASSERTION that must equal the row's effective set, not a second source")
 
     r = sub.add_parser(
         "required-set",
-        help="read both required-check sources and persist their canonical union in the ledger",
+        help="read each distinct base's required-check sources and persist the canonical union per row",
     )
     r.add_argument("--ledger", required=True, type=Path, help="the run's state.jsonl")
     r.add_argument("--repo", help="owner/name (default: the current checkout's, via `gh repo view`)")
@@ -2377,7 +2490,16 @@ def main() -> int:
     # during promotion, or as a verdict about the PR — is a defect reported against the wrong thing.
     check_head_sha(args.head_sha)
     check_rundir(args.rundir)
-    required = check_required_set(args.required_set)
+    # The required set is the ROW's effective set when a ledger is named (the production form); an explicit
+    # `--required-set` is the pure/test path AND, with `--ledger`, an assertion. One of the two is required —
+    # a derive with NEITHER would have no set to decide under, and defaulting one is the false green this
+    # whole tool exists to kill.
+    if args.ledger is not None:
+        required = resolve_required_for_derive(str(args.ledger), args.pr, args.required_set)
+    elif args.required_set is not None:
+        required = check_required_set(args.required_set)
+    else:
+        fail("derive needs --ledger (resolve the row's effective required set) or an explicit --required-set")
 
     repo = args.repo
     if not repo:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -581,15 +581,23 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
                            "reason": reason})
 
     # EXPLICIT-BASE ROW GROUPS. Act on a group when any row's OWN stored `required_set` is unsettled — the
-    # row STORES its base's set, and its base may differ from the header base, so the header fallback must
-    # NOT settle it here (an explicit `-` row has simply not had ITS base read yet: `_read_needed("-")` is
-    # True). A SETTLED row's value (`declared:<json>`/`none`) is NEVER overwritten — not by a failed read
-    # (which would clobber it with `unknown`) and not by a fresh read (settled reads are never re-read:
-    # `_read_needed`). So when the group already holds exactly one settled value, the unsettled rows ADOPT it
-    # with no GitHub read; only a group with no settled value (or with disagreeing settled values — a
-    # hand-edit this never papers over) reads GitHub, and the result lands ONLY on the rows that needed it.
-    # A base that is unusable (blank/`-`) cannot be read — leave the group `unknown` rather than fabricate a
-    # permissive answer.
+    # row STORES its base's set (an explicit `-` row has simply not had ITS base read yet: `_read_needed("-")`
+    # is True). A SETTLED value for the group's base is NEVER overwritten — not by a failed read (which would
+    # clobber it with `unknown`) and not by a fresh read (settled reads are never re-read: `_read_needed`). So
+    # when the group's base already holds exactly one settled value, the unsettled rows ADOPT it with no
+    # GitHub read; only a group with no settled value (or with disagreeing settled values — a hand-edit this
+    # never papers over) reads GitHub, and the result lands ONLY on the rows that needed it. A base that is
+    # unusable (blank/`-`) cannot be read — leave the group `unknown` rather than fabricate a permissive answer.
+    #
+    # "THE SETTLED SET FOR BASE B" HAS TWO STORAGE CHANNELS, and they are ONE fact: each group row's OWN
+    # settled value, AND the header value WHEN B IS the header base and the header is itself settled. The
+    # header describes base B only for B == header base (a legacy single-base run, or a migrated one whose
+    # header settled before a new same-base row joined), so it is unioned in ONLY then — never for a DIFFERENT
+    # base, which would settle a base off another base's set (a false green). Folding it in is what makes a
+    # `-` row on the header base ADOPT the header's settled value with no read, and what stops a FAILED read
+    # from clobbering a value already settled through the header channel — the round-1 row-adoption rule,
+    # extended to the header's copy of the same fact. `effective_required_set` (ledger.py) draws the SAME
+    # base-agreement line for the single-row accessor, so the two never disagree.
     for base, group_rows in explicit_groups.items():
         unsettled = []
         settled_values = set()
@@ -599,6 +607,8 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
                 unsettled.append(r)
             else:
                 settled_values.add(spec)
+        if base == header_base and not _read_needed(header_spec):
+            settled_values.add(header_spec)
         if not unsettled:
             continue
         prs = [r["pr"] for r in group_rows]

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -341,6 +341,29 @@ def t_base_mismatch_refused():
         check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "nothing mutated — head_sha untouched")
 
 
+def t_origin_named_base_agrees():
+    # A row base LITERALLY named `origin/rel` (a legal branch name) matches an identical `--base` — the
+    # assertion routes through `ledger.py base_agrees`, where identical strings always agree. The refusal
+    # that follows is the MISSING WORKTREE (step 3), proving the base assertion (step 1a) passed. The bare
+    # form still refuses `base-mismatch`: the STORED base is never stripped.
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        ledger = tmp / "state.jsonl"
+        _ledger("--file", str(ledger), "header", "set", "run_id", "t")
+        _ledger("--file", str(ledger), "add-row", "--pr", "12", "--head-sha", "a" * 40,
+                "--base-branch", "origin/rel", "--status", "in_review")
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(ledger), "--pr", "12",
+                                            "--worktree", str(tmp / "missing"), "--base", "origin/rel"])
+        check(code == M.EXIT_PRECONDITION, f"the missing worktree still refuses at exit 2 (code={code})")
+        check('"refused": "worktree-missing"' in out and '"base-mismatch"' not in out,
+              f"identical origin/rel strings must pass the base assertion and reach the worktree check; "
+              f"got {out!r}")
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(ledger), "--pr", "12",
+                                            "--worktree", str(tmp / "missing"), "--base", "rel"])
+        check(code == M.EXIT_PRECONDITION and '"refused": "base-mismatch"' in out,
+              f"a bare --base must disagree with a stored origin/-named base; got {out!r}")
+
+
 def t_absent_remote_refused():
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
@@ -430,6 +453,8 @@ CASES = [
      t_head_mismatch_refused),
     ("held-refused", "a held row is refused at exit 2 and never rebased", t_held_row_refused),
     ("no-row-refused", "a PR with no ledger row is refused at exit 2", t_no_row_refused),
+    ("origin-named-base-agrees", "a base literally named origin/<x> matches itself; the bare form disagrees",
+     t_origin_named_base_agrees),
     ("base-mismatch-refused", "a --base disagreeing with the row's effective base is refused at exit 2",
      t_base_mismatch_refused),
     ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -341,6 +341,24 @@ def t_base_mismatch_refused():
         check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "nothing mutated — head_sha untouched")
 
 
+def t_unresolved_base_refused():
+    # A both-`-` ledger (header base_branch unset AND row base-branch unset) resolves through
+    # `effective_base` to the `-` sentinel — an UNRESOLVED base. It is refused at step 1a as `no-base`
+    # BEFORE any fetch/rebase, never treated as a real branch (`ledger.py require_effective_base`, the one
+    # owner). If that guard is deleted, the base assertion is SKIPPED and execution falls through to a later
+    # precondition (worktree-missing), so this fixture FAILS — that is exactly the bug the guard fixes.
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        ledger = tmp / "state.jsonl"
+        _ledger("--file", str(ledger), "header", "set", "run_id", "t")            # base_branch left `-`
+        _ledger("--file", str(ledger), "add-row", "--pr", PR_NUMBER, "--status", "in_review")  # base `-`
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(ledger), "--pr", PR_NUMBER,
+                                            "--worktree", str(tmp / "missing"), "--base", "v3"])
+        check(code == M.EXIT_PRECONDITION, f"an unresolved (`-`) base is refused at exit 2 (code={code})")
+        check('"refused": "no-base"' in out, f"the refusal names the unresolved base as no-base; got {out!r}")
+        check("no usable effective base" in out, f"the refusal explains the unresolved base; got {out!r}")
+
+
 def t_origin_named_base_agrees():
     # A row base LITERALLY named `origin/rel` (a legal branch name) matches an identical `--base` — the
     # assertion routes through `ledger.py base_agrees`, where identical strings always agree. The refusal
@@ -457,6 +475,8 @@ CASES = [
      t_origin_named_base_agrees),
     ("base-mismatch-refused", "a --base disagreeing with the row's effective base is refused at exit 2",
      t_base_mismatch_refused),
+    ("unresolved-base-refused", "a both-`-` ledger resolves to `-`; the unresolved base is refused as no-base at exit 2",
+     t_unresolved_base_refused),
     ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),
     ("worktree-missing-refused", "a missing/non-git worktree is refused at exit 2", t_worktree_missing_refused),
     ("push-rejected-preserves-rebase", "a rejected push preserves the local rebase and does NOT write the "

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -439,6 +439,28 @@ def t_push_rejected_preserves_local_rebase():
               "the remote PR branch was not clobbered (force-with-lease refused it)")
 
 
+def t_variant_spelling_rebases_against_row_base():
+    # `--base origin/main` against a row whose effective base is `main` is ACCEPTED by `base_agrees` (a
+    # leading `origin/` on the argument is stripped). The operational fetch/rebase must target the ROW's
+    # resolved base, so this runs `git fetch origin main` / rebase onto `origin/main` — the SAME clean rebase
+    # as `--base main`, exit 0, remote pushed. Trusting the raw `--base` (the reverted bug) would instead run
+    # `git fetch origin origin/main`, which has no such remote ref → `fetch-failed`, refused at exit 2. This
+    # FAILS if the operational ref is taken from the raw `--base` rather than the row's effective base.
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        s.advance_base({12: "12-BASE"})  # a clean FAR edit — the rebase itself succeeds
+        argv = ["run", "--ledger", str(s.ledger), "--pr", PR_NUMBER, "--worktree", str(s.wt),
+                "--base", "origin/main"]
+        code, out, err = capture_cli(M.main, argv)
+        check(code == M.EXIT_OK,
+              f"--base origin/main must rebase against the row's effective base 'main' and exit 0 "
+              f"(code={code}, out={out!r}, err={err!r})")
+        new_head = head(s.wt)
+        check(new_head != s.orig_head, "the clean rebase moved the worktree HEAD")
+        check(s.remote_pr_head() == new_head,
+              "the remote PR branch was force-with-lease pushed to the rebased head")
+
+
 # --- --dry-run mutates nothing -----------------------------------------------
 
 def t_dry_run_mutates_nothing():
@@ -475,6 +497,9 @@ CASES = [
      t_origin_named_base_agrees),
     ("base-mismatch-refused", "a --base disagreeing with the row's effective base is refused at exit 2",
      t_base_mismatch_refused),
+    ("variant-spelling-rebases-row-base",
+     "an accepted origin/main spelling rebases against the row's effective base 'main', not the raw arg",
+     t_variant_spelling_rebases_against_row_base),
     ("unresolved-base-refused", "a both-`-` ledger resolves to `-`; the unresolved base is refused as no-base at exit 2",
      t_unresolved_base_refused),
     ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -328,6 +328,19 @@ def t_no_row_refused():
         check('"refused": "no-row"' in out, f"the refusal names the missing row; got {out!r}")
 
 
+def t_base_mismatch_refused():
+    # `--base` is an ASSERTION: a value disagreeing with the row's effective base is refused BEFORE any
+    # fetch/rebase, and nothing mutates. The scenario's row inherits header base `main`; assert `v3`.
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        code, out, _ = capture_cli(M.main, ["run", "--ledger", str(s.ledger), "--pr", PR_NUMBER,
+                                            "--worktree", str(s.wt), "--base", "v3"])
+        check(code == M.EXIT_PRECONDITION, f"a --base disagreeing with the row is refused at exit 2 (code={code})")
+        check('"refused": "base-mismatch"' in out, f"the refusal names the base mismatch; got {out!r}")
+        check("v3" in out and "main" in out, "the refusal names BOTH the passed --base and the effective base")
+        check(_field(s.ledger, PR_NUMBER, "head_sha") == s.orig_head, "nothing mutated — head_sha untouched")
+
+
 def t_absent_remote_refused():
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
@@ -417,6 +430,8 @@ CASES = [
      t_head_mismatch_refused),
     ("held-refused", "a held row is refused at exit 2 and never rebased", t_held_row_refused),
     ("no-row-refused", "a PR with no ledger row is refused at exit 2", t_no_row_refused),
+    ("base-mismatch-refused", "a --base disagreeing with the row's effective base is refused at exit 2",
+     t_base_mismatch_refused),
     ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),
     ("worktree-missing-refused", "a missing/non-git worktree is refused at exit 2", t_worktree_missing_refused),
     ("push-rejected-preserves-rebase", "a rejected push preserves the local rebase and does NOT write the "

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -155,12 +155,12 @@ def run(args) -> int:
     # 1a. `--base` is an ASSERTION, not a base source: the ROW owns the base. It must equal the row's
     #     `effective_base` (its explicit `base_branch`, else the legacy header fallback — resolved through
     #     `ledger.py`'s accessor, never a second copy of that rule). Refuse a disagreement BEFORE any
-    #     fetch/rebase so a caller can never rebase this PR onto a branch the row does not track. An
-    #     `origin/<base>` form is normalized to its bare branch first. (A base that merely ADVANCED — same
-    #     branch, new commits — is exactly what this rebase HANDLES; only a different branch NAME disagrees.)
+    #     fetch/rebase so a caller can never rebase this PR onto a branch the row does not track. Agreement
+    #     is decided by `ledger.py`'s `base_agrees` — the one owner of that comparison. (A base that merely
+    #     ADVANCED — same branch, new commits — is exactly what this rebase HANDLES; only a different branch
+    #     NAME disagrees.)
     effective_base = L.effective_base(header, row)
-    normalized_base = base[len("origin/"):] if base.startswith("origin/") else base
-    if effective_base and effective_base != "-" and normalized_base != effective_base:
+    if effective_base and effective_base != "-" and not L.base_agrees(base, effective_base):
         return refuse("base-mismatch",
                       f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
                       f"--base is an assertion, not a base source", EXIT_PRECONDITION)

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -168,6 +168,11 @@ def run(args) -> int:
         return refuse("base-mismatch",
                       f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
                       f"--base is an assertion, not a base source", EXIT_PRECONDITION)
+    # Operate on the ROW's resolved base, never the raw `--base` spelling: two spellings `base_agrees`
+    # accepts (`main` vs `origin/main`) fetch/rebase against different refs (`git fetch origin main` vs
+    # `git fetch origin origin/main`), so every operational fetch/rebase/patch-identity below follows the
+    # row, not the caller's argument.
+    base = effective_base
 
     # 2. A HELD PR is FROZEN — no rebase (a mutation) is dispatched on it — and a TERMINAL PR is done.
     status = row.get("status", "-")

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -154,13 +154,17 @@ def run(args) -> int:
 
     # 1a. `--base` is an ASSERTION, not a base source: the ROW owns the base. It must equal the row's
     #     `effective_base` (its explicit `base_branch`, else the legacy header fallback — resolved through
-    #     `ledger.py`'s accessor, never a second copy of that rule). Refuse a disagreement BEFORE any
-    #     fetch/rebase so a caller can never rebase this PR onto a branch the row does not track. Agreement
+    #     `ledger.py`'s accessor, never a second copy of that rule). An UNRESOLVED base (blank or the `-`
+    #     sentinel) is refused FIRST through `ledger.py`'s `require_effective_base` — the one owner of that
+    #     fail-closed rule — so a `-` base is never treated as a real branch. Then refuse a disagreement BEFORE
+    #     any fetch/rebase so a caller can never rebase this PR onto a branch the row does not track. Agreement
     #     is decided by `ledger.py`'s `base_agrees` — the one owner of that comparison. (A base that merely
     #     ADVANCED — same branch, new commits — is exactly what this rebase HANDLES; only a different branch
     #     NAME disagrees.)
-    effective_base = L.effective_base(header, row)
-    if effective_base and effective_base != "-" and not L.base_agrees(base, effective_base):
+    effective_base, base_problem = L.require_effective_base(header, row, pr)
+    if base_problem is not None:
+        return refuse("no-base", base_problem, EXIT_PRECONDITION)
+    if not L.base_agrees(base, effective_base):
         return refuse("base-mismatch",
                       f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
                       f"--base is an assertion, not a base source", EXIT_PRECONDITION)

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -146,11 +146,24 @@ def run(args) -> int:
     # --- PRECONDITIONS: each fails CLOSED at exit 2, mutating NOTHING ----------
 
     # 1. The ledger row must exist — there is nothing to rebase for a PR the run does not track.
-    _, rows = L.load(ledger_path)
+    header, rows = L.load(ledger_path)
     row = L.find_row(rows, pr)
     if row is None:
         return refuse("no-row", f"no ledger row for pr {pr} — adopt it first (`pr-adopt.py adopt`)",
                       EXIT_PRECONDITION)
+
+    # 1a. `--base` is an ASSERTION, not a base source: the ROW owns the base. It must equal the row's
+    #     `effective_base` (its explicit `base_branch`, else the legacy header fallback — resolved through
+    #     `ledger.py`'s accessor, never a second copy of that rule). Refuse a disagreement BEFORE any
+    #     fetch/rebase so a caller can never rebase this PR onto a branch the row does not track. An
+    #     `origin/<base>` form is normalized to its bare branch first. (A base that merely ADVANCED — same
+    #     branch, new commits — is exactly what this rebase HANDLES; only a different branch NAME disagrees.)
+    effective_base = L.effective_base(header, row)
+    normalized_base = base[len("origin/"):] if base.startswith("origin/") else base
+    if effective_base and effective_base != "-" and normalized_base != effective_base:
+        return refuse("base-mismatch",
+                      f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
+                      f"--base is an assertion, not a base source", EXIT_PRECONDITION)
 
     # 2. A HELD PR is FROZEN — no rebase (a mutation) is dispatched on it — and a TERMINAL PR is done.
     status = row.get("status", "-")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2372,9 +2372,9 @@ def t_pending_adoption_is_an_ordinary_field(L: ModuleType, tmp: Path) -> None:
 # --- row-owned base / required set, with the header as the LEGACY FALLBACK -------------------------------
 #
 # `base_branch` and `required_set` are per-ROW state now; the header fields are only what a row with no
-# explicit value inherits. These fixtures pin the schema half of static mixed-base support (the consumers
-# that resolve through the accessors are converted in a later stage): the two accessors, the immutable
-# creation-only row base, and the `-` (inherit) vs `unknown` (explicit, fail-closed) distinction.
+# explicit value inherits. These fixtures pin the schema half of mixed-base support (each consumer's own
+# resolution through the accessors is exercised by that consumer's test suite): the two accessors, the
+# immutable creation-only row base, and the `-` (inherit) vs `unknown` (explicit, fail-closed) distinction.
 
 def t_old_ledger_resolves_through_the_header(L: ModuleType, tmp: Path) -> None:
     """An old ledger — written before the row base fields existed — loads and resolves through the header.
@@ -2447,11 +2447,11 @@ def t_row_base_is_creation_only(L: ModuleType, tmp: Path) -> None:
     # …and the stored base is untouched by the refused write.
     code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "base_branch"])
     check(out == "v3\n", f"the recorded base changed despite the refusal: {out!r}")
-    # `required_set` is NOT creation-only: the stage-2 grouped refresh will rewrite it through `set`.
+    # `required_set` is NOT creation-only: the grouped required-set refresh rewrites it through `set`.
     check("required_set" not in L.CREATE_ONLY,
-          "required_set must stay settable via `set` — the stage-2 grouped refresh will write it")
+          "required_set must stay settable via `set` — the grouped required-set refresh writes it")
     code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--required-set", "none"])
-    check(code == 0, f"`set --required-set` must stay open for the stage-2 grouped refresh: exit {code}, {err!r}")
+    check(code == 0, f"`set --required-set` must stay open for the grouped required-set refresh: exit {code}, {err!r}")
 
 
 def t_required_set_dash_vs_unknown(L: ModuleType, tmp: Path) -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2480,6 +2480,17 @@ def t_required_set_dash_vs_unknown(L: ModuleType, tmp: Path) -> None:
     check(L.effective_base({"base_branch": "main"}, {"base_branch": "v3"}) == "v3",
           "an explicit base must win over the header")
 
+    # A `-` row inherits the header required_set ONLY when its base IS the header base — the header describes
+    # the header base alone. A `-` row on a DIFFERENT base (a mixed-base config) has no settled set here and
+    # stays the fail-closed `unknown`, never reading as the header base's set (a false green). This is the
+    # SAME base-agreement rule the grouped refresh applies (ci-status.refresh_required_set).
+    mixed_header = {"base_branch": "main", "required_set": "none"}
+    check(L.effective_required_set(mixed_header, {"base_branch": "main", "required_set": "-"}) == "none",
+          "a `-` row on the header base must inherit the settled header")
+    other = L.effective_required_set(mixed_header, {"base_branch": "v3", "required_set": "-"})
+    check(other == L.HEADER_DEFAULTS["required_set"],
+          f"a `-` row on a DIFFERENT base must NOT read as the header base's set — fail closed: {other!r}")
+
 
 def t_base_agrees(L: ModuleType, _tmp: Path) -> None:
     """`base_agrees` — the ONE owner of the `--base`-assertion comparison every consumer routes through.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2481,6 +2481,26 @@ def t_required_set_dash_vs_unknown(L: ModuleType, tmp: Path) -> None:
           "an explicit base must win over the header")
 
 
+def t_base_agrees(L: ModuleType, _tmp: Path) -> None:
+    """`base_agrees` — the ONE owner of the `--base`-assertion comparison every consumer routes through.
+
+    Identical strings ALWAYS agree — a base literally named `origin/<x>` (a legal branch name) must match
+    itself, so `--base origin/release` against a stored `origin/release` can never be read as a
+    disagreement. A leading `origin/` is stripped from the ARGUMENT only (the review-diff form asserting a
+    bare stored base); the STORED base is never stripped, so a bare argument cannot assert a base literally
+    named `origin/<x>`.
+    """
+    check(L.base_agrees("main", "main"), "identical bare names must agree")
+    check(L.base_agrees("origin/main", "main"), "an origin/-prefixed ARGUMENT asserts the bare stored base")
+    check(L.base_agrees("origin/release", "origin/release"),
+          "identical strings must ALWAYS agree — a base literally named origin/release matches itself")
+    check(not L.base_agrees("release", "origin/release"),
+          "the STORED base is never stripped — a bare argument cannot assert a base literally named "
+          "origin/release")
+    check(not L.base_agrees("v3", "main"), "different names must disagree")
+    check(not L.base_agrees("origin/v3", "main"), "a stripped argument naming a different base must disagree")
+
+
 def t_table_shows_the_effective_base(L: ModuleType, tmp: Path) -> None:
     """`table` shows a computed, display-only `base` column: the row's EFFECTIVE base, not the raw field.
 
@@ -2597,6 +2617,7 @@ CASES = [
     ("new-row-owns-its-base", "a new row's explicit base wins over the header, per row", t_new_row_owns_its_base),
     ("row-base-creation-only", "the row base is written once at add-row and immutable — no `set --base-branch`", t_row_base_is_creation_only),
     ("required-set-dash-vs-unknown", "`-` inherits the header; explicit `unknown` fails closed, never inherits", t_required_set_dash_vs_unknown),
+    ("base-agrees", "base_agrees: identical strings always agree; only the ARGUMENT's origin/ is stripped", t_base_agrees),
     ("table-effective-base", "table shows a computed `base` column — the effective base, escaped like any cell", t_table_shows_the_effective_base),
 ]
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2512,6 +2512,30 @@ def t_base_agrees(L: ModuleType, _tmp: Path) -> None:
     check(not L.base_agrees("origin/v3", "main"), "a stripped argument naming a different base must disagree")
 
 
+def t_require_effective_base(L: ModuleType, _tmp: Path) -> None:
+    """`require_effective_base` — the ONE owner of "a resolved-base consumer fails closed on an unresolved base".
+
+    A usable base is returned as `(base, None)`; an unresolved one — blank, whitespace-only, or the `-` unset
+    sentinel on BOTH the row and the header — is refused as `(None, reason)`, the reason naming the PR. This is
+    what every base-USING consumer (clean-rebase, review-dispatch, worker-prompt, carryover, base-preflight,
+    triage, repair-pass) routes through, so a `-` base is refused BEFORE it is compared, written, or diffed.
+    """
+    # A real resolved base passes through unchanged, with no problem.
+    base, problem = L.require_effective_base({"base_branch": "main"}, {"base_branch": "-"}, "1")
+    check(base == "main" and problem is None, f"a `-` row inheriting a real header base is usable: {base!r} {problem!r}")
+    base, problem = L.require_effective_base({"base_branch": "main"}, {"base_branch": "v3"}, "1")
+    check(base == "v3" and problem is None, f"an explicit row base is usable: {base!r} {problem!r}")
+    # The both-`-` state (row AND header unset) — `effective_base` returns `-` — is REFUSED, not returned.
+    base, problem = L.require_effective_base({"base_branch": "-"}, {"base_branch": "-"}, "999")
+    check(base is None and problem == "pr 999 has no usable effective base in the ledger",
+          f"a both-`-` ledger must fail closed, naming the PR: {base!r} {problem!r}")
+    # A blank or whitespace-only resolved base is unresolved too — never a branch a caller may use.
+    base, problem = L.require_effective_base({"base_branch": ""}, {"base_branch": "-"}, "5")
+    check(base is None and problem is not None, f"a blank effective base must fail closed: {base!r} {problem!r}")
+    base, problem = L.require_effective_base({"base_branch": "  "}, {"base_branch": "-"}, "5")
+    check(base is None and problem is not None, f"a whitespace-only effective base must fail closed: {base!r} {problem!r}")
+
+
 def t_table_shows_the_effective_base(L: ModuleType, tmp: Path) -> None:
     """`table` shows a computed, display-only `base` column: the row's EFFECTIVE base, not the raw field.
 
@@ -2629,6 +2653,7 @@ CASES = [
     ("row-base-creation-only", "the row base is written once at add-row and immutable — no `set --base-branch`", t_row_base_is_creation_only),
     ("required-set-dash-vs-unknown", "`-` inherits the header; explicit `unknown` fails closed, never inherits", t_required_set_dash_vs_unknown),
     ("base-agrees", "base_agrees: identical strings always agree; only the ARGUMENT's origin/ is stripped", t_base_agrees),
+    ("require-effective-base", "require_effective_base: a usable base passes; a blank/whitespace/`-` base fails closed naming the PR", t_require_effective_base),
     ("table-effective-base", "table shows a computed `base` column — the effective base, escaped like any cell", t_table_shows_the_effective_base),
 ]
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -192,9 +192,12 @@ ROW_FIELDS = (
     # `declared:<json>` / `none` / `unknown`, owned by stage-2-ci.md exactly as the header field's are.
     #
     # The default is `-`, which — like `base_branch` — means "inherit the legacy header", and is DISTINCT
-    # from `unknown`: `-` says "this row owns no set; read the header", while `unknown` says "a read was
-    # attempted for THIS base and failed, so fail closed and do not go green" (stage-2-ci.md). An old row
-    # reads back `-` and inherits; a new run will write `unknown` on each row until a grouped read succeeds
+    # from `unknown`: `-` says "this row owns no set; inherit the header — but only for the header's OWN base"
+    # (`effective_required_set` returns the header value ONLY when the row's effective base IS the header base;
+    # a row on a different base has no set here and stays `unknown` until read — the header never describes
+    # another base's set), while `unknown` says "a read was attempted for THIS base and failed, so fail closed
+    # and do not go green" (stage-2-ci.md). An old single-base row reads back `-` and inherits (its base IS the
+    # header base); a new run will write `unknown` on each row until a grouped read succeeds
     # (stage-2 work). An ordinary settable field: the stage-2 grouped required-set refresh will write the
     # canonical value through `set` (unlike `base_branch`, which is immutable after creation).
     "required_set",
@@ -676,11 +679,19 @@ def effective_required_set(header: dict, row: dict) -> str:
     `-` on the row means "inherit the header"; it is DISTINCT from `unknown`, which is an explicit row value
     meaning a read for this base failed and must fail closed (stage-2-ci.md). So a new row's `unknown` is
     returned as `unknown` and never silently replaced by the header, while an old row's `-` reads the header.
+
+    But the header required_set describes the HEADER base ONLY. A `-` row inherits it only when its effective
+    base IS that base; a row on a DIFFERENT base (a mixed-base config) has no settled set here and stays the
+    fail-closed `unknown` default until its OWN base is read — a header `none` must never read as another
+    base's set (a false green). This is the SAME base-agreement rule the grouped refresh applies when it folds
+    the header into a base's settled sources (ci-status.refresh_required_set): the two never disagree.
     """
     value = row.get("required_set", ROW_DEFAULTS["required_set"])
     if value != "-":
         return value
-    return header.get("required_set", HEADER_DEFAULTS["required_set"])
+    if effective_base(header, row) == header.get("base_branch", HEADER_DEFAULTS["base_branch"]):
+        return header.get("required_set", HEADER_DEFAULTS["required_set"])
+    return HEADER_DEFAULTS["required_set"]  # the `unknown` fail-closed default — this base has no read yet
 
 
 def base_agrees(base_arg: str, effective: str) -> bool:

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -709,6 +709,28 @@ def base_agrees(base_arg: str, effective: str) -> bool:
     return base_arg.startswith("origin/") and base_arg[len("origin/"):] == effective
 
 
+def require_effective_base(header: dict, row: dict, pr: str) -> "tuple[str | None, str | None]":
+    """Resolve `row`'s effective base and REFUSE it when it is unresolved — blank/whitespace or the `-` sentinel.
+
+    THE one owner of the consumer-side contract "a resolved-base consumer must FAIL CLOSED on an unresolved
+    effective base BEFORE using it." Every consumer that resolves an effective base and then USES it — compares
+    a `--base` assertion against it, writes it into the durable history, bakes it into a published bundle, or
+    diffs `origin/<base>` — routes through here instead of inlining its own `effective_base(...) == "-"` test,
+    so the refusal rule and its wording live in ONE place, not once per consumer.
+
+    Returns `(base, None)` when the base is usable, or `(None, reason)` — a ready-to-emit refusal message naming
+    the PR — when it is not. `-` on BOTH the row and the header means "no base was ever resolved" (`effective_base`
+    faithfully returns it); it is NOT a branch a caller may rebase onto, write to history, or diff against, so it
+    is refused here. This mirrors `base_agrees`, which already refuses `-`. A normal run never reaches this: the
+    header base is filled at run start and each row's at adoption, so `effective_base` returns a real branch; a
+    both-`-` ledger is a driver-authored/hand-edited state (a single-user foot-gun), and this is the cheap
+    fail-closed insurance against it — not machinery to defend the user from themselves."""
+    base = effective_base(header, row)
+    if not base.strip() or base == "-":
+        return None, f"pr {pr} has no usable effective base in the ledger"
+    return base, None
+
+
 def check_field(name: str, valid: "tuple[str, ...]") -> None:
     if name not in valid:
         fail(f"unknown field '{name}'; valid: {', '.join(valid)}")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -722,7 +722,8 @@ def require_effective_base(header: dict, row: dict, pr: str) -> "tuple[str | Non
     Returns `(base, None)` when the base is usable, or `(None, reason)` — a ready-to-emit refusal message naming
     the PR — when it is not. `-` on BOTH the row and the header means "no base was ever resolved" (`effective_base`
     faithfully returns it); it is NOT a branch a caller may rebase onto, write to history, or diff against, so it
-    is refused here. This mirrors `base_agrees`, which already refuses `-`. A normal run never reaches this: the
+    is refused here. This function is the ONLY one that refuses `-`: `base_agrees` does NOT — it checks
+    equality first, so `base_agrees("-", "-")` returns True. A normal run never reaches this: the
     header base is filled at run start and each row's at adoption, so `effective_base` returns a real branch; a
     both-`-` ledger is a driver-authored/hand-edited state (a single-user foot-gun), and this is the cheap
     fail-closed insurance against it — not machinery to defend the user from themselves."""

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -44,10 +44,11 @@ HEADER_DEFAULTS = {
     # LEGACY FALLBACK for the base branch. The base a PR merges into is now ROW state (`base_branch` in
     # ROW_FIELDS), written once at row creation. This header field is only what a row with NO explicit base
     # inherits, through `effective_base` — the schema-owned resolver, the sanctioned door for base
-    # consumers. This is STAGE 1 of the per-row-base work: the field and resolver exist, and consumers are
-    # deliberately unchanged — TODAY they still read this header field directly; stages 2-3 move them
-    # through the resolver. An old single-base ledger keeps its header value and every one of its rows
-    # reads it. files-and-ledger.md, "Base branch", owns the field.
+    # consumers. Per-row base resolution is LIVE: adoption records each row's base and every consumer
+    # resolves through the accessor, never this header directly. What remains is mixed-base ADMISSION (the
+    # rollout's final PR — docs/designs/campaign-mixed-base-branches.md, "Staged implementation plan"). An
+    # old single-base ledger keeps its header value and every one of its rows reads it.
+    # files-and-ledger.md, "Base branch", owns the field.
     "base_branch": "-",
     "api_changes": "ask",
     "reviewer": "default",
@@ -68,10 +69,9 @@ HEADER_DEFAULTS = {
     # the base is now ROW state (`base_branch` in ROW_FIELDS), so the canonical required set is row state
     # too (`required_set` in ROW_FIELDS). This header field is only what a row with NO explicit value
     # inherits, through `effective_required_set` — the schema-owned resolver, the sanctioned door for
-    # consumers, staged exactly like `effective_base` above: TODAY consumers still read this header field
-    # directly; stages 2-3 move them through the resolver. An old single-base ledger keeps its header value
-    # and every one of its rows reads it; once stages 2-3 land, a new run will write `unknown` here and the
-    # canonical set on each row. stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?",
+    # consumers, resolved per row LIVE exactly like `effective_base` above. An old single-base ledger keeps
+    # its header value and every one of its rows reads it; a new run writes `unknown` on each row until a
+    # grouped read succeeds. stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?",
     # owns the three states and the format:
     #
     #   declared:<json>  the required checks, READ. `ci-snapshot.py --required-set` is the one parser.
@@ -171,7 +171,7 @@ ROW_FIELDS = (
     # reads back `-`, which never equals a 40-hex head, so `verdict` fails CLOSED until base-preflight runs.
     "base_ok_sha",
     # THE BASE THIS ROW MERGES INTO — the target `baseRefName` from live GitHub, written once at row
-    # creation (`add-row --base-branch`; stage-2 work wires adoption to record it). A run may hold rows on
+    # creation (`add-row --base-branch`; adoption records it). A run may hold rows on
     # DIFFERENT bases (`v3`, `main`), so the base is per-ROW, not per-run: the header `base_branch` is only
     # a LEGACY FALLBACK for a row that carries none. `effective_base(header, row)` is the schema-owned
     # resolver — an explicit row value, else the header. files-and-ledger.md, "Base branch", owns the field.
@@ -179,7 +179,7 @@ ROW_FIELDS = (
     # It is TOOL-OWNED and CREATION-ONLY (`CREATE_ONLY`): `add-row` writes it when the row appears and
     # NOTHING changes it after — there is no `--base-branch` flag at `set`. The campaign never migrates a row
     # to a new base; a live base that no longer matches the recorded one is an unsupported change a consumer
-    # parks for the user (stage-2 work), never a value `set` rewrites.
+    # parks for the user, never a value `set` rewrites.
     #
     # The default is `-`, the schema's own "not set" spelling AND its "inherit the legacy header" signal:
     # an old ledger's rows read back `-` and resolve through the header, exactly as they always did. A `-`
@@ -197,8 +197,8 @@ ROW_FIELDS = (
     # a row on a different base has no set here and stays `unknown` until read — the header never describes
     # another base's set), while `unknown` says "a read was attempted for THIS base and failed, so fail closed
     # and do not go green" (stage-2-ci.md). An old single-base row reads back `-` and inherits (its base IS the
-    # header base); a new run will write `unknown` on each row until a grouped read succeeds
-    # (stage-2 work). An ordinary settable field: the stage-2 grouped required-set refresh will write the
+    # header base); a new run writes `unknown` on each row until a grouped read succeeds.
+    # An ordinary settable field: the grouped required-set refresh writes the
     # canonical value through `set` (unlike `base_branch`, which is immutable after creation).
     "required_set",
     # WHERE THIS PR'S INTENT CAME FROM — the PROVENANCE of `<rundir>/intent-<pr>.md`:
@@ -323,8 +323,8 @@ PREFLIGHT_OWNED = ("base_ok_sha",)
 # the same absent-door one `PREFLIGHT_OWNED` uses, but ASYMMETRIC across the two write doors: the flag is
 # present at `add-row` (creation must be able to record the base) and ABSENT at `set` (argparse then refuses
 # `set --base-branch`, so nothing can rewrite it). A field here is still `settable()`; CREATE_ONLY narrows
-# only WHICH door may write it. (`required_set` is NOT here — the stage-2 grouped required-set refresh will
-# rewrite it through `set`, so that door stays open; only the base itself is fixed for a row's life.)
+# only WHICH door may write it. (`required_set` is NOT here — the grouped required-set refresh
+# rewrites it through `set`, so that door stays open; only the base itself is fixed for a row's life.)
 CREATE_ONLY = ("base_branch",)
 
 # The park/unpark TRANSITIONS `park`/`unpark` own — the same mechanism as VERDICT_OWNED, one level up at the
@@ -657,10 +657,11 @@ def find_row(rows: list[dict], pr: str) -> "dict | None":
 #
 # The base a PR merges into, and the required-check set that base demands, are now per-ROW state. These two
 # accessors are the ONE place the fallback lives: a row's explicit value if it has one, otherwise the legacy
-# header value. They are STAGE 1 of the per-row-base work — the sanctioned door every base/required-set
-# consumer resolves through once stages 2-3 convert them. TODAY the only non-test caller is `table`'s
-# computed, display-only `base` column; every other consumer still reads the header field directly, exactly
-# as it did before this stage. `-` is the row default and means exactly "inherit the header": an old
+# header value. They are the sanctioned door every base/required-set consumer resolves through, and that
+# resolution is LIVE: adoption records each row's base, and every consumer routes through these accessors
+# rather than reading the header field directly. What remains is mixed-base ADMISSION
+# (docs/designs/campaign-mixed-base-branches.md, "Staged implementation plan").
+# `-` is the row default and means exactly "inherit the header": an old
 # ledger's rows carry `-` and resolve to the header value they always used, while a row with an explicit
 # base (or an explicit required set) has that value returned unchanged. This is what lets legacy inheriting
 # rows and new explicit-base rows coexist in one run.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -683,6 +683,21 @@ def effective_required_set(header: dict, row: dict) -> str:
     return header.get("required_set", HEADER_DEFAULTS["required_set"])
 
 
+def base_agrees(base_arg: str, effective: str) -> bool:
+    """Does a caller's `--base` assertion agree with a row's effective base?
+
+    Identical strings ALWAYS agree — a base literally named `origin/<x>` (a legal branch name) must match
+    itself, so equality is checked BEFORE any normalization. Otherwise a leading `origin/` on the ARGUMENT
+    (the review-diff `origin/<base>` form) is stripped and compared against the stored base. The STORED base
+    is never stripped: `origin/x` in the ledger names a branch literally called that, and stripping it would
+    let `--base x` assert a different branch. This is the ONE owner of the comparison for every
+    `--base`-assertion consumer (base-preflight, triage, clean-rebase, worker-prompt, review-dispatch) —
+    never a second copy of this rule."""
+    if base_arg == effective:
+        return True
+    return base_arg.startswith("origin/") and base_arg[len("origin/"):] == effective
+
+
 def check_field(name: str, valid: "tuple[str, ...]") -> None:
     if name not in valid:
         fail(f"unknown field '{name}'; valid: {', '.join(valid)}")

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -370,6 +370,36 @@ def t_cli_gh_spawn_failure():
           f"the reason must name the failed view fetch, got {result['reason']!r}")
 
 
+def t_cli_unresolved_base_never_merges():
+    """THE FINDING #2 REGRESSION TEST: a both-`-` ledger (header AND row base_branch='-', so effective_base
+    resolves to '-') with a CLEAN/MERGEABLE/OPEN view whose baseRefName='-' must NEVER merge — even when the
+    base-ancestry probe would report `current` (a git branch literally named '-' that HEAD descends from).
+    The '-' == '-' coincidence slips `decide`'s retarget check, so the guard MUST be the shared
+    `require_effective_base` fail-closed at the top of `check`, before `decide` and before the probe. Run
+    against the pre-fix code (which resolved the base through the raw `effective_base` accessor with no
+    refusal) this printed `{"verdict":"merge"}` at exit 0 — a false permissive at the merge gate."""
+    real_check = M.B.check_base_ancestry
+    # `current` is the WORST case: even if the probe would clear, the unresolved base must still block merge.
+    M.B.check_base_ancestry = lambda *_args: ("current", "")
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            # header base '-' too, so a `-` row's effective base stays the unresolved '-' sentinel.
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1", base_branch="-"), [row(base_branch="-")])
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view(baseRefName="-")), encoding="utf-8")
+            code, out, err = capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    finally:
+        M.B.check_base_ancestry = real_check
+    check(code != 0, f"an unresolved base must fail closed (exit non-zero), got {code} (stderr: {err})")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet",
+          f"an unresolved base must decide not-yet, NEVER merge, got {result!r}")
+    check(result["reason"] == "pr 9 has no usable effective base in the ledger",
+          f"the reason must be require_effective_base's ready-to-emit refusal, got {result['reason']!r}")
+
+
 def t_base_retarget_parks():
     # A fully clean+green+in_review PR whose live base no longer matches its recorded (effective) base. The
     # recorded base is IMMUTABLE; a retarget is unsupported and parks with the SAME machine-blocker wording
@@ -412,6 +442,8 @@ CASES = [
     ("mss-unknown-value-parks", "an unrecognised merge state parks (totality)", t_unknown_mergestate_value_parks),
     ("mergeable-unknown-value-parks", "an unrecognised mergeable value parks", t_unknown_mergeable_value_parks),
     ("cli-injected-view", "check --view-json decides without gh and exits 0", t_cli_injected_view),
+    ("cli-unresolved-base", "a both-`-` unresolved base never merges — the finding #2 false-permissive fix",
+     t_cli_unresolved_base_never_merges),
     ("cli-stale-base", "a CLEAN candidate behind refreshed base cannot merge", t_cli_stale_base_blocks_merge),
     ("cli-unverified-base", "an unreadable base ancestry fails closed", t_cli_unverified_base_blocks_merge),
     ("cli-blocked-behind", "a BLOCKED PR behind its base routes to rebase (the #134 fix)",

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -36,21 +36,28 @@ SHA_A = "a" * 40   # the reviewed head
 SHA_B = "b" * 40   # a head the tip has moved to
 
 
-def row(*, status="in_review", head_sha=SHA_A, ci="green", tier="HIGH", reviews_ok=2) -> dict:
+def row(*, status="in_review", head_sha=SHA_A, ci="green", tier="HIGH", reviews_ok=2,
+        base_branch="-") -> dict:
     r = dict(L.ROW_DEFAULTS)
-    r.update(pr="9", status=status, head_sha=head_sha, ci=ci, tier=tier, reviews_ok=str(reviews_ok))
+    r.update(pr="9", status=status, head_sha=head_sha, ci=ci, tier=tier, reviews_ok=str(reviews_ok),
+             base_branch=base_branch)
     r["id"] = "pr9"
     return r
 
 
 def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN", isDraft=False, state="OPEN",
-         headRefOid=SHA_A) -> dict:
+         headRefOid=SHA_A, baseRefName="main") -> dict:
     return {"mergeable": mergeable, "mergeStateStatus": mergeStateStatus, "isDraft": isDraft,
-            "state": state, "headRefOid": headRefOid}
+            "state": state, "headRefOid": headRefOid, "baseRefName": baseRefName}
+
+
+# The header carries base_branch "main", so a `-` row inherits "main" and matches view()'s default
+# baseRefName — the effective base every fixture below decides under, unless it sets one explicitly.
+_HEADER = {"base_branch": "main"}
 
 
 def decide(r: dict, v: dict) -> dict:
-    return M.decide(r, v, required=M.REQUIRED)
+    return M.decide(r, v, required=M.REQUIRED, effective_base=L.effective_base(_HEADER, r))
 
 
 def check(cond: bool, msg: str) -> None:
@@ -363,9 +370,27 @@ def t_cli_gh_spawn_failure():
           f"the reason must name the failed view fetch, got {result['reason']!r}")
 
 
+def t_base_retarget_parks():
+    # A fully clean+green+in_review PR whose live base no longer matches its recorded (effective) base. The
+    # recorded base is IMMUTABLE; a retarget is unsupported and parks with the SAME machine-blocker wording
+    # every base door records. This fixture pins that the merge door catches it and uses the shared reason.
+    expected = M.PA.BASE_CHANGE_PARK_REASON.format(recorded="v3", live="main")
+    expect(row(base_branch="v3"), view(baseRefName="main"), "not-yet", expected)
+
+
+def t_base_advance_is_not_a_retarget():
+    # SAME base name on both sides — this is NOT a retarget, so the base step falls through to the enums and
+    # (with a CLEAN view) reaches merge. A base that ADVANCED with new commits is the ancestry probe's job,
+    # not this equality check. Guards against over-firing the retarget park on a normal base advance.
+    expect(row(base_branch="v3"), view(baseRefName="v3"), "merge", "")
+
+
 CASES = [
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),
+    ("base-retarget-parks", "a live base retarget parks with the shared reason", t_base_retarget_parks),
+    ("base-advance-not-retarget", "same base name is not a retarget -> reaches merge",
+     t_base_advance_is_not_a_retarget),
     ("held-frozen", "a held PR never merges, whatever the counters/enums say", t_held_never_merges),
     ("terminal-frozen", "a terminal row (aborted/merged) never merges — the allow-list repro",
      t_terminal_status_never_merges),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -62,6 +62,10 @@ def _load(name: str, filename: str):
 L = _load("merge_check_ledger", "ledger.py")
 HELD_STATUSES = L.HELD_STATUSES
 B = _load("merge_check_base_preflight", "base-preflight.py")
+# pr-adopt.py OWNS `BASE_CHANGE_PARK_REASON` — the EXACT machine-blocker wording a re-adoption / reconcile /
+# preflight park records. Both merge doors reuse that one owner so a live-base retarget reads identically
+# everywhere; never a second copy of the string here.
+PA = _load("merge_check_pr_adopt", "pr-adopt.py")
 
 # `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped. The rule already lives in `nudge.py`
 # (and `review-pass.py`); a third copy here would be the drift this repo keeps killing. So merge-check
@@ -123,13 +127,15 @@ def _short(sha: str) -> str:
     return sha[:7] if len(sha) > 7 else sha
 
 
-def decide(row: dict, view: dict, *, required) -> dict:
+def decide(row: dict, view: dict, *, required, effective_base: str) -> dict:
     """PURE. Return `{"verdict": "merge"|"not-yet", "reason": str}` for one PR. No I/O.
 
     The order is FIRST-FAILING-CHECK-WINS, and it is deliberate: the status ALLOW-LIST is asked before
     anything else, so a PR that is not `in_review` (held, terminal, or anything else) is frozen regardless
     of counters; the two GitHub enums are asked LAST, only once every ledger precondition has already
-    passed. `required` is the gate's `required(tier)` helper, passed in.
+    passed. `required` is the gate's `required(tier)` helper, passed in. `effective_base` is the row's
+    RECORDED base (its explicit `base_branch`, else the legacy header — resolved by the caller through
+    `ledger.py`'s accessor), compared against the live `baseRefName` to catch an unsupported retarget.
     """
     # 1. STATUS ALLOW-LIST — only an `in_review` row is EVER a merge candidate. This is an ALLOW-LIST, not a
     #    reject-list, and that is the whole point: every OTHER status parks, so nothing can slip through to a
@@ -146,6 +152,15 @@ def decide(row: dict, view: dict, *, required) -> dict:
     state = view["state"]
     if state != "OPEN":
         return _not_yet(f"pr is {state}, not open")
+
+    # 2b. BASE RETARGET — the live target no longer matches the row's recorded (effective) base. The recorded
+    #     base is IMMUTABLE, and a retarget is an unsupported mid-run change: fail closed with the SAME
+    #     machine-blocker wording a re-adoption / reconcile / preflight park records, so the driver parks the
+    #     row. (A base that merely ADVANCED — same NAME, new commits — is NOT this; that is the ancestry probe
+    #     in `check`, which routes a behind-base candidate to a rebase.)
+    base_now = view["baseRefName"]
+    if base_now != effective_base:
+        return _not_yet(PA.BASE_CHANGE_PARK_REASON.format(recorded=effective_base, live=base_now))
 
     # 3. DRAFT — GitHub blocks the merge regardless of CI.
     if view["isDraft"]:
@@ -192,7 +207,7 @@ def decide(row: dict, view: dict, *, required) -> dict:
 
 # --- obtain the live PR view ---------------------------------------------------
 
-VIEW_FIELDS = "mergeable,mergeStateStatus,isDraft,state,headRefOid"
+VIEW_FIELDS = "mergeable,mergeStateStatus,isDraft,state,headRefOid,baseRefName"
 
 
 class ViewError(Exception):
@@ -202,7 +217,7 @@ class ViewError(Exception):
 # Every field `decide` reads off the view, with the JSON type it requires. `isDraft` is a bool; the other
 # four are strings. `validate_view` pins this at the boundary so `decide` may assume a shaped view and never
 # raises `KeyError`/`TypeError` on a value the caller handed in.
-_VIEW_STR_FIELDS = ("mergeable", "mergeStateStatus", "state", "headRefOid")
+_VIEW_STR_FIELDS = ("mergeable", "mergeStateStatus", "state", "headRefOid", "baseRefName")
 
 
 def validate_view(view: object) -> "str | None":
@@ -272,7 +287,11 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
     if problem is not None:
         print(json.dumps(_not_yet(f"malformed PR view: {problem}")))
         return 1
-    result = decide(row, view, required=REQUIRED)
+    # The ROW owns the base: resolve its `effective_base` (its explicit `base_branch`, else the legacy header)
+    # through `ledger.py`'s accessor. `decide` compares it with the live `baseRefName` for a retarget, and the
+    # ancestry probe below measures against the base the row actually tracks — never the one header base.
+    effective_base = L.effective_base(header, row)
+    result = decide(row, view, required=REQUIRED, effective_base=effective_base)
     verdict = result["verdict"]
     if verdict == NOT_YET:
         print(json.dumps(result))
@@ -283,7 +302,7 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
     # unprotected base, and a BLOCKED PR may merely be BEHIND its base — a rebase fixes both. So re-fetch and
     # compare actual ancestry before the final decision; the shared preflight helper owns the graph check so
     # review dispatch and Stage 3 cannot disagree about what "current base" means.
-    ancestry, detail = B.check_base_ancestry(row.get("worktree"), header.get("base_branch"), "origin")
+    ancestry, detail = B.check_base_ancestry(row.get("worktree"), effective_base, "origin")
     if ancestry == "stale":                       # behind base -> rebase (BOTH paths; never a merge)
         print(json.dumps(_not_yet(REBASE_REASON)))
         return 0

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -288,9 +288,15 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
         print(json.dumps(_not_yet(f"malformed PR view: {problem}")))
         return 1
     # The ROW owns the base: resolve its `effective_base` (its explicit `base_branch`, else the legacy header)
-    # through `ledger.py`'s accessor. `decide` compares it with the live `baseRefName` for a retarget, and the
-    # ancestry probe below measures against the base the row actually tracks — never the one header base.
-    effective_base = L.effective_base(header, row)
+    # through `ledger.require_effective_base` — the ONE owner of the consumer-side "fail CLOSED on an unresolved
+    # base" contract (its blank/`-` refusal), the SAME guard `base-preflight.py` routes through. An unresolved
+    # base is NEVER a merge: refuse it HERE, before `decide` and before the ancestry probe, with the owner's
+    # ready-to-emit reason naming the PR. Without this, a both-`-` ledger + a `baseRefName="-"` view slips the
+    # retarget check (`"-" == "-"`) and false-permits a `merge` over a base that was never resolved.
+    effective_base, base_problem = L.require_effective_base(header, row, str(pr))
+    if base_problem is not None:
+        print(json.dumps(_not_yet(base_problem)))
+        return 1
     result = decide(row, view, required=REQUIRED, effective_base=effective_base)
     verdict = result["verdict"]
     if verdict == NOT_YET:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -54,10 +54,14 @@ class Fake:
                  view_base: "str | None" = None, base: str = "main",
                  labels: "list[dict] | None" = None, local_base: str = "absent",
                  repo_identity: str = "o/r", mergeable: str = "MERGEABLE",
-                 merge_state_status: str = "CLEAN"):
+                 merge_state_status: str = "CLEAN", header_base: "str | None" = None):
         self.root = root
         self.branch = "feat-pr"
+        # `base` is the row's RECORDED base — an explicit row `base_branch`, unless `header_base` is given, in
+        # which case the row inherits it as a legacy `-` row. Either way `effective_base` resolves to `base`,
+        # which is what every base door (validate, ancestry, sync) must target.
         self.base = base
+        self.header_base = header_base
         self.worktree = root / ".worktrees" / self.branch
         self.worktree_owned = worktree_owned
         self.branch_owned = branch_owned
@@ -104,7 +108,12 @@ class Fake:
 
     def ledger(self, path: Path, *, worktree: "Path | None" = None, branch: "str | None" = None,
                run_id="g1", worktree_field: "str | None" = None) -> None:
-        header = dict(L.HEADER_DEFAULTS, run_id=run_id, base_branch=self.base)
+        # Default: legacy shape — header holds the base, the row inherits it as `-`. With `header_base` set,
+        # the row owns an EXPLICIT `base_branch` (self.base) and the header carries `header_base` (e.g. "-"):
+        # the mixed-base shape. `effective_base` resolves to self.base either way.
+        header_base = self.header_base if self.header_base is not None else self.base
+        row_base = self.base if self.header_base is not None else "-"
+        header = dict(L.HEADER_DEFAULTS, run_id=run_id, base_branch=header_base)
         row = dict(L.ROW_DEFAULTS)
         # `worktree_field` writes the row's worktree column VERBATIM — passing the ROW_DEFAULTS "-" models a
         # HALF-ADOPTION (pr-adopt.py registered the row before it resolved the worktree). Otherwise the
@@ -113,7 +122,7 @@ class Fake:
         row.update(pr="9", id="pr9", branch=branch or self.branch,
                    worktree=wt, worktree_owned=self.worktree_owned,
                    branch_owned=self.branch_owned, head_sha=SHA, reviews_ok=self.reviews,
-                   ci=self.ci, tier="HIGH", status=self.status)
+                   ci=self.ci, tier="HIGH", status=self.status, base_branch=row_base)
         L.dump(path, header, [row])
 
     def view(self) -> dict:
@@ -466,6 +475,37 @@ def t_dash_leading_base_is_never_option_parseable():
               f"absent-base sync did not use the safe local refspec: {root_fetches}")
         check(not any(token == f"{base}:{base}" for argv, _ in f.calls for token in argv),
               "the option-parseable bare `<base>:<base>` refspec is still assembled")
+    finally:
+        finish(td, real)
+
+
+def t_live_base_retarget_refuses_with_shared_reason():
+    # The live PR base no longer matches the row's recorded base: an unsupported mid-run retarget. The merge
+    # runner must REFUSE (never merge onto the new base) with the SAME machine-blocker wording every base door
+    # records — pr-adopt.py owns it, reached here via merge-check (M.MC.PA).
+    td, root, f, led, real = scenario(view_base="v9")
+    try:
+        code, _result, err = invoke(f, led, root)
+        expected = M.MC.PA.BASE_CHANGE_PARK_REASON.format(recorded="main", live="v9")
+        check(code != 0, f"a live base retarget must refuse, not merge: {err}")
+        check(expected in err, f"the refusal must use the shared base-change reason, got: {err!r}")
+    finally:
+        finish(td, real)
+
+
+def t_explicit_row_base_drives_every_base_door():
+    # A MIXED-BASE row: header base is `-`, the row owns an explicit base_branch ("v3"). Every base door
+    # (validate, ancestry, post-merge sync) must target the ROW's base, not the header. A clean external MERGE
+    # exercises validate + sync end to end; landing at merged proves the row base drove them.
+    td, root, f, led, real = scenario(state="MERGED", base="v3", header_base="-")
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code == 0, f"an explicit-row-base merge must finalize through the row base: {err}")
+        check(status(led) == "merged", "the row must reach terminal merged")
+        # the post-merge sync fetched origin/v3 (the ROW's base), never the header's `-`.
+        synced = [argv for argv, _ in f.calls
+                  if argv[:5] == ["git", "-C", str(root), "fetch", "origin"] and "v3" in argv[-1]]
+        check(bool(synced), f"post-merge sync must target the row base v3: {[a for a, _ in f.calls]!r}")
     finally:
         finish(td, real)
 
@@ -989,6 +1029,8 @@ CASES = [
     ("owner-and-view", "another run and uncertain GitHub state fail closed", t_owner_label_and_uncertain_view_refused),
     ("base-location", "checked-out and absent local base use their documented update paths", t_base_checked_out_and_absent),
     ("dash-base-safe", "a dash-leading base name is fully-qualified at both fetch sites, never option-parseable", t_dash_leading_base_is_never_option_parseable),
+    ("live-base-retarget", "a live base retarget refuses with the shared machine-blocker reason", t_live_base_retarget_refuses_with_shared_reason),
+    ("explicit-row-base", "an explicit row base_branch (header `-`) drives validate/ancestry/sync", t_explicit_row_base_drives_every_base_door),
     ("local-ahead-base-synced", "a local-ahead base is already synced: base-sync skips the non-ff fetch and finalization reaches cleanup + terminal write", t_local_ahead_base_skips_fetch_and_finalizes),
     ("merge-resume", "merge and confirmation failures resume safely", t_merge_and_confirmation_failures_resume),
     ("postmerge-resume", "every post-merge phase resumes without another merge", t_postmerge_phase_failures_resume),

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -173,7 +173,9 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
     run_id = header.get("run_id", "-")
     if not run_id or run_id == "-":
         raise Refusal("ledger run_id is unresolved")
-    base = header.get("base_branch", "-")
+    # The ROW owns the base: its explicit `base_branch`, else the legacy header, through `ledger.py`'s
+    # accessor. A run may hold rows on different bases, so every base check here is per-row, never the header.
+    base = L.effective_base(header, row)
     branch = row.get("branch", "-")
     _validate_ref(root, base, "base_branch")
     _validate_ref(root, branch, "row branch")
@@ -200,8 +202,10 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
             raise Refusal(
                 f"live head branch {view['headRefName']!r} differs from ledger branch {branch!r}")
         if view["baseRefName"] != base:
-            raise Refusal(
-                f"live base {view['baseRefName']!r} differs from ledger base {base!r}")
+            # A live retarget away from the recorded base is an unsupported mid-run change — fail closed with
+            # the SAME machine-blocker wording every other base door records (pr-adopt.py owns it, via
+            # merge-check). A base that merely ADVANCED (same name) is handled by _base_is_current, not here.
+            raise Refusal(MC.PA.BASE_CHANGE_PARK_REASON.format(recorded=base, live=view["baseRefName"]))
     labels = _labels(view)
     ours = f"{RUN_LABEL_PREFIX}{run_id}"
     run_labels = [name for name in labels if name.startswith(RUN_LABEL_PREFIX)]
@@ -231,7 +235,7 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
 
 def _base_is_current(row: dict, header: dict) -> None:
     worktree = row["worktree"]
-    base = header["base_branch"]
+    base = L.effective_base(header, row)
     # Fully-qualified refspec so a dash-leading base name (network-supplied via baseRefName) can never be
     # parsed by git as an option; the same safety idiom as _sync_base and pr-adopt.py. This updates the very
     # origin/<base> remote-tracking ref the ancestry probe below reads.
@@ -257,7 +261,7 @@ def _require_ready(row: dict, header: dict, view: dict) -> None:
     exactly as the gate does — NOT parked. A PROBE that survives the probe is BLOCKED-but-current: a genuine
     human/ruleset block that parks. PROBE never reaches an actual merge; it can only refuse (rebase or park).
     """
-    result = MC.decide(row, view, required=MC.REQUIRED)
+    result = MC.decide(row, view, required=MC.REQUIRED, effective_base=L.effective_base(header, row))
     verdict = result.get("verdict")
     if verdict not in (MC.MERGE, MC.PROBE):
         raise Refusal(f"merge-check: {result.get('reason', 'not ready')}")
@@ -543,7 +547,8 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
         raise Refusal(f"PR {pr} state is {view['state']!r}; expected OPEN, MERGED, or CLOSED")
 
     # MERGED is confirmed before any local ref or worktree is changed. Each following phase is idempotent.
-    _sync_base(root, header["base_branch"])
+    # Post-merge local sync targets THIS row's base — after a v3 PR, local v3; after a main PR, local main.
+    _sync_base(root, L.effective_base(header, row))
     cleanup = _cleanup(root, row)
     _mark_terminal(ledger, pr, "merged")
     return {"status": "merged", "pr": pr, "cleanup": cleanup}

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -121,8 +121,28 @@ def t_required_set_unknown_is_per_base():
     lines = fire(rows, hdr=hdr)
     check(has(lines, "required set unknown for base main (PR(s) 2)"),
           "only the unsettled base is reminded, naming its PR(s)")
-    check(not has(lines, "base v3"),
-          "a base whose required set is already settled must NOT be reminded")
+    check(not has(lines, "required set unknown for base v3"),
+          "a base whose required set is already settled must NOT fire the unknown reminder")
+    check(has(lines, "base v3 (PR(s) 1): required set declared:[]."),
+          "a settled base is REPORTED with its effective base and required set instead")
+
+
+def t_settled_base_report():
+    # The intent's purpose bullet: nudge NAMES each active row's effective base and required set. A settled
+    # single-base ledger (legacy channel: header base + required set, rows inheriting) must report both
+    # values — not only the generic re-resolve instruction; an explicit row value reports the same way.
+    hdr = header(run_id="g1", base_branch="release/v3", required_set="none")
+    lines = fire([row(1, "in_review")], hdr=hdr)  # row base/required_set `-` → inherit header
+    check(has(lines, "base release/v3 (PR(s) 1): required set none."),
+          "a settled base must be reported naming its effective base and required set")
+    lines = fire([row(2, "in_review", base_branch="v3", required_set="declared:[]")], hdr=hdr)
+    check(has(lines, "base v3 (PR(s) 2): required set declared:[]."),
+          "an explicit row base/required set must drive the report (row-owned, not the header)")
+    # Teeth: the report is computed from ACTIVE rows — no active row, no report line.
+    check(not has(fire([], hdr=hdr), "required set"),
+          "with no active PR there is no per-base report")
+    check(not has(fire([row(1, "merged")], hdr=hdr), "base release/v3"),
+          "a terminal row must not be reported")
 
 
 def t_fanout_fires_only_with_open_work():
@@ -319,6 +339,8 @@ CASES = [
      t_required_set_unknown),
     ("required-set-per-base", "the unknown-required-set nudge is per distinct effective base",
      t_required_set_unknown_is_per_base),
+    ("settled-base-report", "each active base is reported with its effective base and required set",
+     t_settled_base_report),
     ("fanout-open-only", "fan-out nudges only with open work", t_fanout_fires_only_with_open_work),
     ("followups-open-only", "follow-ups nudge only when open, with the count", t_followups_fire_only_when_open),
     ("parked-short-circuits", "a parked PR fires only its held reminder", t_parked_pr_fires_only_its_own_reminder),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -96,10 +96,33 @@ def t_labels_fire_only_with_an_active_pr():
 # --- run-level ----------------------------------------------------------------
 
 def t_required_set_unknown():
-    check(has(fire([], hdr=header(required_set="unknown")), "required_set is unknown"),
-          "an unknown required_set must nudge to derive it")
-    check(not has(fire([], hdr=header(required_set="none")), "required_set is unknown"),
-          "a known required_set must NOT fire the derive nudge")
+    # An active row whose EFFECTIVE required set is unknown (here inherited from the legacy header) nudges
+    # to run the grouped read, NAMING the base it blocks.
+    hdr = header(run_id="g1", base_branch="main", required_set="unknown")
+    lines = fire([row(1, "in_review")], hdr=hdr)  # row base/required_set `-` → inherit header
+    check(has(lines, "required set unknown for base main"),
+          "an unknown effective required set must nudge to run the grouped read, naming the base")
+    # A row with its OWN settled required set does NOT fire — even when the header fallback is unknown.
+    check(not has(fire([row(1, "in_review", required_set="none")], hdr=hdr), "required set unknown"),
+          "a row with an explicit, settled required set must NOT fire the derive nudge")
+    # No active PR → there is no per-base required set to derive, whatever the header holds.
+    check(not has(fire([], hdr=hdr), "required set unknown"),
+          "with no active PR there is no per-base required set to derive")
+
+
+def t_required_set_unknown_is_per_base():
+    # A mixed-base run: one base is settled, one is still unknown. Only the unsettled base is reminded,
+    # named with its PR(s) — the grouped read is per distinct effective base.
+    hdr = header(run_id="g1", base_branch="-", required_set="unknown")
+    rows = [
+        row(1, "in_review", base_branch="v3", required_set="declared:[]"),  # settled for v3
+        row(2, "in_review", base_branch="main", required_set="unknown"),    # unsettled for main
+    ]
+    lines = fire(rows, hdr=hdr)
+    check(has(lines, "required set unknown for base main (PR(s) 2)"),
+          "only the unsettled base is reminded, naming its PR(s)")
+    check(not has(lines, "base v3"),
+          "a base whose required set is already settled must NOT be reminded")
 
 
 def t_fanout_fires_only_with_open_work():
@@ -292,7 +315,10 @@ CASES = [
     ("heartbeat-always", "the heartbeat reminder fires every heartbeat", t_heartbeat_always_fires),
     ("header-always", "the header-reread reminder fires every heartbeat", t_header_reread_always_fires),
     ("labels-active-only", "the labels reminder fires only with an active PR", t_labels_fire_only_with_an_active_pr),
-    ("required-set-unknown", "unknown required_set nudges to derive it", t_required_set_unknown),
+    ("required-set-unknown", "an unknown effective required set nudges to run the grouped read",
+     t_required_set_unknown),
+    ("required-set-per-base", "the unknown-required-set nudge is per distinct effective base",
+     t_required_set_unknown_is_per_base),
     ("fanout-open-only", "fan-out nudges only with open work", t_fanout_fires_only_with_open_work),
     ("followups-open-only", "follow-ups nudge only when open, with the count", t_followups_fire_only_when_open),
     ("parked-short-circuits", "a parked PR fires only its held reminder", t_parked_pr_fires_only_its_own_reminder),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -109,11 +109,27 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
     out.append('follow loop-control.md, "Primary continuity", before yielding.')
     out.append("re-read the ledger header (base_branch, reviewer, required_set, skill_version).")
     if active:
+        # The base a PR merges into and its required-check set are per-ROW state now (`effective_base` /
+        # `effective_required_set`); the header `base_branch`/`required_set` are only the LEGACY FALLBACK a
+        # row with none inherits. So the heartbeat re-resolves them PER active PR, not once from the header.
         out.append("check each active PR's labels match its gate state.")
+        out.append("re-resolve each active PR's effective base and required set (row-owned; the header "
+                   "base_branch/required_set are only the legacy fallback for a row that carries none).")
 
     # --- run-level -------------------------------------------------------------
-    if header.get("required_set") == "unknown":
-        out.append("required_set is unknown — derive it.")
+    # Required checks are per-BASE row state. Group active rows by effective base; a base whose effective
+    # required set is still `unknown` (a read failed or never ran) FAILS CLOSED — it cannot go green — and
+    # blocks only ITS group, so the reminder names the base and its PRs. `-` is NOT `unknown`: it means
+    # "inherit the header", which `effective_required_set` resolves; a new run's rows read the header's
+    # `unknown` until the grouped read (ci-status.py required-set) writes each base's canonical set.
+    unknown_bases: "dict[str, list]" = {}
+    for r in active:
+        if L.effective_required_set(header, r) == "unknown":
+            unknown_bases.setdefault(L.effective_base(header, r), []).append(r["pr"])
+    for base in sorted(unknown_bases):
+        prs = ", ".join(unknown_bases[base])
+        out.append(f"required set unknown for base {base} (PR(s) {prs}) — run the grouped required-set "
+                   f"read (ci-status.py required-set).")
     if active:
         out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
     if n_followups:

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -117,19 +117,25 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
                    "base_branch/required_set are only the legacy fallback for a row that carries none).")
 
     # --- run-level -------------------------------------------------------------
-    # Required checks are per-BASE row state. Group active rows by effective base; a base whose effective
-    # required set is still `unknown` (a read failed or never ran) FAILS CLOSED — it cannot go green — and
-    # blocks only ITS group, so the reminder names the base and its PRs. `-` is NOT `unknown`: it means
-    # "inherit the header", which `effective_required_set` resolves; a new run's rows read the header's
-    # `unknown` until the grouped read (ci-status.py required-set) writes each base's canonical set.
-    unknown_bases: "dict[str, list]" = {}
+    # Required checks are per-BASE row state. Group active rows by (effective base, effective required set)
+    # and REPORT every pairing — naming each active row's effective base and required set is the point, not
+    # only the blocked ones. A settled pairing is stated verbatim (the raw ledger spelling — nudge never
+    # parses a required-set spec); a base whose effective set is still `unknown` (a read failed or never
+    # ran) FAILS CLOSED — it cannot go green — and blocks only ITS group, so ITS line also says to run the
+    # grouped read. `-` is NOT `unknown`: it means "inherit the header", which `effective_required_set`
+    # resolves; a new run's rows read the header's `unknown` until the grouped read (ci-status.py
+    # required-set) writes each base's canonical set.
+    base_groups: "dict[tuple, list]" = {}
     for r in active:
-        if L.effective_required_set(header, r) == "unknown":
-            unknown_bases.setdefault(L.effective_base(header, r), []).append(r["pr"])
-    for base in sorted(unknown_bases):
-        prs = ", ".join(unknown_bases[base])
-        out.append(f"required set unknown for base {base} (PR(s) {prs}) — run the grouped required-set "
-                   f"read (ci-status.py required-set).")
+        key = (L.effective_base(header, r), L.effective_required_set(header, r))
+        base_groups.setdefault(key, []).append(r["pr"])
+    for base, rset in sorted(base_groups):
+        prs = ", ".join(base_groups[(base, rset)])
+        if rset == "unknown":
+            out.append(f"required set unknown for base {base} (PR(s) {prs}) — run the grouped required-set "
+                       f"read (ci-status.py required-set).")
+        else:
+            out.append(f"base {base} (PR(s) {prs}): required set {rset}.")
     if active:
         out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
     if n_followups:

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -117,10 +117,11 @@ def t_adopt_same_repo():
     check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing"],
           "labels_add == [our owner label, gauntlet-reviewing]")
     check(p["worktree"] == str(Path("/wt") / "feat-x"), "worktree == worktrees_root / headRefName")
-    check(p["base"] == "main", "base == baseRefName (a HEADER field, carried under `base`)")
-    # teeth: base/worktree/ownership flags are NOT row fields — they are the caller's or step 5's
+    check(p["base"] == "main", "base == baseRefName, carried under `base` for the executor to record per-row")
+    # teeth: base/worktree/ownership flags are NOT in the PLAN row — the executor writes the row base_branch
+    # (add-row --base-branch), and step 5 decides worktree ownership; build_plan carries neither.
     check("base" not in row and "base_branch" not in row and "worktree" not in row,
-          "base/base_branch/worktree must NOT be written as row fields")
+          "base/base_branch/worktree must NOT be in the plan row (base rides `base`; the executor records it)")
     check("worktree_owned" not in row and "branch_owned" not in row,
           "worktree_owned/branch_owned are decided at step 5, never in the plan row")
 
@@ -231,8 +232,12 @@ def _ledger(*args) -> int:
         return M.L.main(list(args))
 
 
-def _init_ledger(ledger: Path, run_id: str = "g1") -> None:
+def _init_ledger(ledger: Path, run_id: str = "g1", base_branch: str = "main") -> None:
+    # A legacy-style header carries the run's real base (the `view()` default `baseRefName` is "main"), so a
+    # re-adopted legacy row with NO explicit row base resolves through `effective_base` to the live base and
+    # does not trip the re-adoption base gate. Pass a different `base_branch` to exercise a mismatch/park.
     _ledger("--file", str(ledger), "header", "set", "run_id", run_id)
+    _ledger("--file", str(ledger), "header", "set", "base_branch", base_branch)
 
 
 def _add_row(ledger: Path, pr, **fields) -> None:
@@ -751,6 +756,91 @@ def t_absent_creates_and_verifies():
               "with a local branch present, the add is plain `worktree add <path> <branch>` (no -b)")
 
 
+# --- mixed-base: the row RECORDS its live base at creation; a re-adoption mismatch PARKS ----------------
+
+def t_adopt_records_row_base():
+    """A fresh adoption RECORDS the PR's live `baseRefName` on the new row via `add-row --base-branch`.
+
+    The base is per-row from creation (design: every new row writes an explicit base, even in a single-base
+    run). It rides the plan under `base` and the executor writes it once; the plan row itself never carries it.
+    """
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        # A NEW-run-style header (base_branch "-"); the row still records its own explicit base.
+        _init_ledger(ledger, base_branch="-")
+        code, _, err, rec = _adopt(d, ledger, view(baseRefName="v4"), wroot=d / "wt")
+        check(code == 0, f"a clean adopt succeeds (got {code}: {err})")
+        check(_field(ledger, 12, "base_branch") == "v4",
+              f"the new row must record its live baseRefName; got {_field(ledger, 12, 'base_branch')!r}")
+        # The executor wrote it through add-row --base-branch (the CREATE_ONLY door), not a bare set.
+        addrow = next((c["argv"] for c in rec.calls
+                       if c["argv"][:1] == ["python3"] and "add-row" in c["argv"]), None)
+        check(addrow is not None and "--base-branch" in addrow and addrow[addrow.index("--base-branch") + 1] == "v4",
+              f"add-row must carry --base-branch v4; got {addrow!r}")
+
+
+def t_readopt_base_mismatch_parks():
+    """A re-adoption whose live base no longer matches the row's effective_base PARKS the row and stops.
+
+    The recorded base is immutable; the campaign does not migrate it. pr-adopt parks through the existing
+    machine-blocker transition with the EXACT reason, rewrites no base, and refreshes no SHA-bound evidence.
+    """
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger, base_branch="main")        # header base main
+        _add_row(ledger, 12, head_sha=sha, base_branch="v3", status="in_review", tier="HIGH")
+        _record_verdict(ledger, 12, sha)                # reviews_ok -> 1 (evidence that must survive)
+        # Live target is the view default `main`, which differs from the row's recorded `v3`.
+        code, out, err, rec = _adopt(d, ledger, view(headRefOid=sha, baseRefName="main"),
+                                     wroot=wroot, worktree_head=sha)
+        check(code == 0, f"a base-mismatch re-adoption exits 0 after parking (got {code}: {err})")
+        summary = json.loads(out)
+        check(summary.get("parked") is True, f"the summary must report the park; got {summary!r}")
+        check(_field(ledger, 12, "status") == "awaiting-user", "a base mismatch PARKS the row (awaiting-user)")
+        check(_field(ledger, 12, "ci_reason") == "base changed from v3 to main; not supported mid-run",
+              f"the durable park reason must be EXACT; got {_field(ledger, 12, 'ci_reason')!r}")
+        check(_field(ledger, 12, "blocker_ruling") == "-", "the park clears blocker_ruling (park contract)")
+        # The recorded base is NOT rewritten, and SHA-bound evidence is NOT refreshed.
+        check(_field(ledger, 12, "base_branch") == "v3", "the recorded row base is immutable — never rewritten")
+        check(_field(ledger, 12, "reviews_ok") == "1", "a parked mismatch refreshes no review evidence")
+        # It stopped BEFORE touching any label — only the `gh pr view` (step 1) ran, no create/edit.
+        ghs = [c["argv"][:3] for c in rec.gh_calls()]
+        check(ghs == [["gh", "pr", "view"]],
+              f"a parked mismatch applies no labels — only the pr view runs; got {ghs!r}")
+
+
+def t_readopt_base_mismatch_already_held_keeps_question():
+    """An ALREADY-held row keeps its open question — a base mismatch does not overwrite it.
+
+    `ledger.py park` refuses a second park (EXIT_STOP) and leaves the existing `ci_reason` untouched; the
+    executor reports the mismatch without disturbing the open blocker (design: held row keeps its question).
+    """
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        sha = "a" * 40
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger, base_branch="main")
+        _add_row(ledger, 12, head_sha=sha, base_branch="v3", tier="HIGH")
+        # The row is already parked on a DIFFERENT question, with a ruling the park is waiting on.
+        _set_row(ledger, 12, status="awaiting-user", ci_reason="CI has settled and is still not green",
+                 blocker_ruling="retry@2026-01-01T00:00:00Z")
+        code, out, err, _ = _adopt(d, ledger, view(headRefOid=sha, baseRefName="main"),
+                                   wroot=wroot, worktree_head=sha)
+        check(code == 0, f"an already-held mismatch exits 0 (got {code}: {err})")
+        summary = json.loads(out)
+        check(summary.get("already_held") is True and summary.get("parked") is False,
+              f"the summary must report the row was already held; got {summary!r}")
+        check(_field(ledger, 12, "ci_reason") == "CI has settled and is still not green",
+              "the existing open question must be PRESERVED, not overwritten by the base mismatch")
+        check(_field(ledger, 12, "blocker_ruling") == "retry@2026-01-01T00:00:00Z",
+              "the pending ruling on the open park is untouched")
+
+
 CASES = [
     ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),
     ("refuse_foreign_run", "a PR owned by another run is refused", t_refuse_foreign_run),
@@ -780,4 +870,7 @@ CASES = [
     ("different_branch_at_path_refused", "a DIFFERENT branch at the default path fails closed", t_different_branch_at_path_refused),
     ("dirty_at_path_refused", "a DIRTY reused checkout fails closed, touches nothing further", t_dirty_at_path_refused),
     ("absent_creates_and_verifies", "an absent branch is created (with/without a pre-existing local branch), SHA-verified", t_absent_creates_and_verifies),
+    ("adopt_records_row_base", "a fresh adoption records the live base on the new row (add-row --base-branch)", t_adopt_records_row_base),
+    ("readopt_base_mismatch_parks", "a re-adoption whose live base diverges from effective_base parks the row, exact reason, no rewrite", t_readopt_base_mismatch_parks),
+    ("readopt_base_mismatch_already_held", "an already-held row keeps its open question on a base mismatch", t_readopt_base_mismatch_already_held_keeps_question),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -56,6 +56,15 @@ RUN_LABEL_COLOR = "5319E7"
 # it opens). It is the ONLY thing that makes `pr_origin` = `gauntlet`; a driver cannot assert it by flag.
 GAUNTLET_AUTHORED_LABEL = "gauntlet-authored"
 
+# The EXACT durable reason recorded in `ci_reason` when a re-adoption sees the PR's live base diverge from
+# its recorded base. The campaign does NOT migrate a row to a new base; the mismatch is an unsupported user
+# change that PARKS the row through the existing machine-blocker transition (design:
+# campaign-mixed-base-branches.md, "Unsupported base changes park the row"). The reconcile→loop-control
+# routing parks with this SAME wording built from the `base_changed` fact, so the string is a shared
+# contract — search `not supported mid-run` to reconcile every site. `{recorded}` is the row's
+# `effective_base`, `{live}` the live `baseRefName`.
+BASE_CHANGE_PARK_REASON = "base changed from {recorded} to {live}; not supported mid-run"
+
 
 def _load(name: str, filename: str):
     mod = load_module_from_path(name, _HERE / filename)
@@ -171,9 +180,10 @@ def build_plan(view: dict, *, run_id: str, tier: str, worktrees_root: str) -> di
         return {"verdict": "refuse", "reason": f"PR is {state}, not open"}
 
     branch = view["headRefName"]
-    # COMPUTED fields only. `base_branch` is a HEADER field, not a row field, so `baseRefName` rides the
-    # plan under `base` for the caller and is never written as a row field. `worktree_owned`/`branch_owned`
-    # are decided at worktree creation (step 5), never here.
+    # COMPUTED fields only. The row's `base_branch` is TOOL-OWNED and CREATION-ONLY, so it is NOT in this
+    # plan row: `baseRefName` rides the plan under `base`, and the EXECUTOR records it once via `add-row
+    # --base-branch` when it creates the row (never here, and never rewritten on a re-adoption).
+    # `worktree_owned`/`branch_owned` are decided at worktree creation (step 5), never here.
     row = {
         "head_sha": view["headRefOid"],
         "tier": tier,
@@ -213,6 +223,30 @@ def cmd_plan(args) -> int:
     return 0
 
 
+def _park_base_mismatch(args, pr: str, recorded: str, live: str) -> int:
+    """A re-adoption saw the PR's live base diverge from its recorded base. PARK the row on the user through
+    the existing machine-blocker transition (`ledger.py park`) with the design's exact reason, and STOP —
+    no refresh, no relabel, no base rewrite. The park is the ONE mechanism; this reuses it rather than adding
+    a transition. An ALREADY-held row keeps its open question: `park` returns `EXIT_STOP` and leaves the
+    existing `ci_reason` untouched (design: "An already-held row keeps its open question")."""
+    reason = BASE_CHANGE_PARK_REASON.format(recorded=recorded, live=live)
+    park_argv = ["python3", str(LEDGER_PY), "--file", args.file, "park", "--pr", pr, "--reason", reason]
+    proc = _run(park_argv, cwd=args.project_root)
+    mismatch = {"recorded": recorded, "live": live}
+    if proc.returncode == L.EXIT_STOP:
+        # Already awaiting-user — a park is open and its question is preserved. Nothing to do but report it.
+        print(json.dumps({"pr": pr, "run_id": args.run_id, "parked": False,
+                          "already_held": True, "base_mismatch": mismatch}))
+        return 0
+    if proc.returncode != 0:
+        # A terminal row (or other park refusal) — parking does not apply; surface it fail-closed.
+        return _refuse(f"PR {pr} base changed (recorded {recorded}, live {live}) but the row could NOT be "
+                       f"parked: {proc.stderr.strip()}")
+    print(json.dumps({"pr": pr, "run_id": args.run_id, "parked": True,
+                      "reason": reason, "base_mismatch": mismatch}))
+    return 0
+
+
 def cmd_adopt(args) -> int:
     pr = str(args.pr)
     run_label = f"{RUN_LABEL_PREFIX}{args.run_id}"
@@ -246,6 +280,21 @@ def cmd_adopt(args) -> int:
     row = plan["row"]
     planned_head = str(row["head_sha"])
 
+    # Load the ledger ONCE for the re-adoption checks here and the row refresh in step 4.
+    header, rows = L.load(Path(args.file))
+    existing = L.find_row(rows, pr)
+
+    # RE-ADOPTION BASE GATE — runs BEFORE any write. The recorded row base is IMMUTABLE (ledger CREATE_ONLY),
+    # and the campaign never migrates a row to a new base. If the PR's live base no longer matches the row's
+    # `effective_base` (its explicit base, else the legacy header), PARK the row on the user through the
+    # existing machine-blocker transition and STOP — refresh no evidence, rewrite no base, apply no label
+    # (design: "Unsupported base changes park the row"). A NEW row (existing is None) has no recorded base to
+    # diverge from; it records the live base in step 4.
+    if existing is not None:
+        recorded_base = L.effective_base(header, existing)
+        if recorded_base != base:
+            return _park_base_mismatch(args, pr, recorded_base, base)
+
     # 3. Ensure the run owner label exists (idempotent — `--force` creates or updates).
     label_argv = ["gh", "label", "create", run_label, "--color", RUN_LABEL_COLOR,
                   "--description", f"gauntlet: run {args.run_id}", "--force"]
@@ -269,8 +318,8 @@ def cmd_adopt(args) -> int:
     #   * UNCHANGED head on an existing row: name none of the SHA-bound fields — the accumulated verdicts,
     #     ci and liveness state all describe content that is still there and are preserved (the accessor's
     #     same-value `--head-sha` write is a no-op, so the counters are untouched).
-    _, rows = L.load(Path(args.file))
-    existing = L.find_row(rows, pr)
+    # `existing`/`rows` were loaded above (the re-adoption base gate needs them); nothing has written the
+    # ledger since, so they are still current.
     head_changed = existing is not None and existing.get("head_sha") != planned_head
     verb = "set" if existing is not None else "add-row"
     ledger_argv = ["python3", str(LEDGER_PY), "--file", args.file, verb, "--pr", pr,
@@ -279,7 +328,11 @@ def cmd_adopt(args) -> int:
                    "--slug", str(row["slug"]),
                    "--pr-origin", str(row["pr_origin"])]
     if existing is None:
-        ledger_argv += ["--tier", str(row["tier"]),
+        # A NEW row RECORDS its live base once, through the CREATE_ONLY `--base-branch` door. Every new row
+        # carries an explicit base — even in a single-base run — so the base is per-row from creation. `set`
+        # has no `--base-branch` flag, so a re-adoption can never rewrite it (the gate above parks instead).
+        ledger_argv += ["--base-branch", base,
+                        "--tier", str(row["tier"]),
                         "--ci", str(row["ci"]),
                         "--status", str(row["status"]),
                         "--reviews-ok", str(row["reviews_ok"])]

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -322,12 +322,37 @@ def t_head_moved():
 
 
 def t_base_changed():
+    # A LEGACY row (no explicit base_branch) inherits the header base through effective_base, so the
+    # comparison is against "main" — the same result the old header-only compare gave, now via the accessor.
     code, res, err = scenario([row(41)], [entry(41, base="develop")], base_branch="main")
     check(code == 0, f"exit 0, got {code} (stderr {err!r})")
     facts = res["rows"]["41"]
     check(facts.get("base_changed") == {"ledger": "main", "snapshot": "develop"},
-          f"base_changed compares snapshot baseRefName to the HEADER base_branch, got {facts!r}")
+          f"base_changed compares snapshot baseRefName to the row's effective_base (legacy row inherits the "
+          f"header), got {facts!r}")
     check(res["counts"]["base_changed"] == 1, f"base_changed count drifted, got {res['counts']!r}")
+
+
+def t_base_changed_uses_row_effective_base():
+    """base_changed compares against the ROW's effective_base, not the one header base — the mixed-base rule.
+
+    A row on `v3` (explicit row base) whose live target is `v3` is UNCHANGED even though the header base is
+    `main`; the same row whose live target reverted to `main` is a base_changed{ledger: v3, snapshot: main}
+    — the row's recorded base, not the header, is the currency. loop-control.md routes that fact to the park.
+    """
+    # Explicit row base v3 matches the live v3 target -> no base_changed, even though the header base is main.
+    code, res, err = scenario([row(41, base_branch="v3")], [entry(41, base="v3")], base_branch="main")
+    check(code == 0, f"exit 0, got {code} (stderr {err!r})")
+    facts = res["rows"]["41"]
+    check("base_changed" not in facts,
+          f"a row whose live base equals its EXPLICIT row base is unchanged, header base notwithstanding: {facts!r}")
+    check(res["counts"]["base_changed"] == 0, f"base_changed count should be 0, got {res['counts']!r}")
+    # The same row retargeted back to the header's `main` DIFFERS from its recorded `v3` -> base_changed.
+    code, res, err = scenario([row(41, base_branch="v3")], [entry(41, base="main")], base_branch="main")
+    check(code == 0, f"exit 0, got {code} (stderr {err!r})")
+    facts = res["rows"]["41"]
+    check(facts.get("base_changed") == {"ledger": "v3", "snapshot": "main"},
+          f"the recorded row base v3 is the currency, not the header main: {facts!r}")
 
 
 def t_branch_mismatch():
@@ -577,7 +602,8 @@ CASES = [
     ("merged-by-absence", "an absent live row -> absent_from_snapshot:true, exit 0, NOT an error",
      t_merged_by_absence),
     ("head-moved", "headRefOid != row head_sha -> head_moved{ledger,snapshot}", t_head_moved),
-    ("base-changed", "baseRefName != header base_branch -> base_changed{ledger,snapshot}", t_base_changed),
+    ("base-changed", "baseRefName != a legacy row's inherited effective_base -> base_changed{ledger,snapshot}", t_base_changed),
+    ("base-changed-row-effective", "base_changed compares against the row's effective_base, not the header base", t_base_changed_uses_row_effective_base),
     ("branch-mismatch", "headRefName != row branch -> branch_mismatch{ledger,snapshot}", t_branch_mismatch),
     ("all-three-changes", "head+base+branch differ together -> all three keys + verbatim fields",
      t_all_three_changes_together),

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -305,16 +305,22 @@ def fetch_snapshot(
     return len(entries)
 
 
-def _facts_for_present_row(row: dict, base_branch: str, entry: dict) -> dict:
+def _facts_for_present_row(row: dict, effective_base: str, entry: dict) -> dict:
     """The facts for a LIVE row that IS present in the snapshot. Neutral observations only — a detected
     change (head/base/branch) appears as a `{ledger, snapshot}` pair, and the verbatim GitHub fields are
-    passed through as-is. No key here names or implies an action."""
+    passed through as-is. No key here names or implies an action.
+
+    `effective_base` is THIS row's effective base — its explicit `base_branch`, else the legacy header
+    fallback, resolved by the caller through `ledger.py`'s `effective_base(header, row)`. A run may hold
+    rows on different bases, so the comparison is per-row, never against the one header base. `base_changed`
+    reports the row's RECORDED base as `ledger` and the live `baseRefName` as `snapshot`; loop-control.md
+    routes that fact to the machine-blocker park (an unsupported mid-run base change is not migrated)."""
     facts: dict = {"absent_from_snapshot": False}
     # A detected difference is emitted ONLY when it differs — the key's PRESENCE is the fact.
     if entry["headRefOid"] != row["head_sha"]:
         facts["head_moved"] = {"ledger": row["head_sha"], "snapshot": entry["headRefOid"]}
-    if entry["baseRefName"] != base_branch:
-        facts["base_changed"] = {"ledger": base_branch, "snapshot": entry["baseRefName"]}
+    if entry["baseRefName"] != effective_base:
+        facts["base_changed"] = {"ledger": effective_base, "snapshot": entry["baseRefName"]}
     if entry["headRefName"] != row["branch"]:
         facts["branch_mismatch"] = {"ledger": row["branch"], "snapshot": entry["headRefName"]}
     # Verbatim GitHub observations — always reported when present, never judged.
@@ -344,7 +350,6 @@ def detect(ledger_path: Path, prs_path: Path, run_id: str) -> dict:
 
     entries = read_snapshot(prs_path, run_id)
     by_pr = {str(e["number"]): e for e in entries}
-    base_branch = header["base_branch"]
 
     ledger_prs = {row["pr"] for row in rows}
     result_rows: dict[str, dict] = {}
@@ -369,7 +374,7 @@ def detect(ledger_path: Path, prs_path: Path, run_id: str) -> dict:
             result_rows[pr] = {"absent_from_snapshot": True}
             absent_n += 1
             continue
-        facts = _facts_for_present_row(row, base_branch, entry)
+        facts = _facts_for_present_row(row, L.effective_base(header, row), entry)
         result_rows[pr] = facts
         present_n += 1
         head_moved_n += "head_moved" in facts

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -119,24 +119,29 @@ def bundle_for(record: Path) -> Path:
 
 
 def bind_record(ledger: Path, record: Path, pr: str, head_sha: str, worktree: Path,
-                decision: str = "demote") -> Path:
+                decision: str = "demote", base_ref: str = "origin/main",
+                base_sha: "str | None" = None) -> Path:
     """Create the smallest valid prepared-bundle witness for decision-door fixtures.
 
     The record declares its chosen decision in the machine-readable `DECISION: <decision>` line decide reads.
+    `base_ref`/`base_sha` default to the header base (`origin/main`, at `head_sha`); a row-base fixture passes
+    the row's effective base so decide can re-derive it through `L.effective_base(header, row)`.
     """
     _, rows = L.load(ledger)
     row = L.find_row(rows, pr)
     check(row is not None, f"fixture ledger has no row for pr {pr}")
     assert row is not None
     permitted = R.permitted_record(row)
+    if base_sha is None:
+        base_sha = head_sha
     # `decision_repo` points `origin/main` at its single commit, which is also this fixture's `head_sha`, so
-    # the bundle's pinned base SHA (F2) is `head_sha` here — decide re-resolves `origin/main` and matches it.
+    # the bundle's pinned base SHA (F2) is `head_sha` here — decide re-resolves the base ref and matches it.
     payload = R.canonical_json({
         "schema": R.BUNDLE_SCHEMA,
         "pr": pr,
         "head_sha": head_sha,
-        "base_ref": "origin/main",
-        "base_sha": head_sha,
+        "base_ref": base_ref,
+        "base_sha": base_sha,
         "ledger": {"path": str(ledger.resolve()), "row": R.decision_projection(row)},
         "intent": {},
         "rounds": [],
@@ -162,8 +167,8 @@ def bind_record(ledger: Path, record: Path, pr: str, head_sha: str, worktree: Pa
         "worktree": str(worktree.resolve()),
         "pr": pr,
         "head_sha": head_sha,
-        "base_ref": "origin/main",
-        "base_sha": head_sha,
+        "base_ref": base_ref,
+        "base_sha": base_sha,
         "rounds": [],
     }))
     record.write_text(
@@ -1088,6 +1093,64 @@ def t_bundle_pins_base_sha_against_a_racing_fetch(tmp: Path) -> None:
           f"{len(payload['diff_growth'])} commits")
 
 
+def t_bundle_uses_row_effective_base_over_header(tmp: Path) -> None:
+    """The bundle binds THIS row's effective base, not the one header base. A row whose explicit
+    `base_branch` differs from the header's `main` resolves `origin/<row-base>` — so a mixed-base run bundles
+    each PR against its own release line."""
+    case = bundle_setup(tmp)
+    repo, head = case["repo"], case["head_sha"]
+    header_line, row_line = case["ledger"].read_text().splitlines()
+    row = json.loads(row_line)
+    row["base_branch"] = "release"  # an explicit ROW base, differing from the header's `main`
+    case["ledger"].write_text(header_line + "\n" + json.dumps(row) + "\n")
+    git(repo, "update-ref", "refs/remotes/origin/release", head)  # make the row base resolvable
+    output = case["rundir"] / "repair-1-1.prompt.txt"
+    code, _, err = run_bundle(case, output)
+    check(code == 0, f"bundle refused a row-based base: {err!r}")
+    payload = prompt_payload(output)
+    manifest = json.loads(R.bundle_manifest_path(output).read_text())
+    check(payload["base_ref"] == "origin/release",
+          f"bundle used the header base, not the row's effective base: {payload['base_ref']!r}")
+    check(manifest["base_ref"] == "origin/release",
+          f"manifest bound the header base, not the row's effective base: {manifest['base_ref']!r}")
+
+
+def _row_base_decide_ledger(tmp: Path, name: str) -> "tuple[Path, str, Path]":
+    """A cap-status gauntlet-owned row with an EXPLICIT `base_branch` of `release` (differing from the header
+    `main`), plus a decision worktree carrying an `origin/release` ref. Returns (ledger, head_sha, repo)."""
+    repo, head_sha = decision_repo(tmp)
+    git(repo, "update-ref", "refs/remotes/origin/release", head_sha)
+    path = tmp / name
+    fields = {**L.ROW_DEFAULTS, "pr": "1", "head_sha": head_sha, "worktree": str(repo.resolve()),
+              "status": L.REPAIR_STATUS, "review_rounds": str(L.ROUND_CAP), "ns_streak": "1",
+              "pr_origin": "gauntlet", "base_branch": "release"}
+    path.write_text(
+        json.dumps({"type": "header", **L.HEADER_DEFAULTS, "base_branch": "main"}) + "\n"
+        + json.dumps({"type": "row", **fields}) + "\n")
+    return path, head_sha, repo
+
+
+def t_decide_uses_row_effective_base_over_header(tmp: Path) -> None:
+    """decide re-derives the ROW's effective base: a manifest bound to `origin/release` (the row's explicit
+    base) validates, while one still bound to the header base `origin/main` is refused as the wrong base."""
+    # Accepted: the manifest built from the row's effective base.
+    path, head_sha, repo = _row_base_decide_ledger(tmp, "rowbase-ok.jsonl")
+    record = tmp / "rowbase-ok.md"
+    bind_record(path, record, "1", head_sha, repo, decision="demote", base_ref="origin/release")
+    code, _, err = decide(path, record, "demote")
+    check(code == 0, f"decide refused a bundle bound to the row's effective base: {err!r}")
+    check(field(path, "repair_decision").startswith("demote"), "the row-base decision was not recorded")
+
+    # Refused: a manifest bound to the HEADER base is stale against the row's effective base.
+    stale_path, stale_head, stale_repo = _row_base_decide_ledger(tmp, "rowbase-stale.jsonl")
+    stale_record = tmp / "rowbase-stale.md"
+    bind_record(stale_path, stale_record, "1", stale_head, stale_repo, decision="demote", base_ref="origin/main")
+    code, _, err = decide(stale_path, stale_record, "demote")
+    check(code == 1, f"a header-base manifest was accepted against a release-base row (exit {code})")
+    check("origin/release" in err,
+          f"the refusal must name the row's effective base as the expected one: {err!r}")
+
+
 def t_bundle_resumes_after_context_loss(tmp: Path) -> None:
     """A heartbeat that built the bundle and died before `decide` re-runs `bundle` and RESUMES, not wedges.
 
@@ -1378,6 +1441,8 @@ CASES = [
     ("bundle-cap-needs-finding", "a cap round with no gating finding is unusable history and refused", t_bundle_refuses_a_cap_round_with_no_gating_finding),
     ("bundle-report-needs-verdict", "a report with no terminal VERDICT line fails closed through parse_report", t_bundle_refuses_a_report_with_no_verdict),
     ("bundle-base-sha-pinned", "the base is pinned to one SHA before any read; a racing fetch cannot mix bases", t_bundle_pins_base_sha_against_a_racing_fetch),
+    ("bundle-row-effective-base", "the bundle binds the row's effective base, not the one header base", t_bundle_uses_row_effective_base_over_header),
+    ("decide-row-effective-base", "decide re-derives the row's effective base; a header-base manifest is stale", t_decide_uses_row_effective_base_over_header),
     ("bundle-resume", "a bundle rebuilt after context loss reuses or regenerates, never wedges", t_bundle_resumes_after_context_loss),
     ("bundle-identity-scope", "a liveness write never wedges resume; a decision-field drift is still stale", t_bundle_identity_ignores_liveness_but_not_decision_fields),
     ("bundle-atomic", "Git and atomic-write failures leave no partial bundle", t_bundle_git_and_atomic_failures_leave_no_output),

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -787,9 +787,9 @@ def cmd_bundle(path: Path, args) -> int:
     # The base is ROW state: resolve this row's `effective_base` (its explicit `base_branch`, else the legacy
     # header fallback) through `ledger.py`'s accessor — never the one header base, so a mixed-base run bundles
     # each PR against the base its own row tracks.
-    base = L.effective_base(header, row)
-    if not base.strip() or base == "-":
-        fail(f"pr {pr} has no usable effective base in the ledger")
+    base, base_problem = L.require_effective_base(header, row, pr)
+    if base_problem is not None:
+        fail(base_problem)
     base_ref = f"origin/{base}"
     # F2 — resolve the symbolic remote-tracking ref to ONE immutable commit SHA BEFORE any bundle read, and
     # use that SHA (never `base_ref`) for the current diff and every growth query below. `origin/<base>` is
@@ -919,8 +919,12 @@ def validate_decision_bundle(path: Path, header: dict, row: dict, pr: str, recor
     if manifest["head_sha"] != row["head_sha"]:
         fail(f"bundle manifest is stale: it names {manifest['head_sha']!r}, row names {row['head_sha']!r}")
     # The bundle was built against THIS row's effective base (its explicit `base_branch`, else the legacy
-    # header fallback), so re-derive it the same way — never the one header base.
-    expected_base_ref = f"origin/{L.effective_base(header, row)}"
+    # header fallback), so re-derive it the same way — never the one header base. An unresolved base is refused
+    # here exactly as `bundle` refused to build one (`ledger.py`'s `require_effective_base`, the one owner).
+    base, base_problem = L.require_effective_base(header, row, pr)
+    if base_problem is not None:
+        fail(base_problem)
+    expected_base_ref = f"origin/{base}"
     if manifest["base_ref"] != expected_base_ref:
         fail(f"bundle manifest is bound to base {manifest['base_ref']!r}, not {expected_base_ref!r}")
     if not isinstance(manifest["worktree"], str):

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -784,9 +784,12 @@ def cmd_bundle(path: Path, args) -> int:
     if row["head_sha"] != head_sha:
         fail(f"stale ledger head for pr {pr}: row has {row['head_sha']}, worktree HEAD is {head_sha}")
 
-    base = header.get("base_branch", "-")
-    if not isinstance(base, str) or not base.strip() or base == "-":
-        fail("ledger header has no usable base_branch")
+    # The base is ROW state: resolve this row's `effective_base` (its explicit `base_branch`, else the legacy
+    # header fallback) through `ledger.py`'s accessor — never the one header base, so a mixed-base run bundles
+    # each PR against the base its own row tracks.
+    base = L.effective_base(header, row)
+    if not base.strip() or base == "-":
+        fail(f"pr {pr} has no usable effective base in the ledger")
     base_ref = f"origin/{base}"
     # F2 — resolve the symbolic remote-tracking ref to ONE immutable commit SHA BEFORE any bundle read, and
     # use that SHA (never `base_ref`) for the current diff and every growth query below. `origin/<base>` is
@@ -915,7 +918,9 @@ def validate_decision_bundle(path: Path, header: dict, row: dict, pr: str, recor
         fail(f"bundle manifest is bound to run directory {manifest['run_dir']!r}, not {str(path.resolve().parent)!r}")
     if manifest["head_sha"] != row["head_sha"]:
         fail(f"bundle manifest is stale: it names {manifest['head_sha']!r}, row names {row['head_sha']!r}")
-    expected_base_ref = f"origin/{header.get('base_branch', '-')}"
+    # The bundle was built against THIS row's effective base (its explicit `base_branch`, else the legacy
+    # header fallback), so re-derive it the same way — never the one header base.
+    expected_base_ref = f"origin/{L.effective_base(header, row)}"
     if manifest["base_ref"] != expected_base_ref:
         fail(f"bundle manifest is bound to base {manifest['base_ref']!r}, not {expected_base_ref!r}")
     if not isinstance(manifest["worktree"], str):

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -733,6 +733,23 @@ def t_ledger_origin_named_base_matches() -> None:
         _refused(args, "disagrees")
 
 
+def t_ledger_unresolved_base_refuses() -> None:
+    """A both-`-` ledger (header base unset AND row base unset) resolves through `effective_base` to the `-`
+    sentinel — an UNRESOLVED base. `--base` is refused as "no usable effective base" BEFORE it can ride the
+    transport, never accepted (`ledger.py require_effective_base`, the one owner). If that guard is deleted,
+    the base assertion is SKIPPED and a caller `--base` prepares a transport unvalidated — so this FAILS."""
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        ledger = root / "state.jsonl"
+        for argv in (["header", "set", "run_id", "t"],                      # base_branch left `-`
+                     ["add-row", "--pr", "41", "--head-sha", "a" * 40]):    # row base-branch left `-`
+            proc = subprocess.run([sys.executable, os.fspath(D.LEDGER), "--file", os.fspath(ledger), *argv],  # noqa: S603
+                                  capture_output=True, text=True, check=False)
+            check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
+        args = _fixture(root, base="v3", file=os.fspath(ledger))
+        _refused(args, "no usable effective base")
+
+
 def t_ledger_missing_row_refuses() -> None:
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
@@ -772,5 +789,7 @@ CASES = [
      t_ledger_base_assertion_mismatch_refuses),
     ("ledger-origin-named-base", "a base literally named origin/<x> matches itself; the bare form refuses",
      t_ledger_origin_named_base_matches),
+    ("ledger-unresolved-base", "--file resolving to a `-`/blank effective base refuses before the assertion",
+     t_ledger_unresolved_base_refuses),
     ("ledger-missing-row", "--file naming an unknown PR row refuses", t_ledger_missing_row_refuses),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -67,6 +67,8 @@ def _fixture(
     route: str = "native",
     producer: str = "native-worker-write",
     intent: bytes | None = None,
+    base: str = "main",
+    file: str | None = None,
 ) -> SimpleNamespace:
     rundir = root / "run artifacts"
     worktree = root / "candidate worktree"
@@ -80,12 +82,13 @@ def _fixture(
         review_pass=review_pass,
         launch_attempt=launch_attempt,
         worktree=os.fspath(worktree),
-        base="main",
+        base=base,
         route=route,
         report_producer=producer,
         head_sha=SHA,
         dispatched_at=STAMP,
         intent_file=os.fspath(intent_path),
+        file=file,
     )
 
 
@@ -682,6 +685,44 @@ def t_cli_emits_only_canonical_host_neutral_json() -> None:
               "materializer must not select or launch a host process")
 
 
+def _build_ledger(directory: Path, pr: str, base_branch: str) -> Path:
+    """A real ledger (through ledger.py) with one row for `pr` carrying an EXPLICIT `base_branch`."""
+    ledger = directory / "state.jsonl"
+    for argv in (["header", "set", "run_id", "t"],
+                 ["add-row", "--pr", pr, "--head-sha", "a" * 40, "--base-branch", base_branch]):
+        proc = subprocess.run([sys.executable, os.fspath(D.LEDGER), "--file", os.fspath(ledger), *argv],  # noqa: S603
+                              capture_output=True, text=True, check=False)
+        check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
+    return ledger
+
+
+def t_ledger_base_assertion_matches_prepares() -> None:
+    """A `--file` whose row base equals `--base` passes the assertion and prepares one record as usual."""
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "41", "main")
+        args = _fixture(root, base="main", file=os.fspath(ledger))
+        payload = D.prepare(args)
+        check(payload["transport"]["base"] == "main", f"the matching base must ride the transport: {payload!r}")
+
+
+def t_ledger_base_assertion_mismatch_refuses() -> None:
+    """A `--file` whose row base disagrees with `--base` refuses — --base is an assertion, not a source."""
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "41", "main")
+        args = _fixture(root, base="v3", file=os.fspath(ledger))
+        _refused(args, "disagrees")
+
+
+def t_ledger_missing_row_refuses() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "99", "main")
+        args = _fixture(root, pr="41", base="main", file=os.fspath(ledger))
+        _refused(args, "no ledger row for pr 41")
+
+
 CASES = [
     (
         "relaunch-path-coherence",
@@ -707,4 +748,9 @@ CASES = [
     ("transition-mapping", "review actions map directly to route and producer", t_transition_actions_map_directly_to_prepare_inputs),
     ("unicode-delivery", "a Unicode path is delivered as UTF-8 bytes under ASCII stdout", t_unicode_worktree_delivers_under_ascii_stdout),
     ("host-neutral-json", "CLI emits canonical data and never launches", t_cli_emits_only_canonical_host_neutral_json),
+    ("ledger-base-match", "--file with a matching row base passes the assertion and prepares",
+     t_ledger_base_assertion_matches_prepares),
+    ("ledger-base-mismatch", "--file with a disagreeing row base refuses (--base is an assertion)",
+     t_ledger_base_assertion_mismatch_refuses),
+    ("ledger-missing-row", "--file naming an unknown PR row refuses", t_ledger_missing_row_refuses),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -715,6 +715,24 @@ def t_ledger_base_assertion_mismatch_refuses() -> None:
         _refused(args, "disagrees")
 
 
+def t_ledger_origin_named_base_matches() -> None:
+    """A row base LITERALLY named `origin/rel` (a legal branch name) matches an identical `--base` — the
+    assertion routes through `ledger.py base_agrees`, where identical strings always agree. The bare form
+    refuses: the STORED base is never stripped."""
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "41", "origin/rel")
+        args = _fixture(root, base="origin/rel", file=os.fspath(ledger))
+        payload = D.prepare(args)
+        check(payload["transport"]["base"] == "origin/rel",
+              f"identical origin/rel strings must pass the assertion and prepare: {payload!r}")
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "41", "origin/rel")
+        args = _fixture(root, base="rel", file=os.fspath(ledger))
+        _refused(args, "disagrees")
+
+
 def t_ledger_missing_row_refuses() -> None:
     with tempfile.TemporaryDirectory() as raw:
         root = Path(raw)
@@ -752,5 +770,7 @@ CASES = [
      t_ledger_base_assertion_matches_prepares),
     ("ledger-base-mismatch", "--file with a disagreeing row base refuses (--base is an assertion)",
      t_ledger_base_assertion_mismatch_refuses),
+    ("ledger-origin-named-base", "a base literally named origin/<x> matches itself; the bare form refuses",
+     t_ledger_origin_named_base_matches),
     ("ledger-missing-row", "--file naming an unknown PR row refuses", t_ledger_missing_row_refuses),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -733,6 +733,23 @@ def t_ledger_origin_named_base_matches() -> None:
         _refused(args, "disagrees")
 
 
+def t_ledger_variant_spelling_uses_row_base() -> None:
+    """A `--base` spelling `base_agrees` accepts but that names a DIFFERENT git ref than the row's base must
+    NOT ride the transport. The reviewer diffs `origin/<TRANSPORT.base>...HEAD`, so an `origin/main` transport
+    base against a row base `main` would diff `origin/origin/main` — a doubled, usually-nonexistent ref. The
+    transport carries the ROW's resolved `effective_base`, so both `main` and the accepted `origin/main` form
+    prepare the SAME `base=main`. FAILS if the raw `--base` rides the transport instead of the row's base."""
+    for spelling in ("main", "origin/main"):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            ledger = _build_ledger(root, "41", "main")
+            args = _fixture(root, base=spelling, file=os.fspath(ledger))
+            transport = D.prepare(args)["transport"]
+            check(transport["base"] == "main",
+                  f"--base {spelling} must ride the transport as the row's effective base 'main', "
+                  f"got {transport['base']!r}")
+
+
 def t_ledger_unresolved_base_refuses() -> None:
     """A both-`-` ledger (header base unset AND row base unset) resolves through `effective_base` to the `-`
     sentinel — an UNRESOLVED base. `--base` is refused as "no usable effective base" BEFORE it can ride the
@@ -789,6 +806,9 @@ CASES = [
      t_ledger_base_assertion_mismatch_refuses),
     ("ledger-origin-named-base", "a base literally named origin/<x> matches itself; the bare form refuses",
      t_ledger_origin_named_base_matches),
+    ("ledger-variant-spelling-row-base",
+     "an accepted origin/<base> spelling rides the transport as the row's effective base, not the raw arg",
+     t_ledger_variant_spelling_uses_row_base),
     ("ledger-unresolved-base", "--file resolving to a `-`/blank effective base refuses before the assertion",
      t_ledger_unresolved_base_refuses),
     ("ledger-missing-row", "--file naming an unknown PR row refuses", t_ledger_missing_row_refuses),

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -378,6 +378,7 @@ def prepare(args) -> dict:
     # legacy header fallback, through `ledger.py`'s accessor — never a second copy of that rule). Agreement
     # is decided by `ledger.py`'s `base_agrees` — the one owner of that comparison. Absent `--file`,
     # `--base` is carried as-is, as before.
+    operational_base = args.base
     if args.file is not None:
         try:
             header, rows = L.load(Path(args.file))
@@ -392,6 +393,10 @@ def prepare(args) -> dict:
         if not L.base_agrees(args.base, effective_base):
             refuse(f"--base {args.base!r} disagrees with pr {args.pr}'s ledger effective base "
                    f"{effective_base!r} — --base is an assertion, not a base source")
+        # The transport carries the ROW's resolved base, never the raw `--base` spelling: two spellings
+        # `base_agrees` accepts (`main` vs `origin/main`) make the reviewer diff `origin/<base>...HEAD`
+        # against different refs, so the transport must follow the row, not the caller's argument.
+        operational_base = effective_base
 
     if args.route not in ROUTE_PRODUCERS:
         refuse(f"unknown review route {args.route!r}; expected one of {list(ROUTE_PRODUCERS)}")
@@ -427,7 +432,7 @@ def prepare(args) -> dict:
     transport = build_transport(
         rundir=rundir,
         worktree=worktree,
-        base=args.base,
+        base=operational_base,
         pr=args.pr,
         review_pass=args.review_pass,
         launch_attempt=args.launch_attempt,

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -26,6 +26,7 @@ _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "review-dispatch-test.py"
 TEMPLATE = _HERE / "review-prompt.txt"
 REVIEW_PASS = _HERE / "review-pass.py"
+LEDGER = _HERE / "ledger.py"
 
 TRANSPORT_SLOT = b"<TRANSPORT-RECORD>"
 INTENT_SLOT = b"<INTENT>"
@@ -47,6 +48,16 @@ def _load_review_pass():
 
 
 RP = _load_review_pass()
+
+
+def _load_ledger():
+    mod = load_module_from_path("review_dispatch_ledger", LEDGER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER}")
+    return mod
+
+
+L = _load_ledger()
 
 
 class Refusal(Exception):
@@ -361,6 +372,25 @@ def prepare(args) -> dict:
     if not args.base.strip():
         refuse("--base must be non-blank text")
 
+    # The base rides the typed transport as DATA (the reviewer diffs `origin/<base>...HEAD`). When a ledger
+    # is supplied, that data is an ASSERTION against the row's source of truth: the row OWNS the base, so
+    # `--base` must equal the selected row's `effective_base` (its explicit `base_branch`, else the legacy
+    # header fallback, through `ledger.py`'s accessor — never a second copy of that rule). A leading
+    # `origin/` is stripped before the compare. Absent `--file`, `--base` is carried as-is, as before.
+    if args.file is not None:
+        try:
+            header, rows = L.load(Path(args.file))
+        except SystemExit as exc:
+            refuse(f"could not read ledger {args.file}: {exc}")
+        row = L.find_row(rows, str(args.pr))
+        if row is None:
+            refuse(f"no ledger row for pr {args.pr} — its base cannot be resolved")
+        effective_base = L.effective_base(header, row)
+        normalized = args.base[len("origin/"):] if args.base.startswith("origin/") else args.base
+        if effective_base and effective_base != "-" and normalized != effective_base:
+            refuse(f"--base {args.base!r} disagrees with pr {args.pr}'s ledger effective base "
+                   f"{effective_base!r} — --base is an assertion, not a base source")
+
     if args.route not in ROUTE_PRODUCERS:
         refuse(f"unknown review route {args.route!r}; expected one of {list(ROUTE_PRODUCERS)}")
     if args.report_producer not in REPORT_PRODUCERS:
@@ -483,7 +513,10 @@ def build_parser() -> argparse.ArgumentParser:
     command.add_argument("--pass", dest="review_pass", required=True, help="positive decimal review pass")
     command.add_argument("--launch-attempt", required=True, help="positive decimal launch attempt")
     command.add_argument("--worktree", required=True, help="absolute candidate worktree directory")
-    command.add_argument("--base", required=True, help="base branch text carried as data")
+    command.add_argument("--base", required=True, help="base branch text carried as data; with --file it is "
+                                                        "asserted against the row's effective base")
+    command.add_argument("--file", help="OPTIONAL ledger (state.jsonl); when given, --base is asserted "
+                                        "against the selected --pr row's effective base")
     command.add_argument("--route", required=True, choices=tuple(ROUTE_PRODUCERS),
                          help="route already selected by the host adapter")
     command.add_argument("--report-producer", required=True, choices=REPORT_PRODUCERS,

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -386,8 +386,10 @@ def prepare(args) -> dict:
         row = L.find_row(rows, str(args.pr))
         if row is None:
             refuse(f"no ledger row for pr {args.pr} — its base cannot be resolved")
-        effective_base = L.effective_base(header, row)
-        if effective_base and effective_base != "-" and not L.base_agrees(args.base, effective_base):
+        effective_base, base_problem = L.require_effective_base(header, row, str(args.pr))
+        if base_problem is not None:
+            refuse(base_problem)
+        if not L.base_agrees(args.base, effective_base):
             refuse(f"--base {args.base!r} disagrees with pr {args.pr}'s ledger effective base "
                    f"{effective_base!r} — --base is an assertion, not a base source")
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -374,9 +374,10 @@ def prepare(args) -> dict:
 
     # The base rides the typed transport as DATA (the reviewer diffs `origin/<base>...HEAD`). When a ledger
     # is supplied, that data is an ASSERTION against the row's source of truth: the row OWNS the base, so
-    # `--base` must equal the selected row's `effective_base` (its explicit `base_branch`, else the legacy
-    # header fallback, through `ledger.py`'s accessor — never a second copy of that rule). A leading
-    # `origin/` is stripped before the compare. Absent `--file`, `--base` is carried as-is, as before.
+    # `--base` must agree with the selected row's `effective_base` (its explicit `base_branch`, else the
+    # legacy header fallback, through `ledger.py`'s accessor — never a second copy of that rule). Agreement
+    # is decided by `ledger.py`'s `base_agrees` — the one owner of that comparison. Absent `--file`,
+    # `--base` is carried as-is, as before.
     if args.file is not None:
         try:
             header, rows = L.load(Path(args.file))
@@ -386,8 +387,7 @@ def prepare(args) -> dict:
         if row is None:
             refuse(f"no ledger row for pr {args.pr} — its base cannot be resolved")
         effective_base = L.effective_base(header, row)
-        normalized = args.base[len("origin/"):] if args.base.startswith("origin/") else args.base
-        if effective_base and effective_base != "-" and normalized != effective_base:
+        if effective_base and effective_base != "-" and not L.base_agrees(args.base, effective_base):
             refuse(f"--base {args.base!r} disagrees with pr {args.pr}'s ledger effective base "
                    f"{effective_base!r} — --base is an assertion, not a base source")
 

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -24,6 +25,7 @@ from _gauntlet.modules import load_module_from_path
 from _gauntlet.testing import capture_cli
 
 OWNER = Path(__file__).resolve().parent / "triage.py"
+LEDGER = Path(__file__).resolve().parent / "ledger.py"
 
 
 def _load_owner():
@@ -94,6 +96,17 @@ def derive(repo: Path, base: str, *, tier: str | None = None) -> dict:
 def one_file(result: dict) -> dict:
     check(len(result["files"]) == 1, f"expected one changed file, got {result['files']!r}")
     return result["files"][0]
+
+
+def _build_ledger(directory: Path, pr: str, base_branch: str) -> Path:
+    """A real ledger (through ledger.py) with one row for `pr` carrying an EXPLICIT `base_branch`."""
+    ledger = directory / "state.jsonl"
+    for argv in (["header", "set", "run_id", "t"],
+                 ["add-row", "--pr", pr, "--head-sha", "a" * 40, "--base-branch", base_branch]):
+        proc = subprocess.run([sys.executable, str(LEDGER), "--file", str(ledger), *argv],  # noqa: S603
+                              capture_output=True, text=True, check=False)
+        check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
+    return ledger
 
 
 def t_human_docs_have_no_floor() -> None:
@@ -718,6 +731,62 @@ def t_pip_source_and_conda_manifests_are_sensitive() -> None:
               f"{name} must floor HIGH as a dependency manifest: {result!r}")
 
 
+def t_ledger_base_assertion_passes() -> None:
+    # `--file --pr` with a `--base` that MATCHES the row's effective base falls through to the normal
+    # analysis. `origin/main` is normalized to `main` for the assertion AND resolved as the diff base — so a
+    # real remote-tracking ref is set at the base commit and a source change on main gives a STANDARD floor.
+    with repository() as (repo, base):
+        write(repo, "src/widget.py", "value = 1\n")
+        head = commit(repo, "source change")
+        git(repo, "update-ref", "refs/remotes/origin/main", base)
+        with tempfile.TemporaryDirectory() as d:
+            ledger = _build_ledger(Path(d), "31", "main")
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/main", "--head-sha", head,
+                "--file", str(ledger), "--pr", "31"])
+        check(code == M.EXIT_OK, f"a matching --base must pass the assertion and derive (code={code}, err={err!r})")
+        check(json.loads(out)["floor"] == M.STANDARD, f"a source change floors STANDARD: {out!r}")
+
+
+def t_ledger_base_assertion_refuses() -> None:
+    # `--base` disagreeing with the row's effective base is refused BEFORE any analysis, and emits no JSON.
+    with repository() as (repo, _base):
+        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        with tempfile.TemporaryDirectory() as d:
+            ledger = _build_ledger(Path(d), "31", "main")
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/v3", "--head-sha", head,
+                "--file", str(ledger), "--pr", "31"])
+        check(code == M.EXIT_REFUSED and out == "",
+              f"a --base disagreeing with the row must refuse without JSON (code={code}, out={out!r})")
+        check("disagrees" in err and "effective base" in err, f"the refusal must name the disagreement: {err!r}")
+
+
+def t_ledger_file_without_pr_refuses() -> None:
+    # `--file` needs `--pr` to select the row; without it, refuse rather than silently skip the assertion.
+    with repository() as (repo, _base):
+        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        with tempfile.TemporaryDirectory() as d:
+            ledger = _build_ledger(Path(d), "31", "main")
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/main", "--head-sha", head,
+                "--file", str(ledger)])
+        check(code == M.EXIT_REFUSED and out == "", f"--file without --pr must refuse (code={code}, out={out!r})")
+        check("--pr" in err, f"the refusal must name the missing --pr: {err!r}")
+
+
+def t_ledger_missing_row_refuses() -> None:
+    with repository() as (repo, _base):
+        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        with tempfile.TemporaryDirectory() as d:
+            ledger = _build_ledger(Path(d), "31", "main")
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/main", "--head-sha", head,
+                "--file", str(ledger), "--pr", "99"])
+        check(code == M.EXIT_REFUSED and out == "", f"an unknown row must refuse (code={code}, out={out!r})")
+        check("no ledger row for pr 99" in err, f"the refusal must name the missing row: {err!r}")
+
+
 CASES = [
     ("human-doc", "an all-prose diff has no floor — the tool never grants TRIVIAL", t_human_docs_have_no_floor),
     ("human-names", "top-level README/CHANGELOG/LICENSE and prose suffixes are HUMAN-DOC", t_top_level_human_doc_names),
@@ -756,6 +825,12 @@ CASES = [
     ("frontmatter-extensions", "the frontmatter check runs for .txt/.rst prose too", t_frontmatter_runs_for_all_prose_extensions),
     ("frontmatter-long", "frontmatter closing past line 100 still classifies CODE", t_frontmatter_closing_past_line_100_is_code),
     ("frontmatter-unterminated", "an unterminated frontmatter block fails closed to CODE", t_unterminated_frontmatter_fails_closed_to_code),
+    ("ledger-base-assert-pass", "--file --pr with a matching --base passes the assertion and derives",
+     t_ledger_base_assertion_passes),
+    ("ledger-base-assert-refuse", "--file --pr with a disagreeing --base refuses without JSON",
+     t_ledger_base_assertion_refuses),
+    ("ledger-file-needs-pr", "--file without --pr is refused", t_ledger_file_without_pr_refuses),
+    ("ledger-missing-row", "--file --pr naming an unknown row is refused", t_ledger_missing_row_refuses),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -762,6 +762,20 @@ def t_ledger_base_assertion_refuses() -> None:
         check("disagrees" in err and "effective base" in err, f"the refusal must name the disagreement: {err!r}")
 
 
+def t_ledger_origin_named_base_agrees() -> None:
+    # A row base LITERALLY named `origin/rel` (a legal branch name) matches an identical `--base` — the
+    # assertion routes through `ledger.py base_agrees`, where identical strings always agree. The bare form
+    # disagrees: the STORED base is never stripped.
+    with tempfile.TemporaryDirectory() as d:
+        ledger = _build_ledger(Path(d), "31", "origin/rel")
+        problem = M._assert_ledger_base(str(ledger), "31", "origin/rel")
+        check(problem is None,
+              f"identical origin/rel strings must pass the assertion, got {problem!r}")
+        problem = M._assert_ledger_base(str(ledger), "31", "rel")
+        check(problem is not None and "disagrees" in problem,
+              f"a bare --base must disagree with a stored origin/-named base, got {problem!r}")
+
+
 def t_ledger_file_without_pr_refuses() -> None:
     # `--file` needs `--pr` to select the row; without it, refuse rather than silently skip the assertion.
     with repository() as (repo, _base):
@@ -829,6 +843,8 @@ CASES = [
      t_ledger_base_assertion_passes),
     ("ledger-base-assert-refuse", "--file --pr with a disagreeing --base refuses without JSON",
      t_ledger_base_assertion_refuses),
+    ("ledger-origin-named-base", "a base literally named origin/<x> matches itself; the bare form disagrees",
+     t_ledger_origin_named_base_agrees),
     ("ledger-file-needs-pr", "--file without --pr is refused", t_ledger_file_without_pr_refuses),
     ("ledger-missing-row", "--file --pr naming an unknown row is refused", t_ledger_missing_row_refuses),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -768,12 +768,56 @@ def t_ledger_origin_named_base_agrees() -> None:
     # disagrees: the STORED base is never stripped.
     with tempfile.TemporaryDirectory() as d:
         ledger = _build_ledger(Path(d), "31", "origin/rel")
-        problem = M._assert_ledger_base(str(ledger), "31", "origin/rel")
-        check(problem is None,
-              f"identical origin/rel strings must pass the assertion, got {problem!r}")
-        problem = M._assert_ledger_base(str(ledger), "31", "rel")
-        check(problem is not None and "disagrees" in problem,
-              f"a bare --base must disagree with a stored origin/-named base, got {problem!r}")
+        resolved, problem = M._assert_ledger_base(str(ledger), "31", "origin/rel")
+        check(problem is None and resolved == "origin/rel",
+              f"identical origin/rel strings must pass and return the row base, got {resolved!r}/{problem!r}")
+        resolved, problem = M._assert_ledger_base(str(ledger), "31", "rel")
+        check(resolved is None and problem is not None and "disagrees" in problem,
+              f"a bare --base must disagree with a stored origin/-named base, got {resolved!r}/{problem!r}")
+
+
+def t_ledger_variant_spelling_floors_canonically() -> None:
+    # A row whose effective base is LITERALLY `origin/rel` (a sibling `rel` branch also exists). `base_agrees`
+    # accepts BOTH `origin/origin/rel` (canonical) and `origin/rel` (variant) as the assertion — but git
+    # resolves those two spellings to DIFFERENT refs: `origin/origin/rel` -> the literal base (no deploy.sh),
+    # `origin/rel` -> the ordinary sibling's tracking ref (has deploy.sh via the merge-base). Triage must build
+    # its diff ref from the ROW's resolved base, so BOTH spellings floor HIGH and veto TRIVIAL. Trusting the
+    # raw `--base` (the reverted bug) makes the variant diff the sibling, drop the SENSITIVE file, floor null,
+    # and ACCEPT TRIVIAL — a false permissive that under-triages a sensitive change. This fixture FAILS if the
+    # operational ref is taken from the raw `--base` instead of the row's effective base.
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory)
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.name", "Gauntlet Test")
+        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        write(repo, "README.md", "readme\n")
+        base0 = commit(repo, "base0")
+        # ordinary sibling `rel`: adds the SENSITIVE script; its tracking ref becomes `origin/rel`.
+        git(repo, "checkout", "-q", "-b", "rel", base0)
+        write(repo, "scripts/deploy.sh", "#!/bin/sh\necho deploy\n", 0o755)
+        rel_tip = commit(repo, "rel: add deploy.sh")
+        # head (the PR) descends FROM the sibling, so the merge-base against `origin/rel` HIDES deploy.sh;
+        # its only own change is a prose doc. Against the literal base (base0) deploy.sh is a fresh add.
+        git(repo, "checkout", "-q", "-b", "pr-head", rel_tip)
+        write(repo, "docs/notes.md", "notes\n")
+        head = commit(repo, "pr: add notes")
+        # remote-tracking layout: origin/rel -> sibling (has deploy.sh); origin/origin/rel -> literal base.
+        git(repo, "update-ref", "refs/remotes/origin/rel", rel_tip)
+        git(repo, "update-ref", "refs/remotes/origin/origin/rel", base0)
+        with tempfile.TemporaryDirectory() as d:
+            ledger = _build_ledger(Path(d), "31", "origin/rel")
+            for spelling in ("origin/origin/rel", "origin/rel"):
+                code, out, err = capture_cli(M.main, [
+                    "derive", "--worktree", str(repo), "--base", spelling, "--head-sha", head,
+                    "--file", str(ledger), "--pr", "31"])
+                check(code == M.EXIT_OK, f"--base {spelling} must derive against the row base (code={code}, err={err!r})")
+                check(json.loads(out)["floor"] == M.HIGH,
+                      f"--base {spelling} must floor HIGH from the row's literal base, not a sibling: {out!r}")
+                code, out, err = capture_cli(M.main, [
+                    "derive", "--worktree", str(repo), "--base", spelling, "--head-sha", head,
+                    "--tier", M.TRIVIAL, "--file", str(ledger), "--pr", "31"])
+                check(code == M.EXIT_REFUSED and out == "",
+                      f"--base {spelling} with --tier TRIVIAL must be vetoed by the HIGH floor (code={code}, out={out!r})")
 
 
 def t_ledger_file_without_pr_refuses() -> None:
@@ -845,6 +889,9 @@ CASES = [
      t_ledger_base_assertion_refuses),
     ("ledger-origin-named-base", "a base literally named origin/<x> matches itself; the bare form disagrees",
      t_ledger_origin_named_base_agrees),
+    ("ledger-variant-spelling-floors-canonically",
+     "both origin/rel and origin/origin/rel resolve to the row's literal base and floor HIGH (no under-triage)",
+     t_ledger_variant_spelling_floors_canonically),
     ("ledger-file-needs-pr", "--file without --pr is refused", t_ledger_file_without_pr_refuses),
     ("ledger-missing-row", "--file --pr naming an unknown row is refused", t_ledger_missing_row_refuses),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -17,7 +17,12 @@ DECIDED; the command then acts as a LOWER-BOUND check and REFUSES a tier below t
 It never grants a tier and never lowers one.
 
     triage.py derive --worktree <path> --base <ref> --head-sha <40-hex> [--tier TRIVIAL|STANDARD|HIGH]
+        [--file <ledger> --pr <N>]
     triage.py self-test
+
+When ``--file <ledger> --pr <N>`` is given, ``--base`` is an ASSERTION checked against the selected row's
+effective base (its explicit ``base_branch``, else the legacy header fallback), never an independent base
+source; a disagreement refuses.  Omit them and ``--base`` is used exactly as before.
 
 Success prints one deterministic JSON object and exits 0.  Any Git failure, malformed evidence, stale
 expected head, moving head, or a ``--tier`` below the floor prints no JSON, explains the refusal on
@@ -40,6 +45,17 @@ from _gauntlet.modules import load_module_from_path
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "triage-test.py"
+LEDGER_PY = _HERE / "ledger.py"
+
+
+def _load_ledger():
+    mod = load_module_from_path("triage_ledger", LEDGER_PY)
+    if mod is None:
+        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER_PY}")
+    return mod
+
+
+L = _load_ledger()
 
 EXIT_OK = 0
 EXIT_REFUSED = 2
@@ -572,7 +588,38 @@ def derive(*, worktree: str, base: str, head_sha: str, tier: str | None = None,
     }
 
 
+def _assert_ledger_base(file: str, pr: str, base: str) -> "str | None":
+    """When a ledger is supplied, `--base` is an ASSERTION, not a base source: the ROW owns the base. Resolve
+    the row's `effective_base` (its explicit `base_branch`, else the legacy header fallback, through
+    `ledger.py`'s accessor — never a second copy of that rule) and return an error string if `--base`
+    disagrees, else `None`. Triage passes `--base` as `origin/<base>`, so a leading `origin/` is stripped
+    before the compare. Only a different branch NAME disagrees; this never inspects live GitHub."""
+    try:
+        header, rows = L.load(Path(file))
+    except SystemExit as exc:
+        return f"could not read ledger {file}: {exc}"
+    row = L.find_row(rows, str(pr))
+    if row is None:
+        return f"no ledger row for pr {pr} — its base cannot be resolved"
+    effective_base = L.effective_base(header, row)
+    if not effective_base or effective_base == "-":
+        return f"pr {pr} has no usable effective base in the ledger"
+    normalized = base[len("origin/"):] if base.startswith("origin/") else base
+    if normalized != effective_base:
+        return (f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
+                f"--base is an assertion, not a base source")
+    return None
+
+
 def cmd_derive(args: argparse.Namespace) -> int:
+    if args.file is not None:
+        if args.pr is None:
+            print("triage: REFUSED — --file requires --pr to select the ledger row", file=sys.stderr)
+            return EXIT_REFUSED
+        problem = _assert_ledger_base(args.file, args.pr, args.base)
+        if problem is not None:
+            print(f"triage: REFUSED — {problem}", file=sys.stderr)
+            return EXIT_REFUSED
     try:
         result = derive(
             worktree=args.worktree,
@@ -622,6 +669,11 @@ def parser() -> argparse.ArgumentParser:
     derive_parser.add_argument(
         "--tier", choices=sorted(TIER_VALUES),
         help="the caller's DECIDED tier; refused if it is below the mechanical floor (veto-downward)")
+    derive_parser.add_argument(
+        "--file", help="OPTIONAL ledger (state.jsonl); when given, --base is asserted against the selected "
+                       "row's effective base (requires --pr). Absent: --base is used as-is, as before")
+    derive_parser.add_argument(
+        "--pr", help="PR number (row key) selecting the ledger row for the --file base assertion")
     derive_parser.set_defaults(func=cmd_derive)
     test_parser = sub.add_parser("self-test", help="run the sibling fixture suite")
     test_parser.set_defaults(func=cmd_self_test)

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -603,9 +603,9 @@ def _assert_ledger_base(file: str, pr: str, base: str) -> "str | None":
     row = L.find_row(rows, str(pr))
     if row is None:
         return f"no ledger row for pr {pr} — its base cannot be resolved"
-    effective_base = L.effective_base(header, row)
-    if not effective_base or effective_base == "-":
-        return f"pr {pr} has no usable effective base in the ledger"
+    effective_base, base_problem = L.require_effective_base(header, row, pr)
+    if base_problem is not None:
+        return base_problem
     if not L.base_agrees(base, effective_base):
         return (f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
                 f"--base is an assertion, not a base source")

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -588,43 +588,52 @@ def derive(*, worktree: str, base: str, head_sha: str, tier: str | None = None,
     }
 
 
-def _assert_ledger_base(file: str, pr: str, base: str) -> "str | None":
+def _assert_ledger_base(file: str, pr: str, base: str) -> "tuple[str | None, str | None]":
     """When a ledger is supplied, `--base` is an ASSERTION, not a base source: the ROW owns the base. Resolve
     the row's `effective_base` (its explicit `base_branch`, else the legacy header fallback, through
-    `ledger.py`'s accessor — never a second copy of that rule) and return an error string if `--base`
-    disagrees, else `None`. Triage passes `--base` as `origin/<base>`; agreement is decided by `ledger.py`'s
-    `base_agrees` (the one owner of that comparison — identical strings always agree, and a leading
-    `origin/` on the ARGUMENT is stripped, never on the stored base). Only a different branch NAME
-    disagrees; this never inspects live GitHub."""
+    `ledger.py`'s accessor — never a second copy of that rule) and return `(effective_base, None)` when
+    `--base` agrees, else `(None, <error string>)`. Triage passes `--base` as `origin/<base>`; agreement is
+    decided by `ledger.py`'s `base_agrees` (the one owner of that comparison — identical strings always
+    agree, and a leading `origin/` on the ARGUMENT is stripped, never on the stored base). Only a different
+    branch NAME disagrees; this never inspects live GitHub.
+
+    The RESOLVED `effective_base` is returned so the caller builds the operational git ref from the ROW's
+    base, not the raw `--base` spelling: two spellings `base_agrees` accepts (`rel` vs `origin/rel`) resolve
+    to DIFFERENT git refs, so trusting the raw string would diff against the wrong branch (a false permissive
+    that under-triages a sensitive change). The row's base is authoritative; the operational ref follows it."""
     try:
         header, rows = L.load(Path(file))
     except SystemExit as exc:
-        return f"could not read ledger {file}: {exc}"
+        return None, f"could not read ledger {file}: {exc}"
     row = L.find_row(rows, str(pr))
     if row is None:
-        return f"no ledger row for pr {pr} — its base cannot be resolved"
+        return None, f"no ledger row for pr {pr} — its base cannot be resolved"
     effective_base, base_problem = L.require_effective_base(header, row, pr)
     if base_problem is not None:
-        return base_problem
+        return None, base_problem
     if not L.base_agrees(base, effective_base):
-        return (f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
-                f"--base is an assertion, not a base source")
-    return None
+        return None, (f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
+                      f"--base is an assertion, not a base source")
+    return effective_base, None
 
 
 def cmd_derive(args: argparse.Namespace) -> int:
+    base = args.base
     if args.file is not None:
         if args.pr is None:
             print("triage: REFUSED — --file requires --pr to select the ledger row", file=sys.stderr)
             return EXIT_REFUSED
-        problem = _assert_ledger_base(args.file, args.pr, args.base)
+        effective_base, problem = _assert_ledger_base(args.file, args.pr, args.base)
         if problem is not None:
             print(f"triage: REFUSED — {problem}", file=sys.stderr)
             return EXIT_REFUSED
+        # Build the operational git ref from the ROW's resolved base, never the raw `--base` spelling:
+        # `origin/<effective_base>` is the remote-tracking ref triage diffs against.
+        base = f"origin/{effective_base}"
     try:
         result = derive(
             worktree=args.worktree,
-            base=args.base,
+            base=base,
             head_sha=args.head_sha,
             tier=args.tier,
         )

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -592,8 +592,10 @@ def _assert_ledger_base(file: str, pr: str, base: str) -> "str | None":
     """When a ledger is supplied, `--base` is an ASSERTION, not a base source: the ROW owns the base. Resolve
     the row's `effective_base` (its explicit `base_branch`, else the legacy header fallback, through
     `ledger.py`'s accessor — never a second copy of that rule) and return an error string if `--base`
-    disagrees, else `None`. Triage passes `--base` as `origin/<base>`, so a leading `origin/` is stripped
-    before the compare. Only a different branch NAME disagrees; this never inspects live GitHub."""
+    disagrees, else `None`. Triage passes `--base` as `origin/<base>`; agreement is decided by `ledger.py`'s
+    `base_agrees` (the one owner of that comparison — identical strings always agree, and a leading
+    `origin/` on the ARGUMENT is stripped, never on the stored base). Only a different branch NAME
+    disagrees; this never inspects live GitHub."""
     try:
         header, rows = L.load(Path(file))
     except SystemExit as exc:
@@ -604,8 +606,7 @@ def _assert_ledger_base(file: str, pr: str, base: str) -> "str | None":
     effective_base = L.effective_base(header, row)
     if not effective_base or effective_base == "-":
         return f"pr {pr} has no usable effective base in the ledger"
-    normalized = base[len("origin/"):] if base.startswith("origin/") else base
-    if normalized != effective_base:
+    if not L.base_agrees(base, effective_base):
         return (f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
                 f"--base is an assertion, not a base source")
     return None

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
@@ -8,6 +8,7 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -380,6 +381,61 @@ def t_economy_preflight_command_survives_word_splitting() -> None:
         check(not never_marker.exists(), "the worktree path command-substituted instead of staying quoted")
 
 
+def _build_ledger(directory: Path, pr: str, base_branch: str) -> Path:
+    """A real ledger (through ledger.py) with one row for `pr` carrying an EXPLICIT `base_branch`."""
+    ledger = directory / "state.jsonl"
+    for argv in (["header", "set", "run_id", "t"],
+                 ["add-row", "--pr", pr, "--head-sha", "a" * 40, "--base-branch", base_branch]):
+        proc = subprocess.run([sys.executable, str(M.LEDGER), "--file", str(ledger), *argv],  # noqa: S603
+                              capture_output=True, text=True, check=False)
+        check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
+    return ledger
+
+
+def _fix_argv(root: Path, base: str, ledger: "Path | None") -> "list[str]":
+    repo = root / "repo"
+    worktree = root / "worktree"
+    repo.mkdir(exist_ok=True)
+    worktree.mkdir(exist_ok=True)
+    issues = root / "issues.bin"
+    issues.write_bytes(ISSUES)
+    argv = ["fix", "--role", "review", "--project-root", str(repo), "--worktree", str(worktree),
+            "--pr", "42", "--base", base, "--preflight-verdict", "proceed",
+            "--issues-file", str(issues), "--output-dir", str(root / "out")]
+    if ledger is not None:
+        argv += ["--file", str(ledger)]
+    return argv
+
+
+def t_ledger_base_assertion_matches() -> None:
+    """`--file` whose row base equals `--base` passes the assertion and publishes the bundle (exit 0)."""
+    with tempfile.TemporaryDirectory(prefix="worker prompt base match ") as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "42", "main")
+        code, _, err = capture_cli(M.main, _fix_argv(root, "main", ledger))
+        check(code == M.EXIT_OK, f"a matching --base must pass and publish (code={code}, err={err!r})")
+
+
+def t_ledger_base_assertion_mismatch_refuses() -> None:
+    """`--file` whose row base disagrees with `--base` refuses — --base is an assertion, not a source."""
+    with tempfile.TemporaryDirectory(prefix="worker prompt base mismatch ") as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "42", "main")
+        code, _, err = capture_cli(M.main, _fix_argv(root, "v3", ledger))
+        check(code == M.EXIT_REFUSED and "disagrees" in err and "effective base" in err,
+              f"a disagreeing --base must refuse naming the disagreement (code={code}, err={err!r})")
+        check(not (root / "out").exists(), "a refused base assertion must publish no bundle")
+
+
+def t_ledger_missing_row_refuses() -> None:
+    with tempfile.TemporaryDirectory(prefix="worker prompt base norow ") as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "99", "main")
+        code, _, err = capture_cli(M.main, _fix_argv(root, "main", ledger))
+        check(code == M.EXIT_REFUSED and "no ledger row for pr 42" in err,
+              f"an unknown row must refuse naming the PR (code={code}, err={err!r})")
+
+
 TESTS = (
     ("golden bytes", t_golden_bytes_and_metadata),
     ("economy runnable preflight", t_economy_binds_runnable_preflight_command),
@@ -394,6 +450,9 @@ TESTS = (
     ("hostile paths and bytes", t_paths_and_payload_files_fail_closed),
     ("publish probe OSError refusal", t_publish_probe_oserror_is_controlled_refusal),
     ("host-neutral output", t_output_is_host_neutral),
+    ("ledger base assertion matches", t_ledger_base_assertion_matches),
+    ("ledger base assertion mismatch refuses", t_ledger_base_assertion_mismatch_refuses),
+    ("ledger missing row refuses", t_ledger_missing_row_refuses),
 )
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
@@ -445,6 +445,25 @@ def t_ledger_origin_named_base_matches() -> None:
               f"a bare --base must disagree with a stored origin/-named base (code={code}, err={err!r})")
 
 
+def t_ledger_unresolved_base_refuses() -> None:
+    """A both-`-` ledger (header base unset AND row base unset) resolves through `effective_base` to the `-`
+    sentinel — an UNRESOLVED base. `--base` is refused as "no usable effective base" and NO bundle is
+    published (`ledger.py require_effective_base`, the one owner). If that guard is deleted, the base
+    assertion is SKIPPED and the fix bundle is PUBLISHED with the caller `--base` baked in — so this FAILS."""
+    with tempfile.TemporaryDirectory(prefix="worker prompt unresolved base ") as raw:
+        root = Path(raw)
+        ledger = root / "state.jsonl"
+        for argv in (["header", "set", "run_id", "t"],                      # base_branch left `-`
+                     ["add-row", "--pr", "42", "--head-sha", "a" * 40]):    # row base-branch left `-`
+            proc = subprocess.run([sys.executable, str(M.LEDGER), "--file", str(ledger), *argv],  # noqa: S603
+                                  capture_output=True, text=True, check=False)
+            check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
+        code, _, err = capture_cli(M.main, _fix_argv(root, "v3", ledger))
+        check(code == M.EXIT_REFUSED and "no usable effective base" in err,
+              f"an unresolved (`-`) base must refuse (code={code}, err={err!r})")
+        check(not (root / "out").exists(), "a refused unresolved base must publish no bundle")
+
+
 def t_ledger_missing_row_refuses() -> None:
     with tempfile.TemporaryDirectory(prefix="worker prompt base norow ") as raw:
         root = Path(raw)
@@ -471,6 +490,7 @@ TESTS = (
     ("ledger base assertion matches", t_ledger_base_assertion_matches),
     ("ledger base assertion mismatch refuses", t_ledger_base_assertion_mismatch_refuses),
     ("ledger origin-named base matches itself", t_ledger_origin_named_base_matches),
+    ("ledger unresolved base refuses", t_ledger_unresolved_base_refuses),
     ("ledger missing row refuses", t_ledger_missing_row_refuses),
 )
 

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
@@ -427,6 +427,24 @@ def t_ledger_base_assertion_mismatch_refuses() -> None:
         check(not (root / "out").exists(), "a refused base assertion must publish no bundle")
 
 
+def t_ledger_origin_named_base_matches() -> None:
+    """A row base LITERALLY named `origin/rel` (a legal branch name) matches an identical `--base` — the
+    assertion routes through `ledger.py base_agrees`, where identical strings always agree. The bare form
+    refuses: the STORED base is never stripped."""
+    with tempfile.TemporaryDirectory(prefix="worker prompt origin named base ") as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "42", "origin/rel")
+        code, _, err = capture_cli(M.main, _fix_argv(root, "origin/rel", ledger))
+        check(code == M.EXIT_OK,
+              f"identical origin/rel strings must pass the assertion and publish (code={code}, err={err!r})")
+    with tempfile.TemporaryDirectory(prefix="worker prompt origin named bare ") as raw:
+        root = Path(raw)
+        ledger = _build_ledger(root, "42", "origin/rel")
+        code, _, err = capture_cli(M.main, _fix_argv(root, "rel", ledger))
+        check(code == M.EXIT_REFUSED and "disagrees" in err,
+              f"a bare --base must disagree with a stored origin/-named base (code={code}, err={err!r})")
+
+
 def t_ledger_missing_row_refuses() -> None:
     with tempfile.TemporaryDirectory(prefix="worker prompt base norow ") as raw:
         root = Path(raw)
@@ -452,6 +470,7 @@ TESTS = (
     ("host-neutral output", t_output_is_host_neutral),
     ("ledger base assertion matches", t_ledger_base_assertion_matches),
     ("ledger base assertion mismatch refuses", t_ledger_base_assertion_mismatch_refuses),
+    ("ledger origin-named base matches itself", t_ledger_origin_named_base_matches),
     ("ledger missing row refuses", t_ledger_missing_row_refuses),
 )
 

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
@@ -3,9 +3,13 @@
 
     worker-prompt.py fix --role review|ci-session|ci-economy \
         --project-root <absolute-path> --worktree <absolute-path> \
-        --pr <N> --base <base> --preflight-verdict proceed \
+        --pr <N> --base <base> [--file <ledger>] --preflight-verdict proceed \
         --issues-file <path> [--logs-file <path>] --output-dir <new-directory>
     worker-prompt.py self-test
+
+When `--file <ledger>` is given, `--base` is an ASSERTION checked against the `--pr` row's effective base
+(its explicit `base_branch`, else the legacy header fallback), never an independent base source; a
+disagreement refuses. Omit it and `--base` is used exactly as before.
 
 The tool binds dynamic values once as bytes. It launches no worker, chooses no host model name, and
 judges no fix. The published directory appears only after both `prompt.txt` and `metadata.json` are
@@ -32,6 +36,17 @@ HERE = Path(__file__).resolve().parent
 TEMPLATE = HERE / "worker-prompt-template.txt"
 SIBLING = HERE / "worker-prompt-test.py"
 FORMAT_PREFLIGHT = HERE / "format-preflight.py"
+LEDGER = HERE / "ledger.py"
+
+
+def _load_ledger():
+    mod = load_module_from_path("worker_prompt_ledger", LEDGER)
+    if mod is None:
+        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER}")
+    return mod
+
+
+L = _load_ledger()
 
 EXIT_OK = 0
 EXIT_REFUSED = 2
@@ -318,6 +333,24 @@ def run_fix(args: argparse.Namespace) -> int:
     project_root = validate_context_path(args.project_root, "--project-root")
     worktree = validate_context_path(args.worktree, "--worktree")
     base = validate_text(args.base, "--base")
+    # The base goes into the fix prompt as DATA. When a ledger is supplied, that data is an ASSERTION against
+    # the row's source of truth: the row OWNS the base, so `--base` must equal the selected row's
+    # `effective_base` (its explicit `base_branch`, else the legacy header fallback, through `ledger.py`'s
+    # accessor — never a second copy of that rule). A leading `origin/` is stripped first. Absent `--file`,
+    # the base is used as-is, as before.
+    if args.file is not None:
+        try:
+            header, rows = L.load(Path(args.file))
+        except SystemExit as exc:
+            raise Refusal(f"could not read ledger {args.file}: {exc}") from exc
+        row = L.find_row(rows, str(args.pr))
+        if row is None:
+            raise Refusal(f"no ledger row for pr {args.pr} — its base cannot be resolved")
+        effective_base = L.effective_base(header, row)
+        normalized = base[len("origin/"):] if base.startswith("origin/") else base
+        if effective_base and effective_base != "-" and normalized != effective_base:
+            raise Refusal(f"--base {base!r} disagrees with pr {args.pr}'s ledger effective base "
+                          f"{effective_base!r} — --base is an assertion, not a base source")
     issues = _read_payload(args.issues_file, "issues")
     logs = _read_payload(args.logs_file, "logs") if args.logs_file is not None else None
     sections = load_template()
@@ -352,6 +385,8 @@ def main(argv: "list[str] | None" = None) -> int:
     fix.add_argument("--worktree", required=True)
     fix.add_argument("--pr", required=True, type=int)
     fix.add_argument("--base", required=True)
+    fix.add_argument("--file", help="OPTIONAL ledger (state.jsonl); when given, --base is asserted against "
+                                    "the --pr row's effective base")
     fix.add_argument("--preflight-verdict", required=True)
     fix.add_argument("--issues-file", required=True)
     fix.add_argument("--logs-file")

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
@@ -336,8 +336,8 @@ def run_fix(args: argparse.Namespace) -> int:
     # The base goes into the fix prompt as DATA. When a ledger is supplied, that data is an ASSERTION against
     # the row's source of truth: the row OWNS the base, so `--base` must equal the selected row's
     # `effective_base` (its explicit `base_branch`, else the legacy header fallback, through `ledger.py`'s
-    # accessor — never a second copy of that rule). A leading `origin/` is stripped first. Absent `--file`,
-    # the base is used as-is, as before.
+    # accessor — never a second copy of that rule). Agreement is decided by `ledger.py`'s `base_agrees` —
+    # the one owner of that comparison. Absent `--file`, the base is used as-is, as before.
     if args.file is not None:
         try:
             header, rows = L.load(Path(args.file))
@@ -347,8 +347,7 @@ def run_fix(args: argparse.Namespace) -> int:
         if row is None:
             raise Refusal(f"no ledger row for pr {args.pr} — its base cannot be resolved")
         effective_base = L.effective_base(header, row)
-        normalized = base[len("origin/"):] if base.startswith("origin/") else base
-        if effective_base and effective_base != "-" and normalized != effective_base:
+        if effective_base and effective_base != "-" and not L.base_agrees(base, effective_base):
             raise Refusal(f"--base {base!r} disagrees with pr {args.pr}'s ledger effective base "
                           f"{effective_base!r} — --base is an assertion, not a base source")
     issues = _read_payload(args.issues_file, "issues")

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
@@ -346,8 +346,10 @@ def run_fix(args: argparse.Namespace) -> int:
         row = L.find_row(rows, str(args.pr))
         if row is None:
             raise Refusal(f"no ledger row for pr {args.pr} — its base cannot be resolved")
-        effective_base = L.effective_base(header, row)
-        if effective_base and effective_base != "-" and not L.base_agrees(base, effective_base):
+        effective_base, base_problem = L.require_effective_base(header, row, str(args.pr))
+        if base_problem is not None:
+            raise Refusal(base_problem)
+        if not L.base_agrees(base, effective_base):
             raise Refusal(f"--base {base!r} disagrees with pr {args.pr}'s ledger effective base "
                           f"{effective_base!r} — --base is an assertion, not a base source")
     issues = _read_payload(args.issues_file, "issues")


### PR DESCRIPTION
- carryover.py writes format v2: per-object effective base plus a sorted deduplicated `base_branches`; v1 stays readable
- nudge.py reports each active row's effective base and required set, grouping unknown blockers by base
- docs: carryover v2/v1, followup target per follow-up, per-base report, SKILL re-read; one base until stage 3
