### PR TITLE
docs(campaign): scope lean wake to same-session

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -14,10 +14,9 @@ first wait or heartbeat. The gate rules do not change between hosts.
 `<campaign-invocation>` elsewhere in this skill means the active row above. A self-resume always adds
 exactly `--run <run-id> --token <agent-token>`; it never repeats `--new` or the original PR arguments.
 
-A **scheduled wake never schedules this invocation as the prompt**: it schedules the lean same-session
-wake prompt `heartbeat.py callback` prints, which embeds the invocation only as its not-in-context
-fallback ("Background work and heartbeats" below owns the shape and the reason). The invocation itself
-is for a user or a fresh session — starting, adopting, or manually resuming a run.
+**"Background work and heartbeats" below owns scheduled-entry prompt selection** — whether a scheduler
+entry may schedule the lean `heartbeat.py` wake prompt or must lead with this invocation. The invocation
+itself is for a user or a fresh session — starting, adopting, or manually resuming a run.
 
 Do not put either invocation in a shell command. These are host UI forms, not shell syntax.
 
@@ -318,6 +317,14 @@ cost but does not lower the gate.
 Reviews, fixes, audits, reassessments, and CI watches remain asynchronous logical tasks. Fold a
 completion into the same reconcile loop regardless of the host mechanism that reports it.
 
+**Lean prompt vs. full invocation — the boundary.** The lean `heartbeat.py` wake prompts are valid ONLY
+when the scheduler delivers the wake into the SAME live session, where the skill contract is already
+loaded — the case both current hosts provide. A scheduler entry that can OUTLIVE that session or CREATE a
+new one MUST NOT schedule the lean prompt; its adapter lifecycle instead leads with the full
+`<campaign-invocation> --run <run-id> --token <agent-token>` (`/gauntlet:campaign` on Claude Code,
+`$gauntlet:campaign` on Codex — the "Skill invocation" rows) so the fresh session loads the campaign
+contract before resuming.
+
 For the heartbeat fallback, choose exactly one lifecycle:
 
 1. **Scheduled-heartbeat host:** do NOT hand-assemble the wake. Run `scripts/heartbeat.py callback`
@@ -416,7 +423,10 @@ On a host with a session-watchdog capability, use these idempotent operations, k
 - `available?` — report whether the host can schedule an additional wake into this live session.
 - `ensure` — create the recurring nudge if missing. Use `ledger.py watchdog interval` for its cadence
   and schedule only `heartbeat.py watchdog`'s stdout, built with run id, owner token, and campaign
-  invocation. The nudge reaches the same session; it never launches an independent driver.
+  invocation. The nudge reaches the same session; it never launches an independent driver. Scheduling the
+  lean watchdog prompt is valid only because this entry is same-session ("Lean prompt vs. full invocation"
+  above owns the boundary — a watchdog scheduler that could outlive the session or create a new one leads
+  with the full invocation instead).
 - `inspect` — report whether the nudge remains armed for this session.
 - `remove` — delete the nudge during normal finalization.
 - `primary inspect` — on a scheduled-heartbeat host, report whether the next primary callback names this

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -423,10 +423,9 @@ On a host with a session-watchdog capability, use these idempotent operations, k
 - `available?` — report whether the host can schedule an additional wake into this live session.
 - `ensure` — create the recurring nudge if missing. Use `ledger.py watchdog interval` for its cadence
   and schedule only `heartbeat.py watchdog`'s stdout, built with run id, owner token, and campaign
-  invocation. The nudge reaches the same session; it never launches an independent driver. Scheduling the
-  lean watchdog prompt is valid only because this entry is same-session ("Lean prompt vs. full invocation"
-  above owns the boundary — a watchdog scheduler that could outlive the session or create a new one leads
-  with the full invocation instead).
+  invocation. The nudge reaches the same session; it never launches an independent driver. Whether this
+  entry may schedule the lean prompt is owned by "Lean prompt vs. full invocation — the boundary" under
+  "Background work and heartbeats" above.
 - `inspect` — report whether the nudge remains armed for this session.
 - `remove` — delete the nudge during normal finalization.
 - `primary inspect` — on a scheduled-heartbeat host, report whether the next primary callback names this

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -14,9 +14,9 @@ first wait or heartbeat. The gate rules do not change between hosts.
 `<campaign-invocation>` elsewhere in this skill means the active row above. A self-resume always adds
 exactly `--run <run-id> --token <agent-token>`; it never repeats `--new` or the original PR arguments.
 
