### PR TITLE
fix wrapped ci-status doc checks

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1080,6 +1080,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl. Next, run "
                         "echo ledger/state.jsonl.",
     }
+    afterwards_later_commands = {
+        "derive": "Run scripts/ci-status.py derive --pr 1. Afterwards, run echo --ledger "
+                  "<rundir>/state.jsonl.",
+        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1. Afterwards, "
+                    "run echo --machine-action none.",
+        "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl. Afterwards, "
+                        "run echo ledger/state.jsonl.",
+    }
     for subcommand, (check, valid, invalid, detached, later_command, problem_needle) in fixtures.items():
         root = tmp / f"doc-copy-{subcommand}"
         root.mkdir()
@@ -1119,6 +1127,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         )
         (root / "next-introduced-command.md").write_text(
             next_later_commands[subcommand] + "\n", encoding="utf-8"
+        )
+        (root / "afterwards-introduced-command.md").write_text(
+            afterwards_later_commands[subcommand] + "\n", encoding="utf-8"
         )
         boundary_fixtures = {
             "atx-heading.md": (f"{invalid}\n# {detached}\n", 1),
@@ -1190,7 +1201,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        expected_copies = 50 if subcommand == "required-set" else 51
+        expected_copies = 51 if subcommand == "required-set" else 52
         if len(copies) != expected_copies:
             problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected "
                             f"{expected_copies}: {copies!r}")
@@ -1200,13 +1211,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                                   "later-command.md:1",
                                   "inline-introduced-command.md:1",
                                   "next-introduced-command.md:1",
+                                  "afterwards-introduced-command.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items()
                                     if problem_line is not None
                                     and not (subcommand == "required-set"
                                              and name == "bare-later-shell-command.md"))}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        expected_problems = 38 if subcommand == "required-set" else 39
+        expected_problems = 39 if subcommand == "required-set" else 40
         if (len(found_problems) != expected_problems or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
@@ -1236,6 +1248,13 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             problems.append(
                 f"[doc-copy {subcommand}] the Next-introduced command leaked its required input into "
                 f"the prior ci-status invocation: {next_commands!r}"
+            )
+        afterwards_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
+                               if path.name == "afterwards-introduced-command.md"]
+        if len(afterwards_commands) != 1 or inline_later_input in afterwards_commands[0]:
+            problems.append(
+                f"[doc-copy {subcommand}] the Afterwards-introduced command leaked its required input into "
+                f"the prior ci-status invocation: {afterwards_commands!r}"
             )
     return problems
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1028,415 +1028,59 @@ def required_set_matrix_cases(ci, tmp: Path) -> list[str]:
 
 
 def command_copy_cases(ci, tmp: Path) -> list[str]:
-    """Wrapped copies cannot borrow flags from later commands, paragraphs, or Markdown blocks."""
+    """Check the two documented command-copy forms and their own required inputs."""
     problems: list[str] = []
-    fixtures = {
+    forms = {
         "derive": (
             ci.check_derive_copies,
-            "Run `scripts/ci-status.py\n  derive --pr 1 --ledger <rundir>/state.jsonl`.",
-            "Run `scripts/ci-status.py\n  derive --pr 1`.",
-            "`--ledger <rundir>/state.jsonl` is discussed separately.",
-            "Run scripts/ci-status.py derive --pr 1, then echo --ledger ledger/state.jsonl.",
+            "--pr 1 --ledger <rundir>/state.jsonl",
+            "--pr 1",
             "WITHOUT `--ledger` OR `--required-set`",
         ),
         "liveness": (
             ci.check_liveness_copies,
-            "Run `scripts/ci-status.py\n  liveness --ledger <rundir>/state.jsonl --pr 1 "
-            "--machine-action none`.",
-            "Run `scripts/ci-status.py\n  liveness --ledger <rundir>/state.jsonl --pr 1`.",
-            "`--machine-action none` is discussed separately.",
-            "Run scripts/ci-status.py liveness --ledger ledger/state.jsonl --pr 1, then "
-            "echo --machine-action none.",
+            "--ledger <rundir>/state.jsonl --pr 1 --machine-action none",
+            "--ledger <rundir>/state.jsonl --pr 1",
             "WITHOUT `--machine-action`",
         ),
         "required-set": (
             ci.check_required_set_copies,
-            "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/state.jsonl`.",
-            "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/other.jsonl`.",
-            "`state.jsonl` is discussed separately.",
-            "Run scripts/ci-status.py required-set --ledger ledger/other.jsonl, then "
-            "echo ledger/state.jsonl.",
+            "--ledger <rundir>/state.jsonl",
+            "--ledger <rundir>/other.jsonl",
             "without the run ledger's",
         ),
     }
-    bare_later_commands = {
-        "derive": "Run scripts/ci-status.py derive --pr 1\necho --ledger <rundir>/state.jsonl.",
-        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1\n"
-                    "echo --machine-action none.",
-        "required-set": "Run scripts/ci-status.py required-set\necho --ledger <rundir>/state.jsonl.",
-    }
-    prompted_later_commands = {
-        "derive": "Run scripts/ci-status.py derive --pr 1\n$ echo --ledger <rundir>/state.jsonl.",
-        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1\n"
-                    "$ echo --machine-action none.",
-    }
-    derive_json_path_commands = {
-        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1 "
-                    "--derive-json result.py --machine-action none.",
-    }
-    inline_later_commands = {
-        "derive": "Run scripts/ci-status.py derive --pr 1, then `echo --ledger <rundir>/state.jsonl`.",
-        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1, then "
-                    "`echo --machine-action none`.",
-        "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl, then "
-                        "`echo ledger/state.jsonl`.",
-    }
-    next_later_commands = {
-        "derive": "Run scripts/ci-status.py derive --pr 1. Next, run echo --ledger "
-                  "<rundir>/state.jsonl.",
-        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1. Next, run "
-                    "echo --machine-action none.",
-        "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl. Next, run "
-                        "echo ledger/state.jsonl.",
-    }
-    afterwards_later_commands = {
-        "derive": "Run scripts/ci-status.py derive --pr 1. Afterwards, run echo --ledger "
-                  "<rundir>/state.jsonl.",
-        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1. Afterwards, "
-                    "run echo --machine-action none.",
-        "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl. Afterwards, "
-                        "run echo ledger/state.jsonl.",
-    }
-    for subcommand, (check, valid, invalid, detached, later_command, problem_needle) in fixtures.items():
-        root = tmp / f"doc-copy-{subcommand}"
+    for subcommand, (check, valid, invalid, needle) in forms.items():
+        root = tmp / f"command-copy-{subcommand}"
         root.mkdir()
-        shell_valid = valid.replace("ci-status.py\n", "ci-status.py \\\n")
-        shell_invalid = invalid.replace("ci-status.py\n", "ci-status.py \\\n")
-        quoted = lambda command: "\n".join(f"> {line}" for line in command.splitlines())
-        quoted_valid = quoted(valid)
-        quoted_invalid = quoted(invalid)
-        quoted_shell_valid = quoted(shell_valid)
-        quoted_shell_invalid = quoted(shell_invalid)
-        quoted_detached = quoted(detached)
-        inline_invalid = invalid.replace("`", "").replace("\n  ", " ")
-        inline_valid = valid.replace("`", "").replace("\n  ", " ")
-        ordered_invalid = invalid.replace("\n", "\n   ")
-        nested_unordered_invalid = invalid.replace("\n", "\n      ")
-        nested_ordered_invalid = invalid.replace("\n", "\n       ")
-        mixed_space_tab_invalid = invalid.replace("\n", "\n \t")
-        nested_item = "- Parent item\n    - "
-        nested_indent = "      "
-        (root / "wrapped.md").write_text(
-            f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n\n"
-            f"{quoted_valid}\n>\n{quoted_invalid}\n>\n{quoted_detached}\n>\n"
-            f"{quoted_shell_valid}\n>\n{quoted_shell_invalid}\n>\n{quoted_detached}\n",
+        shell_wrap = chr(92) + "\n"
+        fenced_valid = valid.replace(" ", f" {shell_wrap}  ", 1)
+        fenced_invalid = invalid.replace(" ", f" {shell_wrap}  ", 1)
+        (root / "commands.md").write_text(
+            f"Prose mentions ci-status.py {subcommand} {valid}; it is not a command copy.\n\n"
+            f"`scripts/ci-status.py\n  {subcommand} {valid}`\n\n"
+            f"```sh\npython3 <skill>/scripts/ci-status.py {subcommand} {fenced_valid}\n```\n\n"
+            f"`scripts/ci-status.py\n  {subcommand} {invalid}`\n\n"
+            f"```sh\npython3 <skill>/scripts/ci-status.py {subcommand} {fenced_invalid}\n```\n",
             encoding="utf-8",
         )
-        (root / "quote-transition.md").write_text(
-            f"{invalid}\n{quoted_detached}\n",
-            encoding="utf-8",
-        )
-        (root / "same-paragraph.md").write_text(
-            f"{inline_invalid} Then run {inline_valid}; run {inline_valid}\n",
-            encoding="utf-8",
-        )
-        (root / "later-command.md").write_text(later_command + "\n", encoding="utf-8")
-        if subcommand in prompted_later_commands:
-            (root / "prompted-later-shell-command.md").write_text(
-                prompted_later_commands[subcommand] + "\n", encoding="utf-8"
-            )
-        if subcommand in derive_json_path_commands:
-            (root / "derive-json-path.md").write_text(
-                derive_json_path_commands[subcommand] + "\n", encoding="utf-8"
-            )
-        (root / "inline-introduced-command.md").write_text(
-            inline_later_commands[subcommand] + "\n", encoding="utf-8"
-        )
-        (root / "next-introduced-command.md").write_text(
-            next_later_commands[subcommand] + "\n", encoding="utf-8"
-        )
-        (root / "afterwards-introduced-command.md").write_text(
-            afterwards_later_commands[subcommand] + "\n", encoding="utf-8"
-        )
-        boundary_fixtures = {
-            "atx-heading.md": (f"{invalid}\n# {detached}\n", 1),
-            "unordered-list.md": (f"{invalid}\n- {detached}\n", 1),
-            "fenced-block.md": (f"{invalid}\n```\n{detached}\n```\n", 1),
-            "thematic-break.md": (f"{invalid}\n* * *\n{detached}\n", 1),
-            "html-block.md": (f"{invalid}\n<div>\n{detached}\n</div>\n", 1),
-            "html-script.md": (f"{invalid}\n<script>\n{detached}\n</script>\n", 1),
-            "html-comment.md": (f"{invalid}\n<!--\n{detached}\n-->\n", 1),
-            "html-processing.md": (f"{invalid}\n<?fixture\n{detached}\n?>\n", 1),
-            "html-declaration.md": (f"{invalid}\n<!FIXTURE>\n{detached}\n", 1),
-            "html-cdata.md": (f"{invalid}\n<![CDATA[\n{detached}\n]]>\n", 1),
-            "html-block-valid.md": (f"{valid}\n<div>\n{detached}\n</div>\n", None),
-            "setext-heading.md": (f"{invalid}\n===\n{detached}\n", 1),
-            "atx-heading-reverse.md": (f"# {inline_invalid}\n{detached}\n", 1),
-            "fenced-block-reverse.md": (f"```\n{inline_invalid}\n```\n{detached}\n", 2),
-            "html-block-reverse.md": (f"<script>\n{inline_invalid}\n</script>\n{detached}\n", 2),
-            "indented-code.md": (f"    {inline_invalid}\n{detached}\n", 1),
-            "quoted-fenced-exit.md": (f"> ```sh\n{quoted_invalid}\n{detached}\n", 2),
-            "quoted-html-exit.md": (f"> <script>\n{quoted_invalid}\n{detached}\n", 2),
-            "ordered-non-one-paragraph.md": (f"{invalid}\n2. {detached}\n", None),
-            "ordered-siblings.md": (f"1. {ordered_invalid}\n2. {detached}\n", 1),
-            "nested-unordered-siblings.md": (
-                f"- Parent item\n    - {nested_unordered_invalid}\n    - {detached}\n", 2
-            ),
-            "nested-ordered-siblings.md": (
-                f"1. Parent item\n    1. {nested_ordered_invalid}\n    2. {detached}\n", 2
-            ),
-            "nested-atx-heading.md": (
-                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}# {detached}\n", 2
-            ),
-            "nested-fenced-block.md": (
-                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}```\n"
-                f"{nested_indent}{detached}\n{nested_indent}```\n", 2
-            ),
-            "nested-thematic-break.md": (
-                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}* * *\n"
-                f"{nested_indent}{detached}\n", 2
-            ),
-            "nested-html-block.md": (
-                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}<div>\n"
-                f"{nested_indent}{detached}\n{nested_indent}</div>\n", 2
-            ),
-            "nested-setext-heading.md": (
-                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}===\n"
-                f"{nested_indent}{detached}\n", 2
-            ),
-            "nested-blockquote.md": (
-                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}> {detached}\n", 2
-            ),
-            "nested-indented-code.md": (
-                f"{nested_item}Item intro\n\n{nested_indent}    {inline_invalid}\n"
-                f"{nested_indent}{detached}\n", 4
-            ),
-            "list-heading-indented-code.md": (
-                f"- Earlier item\n# Heading\n    {inline_invalid}\n{detached}\n", 3
-            ),
-            "bare-later-shell-command.md": (bare_later_commands[subcommand] + "\n", 1),
-            "stale-ordered-list.md": (f"1. Earlier item\n\n{invalid}\n2. {detached}\n", None),
-            "malformed-fence.md": (f"{invalid}\n```bad`info\n{detached}\n", None),
-            "malformed-html-close.md": (
-                f"<script>\n{invalid}\n</script   >\n{detached}\n</script>\n", None
-            ),
-            "blank-indented-code.md": (f"    {inline_invalid}\n\n    {detached}\n", None),
-            "mixed-space-tab-code.md": (
-                f" \t{mixed_space_tab_invalid}\n{detached}\n", 1
-            ),
-        }
-        for name, (text, _problem_line) in boundary_fixtures.items():
-            (root / name).write_text(text, encoding="utf-8")
-        found_problems, copies = check(root)
-        expected_copies = (51 if subcommand == "required-set" else 52) + (
-            1 if subcommand in prompted_later_commands else 0
-        ) + (1 if subcommand in derive_json_path_commands else 0)
-        if len(copies) != expected_copies:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected "
-                            f"{expected_copies}: {copies!r}")
-        expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
-                                  "quote-transition.md:1",
-                                  "same-paragraph.md:1",
-                                  "later-command.md:1",
-                                  "inline-introduced-command.md:1",
-                                  "next-introduced-command.md:1",
-                                  "afterwards-introduced-command.md:1",
-                                  *(f"{name}:{problem_line}" for name, (_text, problem_line)
-                                    in boundary_fixtures.items()
-                                    if problem_line is not None
-                                    and not (subcommand == "required-set"
-                                             and name == "bare-later-shell-command.md")),
-                                  *({"prompted-later-shell-command.md:1"}
-                                    if subcommand in prompted_later_commands else set())}
-        problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        expected_problems = (39 if subcommand == "required-set" else 40) + (
-            1 if subcommand in prompted_later_commands else 0
-        )
-        if (len(found_problems) != expected_problems or problem_sites != expected_problem_sites
-                or any(problem_needle not in problem for problem in found_problems)):
+        copies = ci.documented_ci_status_copies(root, subcommand)
+        found_problems, checked = check(root)
+        if len(copies) != 4 or len(checked) != 4:
             problems.append(
-                f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "
-                f"rejected by their own missing flag: "
+                f"[command copy {subcommand}] expected four documented copies, got "
+                f"{len(copies)} extracted and {len(checked)} checked"
+            )
+        if len(found_problems) != 2 or any(needle not in problem for problem in found_problems):
+            problems.append(
+                f"[command copy {subcommand}] wrapped copies did not reject only their own missing input: "
                 f"{found_problems!r}"
             )
