### PR TITLE
feat(campaign): enable mixed-base admission

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -495,8 +495,10 @@
   `baseRefName` and **not assumed to be `main`**. One run may hold PRs on different bases; they need **NOT**
   agree. Resolve a PR's base through `effective_base` (its row value, else the legacy header fallback).
   Reviews diff `origin/<base>...HEAD` and each PR merges into its `<base>`; a fix worktree branches off the
-  PR's OWN head branch/SHA, never off `<base>` (see `pr-adoption.md`). Re-resolve it each heartbeat (see
-  "Base branch").
+  PR's OWN head branch/SHA, never off `<base>` (see `pr-adoption.md`). That recorded row base is
+  **immutable** — the campaign never migrates a row to a new base; a live `baseRefName` retarget **PARKS the
+  row** (never rewrites `base_branch`), through the park procedure owned by `pr-adoption.md` (re-adoption
+  base gate) and `loop-control.md` (`base_changed` route). Re-resolve it each heartbeat (see "Base branch").
 - After every merge, let `merge.py run` fast-forward local `<base>` to `origin/<base>` (Stage 3,
   **"Resumable merge execution"**) so later diffs and rebases use the just-merged tip. If it fails,
   re-run the command after fixing the named cause — never force the base.

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -491,12 +491,12 @@
 
 ### Merge and base hygiene
 
-- The run targets a **base branch**, **not assumed to be `main`** — it is the `baseRefName` of the
-  adopted PRs (must agree across them, else prompt). The base is **per-row** state, resolved through
-  `ledger.py`'s `effective_base` (a row's explicit `base_branch`, else the legacy header fallback), never
-  re-read from the one header field (see "Base branch"). Reviews diff `origin/<base>...HEAD` and PRs merge
-  into `<base>`; a fix worktree branches off the PR's OWN head branch/SHA, never off `<base>` (see
-  `pr-adoption.md`).
+- Each PR targets its **own base branch**, recorded once on its ledger row (`base_branch`) from its live
+  `baseRefName` and **not assumed to be `main`**. One run may hold PRs on different bases; they need **NOT**
+  agree. Resolve a PR's base through `effective_base` (its row value, else the legacy header fallback).
+  Reviews diff `origin/<base>...HEAD` and each PR merges into its `<base>`; a fix worktree branches off the
+  PR's OWN head branch/SHA, never off `<base>` (see `pr-adoption.md`). Re-resolve it each heartbeat (see
+  "Base branch").
 - After every merge, let `merge.py run` fast-forward local `<base>` to `origin/<base>` (Stage 3,
   **"Resumable merge execution"**) so later diffs and rebases use the just-merged tip. If it fails,
   re-run the command after fixing the named cause — never force the base.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -305,10 +305,10 @@ Header field notes (the header fields above; per-row fields follow):
   one place the fallback lives, and it is the **sanctioned door** for resolving a row's base;
   `require_effective_base` is the fail-closed form the resolved-base consumers route through. **Per-row
   base resolution is LIVE:** adoption records each new row's base at creation (`add-row --base-branch`),
-  and every consumer resolves a row's base through those accessors, never the one header base. What
-  REMAINS is mixed-base **admission** — surfacing PRs on DIFFERENT bases into one run; adoption still
-  admits only the run's one agreed base (the mixed-base rollout's final PR —
-  `docs/designs/campaign-mixed-base-branches.md`, "Staged implementation plan"). It is **TOOL-OWNED and
+  and every consumer resolves a row's base through those accessors, never the one header base. Mixed-base
+  **admission** is LIVE too: adoption surfaces PRs on DIFFERENT bases into one run, each row owning the
+  base it was created with, and PRs adopted together need **NOT** agree on `baseRefName` (`pr-adoption.md`,
+  "PR adoption"). A new run leaves the header `base_branch` at `-` and records only per-row bases. It is **TOOL-OWNED and
   IMMUTABLE after creation** (`CREATE_ONLY` in `scripts/ledger.py`): `add-row` writes it and **`set` has no
   `--base-branch` flag**, so the recorded base can never be rewritten — the campaign does not migrate a row
   to a new base. The default is **`-`**, which is both the schema's "not set" spelling **and** its "inherit

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -201,20 +201,17 @@ about and one whose partial rejection strands the rest.
    from one PR** takes **that PR's recorded base** (`effective_base` of its ledger row) as the proposed
    target; a **run-level** follow-up has **no implicit target**, so the **user chooses** it. The user may
    override the proposed target before the PR is opened. The resulting PR then enters through **normal
