### PR TITLE
reject terminal rows during PR re-adoption

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -97,9 +97,11 @@ it — no trigger means the step runs unconditionally at that point in the seque
 **Adoption** (`references/pr-adoption.md`) — for each explicit `#PR` arg, and on every heartbeat for
 every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snapshot):
 
-6. Fetch the PR; REFUSE foreign-owned and cross-repo/fork PRs. Register the ledger row (refresh on
-   re-adoption, never duplicate), run label, status label, and worktree. THEN write (or preserve) the
-   PR's **base** intent artifact (`intent-<pr>.md`: `## Purpose` / `## Non-goals` / `## Threat model`;
+6. Fetch the PR; REFUSE foreign-owned and cross-repo/fork PRs. REFUSE an existing terminal row before
+   any refresh, label, worktree, or intent work. For new and existing non-terminal rows, register the
+   ledger row (refresh in place on re-adoption, never duplicate), run label, status label, and worktree.
+   THEN write (or preserve) the PR's **base** intent artifact (`intent-<pr>.md`: `## Purpose` /
+   `## Non-goals` / `## Threat model`;
    local, git-ignored, never written back to the PR) and `pr-adopt.py intent-sync` to fold the run's
    default Non-goals into its managed block — the row must exist FIRST, because `intent-sync` REFUSES a PR
    with no ledger row (`pr-adoption.md`). Run `triage.py derive` on that resolved worktree for the

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -244,8 +244,9 @@ Header field notes (the header fields above; per-row fields follow):
   the root/main checkout, and a reused local branch are **never** removed. `merge.py run` owns the
   resumable enforcement; see Stage 3, **"Resumable merge execution"**.
 
-- `id` — `pr<N>` (the adopted PR number). `slug` — slugified PR title. Together they identify the row;
-  re-adoption looks up by `pr`/`id` and refreshes in place, never appends a duplicate.
+- `id` — `pr<N>` (the adopted PR number). `slug` — slugified PR title. Together they identify the row.
+  Re-adoption looks up by `pr`/`id`. An existing non-terminal row refreshes in place. A terminal row is
+  final, so adoption refuses it before any refresh. Adoption never appends a duplicate.
 - `branch` — the PR's **own** `headRefName`. Adopted PRs keep their branch — campaign does NOT mint a
   `fix-<run-id>-...` branch, so the branch name won't carry the run id. **The `gauntlet-run-<run-id>`
   label is the ownership marker**, not the branch prefix.

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -167,10 +167,12 @@ about and one whose partial rejection strands the rest.
    - **`in-pr`** — a PR is open and named in the entry, but an interrupted heartbeat may have recorded `open-pr`
      **without** finishing ADOPTION. Adoption is a campaign action, not a store edge — no `in-pr`
      transition performs it — so "defer to the graph" strands the PR. On resume, **reconcile the recorded
-     PR against the current run and ADOPT it** (the existing idempotent adoption, step 4) if it lacks a run
-     label or ledger row, **then** wait for `merged`/`closed-unmerged`. An unadopted follow-up PR sits
-     **outside the campaign gate** — the exact thing "fold that PR into the current campaign" exists to
-     prevent.
+     PR against the current run.** If it has no ledger row, or its **non-terminal** row lacks the run label,
+     ADOPT it through step 4. **If its existing row is terminal, NEVER refresh, re-adopt, or relabel it** —
+     surface that terminal campaign result and leave the follow-up lifecycle unchanged. Choosing the next
+     follow-up transition for an aborted-but-open PR is separate lifecycle work; this adoption guard does
+     not invent one. An unadopted follow-up PR with no terminal row sits **outside the campaign gate** —
+     the exact thing "fold that PR into the current campaign" exists to prevent.
    - **`reopened`** — its PR died and it already carries the decision it earned, so it does **not** re-decide:
      it resumes at opening the **replacement** PR. Dispatch the fixer, which opens the replacement PR, then
      `open-pr` records it (→ `in-pr`) and step 4 adopts it — no reconciliation, same as `self-accepted`. The

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -10,9 +10,10 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   from `files-and-ledger.md`, then reconcile PRs already labelled for this run. The executable owner is
   `scripts/reconcile.py fetch`; NEVER reconstruct its GitHub query in prose.
 