-        bare_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
-                         if path.name == "bare-later-shell-command.md"]
-        later_flag = "--machine-action" if subcommand == "liveness" else "--ledger"
-        if len(bare_commands) != 1 or later_flag in bare_commands[0]:
-            problems.append(
-                f"[doc-copy {subcommand}] the bare later shell command leaked its flag into the prior "
-                f"ci-status invocation: {bare_commands!r}"
-            )
-        if subcommand in prompted_later_commands:
-            prompted_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
-                                 if path.name == "prompted-later-shell-command.md"]
-            if len(prompted_commands) != 1 or later_flag in prompted_commands[0]:
-                problems.append(
-                    f"[doc-copy {subcommand}] the prompted later shell command leaked its flag into the "
-                    f"prior ci-status invocation: {prompted_commands!r}"
-                )
-        if subcommand in derive_json_path_commands:
-            derive_json_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
-                                    if path.name == "derive-json-path.md"]
-            if (len(derive_json_commands) != 1
-                    or "result.py --machine-action none" not in derive_json_commands[0]):
-                problems.append(
-                    f"[doc-copy {subcommand}] a --derive-json .py value cut off later arguments: "
-                    f"{derive_json_commands!r}"
-                )
-        inline_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
-                           if path.name == "inline-introduced-command.md"]
-        inline_later_input = "state.jsonl" if subcommand == "required-set" else later_flag
-        if len(inline_commands) != 1 or inline_later_input in inline_commands[0]:
-            problems.append(
-                f"[doc-copy {subcommand}] the inline introduced command leaked its required input into "
-                f"the prior ci-status invocation: {inline_commands!r}"
-            )
-        next_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
-                         if path.name == "next-introduced-command.md"]
-        if len(next_commands) != 1 or inline_later_input in next_commands[0]:
-            problems.append(
-                f"[doc-copy {subcommand}] the Next-introduced command leaked its required input into "
-                f"the prior ci-status invocation: {next_commands!r}"
-            )
-        afterwards_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
-                               if path.name == "afterwards-introduced-command.md"]
-        if len(afterwards_commands) != 1 or inline_later_input in afterwards_commands[0]:
-            problems.append(
-                f"[doc-copy {subcommand}] the Afterwards-introduced command leaked its required input into "
-                f"the prior ci-status invocation: {afterwards_commands!r}"
-            )
-    return problems
-
-
-def command_span_root_cause_cases(ci, tmp: Path) -> list[str]:
-    """Pin every mapped command-boundary gap and its literal-code controls."""
-    problems: list[str] = []
-
-    def case(name: str, subcommand: str, check, text: str, expect_problem: bool,
-             contains: tuple[str, ...], excludes: tuple[str, ...] = ()) -> None:
-        root = tmp / f"command-span-{name}"
-        root.mkdir()
-        (root / "fixture.md").write_text(text, encoding="utf-8")
-        found_problems, copies = check(root)
-        commands = [command for _path, _line, command in ci.find_ci_status_copies(root, subcommand)]
-        if len(commands) != 1:
-            problems.append(f"[command span {name}] found {len(commands)} copies: {commands!r}")
-            return
-        command = commands[0]
-        if bool(found_problems) != expect_problem:
-            problems.append(
-                f"[command span {name}] problems {found_problems!r}, expected "
-                f"{'one' if expect_problem else 'none'}"
-            )
-        if len(copies) != 1:
-            problems.append(f"[command span {name}] runnable copies {copies!r}, expected one")
-        missing = tuple(value for value in contains if value not in command)
-        present = tuple(value for value in excludes if value in command)
-        if missing or present:
-            problems.append(
-                f"[command span {name}] command {command!r}, missing {missing!r}, included {present!r}"
-            )
-
-    # Each option value remains attached to the preceding command across a prose reflow. The liveness
-    # script path is separate because a value ending in .py used to be mistaken for a later command.
-    case(
-        "wrapped-value-derive", "derive", ci.check_derive_copies,
-        "Run scripts/ci-status.py derive --ledger\n<rundir>/state.jsonl --pr 1.\n",
-        False, ("<rundir>/state.jsonl --pr 1",),
-    )
-    case(
-        "wrapped-value-liveness-plain", "liveness", ci.check_liveness_copies,
-        "Run scripts/ci-status.py liveness --ledger\n"
-        "<rundir>/state.jsonl --pr 1 --machine-action none.\n",
-        False, ("<rundir>/state.jsonl --pr 1 --machine-action none",),
-    )
-    case(
-        "wrapped-value-liveness-script", "liveness", ci.check_liveness_copies,
-        "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1 --derive-json\n"
-        "result.py --machine-action none.\n",
-        False, ("result.py --machine-action none",),
-    )
-    case(
-        "wrapped-value-required-set", "required-set", ci.check_required_set_copies,
-        "Run scripts/ci-status.py required-set --ledger\n<rundir>/state.jsonl --repo owner/repo.\n",
-        False, ("<rundir>/state.jsonl --repo owner/repo",),
-    )
-
-    # A generic later command may carry only an operand, with or without a shell prompt. It must not lend
-    # state.jsonl to an earlier required-set command that names another ledger.
-    case(
-        "operand-bare-required-set", "required-set", ci.check_required_set_copies,
-        "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
-        "echo <rundir>/state.jsonl.\n",
-        True, ("other.jsonl",), ("echo", "state.jsonl"),
-    )
-    case(
-        "operand-prompt-required-set", "required-set", ci.check_required_set_copies,
-        "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
-        "$ echo <rundir>/state.jsonl.\n",
-        True, ("other.jsonl",), ("echo", "state.jsonl"),
-    )
-
-    # Quote prefixes, fences, and raw HTML change the physical line but not a runnable later command.
-    case(
-        "quoted-bare-derive", "derive", ci.check_derive_copies,
-        "> Run scripts/ci-status.py derive --pr 1\n"
-        "> echo --ledger <rundir>/state.jsonl.\n",
-        True, ("--pr 1",), ("echo", "--ledger"),
-    )
-    case(
-        "quoted-bare-liveness", "liveness", ci.check_liveness_copies,
-        "> Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1\n"
-        "> echo --machine-action none.\n",
-        True, ("--pr 1",), ("echo", "--machine-action"),
-    )
-    case(
-        "quoted-bare-required-set", "required-set", ci.check_required_set_copies,
-        "> Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
-        "> echo <rundir>/state.jsonl.\n",
-        True, ("other.jsonl",), ("echo", "state.jsonl"),
-    )
-    case(
-        "fenced-bare-required-set", "required-set", ci.check_required_set_copies,
-        "```sh\nRun scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
-        "echo <rundir>/state.jsonl.\n```\n",
-        True, ("other.jsonl",), ("echo", "state.jsonl"),
-    )
-    case(
-        "raw-html-bare-required-set", "required-set", ci.check_required_set_copies,
-        "<script>\nRun scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
-        "echo <rundir>/state.jsonl.\n</script>\n",
-        True, ("other.jsonl",), ("echo", "state.jsonl"),
-    )
-
-    # A newline inside an inline literal is not a shell boundary. A prose-introduced later inline command
-    # is one. These paired controls keep the generic line rule from changing either established behavior.
-    case(
-        "literal-operand-derive", "derive", ci.check_derive_copies,
-        "Run `scripts/ci-status.py derive --pr 1 --ledger <rundir>/state.jsonl\n"
-        "echo literal-operand`.\n",
-        False, ("echo literal-operand",),
-    )
-    case(
-        "literal-operand-liveness", "liveness", ci.check_liveness_copies,
-        "Run `scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1 "
-        "--machine-action none\necho literal-operand`.\n",
-        False, ("echo literal-operand",),
-    )
-    case(
-        "literal-operand-required-set", "required-set", ci.check_required_set_copies,
-        "Run `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl\n"
-        "echo literal-operand`.\n",
-        False, ("echo literal-operand",),
-    )
-    case(
-        "literal-introduced-derive", "derive", ci.check_derive_copies,
-        "Run scripts/ci-status.py derive --pr 1, then `echo --ledger <rundir>/state.jsonl`.\n",
-        True, ("--pr 1",), ("echo", "--ledger"),
-    )
-    case(
-        "literal-introduced-liveness", "liveness", ci.check_liveness_copies,
-        "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1, then "
-        "`echo --machine-action none`.\n",
-        True, ("--pr 1",), ("echo", "--machine-action"),
-    )
-    case(
-        "literal-introduced-required-set", "required-set", ci.check_required_set_copies,
-        "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl, then "
-        "`echo <rundir>/state.jsonl`.\n",
-        True, ("other.jsonl",), ("echo", "state.jsonl"),
-    )
+        if not any("\n" in command for _path, _line, command in copies):
+            problems.append(f"[command copy {subcommand}] inline wrapped command was not preserved")
+        if not any(valid in " ".join(command.split()) and "\n" not in command
+                   for _path, _line, command in copies):
+            problems.append(f"[command copy {subcommand}] fenced shell continuation was not joined")
     return problems
 
 
@@ -1748,16 +1392,8 @@ def run(ci, tmp: Path) -> int:
         failures += 1
         print(f"FAIL     {problem}")
     if not command_problems:
-        print(f"ok       {'wrapped doc command copies':32} -> derive, liveness, and required-set; valid and "
-              f"invalid plain, blockquoted, and interrupting-block fixtures stay paragraph-bounded")
-
-    command_span_problems = command_span_root_cause_cases(ci, tmp)
-    for problem in command_span_problems:
-        failures += 1
-        print(f"FAIL     {problem}")
-    if not command_span_problems:
-        print(f"ok       {'command span root-cause map':32} -> wrapped option values, bare operand commands, "
-              f"quote, fence, HTML, and inline-literal boundaries")
+        print(f"ok       {'wrapped doc command copies':32} -> inline literals and fenced shell commands; "
+              f"each valid copy keeps its inputs and each invalid copy fails on its own missing input")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1299,6 +1299,147 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
+def command_span_root_cause_cases(ci, tmp: Path) -> list[str]:
+    """Pin every mapped command-boundary gap and its literal-code controls."""
+    problems: list[str] = []
+
+    def case(name: str, subcommand: str, check, text: str, expect_problem: bool,
+             contains: tuple[str, ...], excludes: tuple[str, ...] = ()) -> None:
+        root = tmp / f"command-span-{name}"
+        root.mkdir()
+        (root / "fixture.md").write_text(text, encoding="utf-8")
+        found_problems, copies = check(root)
+        commands = [command for _path, _line, command in ci.find_ci_status_copies(root, subcommand)]
+        if len(commands) != 1:
+            problems.append(f"[command span {name}] found {len(commands)} copies: {commands!r}")
+            return
+        command = commands[0]
+        if bool(found_problems) != expect_problem:
+            problems.append(
+                f"[command span {name}] problems {found_problems!r}, expected "
+                f"{'one' if expect_problem else 'none'}"
+            )
+        if len(copies) != 1:
+            problems.append(f"[command span {name}] runnable copies {copies!r}, expected one")
+        missing = tuple(value for value in contains if value not in command)
+        present = tuple(value for value in excludes if value in command)
+        if missing or present:
+            problems.append(
+                f"[command span {name}] command {command!r}, missing {missing!r}, included {present!r}"
+            )
+
+    # Each option value remains attached to the preceding command across a prose reflow. The liveness
+    # script path is separate because a value ending in .py used to be mistaken for a later command.
+    case(
+        "wrapped-value-derive", "derive", ci.check_derive_copies,
+        "Run scripts/ci-status.py derive --ledger\n<rundir>/state.jsonl --pr 1.\n",
+        False, ("<rundir>/state.jsonl --pr 1",),
+    )
+    case(
+        "wrapped-value-liveness-plain", "liveness", ci.check_liveness_copies,
+        "Run scripts/ci-status.py liveness --ledger\n"
+        "<rundir>/state.jsonl --pr 1 --machine-action none.\n",
+        False, ("<rundir>/state.jsonl --pr 1 --machine-action none",),
+    )
+    case(
+        "wrapped-value-liveness-script", "liveness", ci.check_liveness_copies,
+        "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1 --derive-json\n"
+        "result.py --machine-action none.\n",
+        False, ("result.py --machine-action none",),
+    )
+    case(
+        "wrapped-value-required-set", "required-set", ci.check_required_set_copies,
+        "Run scripts/ci-status.py required-set --ledger\n<rundir>/state.jsonl --repo owner/repo.\n",
+        False, ("<rundir>/state.jsonl --repo owner/repo",),
+    )
+
+    # A generic later command may carry only an operand, with or without a shell prompt. It must not lend
+    # state.jsonl to an earlier required-set command that names another ledger.
+    case(
+        "operand-bare-required-set", "required-set", ci.check_required_set_copies,
+        "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
+        "echo <rundir>/state.jsonl.\n",
+        True, ("other.jsonl",), ("echo", "state.jsonl"),
+    )
+    case(
+        "operand-prompt-required-set", "required-set", ci.check_required_set_copies,
+        "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
+        "$ echo <rundir>/state.jsonl.\n",
+        True, ("other.jsonl",), ("echo", "state.jsonl"),
+    )
+
+    # Quote prefixes, fences, and raw HTML change the physical line but not a runnable later command.
+    case(
+        "quoted-bare-derive", "derive", ci.check_derive_copies,
+        "> Run scripts/ci-status.py derive --pr 1\n"
+        "> echo --ledger <rundir>/state.jsonl.\n",
+        True, ("--pr 1",), ("echo", "--ledger"),
+    )
+    case(
+        "quoted-bare-liveness", "liveness", ci.check_liveness_copies,
+        "> Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1\n"
+        "> echo --machine-action none.\n",
+        True, ("--pr 1",), ("echo", "--machine-action"),
+    )
+    case(
+        "quoted-bare-required-set", "required-set", ci.check_required_set_copies,
+        "> Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
+        "> echo <rundir>/state.jsonl.\n",
+        True, ("other.jsonl",), ("echo", "state.jsonl"),
+    )
+    case(
+        "fenced-bare-required-set", "required-set", ci.check_required_set_copies,
+        "```sh\nRun scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
+        "echo <rundir>/state.jsonl.\n```\n",
+        True, ("other.jsonl",), ("echo", "state.jsonl"),
+    )
+    case(
+        "raw-html-bare-required-set", "required-set", ci.check_required_set_copies,
+        "<script>\nRun scripts/ci-status.py required-set --ledger <rundir>/other.jsonl\n"
+        "echo <rundir>/state.jsonl.\n</script>\n",
+        True, ("other.jsonl",), ("echo", "state.jsonl"),
+    )
+
+    # A newline inside an inline literal is not a shell boundary. A prose-introduced later inline command
+    # is one. These paired controls keep the generic line rule from changing either established behavior.
+    case(
+        "literal-operand-derive", "derive", ci.check_derive_copies,
+        "Run `scripts/ci-status.py derive --pr 1 --ledger <rundir>/state.jsonl\n"
+        "echo literal-operand`.\n",
+        False, ("echo literal-operand",),
+    )
+    case(
+        "literal-operand-liveness", "liveness", ci.check_liveness_copies,
+        "Run `scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1 "
+        "--machine-action none\necho literal-operand`.\n",
+        False, ("echo literal-operand",),
+    )
+    case(
+        "literal-operand-required-set", "required-set", ci.check_required_set_copies,
+        "Run `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl\n"
+        "echo literal-operand`.\n",
+        False, ("echo literal-operand",),
+    )
+    case(
+        "literal-introduced-derive", "derive", ci.check_derive_copies,
+        "Run scripts/ci-status.py derive --pr 1, then `echo --ledger <rundir>/state.jsonl`.\n",
+        True, ("--pr 1",), ("echo", "--ledger"),
+    )
+    case(
+        "literal-introduced-liveness", "liveness", ci.check_liveness_copies,
+        "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1, then "
+        "`echo --machine-action none`.\n",
+        True, ("--pr 1",), ("echo", "--machine-action"),
+    )
+    case(
+        "literal-introduced-required-set", "required-set", ci.check_required_set_copies,
+        "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl, then "
+        "`echo <rundir>/state.jsonl`.\n",
+        True, ("other.jsonl",), ("echo", "state.jsonl"),
+    )
+    return problems
+
+
 def liveness_cases(ci, tmp: Path) -> list[str]:
     """Drive `liveness` through every transition the derivation block defines, on a real ledger file.
 
@@ -1609,6 +1750,14 @@ def run(ci, tmp: Path) -> int:
     if not command_problems:
         print(f"ok       {'wrapped doc command copies':32} -> derive, liveness, and required-set; valid and "
               f"invalid plain, blockquoted, and interrupting-block fixtures stay paragraph-bounded")
+
+    command_span_problems = command_span_root_cause_cases(ci, tmp)
+    for problem in command_span_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not command_span_problems:
+        print(f"ok       {'command span root-cause map':32} -> wrapped option values, bare operand commands, "
+              f"quote, fence, HTML, and inline-literal boundaries")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1028,7 +1028,7 @@ def required_set_matrix_cases(ci, tmp: Path) -> list[str]:
 
 
 def command_copy_cases(ci, tmp: Path) -> list[str]:
-    """Wrapped valid and invalid command copies are both found, without borrowing a later paragraph's flag."""
+    """Plain and blockquoted wrapped copies are found without borrowing a later paragraph's flag."""
     problems: list[str] = []
     fixtures = {
         "derive": (
@@ -1059,17 +1059,25 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         root.mkdir()
         shell_valid = valid.replace("ci-status.py\n", "ci-status.py \\\n")
         shell_invalid = invalid.replace("ci-status.py\n", "ci-status.py \\\n")
+        quoted = lambda command: "\n".join(f"> {line}" for line in command.splitlines())
+        quoted_valid = quoted(valid)
+        quoted_invalid = quoted(invalid)
+        quoted_shell_valid = quoted(shell_valid)
+        quoted_shell_invalid = quoted(shell_invalid)
+        quoted_detached = quoted(detached)
         (root / "wrapped.md").write_text(
-            f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n",
+            f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n\n"
+            f"{quoted_valid}\n>\n{quoted_invalid}\n>\n{quoted_detached}\n>\n"
+            f"{quoted_shell_valid}\n>\n{quoted_shell_invalid}\n>\n{quoted_detached}\n",
             encoding="utf-8",
         )
         found_problems, copies = check(root)
-        if len(copies) != 4:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 4: {copies!r}")
-        if len(found_problems) != 2 or any(problem_needle not in problem for problem in found_problems):
+        if len(copies) != 8:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 8: {copies!r}")
+        if len(found_problems) != 4 or any(problem_needle not in problem for problem in found_problems):
             problems.append(
-                f"[doc-copy {subcommand}] invalid plain and shell-wrapped copies were not rejected by "
-                f"their own missing flag: "
+                f"[doc-copy {subcommand}] invalid plain and blockquoted copies were not rejected by their "
+                f"own missing flag: "
                 f"{found_problems!r}"
             )
     return problems
@@ -1384,7 +1392,7 @@ def run(ci, tmp: Path) -> int:
         print(f"FAIL     {problem}")
     if not command_problems:
         print(f"ok       {'wrapped doc command copies':32} -> derive, liveness, and required-set; valid and "
-              f"invalid fixtures stay paragraph-bounded")
+              f"invalid plain and blockquoted fixtures stay paragraph-bounded")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1027,6 +1027,51 @@ def required_set_matrix_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
+def command_copy_cases(ci, tmp: Path) -> list[str]:
+    """Wrapped valid and invalid command copies are both found, without borrowing a later paragraph's flag."""
+    problems: list[str] = []
+    fixtures = {
+        "derive": (
+            ci.check_derive_copies,
+            "Run `scripts/ci-status.py\n  derive --pr 1 --ledger <rundir>/state.jsonl`.",
+            "Run `scripts/ci-status.py\n  derive --pr 1`.",
+            "`--ledger <rundir>/state.jsonl` is discussed separately.",
+            "WITHOUT `--ledger` OR `--required-set`",
+        ),
+        "liveness": (
+            ci.check_liveness_copies,
+            "Run `scripts/ci-status.py\n  liveness --ledger <rundir>/state.jsonl --pr 1 "
+            "--machine-action none`.",
+            "Run `scripts/ci-status.py\n  liveness --ledger <rundir>/state.jsonl --pr 1`.",
+            "`--machine-action none` is discussed separately.",
+            "WITHOUT `--machine-action`",
+        ),
+        "required-set": (
+            ci.check_required_set_copies,
+            "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/state.jsonl`.",
+            "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/other.jsonl`.",
+            "`state.jsonl` is discussed separately.",
+            "without the run ledger's",
+        ),
+    }
+    for subcommand, (check, valid, invalid, detached, problem_needle) in fixtures.items():
+        root = tmp / f"doc-copy-{subcommand}"
+        root.mkdir()
+        (root / "wrapped.md").write_text(
+            f"{valid}\n\n{invalid}\n\n{detached}\n",
+            encoding="utf-8",
+        )
+        found_problems, copies = check(root)
+        if len(copies) != 2:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 2: {copies!r}")
+        if len(found_problems) != 1 or problem_needle not in found_problems[0]:
+            problems.append(
+                f"[doc-copy {subcommand}] invalid wrapped copy was not rejected by its own missing flag: "
+                f"{found_problems!r}"
+            )
+    return problems
+
+
 def liveness_cases(ci, tmp: Path) -> list[str]:
     """Drive `liveness` through every transition the derivation block defines, on a real ledger file.
 
@@ -1329,6 +1374,14 @@ def run(ci, tmp: Path) -> int:
         print(f"ok       {'required-set CLI exits':32} -> settled=0, unknown=1, "
               f"caller/store/output errors=2; "
               f"errors preserve the ledger and emit one diagnostic without a traceback")
+
+    command_problems = command_copy_cases(ci, tmp)
+    for problem in command_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not command_problems:
+        print(f"ok       {'wrapped doc command copies':32} -> derive, liveness, and required-set; valid and "
+              f"invalid fixtures stay paragraph-bounded")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1028,7 +1028,7 @@ def required_set_matrix_cases(ci, tmp: Path) -> list[str]:
 
 
 def command_copy_cases(ci, tmp: Path) -> list[str]:
-    """Plain and blockquoted wrapped copies are found without borrowing a later paragraph's flag."""
+    """Wrapped copies cannot borrow flags from later paragraphs or interrupting Markdown blocks."""
     problems: list[str] = []
     fixtures = {
         "derive": (
@@ -1075,13 +1075,26 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             f"{invalid}\n{quoted_detached}\n",
             encoding="utf-8",
         )
+        boundary_fixtures = {
+            "atx-heading.md": f"{invalid}\n# {detached}\n",
+            "unordered-list.md": f"{invalid}\n- {detached}\n",
+            "fenced-block.md": f"{invalid}\n```\n{detached}\n```\n",
+            "thematic-break.md": f"{invalid}\n* * *\n{detached}\n",
+        }
+        for name, text in boundary_fixtures.items():
+            (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 9:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 9: {copies!r}")
-        if len(found_problems) != 5 or any(problem_needle not in problem for problem in found_problems):
+        if len(copies) != 13:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 13: {copies!r}")
+        expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
+                                  "quote-transition.md:1",
+                                  *(f"{name}:1" for name in boundary_fixtures)}
+        problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
+        if (len(found_problems) != 9 or problem_sites != expected_problem_sites
+                or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
-                f"[doc-copy {subcommand}] invalid plain and blockquoted copies were not rejected by their "
-                f"own missing flag: "
+                f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "
+                f"rejected by their own missing flag: "
                 f"{found_problems!r}"
             )
     return problems
@@ -1396,7 +1409,7 @@ def run(ci, tmp: Path) -> int:
         print(f"FAIL     {problem}")
     if not command_problems:
         print(f"ok       {'wrapped doc command copies':32} -> derive, liveness, and required-set; valid and "
-              f"invalid plain and blockquoted fixtures stay paragraph-bounded")
+              f"invalid plain, blockquoted, and interrupting-block fixtures stay paragraph-bounded")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1065,6 +1065,15 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                     "echo --machine-action none.",
         "required-set": "Run scripts/ci-status.py required-set\necho --ledger <rundir>/state.jsonl.",
     }