-**"Background work and heartbeats" below owns scheduled-entry prompt selection** — whether a scheduler
-entry may schedule the lean `heartbeat.py` wake prompt or must lead with this invocation. The invocation
-itself is for a user or a fresh session — starting, adopting, or manually resuming a run.
+**"Background work and heartbeats" below, "Lean prompt vs. full invocation — the boundary", owns
+scheduled-entry prompt selection.** The invocation itself is for a user or a fresh session — starting,
+adopting, or manually resuming a run.
 
 Do not put either invocation in a shell command. These are host UI forms, not shell syntax.
 

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -9,6 +9,11 @@ into the session on every wake, and over a long campaign that walks the driver i
 (field feedback from a live 8-PR run). The invocation appears exactly once, at the tail, as the explicit
 fallback for a session whose context no longer holds the skill contract.
 
+These lean prompts are valid ONLY because the current hosts deliver the wake into the same live session;
+`runtime-adapter.md`, "Background work and heartbeats", owns the boundary — a scheduler entry that can
+outlive the session or create a new one must instead lead with the full `<campaign-invocation> --run
+--token`, not this lean prompt.
+
 The wake carries ONLY two flags:
 
     --run <run-id> --token <agent-token>

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -9,10 +9,8 @@ into the session on every wake, and over a long campaign that walks the driver i
 (field feedback from a live 8-PR run). The invocation appears exactly once, at the tail, as the explicit
 fallback for a session whose context no longer holds the skill contract.
 
-These lean prompts are valid ONLY because the current hosts deliver the wake into the same live session;
-`runtime-adapter.md`, "Background work and heartbeats", owns the boundary — a scheduler entry that can
-outlive the session or create a new one must instead lead with the full `<campaign-invocation> --run
---token`, not this lean prompt.
+Whether a given scheduler entry may use these lean prompts at all is owned by `runtime-adapter.md`,
+"Background work and heartbeats" ("Lean prompt vs. full invocation — the boundary").
 
 The wake carries ONLY two flags:
 

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -332,6 +332,13 @@ def emit(verdict: str, rec: "dict | None", **extra) -> None:
 # exits non-zero and its stderr says what happened, WHAT STATE CHANGED, what NOT to do, and what to do
 # instead. It names no host mechanism — `runtime-adapter.md` owns that mapping — and it offers NO
 # alternative, because the moment it names a way to proceed without a proof, that way becomes the default.
+#
+# This message concerns the ACQUIRE-TIME heartbeat proof (`--heartbeat-id` presented here to take the
+# lease), NOT the same-session wake-prompt SHAPE (lean prompt vs. full invocation) owned by
+# runtime-adapter.md "Background work and heartbeats". Evidence it does not restate that boundary: the
+# text is unchanged by the wake-shape PR (not in its diff), it delegates the host mechanism to
+# runtime-adapter.md by name rather than reconstructing it, and heartbeat.py callback — not this string —
+# still prints the wake prompt. A driver following this message consults that owner for the shape.
 
 NO_HEARTBEAT = """\
 lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -332,13 +332,6 @@ def emit(verdict: str, rec: "dict | None", **extra) -> None:
 # exits non-zero and its stderr says what happened, WHAT STATE CHANGED, what NOT to do, and what to do
 # instead. It names no host mechanism — `runtime-adapter.md` owns that mapping — and it offers NO
 # alternative, because the moment it names a way to proceed without a proof, that way becomes the default.
-#
-# This message concerns the ACQUIRE-TIME heartbeat proof (`--heartbeat-id` presented here to take the
-# lease), NOT the same-session wake-prompt SHAPE (lean prompt vs. full invocation) owned by
-# runtime-adapter.md "Background work and heartbeats". Evidence it does not restate that boundary: the
-# text is unchanged by the wake-shape PR (not in its diff), it delegates the host mechanism to
-# runtime-adapter.md by name rather than reconstructing it, and heartbeat.py callback — not this string —
-# still prints the wake prompt. A driver following this message consults that owner for the shape.
 
 NO_HEARTBEAT = """\
 lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.


### PR DESCRIPTION
- runtime-adapter.md owns the lean-vs-full boundary: cross-session scheduler entries must lead with the invocation
- Skill invocation and session-watchdog sentences now point at that owner
- heartbeat.py docstring gains a one-sentence boundary note; emitted prompt shapes unchanged