-  Every PR returned by the canonical snapshot is already ours — refresh its row from that snapshot.
-  A PR with the label but no row is a re-adoption after an amnesiac heartbeat; a row whose PR is gone
-  (merged/closed) reconciles to its terminal status.
+  Every PR returned by the canonical snapshot is already ours. Refresh it only when its existing row is
+  non-terminal. A PR with the label but no row is a re-adoption after an amnesiac heartbeat. An existing
+  terminal row is final for this run: NEVER refresh, re-adopt, or relabel it, even when the PR is still
+  open. A row whose PR is gone (merged/closed) reconciles to its terminal status.
 
   A fetch refusal produces no discovery input. Keep the previous snapshot untouched and resolve the
   reported blocker before adoption.
@@ -118,7 +119,10 @@ For each `#PR` to adopt:
 3. **Register the ledger row — refresh, never duplicate.** Write the row through
    `scripts/ledger.py` (the schema-owning accessor — `references/files-and-ledger.md`), addressing
    every field **by name**; never hand-edit `state.jsonl` rows by column position. Look the PR up first
-   (`ledger.py --file <state.jsonl> get --pr <N>`): if a row already exists (re-adoption / resume),
+   (`ledger.py --file <state.jsonl> get --pr <N>`). **If the row is terminal, REFUSE before `pr-adopt.py`
+   creates the run label, applies PR labels, refreshes the ledger, or resolves a worktree.** An open PR or
+   missing run label does not revive a row this run already finished or abandoned. If a non-terminal row
+   already exists (re-adoption / resume),
    **refresh it in place** with `ledger.py … set --pr <N> --<field> <val> …` — never append a second
    row for the same PR (`add-row` refuses a duplicate `pr`). Otherwise create it with
    `ledger.py … add-row --pr <N> --<field> <val> …`. Write every field that needs a **COMPUTED** value —
@@ -128,7 +132,8 @@ For each `#PR` to adopt:
    one: the schema lives in the script, and a copy of it retyped here would be stale the next time a row
    field is added.
 
-   **Re-adoption base gate — BEFORE any refresh write.** The recorded row `base_branch` is immutable, and
+   **Re-adoption base gate — AFTER the terminal-row refusal and BEFORE any refresh write.** The recorded
+   row `base_branch` is immutable, and
    the campaign never migrates a row to a new base. On a re-adoption, `pr-adopt.py` first compares the PR's
    live `baseRefName` with the row's `effective_base`; **if they differ it PARKS the row** (machine-blocker,
    `status = awaiting-user`, `ci_reason` = `base changed from <recorded> to <live>; not supported mid-run`,
@@ -168,7 +173,7 @@ For each `#PR` to adopt:
      who wrote this"* is not *"I wrote this"*. It is **NOT** `worktree_owned`/`branch_owned`: those say
      whether campaign created the local checkout and branch, which is a **cleanup** question, and a PR can
      have a campaign-created worktree and still belong entirely to someone else.
-   - **On a REFRESH of an existing row, only re-read `head_sha`/`ci` from ground truth; reset
+   - **On a REFRESH of an existing non-terminal row, only re-read `head_sha`/`ci` from ground truth; reset
      `reviews_ok` to `0` and re-triage `tier` only if** reconciliation detects a PR-content change
      since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
      site: in the same step, reconcile the label by running `label-mirror.py mirror` for the PR**, which
@@ -275,9 +280,9 @@ For each `#PR` to adopt:
 
    **After copying or authoring the base artifact, run `pr-adopt.py intent-sync --file <rundir>/state.jsonl
    --pr <pr>`** to fold in the run defaults (it reports `updated`, `unchanged`, or `pending-intent`).