+    prompted_later_commands = {
+        "derive": "Run scripts/ci-status.py derive --pr 1\n$ echo --ledger <rundir>/state.jsonl.",
+        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1\n"
+                    "$ echo --machine-action none.",
+    }
+    derive_json_path_commands = {
+        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1 "
+                    "--derive-json result.py --machine-action none.",
+    }
     inline_later_commands = {
         "derive": "Run scripts/ci-status.py derive --pr 1, then `echo --ledger <rundir>/state.jsonl`.",
         "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1, then "
@@ -1122,6 +1131,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             encoding="utf-8",
         )
         (root / "later-command.md").write_text(later_command + "\n", encoding="utf-8")
+        if subcommand in prompted_later_commands:
+            (root / "prompted-later-shell-command.md").write_text(
+                prompted_later_commands[subcommand] + "\n", encoding="utf-8"
+            )
+        if subcommand in derive_json_path_commands:
+            (root / "derive-json-path.md").write_text(
+                derive_json_path_commands[subcommand] + "\n", encoding="utf-8"
+            )
         (root / "inline-introduced-command.md").write_text(
             inline_later_commands[subcommand] + "\n", encoding="utf-8"
         )
@@ -1201,7 +1218,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        expected_copies = 51 if subcommand == "required-set" else 52
+        expected_copies = (51 if subcommand == "required-set" else 52) + (
+            1 if subcommand in prompted_later_commands else 0
+        ) + (1 if subcommand in derive_json_path_commands else 0)
         if len(copies) != expected_copies:
             problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected "
                             f"{expected_copies}: {copies!r}")
@@ -1216,9 +1235,13 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                                     in boundary_fixtures.items()
                                     if problem_line is not None
                                     and not (subcommand == "required-set"
-                                             and name == "bare-later-shell-command.md"))}
+                                             and name == "bare-later-shell-command.md")),
+                                  *({"prompted-later-shell-command.md:1"}
+                                    if subcommand in prompted_later_commands else set())}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        expected_problems = 39 if subcommand == "required-set" else 40
+        expected_problems = (39 if subcommand == "required-set" else 40) + (
+            1 if subcommand in prompted_later_commands else 0
+        )
         if (len(found_problems) != expected_problems or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
@@ -1234,6 +1257,23 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                 f"[doc-copy {subcommand}] the bare later shell command leaked its flag into the prior "
                 f"ci-status invocation: {bare_commands!r}"
             )
+        if subcommand in prompted_later_commands:
+            prompted_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
+                                 if path.name == "prompted-later-shell-command.md"]
+            if len(prompted_commands) != 1 or later_flag in prompted_commands[0]:
+                problems.append(
+                    f"[doc-copy {subcommand}] the prompted later shell command leaked its flag into the "
+                    f"prior ci-status invocation: {prompted_commands!r}"
+                )
+        if subcommand in derive_json_path_commands:
+            derive_json_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
+                                    if path.name == "derive-json-path.md"]
+            if (len(derive_json_commands) != 1
+                    or "result.py --machine-action none" not in derive_json_commands[0]):
+                problems.append(
+                    f"[doc-copy {subcommand}] a --derive-json .py value cut off later arguments: "
+                    f"{derive_json_commands!r}"
+                )
         inline_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
                            if path.name == "inline-introduced-command.md"]
         inline_later_input = "state.jsonl" if subcommand == "required-set" else later_flag

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1072,6 +1072,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl, then "
                         "`echo ledger/state.jsonl`.",
     }
+    next_later_commands = {
+        "derive": "Run scripts/ci-status.py derive --pr 1. Next, run echo --ledger "
+                  "<rundir>/state.jsonl.",
+        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1. Next, run "
+                    "echo --machine-action none.",
+        "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl. Next, run "
+                        "echo ledger/state.jsonl.",
+    }
     for subcommand, (check, valid, invalid, detached, later_command, problem_needle) in fixtures.items():
         root = tmp / f"doc-copy-{subcommand}"
         root.mkdir()
@@ -1108,6 +1116,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         (root / "later-command.md").write_text(later_command + "\n", encoding="utf-8")
         (root / "inline-introduced-command.md").write_text(
             inline_later_commands[subcommand] + "\n", encoding="utf-8"
+        )
+        (root / "next-introduced-command.md").write_text(
+            next_later_commands[subcommand] + "\n", encoding="utf-8"
         )
         boundary_fixtures = {
             "atx-heading.md": (f"{invalid}\n# {detached}\n", 1),
@@ -1179,7 +1190,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        expected_copies = 49 if subcommand == "required-set" else 50
+        expected_copies = 50 if subcommand == "required-set" else 51
         if len(copies) != expected_copies:
             problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected "
                             f"{expected_copies}: {copies!r}")
@@ -1188,13 +1199,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                                   "same-paragraph.md:1",
                                   "later-command.md:1",
                                   "inline-introduced-command.md:1",
+                                  "next-introduced-command.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items()
                                     if problem_line is not None
                                     and not (subcommand == "required-set"
                                              and name == "bare-later-shell-command.md"))}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        expected_problems = 37 if subcommand == "required-set" else 38
+        expected_problems = 38 if subcommand == "required-set" else 39
         if (len(found_problems) != expected_problems or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
@@ -1217,6 +1229,13 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             problems.append(
                 f"[doc-copy {subcommand}] the inline introduced command leaked its required input into "
                 f"the prior ci-status invocation: {inline_commands!r}"
+            )
+        next_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
+                         if path.name == "next-introduced-command.md"]
+        if len(next_commands) != 1 or inline_later_input in next_commands[0]:
+            problems.append(
+                f"[doc-copy {subcommand}] the Next-introduced command leaked its required input into "
+                f"the prior ci-status invocation: {next_commands!r}"
             )
     return problems
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1065,6 +1065,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         quoted_shell_valid = quoted(shell_valid)
         quoted_shell_invalid = quoted(shell_invalid)
         quoted_detached = quoted(detached)
+        inline_invalid = invalid.replace("\n  ", " ")
         (root / "wrapped.md").write_text(
             f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n\n"
             f"{quoted_valid}\n>\n{quoted_invalid}\n>\n{quoted_detached}\n>\n"
@@ -1076,21 +1077,34 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             encoding="utf-8",
         )
         boundary_fixtures = {
-            "atx-heading.md": f"{invalid}\n# {detached}\n",
-            "unordered-list.md": f"{invalid}\n- {detached}\n",
-            "fenced-block.md": f"{invalid}\n```\n{detached}\n```\n",
-            "thematic-break.md": f"{invalid}\n* * *\n{detached}\n",
+            "atx-heading.md": (f"{invalid}\n# {detached}\n", 1),
+            "unordered-list.md": (f"{invalid}\n- {detached}\n", 1),
+            "fenced-block.md": (f"{invalid}\n```\n{detached}\n```\n", 1),
+            "thematic-break.md": (f"{invalid}\n* * *\n{detached}\n", 1),
+            "html-block.md": (f"{invalid}\n<div>\n{detached}\n</div>\n", 1),
+            "html-script.md": (f"{invalid}\n<script>\n{detached}\n</script>\n", 1),
+            "html-comment.md": (f"{invalid}\n<!--\n{detached}\n-->\n", 1),
+            "html-processing.md": (f"{invalid}\n<?fixture\n{detached}\n?>\n", 1),
+            "html-declaration.md": (f"{invalid}\n<!FIXTURE>\n{detached}\n", 1),
+            "html-cdata.md": (f"{invalid}\n<![CDATA[\n{detached}\n]]>\n", 1),
+            "html-block-valid.md": (f"{valid}\n<div>\n{detached}\n</div>\n", None),
+            "setext-heading.md": (f"{invalid}\n===\n{detached}\n", 1),
+            "atx-heading-reverse.md": (f"# {inline_invalid}\n{detached}\n", 1),
+            "fenced-block-reverse.md": (f"```\n{inline_invalid}\n```\n{detached}\n", 2),
+            "html-block-reverse.md": (f"<script>\n{inline_invalid}\n</script>\n{detached}\n", 2),
+            "indented-code.md": (f"    {inline_invalid}\n{detached}\n", 1),
         }
-        for name, text in boundary_fixtures.items():
+        for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 13:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 13: {copies!r}")
+        if len(copies) != 25:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 25: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
-                                  *(f"{name}:1" for name in boundary_fixtures)}
+                                  *(f"{name}:{problem_line}" for name, (_text, problem_line)
+                                    in boundary_fixtures.items() if problem_line is not None)}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 9 or problem_sites != expected_problem_sites
+        if (len(found_problems) != 20 or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1036,6 +1036,8 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "Run `scripts/ci-status.py\n  derive --pr 1 --ledger <rundir>/state.jsonl`.",
             "Run `scripts/ci-status.py\n  derive --pr 1`.",
             "`--ledger <rundir>/state.jsonl` is discussed separately.",
+            "Run scripts/ci-status.py derive --pr 1, then scripts/ledger.py set "
+            "--ledger ledger/state.jsonl.",
             "WITHOUT `--ledger` OR `--required-set`",
         ),
         "liveness": (
@@ -1044,6 +1046,8 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "--machine-action none`.",
             "Run `scripts/ci-status.py\n  liveness --ledger <rundir>/state.jsonl --pr 1`.",
             "`--machine-action none` is discussed separately.",
+            "Run scripts/ci-status.py liveness --ledger ledger/state.jsonl --pr 1, then "
+            "scripts/ledger.py set --machine-action none.",
             "WITHOUT `--machine-action`",
         ),
         "required-set": (
@@ -1051,10 +1055,12 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/state.jsonl`.",
             "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/other.jsonl`.",
             "`state.jsonl` is discussed separately.",
+            "Run scripts/ci-status.py required-set --ledger ledger/other.jsonl, then "
+            "scripts/ledger.py set --ledger ledger/state.jsonl.",
             "without the run ledger's",
         ),
     }
-    for subcommand, (check, valid, invalid, detached, problem_needle) in fixtures.items():
+    for subcommand, (check, valid, invalid, detached, later_command, problem_needle) in fixtures.items():
         root = tmp / f"doc-copy-{subcommand}"
         root.mkdir()
         shell_valid = valid.replace("ci-status.py\n", "ci-status.py \\\n")
@@ -1087,6 +1093,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             f"{inline_invalid} Then run {inline_valid}; run {inline_valid}\n",
             encoding="utf-8",
         )