-   adoption**, which records its live `baseRefName` once (`pr-adoption.md`). **Adoption still admits only
-   the run's one agreed base** (`pr-adoption.md`, "PR adoption") — mixed bases in one run are a later
-   stage (stage 3, PR #148). So the follow-up folds into THIS run (step 4) **only when its target equals
-   the run's agreed base**; a follow-up targeting a **different** base is NOT adopted here — surface it
-   (step 5) for its own run and leave the entry open. In a single-base run a PR-derived follow-up always
-   shares that base, so this only diverts a user-chosen different-base target. When the target is the
-   run's base, that PR is opened
+   adoption**, which records its live `baseRefName` once as its immutable row base (`pr-adoption.md`).
+   **Adoption admits PRs on DIFFERENT bases into one run** (`pr-adoption.md`, "PR adoption"), so the
+   follow-up folds into THIS run (step 4) **regardless of whether its target matches the existing rows** —
+   a different-base target is adopted here, never diverted for base disagreement. That PR is opened
    **`gauntlet-authored`** and adopted into the current run so `pr-adoption.md` reads it as
    `pr_origin=gauntlet` — without the label it defaults to `external`, which then blocks campaign's own
    later autonomous repair of the very PR it authored. Record the PR with `followups.py open-pr --id fuN
    --pr <ref>`; the entry stays `in-pr` and names which PR is addressing it.
 
-4. **FOLD THE PR INTO THE CURRENT CAMPAIGN.** The follow-up's PR — which step 3 admitted only on the run's
-   agreed base — is **adopted into this run** like any other
+4. **FOLD THE PR INTO THE CURRENT CAMPAIGN.** The follow-up's PR — which step 3 admitted on its own
+   recorded base — is **adopted into this run** like any other
    (`pr-adoption.md` — the `gauntlet-authored` label, ledger row, intent, CI) and **gated by the same
    review gauntlet**. This is the
    whole point of "self-accepted, not accepted": the driver may take a follow-up up on its own, but the PR

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -141,20 +141,25 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      orphan run that later no-arg invocations rediscover as bogus state.
 
      When there **are** `#PR` args, **preflight the whole set FIRST — read-only, before creating any
-     run state**: read every PR's metadata (`gh pr view`), run the refusal checks (foreign-owned,
-     cross-repo/fork per `pr-adoption.md`), and verify all share a common `baseRefName`. This touches
-     **no** run-id, `<rundir>`, lease, `state.jsonl`, label, worktree, or CI watch. **If the bases
-     disagree or any PR is refused, prompt and create nothing** — so a rejected set never leaves an
+     run state**: read every PR's metadata (`gh pr view`, including each PR's `baseRefName`) and run the
+     refusal checks (foreign-owned, cross-repo/fork per `pr-adoption.md`). **The PRs need NOT share a
+     base** — one run may hold PRs targeting different bases, each driven against its own recorded base
+     (`run-identity-and-lease.md`, "Base branch"); preflight only confirms each PR exists and is open.
+     This touches **no** run-id, `<rundir>`, lease, `state.jsonl`, label, worktree, or CI watch. **If any
+     PR is refused, prompt and create nothing** — so a rejected set never leaves an
      empty orphan run behind. **Only once the full set passes preflight**: call `create_run_directory`
      **first** — it mints the run-id and atomically creates `<rundir>` — and derive `run_id` from the
      returned directory's final path component; **then** take the run per `run-identity-and-lease.md`,
      "Take a run" (which, BEFORE arming, records `pending_adoption` = this set's PR list; then token,
      heartbeat arming, `lease.py acquire` — in that order),