-   Adoption also runs it automatically at the end of `pr-adopt.py adopt`, so a re-adoption whose intent
-   artifact is present is synced without a separate call; the explicit invocation is for the fresh-adoption
-   path, where the driver authors the base intent first and then syncs.
+   Adoption also runs it automatically at the end of `pr-adopt.py adopt`, so a non-terminal re-adoption
+   whose intent artifact is present is synced without a separate call; the explicit invocation is for the
+   fresh-adoption path, where the driver authors the base intent first and then syncs.
 
    **USABLE means the parser will take it — `review-pass.py` is the definition, and this is the same rule
    stated for a human:** all three headings, **at least one `## Purpose` bullet, AND at least one
@@ -351,14 +356,14 @@ For each `#PR` to adopt:
    consultation only; the store is DRIVER-POPULATED and auto-staling is out of scope). Do not import a Non-goal
    from a learning whose anchor this diff just moved.
 
-   **On a RE-ADOPTION, do not re-author — but DO re-sync.** `intent` is one of the fields the refresh
-   **preserves** (step 3), and the base `intent-<pr>.md` is re-read, never re-derived — a heartbeat is a
-   fresh agent instance, and an intent invented twice is two intents. The run-default managed block IS
+   **On a NON-TERMINAL RE-ADOPTION, do not re-author — but DO re-sync.** `intent` is one of the fields the
+   refresh **preserves** (step 3), and the base `intent-<pr>.md` is re-read, never re-derived — a heartbeat
+   is a fresh agent instance, and an intent invented twice is two intents. The run-default managed block IS
    re-synced, automatically, by `pr-adopt.py adopt` (it runs `intent-sync` at the end), so a header change
-   propagates on the next re-adoption without re-authoring the base. Re-author only if the file is **gone**
-   (a wiped `<rundir>`) — then re-run `intent-sync` and `intent-check` after authoring, exactly as a fresh
-   adoption does — and say so. After a `REPAIR-INTENT` re-authoring (`repair-pass.md`), likewise re-run
-   `intent-sync` and the intent check.
+   propagates on the next eligible re-adoption without re-authoring the base. Re-author only if the file is
+   **gone** (a wiped `<rundir>`) — then re-run `intent-sync` and `intent-check` after authoring, exactly as a
+   fresh adoption does — and say so. After a `REPAIR-INTENT` re-authoring (`repair-pass.md`), likewise
+   re-run `intent-sync` and the intent check.
 
 #### Step 4 — Label it ours, and set the status label from the LIVE gate
 
@@ -376,11 +381,11 @@ For each `#PR` to adopt:
    that you are adopting:
 
    ```
-   # Gate NOT met at the current HEAD — a fresh adoption (reviews_ok = 0), or a re-adoption whose
+   # Gate NOT met at the current HEAD — a fresh adoption (reviews_ok = 0), or a non-terminal re-adoption whose
    # content changed (step 3 just reset reviews_ok). The common case:
    gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-reviewing --remove-label gauntlet-accepted
 
-   # Gate ALREADY met at the current HEAD — re-adoption of a PR whose content did NOT change, so step 3
+   # Gate ALREADY met at the current HEAD — non-terminal re-adoption of a PR whose content did NOT change, so step 3
    # preserved reviews_ok >= required(tier). Its acceptance is still valid; do not revoke it:
    gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-accepted --remove-label gauntlet-reviewing
    ```
@@ -462,7 +467,7 @@ For each `#PR` to adopt:
    #### Two fail-closed guarantees the pseudocode leaves implicit
 
    **Two fail-closed guarantees the pseudocode leaves implicit:**
-   - **On a re-adoption of the SAME worktree campaign itself created, PRESERVE its recorded
+   - **On a non-terminal re-adoption of the SAME worktree campaign itself created, PRESERVE its recorded
      `worktree_owned`/`branch_owned`** rather than downgrading them to `no`. A first adopt that **created**
      the worktree recorded `yes`; blanking that to `no` on a later heartbeat would strand the
      campaign-created worktree from Stage-3 cleanup. The `existing is present` branch's `worktree_owned =
@@ -510,10 +515,10 @@ followed by a second. Without this second veto derive the adoption path would
 write a below-floor tier straight through — gate work could start below the emitted floor, an
 under-reviewed stricter tier — the exact hole the heartbeat veto closes; the two paths are symmetric. A
 refusal from EITHER derive leaves the conservative bootstrap in place and blocks gate dispatch until the