+        (root / "later-command.md").write_text(later_command + "\n", encoding="utf-8")
         boundary_fixtures = {
             "atx-heading.md": (f"{invalid}\n# {detached}\n", 1),
             "unordered-list.md": (f"{invalid}\n- {detached}\n", 1),
@@ -1153,15 +1160,16 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 46:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 46: {copies!r}")
+        if len(copies) != 47:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 47: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
                                   "same-paragraph.md:1",
+                                  "later-command.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items() if problem_line is not None)}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 34 or problem_sites != expected_problem_sites
+        if (len(found_problems) != 35 or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1057,16 +1057,19 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
     for subcommand, (check, valid, invalid, detached, problem_needle) in fixtures.items():
         root = tmp / f"doc-copy-{subcommand}"
         root.mkdir()
+        shell_valid = valid.replace("ci-status.py\n", "ci-status.py \\\n")
+        shell_invalid = invalid.replace("ci-status.py\n", "ci-status.py \\\n")
         (root / "wrapped.md").write_text(
-            f"{valid}\n\n{invalid}\n\n{detached}\n",
+            f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n",
             encoding="utf-8",
         )
         found_problems, copies = check(root)
-        if len(copies) != 2:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 2: {copies!r}")
-        if len(found_problems) != 1 or problem_needle not in found_problems[0]:
+        if len(copies) != 4:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 4: {copies!r}")
+        if len(found_problems) != 2 or any(problem_needle not in problem for problem in found_problems):
             problems.append(
-                f"[doc-copy {subcommand}] invalid wrapped copy was not rejected by its own missing flag: "
+                f"[doc-copy {subcommand}] invalid plain and shell-wrapped copies were not rejected by "
+                f"their own missing flag: "
                 f"{found_problems!r}"
             )
     return problems

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1066,6 +1066,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         quoted_shell_invalid = quoted(shell_invalid)
         quoted_detached = quoted(detached)
         inline_invalid = invalid.replace("\n  ", " ")
+        ordered_invalid = invalid.replace("\n", "\n   ")
+        nested_unordered_invalid = invalid.replace("\n", "\n      ")
+        nested_ordered_invalid = invalid.replace("\n", "\n       ")
         (root / "wrapped.md").write_text(
             f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n\n"
             f"{quoted_valid}\n>\n{quoted_invalid}\n>\n{quoted_detached}\n>\n"
@@ -1093,18 +1096,28 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "fenced-block-reverse.md": (f"```\n{inline_invalid}\n```\n{detached}\n", 2),
             "html-block-reverse.md": (f"<script>\n{inline_invalid}\n</script>\n{detached}\n", 2),
             "indented-code.md": (f"    {inline_invalid}\n{detached}\n", 1),
+            "quoted-fenced-exit.md": (f"> ```sh\n{quoted_invalid}\n{detached}\n", 2),
+            "quoted-html-exit.md": (f"> <script>\n{quoted_invalid}\n{detached}\n", 2),
+            "ordered-non-one-paragraph.md": (f"{invalid}\n2. {detached}\n", None),
+            "ordered-siblings.md": (f"1. {ordered_invalid}\n2. {detached}\n", 1),
+            "nested-unordered-siblings.md": (
+                f"- Parent item\n    - {nested_unordered_invalid}\n    - {detached}\n", 2
+            ),
+            "nested-ordered-siblings.md": (
+                f"1. Parent item\n    1. {nested_ordered_invalid}\n    2. {detached}\n", 2
+            ),
         }
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 25:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 25: {copies!r}")
+        if len(copies) != 31:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 31: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items() if problem_line is not None)}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 20 or problem_sites != expected_problem_sites
+        if (len(found_problems) != 25 or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1028,7 +1028,7 @@ def required_set_matrix_cases(ci, tmp: Path) -> list[str]:
 
 
 def command_copy_cases(ci, tmp: Path) -> list[str]:
-    """Wrapped copies cannot borrow flags from later paragraphs or interrupting Markdown blocks."""
+    """Wrapped copies cannot borrow flags from later commands, paragraphs, or Markdown blocks."""
     problems: list[str] = []
     fixtures = {
         "derive": (
@@ -1065,7 +1065,8 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         quoted_shell_valid = quoted(shell_valid)
         quoted_shell_invalid = quoted(shell_invalid)
         quoted_detached = quoted(detached)
-        inline_invalid = invalid.replace("\n  ", " ")
+        inline_invalid = invalid.replace("`", "").replace("\n  ", " ")
+        inline_valid = valid.replace("`", "").replace("\n  ", " ")
         ordered_invalid = invalid.replace("\n", "\n   ")
         nested_unordered_invalid = invalid.replace("\n", "\n      ")
         nested_ordered_invalid = invalid.replace("\n", "\n       ")
@@ -1080,6 +1081,10 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         )
         (root / "quote-transition.md").write_text(
             f"{invalid}\n{quoted_detached}\n",
+            encoding="utf-8",
+        )
+        (root / "same-paragraph.md").write_text(
+            f"{inline_invalid} Then run {inline_valid}; run {inline_valid}\n",
             encoding="utf-8",
         )
         boundary_fixtures = {
@@ -1148,14 +1153,15 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 43:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 43: {copies!r}")
+        if len(copies) != 46:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 46: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
+                                  "same-paragraph.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items() if problem_line is not None)}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 33 or problem_sites != expected_problem_sites
+        if (len(found_problems) != 34 or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1036,8 +1036,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "Run `scripts/ci-status.py\n  derive --pr 1 --ledger <rundir>/state.jsonl`.",
             "Run `scripts/ci-status.py\n  derive --pr 1`.",
             "`--ledger <rundir>/state.jsonl` is discussed separately.",
-            "Run scripts/ci-status.py derive --pr 1, then scripts/ledger.py set "
-            "--ledger ledger/state.jsonl.",
+            "Run scripts/ci-status.py derive --pr 1, then echo --ledger ledger/state.jsonl.",
             "WITHOUT `--ledger` OR `--required-set`",
         ),
         "liveness": (
@@ -1047,7 +1046,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "Run `scripts/ci-status.py\n  liveness --ledger <rundir>/state.jsonl --pr 1`.",
             "`--machine-action none` is discussed separately.",
             "Run scripts/ci-status.py liveness --ledger ledger/state.jsonl --pr 1, then "
-            "scripts/ledger.py set --machine-action none.",
+            "echo --machine-action none.",
             "WITHOUT `--machine-action`",
         ),
         "required-set": (
@@ -1056,7 +1055,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "Run `scripts/ci-status.py\n  required-set --ledger <rundir>/other.jsonl`.",
             "`state.jsonl` is discussed separately.",
             "Run scripts/ci-status.py required-set --ledger ledger/other.jsonl, then "
-            "scripts/ledger.py set --ledger ledger/state.jsonl.",
+            "echo ledger/state.jsonl.",
             "without the run ledger's",
         ),
     }
@@ -1147,6 +1146,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                 f"{nested_item}Item intro\n\n{nested_indent}    {inline_invalid}\n"
                 f"{nested_indent}{detached}\n", 4
             ),
+            "list-heading-indented-code.md": (
+                f"- Earlier item\n# Heading\n    {inline_invalid}\n{detached}\n", 3
+            ),
             "stale-ordered-list.md": (f"1. Earlier item\n\n{invalid}\n2. {detached}\n", None),
             "malformed-fence.md": (f"{invalid}\n```bad`info\n{detached}\n", None),
             "malformed-html-close.md": (
@@ -1160,8 +1162,8 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 47:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 47: {copies!r}")
+        if len(copies) != 48:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 48: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
                                   "same-paragraph.md:1",
@@ -1169,7 +1171,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items() if problem_line is not None)}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 35 or problem_sites != expected_problem_sites
+        if (len(found_problems) != 36 or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1059,6 +1059,12 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "without the run ledger's",
         ),
     }
+    bare_later_commands = {
+        "derive": "Run scripts/ci-status.py derive --pr 1\necho --ledger <rundir>/state.jsonl.",
+        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1\n"
+                    "echo --machine-action none.",
+        "required-set": "Run scripts/ci-status.py required-set\necho --ledger <rundir>/state.jsonl.",
+    }
     for subcommand, (check, valid, invalid, detached, later_command, problem_needle) in fixtures.items():
         root = tmp / f"doc-copy-{subcommand}"
         root.mkdir()
@@ -1149,6 +1155,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "list-heading-indented-code.md": (
                 f"- Earlier item\n# Heading\n    {inline_invalid}\n{detached}\n", 3
             ),
+            "bare-later-shell-command.md": (bare_later_commands[subcommand] + "\n", 1),
             "stale-ordered-list.md": (f"1. Earlier item\n\n{invalid}\n2. {detached}\n", None),
             "malformed-fence.md": (f"{invalid}\n```bad`info\n{detached}\n", None),
             "malformed-html-close.md": (
@@ -1162,21 +1169,35 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 48:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 48: {copies!r}")
+        expected_copies = 48 if subcommand == "required-set" else 49
+        if len(copies) != expected_copies:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected "
+                            f"{expected_copies}: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
                                   "same-paragraph.md:1",
                                   "later-command.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
-                                    in boundary_fixtures.items() if problem_line is not None)}
+                                    in boundary_fixtures.items()
+                                    if problem_line is not None
+                                    and not (subcommand == "required-set"
+                                             and name == "bare-later-shell-command.md"))}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 36 or problem_sites != expected_problem_sites
+        expected_problems = 36 if subcommand == "required-set" else 37
+        if (len(found_problems) != expected_problems or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "
                 f"rejected by their own missing flag: "
                 f"{found_problems!r}"
+            )
+        bare_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
+                         if path.name == "bare-later-shell-command.md"]
+        later_flag = "--machine-action" if subcommand == "liveness" else "--ledger"
+        if len(bare_commands) != 1 or later_flag in bare_commands[0]:
+            problems.append(
+                f"[doc-copy {subcommand}] the bare later shell command leaked its flag into the prior "
+                f"ci-status invocation: {bare_commands!r}"
             )
     return problems
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1069,6 +1069,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         ordered_invalid = invalid.replace("\n", "\n   ")
         nested_unordered_invalid = invalid.replace("\n", "\n      ")
         nested_ordered_invalid = invalid.replace("\n", "\n       ")
+        mixed_space_tab_invalid = invalid.replace("\n", "\n \t")
+        nested_item = "- Parent item\n    - "
+        nested_indent = "      "
         (root / "wrapped.md").write_text(
             f"{valid}\n\n{invalid}\n\n{shell_valid}\n\n{shell_invalid}\n\n{detached}\n\n"
             f"{quoted_valid}\n>\n{quoted_invalid}\n>\n{quoted_detached}\n>\n"
@@ -1106,18 +1109,53 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             "nested-ordered-siblings.md": (
                 f"1. Parent item\n    1. {nested_ordered_invalid}\n    2. {detached}\n", 2
             ),
+            "nested-atx-heading.md": (
+                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}# {detached}\n", 2
+            ),
+            "nested-fenced-block.md": (
+                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}```\n"
+                f"{nested_indent}{detached}\n{nested_indent}```\n", 2
+            ),
+            "nested-thematic-break.md": (
+                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}* * *\n"
+                f"{nested_indent}{detached}\n", 2
+            ),
+            "nested-html-block.md": (
+                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}<div>\n"
+                f"{nested_indent}{detached}\n{nested_indent}</div>\n", 2
+            ),
+            "nested-setext-heading.md": (
+                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}===\n"
+                f"{nested_indent}{detached}\n", 2
+            ),
+            "nested-blockquote.md": (
+                f"{nested_item}{nested_unordered_invalid}\n{nested_indent}> {detached}\n", 2
+            ),
+            "nested-indented-code.md": (
+                f"{nested_item}Item intro\n\n{nested_indent}    {inline_invalid}\n"
+                f"{nested_indent}{detached}\n", 4
+            ),
+            "stale-ordered-list.md": (f"1. Earlier item\n\n{invalid}\n2. {detached}\n", None),
+            "malformed-fence.md": (f"{invalid}\n```bad`info\n{detached}\n", None),
+            "malformed-html-close.md": (
+                f"<script>\n{invalid}\n</script   >\n{detached}\n</script>\n", None
+            ),
+            "blank-indented-code.md": (f"    {inline_invalid}\n\n    {detached}\n", None),
+            "mixed-space-tab-code.md": (
+                f" \t{mixed_space_tab_invalid}\n{detached}\n", 1
+            ),
         }
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        if len(copies) != 31:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 31: {copies!r}")
+        if len(copies) != 43:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 43: {copies!r}")
         expected_problem_sites = {"wrapped.md:4", "wrapped.md:10", "wrapped.md:18", "wrapped.md:26",
                                   "quote-transition.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items() if problem_line is not None)}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        if (len(found_problems) != 25 or problem_sites != expected_problem_sites
+        if (len(found_problems) != 33 or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain, blockquoted, and block-boundary copies were not "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1071,10 +1071,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             f"{quoted_shell_valid}\n>\n{quoted_shell_invalid}\n>\n{quoted_detached}\n",
             encoding="utf-8",
         )
+        (root / "quote-transition.md").write_text(
+            f"{invalid}\n{quoted_detached}\n",
+            encoding="utf-8",
+        )
         found_problems, copies = check(root)
-        if len(copies) != 8:
-            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 8: {copies!r}")
-        if len(found_problems) != 4 or any(problem_needle not in problem for problem in found_problems):
+        if len(copies) != 9:
+            problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected 9: {copies!r}")
+        if len(found_problems) != 5 or any(problem_needle not in problem for problem in found_problems):
             problems.append(
                 f"[doc-copy {subcommand}] invalid plain and blockquoted copies were not rejected by their "
                 f"own missing flag: "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1065,6 +1065,13 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                     "echo --machine-action none.",
         "required-set": "Run scripts/ci-status.py required-set\necho --ledger <rundir>/state.jsonl.",
     }
+    inline_later_commands = {
+        "derive": "Run scripts/ci-status.py derive --pr 1, then `echo --ledger <rundir>/state.jsonl`.",
+        "liveness": "Run scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr 1, then "
+                    "`echo --machine-action none`.",
+        "required-set": "Run scripts/ci-status.py required-set --ledger <rundir>/other.jsonl, then "
+                        "`echo ledger/state.jsonl`.",
+    }
     for subcommand, (check, valid, invalid, detached, later_command, problem_needle) in fixtures.items():
         root = tmp / f"doc-copy-{subcommand}"
         root.mkdir()
@@ -1099,6 +1106,9 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             encoding="utf-8",
         )
         (root / "later-command.md").write_text(later_command + "\n", encoding="utf-8")
+        (root / "inline-introduced-command.md").write_text(
+            inline_later_commands[subcommand] + "\n", encoding="utf-8"
+        )
         boundary_fixtures = {
             "atx-heading.md": (f"{invalid}\n# {detached}\n", 1),
             "unordered-list.md": (f"{invalid}\n- {detached}\n", 1),
@@ -1169,7 +1179,7 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
         for name, (text, _problem_line) in boundary_fixtures.items():
             (root / name).write_text(text, encoding="utf-8")
         found_problems, copies = check(root)
-        expected_copies = 48 if subcommand == "required-set" else 49
+        expected_copies = 49 if subcommand == "required-set" else 50
         if len(copies) != expected_copies:
             problems.append(f"[doc-copy {subcommand}] found {len(copies)} wrapped copies, expected "
                             f"{expected_copies}: {copies!r}")
@@ -1177,13 +1187,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
                                   "quote-transition.md:1",
                                   "same-paragraph.md:1",
                                   "later-command.md:1",
+                                  "inline-introduced-command.md:1",
                                   *(f"{name}:{problem_line}" for name, (_text, problem_line)
                                     in boundary_fixtures.items()
                                     if problem_line is not None
                                     and not (subcommand == "required-set"
                                              and name == "bare-later-shell-command.md"))}
         problem_sites = {problem.split(" ", 1)[0] for problem in found_problems}
