### PR TITLE
docs(campaign): primary heartbeat continuity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,9 +233,10 @@ jobs:
       - name: Carryover distiller contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/carryover.py self-test
 
-      # The nudge printer's rules, executed. It reminds the orchestrator each wake of what to check
-      # (heartbeat armed, fan out work, PR labels, a review that may have died) — a sticky-note printer,
-      # not gate machinery: it decides nothing and always exits 0. Each fixture pins a rule with teeth
+      # The nudge printer's rules, executed. It reminds the orchestrator each wake of what to check —
+      # the reminder inventory is owned by nudge.py's rules and pinned by its fixtures, never restated
+      # here — a sticky-note printer, not gate machinery: it decides nothing and always exits 0. Each
+      # fixture pins a rule with teeth
       # (fires when its condition holds, absent when it does not), so a printer that emitted every line
       # unconditionally would go red. The sibling `nudge-test.py` is loaded by path; a MISSING sibling
       # fails loudly, so this can never report health over a suite it did not run. As with the triage

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -114,9 +114,10 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
    the contract and the inline fallback). When the run is **QUIET** (nudge, no meaningful
    ledger activity for its window) **OR** `ledger.py watchdog check` says the long-cadence deadline is
    `due`/`unset`/`invalid`, run the **health pass** (one pass, then one `ledger.py watchdog arm`)
-   before rescheduling and lead the status with the diagnosis. A `--watchdog` wake audits that the primary
-   heartbeat is armed; it runs the health pass only when one of those normal triggers applies
-   (`references/loop-control.md`, "Reschedule or exit").
+   before rescheduling and lead the status with the diagnosis. A `--watchdog` wake runs the runtime
+   adapter's advisory inspections (`references/runtime-adapter.md`, "Session watchdog nudge") and runs the
+   health pass only when one of those normal triggers applies; it never decides the primary re-arm —
+   `references/loop-control.md`, "Primary continuity", owns continuing the loop.
 9. `ci-status.py required-set --ledger <rundir>/state.jsonl`: refresh the required set before any CI
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that
@@ -129,13 +130,13 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     reviews doomed by a content change.
 12. Before sleeping, audit: re-run the dispatch scan across both concurrency pools and confirm every
     due launch actually happened, every PR at a liveness cap was escalated rather than left spinning,