-next heartbeat refreshes the worktree/head and derives successfully.
+next heartbeat refreshes the non-terminal row's worktree/head and derives successfully.
 
 **A same-SHA tier change is TWO events by direction** (`stage-2-review-gate.md`, "Status labels mirror the
-review gate", owns the split; depth order TRIVIAL < STANDARD < HIGH), and on an UNCHANGED re-adoption
+review gate", owns the split; depth order TRIVIAL < STANDARD < HIGH), and on an UNCHANGED non-terminal re-adoption
 `pr-adopt.py` PRESERVES `reviews_ok` (>= 1) (it preserves it when the head did not move), so this
 decided-tier write must honour the direction before the mirror:
 - **Depth-raising escalation** (this decision raises the preserved tier to a strictly deeper one —
@@ -531,7 +536,7 @@ decided-tier write must honour the direction before the mirror:
 **Then, in the SAME step, run `label-mirror.py mirror` for the PR** — idempotent, a no-op when the label
 already matches — so the tier, `required(tier)`, and the public status label move together
 (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool). **Run it
-on an UNCHANGED re-adoption too, NOT only a fresh one:** step 4 labelled against the *preserved* tier
+on an UNCHANGED non-terminal re-adoption too, NOT only a fresh one:** step 4 labelled against the *preserved* tier
 before this decision, so a PR left `gauntlet-accepted` under a preserved lower tier keeps that false label
 until the mirror flips it to `gauntlet-reviewing` (the escalation reset above took the tally below
 `required`). Never skip it as a presumed no-op — a fresh adoption's `reviews_ok=0` is the ONLY case the

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -522,6 +522,38 @@ def t_readopt_changed_head_preserves_held_status():
               f"(exit {M.L.EXIT_STOP}); got {dc}")
 
 
+# --- terminal rows are final — an OPEN PR cannot re-adopt them ----------------
+
+def t_readopt_terminal_rows_refused():
+    """Every ledger-owned terminal status refuses before any adoption mutation.
+
+    Bailout may leave the PR OPEN after recording `aborted` and removing its labels. That missing label is
+    not adoption work: the terminal row wins. Drive every member of ledger.py's one terminal-status set so
+    adding a terminal status there automatically adds an executor fixture here.
+    """
+    for status in M.L.TERMINAL_STATUSES:
+        with tempfile.TemporaryDirectory() as dd:
+            d = Path(dd)
+            ledger = d / "state.jsonl"
+            _init_ledger(ledger)
+            _add_row(ledger, 12, head_sha="a" * 40, status=status, tier="HIGH")
+            before = ledger.read_bytes()
+
+            code, _, err, rec = _adopt(d, ledger, view(labels=[]), wroot=d / "wt")
+
+            check(code != 0, f"an OPEN PR with terminal row status={status} must be REFUSED")
+            check("terminal" in err.lower() and status in err,
+                  f"the refusal must name terminal status={status}; got {err!r}")
+            check(ledger.read_bytes() == before,
+                  f"terminal status={status} must leave the ledger byte-identical")
+            check([c["argv"][:3] for c in rec.gh_calls()] == [["gh", "pr", "view"]],
+                  f"terminal status={status} must stop before label create/edit; got {rec.gh_calls()!r}")
+            check(not rec.any_call(lambda a: a[0] == "git"),
+                  f"terminal status={status} must stop before every worktree/git operation")
+            check(not rec.any_call(lambda a: a[0] == "python3"),
+                  f"terminal status={status} must stop before every ledger subprocess mutation")
+
+
 # --- fix 6: the ONE status label mirrors the live gate, mutually exclusive -----
 
 def t_readopt_accepted_unchanged_head_labels():
@@ -1205,6 +1237,7 @@ CASES = [
     ("readopt_unchanged_head_preserves_verdicts", "an unchanged head keeps reviews_ok/ci (fix 5)", t_readopt_unchanged_head_preserves_verdicts),
     ("readopt_changed_head_resets", "a moved head resets reviews_ok/ci and the liveness counters, review_rounds stays (fix 5)", t_readopt_changed_head_resets),
     ("readopt_changed_head_preserves_held_status", "a moved head preserves a held status and stays HELD, resetting only SHA-bound evidence", t_readopt_changed_head_preserves_held_status),
+    ("readopt_terminal_rows_refused", "every terminal row refuses before label, ledger, or worktree mutation", t_readopt_terminal_rows_refused),
     ("readopt_accepted_unchanged_head_labels", "accepted+unchanged head keeps gauntlet-accepted, mutually exclusive (fix 6)", t_readopt_accepted_unchanged_head_labels),
     ("readopt_changed_head_labels", "a moved head returns to gauntlet-reviewing, removes accepted (fix 6)", t_readopt_changed_head_labels),
     ("stale_local_branch_refused", "a worktree off a stale local branch is refused (fix 7)", t_stale_local_branch_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -14,7 +14,8 @@ under load:
 
   * READ the PR (one `gh pr view` for the fields the ledger row needs, including the cross-repo field);
   * REFUSE fork/foreign/closed PRs — FAIL CLOSED, touching nothing when it refuses (step 2);
-  * REGISTER the ledger row (refresh in place if it exists, never a duplicate `add-row`) (step 3, row);
+  * REGISTER the ledger row (refuse an existing terminal row; otherwise refresh in place if it exists,
+    never a duplicate `add-row`) (step 3, row);
   * RESOLVE the PR-head worktree — DISCOVER the branch's actual checkout via `git worktree list` and REUSE
     it (fast-forwarded, clean), else CREATE one at the default path; fail closed on a dirty/detached/foreign
     checkout or a head-SHA mismatch (step 5);
@@ -344,6 +345,14 @@ def cmd_adopt(args) -> int:
     header, rows = L.load(Path(args.file))
     existing = L.find_row(rows, pr)
 
+    # TERMINAL ROW GATE — runs before every label, ledger and worktree mutation. A terminal row records
+    # that this run already finished or gave up on the PR; an OPEN PR with labels removed is not permission
+    # to revive it. Re-adoption applies only to new or non-terminal rows.
+    if existing is not None and existing.get("status") in L.TERMINAL_STATUSES:
+        status = existing["status"]
+        return _refuse(f"PR {pr} already has terminal ledger status {status}; terminal rows are not "
+                       f"re-adoptable")
+
     # RE-ADOPTION BASE GATE — runs BEFORE any write. The recorded row base is IMMUTABLE (ledger CREATE_ONLY),
     # and the campaign never migrates a row to a new base. If the PR's live base no longer matches the row's
     # `effective_base` (its explicit base, else the legacy header), PARK the row on the user through the
@@ -518,11 +527,12 @@ def cmd_adopt(args) -> int:
         return _refuse(f"`gh pr edit {pr}` (labels) failed: {proc.stderr.strip()} "
                        f"(the ledger row and worktree for PR {pr} were already written)")
 
-    # 7. Fold the run's default Non-goals into the PR's intent managed block. On a RE-ADOPTION the intent
-    # artifact is already present, so this syncs it automatically; on a FRESH adoption it does not exist yet
-    # (the driver authors it next, then runs `intent-sync`), so this reports `pending-intent`. A malformed
-    # ledger/intent surfaces as a refusal rather than a silent skip — but the row and labels already landed,
-    # exactly like a half-adoption, and re-running `intent-sync` recovers it.
+    # 7. Fold the run's default Non-goals into the PR's intent managed block. On an eligible RE-ADOPTION
+    # (terminal rows stopped above) the intent artifact is already present, so this syncs it automatically;
+    # on a FRESH adoption it does not exist yet (the driver authors it next, then runs `intent-sync`), so
+    # this reports `pending-intent`. A malformed ledger/intent surfaces as a refusal rather than a silent
+    # skip — but the row and labels already landed, exactly like a half-adoption, and re-running
+    # `intent-sync` recovers it.
     try:
         intent_sync = sync_intent_defaults(args.file, pr)
     except ValueError as exc:


### PR DESCRIPTION
- reject re-adoption before labels or worktrees when the ledger row is terminal
- cover every ledger-owned terminal status with executor fixtures
- align follow-up resume and PR refresh documentation