-        expected_problems = 36 if subcommand == "required-set" else 37
+        expected_problems = 37 if subcommand == "required-set" else 38
         if (len(found_problems) != expected_problems or problem_sites != expected_problem_sites
                 or any(problem_needle not in problem for problem in found_problems)):
             problems.append(
@@ -1198,6 +1209,14 @@ def command_copy_cases(ci, tmp: Path) -> list[str]:
             problems.append(
                 f"[doc-copy {subcommand}] the bare later shell command leaked its flag into the prior "
                 f"ci-status invocation: {bare_commands!r}"
+            )
+        inline_commands = [command for path, _line, command in ci.find_ci_status_copies(root, subcommand)
+                           if path.name == "inline-introduced-command.md"]
+        inline_later_input = "state.jsonl" if subcommand == "required-set" else later_flag
+        if len(inline_commands) != 1 or inline_later_input in inline_commands[0]:
+            problems.append(
+                f"[doc-copy {subcommand}] the inline introduced command leaked its required input into "
+                f"the prior ci-status invocation: {inline_commands!r}"
             )
     return problems
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2328,10 +2328,12 @@ def markdown_list_marker(content: str) -> tuple[int, int, str, int | None] | Non
 
 
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
-    """Find wrapped candidates without crossing Markdown paragraph, block, or quote boundaries."""
+    """Find wrapped candidates without crossing Markdown or command boundaries."""
     quote_prefix = r"(?:[ \t]*>[ \t]*)+"
     separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
+    command_start = re.compile(rf"ci-status\.py{separator}\S+\b")
+    command_delimiter = re.compile(r"`|&&|\|\||;|\|")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")
@@ -2525,7 +2527,12 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
             paragraph = text[start:end]
             for match in needle.finditer(paragraph):
                 offset = start + match.start()
-                copies.append((md, text.count("\n", 0, offset) + 1, paragraph[match.start():]))
+                command_end = len(paragraph)
+                if (next_command := command_start.search(paragraph, match.end())) is not None:
+                    command_end = next_command.start()
+                if (delimiter := command_delimiter.search(paragraph, match.end(), command_end)) is not None:
+                    command_end = delimiter.start()
+                copies.append((md, text.count("\n", 0, offset) + 1, paragraph[match.start():command_end]))
     return copies
 
 
@@ -2542,7 +2549,7 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
     A copy is any occurrence that RUNS the command (`ci-status.py derive` carrying `--pr`) — prose that
     merely NAMES the command is not a copy, and is not checked. **THE UNIT IS THE COMMAND, NOT THE LINE**:
     an invocation WRAPS (a shell `\\`, or plain prose reflow), and a line-by-line check would report the
-    continuation line as a violation of itself. So each copy is read to the end of its PARAGRAPH.
+    continuation line as a violation of itself. So each copy is read to its paragraph's next command boundary.
 
     FINDING ZERO COPIES IS A FAILURE: the command is prescribed by at least `stage-2-ci.md` and
     `critical-rules.md`, and a check that cannot find its subject never passes.

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2329,42 +2329,99 @@ def markdown_list_marker(content: str) -> tuple[int, int, str, int | None] | Non
 
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
     """Find wrapped candidates without crossing Markdown or command boundaries."""
-    quote_prefix = r"(?:[ \t]*>[ \t]*)+"
-    separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
+    separator = r"(?:\s+|[ \t]*\\\r?\n[ \t]*)"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     # A later known interpreter or script starts a new span directly. An explicitly introduced later
     # command does too, even when it is not a known interpreter or script. Its flags describe that command,
     # never the ci-status.py invocation before it. `Next, run` and `Afterwards, run` are sentence-level
     # introductions, so they must be recognized even though their commands start after prose rather than a
     # Markdown block boundary.
-    command_start = re.compile(
+    named_command_start = re.compile(
         rf"(?:"
         rf"(?<![\w./-])(?:(?P<script>(?:[\w.-]+/)*[\w.-]+\.py)|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
         rf"|\b(?:and[ \t]+then|then|followed[ \t]+by|(?:[Nn]ext|[Aa]fterwards?),?[ \t]+run)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
         rf")"
     )
-    option_value_before_script = re.compile(r"(?:^|\s)--[A-Za-z][\w-]*(?:=[^\s]*)?\s*$")
-
-    def later_command_start(paragraph: str, offset: int) -> re.Match[str] | None:
-        """Find a later command, preserving a `.py` value supplied to a long option."""
-        for candidate in command_start.finditer(paragraph, offset):
-            # `--derive-json result.py` is one invocation argument, not a new command.  A later script
-            # command can still begin after an option value, so keep looking when this candidate is one.
-            if (candidate.group("script") is not None
-                    and option_value_before_script.search(paragraph[:candidate.start()])):
-                continue
-            return candidate
-        return None
-    # A bare, later shell-command line needs no prose introduction. Limit this to a command word followed
-    # by a long option: that is the only form that can lend a checked flag to the prior invocation, while a
-    # valid wrapped continuation starts with its option instead of a new command word.
-    bare_shell_command_start = re.compile(
-        r"(?:^|\r?\n)(?:[ \t]*\$[ \t]+)?(?=[A-Za-z_./])[A-Za-z_./][\w./-]*"
-        r"(?=[ \t]+[^\r\n]*--[A-Za-z][\w-]*\b)"
+    # A bare command may have only an operand, not a long option. It starts only on a new logical line:
+    # inline literals stay literal unless prose explicitly introduces another runnable command.
+    bare_command_start = re.compile(
+        r"(?:^|\r?\n)[ \t]*(?:\$[ \t]+)?(?P<command>[A-Za-z_./][\w./-]*)"
+        r"(?=[ \t]+[^\r\n]*\S)"
     )
     # A Markdown backtick alone does not start a command. An explicit prose introduction followed by inline
     # code does: the later command's flags must not extend the ci-status.py invocation before it.
     command_delimiter = re.compile(r"&&|\|\||;|\|")
+
+    def normalize_markdown_prefixes(paragraph: str) -> tuple[str, list[int]]:
+        """Remove active quote markers while retaining each logical byte's source offset."""
+        logical, source_offsets = [], []
+        offset = 0
+        for line in paragraph.splitlines(keepends=True):
+            prefix = re.match(r"(?:[ \t]*>[ \t]*)+", line)
+            content_start = prefix.end() if prefix is not None else 0
+            logical.extend(line[content_start:])
+            source_offsets.extend(range(offset + content_start, offset + len(line)))
+            offset += len(line)
+        return "".join(logical), source_offsets
+
+    def option_awaits_value(logical: str, command_start: int, candidate_start: int) -> bool:
+        """Track the current command's long-option value slot across an allowed wrap."""
+        awaiting_value = False
+        for token in re.finditer(r"\S+", logical[command_start:candidate_start]):
+            value = token.group(0)
+            if value in ("$", "\\"):
+                continue
+            if awaiting_value:
+                awaiting_value = False
+                continue
+            if value.startswith("--") and value != "--":
+                awaiting_value = "=" not in value
+        return awaiting_value
+
+    def inside_inline_code(logical: str, position: int) -> bool:
+        """Keep a newline inside one inline literal from becoming a shell boundary."""
+        marker: str | None = None
+        index = 0
+        while index < position:
+            if logical[index] != "`":
+                index += 1
+                continue
+            end = index
+            while end < len(logical) and logical[end] == "`":
+                end += 1
+            run = logical[index:end]
+            line_start = logical.rfind("\n", 0, index) + 1
+            if len(run) >= 3 and not logical[line_start:index].strip(" \t"):
+                index = end
+                continue
+            if marker is None:
+                marker = run
+            elif marker == run:
+                marker = None
+            index = end
+        return marker is not None
+
+    def command_span_end(logical: str, command_start: int) -> int:
+        """Return the first real later-command boundary in normalized Markdown text."""
+        candidates: list[int] = []
+        for candidate in named_command_start.finditer(logical, command_start):
+            if (not inside_inline_code(logical, candidate.start())
+                    and not option_awaits_value(logical, command_start, candidate.start())):
+                candidates.append(candidate.start())
+                break
+        for candidate in bare_command_start.finditer(logical, command_start):
+            line_start = candidate.start()
+            if line_start and logical[:line_start].rstrip(" \t").endswith("\\"):
+                continue
+            if (inside_inline_code(logical, candidate.start("command"))
+                    or option_awaits_value(logical, command_start, candidate.start("command"))):
+                continue
+            candidates.append(line_start)
+            break
+        if not candidates:
+            return len(logical)
+        return min(candidates)
+
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")
@@ -2571,19 +2628,16 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
             regions.append((start, len(text)))
         for start, end in regions:
             paragraph = text[start:end]
-            for match in needle.finditer(paragraph):
-                offset = start + match.start()
-                command_end = len(paragraph)
-                candidates = (
-                    later_command_start(paragraph, match.end()),
-                    bare_shell_command_start.search(paragraph, match.end()),
-                )
-                if (next_command := min((candidate for candidate in candidates if candidate is not None),
-                                        key=lambda candidate: candidate.start(), default=None)) is not None:
-                    command_end = next_command.start()
-                if (delimiter := command_delimiter.search(paragraph, match.end(), command_end)) is not None:
+            logical, source_offsets = normalize_markdown_prefixes(paragraph)
+            for match in needle.finditer(logical):
+                command_end = command_span_end(logical, match.end())
+                if (delimiter := command_delimiter.search(logical, match.end(), command_end)) is not None:
                     command_end = delimiter.start()
-                copies.append((md, text.count("\n", 0, offset) + 1, paragraph[match.start():command_end]))
+                source_start = source_offsets[match.start()]
+                source_end = len(paragraph) if command_end == len(logical) else source_offsets[command_end]
+                offset = start + source_start
+                copies.append((md, text.count("\n", 0, offset) + 1,
+                               paragraph[source_start:source_end]))
     return copies
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2248,20 +2248,39 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
 
 
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
-    """Find wrapped blockquote candidates, stopping at quoted or unquoted blank lines."""
+    """Find wrapped candidates without crossing Markdown paragraph or blockquote boundaries."""
     quote_prefix = r"(?:[ \t]*>[ \t]*)+"
     separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        starts = [0]
-        ends = []
-        for boundary in re.finditer(rf"\r?\n(?:[ \t]*|{quote_prefix})\r?\n", text):
-            ends.append(boundary.start())
-            starts.append(boundary.end())
-        ends.append(len(text))
-        for start, end in zip(starts, ends):
+        regions: list[tuple[int, int]] = []
+        start = offset = active_quote_depth = 0
+        for line in text.splitlines(keepends=True):
+            body = line.rstrip("\r\n")
+            prefix = re.match(r"[ \t]*(?:>[ \t]*)*", body)
+            assert prefix is not None
+            quote_depth = prefix.group(0).count(">")
+            content = body[prefix.end():]
+            line_end = offset + len(line)
+            if not content.strip():
+                if start < offset:
+                    regions.append((start, offset))
+                start = line_end
+                active_quote_depth = 0
+            elif quote_depth:
+                if quote_depth != active_quote_depth:
+                    if start < offset:
+                        regions.append((start, offset))
+                    start = offset
+                active_quote_depth = quote_depth
+            # An unquoted nonblank line after a quote may be a lazy continuation, so it keeps the
+            # active quote depth. A later explicit quote at that depth remains in the same paragraph.
+            offset = line_end
+        if start < len(text):
+            regions.append((start, len(text)))
+        for start, end in regions:
             paragraph = text[start:end]
             for match in needle.finditer(paragraph):
                 offset = start + match.start()

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2332,9 +2332,13 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     quote_prefix = r"(?:[ \t]*>[ \t]*)+"
     separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
-    command_start = re.compile(rf"ci-status\.py{separator}\S+\b")
+    # A later runnable command starts a new span even when it is not ci-status.py. Its flags describe
+    # that command, never the ci-status.py invocation before it.
+    command_start = re.compile(
+        rf"(?<![\w./-])(?:(?:[\w.-]+/)*[\w.-]+\.py|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
+    )
     # Markdown backticks delimit a span, not a shell command. An invocation may be followed in the same
-    # paragraph by inline code that supplies its required flag, so only shell separators end the command.
+    # paragraph by inline code that supplies its required flag, so a backtick is never a command boundary.
     command_delimiter = re.compile(r"&&|\|\||;|\|")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
@@ -2585,9 +2589,8 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
     """
     problems, copies = [], []
     for md, line, command in find_ci_status_copies(root or HERE.parent, "liveness"):
-        # `--ledger`, not `--pr`, is the runnable-copy gate here: prose about liveness routinely sits
-        # in the same paragraph as a `ledger.py … set --pr` command, and `--pr` alone would condemn
-        # every such mention as a flagless invocation.
+        # `--ledger`, not `--pr`, is the runnable-copy gate: prose can name a PR without spelling the
+        # ledger input that makes liveness runnable.
         if "--ledger" not in command:
             continue  # prose that names the subcommand, not a runnable copy
         copies.append(f"{md.name}:{line}")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2339,15 +2339,28 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     # Markdown block boundary.
     command_start = re.compile(
         rf"(?:"
-        rf"(?<![\w./-])(?:(?:[\w.-]+/)*[\w.-]+\.py|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
+        rf"(?<![\w./-])(?:(?P<script>(?:[\w.-]+/)*[\w.-]+\.py)|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
         rf"|\b(?:and[ \t]+then|then|followed[ \t]+by|(?:[Nn]ext|[Aa]fterwards?),?[ \t]+run)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
         rf")"
     )
+    option_value_before_script = re.compile(r"(?:^|\s)--[A-Za-z][\w-]*(?:=[^\s]*)?\s*$")
+
+    def later_command_start(paragraph: str, offset: int) -> re.Match[str] | None:
+        """Find a later command, preserving a `.py` value supplied to a long option."""
+        for candidate in command_start.finditer(paragraph, offset):
+            # `--derive-json result.py` is one invocation argument, not a new command.  A later script
+            # command can still begin after an option value, so keep looking when this candidate is one.
+            if (candidate.group("script") is not None
+                    and option_value_before_script.search(paragraph[:candidate.start()])):
+                continue
+            return candidate
+        return None
     # A bare, later shell-command line needs no prose introduction. Limit this to a command word followed
     # by a long option: that is the only form that can lend a checked flag to the prior invocation, while a
     # valid wrapped continuation starts with its option instead of a new command word.
     bare_shell_command_start = re.compile(
-        r"(?:^|\r?\n)(?=[A-Za-z_./])[A-Za-z_./][\w./-]*(?=[ \t]+[^\r\n]*--[A-Za-z][\w-]*\b)"
+        r"(?:^|\r?\n)(?:[ \t]*\$[ \t]+)?(?=[A-Za-z_./])[A-Za-z_./][\w./-]*"
+        r"(?=[ \t]+[^\r\n]*--[A-Za-z][\w-]*\b)"
     )
     # A Markdown backtick alone does not start a command. An explicit prose introduction followed by inline
     # code does: the later command's flags must not extend the ci-status.py invocation before it.
@@ -2562,7 +2575,7 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 offset = start + match.start()
                 command_end = len(paragraph)
                 candidates = (
-                    command_start.search(paragraph, match.end()),
+                    later_command_start(paragraph, match.end()),
                     bare_shell_command_start.search(paragraph, match.end()),
                 )
                 if (next_command := min((candidate for candidate in candidates if candidate is not None),

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2247,402 +2247,55 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
     return problems
 
 
-HTML_BLOCK_TAGS = (
-    "address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|"
-    "dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|"
-    "hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|"
-    "section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul"
-)
+def documented_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
+    """Return supported command copies: inline literals and fenced shell commands.
 
-
-def markdown_quote_prefix(body: str) -> tuple[int, int]:
-    """Return CommonMark blockquote depth and the first content byte without eating code indentation."""
-    depth = position = 0
-    while marker := re.match(r" {0,3}>", body[position:]):
-        position += marker.end()
-        if position < len(body) and body[position] in " \t":
-            position += 1
-        depth += 1
-    return depth, position
-
-
-def html_block_start(content: str) -> re.Pattern[str] | str | None:
-    """Return an explicit end matcher, `"blank"` for a blank-ended block, or `None` for no HTML block."""
-    if match := re.match(r" {0,3}<(script|pre|style|textarea)(?:[ \t]+|>|$)", content, re.IGNORECASE):
-        return re.compile(rf"</{re.escape(match.group(1))}>", re.IGNORECASE)
-    if re.match(r" {0,3}<!--", content):
-        return re.compile(r"-->")
-    if re.match(r" {0,3}<\?", content):
-        return re.compile(r"\?>")
-    if re.match(r" {0,3}<![A-Z]", content):
-        return re.compile(r">")
-    if re.match(r" {0,3}<!\[CDATA\[", content):
-        return re.compile(r"\]\]>")
-    if re.match(rf" {{0,3}}</?(?:{HTML_BLOCK_TAGS})(?:[ \t]+|/?>|$)", content, re.IGNORECASE):
-        return "blank"
-    return None
-
-
-def markdown_leading_indent(content: str) -> tuple[int, int]:
-    """Return leading whitespace columns and bytes using CommonMark's four-column tab stops."""
-    columns = position = 0
-    while position < len(content) and content[position] in " \t":
-        if content[position] == "\t":
-            columns += 4 - columns % 4
-        else:
-            columns += 1
-        position += 1
-    return columns, position
-
-
-def markdown_remove_indent(content: str, width: int) -> str | None:
-    """Remove `width` indentation columns, preserving columns left by a partially consumed tab."""
-    columns = position = 0
-    while columns < width and position < len(content) and content[position] in " \t":
-        if content[position] == "\t":
-            next_columns = columns + 4 - columns % 4
-        else:
-            next_columns = columns + 1
-        position += 1
-        if next_columns > width:
-            return " " * (next_columns - width) + content[position:]
-        columns = next_columns
-    if columns < width:
-        return None
-    return content[position:]
-
-
-def markdown_list_marker(content: str) -> tuple[int, int, str, int | None] | None:
-    """Return a list marker's indent, content indent, family, and ordered start."""
-    match = re.match(r"( *)([*+-]|[0-9]{1,9}([.)]))([ \t]+)(?=\S)", content)
-    if match is None:
-        return None
-    indent = len(match.group(1))
-    token = match.group(2)
-    marker_end = indent + len(token)
-    padding = len((" " * marker_end + match.group(4)).expandtabs(4)) - marker_end
-    content_indent = indent + len(token) + (padding if padding <= 4 else 1)
-    if token[0].isdigit():
-        return indent, content_indent, f"ordered:{match.group(3)}", int(token[:-1])
-    return indent, content_indent, "unordered", None
-
-
-def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
-    """Find wrapped candidates without crossing Markdown or command boundaries."""
-    separator = r"(?:\s+|[ \t]*\\\r?\n[ \t]*)"
-    needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
-    # A later known interpreter or script starts a new span directly. An explicitly introduced later
-    # command does too, even when it is not a known interpreter or script. Its flags describe that command,
-    # never the ci-status.py invocation before it. `Next, run` and `Afterwards, run` are sentence-level
-    # introductions, so they must be recognized even though their commands start after prose rather than a
-    # Markdown block boundary.
-    named_command_start = re.compile(
-        rf"(?:"
-        rf"(?<![\w./-])(?:(?P<script>(?:[\w.-]+/)*[\w.-]+\.py)|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
-        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by|(?:[Nn]ext|[Aa]fterwards?),?[ \t]+run)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
-        rf")"
+    The command-copy guard owns two documentation forms. Inline literals carry a complete command, even
+    when Markdown wraps the literal. Fenced shell blocks carry one shell command, whose continued lines end
+    in ``\\``. Other prose and Markdown constructs are deliberately outside this guard's scope.
+    """
+    command = re.compile(rf"ci-status\.py\s+{re.escape(subcommand)}\b")
+    fenced_command = re.compile(
+        rf"(?m)^[ \t]*(?:\$[ \t]+)?(?:python3?[ \t]+)?(?:\S*/)?ci-status\.py\s+"
+        rf"{re.escape(subcommand)}\b"
     )
-    # A bare command may have only an operand, not a long option. It starts only on a new logical line:
-    # inline literals stay literal unless prose explicitly introduces another runnable command.
-    bare_command_start = re.compile(
-        r"(?:^|\r?\n)[ \t]*(?:\$[ \t]+)?(?P<command>[A-Za-z_./][\w./-]*)"
-        r"(?=[ \t]+[^\r\n]*\S)"
-    )
-    # A Markdown backtick alone does not start a command. An explicit prose introduction followed by inline
-    # code does: the later command's flags must not extend the ci-status.py invocation before it.
-    command_delimiter = re.compile(r"&&|\|\||;|\|")
-
-    def normalize_markdown_prefixes(paragraph: str) -> tuple[str, list[int]]:
-        """Remove active quote markers while retaining each logical byte's source offset."""
-        logical, source_offsets = [], []
-        offset = 0
-        for line in paragraph.splitlines(keepends=True):
-            prefix = re.match(r"(?:[ \t]*>[ \t]*)+", line)
-            content_start = prefix.end() if prefix is not None else 0
-            logical.extend(line[content_start:])
-            source_offsets.extend(range(offset + content_start, offset + len(line)))
-            offset += len(line)
-        return "".join(logical), source_offsets
-
-    def option_awaits_value(logical: str, command_start: int, candidate_start: int) -> bool:
-        """Track the current command's long-option value slot across an allowed wrap."""
-        awaiting_value = False
-        for token in re.finditer(r"\S+", logical[command_start:candidate_start]):
-            value = token.group(0)
-            if value in ("$", "\\"):
-                continue
-            if awaiting_value:
-                awaiting_value = False
-                continue
-            if value.startswith("--") and value != "--":
-                awaiting_value = "=" not in value
-        return awaiting_value
-
-    def inside_inline_code(logical: str, position: int) -> bool:
-        """Keep a newline inside one inline literal from becoming a shell boundary."""
-        marker: str | None = None
-        index = 0
-        while index < position:
-            if logical[index] != "`":
-                index += 1
-                continue
-            end = index
-            while end < len(logical) and logical[end] == "`":
-                end += 1
-            run = logical[index:end]
-            line_start = logical.rfind("\n", 0, index) + 1
-            if len(run) >= 3 and not logical[line_start:index].strip(" \t"):
-                index = end
-                continue
-            if marker is None:
-                marker = run
-            elif marker == run:
-                marker = None
-            index = end
-        return marker is not None
-
-    def command_span_end(logical: str, command_start: int) -> int:
-        """Return the first real later-command boundary in normalized Markdown text."""
-        candidates: list[int] = []
-        for candidate in named_command_start.finditer(logical, command_start):
-            if (not inside_inline_code(logical, candidate.start())
-                    and not option_awaits_value(logical, command_start, candidate.start())):
-                candidates.append(candidate.start())
-                break
-        for candidate in bare_command_start.finditer(logical, command_start):
-            line_start = candidate.start()
-            if line_start and logical[:line_start].rstrip(" \t").endswith("\\"):
-                continue
-            if (inside_inline_code(logical, candidate.start("command"))
-                    or option_awaits_value(logical, command_start, candidate.start("command"))):
-                continue
-            candidates.append(line_start)
-            break
-        if not candidates:
-            return len(logical)
-        return min(candidates)
-
+    fence = re.compile(r"(?ms)^```(?:sh|bash|shell)?[ \t]*\n(?P<body>.*?)^```[ \t]*$")
+    inline = re.compile(r"`(?P<body>[^`]*?)`", re.DOTALL)
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        regions: list[tuple[int, int]] = []
-        start = offset = active_quote_depth = 0
-        active_fence: tuple[str, int] | None = None
-        active_html: re.Pattern[str] | str | None = None
-        active_indented_code = False
-        active_lists: list[tuple[int, int, int, str]] = []
-        list_blank_pending = False
-        for line in text.splitlines(keepends=True):
-            body = line.rstrip("\r\n")
-            outer_quote_depth, content_start = markdown_quote_prefix(body)
-            content = body[content_start:]
-            line_end = offset + len(line)
-            list_marker = markdown_list_marker(content)
-            candidate_same_list = bool(
-                list_marker is not None
-                and any(depth == outer_quote_depth and indent == list_marker[0]
-                        and family == list_marker[2]
-                        for depth, indent, _content_indent, family in active_lists)
-            )
-            candidate_nested_list = bool(
-                list_marker is not None
-                and any(depth == outer_quote_depth and content_indent <= list_marker[0]
-                        for depth, _indent, content_indent, _family in active_lists)
-            )
-            inside_list_item = any(
-                depth == outer_quote_depth and markdown_remove_indent(content, content_indent) is not None
-                for depth, _indent, content_indent, _family in active_lists
-            )
-            if list_blank_pending and content.strip():
-                if not (candidate_same_list or candidate_nested_list or inside_list_item):
-                    active_lists.clear()
-                list_blank_pending = False
-                list_marker = markdown_list_marker(content)
-
-            list_content = content
-            for depth, _indent, content_indent, _family in reversed(active_lists):
-                if depth != outer_quote_depth:
-                    continue
-                stripped = markdown_remove_indent(content, content_indent)
-                if stripped is not None:
-                    list_content = stripped
-                    break
-            nested_quote_depth, nested_content_start = markdown_quote_prefix(list_content)
-            quote_depth = outer_quote_depth + nested_quote_depth
-            block_content = list_content[nested_content_start:]
-
-            # Only ordered marker 1 can interrupt a paragraph to start a list. Later numbers split an
-            # active ordered list, and child markers are measured from the active item's content indent.
-            same_list = bool(
-                list_marker is not None
-                and any(depth == quote_depth and indent == list_marker[0] and family == list_marker[2]
-                        for depth, indent, _content_indent, family in active_lists)
-            )
-            nested_list = bool(
-                list_marker is not None
-                and any(depth == quote_depth and content_indent <= list_marker[0]
-                        for depth, _indent, content_indent, _family in active_lists)
-            )
-            list_starts_block = bool(
-                list_marker is not None
-                and (same_list
-                     or ((list_marker[3] is None or list_marker[3] == 1)
-                         and (list_marker[0] <= 3 or nested_list))
-                     or (start == offset and (list_marker[0] <= 3 or nested_list)))
-            )
-            # A block outside the list's content indentation ends the list. Clear its state before a later
-            # top-level indented block can be mistaken for list text.
-            block_ends_active_list = bool(active_lists and not inside_list_item)
-
-            # Fenced and HTML blocks cannot lazily continue after their blockquote container ends. Close
-            # the region before processing the first line outside that container.
-            if ((active_fence is not None or active_html is not None)
-                    and active_quote_depth and quote_depth < active_quote_depth):
-                if start < offset:
-                    regions.append((start, offset))
-                start = offset
-                active_fence = None
-                active_html = None
-                active_quote_depth = 0
-
-            if active_fence is not None:
-                fence_char, fence_length = active_fence
-                if re.match(rf" {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*$", block_content):
-                    regions.append((start, line_end))
-                    start = line_end
-                    active_fence = None
-                    active_quote_depth = 0
-                offset = line_end
+        blocks = list(fence.finditer(text))
+        for literal in inline.finditer(text):
+            if any(block.start() <= literal.start() < block.end() for block in blocks):
                 continue
-
-            if active_html is not None:
-                if isinstance(active_html, re.Pattern) and active_html.search(block_content):
-                    regions.append((start, line_end))
-                    start = line_end
-                    active_html = None
-                    active_quote_depth = 0
-                    offset = line_end
-                    continue
-                if block_content.strip():
-                    offset = line_end
-                    continue
-                regions.append((start, offset))
-                start = line_end
-                active_html = None
-                active_quote_depth = 0
-                offset = line_end
+            match = command.search(literal.group("body"))
+            if match is None:
                 continue
-
-            if active_indented_code:
-                if not block_content.strip():
-                    list_blank_pending = bool(active_lists)
-                    offset = line_end
-                    continue
-                if markdown_leading_indent(block_content)[0] >= 4:
-                    offset = line_end
-                    continue
-                if start < offset:
-                    regions.append((start, offset))
-                start = offset
-                active_indented_code = False
-                active_quote_depth = 0
-
-            if not block_content.strip():
-                if start < offset:
-                    regions.append((start, offset))
-                start = line_end
-                active_quote_depth = 0
-                list_blank_pending = bool(active_lists)
-            elif (markdown_leading_indent(block_content)[0] >= 4
-                  and start == offset and not list_starts_block):
-                active_indented_code = True
-                active_quote_depth = quote_depth
-            elif re.match(r" {0,3}(?:=+|-+)[ \t]*$", block_content) and start < offset:
-                if block_ends_active_list:
-                    active_lists.clear()
-                regions.append((start, line_end))
-                start = line_end
-                active_quote_depth = 0
-            elif re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", block_content):
-                if block_ends_active_list:
-                    active_lists.clear()
-                if start < offset:
-                    regions.append((start, offset))
-                regions.append((offset, line_end))
-                start = line_end
-                active_quote_depth = 0
-            elif ((fence := re.match(r" {0,3}(`{3,}|~{3,})(.*)$", block_content)) is not None
-                  and (fence.group(1)[0] == "~" or "`" not in fence.group(2))):
-                if block_ends_active_list:
-                    active_lists.clear()
-                if start < offset:
-                    regions.append((start, offset))
-                start = offset
-                active_fence = (fence.group(1)[0], len(fence.group(1)))
-                active_quote_depth = quote_depth
-            elif (html_end := html_block_start(block_content)) is not None:
-                if block_ends_active_list:
-                    active_lists.clear()
-                if start < offset:
-                    regions.append((start, offset))
-                start = offset
-                active_html = html_end
-                active_quote_depth = quote_depth
-                if isinstance(html_end, re.Pattern) and html_end.search(block_content[1:]):
-                    regions.append((start, line_end))
-                    start = line_end
-                    active_html = None
-                    active_quote_depth = 0
-            elif re.match(r" {0,3}(?:\*(?:[ \t]*\*){2,}|-(?:[ \t]*-){2,}|_(?:[ \t]*_){2,})[ \t]*$",
-                          block_content):
-                if block_ends_active_list:
-                    active_lists.clear()
-                if start < offset:
-                    regions.append((start, offset))
-                regions.append((offset, line_end))
-                start = line_end
-                active_quote_depth = 0
-            elif list_starts_block and list_marker is not None:
-                if start < offset:
-                    regions.append((start, offset))
-                start = offset
-                active_quote_depth = quote_depth
-                while (active_lists
-                       and (active_lists[-1][0] > quote_depth
-                            or (active_lists[-1][0] == quote_depth
-                                and active_lists[-1][1] >= list_marker[0]))):
-                    active_lists.pop()
-                active_lists.append((quote_depth, list_marker[0], list_marker[1], list_marker[2]))
-            elif quote_depth:
-                if block_ends_active_list:
-                    active_lists.clear()
-                if quote_depth != active_quote_depth:
-                    if start < offset:
-                        regions.append((start, offset))
-                    start = offset
-                active_quote_depth = quote_depth
-            # An unquoted nonblank line after a quote may be a lazy continuation, so it keeps the
-            # active quote depth. A later explicit quote at that depth remains in the same paragraph.
-            offset = line_end
-        if start < len(text):
-            regions.append((start, len(text)))
-        for start, end in regions:
-            paragraph = text[start:end]
-            logical, source_offsets = normalize_markdown_prefixes(paragraph)
-            for match in needle.finditer(logical):
-                command_end = command_span_end(logical, match.end())
-                if (delimiter := command_delimiter.search(logical, match.end(), command_end)) is not None:
-                    command_end = delimiter.start()
-                source_start = source_offsets[match.start()]
-                source_end = len(paragraph) if command_end == len(logical) else source_offsets[command_end]
-                offset = start + source_start
+            offset = literal.start("body") + match.start()
+            copies.append((md, text.count("\n", 0, offset) + 1, literal.group("body")[match.start():]))
+        for block in blocks:
+            body = block.group("body")
+            for match in fenced_command.finditer(body):
+                line_end = body.find("\n", match.start())
+                if line_end < 0:
+                    line_end = len(body)
+                command_end = line_end
+                while body[command_end - 1:command_end].rstrip().endswith("\\"):
+                    next_end = body.find("\n", command_end + 1)
+                    if next_end < 0:
+                        command_end = len(body)
+                        break
+                    command_end = next_end
+                offset = block.start("body") + match.start()
+                span = body[match.start():command_end]
                 copies.append((md, text.count("\n", 0, offset) + 1,
-                               paragraph[source_start:source_end]))
+                               re.sub(r"\\\n[ \t]*", " ", span)))
     return copies
 
 
+
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """EVERY COPY OF THE DERIVE COMMAND, IN EVERY SKILL DOC — not just the one in the doc under test.
+    """Every supported documented derive command copy names its required-set input.
 
     THE FLAG THAT NAMES THE REQUIRED SET MUST NOT BE DROPPABLE BY A RECAP. The required set is what makes
     `green` mean *the required set passed*, and it is now the ROW's `effective_required_set`: a copy names it
@@ -2651,16 +2304,15 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
     the class TWICE: a fourth copy of a canonical command that had gone stale, and a doc recap that dropped
     `,headRefOid` from the rollup fetch.
 
-    A copy is any occurrence that RUNS the command (`ci-status.py derive` carrying `--pr`) — prose that
-    merely NAMES the command is not a copy, and is not checked. **THE UNIT IS THE COMMAND, NOT THE LINE**:
-    an invocation WRAPS (a shell `\\`, or plain prose reflow), and a line-by-line check would report the
-    continuation line as a violation of itself. So each copy is read to its paragraph's next command boundary.
+    A copy is a command in an inline literal or a fenced shell block. Inline literals may wrap across
+    Markdown lines; fenced shell commands may wrap with a trailing `\\`. Other prose is not an invocation,
+    so this guard does not parse it.
 
     FINDING ZERO COPIES IS A FAILURE: the command is prescribed by at least `stage-2-ci.md` and
     `critical-rules.md`, and a check that cannot find its subject never passes.
     """
     problems, copies = [], []
-    for md, line, command in find_ci_status_copies(root or HERE.parent, "derive"):
+    for md, line, command in documented_ci_status_copies(root or HERE.parent, "derive"):
         if "--pr" not in command:
             continue  # prose that NAMES the command, not a copy of it
         copies.append(f"{md.name}:{line}")
@@ -2683,11 +2335,12 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
 def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
     """Every runnable liveness copy carries `--machine-action` — the judgment flag a recap must not drop.
 
-    Same class as `check_derive_copies`: a copy without the flag is a command the tool refuses, and a
-    reader who "fixes" it by inventing a default answers the one question the tool deliberately asks.
+    The supported forms are `documented_ci_status_copies`' inline literal and fenced shell command. A copy
+    without the flag is a command the tool refuses, and a reader who "fixes" it by inventing a default
+    answers the one question the tool deliberately asks.
     """
     problems, copies = [], []
-    for md, line, command in find_ci_status_copies(root or HERE.parent, "liveness"):
+    for md, line, command in documented_ci_status_copies(root or HERE.parent, "liveness"):
         # `--ledger`, not `--pr`, is the runnable-copy gate: prose can name a PR without spelling the
         # ledger input that makes liveness runnable.
         if "--ledger" not in command:
@@ -2708,9 +2361,9 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
 
 
 def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every runnable required-set copy names the ledger whose per-row required sets the command persists."""
+    """Every supported required-set command copy names the ledger it persists."""
     problems, copies = [], []
-    for md, line, command in find_ci_status_copies(root or HERE.parent, "required-set"):
+    for md, line, command in documented_ci_status_copies(root or HERE.parent, "required-set"):
         if "--ledger" not in command:
             continue  # prose that names the subcommand, not a runnable copy
         copies.append(f"{md.name}:{line}")
@@ -2743,7 +2396,7 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          paragraphs. A value in a hole matches NO branch: not green, not red, not pending — the PR can never
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
-         every copy of the derive and required-set commands and their required ledger inputs.
+         the supported derive and required-set command copies and their required ledger inputs.
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2269,7 +2269,7 @@ def markdown_quote_prefix(body: str) -> tuple[int, int]:
 def html_block_start(content: str) -> re.Pattern[str] | str | None:
     """Return an explicit end matcher, `"blank"` for a blank-ended block, or `None` for no HTML block."""
     if match := re.match(r" {0,3}<(script|pre|style|textarea)(?:[ \t]+|>|$)", content, re.IGNORECASE):
-        return re.compile(rf"</{re.escape(match.group(1))}[ \t]*>", re.IGNORECASE)
+        return re.compile(rf"</{re.escape(match.group(1))}>", re.IGNORECASE)
     if re.match(r" {0,3}<!--", content):
         return re.compile(r"-->")
     if re.match(r" {0,3}<\?", content):
@@ -2283,6 +2283,35 @@ def html_block_start(content: str) -> re.Pattern[str] | str | None:
     return None
 
 
+def markdown_leading_indent(content: str) -> tuple[int, int]:
+    """Return leading whitespace columns and bytes using CommonMark's four-column tab stops."""
+    columns = position = 0
+    while position < len(content) and content[position] in " \t":
+        if content[position] == "\t":
+            columns += 4 - columns % 4
+        else:
+            columns += 1
+        position += 1
+    return columns, position
+
+
+def markdown_remove_indent(content: str, width: int) -> str | None:
+    """Remove `width` indentation columns, preserving columns left by a partially consumed tab."""
+    columns = position = 0
+    while columns < width and position < len(content) and content[position] in " \t":
+        if content[position] == "\t":
+            next_columns = columns + 4 - columns % 4
+        else:
+            next_columns = columns + 1
+        position += 1
+        if next_columns > width:
+            return " " * (next_columns - width) + content[position:]
+        columns = next_columns
+    if columns < width:
+        return None
+    return content[position:]
+
+
 def markdown_list_marker(content: str) -> tuple[int, int, str, int | None] | None:
     """Return a list marker's indent, content indent, family, and ordered start."""
     match = re.match(r"( *)([*+-]|[0-9]{1,9}([.)]))([ \t]+)(?=\S)", content)
@@ -2290,7 +2319,8 @@ def markdown_list_marker(content: str) -> tuple[int, int, str, int | None] | Non
         return None
     indent = len(match.group(1))
     token = match.group(2)
-    padding = len(match.group(4).expandtabs(4))
+    marker_end = indent + len(token)
+    padding = len((" " * marker_end + match.group(4)).expandtabs(4)) - marker_end
     content_indent = indent + len(token) + (padding if padding <= 4 else 1)
     if token[0].isdigit():
         return indent, content_indent, f"ordered:{match.group(3)}", int(token[:-1])
@@ -2311,12 +2341,46 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
         active_html: re.Pattern[str] | str | None = None
         active_indented_code = False
         active_lists: list[tuple[int, int, int, str]] = []
+        list_blank_pending = False
         for line in text.splitlines(keepends=True):
             body = line.rstrip("\r\n")
-            quote_depth, content_start = markdown_quote_prefix(body)
+            outer_quote_depth, content_start = markdown_quote_prefix(body)
             content = body[content_start:]
             line_end = offset + len(line)
             list_marker = markdown_list_marker(content)
+            candidate_same_list = bool(
+                list_marker is not None
+                and any(depth == outer_quote_depth and indent == list_marker[0]
+                        and family == list_marker[2]
+                        for depth, indent, _content_indent, family in active_lists)
+            )
+            candidate_nested_list = bool(
+                list_marker is not None
+                and any(depth == outer_quote_depth and content_indent <= list_marker[0]
+                        for depth, _indent, content_indent, _family in active_lists)
+            )
+            inside_list_item = any(
+                depth == outer_quote_depth and markdown_remove_indent(content, content_indent) is not None
+                for depth, _indent, content_indent, _family in active_lists
+            )
+            if list_blank_pending and content.strip():
+                if not (candidate_same_list or candidate_nested_list or inside_list_item):
+                    active_lists.clear()
+                list_blank_pending = False
+                list_marker = markdown_list_marker(content)
+
+            list_content = content
+            for depth, _indent, content_indent, _family in reversed(active_lists):
+                if depth != outer_quote_depth:
+                    continue
+                stripped = markdown_remove_indent(content, content_indent)
+                if stripped is not None:
+                    list_content = stripped
+                    break
+            nested_quote_depth, nested_content_start = markdown_quote_prefix(list_content)
+            quote_depth = outer_quote_depth + nested_quote_depth
+            block_content = list_content[nested_content_start:]
+
             # Only ordered marker 1 can interrupt a paragraph to start a list. Later numbers split an
             # active ordered list, and child markers are measured from the active item's content indent.
             same_list = bool(
@@ -2350,7 +2414,7 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
 
             if active_fence is not None:
                 fence_char, fence_length = active_fence
-                if re.match(rf" {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*$", content):
+                if re.match(rf" {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*$", block_content):
                     regions.append((start, line_end))
                     start = line_end
                     active_fence = None
@@ -2359,14 +2423,14 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 continue
 
             if active_html is not None:
-                if isinstance(active_html, re.Pattern) and active_html.search(content):
+                if isinstance(active_html, re.Pattern) and active_html.search(block_content):
                     regions.append((start, line_end))
                     start = line_end
                     active_html = None
                     active_quote_depth = 0
                     offset = line_end
                     continue
-                if content.strip():
+                if block_content.strip():
                     offset = line_end
                     continue
                 regions.append((start, offset))
@@ -2377,7 +2441,11 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 continue
 
             if active_indented_code:
-                if content.startswith("    ") or content.startswith("\t"):
+                if not block_content.strip():
+                    list_blank_pending = bool(active_lists)
+                    offset = line_end
+                    continue
+                if markdown_leading_indent(block_content)[0] >= 4:
                     offset = line_end
                     continue
                 if start < offset:
@@ -2386,44 +2454,46 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 active_indented_code = False
                 active_quote_depth = 0
 
-            if not content.strip():
+            if not block_content.strip():
                 if start < offset:
                     regions.append((start, offset))
                 start = line_end
                 active_quote_depth = 0
-            elif ((content.startswith("    ") or content.startswith("\t"))
+                list_blank_pending = bool(active_lists)
+            elif (markdown_leading_indent(block_content)[0] >= 4
                   and start == offset and not list_starts_block):
                 active_indented_code = True
                 active_quote_depth = quote_depth
-            elif re.match(r" {0,3}(?:=+|-+)[ \t]*$", content) and start < offset:
+            elif re.match(r" {0,3}(?:=+|-+)[ \t]*$", block_content) and start < offset:
                 regions.append((start, line_end))
                 start = line_end
                 active_quote_depth = 0
-            elif re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", content):
+            elif re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", block_content):
                 if start < offset:
                     regions.append((start, offset))
                 regions.append((offset, line_end))
                 start = line_end
                 active_quote_depth = 0
-            elif fence := re.match(r" {0,3}(`{3,}|~{3,})", content):
+            elif ((fence := re.match(r" {0,3}(`{3,}|~{3,})(.*)$", block_content)) is not None
+                  and (fence.group(1)[0] == "~" or "`" not in fence.group(2))):
                 if start < offset:
                     regions.append((start, offset))
                 start = offset
                 active_fence = (fence.group(1)[0], len(fence.group(1)))
                 active_quote_depth = quote_depth
-            elif (html_end := html_block_start(content)) is not None:
+            elif (html_end := html_block_start(block_content)) is not None:
                 if start < offset:
                     regions.append((start, offset))
                 start = offset
                 active_html = html_end
                 active_quote_depth = quote_depth
-                if isinstance(html_end, re.Pattern) and html_end.search(content[1:]):
+                if isinstance(html_end, re.Pattern) and html_end.search(block_content[1:]):
                     regions.append((start, line_end))
                     start = line_end
                     active_html = None
                     active_quote_depth = 0
             elif re.match(r" {0,3}(?:\*(?:[ \t]*\*){2,}|-(?:[ \t]*-){2,}|_(?:[ \t]*_){2,})[ \t]*$",
-                          content):
+                          block_content):
                 if start < offset:
                     regions.append((start, offset))
                 regions.append((offset, line_end))

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2247,14 +2247,40 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
     return problems
 
 
-def starts_interrupting_markdown_block(content: str) -> bool:
-    """Return whether a CommonMark block start interrupts the current paragraph."""
-    return bool(
-        re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", content)
-        or re.match(r" {0,3}(?:[*+-]|1[.)])[ \t]+\S", content)
-        or re.match(r" {0,3}(?:`{3,}|~{3,})", content)
-        or re.match(r" {0,3}(?:\*(?:[ \t]*\*){2,}|-(?:[ \t]*-){2,}|_(?:[ \t]*_){2,})[ \t]*$", content)
-    )
+HTML_BLOCK_TAGS = (
+    "address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|"
+    "dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h1|h2|h3|h4|h5|h6|head|header|"
+    "hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|"
+    "section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul"
+)
+
+
+def markdown_quote_prefix(body: str) -> tuple[int, int]:
+    """Return CommonMark blockquote depth and the first content byte without eating code indentation."""
+    depth = position = 0
+    while marker := re.match(r" {0,3}>", body[position:]):
+        position += marker.end()
+        if position < len(body) and body[position] in " \t":
+            position += 1
+        depth += 1
+    return depth, position
+
+
+def html_block_start(content: str) -> re.Pattern[str] | str | None:
+    """Return an explicit end matcher, `"blank"` for a blank-ended block, or `None` for no HTML block."""
+    if match := re.match(r" {0,3}<(script|pre|style|textarea)(?:[ \t]+|>|$)", content, re.IGNORECASE):
+        return re.compile(rf"</{re.escape(match.group(1))}[ \t]*>", re.IGNORECASE)
+    if re.match(r" {0,3}<!--", content):
+        return re.compile(r"-->")
+    if re.match(r" {0,3}<\?", content):
+        return re.compile(r"\?>")
+    if re.match(r" {0,3}<![A-Z]", content):
+        return re.compile(r">")
+    if re.match(r" {0,3}<!\[CDATA\[", content):
+        return re.compile(r"\]\]>")
+    if re.match(rf" {{0,3}}</?(?:{HTML_BLOCK_TAGS})(?:[ \t]+|/?>|$)", content, re.IGNORECASE):
+        return "blank"
+    return None
 
 
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
@@ -2267,19 +2293,96 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
         text = md.read_text(encoding="utf-8")
         regions: list[tuple[int, int]] = []
         start = offset = active_quote_depth = 0
+        active_fence: tuple[str, int] | None = None
+        active_html: re.Pattern[str] | str | None = None
+        active_indented_code = False
         for line in text.splitlines(keepends=True):
             body = line.rstrip("\r\n")
-            prefix = re.match(r"[ \t]*(?:>[ \t]*)*", body)
-            assert prefix is not None
-            quote_depth = prefix.group(0).count(">")
-            content = body[prefix.end():]
+            quote_depth, content_start = markdown_quote_prefix(body)
+            content = body[content_start:]
             line_end = offset + len(line)
+
+            if active_fence is not None:
+                fence_char, fence_length = active_fence
+                if re.match(rf" {{0,3}}{re.escape(fence_char)}{{{fence_length},}}[ \t]*$", content):
+                    regions.append((start, line_end))
+                    start = line_end
+                    active_fence = None
+                    active_quote_depth = 0
+                offset = line_end
+                continue
+
+            if active_html is not None:
+                if isinstance(active_html, re.Pattern) and active_html.search(content):
+                    regions.append((start, line_end))
+                    start = line_end
+                    active_html = None
+                    active_quote_depth = 0
+                    offset = line_end
+                    continue
+                if content.strip():
+                    offset = line_end
+                    continue
+                regions.append((start, offset))
+                start = line_end
+                active_html = None
+                active_quote_depth = 0
+                offset = line_end
+                continue
+
+            if active_indented_code:
+                if content.startswith("    ") or content.startswith("\t"):
+                    offset = line_end
+                    continue
+                if start < offset:
+                    regions.append((start, offset))
+                start = offset
+                active_indented_code = False
+                active_quote_depth = 0
+
             if not content.strip():
                 if start < offset:
                     regions.append((start, offset))
                 start = line_end
                 active_quote_depth = 0
-            elif starts_interrupting_markdown_block(content):
+            elif (content.startswith("    ") or content.startswith("\t")) and start == offset:
+                active_indented_code = True
+                active_quote_depth = quote_depth
+            elif re.match(r" {0,3}(?:=+|-+)[ \t]*$", content) and start < offset:
+                regions.append((start, line_end))
+                start = line_end
+                active_quote_depth = 0
+            elif re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", content):
+                if start < offset:
+                    regions.append((start, offset))
+                regions.append((offset, line_end))
+                start = line_end
+                active_quote_depth = 0
+            elif fence := re.match(r" {0,3}(`{3,}|~{3,})", content):
+                if start < offset:
+                    regions.append((start, offset))
+                start = offset
+                active_fence = (fence.group(1)[0], len(fence.group(1)))
+                active_quote_depth = quote_depth
+            elif (html_end := html_block_start(content)) is not None:
+                if start < offset:
+                    regions.append((start, offset))
+                start = offset
+                active_html = html_end
+                active_quote_depth = quote_depth
+                if isinstance(html_end, re.Pattern) and html_end.search(content[1:]):
+                    regions.append((start, line_end))
+                    start = line_end
+                    active_html = None
+                    active_quote_depth = 0
+            elif re.match(r" {0,3}(?:\*(?:[ \t]*\*){2,}|-(?:[ \t]*-){2,}|_(?:[ \t]*_){2,})[ \t]*$",
+                          content):
+                if start < offset:
+                    regions.append((start, offset))
+                regions.append((offset, line_end))
+                start = line_end
+                active_quote_depth = 0
+            elif re.match(r" {0,3}(?:[*+-]|1[.)])[ \t]+\S", content):
                 if start < offset:
                     regions.append((start, offset))
                 start = offset

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2333,7 +2333,9 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     command_start = re.compile(rf"ci-status\.py{separator}\S+\b")
-    command_delimiter = re.compile(r"`|&&|\|\||;|\|")
+    # Markdown backticks delimit a span, not a shell command. An invocation may be followed in the same
+    # paragraph by inline code that supplies its required flag, so only shell separators end the command.
+    command_delimiter = re.compile(r"&&|\|\||;|\|")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2248,15 +2248,16 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
 
 
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
-    """Find runnable-command candidates, allowing the subcommand to wrap within its paragraph."""
-    separator = r"(?:\s+|[ \t]+\\\r?\n[ \t]*|[ \t]*\\\r?\n[ \t]+)"
+    """Find wrapped blockquote candidates, stopping at quoted or unquoted blank lines."""
+    quote_prefix = r"(?:[ \t]*>[ \t]*)+"
+    separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")
         starts = [0]
         ends = []
-        for boundary in re.finditer(r"\n[ \t]*\n", text):
+        for boundary in re.finditer(rf"\r?\n(?:[ \t]*|{quote_prefix})\r?\n", text):
             ends.append(boundary.start())
             starts.append(boundary.end())
         ends.append(len(text))

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2341,6 +2341,12 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
         rf"|\b(?:and[ \t]+then|then|followed[ \t]+by)[ \t]+[A-Za-z_][\w./-]*{separator}\S+\b"
         rf")"
     )
+    # A bare, later shell-command line needs no prose introduction. Limit this to a command word followed
+    # by a long option: that is the only form that can lend a checked flag to the prior invocation, while a
+    # valid wrapped continuation starts with its option instead of a new command word.
+    bare_shell_command_start = re.compile(
+        r"(?:^|\r?\n)(?=[A-Za-z_./])[A-Za-z_./][\w./-]*(?=[ \t]+[^\r\n]*--[A-Za-z][\w-]*\b)"
+    )
     # Markdown backticks delimit a span, not a shell command. An invocation may be followed in the same
     # paragraph by inline code that supplies its required flag, so a backtick is never a command boundary.
     command_delimiter = re.compile(r"&&|\|\||;|\|")
@@ -2553,7 +2559,12 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
             for match in needle.finditer(paragraph):
                 offset = start + match.start()
                 command_end = len(paragraph)
-                if (next_command := command_start.search(paragraph, match.end())) is not None:
+                candidates = (
+                    command_start.search(paragraph, match.end()),
+                    bare_shell_command_start.search(paragraph, match.end()),
+                )
+                if (next_command := min((candidate for candidate in candidates if candidate is not None),
+                                        key=lambda candidate: candidate.start(), default=None)) is not None:
                     command_end = next_command.start()
                 if (delimiter := command_delimiter.search(paragraph, match.end(), command_end)) is not None:
                     command_end = delimiter.start()

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2247,6 +2247,26 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
     return problems
 
 
+def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
+    """Find runnable-command candidates, allowing the subcommand to wrap within its paragraph."""
+    needle = re.compile(rf"ci-status\.py\s+{re.escape(subcommand)}\b")
+    copies: list[tuple[Path, int, str]] = []
+    for md in sorted(root.rglob("*.md")):
+        text = md.read_text(encoding="utf-8")
+        starts = [0]
+        ends = []
+        for boundary in re.finditer(r"\n[ \t]*\n", text):
+            ends.append(boundary.start())
+            starts.append(boundary.end())
+        ends.append(len(text))
+        for start, end in zip(starts, ends):
+            paragraph = text[start:end]
+            for match in needle.finditer(paragraph):
+                offset = start + match.start()
+                copies.append((md, text.count("\n", 0, offset) + 1, paragraph[match.start():]))
+    return copies
+
+
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
     """EVERY COPY OF THE DERIVE COMMAND, IN EVERY SKILL DOC — not just the one in the doc under test.
 
@@ -2266,22 +2286,17 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
     `critical-rules.md`, and a check that cannot find its subject never passes.
     """
     problems, copies = [], []
-    for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = md.read_text(encoding="utf-8")
-        for m in re.finditer(r"ci-status\.py derive", text):
-            end = text.find("\n\n", m.start())
-            command = text[m.start(): end if end > 0 else len(text)]
-            if "--pr" not in command:
-                continue  # prose that NAMES the command, not a copy of it
-            n = text.count("\n", 0, m.start()) + 1
-            copies.append(f"{md.name}:{n}")
-            if "--ledger" not in command and "--required-set" not in command:
-                problems.append(
-                    f"{md.name}:{n} runs `ci-status.py derive` WITHOUT `--ledger` OR `--required-set` — the "
-                    f"flag that makes `green` mean the REQUIRED SET passed. A reader following this copy "
-                    f"issues a command the tool refuses; a reader who 'fixes' it by dropping the set gets a "
-                    f"verdict about the rows that showed up, which is the registration gap, reopened by a recap."
-                )
+    for md, line, command in find_ci_status_copies(root or HERE.parent, "derive"):
+        if "--pr" not in command:
+            continue  # prose that NAMES the command, not a copy of it
+        copies.append(f"{md.name}:{line}")
+        if "--ledger" not in command and "--required-set" not in command:
+            problems.append(
+                f"{md.name}:{line} runs `ci-status.py derive` WITHOUT `--ledger` OR `--required-set` — the "
+                f"flag that makes `green` mean the REQUIRED SET passed. A reader following this copy "
+                f"issues a command the tool refuses; a reader who 'fixes' it by dropping the set gets a "
+                f"verdict about the rows that showed up, which is the registration gap, reopened by a recap."
+            )
     if not copies:
         problems.append(
             "ZERO copies of `ci-status.py derive` were found in the skill's docs — the command is "
@@ -2298,24 +2313,19 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
     reader who "fixes" it by inventing a default answers the one question the tool deliberately asks.
     """
     problems, copies = [], []
-    for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = md.read_text(encoding="utf-8")
-        for match in re.finditer(r"ci-status\.py liveness", text):
-            end = text.find("\n\n", match.start())
-            command = text[match.start(): end if end > 0 else len(text)]
-            # `--ledger`, not `--pr`, is the runnable-copy gate here: prose about liveness routinely sits
-            # in the same paragraph as a `ledger.py … set --pr` command, and `--pr` alone would condemn
-            # every such mention as a flagless invocation.
-            if "--ledger" not in command:
-                continue  # prose that names the subcommand, not a runnable copy
-            line = text.count("\n", 0, match.start()) + 1
-            copies.append(f"{md.name}:{line}")
-            if "--machine-action" not in command:
-                problems.append(
-                    f"{md.name}:{line} runs `ci-status.py liveness` WITHOUT `--machine-action` — the one "
-                    f"judgment the command asks of its caller. The tool refuses the invocation; a reader "
-                    f"who drops the flag's question strikes the very PR a fix is about to move."
-                )
+    for md, line, command in find_ci_status_copies(root or HERE.parent, "liveness"):
+        # `--ledger`, not `--pr`, is the runnable-copy gate here: prose about liveness routinely sits
+        # in the same paragraph as a `ledger.py … set --pr` command, and `--pr` alone would condemn
+        # every such mention as a flagless invocation.
+        if "--ledger" not in command:
+            continue  # prose that names the subcommand, not a runnable copy
+        copies.append(f"{md.name}:{line}")
+        if "--machine-action" not in command:
+            problems.append(
+                f"{md.name}:{line} runs `ci-status.py liveness` WITHOUT `--machine-action` — the one "
+                f"judgment the command asks of its caller. The tool refuses the invocation; a reader "
+                f"who drops the flag's question strikes the very PR a fix is about to move."
+            )
     if not copies:
         problems.append(
             "ZERO runnable copies of `ci-status.py liveness` were found in the skill's docs — the command "
@@ -2327,20 +2337,15 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
 def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
     """Every runnable required-set copy names the ledger whose per-row required sets the command persists."""
     problems, copies = [], []
-    for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = md.read_text(encoding="utf-8")
-        for match in re.finditer(r"ci-status\.py required-set", text):
-            end = text.find("\n\n", match.start())
-            command = text[match.start(): end if end > 0 else len(text)]
-            if "--ledger" not in command:
-                continue  # prose that names the subcommand, not a runnable copy
-            line = text.count("\n", 0, match.start()) + 1
-            copies.append(f"{md.name}:{line}")
-            if "state.jsonl" not in command:
-                problems.append(
-                    f"{md.name}:{line} runs `ci-status.py required-set` without the run ledger's "
-                    f"`state.jsonl` — the command must persist the value it read before the value exists"
-                )
+    for md, line, command in find_ci_status_copies(root or HERE.parent, "required-set"):
+        if "--ledger" not in command:
+            continue  # prose that names the subcommand, not a runnable copy
+        copies.append(f"{md.name}:{line}")
+        if "state.jsonl" not in command:
+            problems.append(
+                f"{md.name}:{line} runs `ci-status.py required-set` without the run ledger's "
+                f"`state.jsonl` — the command must persist the value it read before the value exists"
+            )
     if not copies:
         problems.append(
             "ZERO runnable copies of `ci-status.py required-set` were found in the skill's docs — finding "

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2249,7 +2249,8 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
 
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
     """Find runnable-command candidates, allowing the subcommand to wrap within its paragraph."""
-    needle = re.compile(rf"ci-status\.py\s+{re.escape(subcommand)}\b")
+    separator = r"(?:\s+|[ \t]+\\\r?\n[ \t]*|[ \t]*\\\r?\n[ \t]+)"
+    needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):
         text = md.read_text(encoding="utf-8")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2334,12 +2334,13 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     # A later known interpreter or script starts a new span directly. An explicitly introduced later
     # command does too, even when it is not a known interpreter or script. Its flags describe that command,
-    # never the ci-status.py invocation before it. `Next, run` is a sentence-level introduction, so it
-    # must be recognized even though its command starts after prose rather than a Markdown block boundary.
+    # never the ci-status.py invocation before it. `Next, run` and `Afterwards, run` are sentence-level
+    # introductions, so they must be recognized even though their commands start after prose rather than a
+    # Markdown block boundary.
     command_start = re.compile(
         rf"(?:"
         rf"(?<![\w./-])(?:(?:[\w.-]+/)*[\w.-]+\.py|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
-        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by|[Nn]ext,?[ \t]+run)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
+        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by|(?:[Nn]ext|[Aa]fterwards?),?[ \t]+run)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
         rf")"
     )
     # A bare, later shell-command line needs no prose introduction. Limit this to a command word followed

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2283,6 +2283,20 @@ def html_block_start(content: str) -> re.Pattern[str] | str | None:
     return None
 
 
+def markdown_list_marker(content: str) -> tuple[int, int, str, int | None] | None:
+    """Return a list marker's indent, content indent, family, and ordered start."""
+    match = re.match(r"( *)([*+-]|[0-9]{1,9}([.)]))([ \t]+)(?=\S)", content)
+    if match is None:
+        return None
+    indent = len(match.group(1))
+    token = match.group(2)
+    padding = len(match.group(4).expandtabs(4))
+    content_indent = indent + len(token) + (padding if padding <= 4 else 1)
+    if token[0].isdigit():
+        return indent, content_indent, f"ordered:{match.group(3)}", int(token[:-1])
+    return indent, content_indent, "unordered", None
+
+
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
     """Find wrapped candidates without crossing Markdown paragraph, block, or quote boundaries."""
     quote_prefix = r"(?:[ \t]*>[ \t]*)+"
@@ -2296,11 +2310,43 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
         active_fence: tuple[str, int] | None = None
         active_html: re.Pattern[str] | str | None = None
         active_indented_code = False
+        active_lists: list[tuple[int, int, int, str]] = []
         for line in text.splitlines(keepends=True):
             body = line.rstrip("\r\n")
             quote_depth, content_start = markdown_quote_prefix(body)
             content = body[content_start:]
             line_end = offset + len(line)
+            list_marker = markdown_list_marker(content)
+            # Only ordered marker 1 can interrupt a paragraph to start a list. Later numbers split an
+            # active ordered list, and child markers are measured from the active item's content indent.
+            same_list = bool(
+                list_marker is not None
+                and any(depth == quote_depth and indent == list_marker[0] and family == list_marker[2]
+                        for depth, indent, _content_indent, family in active_lists)
+            )
+            nested_list = bool(
+                list_marker is not None
+                and any(depth == quote_depth and content_indent <= list_marker[0]
+                        for depth, _indent, content_indent, _family in active_lists)
+            )
+            list_starts_block = bool(
+                list_marker is not None
+                and (same_list
+                     or ((list_marker[3] is None or list_marker[3] == 1)
+                         and (list_marker[0] <= 3 or nested_list))
+                     or (start == offset and (list_marker[0] <= 3 or nested_list)))
+            )
+
+            # Fenced and HTML blocks cannot lazily continue after their blockquote container ends. Close
+            # the region before processing the first line outside that container.
+            if ((active_fence is not None or active_html is not None)
+                    and active_quote_depth and quote_depth < active_quote_depth):
+                if start < offset:
+                    regions.append((start, offset))
+                start = offset
+                active_fence = None
+                active_html = None
+                active_quote_depth = 0
 
             if active_fence is not None:
                 fence_char, fence_length = active_fence
@@ -2345,7 +2391,8 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                     regions.append((start, offset))
                 start = line_end
                 active_quote_depth = 0
-            elif (content.startswith("    ") or content.startswith("\t")) and start == offset:
+            elif ((content.startswith("    ") or content.startswith("\t"))
+                  and start == offset and not list_starts_block):
                 active_indented_code = True
                 active_quote_depth = quote_depth
             elif re.match(r" {0,3}(?:=+|-+)[ \t]*$", content) and start < offset:
@@ -2382,11 +2429,17 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 regions.append((offset, line_end))
                 start = line_end
                 active_quote_depth = 0
-            elif re.match(r" {0,3}(?:[*+-]|1[.)])[ \t]+\S", content):
+            elif list_starts_block and list_marker is not None:
                 if start < offset:
                     regions.append((start, offset))
                 start = offset
                 active_quote_depth = quote_depth
+                while (active_lists
+                       and (active_lists[-1][0] > quote_depth
+                            or (active_lists[-1][0] == quote_depth
+                                and active_lists[-1][1] >= list_marker[0]))):
+                    active_lists.pop()
+                active_lists.append((quote_depth, list_marker[0], list_marker[1], list_marker[2]))
             elif quote_depth:
                 if quote_depth != active_quote_depth:
                     if start < offset:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2334,11 +2334,12 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
     # A later known interpreter or script starts a new span directly. An explicitly introduced later
     # command does too, even when it is not a known interpreter or script. Its flags describe that command,
-    # never the ci-status.py invocation before it.
+    # never the ci-status.py invocation before it. `Next, run` is a sentence-level introduction, so it
+    # must be recognized even though its command starts after prose rather than a Markdown block boundary.
     command_start = re.compile(
         rf"(?:"
         rf"(?<![\w./-])(?:(?:[\w.-]+/)*[\w.-]+\.py|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
-        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
+        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by|[Nn]ext,?[ \t]+run)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
         rf")"
     )
     # A bare, later shell-command line needs no prose introduction. Limit this to a command word followed

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2247,8 +2247,18 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
     return problems
 
 
+def starts_interrupting_markdown_block(content: str) -> bool:
+    """Return whether a CommonMark block start interrupts the current paragraph."""
+    return bool(
+        re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", content)
+        or re.match(r" {0,3}(?:[*+-]|1[.)])[ \t]+\S", content)
+        or re.match(r" {0,3}(?:`{3,}|~{3,})", content)
+        or re.match(r" {0,3}(?:\*(?:[ \t]*\*){2,}|-(?:[ \t]*-){2,}|_(?:[ \t]*_){2,})[ \t]*$", content)
+    )
+
+
 def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, str]]:
-    """Find wrapped candidates without crossing Markdown paragraph or blockquote boundaries."""
+    """Find wrapped candidates without crossing Markdown paragraph, block, or quote boundaries."""
     quote_prefix = r"(?:[ \t]*>[ \t]*)+"
     separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
@@ -2269,6 +2279,11 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                     regions.append((start, offset))
                 start = line_end
                 active_quote_depth = 0
+            elif starts_interrupting_markdown_block(content):
+                if start < offset:
+                    regions.append((start, offset))
+                start = offset
+                active_quote_depth = quote_depth
             elif quote_depth:
                 if quote_depth != active_quote_depth:
                     if start < offset:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2332,10 +2332,14 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     quote_prefix = r"(?:[ \t]*>[ \t]*)+"
     separator = rf"(?:\s+|[ \t]*\\\r?\n(?:{quote_prefix})?[ \t]*|\r?\n{quote_prefix})"
     needle = re.compile(rf"ci-status\.py{separator}{re.escape(subcommand)}\b")
-    # A later runnable command starts a new span even when it is not ci-status.py. Its flags describe
-    # that command, never the ci-status.py invocation before it.
+    # A later known interpreter or script starts a new span directly. An explicitly introduced later
+    # command does too, even when it is not a known interpreter or script. Its flags describe that command,
+    # never the ci-status.py invocation before it.
     command_start = re.compile(
+        rf"(?:"
         rf"(?<![\w./-])(?:(?:[\w.-]+/)*[\w.-]+\.py|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
+        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by)[ \t]+[A-Za-z_][\w./-]*{separator}\S+\b"
+        rf")"
     )
     # Markdown backticks delimit a span, not a shell command. An invocation may be followed in the same
     # paragraph by inline code that supplies its required flag, so a backtick is never a command boundary.
