### PR TITLE
fix required-set error exit codes

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -186,8 +186,8 @@ the header base** (the header describes base B for that base alone — never a d
 settle a base off another base's set). So a `-`/`unknown` row on the header base heals from the header's
 settled value with no read, and a failed read cannot knock it back to `unknown`. It
 exits 0 when every group is settled (`declared:…` or `none`), 1 while any group is still `unknown`, and 2
-for a caller or ledger error. A settled group is returned without another GitHub read, and a read that
-fails for one base leaves only that base's unsettled rows `unknown` while the others settle — so the same
+for a caller, ledger, or output error. A settled group is returned without another GitHub read, and a read
+that fails for one base leaves only that base's unsettled rows `unknown` while the others settle — so the same
 command is safe to run on every heartbeat and retries only the `unknown` groups.
 
 The command owns two mandatory reads. They do **not** need the same permission: **`GET

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -518,7 +518,9 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     failed_stdout = cli_tmp / "failed-stdout.jsonl"
     valid_ledger(failed_stdout, header_required=ci.SNAP.NONE_DECLARED)
     failed_stdout_before = failed_stdout.read_bytes()
-    with Path("/dev/full").open("w", encoding="utf-8") as sink:
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    with os.fdopen(write_fd, "w", encoding="utf-8") as sink:
         proc = run_cli(failed_stdout, stdout=sink)
     check_error("failed stdout sink", failed_stdout, failed_stdout_before, proc)
     expected_prefix = f"ci-status: required-set: cannot process --ledger {failed_stdout} ("

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -450,10 +450,11 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     cli_tmp = tmp / "required-set-cli"
     cli_tmp.mkdir()
 
-    def run_cli(ledger: Path, *, repo: str = "o/r", env: "dict[str, str] | None" = None):
+    def run_cli(ledger: Path, *, repo: str = "o/r", env: "dict[str, str] | None" = None,
+                stdout=subprocess.PIPE):
         return subprocess.run(  # noqa: S603 - this suite drives its sibling command
             [sys.executable, str(STATUS_PY), "required-set", "--ledger", str(ledger), "--repo", repo],
-            capture_output=True, text=True, check=False, env=env,
+            stdout=stdout, stderr=subprocess.PIPE, text=True, check=False, env=env,
         )
 
     def valid_ledger(path: Path, *, header_required: str, row_required: "str | None" = None,
@@ -513,6 +514,20 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
         elif len(lines) != 1:
             problems.append(f"[required-set CLI] {name} emitted {len(lines)} diagnostics, not one: "
                             f"{proc.stderr!r}")
+
+    failed_stdout = cli_tmp / "failed-stdout.jsonl"
+    valid_ledger(failed_stdout, header_required=ci.SNAP.NONE_DECLARED)
+    failed_stdout_before = failed_stdout.read_bytes()
+    with Path("/dev/full").open("w", encoding="utf-8") as sink:
+        proc = run_cli(failed_stdout, stdout=sink)
+    check_error("failed stdout sink", failed_stdout, failed_stdout_before, proc)
+    expected_prefix = f"ci-status: required-set: cannot process --ledger {failed_stdout} ("
+    if not proc.stderr.startswith(expected_prefix):
+        problems.append(f"[required-set CLI] failed stdout sink emitted the wrong diagnostic: "
+                        f"{proc.stderr!r}")
+    if "Exception ignored in:" in proc.stderr or "OSError:" in proc.stderr:
+        problems.append(f"[required-set CLI] failed stdout sink leaked a finalization error: "
+                        f"{proc.stderr!r}")
 
     malformed_repo = cli_tmp / "malformed-repo.jsonl"
     valid_ledger(malformed_repo, header_required=ci.SNAP.CANNOT_READ, row_required="-")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -450,9 +450,9 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     cli_tmp = tmp / "required-set-cli"
     cli_tmp.mkdir()
 
-    def run_cli(ledger: Path, *, env: "dict[str, str] | None" = None):
+    def run_cli(ledger: Path, *, repo: str = "o/r", env: "dict[str, str] | None" = None):
         return subprocess.run(  # noqa: S603 - this suite drives its sibling command
-            [sys.executable, str(STATUS_PY), "required-set", "--ledger", str(ledger), "--repo", "o/r"],
+            [sys.executable, str(STATUS_PY), "required-set", "--ledger", str(ledger), "--repo", repo],
             capture_output=True, text=True, check=False, env=env,
         )
 
@@ -507,6 +507,16 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
         elif len(lines) != 1:
             problems.append(f"[required-set CLI] {name} emitted {len(lines)} diagnostics, not one: "
                             f"{proc.stderr!r}")
+
+    malformed_repo = cli_tmp / "malformed-repo.jsonl"
+    valid_ledger(malformed_repo, header_required=ci.SNAP.CANNOT_READ, row_required="-")
+    malformed_repo_before = malformed_repo.read_bytes()
+    check_error(
+        "malformed --repo",
+        malformed_repo,
+        malformed_repo_before,
+        run_cli(malformed_repo, repo="invalid", env=denied_env),
+    )
 
     malformed_cases = {
         "headerless ledger": b'{"type":"row","pr":"1"}\n',

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -456,13 +456,14 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
             capture_output=True, text=True, check=False, env=env,
         )
 
-    def valid_ledger(path: Path, *, header_required: str, row_required: "str | None" = None) -> None:
+    def valid_ledger(path: Path, *, header_required: str, row_required: "str | None" = None,
+                     base_branch: str = "main") -> None:
         header = dict(ci.LEDGER.HEADER_DEFAULTS)
-        header.update({"run_id": path.stem, "base_branch": "main", "required_set": header_required})
+        header.update({"run_id": path.stem, "base_branch": base_branch, "required_set": header_required})
         rows = []
         if row_required is not None:
             row = dict(ci.LEDGER.ROW_DEFAULTS)
-            row.update({"pr": "1", "base_branch": "main", "required_set": row_required,
+            row.update({"pr": "1", "base_branch": base_branch, "required_set": row_required,
                         "status": "in_review"})
             rows.append(row)
         ci.LEDGER.dump(path, header, rows)
@@ -504,6 +505,8 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
             problems.append(f"[required-set CLI] {name} exited {proc.returncode}, not 2: {proc.stderr!r}")
         if ledger.read_bytes() != before:
             problems.append(f"[required-set CLI] {name} mutated the ledger")
+        if proc.stdout:
+            problems.append(f"[required-set CLI] {name} emitted stdout: {proc.stdout!r}")
         lines = [line for line in proc.stderr.splitlines() if line]
         if "Traceback" in proc.stderr:
             problems.append(f"[required-set CLI] {name} emitted a traceback: {proc.stderr!r}")
@@ -547,6 +550,46 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     if gh_calls.read_bytes() != calls_before:
         problems.append("[required-set CLI] embedded-space --repo fetched from GitHub")
 
+    overlong_owner_repo = cli_tmp / "overlong-owner-repo.jsonl"
+    valid_ledger(overlong_owner_repo, header_required=ci.SNAP.CANNOT_READ, row_required="-")
+    overlong_owner_before = overlong_owner_repo.read_bytes()
+    calls_before = gh_calls.read_bytes()
+    check_error(
+        "overlong --repo owner",
+        overlong_owner_repo,
+        overlong_owner_before,
+        run_cli(overlong_owner_repo, repo=f"{'o' * 40}/repo", env=denied_env),
+    )
+    if gh_calls.read_bytes() != calls_before:
+        problems.append("[required-set CLI] overlong --repo owner fetched from GitHub")
+
+    overlong_name_repo = cli_tmp / "overlong-name-repo.jsonl"
+    valid_ledger(overlong_name_repo, header_required=ci.SNAP.CANNOT_READ, row_required="-")
+    overlong_name_before = overlong_name_repo.read_bytes()
+    calls_before = gh_calls.read_bytes()
+    check_error(
+        "overlong --repo name",
+        overlong_name_repo,
+        overlong_name_before,
+        run_cli(overlong_name_repo, repo=f"owner/{'r' * 101}", env=denied_env),
+    )
+    if gh_calls.read_bytes() != calls_before:
+        problems.append("[required-set CLI] overlong --repo name fetched from GitHub")
+
+    settled_surrogate = cli_tmp / "settled-surrogate.jsonl"
+    valid_ledger(
+        settled_surrogate,
+        header_required=ci.SNAP.NONE_DECLARED,
+        base_branch="\ud800",
+    )
+    settled_surrogate_before = settled_surrogate.read_bytes()
+    check_error(
+        "unencodable settled output",
+        settled_surrogate,
+        settled_surrogate_before,
+        run_cli(settled_surrogate),
+    )
+
     malformed_cases = {
         "headerless ledger": b'{"type":"row","pr":"1"}\n',
         "duplicate-row ledger": (b'{"type":"header"}\n'
@@ -580,6 +623,33 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     )
     if gh_calls.read_bytes() != calls_before:
         problems.append("[required-set CLI] malformed row required set fetched from GitHub")
+
+    non_utf_bin = cli_tmp / "non-utf-bin"
+    non_utf_bin.mkdir()
+    non_utf_gh = non_utf_bin / "gh"
+    non_utf_gh.write_text(
+        "#!/bin/sh\nprintf 'called\\n' >> \"$GH_CALLS\"\nprintf '\\377'\n",
+        encoding="utf-8",
+    )
+    non_utf_gh.chmod(0o700)
+    non_utf_env = os.environ.copy()
+    non_utf_env["PATH"] = str(non_utf_bin) + os.pathsep + non_utf_env.get("PATH", "")
+    non_utf_env["GH_CALLS"] = str(gh_calls)
+    non_utf_response = cli_tmp / "non-utf-response.jsonl"
+    valid_ledger(non_utf_response, header_required=ci.SNAP.CANNOT_READ, row_required="-")
+    calls_before = gh_calls.read_bytes()
+    proc = run_cli(non_utf_response, env=non_utf_env)
+    _header, rows = ci.LEDGER.load(non_utf_response)
+    if proc.returncode != 1:
+        problems.append(f"[required-set CLI] non-UTF-8 response exited {proc.returncode}, not 1: "
+                        f"{proc.stderr!r}")
+    elif rows[0]["required_set"] != ci.SNAP.CANNOT_READ:
+        problems.append(f"[required-set CLI] non-UTF-8 response persisted "
+                        f"{rows[0]['required_set']!r}, not `unknown`")
+    elif proc.stderr:
+        problems.append(f"[required-set CLI] non-UTF-8 response emitted stderr: {proc.stderr!r}")
+    if len(gh_calls.read_bytes().splitlines()) != len(calls_before.splitlines()) + 1:
+        problems.append("[required-set CLI] non-UTF-8 response did not make exactly one GitHub call")
 
     if not hasattr(os, "geteuid") or os.geteuid() == 0:
         print("skip     [required-set CLI] chmod cannot make the ledger directory unwritable as this user")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -445,16 +445,17 @@ def required_set_cases(ci, tmp: Path) -> list[str]:
 
 
 def required_set_cli_cases(ci, tmp: Path) -> list[str]:
-    """Pin the required-set process contract: settled=0, retryable unknown=1, caller/store errors=2."""
+    """Pin required-set exits: settled=0, retryable unknown=1, caller/store/output errors=2."""
     problems: list[str] = []
     cli_tmp = tmp / "required-set-cli"
     cli_tmp.mkdir()
 
     def run_cli(ledger: Path, *, repo: str = "o/r", env: "dict[str, str] | None" = None,
-                stdout=subprocess.PIPE):
+                stdout=subprocess.PIPE, preexec_fn=None):
         return subprocess.run(  # noqa: S603 - this suite drives its sibling command
             [sys.executable, str(STATUS_PY), "required-set", "--ledger", str(ledger), "--repo", repo],
             stdout=stdout, stderr=subprocess.PIPE, text=True, check=False, env=env,
+            preexec_fn=preexec_fn,
         )
 
     def valid_ledger(path: Path, *, header_required: str, row_required: "str | None" = None,
@@ -529,6 +530,19 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
                         f"{proc.stderr!r}")
     if "Exception ignored in:" in proc.stderr or "OSError:" in proc.stderr:
         problems.append(f"[required-set CLI] failed stdout sink leaked a finalization error: "
+                        f"{proc.stderr!r}")
+
+    closed_stdout = cli_tmp / "closed-stdout.jsonl"
+    valid_ledger(closed_stdout, header_required=ci.SNAP.NONE_DECLARED)
+    closed_stdout_before = closed_stdout.read_bytes()
+    proc = run_cli(closed_stdout, preexec_fn=lambda: os.close(1))
+    check_error("closed stdout fd", closed_stdout, closed_stdout_before, proc)
+    expected = (
+        f"ci-status: required-set: cannot process --ledger {closed_stdout} "
+        "(stdout is unavailable)\n"
+    )
+    if proc.stderr != expected:
+        problems.append(f"[required-set CLI] closed stdout fd emitted the wrong diagnostic: "
                         f"{proc.stderr!r}")
 
     malformed_repo = cli_tmp / "malformed-repo.jsonl"
@@ -1312,7 +1326,8 @@ def run(ci, tmp: Path) -> int:
         failures += 1
         print(f"FAIL     {problem}")
     if not required_cli_problems:
-        print(f"ok       {'required-set CLI exits':32} -> settled=0, unknown=1, caller/store errors=2; "
+        print(f"ok       {'required-set CLI exits':32} -> settled=0, unknown=1, "
+              f"caller/store/output errors=2; "
               f"errors preserve the ledger and emit one diagnostic without a traceback")
 
     liveness_problems = liveness_cases(ci, tmp)

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -41,7 +41,9 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -439,6 +441,105 @@ def required_set_cases(ci, tmp: Path) -> list[str]:
 
     problems += grouped_required_set_cases(ci, tmp)
     problems += required_set_matrix_cases(ci, tmp)
+    return problems
+
+
+def required_set_cli_cases(ci, tmp: Path) -> list[str]:
+    """Pin the required-set process contract: settled=0, retryable unknown=1, caller/store errors=2."""
+    problems: list[str] = []
+    cli_tmp = tmp / "required-set-cli"
+    cli_tmp.mkdir()
+
+    def run_cli(ledger: Path, *, env: "dict[str, str] | None" = None):
+        return subprocess.run(  # noqa: S603 - this suite drives its sibling command
+            [sys.executable, str(STATUS_PY), "required-set", "--ledger", str(ledger), "--repo", "o/r"],
+            capture_output=True, text=True, check=False, env=env,
+        )
+
+    def valid_ledger(path: Path, *, header_required: str, row_required: "str | None" = None) -> None:
+        header = dict(ci.LEDGER.HEADER_DEFAULTS)
+        header.update({"run_id": path.stem, "base_branch": "main", "required_set": header_required})
+        rows = []
+        if row_required is not None:
+            row = dict(ci.LEDGER.ROW_DEFAULTS)
+            row.update({"pr": "1", "base_branch": "main", "required_set": row_required,
+                        "status": "in_review"})
+            rows.append(row)
+        ci.LEDGER.dump(path, header, rows)
+
+    settled = cli_tmp / "settled.jsonl"
+    valid_ledger(settled, header_required=ci.SNAP.NONE_DECLARED)
+    settled_before = settled.read_bytes()
+    proc = run_cli(settled)
+    if proc.returncode != 0:
+        problems.append(f"[required-set CLI] settled ledger exited {proc.returncode}, not 0: {proc.stderr!r}")
+    elif settled.read_bytes() != settled_before:
+        problems.append("[required-set CLI] settled ledger was rewritten despite needing no read")
+    elif proc.stderr:
+        problems.append(f"[required-set CLI] settled ledger emitted stderr: {proc.stderr!r}")
+
+    fake_bin = cli_tmp / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    fake_gh.chmod(0o700)
+    denied_env = os.environ.copy()
+    denied_env["PATH"] = str(fake_bin) + os.pathsep + denied_env.get("PATH", "")
+    unknown = cli_tmp / "unknown.jsonl"
+    valid_ledger(unknown, header_required=ci.SNAP.CANNOT_READ, row_required="-")
+    proc = run_cli(unknown, env=denied_env)
+    _header, rows = ci.LEDGER.load(unknown)
+    if proc.returncode != 1:
+        problems.append(f"[required-set CLI] unknown group exited {proc.returncode}, not 1: {proc.stderr!r}")
+    elif rows[0]["required_set"] != ci.SNAP.CANNOT_READ:
+        problems.append(f"[required-set CLI] failed read persisted {rows[0]['required_set']!r}, not `unknown`")
+    elif proc.stderr:
+        problems.append(f"[required-set CLI] retryable unknown emitted stderr: {proc.stderr!r}")
+
+    def check_error(name: str, ledger: Path, before: bytes, proc) -> None:
+        if proc.returncode != 2:
+            problems.append(f"[required-set CLI] {name} exited {proc.returncode}, not 2: {proc.stderr!r}")
+        if ledger.read_bytes() != before:
+            problems.append(f"[required-set CLI] {name} mutated the ledger")
+        lines = [line for line in proc.stderr.splitlines() if line]
+        if "Traceback" in proc.stderr:
+            problems.append(f"[required-set CLI] {name} emitted a traceback: {proc.stderr!r}")
+        elif len(lines) != 1:
+            problems.append(f"[required-set CLI] {name} emitted {len(lines)} diagnostics, not one: "
+                            f"{proc.stderr!r}")
+
+    malformed_cases = {
+        "headerless ledger": b'{"type":"row","pr":"1"}\n',
+        "duplicate-row ledger": (b'{"type":"header"}\n'
+                                 b'{"type":"row","pr":"1"}\n'
+                                 b'{"type":"row","pr":"1"}\n'),
+        "non-UTF-8 ledger": b'{"type":"header"}\n\xff\n',
+    }
+    for slug, (name, body) in enumerate(malformed_cases.items(), start=1):
+        ledger = cli_tmp / f"malformed-{slug}.jsonl"
+        ledger.write_bytes(body)
+        check_error(name, ledger, body, run_cli(ledger))
+
+    malformed_spec = cli_tmp / "malformed-spec.jsonl"
+    valid_ledger(malformed_spec, header_required="not-a-required-set")
+    malformed_before = malformed_spec.read_bytes()
+    check_error("malformed required set", malformed_spec, malformed_before, run_cli(malformed_spec))
+
+    if not hasattr(os, "geteuid") or os.geteuid() == 0:
+        print("skip     [required-set CLI] chmod cannot make the ledger directory unwritable as this user")
+    else:
+        unwritable_dir = cli_tmp / "unwritable"
+        unwritable_dir.mkdir()
+        unwritable = unwritable_dir / "state.jsonl"
+        valid_ledger(unwritable, header_required=ci.SNAP.NONE_DECLARED, row_required="-")
+        unwritable_before = unwritable.read_bytes()
+        unwritable_dir.chmod(0o500)
+        try:
+            proc = run_cli(unwritable)
+        finally:
+            unwritable_dir.chmod(0o700)
+        check_error("unwritable ledger", unwritable, unwritable_before, proc)
+
     return problems
 
 
@@ -1062,6 +1163,14 @@ def run(ci, tmp: Path) -> int:
     if not required_problems:
         print(f"ok       {'required-set producer':32} -> both APIs, strict shapes, canonical ledger state, "
               f"grouped per-base refresh, and derive's row-based resolution")
+
+    required_cli_problems = required_set_cli_cases(ci, tmp)
+    for problem in required_cli_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not required_cli_problems:
+        print(f"ok       {'required-set CLI exits':32} -> settled=0, unknown=1, caller/store errors=2; "
+              f"errors preserve the ledger and emit one diagnostic without a traceback")
 
     liveness_problems = liveness_cases(ci, tmp)
     for problem in liveness_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -534,6 +534,19 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     if gh_calls.read_bytes() != calls_before:
         problems.append("[required-set CLI] whitespace-only --repo fetched from GitHub")
 
+    embedded_space_repo = cli_tmp / "embedded-space-repo.jsonl"
+    valid_ledger(embedded_space_repo, header_required=ci.SNAP.CANNOT_READ, row_required="-")
+    embedded_space_repo_before = embedded_space_repo.read_bytes()
+    calls_before = gh_calls.read_bytes()
+    check_error(
+        "embedded-space --repo owner",
+        embedded_space_repo,
+        embedded_space_repo_before,
+        run_cli(embedded_space_repo, repo="bad owner/repo", env=denied_env),
+    )
+    if gh_calls.read_bytes() != calls_before:
+        problems.append("[required-set CLI] embedded-space --repo fetched from GitHub")
+
     malformed_cases = {
         "headerless ledger": b'{"type":"row","pr":"1"}\n',
         "duplicate-row ledger": (b'{"type":"header"}\n'

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -481,10 +481,13 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     fake_bin = cli_tmp / "bin"
     fake_bin.mkdir()
     fake_gh = fake_bin / "gh"
-    fake_gh.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    fake_gh.write_text("#!/bin/sh\nprintf 'called\\n' >> \"$GH_CALLS\"\nexit 1\n", encoding="utf-8")
     fake_gh.chmod(0o700)
+    gh_calls = cli_tmp / "gh-calls"
+    gh_calls.write_bytes(b"")
     denied_env = os.environ.copy()
     denied_env["PATH"] = str(fake_bin) + os.pathsep + denied_env.get("PATH", "")
+    denied_env["GH_CALLS"] = str(gh_calls)
     unknown = cli_tmp / "unknown.jsonl"
     valid_ledger(unknown, header_required=ci.SNAP.CANNOT_READ, row_required="-")
     proc = run_cli(unknown, env=denied_env)
@@ -518,6 +521,19 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
         run_cli(malformed_repo, repo="invalid", env=denied_env),
     )
 
+    whitespace_repo = cli_tmp / "whitespace-repo.jsonl"
+    valid_ledger(whitespace_repo, header_required=ci.SNAP.CANNOT_READ)
+    whitespace_repo_before = whitespace_repo.read_bytes()
+    calls_before = gh_calls.read_bytes()
+    check_error(
+        "whitespace-only --repo owner/name",
+        whitespace_repo,
+        whitespace_repo_before,
+        run_cli(whitespace_repo, repo=" / ", env=denied_env),
+    )
+    if gh_calls.read_bytes() != calls_before:
+        problems.append("[required-set CLI] whitespace-only --repo fetched from GitHub")
+
     malformed_cases = {
         "headerless ledger": b'{"type":"row","pr":"1"}\n',
         "duplicate-row ledger": (b'{"type":"header"}\n'
@@ -534,6 +550,23 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     valid_ledger(malformed_spec, header_required="not-a-required-set")
     malformed_before = malformed_spec.read_bytes()
     check_error("malformed required set", malformed_spec, malformed_before, run_cli(malformed_spec))
+
+    malformed_row = cli_tmp / "malformed-row-spec.jsonl"
+    valid_ledger(
+        malformed_row,
+        header_required=ci.SNAP.NONE_DECLARED,
+        row_required="not-a-required-set",
+    )
+    malformed_row_before = malformed_row.read_bytes()
+    calls_before = gh_calls.read_bytes()
+    check_error(
+        "malformed row required set",
+        malformed_row,
+        malformed_row_before,
+        run_cli(malformed_row, env=denied_env),
+    )
+    if gh_calls.read_bytes() != calls_before:
+        problems.append("[required-set CLI] malformed row required set fetched from GitHub")
 
     if not hasattr(os, "geteuid") or os.geteuid() == 0:
         print("skip     [required-set CLI] chmod cannot make the ledger directory unwritable as this user")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -172,6 +172,11 @@ FIXTURES = HERE / "fixtures" / "ci-status"
 # ERROR (exit 2), never a verdict.
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
+# GitHub repository coordinates are ASCII identifiers. Owners use alphanumerics and single, non-edge
+# hyphens; repository names add `.`, `_`, and unrestricted hyphens.
+OWNER_RE = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9._-]+")
+
 # "this source's response carried no commit oid" — the artifact's word for it, never a sha we made up.
 NO_OID = "-"
 
@@ -386,8 +391,10 @@ def check_rundir(rundir: Path) -> Path:
 def check_repo(repo: str) -> str:
     """An explicit repository is a caller input, not a GitHub read result."""
     parts = repo.split("/")
-    if len(parts) != 2 or any(not part or part != part.strip() for part in parts):
-        fail(f"--repo {repo!r} is not owner/name without surrounding whitespace")
+    if (len(parts) != 2
+            or OWNER_RE.fullmatch(parts[0]) is None
+            or REPOSITORY_RE.fullmatch(parts[1]) is None):
+        fail(f"--repo {repo!r} is not a valid GitHub owner/name")
     return repo
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2637,7 +2637,20 @@ def main() -> int:
         return self_test()
 
     if args.cmd == "required-set":
-        out = refresh_required_set(gh_fetch, args.ledger, args.repo)
+        try:
+            out = refresh_required_set(gh_fetch, args.ledger, args.repo)
+        except SystemExit as exc:
+            # ledger.py owns its diagnostic but uses exit 1 for every refusal. At this command boundary,
+            # those are ledger/caller errors (exit 2), never the retryable "some group is unknown" result.
+            # Re-raise every other code unchanged, and do not print a second diagnostic.
+            if exc.code != 1:
+                raise
+            raise SystemExit(2) from None
+        except (OSError, UnicodeError) as exc:
+            # Read/write/spawn failures otherwise escape as tracebacks whose process status happens to be 1,
+            # colliding with the retryable unknown-group result. Undecodable store bytes are the same class:
+            # malformed ledger input, not an unknown required-check read.
+            fail(f"required-set: cannot process --ledger {args.ledger} ({exc})")
         print(json.dumps(out, indent=2, ensure_ascii=False))
         return 0 if out["settled"] else 1
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -173,9 +173,12 @@ FIXTURES = HERE / "fixtures" / "ci-status"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 # GitHub repository coordinates are ASCII identifiers. Owners use alphanumerics and single, non-edge
-# hyphens; repository names add `.`, `_`, and unrestricted hyphens.
+# hyphens; repository names add `.`, `_`, and unrestricted hyphens. GitHub owns both length limits; the
+# named constants below are this tool's defining sites for them.
 OWNER_RE = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9._-]+")
+OWNER_MAX_LENGTH = 39
+REPOSITORY_MAX_LENGTH = 100
 
 # "this source's response carried no commit oid" — the artifact's word for it, never a sha we made up.
 NO_OID = "-"
@@ -392,6 +395,8 @@ def check_repo(repo: str) -> str:
     """An explicit repository is a caller input, not a GitHub read result."""
     parts = repo.split("/")
     if (len(parts) != 2
+            or not 1 <= len(parts[0]) <= OWNER_MAX_LENGTH
+            or not 1 <= len(parts[1]) <= REPOSITORY_MAX_LENGTH
             or OWNER_RE.fullmatch(parts[0]) is None
             or REPOSITORY_RE.fullmatch(parts[1]) is None):
         fail(f"--repo {repo!r} is not a valid GitHub owner/name")
@@ -837,7 +842,10 @@ def gh_fetch(source: str, argv: list[str]) -> object:
     command that prints valid JSON and exits 1, and one that prints garbage and exits 0. A rule on the only
     code path that talks to GitHub is the last rule that may go untested.
     """
-    proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
+    except UnicodeDecodeError as exc:
+        raise FetchError(f"{source}: response is not UTF-8 ({exc})") from exc
     if proc.returncode != 0:
         raise FetchError(f"{source}: `{' '.join(argv[:3])} …` exited {proc.returncode}: {proc.stderr.strip()}")
     try:
@@ -2680,7 +2688,10 @@ def main() -> int:
             # colliding with the retryable unknown-group result. Undecodable store bytes are the same class:
             # malformed ledger input, not an unknown required-check read.
             fail(f"required-set: cannot process --ledger {args.ledger} ({exc})")
-        print(json.dumps(out, indent=2, ensure_ascii=False))
+        try:
+            print(json.dumps(out, indent=2, ensure_ascii=False))
+        except UnicodeError as exc:
+            fail(f"required-set: cannot process --ledger {args.ledger} ({exc})")
         return 0 if out["settled"] else 1
 
     if args.cmd == "liveness":

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -386,8 +386,8 @@ def check_rundir(rundir: Path) -> Path:
 def check_repo(repo: str) -> str:
     """An explicit repository is a caller input, not a GitHub read result."""
     parts = repo.split("/")
-    if len(parts) != 2 or not all(parts):
-        fail(f"--repo {repo!r} is not a non-empty owner/name")
+    if len(parts) != 2 or any(not part or part != part.strip() for part in parts):
+        fail(f"--repo {repo!r} is not owner/name without surrounding whitespace")
     return repo
 
 
@@ -518,14 +518,12 @@ TERMINAL_STATUSES = ("merged", "aborted")
 
 
 def _read_needed(spec: str) -> bool:
-    """Does this required-set spec still need a (re)read? `unknown` does, and so does a value we cannot even
-    parse (forced to re-read rather than trusted — the same fail-closed stance the header path always took).
-    `declared:<json>` and `none` are SETTLED reads and are never re-read: the head-SHA liveness checks are
-    the freshness boundary, NOT a policy-revision field (stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?")."""
-    try:
-        return SNAP.parse_required_set(spec).state == SNAP.CANNOT_READ
-    except SNAP.SpecError:
+    """Does a validated required-set value still need a (re)read? The row-only `-` sentinel and `unknown`
+    do; `declared:<json>` and `none` are SETTLED reads and are never re-read. The head-SHA liveness checks
+    are the freshness boundary, NOT a policy-revision field (stage-2-ci.md, "WHAT WERE WE EXPECTING TO SEE?")."""
+    if spec == LEDGER.ROW_DEFAULTS["required_set"]:
         return True
+    return SNAP.parse_required_set(spec).state == SNAP.CANNOT_READ
 
 
 def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = None) -> dict:
@@ -551,6 +549,21 @@ def refresh_required_set(fetch: Fetch, ledger_path: Path, repo: str | None = Non
         SNAP.parse_required_set(header_spec)
     except SNAP.SpecError as exc:
         fail(f"ledger required_set {header_spec!r} is malformed ({exc}); refusing to overwrite it")
+
+    # A row may hold the row-only `-` sentinel or one of the parser-owned required-set states. Validate every
+    # row before grouping, including terminal rows: malformed stored input is a ledger error to preserve,
+    # never an unsettled value to replace.
+    for row in rows:
+        row_spec = row.get("required_set", LEDGER.ROW_DEFAULTS["required_set"])
+        if row_spec == LEDGER.ROW_DEFAULTS["required_set"]:
+            continue
+        try:
+            SNAP.parse_required_set(row_spec)
+        except SNAP.SpecError as exc:
+            fail(
+                f"ledger row for pr {row.get('pr', '?')} required_set {row_spec!r} is malformed "
+                f"({exc}); refusing to overwrite it"
+            )
 
     # Explicit-base rows STORE their own `required_set`; group them by that base. Legacy `-` rows inherit the
     # header, so they are NOT grouped here — the header channel below is their storage.

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -383,6 +383,14 @@ def check_rundir(rundir: Path) -> Path:
     return rundir
 
 
+def check_repo(repo: str) -> str:
+    """An explicit repository is a caller input, not a GitHub read result."""
+    parts = repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        fail(f"--repo {repo!r} is not a non-empty owner/name")
+    return repo
+
+
 def check_required_set(spec: str):
     """The base branch's required set, as the ledger holds it (`declared:<json>` | `none` | `unknown`).
 
@@ -2637,8 +2645,9 @@ def main() -> int:
         return self_test()
 
     if args.cmd == "required-set":
+        repo = check_repo(args.repo) if args.repo is not None else None
         try:
-            out = refresh_required_set(gh_fetch, args.ledger, args.repo)
+            out = refresh_required_set(gh_fetch, args.ledger, repo)
         except SystemExit as exc:
             # ledger.py owns its diagnostic but uses exit 1 for every refusal. At this command boundary,
             # those are ledger/caller errors (exit 2), never the retryable "some group is unknown" result.

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2689,8 +2689,14 @@ def main() -> int:
             # malformed ledger input, not an unknown required-check read.
             fail(f"required-set: cannot process --ledger {args.ledger} ({exc})")
         try:
-            print(json.dumps(out, indent=2, ensure_ascii=False))
-        except UnicodeError as exc:
+            print(json.dumps(out, indent=2, ensure_ascii=False), flush=True)
+        except (OSError, UnicodeError) as exc:
+            # A failed buffered flush leaves the bytes pending. Close the stream before `fail()` so
+            # interpreter finalization cannot retry them and replace exit 2 with its own exit 120.
+            try:
+                sys.stdout.close()
+            except (OSError, UnicodeError):
+                pass
             fail(f"required-set: cannot process --ledger {args.ledger} ({exc})")
         return 0 if out["settled"] else 1
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2674,6 +2674,8 @@ def main() -> int:
 
     if args.cmd == "required-set":
         repo = check_repo(args.repo) if args.repo is not None else None
+        if sys.stdout is None:
+            fail(f"required-set: cannot process --ledger {args.ledger} (stdout is unavailable)")
         try:
             out = refresh_required_set(gh_fetch, args.ledger, repo)
         except SystemExit as exc:


### PR DESCRIPTION
- reserve exit 1 for retryable unknown required-set groups
- normalize ledger and caller errors to exit 2 without tracebacks
- cover settled, unknown, malformed, and unwritable CLI cases