-    and a heartbeat or bounded wait is armed whenever non-terminal work remains. NEVER sleep with due
-    work un-launched or no path to the next reconcile. Then follow `references/loop-control.md`,
-    "Reschedule or exit", exactly: a scheduled-heartbeat host renders the status — the `ledger.py table`
-    output that block defines — and then schedules as the turn's LAST action (scheduling ends the turn
-    on that host: `references/runtime-adapter.md`, "Scheduled-heartbeat host"); a scheduler-less host
-    renders the same status, performs one bounded wait, and returns to the reconcile step while
-    non-terminal work remains.
+    and the loop continues per `references/loop-control.md`, "Primary continuity", whenever non-terminal
+    work remains. NEVER sleep with due work un-launched or no path to the next reconcile. Then follow
+    `references/loop-control.md`, "Reschedule or exit", exactly: a scheduled-heartbeat host renders the
+    status — the `ledger.py table` output that block defines — and then schedules-or-replaces the primary
+    wake as the turn's LAST action ("Primary continuity"; scheduling ends the turn on that host:
+    `references/runtime-adapter.md`, "Scheduled-heartbeat host"); a scheduler-less host renders the same
+    status, performs one bounded wait, and returns to the reconcile step while non-terminal work remains.
 
 **Review gate — stage 2a** (`references/stage-2-review-gate.md`)
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -607,10 +607,12 @@ resume. This block OWNS when the loop continues; every other site points here, n
      presented as the whole ledger. Never re-type, trim, or re-align it. Then one line per remaining
      wait naming what it waits on (review in flight, CI watch, parked on the user's answer). Render it
      after every ledger write during this heartbeat — the ledger was reconciled this heartbeat, so the table is the
-     state the next reconcile resumes from. State whether the session watchdog is armed or unavailable; on
-     a host without primary inspection, report `primary inspection unavailable; scheduling/replacing as
-     final action` rather than claiming the primary wake is already armed — it is not armed until the
-     turn-ending schedule call ("Primary continuity" above). Never imply dead-session recovery. Then take
+     state the next reconcile resumes from. State whether the session watchdog is armed or unavailable. For
+     the primary wake, report the active host's `primary inspect` result — `runtime-adapter.md`, "Session
+     watchdog nudge", owns that result set and each host's value — never a claim that the primary wake is
+     already armed: nothing arms it before the turn's final action, and the status names that final action
+     as whichever runtime branch below the active host takes ("Primary continuity" above). Never imply
+     dead-session recovery. Then take
      exactly one runtime branch:
      - **Scheduled-heartbeat host:** with the status above already rendered, schedule-or-replace the
        primary wake as the turn's LAST action ("Primary continuity" above) — scheduling ends the turn on

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -489,6 +489,26 @@ the worker returns, and what never moves into it. The steps below are unchanged 
   Step 1 only ROUTES the absent fact here, it does not finalize it itself.
 ### Step 5 — Reschedule or exit
 
+#### Primary continuity
+
+**Every turn with non-terminal work continues the fallback lifecycle — no matter how the turn was
+entered:** a scheduled wake, a session-watchdog wake, a background-task completion, or a manual `--run`
+resume. This block OWNS when the loop continues; every other site points here, never restates it.
+
+- **Scheduled-heartbeat host: schedule-or-replace the primary wake UNCONDITIONALLY, as the turn's last
+  action.** The host has one replaceable pending-wake slot (`runtime-adapter.md`, "Background work and
+  heartbeats"), so the schedule call arms it when empty or replaces whatever occupies it. **NEVER gate
+  that call on remembered or inspected scheduler state** — not on a belief that a wake is "still armed",
+  not on a `primary inspect` result. Inspection is advisory only (`runtime-adapter.md`, "Session watchdog
+  nudge"); it never decides whether this re-arm happens.
+- **Completion-driven turns re-arm too.** A turn entered by a background completion (CI watch, review, or
+  fix) that still finds work remaining schedules-or-replaces exactly like a scheduled wake — the entry
+  path changes nothing.
+- **Scheduler-less host: start the bounded wait instead** (`runtime-adapter.md`, "Scheduler-less host").
+- **Recalculate the delay from current state every turn** — sized by the tiers below and capped at the
+  time `ledger.py watchdog check` says remains (the `watchdog_due` cap below). Never carry a delay
+  forward.
+
 5. **Reschedule or exit.**
    - Any non-terminal PR remains (in review, pending CI, or awaiting a user ruling on a review-finding
      standoff / API approval / precondition) →
@@ -538,11 +558,13 @@ the worker returns, and what never moves into it. The steps below are unchanged 
 
      The first is #112's quiet sensor (the durable `last_activity` stamp); the second is the durable
      long-cadence deadline (`ledger.py watchdog`, `files-and-ledger.md`). The separate session watchdog
-     nudge (`runtime-adapter.md`, "Session watchdog nudge") audits both wakes during run resolution. It
+     nudge (`runtime-adapter.md`, "Session watchdog nudge") may REPORT scheduler state during run
+     resolution, but it never decides whether the final re-arm happens — "Primary continuity" above owns
+     that, and the re-arm is unconditional. It
      does NOT add a deep-health trigger: a watchdog and primary heartbeat can arrive together, and the first
-     health pass re-arms the deadline for the second. Re-arm a missing primary only as this turn's final
-     normal scheduling action; re-ensure a missing watchdog nudge before that action. A bounded-wait host
-     reports that it has no separate nudge.
+     health pass re-arms the deadline for the second. The primary wake is continued per "Primary
+     continuity" (this turn's final scheduling action); re-ensure a missing watchdog nudge before that
+     action. A bounded-wait host reports that it has no separate nudge.
      **When `need_health` — and open PRs remain — this heartbeat runs exactly ONE health pass and then exactly ONE
      `ledger.py --file <state.jsonl> watchdog arm`, and
      completes BOTH before the status render and the turn's final scheduling action** (the last-action rule
@@ -564,8 +586,8 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      ledger table:** every parked question restated with its waiting age, and every stalled-review finding,
      first; then the mandatory table below. **When every open PR is parked, the run is not stalled — it is
      idle BECAUSE it waits on the user**, and the status says so plainly, leading with the unanswered
-     question rather than presenting the idleness as a fault to chase. Then confirm the next heartbeat is
-     armed, exactly as always.
+     question rather than presenting the idleness as a fault to chase. Then continue the loop per "Primary
+     continuity" above (this turn's final scheduling action), exactly as always.
 
      **The honest boundary: the session watchdog checks a live session, not a dead one.** If the primary
      heartbeat is missing while the session remains live, the watchdog nudge fires, audits it, and the final
@@ -573,8 +595,8 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      a **MANUAL RESUME on every host**: the next `--run <id>` finds a stale lease and adoption reports the
      run as **orphaned**, not merely resumed (`run-identity-and-lease.md`, "Adopt only an orphaned run").
 
-     ALWAYS keep a heartbeat or bounded wait active whenever non-terminal work remains — skipping
-     both means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
+     Continue the loop per "Primary continuity" above whenever non-terminal work remains — skipping the
+     re-arm means a hung or orphaned run wakes no one. **Now render the status — this happens on EVERY
      heartbeat that reschedules, never skipped. Its first and mandatory element is the ledger table
      itself** (a health-pass diagnosis, when one fired above, leads *in front of* the table — it never
      replaces or reorders it). Run
@@ -585,12 +607,15 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      presented as the whole ledger. Never re-type, trim, or re-align it. Then one line per remaining
      wait naming what it waits on (review in flight, CI watch, parked on the user's answer). Render it
      after every ledger write during this heartbeat — the ledger was reconciled this heartbeat, so the table is the
-     state the next reconcile resumes from. State whether the session watchdog is armed or unavailable; never
-     imply dead-session recovery. Then take exactly one runtime branch:
-     - **Scheduled-heartbeat host:** with the status above already rendered, schedule the heartbeat as
-       the turn's LAST action — scheduling ends the turn on this host (`runtime-adapter.md`,
-       "Scheduled-heartbeat host"), so nothing runs after it. The scheduled wake begins again at
-       step 1.
+     state the next reconcile resumes from. State whether the session watchdog is armed or unavailable; on
+     a host without primary inspection, report `primary inspection unavailable; scheduling/replacing as
+     final action` rather than claiming the primary wake is already armed — it is not armed until the
+     turn-ending schedule call ("Primary continuity" above). Never imply dead-session recovery. Then take
+     exactly one runtime branch:
+     - **Scheduled-heartbeat host:** with the status above already rendered, schedule-or-replace the
+       primary wake as the turn's LAST action ("Primary continuity" above) — scheduling ends the turn on
+       this host (`runtime-adapter.md`, "Scheduled-heartbeat host"), so nothing runs after it. The
+       scheduled wake begins again at step 1.
      - **Scheduler-less bounded-wait host:** render the same status, wait only until the first task
        completion or the nearest protected deadline, then go directly back to step 1 and reconcile.
        Repeat this status/wait/reconcile cycle while non-terminal work remains. Do **not** execute the

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -154,8 +154,10 @@ the verdict the tool prints.
    the prompt's `--token`, without `--watchdog`) → `refresh`: `owned` → reconcile, continue;
    `superseded` → stand down; refused because the lease is gone → re-arm, then `acquire` (the turn-split
    in "Take a run" applies on a turn-ending scheduler: the `acquire` runs on the wake the re-arm
-   produces). **Session watchdog** (`--run <id> --token <tok> --watchdog`) → first run the runtime
-   adapter's read-only primary and watchdog inspections, then take the same `refresh`: `owned` → run
+   produces). **Session watchdog** (`--run <id> --token <tok> --watchdog`) → run the runtime
+   adapter's capability-aware inspections (`runtime-adapter.md`, "Session watchdog nudge" — `primary
+   inspect` is optional and advisory; where the host exposes no such operation it records `unavailable`
+   or `not-applicable` without inventing a host call), then take the same `refresh`: `owned` → run
    the soundness audit before normal reconciliation (`loop-control.md`, "Reschedule or exit"); any refusal
    or `superseded` → report the inspections and stop. It NEVER calls `acquire`,
    `--allow-takeover`, or adoption: it is a live-session audit, not a recovery path.

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -320,7 +320,10 @@ completion into the same reconcile loop regardless of the host mechanism that re
 
 For the heartbeat fallback, choose exactly one lifecycle:
 
-1. **Scheduled-heartbeat host:** do NOT hand-assemble the wake. Run `scripts/heartbeat.py callback`
+1. **Scheduled-heartbeat host:** **the scheduled operation is arm-or-replace.** The host exposes one
+   replaceable pending-wake slot, so scheduling ARMS it when empty and REPLACES whatever occupies it — no
+   pre-inspection of scheduler state is required or performed (`loop-control.md`, "Primary continuity",
+   owns the unconditional re-arm). Do NOT hand-assemble the wake. Run `scripts/heartbeat.py callback`
    (resolve `scripts/` from the active `SKILL.md`, per **Bundled resources** above) with the host
    invocation, run-id, and token — `heartbeat.py callback --run <run-id> --token <agent-token>
    --invocation <campaign-invocation>` — render the status — the `ledger.py table` output
@@ -419,16 +422,23 @@ On a host with a session-watchdog capability, use these idempotent operations, k
   invocation. The nudge reaches the same session; it never launches an independent driver.
 - `inspect` — report whether the nudge remains armed for this session.
 - `remove` — delete the nudge during normal finalization.
-- `primary inspect` — on a scheduled-heartbeat host, report whether the next primary callback names this
-  run and owner token. A missing callback is repaired by this turn's final normal scheduling action; a
-  bounded-wait host reports that no callback exists to inspect.
+- `primary inspect` — **OPTIONAL and advisory only.** Where a scheduled-heartbeat host exposes it, it
+  reports one of four results, and none of them decides whether the primary re-arm happens
+  (`loop-control.md`, "Primary continuity", owns that — the re-arm is unconditional):
+  - `armed` — inspection confirmed the pending callback matches this run and owner token.
+  - `missing` — inspection was available and confirmed no matching callback.
+  - `unavailable` — the scheduled host exposes no inspection operation. It causes NO attempted host call
+    and NEVER blocks the watchdog audit.
+  - `not-applicable` — the host is using bounded wait and has no primary callback.
+  All four results return to `loop-control.md`'s "Primary continuity"; they inform the status render, not
+  the re-arm decision.
 
 None of these operations ends the turn. The primary heartbeat's final scheduling action still ends it.
 
-| Host | Session watchdog |
-|---|---|
-| Claude Code | Harness cron, scoped to this session. Its entry must deliver the watchdog command into this session, not create a new worker. |
-| Codex | Absent. The bounded-wait loop still honors `watchdog_due`, but has no separate audit wake. |
+| Host | Session watchdog | Primary inspection |
+|---|---|---|
+| Claude Code | Harness cron, scoped to this session. Its entry must deliver the watchdog command into this session, not create a new worker. | Unavailable — the scheduler exposes no inspection operation, so `primary inspect` returns `unavailable`. Its scheduler has one replaceable pending-wake slot; the turn-ending schedule call arms-or-replaces it unconditionally ("Primary continuity"). |
+| Codex | Absent. The bounded-wait loop still honors `watchdog_due`, but has no separate audit wake. | `not-applicable` — the current scheduler-less bounded-wait path has no primary callback. |
 
 An absent capability or failed `ensure` is non-blocking. State the boundary in the run-start and status
 reports: normal heartbeat health checks remain, but no separate session watchdog is armed. Do not claim

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -68,8 +68,13 @@ def check(cond, msg):
 
 def t_heartbeat_always_fires():
     for rows in ([], [row(1, "in_review")], [row(1, "merged")]):
-        check(has(fire(rows), "heartbeat is armed"),
-              "the heartbeat reminder must fire EVERY heartbeat, whatever the ledger holds")
+        lines = fire(rows)
+        pointers = [l for l in lines if "Primary continuity" in l]
+        check(len(pointers) == 1,
+              "exactly one Primary continuity pointer must fire EVERY heartbeat, whatever the ledger holds")
+        check(not has(lines, "check the heartbeat is armed") and not has(lines, "confirm the next heartbeat"),
+              "the reminder must NEVER tell the driver to check or confirm armed state — inspection is "
+              "unavailable on a scheduled host (loop-control.md, Primary continuity)")
 
 
 def t_header_reread_always_fires():
@@ -200,8 +205,6 @@ def t_quiet_run_fires_when_stale():
     check(has(stale, "review-pass.py status --run <rundir> --verify"),
           "the sweep must remind to run the review-pass status check with --verify")
     check(has(stale, "re-derive CI"), "the sweep must remind to re-derive CI for rows that can move")
-    check(has(stale, "confirm the next heartbeat is armed before you sleep"),
-          "the sweep must remind to arm the next heartbeat before sleeping")
     fresh = fire([row(1, "in_review", ci="green")], hdr=header(run_id="g1", last_activity=stamp(_QUIET_MIN - 5)), now=NOW)
     check(not has(fresh, "QUIET"), "a run with recent activity must NOT fire the quiet sweep")
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -73,8 +73,8 @@ def t_heartbeat_always_fires():
         check(len(pointers) == 1,
               "exactly one Primary continuity pointer must fire EVERY heartbeat, whatever the ledger holds")
         check(not has(lines, "check the heartbeat is armed") and not has(lines, "confirm the next heartbeat"),
-              "the reminder must NEVER tell the driver to check or confirm armed state — inspection is "
-              "unavailable on a scheduled host (loop-control.md, Primary continuity)")
+              "the reminder must NEVER tell the driver to check or confirm armed state — the re-arm is "
+              "unconditional, never gated on inspected state (loop-control.md, Primary continuity)")
 
 
 def t_header_reread_always_fires():

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -106,7 +106,7 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
     active = [r for r in rows if r["status"] not in TERMINAL]
 
     # --- always-fire floor -----------------------------------------------------
-    out.append("check the heartbeat is armed.")
+    out.append('follow loop-control.md, "Primary continuity", before yielding.')
     out.append("re-read the ledger header (base_branch, reviewer, required_set, skill_version).")
     if active:
         out.append("check each active PR's labels match its gate state.")
@@ -156,7 +156,6 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
             tail = f": {why}" if why and why != "-" else ""
             out.append(f"PR {r['pr']}: parked — LEAD your next status to the user with this question and how "
                        f"long it has waited (≥ ~{quiet_min}m quiet){tail}.")
-        out.append("confirm the next heartbeat is armed before you sleep.")
 
     # --- per-PR reminders ------------------------------------------------------
     # A HELD PR (parked or repairing) fires ONLY its held reminder. That exclusion is enforced by the


### PR DESCRIPTION
- add loop-control `Primary continuity` owner: every non-terminal turn schedules-or-replaces unconditionally
- define scheduled op as arm-or-replace, make `primary inspect` optional (armed/missing/unavailable/not-applicable)
- point health-pass, watchdog resolution, SKILL step 12, and nudge reminders at the new owner