@@ -2408,6 +2412,9 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                          and (list_marker[0] <= 3 or nested_list))
                      or (start == offset and (list_marker[0] <= 3 or nested_list)))
             )
+            # A block outside the list's content indentation ends the list. Clear its state before a later
+            # top-level indented block can be mistaken for list text.
+            block_ends_active_list = bool(active_lists and not inside_list_item)
 
             # Fenced and HTML blocks cannot lazily continue after their blockquote container ends. Close
             # the region before processing the first line outside that container.
@@ -2473,10 +2480,14 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 active_indented_code = True
                 active_quote_depth = quote_depth
             elif re.match(r" {0,3}(?:=+|-+)[ \t]*$", block_content) and start < offset:
+                if block_ends_active_list:
+                    active_lists.clear()
                 regions.append((start, line_end))
                 start = line_end
                 active_quote_depth = 0
             elif re.match(r" {0,3}#{1,6}(?:[ \t]+|$)", block_content):
+                if block_ends_active_list:
+                    active_lists.clear()
                 if start < offset:
                     regions.append((start, offset))
                 regions.append((offset, line_end))
@@ -2484,12 +2495,16 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                 active_quote_depth = 0
             elif ((fence := re.match(r" {0,3}(`{3,}|~{3,})(.*)$", block_content)) is not None
                   and (fence.group(1)[0] == "~" or "`" not in fence.group(2))):