-     and write the `state.jsonl` header — now with `run_id` set and `base_branch` filled
-     from the agreed `baseRefName` (known from preflight). Then **adopt** each PR
+     and write the `state.jsonl` header with `run_id` set. **The header `base_branch` stays its `-`
+     default** — the base is per-row now, recorded on each row at adoption from that PR's live
+     `baseRefName`, never a run-wide header value (`files-and-ledger.md`, the row `base_branch` field).
+     Then **adopt** each PR
      (ledger row + labels + worktree, and a CI watch **only when one is due** — `pr-adoption.md` owns what
-     adoption produces and when the watch is warranted); a death mid-adoption still leaves
-     a discoverable, adoptable run. **When the whole requested set is adopted, clear the checkpoint —
+     adoption produces and when the watch is warranted; adoption fetches **each PR's own base ref**, so a
+     set spanning several bases fetches each of them once at its adoption). A death mid-adoption still
+     leaves a discoverable, adoptable run. **When the whole requested set is adopted, clear the checkpoint —
      `ledger.py … header set pending_adoption -`** (this is adoption's final step; a later entry that
      still sees it set knows setup did not finish and resumes it). Then fall through to dispatch/reschedule.
    - **This run's `state.jsonl` is fully terminal — every row `merged`/`aborted`, no open PR carrying this

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -144,7 +144,8 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      run state**: read every PR's metadata (`gh pr view`, including each PR's `baseRefName`) and run the
      refusal checks (foreign-owned, cross-repo/fork per `pr-adoption.md`). **The PRs need NOT share a
      base** — one run may hold PRs targeting different bases, each driven against its own recorded base
-     (`run-identity-and-lease.md`, "Base branch"); preflight only confirms each PR exists and is open.
+     (`run-identity-and-lease.md`, "Base branch"). Preflight imposes no cross-row base agreement; every
+     PR must still pass all `pr-adoption.md` refusal checks (foreign-owner, cross-repo/fork).
      This touches **no** run-id, `<rundir>`, lease, `state.jsonl`, label, worktree, or CI watch. **If any
      PR is refused, prompt and create nothing** — so a rejected set never leaves an
      empty orphan run behind. **Only once the full set passes preflight**: call `create_run_directory`

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -20,10 +20,10 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
 Each adopted PR **records its own live `baseRefName`** on its ledger row — the row's `base_branch`, written
 **once at creation** by `pr-adopt.py` (`add-row --base-branch`) and **immutable** afterward (`files-and-ledger.md`,
 the row `base_branch` field). Resolve a row's base through `ledger.py`'s `effective_base` (an explicit row
-value, else the legacy header fallback), never the raw header field. **For now, when several PRs are adopted
-at once they still must agree on `baseRefName`** — mixed bases in one run are a later stage; if they disagree,
-stop and prompt the user. The header `base_branch` is only the legacy fallback a row with no explicit base
-inherits.
+value, else the legacy header fallback), never the raw header field. **Adopting several PRs at once does
+NOT require their bases to agree** — one run may hold PRs targeting different bases (some on `v3`, others on
+`main`), each driven against its own recorded base (`run-identity-and-lease.md`, "Base branch"). The header
+`base_branch` is only the legacy fallback a row with no explicit base inherits.
 
 Campaign **never** deletes the adopted PR's **remote** head branch. Stage 3,
 **"Resumable merge execution"**, owns merge and cleanup enforcement.

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -1,24 +1,33 @@
 ## Base branch
 