+                if block_ends_active_list:
+                    active_lists.clear()
                 if start < offset:
                     regions.append((start, offset))
                 start = offset
                 active_fence = (fence.group(1)[0], len(fence.group(1)))
                 active_quote_depth = quote_depth
             elif (html_end := html_block_start(block_content)) is not None:
+                if block_ends_active_list:
+                    active_lists.clear()
                 if start < offset:
                     regions.append((start, offset))
                 start = offset
@@ -2502,6 +2517,8 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                     active_quote_depth = 0
             elif re.match(r" {0,3}(?:\*(?:[ \t]*\*){2,}|-(?:[ \t]*-){2,}|_(?:[ \t]*_){2,})[ \t]*$",
                           block_content):
+                if block_ends_active_list:
+                    active_lists.clear()
                 if start < offset:
                     regions.append((start, offset))
                 regions.append((offset, line_end))
@@ -2519,6 +2536,8 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
                     active_lists.pop()
                 active_lists.append((quote_depth, list_marker[0], list_marker[1], list_marker[2]))
             elif quote_depth:
+                if block_ends_active_list:
+                    active_lists.clear()
                 if quote_depth != active_quote_depth:
                     if start < offset:
                         regions.append((start, offset))

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2338,7 +2338,7 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     command_start = re.compile(
         rf"(?:"
         rf"(?<![\w./-])(?:(?:[\w.-]+/)*[\w.-]+\.py|python(?:3)?|bash|sh|gh|git){separator}\S+\b"
-        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by)[ \t]+[A-Za-z_][\w./-]*{separator}\S+\b"
+        rf"|\b(?:and[ \t]+then|then|followed[ \t]+by)[ \t]+[`]*[A-Za-z_][\w./-]*{separator}\S+\b"
         rf")"
     )
     # A bare, later shell-command line needs no prose introduction. Limit this to a command word followed
@@ -2347,8 +2347,8 @@ def find_ci_status_copies(root: Path, subcommand: str) -> list[tuple[Path, int, 
     bare_shell_command_start = re.compile(
         r"(?:^|\r?\n)(?=[A-Za-z_./])[A-Za-z_./][\w./-]*(?=[ \t]+[^\r\n]*--[A-Za-z][\w-]*\b)"
     )
-    # Markdown backticks delimit a span, not a shell command. An invocation may be followed in the same
-    # paragraph by inline code that supplies its required flag, so a backtick is never a command boundary.
+    # A Markdown backtick alone does not start a command. An explicit prose introduction followed by inline
+    # code does: the later command's flags must not extend the ci-status.py invocation before it.
     command_delimiter = re.compile(r"&&|\|\||;|\|")
     copies: list[tuple[Path, int, str]] = []
     for md in sorted(root.rglob("*.md")):


### PR DESCRIPTION
- match wrapped `ci-status.py` subcommands within paragraph boundaries
- cover valid and invalid wrapped derive, liveness, and required-set copies