-The run targets a **base branch** — the branch a PR merges into and its review diff is measured
-against. It is **not assumed to be `main`**: it is a PR's **`baseRefName`** (from `gh pr view`), which
-may be a release or integration branch. PRs adopted together must **agree** on `baseRefName`; if they
-disagree, stop and prompt — **adoption admits only one base per run today** (mixed-base admission is the
-rollout's final, not-yet-shipped stage).
+A run is a **set of PRs, each with its OWN base branch** — the branch that PR merges into and its review
+diff is measured against. It is **not assumed to be `main`**: it is a PR's **`baseRefName`** (from `gh pr
+view`), which may be a release or integration branch. A run is **not** confined to one base: some PRs may
+target `v3`, others `main`, in the same run, and PRs adopted together need **NOT** agree on `baseRefName`.
 
-The base is **per-row** state, recorded on each row at adoption (`pr-adopt.py` → `add-row
---base-branch`); the ledger **header** `base_branch` is only the **legacy fallback** a row carrying none
-inherits. Every consumer resolves a row's base through `ledger.py`'s `effective_base(header, row)` (and
+The base is **per-row** state, recorded on each row **once** at adoption (`pr-adopt.py` → `add-row
+--base-branch`) from its live `baseRefName`; that recorded value is **immutable** — the campaign never
+migrates a row to a new base (a live retarget PARKS the row, see `pr-adoption.md`, `loop-control.md`). The
+ledger **header** `base_branch` is only the **legacy fallback** a row carrying none inherits. Every
+consumer resolves a row's base through `ledger.py`'s `effective_base(header, row)` (and
 `require_effective_base`, its fail-closed form, before acting on it) — never by re-reading the one header
 field. The field, its accessors, and the `CREATE_ONLY` rule are owned by the `base_branch` field in
 `files-and-ledger.md`.
 
-Throughout this doc, `<base>` means that branch and `origin/<base>` its remote-tracking branch.
-Concretely: adopted PRs already target `<base>` (their `baseRefName`), every review diffs
-`origin/<base>...HEAD`, and after each merge local `<base>` is fast-forwarded to `origin/<base>`. **Fix
-worktrees do NOT branch off `<base>`** — they branch off the PR's **own head** (see "PR adoption"),
-since the PR's commits live there. Where examples below show `main`, read it as `<base>` — `main` is
-only the common default.
+Resolve a PR's base through `ledger.py`'s **`effective_base`** — the row's explicit `base_branch`, else
+the legacy header `base_branch` fallback (`files-and-ledger.md`). **Re-resolve each active PR's effective
+base every heartbeat**, from the ledger, never from memory. The header `base_branch` is **only** the
+fallback an old row with no explicit base inherits; a new run leaves it at its `-` default.
+
+Throughout this doc, **`<base>` means the SELECTED PR row's `effective_base`** and `origin/<base>` its
+remote-tracking branch — resolved per PR, not one value for the run. Concretely: an adopted PR already
+targets its `<base>` (its recorded `baseRefName`), its review diffs `origin/<base>...HEAD`, and after
+merging that PR local `<base>` is fast-forwarded to `origin/<base>`. **Fix worktrees do NOT branch off
+`<base>`** — they branch off the PR's **own head** (see "PR adoption"), since the PR's commits live there.
+Where examples below show `main`, read it as that PR's `<base>` — `main` is only a common default.
+
+**Run identity stays run-wide.** One run keeps one run ID, one lease, one heartbeat schedule, one owner
+label, and one serialized merge drain, no matter how many distinct bases its PRs target (below).
 
 ## Run identity and concurrency
 
@@ -50,7 +59,7 @@ host-specific `repository.scratch_root` and owns that invocation. The atomic cre
 retry live in `run-id.py`; the caller no longer mints an id or retries. Do not unpack that operation here.
 
 Record it in the ledger header field `run_id` (`ledger.py --file <state.jsonl> header set run_id
-<run-id>`) and re-read it every heartbeat (`ledger.py … header get run_id`); never trust
+<run-id>`) and re-read it every heartbeat (`ledger.py … header get run_id`, like `reviewer`); never trust
 in-context memory for it — a heartbeat may be a fresh agent instance. It flows into:
 
 | Owned by the run | Namespaced form |

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -45,9 +45,9 @@ HEADER_DEFAULTS = {
     # ROW_FIELDS), written once at row creation. This header field is only what a row with NO explicit base
     # inherits, through `effective_base` — the schema-owned resolver, the sanctioned door for base
     # consumers. Per-row base resolution is LIVE: adoption records each row's base and every consumer
-    # resolves through the accessor, never this header directly. What remains is mixed-base ADMISSION (the
-    # rollout's final PR — docs/designs/campaign-mixed-base-branches.md, "Staged implementation plan"). An
-    # old single-base ledger keeps its header value and every one of its rows reads it.
+    # resolves through the accessor, never this header directly. Mixed-base ADMISSION is ENABLED: adoption
+    # admits PRs on DIFFERENT bases into one run and each admitted row owns its immutable base. A new run
+    # leaves this header at `-`; an old single-base ledger keeps its header value and every one of its rows reads it.
     # files-and-ledger.md, "Base branch", owns the field.
     "base_branch": "-",
     "api_changes": "ask",
@@ -659,8 +659,8 @@ def find_row(rows: list[dict], pr: str) -> "dict | None":
 # accessors are the ONE place the fallback lives: a row's explicit value if it has one, otherwise the legacy
 # header value. They are the sanctioned door every base/required-set consumer resolves through, and that
 # resolution is LIVE: adoption records each row's base, and every consumer routes through these accessors
-# rather than reading the header field directly. What remains is mixed-base ADMISSION
-# (docs/designs/campaign-mixed-base-branches.md, "Staged implementation plan").
+# rather than reading the header field directly. Mixed-base ADMISSION is ENABLED: adoption admits PRs on
+# DIFFERENT bases into one run and each admitted row owns its immutable base.
 # `-` is the row default and means exactly "inherit the header": an old
 # ledger's rows carry `-` and resolve to the header value they always used, while a row with an explicit
 # base (or an explicit required set) has that value returned unchanged. This is what lets legacy inheriting
@@ -723,9 +723,10 @@ def require_effective_base(header: dict, row: dict, pr: str) -> "tuple[str | Non
     the PR — when it is not. `-` on BOTH the row and the header means "no base was ever resolved" (`effective_base`
     faithfully returns it); it is NOT a branch a caller may rebase onto, write to history, or diff against, so it
     is refused here. This function is the ONLY one that refuses `-`: `base_agrees` does NOT — it checks
-    equality first, so `base_agrees("-", "-")` returns True. A normal run never reaches this: the
-    header base is filled at run start and each row's at adoption, so `effective_base` returns a real branch; a
-    both-`-` ledger is a driver-authored/hand-edited state (a single-user foot-gun), and this is the cheap
+    equality first, so `base_agrees("-", "-")` returns True. A normal run never reaches this: a new row carries
+    an explicit base from adoption while its new-run header stays `-`, and a legacy `-` row inherits a populated
+    legacy header — either way `effective_base` returns a real branch. Only the both-`-` shape stays unresolved,
+    and it is a driver-authored/hand-edited state (a single-user foot-gun); this is the cheap
     fail-closed insurance against it — not machinery to defend the user from themselves."""
     base = effective_base(header, row)
     if not base.strip() or base == "-":

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -36,6 +36,15 @@ def _load_owner():
 M = _load_owner()
 
 
+def _sibling(name: str, filename: str):
+    """Load a sibling campaign tool as a module for the cross-script integration fixture below. Guards the
+    `None` return exactly as `_load_owner` does, so every attribute access is on a real module."""
+    mod = load_module_from_path(name, Path(__file__).resolve().parent / filename)
+    if mod is None:
+        raise RuntimeError(f"cannot load the sibling tool at {filename}")
+    return mod
+
+
 def check(cond, msg) -> None:
     if not cond:
         raise M.SelfTestFailure(msg)
@@ -841,7 +850,135 @@ def t_readopt_base_mismatch_already_held_keeps_question():
               "the pending ruling on the open park is untouched")
 
 
+# --- CROSS-SCRIPT: one mixed-base run walks the real tools end to end -----------------------------------
+
+def t_mixed_base_end_to_end():
+    """A v3 row and a main row walk ONE ledger through the REAL tools, in sequence: adopt (pr-adopt) ->
+    grouped required-set (ci-status) -> merge door (merge-check) -> park-on-retarget (reconcile + ledger
+    park) -> distill (carryover). Each tool CONSUMES the ledger the previous one wrote.
+
+    The isolated suites each build their OWN synthetic ledger, so only this fixture proves the row
+    `base_branch` that `pr-adopt` writes at admission is the same value every downstream base door resolves
+    through `effective_base` — the whole point of mixed-base admission. It exercises the composition, not any
+    one tool's internal rules (those stay pinned by their own suites)."""
+    CI = _sibling("mbi_ci_status", "ci-status.py")
+    RC = _sibling("mbi_reconcile", "reconcile.py")
+    MC = _sibling("mbi_merge_check", "merge-check.py")
+    CO = _sibling("mbi_carryover", "carryover.py")
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        wroot = d / "wt"
+        ledger = d / "state.jsonl"
+        run_id = "g1"
+        # A NEW-run header: the base is per-row now, so `base_branch` stays its `-` default and
+        # `required_set` stays `unknown` — never a run-wide value (design: "Resolve row-owned state").
+        _init_ledger(ledger, run_id=run_id, base_branch="-")
+
+        # 1. ADMIT two PRs on DIFFERENT bases into ONE run — no common-base agreement required.
+        sha_v3, sha_main = "a" * 40, "b" * 40
+        v_v3 = view(number=41, headRefName="fix-v3", headRefOid=sha_v3, baseRefName="v3", title="v3 fix")
+        v_main = view(number=52, headRefName="fix-main", headRefOid=sha_main, baseRefName="main",
+                      title="main fix")
+        code, _, err, _ = _adopt(d, ledger, v_v3, wroot=wroot, run_id=run_id)
+        check(code == 0, f"adopt of the v3 PR succeeds (got {code}: {err})")
+        code, _, err, _ = _adopt(d, ledger, v_main, wroot=wroot, run_id=run_id)
+        check(code == 0, f"adopt of the main PR succeeds in the SAME run (got {code}: {err})")
+        check(_field(ledger, 41, "base_branch") == "v3" and _field(ledger, 52, "base_branch") == "main",
+              "each row records its OWN live base — mixed bases admitted into one run")
+        header_after, _ = M.L.load(ledger)
+        check(header_after["base_branch"] == "-",
+              "the run header base stays `-` — the base is per-row, never a run-wide header value")
+
+        # 2. GROUPED required-set (ci-status): one GitHub read per DISTINCT base, written to that base's rows.
+        v3_set = CI.canonical_required_set([("v3-test", CI.SNAP.ANY_APP)])
+        main_set = CI.canonical_required_set([("main-test", CI.SNAP.ANY_APP)])
+        seen: list = []
+
+        def fetch(source: str, argv: list) -> object:
+            endpoint = str(argv[-1])
+            base = "v3" if endpoint.endswith(CI.quote("v3", safe="")) else (
+                "main" if endpoint.endswith(CI.quote("main", safe="")) else None)
+            if base is None:
+                raise CI.FetchError(f"unexpected endpoint {endpoint!r}")
+            if source.endswith("classic"):
+                seen.append(base)
+                ctx = "v3-test" if base == "v3" else "main-test"
+                return {"protection": {"enabled": True,
+                        "required_status_checks": {"checks": [{"context": ctx, "app_id": None}]}}}
+            return [[]]   # ruleset: one empty page
+
+        out = CI.refresh_required_set(fetch, ledger, "o/r")
+        check(out["settled"], f"both base groups settle: {out!r}")
+        check(sorted(seen) == ["main", "v3"], f"each DISTINCT base is read exactly once: {seen!r}")
+        check(_field(ledger, 41, "required_set") == v3_set, "the v3 row gets v3's required set")
+        check(_field(ledger, 52, "required_set") == main_set, "the main row gets main's required set")
+        header_now, _ = M.L.load(ledger)
+        check(header_now["required_set"] == "unknown",
+              "the new-run header required_set stays unknown — never materialized from a base group")
+
+        # 3. MERGE DOOR (merge-check) resolves the SELECTED row's effective base. The v3 row seen live on
+        #    `main` is an unsupported retarget -> the shared park reason; seen live on `v3` it clears the base
+        #    step (and stops later only because its CI is still pending — proof the base door PASSED).
+        hdr, rows = M.L.load(ledger)
+        r41 = M.L.find_row(rows, "41")
+        assert r41 is not None
+        eff41 = M.L.effective_base(hdr, r41)
+        check(eff41 == "v3", f"the merge door resolves #41's effective base to v3; got {eff41!r}")
+
+        def mview(base_ref: str) -> dict:
+            return {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "isDraft": False,
+                    "state": "OPEN", "headRefOid": sha_v3, "baseRefName": base_ref}
+
+        retarget = MC.decide(r41, mview("main"), required=MC.REQUIRED, effective_base=eff41)
+        check(retarget["reason"] == M.BASE_CHANGE_PARK_REASON.format(recorded="v3", live="main"),
+              f"a live retarget parks with the SHARED base-change reason; got {retarget!r}")
+        onbase = MC.decide(r41, mview("v3"), required=MC.REQUIRED, effective_base=eff41)
+        check("ci is pending" in onbase["reason"],
+              f"on its own base the retarget check passes and decision proceeds; got {onbase!r}")
+
+        # 4. PARK ON RETARGET (reconcile detects, ledger parks). Snapshot: #41 now targets `main`, #52 still
+        #    `main`. reconcile flags #41 against its RECORDED v3; #52 on its own base is clean.
+        prs = d / "prs.json"
+        run_label = M.RUN_LABEL_PREFIX + run_id
+
+        def entry(number: int, branch: str, base: str, head: str) -> dict:
+            return {"number": number, "headRefName": branch, "headRefOid": head, "title": f"t{number}",
+                    "baseRefName": base, "state": "OPEN", "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [{"name": run_label}, {"name": M.REVIEWING_LABEL}]}
+
+        prs.write_text(json.dumps([entry(41, "fix-v3", "main", sha_v3),
+                                   entry(52, "fix-main", "main", sha_main)]), encoding="utf-8")
+        facts = RC.detect(ledger, prs, run_id)
+        f41 = facts["rows"]["41"]
+        check(f41.get("base_changed") == {"ledger": "v3", "snapshot": "main"},
+              f"reconcile flags #41's retarget against its RECORDED v3, not the header: {f41!r}")
+        check("base_changed" not in facts["rows"]["52"],
+              f"the main PR on its own base is NOT flagged: {facts['rows']['52']!r}")
+        park_reason = M.BASE_CHANGE_PARK_REASON.format(recorded=f41["base_changed"]["ledger"],
+                                                       live=f41["base_changed"]["snapshot"])
+        _ledger("--file", str(ledger), "park", "--pr", "41", "--reason", park_reason)
+        check(_field(ledger, 41, "status") == "awaiting-user", "the retargeted row is PARKED")
+        check(_field(ledger, 41, "ci_reason") == "base changed from v3 to main; not supported mid-run",
+              f"the durable park reason is EXACT; got {_field(ledger, 41, 'ci_reason')!r}")
+        check(_field(ledger, 41, "base_branch") == "v3",
+              "the recorded base is immutable — a park never rewrites it")
+
+        # 5. DISTILL (carryover v2): each terminal object carries its OWN base; metadata lists both, sorted.
+        _set_row(ledger, 41, status="aborted")
+        _set_row(ledger, 52, status="merged")
+        out_dir = d / "history"
+        summary = CO.distill(M.L, ledger, out_dir, "2026-07-22T00:00:00Z", force=False)
+        check(summary["base_branches"] == ["main", "v3"],
+              f"carryover v2 records the run's distinct bases, sorted: {summary!r}")
+        text = (out_dir / f"{run_id}.md").read_text(encoding="utf-8")
+        check("base_branches: [\"main\", \"v3\"]" in text,
+              f"the distilled v2 metadata names both release lines: {text!r}")
+
+
 CASES = [
+    ("mixed_base_end_to_end", "one mixed-base run walks adopt -> grouped required-set -> merge door -> "
+                              "reconcile park -> distill on ONE ledger", t_mixed_base_end_to_end),
     ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),
     ("refuse_foreign_run", "a PR owned by another run is refused", t_refuse_foreign_run),
     ("refuse_closed", "a MERGED/CLOSED PR is refused", t_refuse_closed),


### PR DESCRIPTION
- remove the common-base agreement refusal; one run may adopt PRs on different bases
- rewrite run-contract owner docs so a run is a set of PRs, each with its own recorded base
- add a cross-script fixture walking a v3+main ledger through adopt, required-set, merge, park, distill
