### PR TITLE
order in-pr rejection after PR disposition

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -172,7 +172,8 @@ about and one whose partial rejection strands the rest.
      surface that terminal campaign result and leave the follow-up lifecycle unchanged. Choosing the next
      follow-up transition for an aborted-but-open PR is separate lifecycle work; this adoption guard does
      not invent one. An unadopted follow-up PR with no terminal row sits **outside the campaign gate** —
-     the exact thing "fold that PR into the current campaign" exists to prevent.
+     the exact thing "fold that PR into the current campaign" exists to prevent. If the user rejects it,
+     follow **Rejecting an `in-pr` follow-up** below.
    - **`reopened`** — its PR died and it already carries the decision it earned, so it does **not** re-decide:
      it resumes at opening the **replacement** PR. Dispatch the fixer, which opens the replacement PR, then
      `open-pr` records it (→ `in-pr`) and step 4 adopts it — no reconciliation, same as `self-accepted`. The
@@ -227,6 +228,27 @@ about and one whose partial rejection strands the rest.
    unsure — it is **not** the driver's to take up. Surface it in the report and let the user rule (`accept` / `reject`). That is
    the normal case, not a failure. And **publishing is never on the autonomous path**: an issue or a
    release always waits for the user's agreement on that specific item (Tier 3).
+
+#### Rejecting an `in-pr` follow-up
+
+**Finish the recorded PR's campaign disposition BEFORE recording `reject`.** `rejected` is terminal, so
+the active loop never resumes it. `reject` records the durable user ruling; it does not finish the
+campaign ledger row or remove campaign labels. Resolve the recorded PR's live state, then use the matching
+sequence:
+
+- **OPEN** — run the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**,
+  to completion. Then run `followups.py --file <store> reject --id fuN`.
+- **CLOSED WITHOUT MERGING** — run `merge.py run` through its existing terminal close-out
+  (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"). Then run
+  `followups.py --file <store> closed-unmerged --id fuN`; only after that succeeds run
+  `followups.py --file <store> reject --id fuN`.
+- **MERGED** — run `merge.py run` to finish the existing merge finalization, then run
+  `followups.py --file <store> merged --id fuN`. Do not record `reject`: the merged PR is now the durable
+  record and `merged` removes the queue entry.
+
+The existing `reject` and `closed-unmerged` edges keep the recorded `pr`; never clear that history.
+Do not add a follow-up state for campaign disposition. The store graph and PR history stay unchanged;
+ordering the existing campaign procedure before the existing terminal ruling closes the gap.
 
 **The two subagents are the load-bearing part.** The investigation reproduces before anything is changed,
 and the fix authors code that the gauntlet judges — never the same worker doing both, and never the driver
@@ -306,7 +328,7 @@ followups.py --file <store> corroborate --id fuN --finding F   # TIER 1 — free
 followups.py --file <store> refute      --id fuN --finding F   # TIER 1 — free. And it stays in the store
 followups.py --file <store> take-up     --id fuN --act-...     # TIER 2 — only with EVERY condition evidenced
 followups.py --file <store> accept  --id fuN        # THE USER AGREED — the only edge into `accepted`
-followups.py --file <store> reject  --id fuN        # the user ruled against it — and the entry is KEPT
+followups.py --file <store> reject  --id fuN        # user ruled against it; `in-pr` follows "Rejecting an `in-pr` follow-up"
 followups.py --file <store> open-pr --id fuN --pr <ref>    # a PR is addressing it — the entry STAYS
 followups.py --file <store> merged  --id fuN        # that PR LANDED — it is the record now, so the entry is DELETED
 followups.py --file <store> closed-unmerged --id fuN       # that PR died — back to OPEN WORK, nothing recorded it

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -224,7 +224,8 @@ about and one whose partial rejection strands the rest.
    whole point of "self-accepted, not accepted": the driver may take a follow-up up on its own, but the PR
    it produces is **judged by the independent gate, not self-approved** — the driver is not its own gate
    authority. When that PR **merges**, run `followups.py merged --id fuN`: the merged PR is the durable
-   record now, so the entry is deleted (`closed-unmerged` if the PR dies instead — back to open work).
+   record now, so the entry is deleted. If the PR dies instead, apply the pending-ruling sensor; only an
+   entry without a pending rejection runs `closed-unmerged` and returns to open work.
 
 5. **ANY TIER-2 CONDITION FAILS OR IS UNCLEAR → SURFACE AND ASK.** If the fix would touch gate machinery,
    **change user-facing behavior at all** (Tier-2 condition 3 requires it **preserved** — a named test is
@@ -255,12 +256,18 @@ PR's live state and continue with the matching branch.
   followed by `followups.py --file <store> reject --id fuN`. If an existing ledger row already records
   terminal `aborted`, NEVER re-adopt; permanent abort is already complete, so run terminal `reject`
   directly. A PR resolved as merged belongs to the MERGED branch below.
-- **CLOSED WITHOUT MERGING** — run `merge.py run` through its existing terminal close-out
-  (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"). Then run
-  `followups.py --file <store> reject --id fuN`.
-- **MERGED** — run `merge.py run` to finish the existing merge finalization, then run
-  `followups.py --file <store> merged --id fuN`. Do not record `reject`: the merged PR is now the durable
-  record and `merged` removes the queue entry.
+- **CLOSED WITHOUT MERGING** — inspect this run's ledger for the recorded PR. If no row names the recorded
+  PR, the heartbeat stopped after `open-pr` and before adoption created one: treat the live **CLOSED**
+  result as complete campaign disposition. NEVER run `merge.py` or `pr-adopt.py`; run
+  `followups.py --file <store> reject --id fuN` directly. If a row exists, run `merge.py run` through its
+  existing terminal close-out (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"). Then
+  run `followups.py --file <store> reject --id fuN`.
+- **MERGED** — inspect this run's ledger for the recorded PR. If no row names the recorded PR, the heartbeat
+  stopped after `open-pr` and before adoption created one: treat the live **MERGED** result as complete
+  campaign disposition. NEVER run `merge.py` or `pr-adopt.py`; run
+  `followups.py --file <store> merged --id fuN` directly. If a row exists, run `merge.py run` to finish the
+  existing merge finalization, then run `followups.py --file <store> merged --id fuN`. Do not record
+  `reject`: the merged PR is now the durable record and `merged` removes the queue entry.
 
 The existing `reject` edge keeps the recorded `pr`; never clear that history.
 Do not add a follow-up state for campaign disposition. The state set and PR history stay unchanged; the
@@ -294,15 +301,17 @@ time. So:
 
 - While the PR is **open**, the entry **STAYS** (`in-pr`) and records **which PR** is addressing it.
 - The PR **merges** → `merged` deletes the entry. The PR is the record now.
-- The PR is **closed WITHOUT merging** → `closed-unmerged` returns it to **open work** (`reopened`), with
-  its history intact — the finding, the ACT grounds or the user's ruling, and the PR that died. It never
-  vanishes with the PR, and it is never stuck in "being worked on" forever.
+- The PR is **closed WITHOUT merging** and no pending rejection exists → `closed-unmerged` returns it to
+  **open work** (`reopened`), with its history intact — the finding, the ACT grounds or the user's ruling,
+  and the PR that died. A pending rejection stays `in-pr` until campaign disposition finishes and
+  terminal `reject` records the ruling.
 
 **Move it in the heartbeat that SAW the event** — the same rule as recording one the moment it is noticed, and
 for the same reason: the driver's memory of it dies with the driver's context. The heartbeat that opens the PR
-addressing a follow-up runs `open-pr`; the heartbeat that observes that PR **merged** or **closed** runs
-`merged` / `closed-unmerged`. A follow-up whose PR landed three heartbeats ago and still sits in `in-pr` is a
-queue nobody can trust to say what is left to do.
+addressing a follow-up runs `open-pr`; the heartbeat that observes that PR **merged** runs `merged`. The
+heartbeat that observes it **closed** first applies the pending-ruling sensor, then runs `closed-unmerged`
+only when no pending rejection exists. A follow-up whose PR landed three heartbeats ago and still sits in
+`in-pr` is a queue nobody can trust to say what is left to do.
 
 **AND REJECTIONS ARE KEPT.** A `rejected` entry stays in the store — hidden from the default view (nobody
 has anything left to do about it), **never deleted**. This is not an exception to the rule above; it is
@@ -348,7 +357,7 @@ followups.py --file <store> reject-pending --id fuN # user rejected an `in-pr` e
 followups.py --file <store> reject  --id fuN        # user ruled against it; `in-pr` follows "Rejecting an `in-pr` follow-up"
 followups.py --file <store> open-pr --id fuN --pr <ref>    # a PR is addressing it — the entry STAYS
 followups.py --file <store> merged  --id fuN        # that PR LANDED — it is the record now, so the entry is DELETED
-followups.py --file <store> closed-unmerged --id fuN       # that PR died — back to OPEN WORK, nothing recorded it
+followups.py --file <store> closed-unmerged --id fuN       # unmarked PR died — back to OPEN WORK
 followups.py --file <store> publish --id fuN --ref <issue> # TIER 3 — only AFTER the user's accept. The ISSUE
                                                            # is the record now, so the entry is DELETED
 followups.py --file <store> set --id fuN --<field> <value>      # edit the PROSE of the claim — never EMPTY it

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -167,13 +167,15 @@ about and one whose partial rejection strands the rest.
    - **`in-pr`** — a PR is open and named in the entry, but an interrupted heartbeat may have recorded `open-pr`
      **without** finishing ADOPTION. Adoption is a campaign action, not a store edge — no `in-pr`
      transition performs it — so "defer to the graph" strands the PR. **Before reconciliation, adoption,
-     or `closed-unmerged`, read the entry's `decided` field and the recorded PR's ledger row.** If `decided`
-     starts with `reject@`, route to **Rejecting an `in-pr` follow-up** below before ordinary adoption,
-     reopening, or replacement. Otherwise, reconcile the recorded PR against the current run. If it has no
-     ledger row, or its **non-terminal** row lacks the run label, ADOPT it through step 4. **If its existing
-     row is terminal, NEVER refresh, re-adopt, or relabel it** — surface that terminal campaign result and
-     leave the follow-up lifecycle unchanged. A terminal row records campaign disposition, not a user
-     ruling, so it never selects rejection. An unadopted follow-up PR with no terminal row sits
+     or `closed-unmerged`, apply the pending-ruling sensor owned by Rejecting an `in-pr` follow-up.** If it
+     selects rejection, route there before ordinary adoption, reopening, or replacement. Otherwise,
+     reconcile the recorded PR against the current run. If it has no ledger row, or its **non-terminal**
+     row lacks the run label, ADOPT it through step 4. **If its existing row is terminal, NEVER refresh,
+     re-adopt, or relabel it** — surface that terminal campaign result and leave the follow-up lifecycle
+     unchanged. A bare terminal `aborted`/`merged` ledger row records campaign
+     disposition, not a user ruling, so it never selects rejection. If separate legacy evidence says the
+     user rejected the entry but the pending-ruling sensor is absent, **SURFACE the entry to the user**.
+     An unadopted follow-up PR with no terminal row sits
      **outside the campaign gate** — the exact thing "fold that PR into the current campaign" exists to
      prevent. If the user rejects it, follow **Rejecting an `in-pr` follow-up** below.
    - **`reopened`** — its PR died and it already carries the decision it earned, so it does **not** re-decide:
@@ -238,11 +240,12 @@ terminal `reject`.** `reject-pending` keeps the entry `in-pr` and writes `reject
 `decided` field. That marker makes a fresh heartbeat return here instead of re-adopting or reopening the
 PR. If `decided` does not already start with `reject@`, run
 `followups.py --file <store> reject-pending --id fuN`. Then resolve the recorded PR's live state and use
-the matching sequence:
+the matching sequence. **`reject@<iso>` is the only campaign-owned pending-rejection sensor.** A terminal
+ledger row records PR disposition, not a user ruling, and MUST NOT route here by itself. If legacy evidence
+outside the follow-up entry indicates user rejection without the marker, SURFACE the entry to the user.
 
 **If this procedure is interrupted, the `in-pr` resume rule routes back here.** Re-resolve the recorded
-PR's live state and continue with the matching branch. A terminal `aborted` or `merged` ledger row is also
-a routing sensor if an older interruption happened before `reject-pending` existed.
+PR's live state and continue with the matching branch.
 
 - **OPEN** — run the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**,
   to completion. Then run `followups.py --file <store> reject --id fuN`.

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -237,8 +237,8 @@ about and one whose partial rejection strands the rest.
 
 **Record `reject-pending` BEFORE starting campaign disposition, then finish disposition BEFORE recording
 terminal `reject`.** `reject-pending` keeps the entry `in-pr` and writes `reject@<iso>` to its existing
-`decided` field. That marker makes a fresh heartbeat return here instead of re-adopting or reopening the
-PR. If `decided` does not already start with `reject@`, run
+`decided` field. That marker makes a fresh heartbeat return here before ordinary adoption or reopening.
+If `decided` does not already start with `reject@`, run
 `followups.py --file <store> reject-pending --id fuN`. Then resolve the recorded PR's live state and use
 the matching sequence. **`reject@<iso>` is the only campaign-owned pending-rejection sensor.** A terminal
 ledger row records PR disposition, not a user ruling, and MUST NOT route here by itself. If legacy evidence
@@ -247,8 +247,14 @@ outside the follow-up entry indicates user rejection without the marker, SURFACE
 **If this procedure is interrupted, the `in-pr` resume rule routes back here.** Re-resolve the recorded
 PR's live state and continue with the matching branch.
 
-- **OPEN** — run the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**,
-  to completion. Then run `followups.py --file <store> reject --id fuN`.
+- **OPEN** — inspect this run's owner label and ledger row before aborting. If the PR lacks this run's
+  owner label or ledger row and no existing row records terminal disposition, complete the existing
+  idempotent ADOPTION (step 4) solely to establish the ownership records required by the permanent-abort
+  procedure. This is the `open-pr`-before-ADOPTION interruption path; do not start review work. Then run
+  the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**, to completion,
+  followed by `followups.py --file <store> reject --id fuN`. If an existing ledger row already records
+  terminal `aborted`, NEVER re-adopt; permanent abort is already complete, so run terminal `reject`
+  directly. A PR resolved as merged belongs to the MERGED branch below.
 - **CLOSED WITHOUT MERGING** — run `merge.py run` through its existing terminal close-out
   (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"). Then run
   `followups.py --file <store> reject --id fuN`.

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -166,14 +166,16 @@ about and one whose partial rejection strands the rest.
      its interrupted-heartbeat gap.
    - **`in-pr`** — a PR is open and named in the entry, but an interrupted heartbeat may have recorded `open-pr`
      **without** finishing ADOPTION. Adoption is a campaign action, not a store edge — no `in-pr`
-     transition performs it — so "defer to the graph" strands the PR. On resume, **reconcile the recorded
-     PR against the current run.** If it has no ledger row, or its **non-terminal** row lacks the run label,
-     ADOPT it through step 4. **If its existing row is terminal, NEVER refresh, re-adopt, or relabel it** —
-     surface that terminal campaign result and leave the follow-up lifecycle unchanged. Choosing the next
-     follow-up transition for an aborted-but-open PR is separate lifecycle work; this adoption guard does
-     not invent one. An unadopted follow-up PR with no terminal row sits **outside the campaign gate** —
-     the exact thing "fold that PR into the current campaign" exists to prevent. If the user rejects it,
-     follow **Rejecting an `in-pr` follow-up** below.
+     transition performs it — so "defer to the graph" strands the PR. **Before reconciliation, adoption,
+     or `closed-unmerged`, read the entry's `decided` field and the recorded PR's ledger row.** If `decided`
+     starts with `reject@`, route to **Rejecting an `in-pr` follow-up** below before ordinary adoption,
+     reopening, or replacement. Otherwise, reconcile the recorded PR against the current run. If it has no
+     ledger row, or its **non-terminal** row lacks the run label, ADOPT it through step 4. **If its existing
+     row is terminal, NEVER refresh, re-adopt, or relabel it** — surface that terminal campaign result and
+     leave the follow-up lifecycle unchanged. A terminal row records campaign disposition, not a user
+     ruling, so it never selects rejection. An unadopted follow-up PR with no terminal row sits
+     **outside the campaign gate** — the exact thing "fold that PR into the current campaign" exists to
+     prevent. If the user rejects it, follow **Rejecting an `in-pr` follow-up** below.
    - **`reopened`** — its PR died and it already carries the decision it earned, so it does **not** re-decide:
      it resumes at opening the **replacement** PR. Dispatch the fixer, which opens the replacement PR, then
      `open-pr` records it (→ `in-pr`) and step 4 adopts it — no reconciliation, same as `self-accepted`. The
@@ -231,13 +233,16 @@ about and one whose partial rejection strands the rest.
 
 #### Rejecting an `in-pr` follow-up
 
-**Finish the recorded PR's campaign disposition BEFORE recording `reject`.** `rejected` is terminal, so
-the active loop never resumes it. `reject` records the durable user ruling; it does not finish the
-campaign ledger row or remove campaign labels. Resolve the recorded PR's live state, then use the matching
-sequence:
+**Record `reject-pending` BEFORE starting campaign disposition, then finish disposition BEFORE recording
+terminal `reject`.** `reject-pending` keeps the entry `in-pr` and writes `reject@<iso>` to its existing
+`decided` field. That marker makes a fresh heartbeat return here instead of re-adopting or reopening the
+PR. If `decided` does not already start with `reject@`, run
+`followups.py --file <store> reject-pending --id fuN`. Then resolve the recorded PR's live state and use
+the matching sequence:
 
-**If this procedure is interrupted, resume here, not through the state-resume list.** Re-resolve the
-recorded PR's live state and continue with the matching branch.
+**If this procedure is interrupted, the `in-pr` resume rule routes back here.** Re-resolve the recorded
+PR's live state and continue with the matching branch. A terminal `aborted` or `merged` ledger row is also
+a routing sensor if an older interruption happened before `reject-pending` existed.
 
 - **OPEN** — run the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**,
   to completion. Then run `followups.py --file <store> reject --id fuN`.
@@ -249,8 +254,8 @@ recorded PR's live state and continue with the matching branch.
   record and `merged` removes the queue entry.
 
 The existing `reject` edge keeps the recorded `pr`; never clear that history.
-Do not add a follow-up state for campaign disposition. The store graph and PR history stay unchanged;
-ordering the existing campaign procedure before the existing terminal ruling closes the gap.
+Do not add a follow-up state for campaign disposition. The state set and PR history stay unchanged; the
+tagged `decided` value is the durable pending-ruling sensor.
 
 **The two subagents are the load-bearing part.** The investigation reproduces before anything is changed,
 and the fix authors code that the gauntlet judges — never the same worker doing both, and never the driver
@@ -330,6 +335,7 @@ followups.py --file <store> corroborate --id fuN --finding F   # TIER 1 — free
 followups.py --file <store> refute      --id fuN --finding F   # TIER 1 — free. And it stays in the store
 followups.py --file <store> take-up     --id fuN --act-...     # TIER 2 — only with EVERY condition evidenced
 followups.py --file <store> accept  --id fuN        # THE USER AGREED — the only edge into `accepted`
+followups.py --file <store> reject-pending --id fuN # user rejected an `in-pr` entry; stamp BEFORE PR disposition
 followups.py --file <store> reject  --id fuN        # user ruled against it; `in-pr` follows "Rejecting an `in-pr` follow-up"
 followups.py --file <store> open-pr --id fuN --pr <ref>    # a PR is addressing it — the entry STAYS
 followups.py --file <store> merged  --id fuN        # that PR LANDED — it is the record now, so the entry is DELETED
@@ -459,12 +465,13 @@ job is to hold claims a human can audit.
 `accept` is a promise the driver makes, and what the graph buys is that **skipping the user is a
 DELIBERATE act rather than an oversight**. It is a footgun guard, **NOT** a security boundary.
 
-**The user's ruling is DURABLE DATA.** `accept`/`reject` stamp when it was made, for the same reason the
-ledger's `api_approval` records `approved@<iso>` rather than living in the driver's head: **a later heartbeat
-is a fresh agent that never saw the conversation**, and it must not re-ask a question the user already
-answered. **Nothing the driver does alone stamps it** — not an investigation, not a `take-up`, not opening
-a PR, not `publish`. A ruling written by anything but the user would launder the driver's action into the
-user's consent (`ruling-recorded` proves the stamp belongs to `accept`/`reject` and to nothing else).
+**The user's ruling is DURABLE DATA.** `accept`/`reject-pending`/`reject` stamp when it was made, for the
+same reason the ledger's `api_approval` records `approved@<iso>` rather than living in the driver's head:
+**a later heartbeat is a fresh agent that never saw the conversation**, and it must not re-ask a question
+the user already answered. **Nothing the driver does alone stamps it** — not an investigation, not a
+`take-up`, not opening a PR, not `publish`. A ruling written by anything but the user would launder the
+driver's action into the user's consent (`ruling-recorded` proves the stamp belongs to the user-ruling
+commands and to nothing else).
 
 ### WHEN TO RECORD ONE — the moment it is noticed, not at the end
 

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -236,17 +236,19 @@ the active loop never resumes it. `reject` records the durable user ruling; it d
 campaign ledger row or remove campaign labels. Resolve the recorded PR's live state, then use the matching
 sequence:
 
+**If this procedure is interrupted, resume here, not through the state-resume list.** Re-resolve the
+recorded PR's live state and continue with the matching branch.
+
 - **OPEN** — run the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**,
   to completion. Then run `followups.py --file <store> reject --id fuN`.
 - **CLOSED WITHOUT MERGING** — run `merge.py run` through its existing terminal close-out
   (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"). Then run
-  `followups.py --file <store> closed-unmerged --id fuN`; only after that succeeds run
   `followups.py --file <store> reject --id fuN`.
 - **MERGED** — run `merge.py run` to finish the existing merge finalization, then run
   `followups.py --file <store> merged --id fuN`. Do not record `reject`: the merged PR is now the durable
   record and `merged` removes the queue entry.
 
-The existing `reject` and `closed-unmerged` edges keep the recorded `pr`; never clear that history.
+The existing `reject` edge keeps the recorded `pr`; never clear that history.
 Do not add a follow-up state for campaign disposition. The store graph and PR history stay unchanged;
 ordering the existing campaign procedure before the existing terminal ruling closes the gap.
 

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -259,19 +259,23 @@ PR's live state and continue with the matching branch.
 - **CLOSED WITHOUT MERGING** — inspect this run's ledger for the recorded PR. If no row names the recorded
   PR, the heartbeat stopped after `open-pr` and before adoption created one: treat the live **CLOSED**
   result as complete campaign disposition. NEVER run `merge.py` or `pr-adopt.py`; run
-  `followups.py --file <store> reject --id fuN` directly. If a row exists, run `merge.py run` through its
-  existing terminal close-out (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"). Then
-  run `followups.py --file <store> reject --id fuN`.
+  `followups.py --file <store> reject --id fuN` directly. If a row exists with nonterminal status, run
+  `merge.py run` through its existing terminal close-out (`loop-control.md`, "Step 4 — Merge queued PRs as
+  a serialized drain"). If its status is already terminal `aborted`, campaign disposition is complete: do
+  not run `merge.py`; run `followups.py --file <store> reject --id fuN` directly.
 - **MERGED** — inspect this run's ledger for the recorded PR. If no row names the recorded PR, the heartbeat
   stopped after `open-pr` and before adoption created one: treat the live **MERGED** result as complete
   campaign disposition. NEVER run `merge.py` or `pr-adopt.py`; run
-  `followups.py --file <store> merged --id fuN` directly. If a row exists, run `merge.py run` to finish the
-  existing merge finalization, then run `followups.py --file <store> merged --id fuN`. Do not record
-  `reject`: the merged PR is now the durable record and `merged` removes the queue entry.
+  `followups.py --file <store> merged --id fuN` directly. If a row exists with nonterminal status, run
+  `merge.py run` to finish the existing merge finalization, then run
+  `followups.py --file <store> merged --id fuN`. If its status is already terminal (`merged` or `aborted`),
+  do not run `merge.py`; run `followups.py --file <store> merged --id fuN` directly. The live **MERGED** PR
+  is the durable record, and `merged` removes the queue entry. Do not record `reject`.
 
 The existing `reject` edge keeps the recorded `pr`; never clear that history.
 Do not add a follow-up state for campaign disposition. The state set and PR history stay unchanged; the
-tagged `decided` value is the durable pending-ruling sensor.
+tagged `decided` value is the durable pending-ruling sensor. Its timestamp is the user's ruling time, so
+terminal `reject` preserves it even when that terminal command receives a later `--at`.
 
 **The two subagents are the load-bearing part.** The investigation reproduces before anything is changed,
 and the fix authors code that the gauntlet judges — never the same worker doing both, and never the driver
@@ -416,9 +420,9 @@ it can ever take a blank. A stamp (`--at`, `--found`) may be **omitted** — it 
 stamp that is **supplied** and shows nothing is refused like anything else.
 
 **And a flag exists on a subcommand only where that subcommand consumes it.** `--at` is offered by the steps
-that **stamp** something and by no others; passing it elsewhere is an argparse **error**, not a value that
-silently vanishes. `<cmd> --help` names every flag a command takes. Never "document" a dropped value: a
-documented silent discard is still a silent discard.
+that **stamp** a ruling and by no others; passing it elsewhere is an argparse **error**, not a value that
+silently vanishes. Terminal `reject` is the one completed-disposition case: it accepts a later `--at` but
+preserves the existing `reject@<iso>` ruling time. `<cmd> --help` names every flag a command takes.
 
 **The claim's `evidence` and the investigation's `finding` are DIFFERENT FIELDS, and both matter.** One is
 why the driver **raised** it; the other is what happened when somebody actually **looked**. A finding never

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -167,14 +167,14 @@ about and one whose partial rejection strands the rest.
    - **`in-pr`** — a PR is open and named in the entry, but an interrupted heartbeat may have recorded `open-pr`
      **without** finishing ADOPTION. Adoption is a campaign action, not a store edge — no `in-pr`
      transition performs it — so "defer to the graph" strands the PR. **Before reconciliation, adoption,
-     or `closed-unmerged`, apply the pending-ruling sensor owned by Rejecting an `in-pr` follow-up.** If it
-     selects rejection, route there before ordinary adoption, reopening, or replacement. Otherwise,
+     or `closed-unmerged`, apply the typed pending-ruling sensor owned by Rejecting an `in-pr` follow-up.** If
+     it selects rejection, route there before ordinary adoption, reopening, or replacement. Otherwise,
      reconcile the recorded PR against the current run. If it has no ledger row, or its **non-terminal**
      row lacks the run label, ADOPT it through step 4. **If its existing row is terminal, NEVER refresh,
      re-adopt, or relabel it** — surface that terminal campaign result and leave the follow-up lifecycle
      unchanged. A bare terminal `aborted`/`merged` ledger row records campaign
      disposition, not a user ruling, so it never selects rejection. If separate legacy evidence says the
-     user rejected the entry but the pending-ruling sensor is absent, **SURFACE the entry to the user**.
+     user rejected the entry but the typed pending-ruling sensor is absent, **SURFACE the entry to the user**.
      An unadopted follow-up PR with no terminal row sits
      **outside the campaign gate** — the exact thing "fold that PR into the current campaign" exists to
      prevent. If the user rejects it, follow **Rejecting an `in-pr` follow-up** below.
@@ -237,13 +237,15 @@ about and one whose partial rejection strands the rest.
 #### Rejecting an `in-pr` follow-up
 
 **Record `reject-pending` BEFORE starting campaign disposition, then finish disposition BEFORE recording
-terminal `reject`.** `reject-pending` keeps the entry `in-pr` and writes `reject@<iso>` to its existing
-`decided` field. That marker makes a fresh heartbeat return here before ordinary adoption or reopening.
-If `decided` does not already start with `reject@`, run
-`followups.py --file <store> reject-pending --id fuN`. Then resolve the recorded PR's live state and use
-the matching sequence. **`reject@<iso>` is the only campaign-owned pending-rejection sensor.** A terminal
-ledger row records PR disposition, not a user ruling, and MUST NOT route here by itself. If legacy evidence
-outside the follow-up entry indicates user rejection without the marker, SURFACE the entry to the user.
+terminal `reject`.** `reject-pending` keeps the entry `in-pr`, preserves the user's ruling time in
+`decided`, and writes the accessor-owned `rejection = pending` phase. That typed phase makes a fresh
+heartbeat return here before ordinary adoption or reopening. If the entry's `rejection` phase is not
+`pending`, run `followups.py --file <store> reject-pending --id fuN`. Then resolve the recorded PR's live
+state and use the matching sequence. **Only the typed `rejection` phase is a campaign-owned
+pending-rejection sensor.** A `decided` value — including a legacy `reject@…` value — is user timestamp data,
+not proof of a pending rejection. A terminal ledger row records PR disposition, not a user ruling, and MUST
+NOT route here by itself. If legacy evidence indicates user rejection without the typed phase, SURFACE the
+entry to the user.
 
 **If this procedure is interrupted, the `in-pr` resume rule routes back here.** Re-resolve the recorded
 PR's live state and continue with the matching branch.
@@ -252,17 +254,22 @@ PR's live state and continue with the matching branch.
   owner label or ledger row and no existing row records terminal disposition, complete the existing
   idempotent ADOPTION (step 4) solely to establish the ownership records required by the permanent-abort
   procedure. This is the `open-pr`-before-ADOPTION interruption path; do not start review work. Then run
-  the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**, to completion,
-  followed by `followups.py --file <store> reject --id fuN`. If an existing ledger row already records
-  terminal `aborted`, NEVER re-adopt; permanent abort is already complete, so run terminal `reject`
-  directly. A PR resolved as merged belongs to the MERGED branch below.
+  the permanent-abort procedure in `bailout-and-final-report.md`, **1-hour cap per task**, to completion.
+  Its terminal `status = aborted` write records `rejection = disposed` for matching pending follow-ups; then
+  run `followups.py --file <store> reject --id fuN`. If an existing ledger row already records terminal
+  `aborted`, NEVER re-adopt; refresh that row through `ledger.py set --pr <N> --status aborted` before
+  terminal `reject`, so the accessor records any pending follow-up disposition. A PR resolved as merged
+  belongs to the MERGED branch below.
 - **CLOSED WITHOUT MERGING** — inspect this run's ledger for the recorded PR. If no row names the recorded
-  PR, the heartbeat stopped after `open-pr` and before adoption created one: treat the live **CLOSED**
-  result as complete campaign disposition. NEVER run `merge.py` or `pr-adopt.py`; run
-  `followups.py --file <store> reject --id fuN` directly. If a row exists with nonterminal status, run
-  `merge.py run` through its existing terminal close-out (`loop-control.md`, "Step 4 — Merge queued PRs as
-  a serialized drain"). If its status is already terminal `aborted`, campaign disposition is complete: do
-  not run `merge.py`; run `followups.py --file <store> reject --id fuN` directly.
+  PR, the heartbeat stopped after `open-pr` and before adoption created one: the observed close is the
+  completed disposition. NEVER run `merge.py` or `pr-adopt.py`; run
+  `followups.py --file <store> closed-unmerged --id fuN` to record it, then run
+  `followups.py --file <store> reject --id fuN`. If a row exists with nonterminal status, run `merge.py run`
+  through its existing terminal close-out
+  (`loop-control.md`, "Step 4 — Merge queued PRs as a serialized drain"); its terminal `aborted` write
+  records the disposition. If its status is already terminal `aborted`, do not run `merge.py`; refresh it
+  through `ledger.py set --pr <N> --status aborted`, then run
+  `followups.py --file <store> reject --id fuN`.
 - **MERGED** — inspect this run's ledger for the recorded PR. If no row names the recorded PR, the heartbeat
   stopped after `open-pr` and before adoption created one: treat the live **MERGED** result as complete
   campaign disposition. NEVER run `merge.py` or `pr-adopt.py`; run
@@ -274,8 +281,9 @@ PR's live state and continue with the matching branch.
 
 The existing `reject` edge keeps the recorded `pr`; never clear that history.
 Do not add a follow-up state for campaign disposition. The state set and PR history stay unchanged; the
-tagged `decided` value is the durable pending-ruling sensor. Its timestamp is the user's ruling time, so
-terminal `reject` preserves it even when that terminal command receives a later `--at`.
+typed `rejection` phase is the durable pending-ruling sensor. Its `pending` phase becomes `disposed` only
+when `closed-unmerged` observes a close or the ledger records `aborted`; terminal `reject` consumes only
+`disposed` and preserves `decided` even when it receives a later `--at`.
 
 **The two subagents are the load-bearing part.** The investigation reproduces before anything is changed,
 and the fix authors code that the gauntlet judges — never the same worker doing both, and never the driver
@@ -307,15 +315,15 @@ time. So:
 - The PR **merges** → `merged` deletes the entry. The PR is the record now.
 - The PR is **closed WITHOUT merging** and no pending rejection exists → `closed-unmerged` returns it to
   **open work** (`reopened`), with its history intact — the finding, the ACT grounds or the user's ruling,
-  and the PR that died. A pending rejection stays `in-pr` until campaign disposition finishes and
-  terminal `reject` records the ruling.
+  and the PR that died. A pending rejection makes that same command record `rejection = disposed` and keep
+  the entry `in-pr`; terminal `reject` then records the ruling.
 
 **Move it in the heartbeat that SAW the event** — the same rule as recording one the moment it is noticed, and
 for the same reason: the driver's memory of it dies with the driver's context. The heartbeat that opens the PR
 addressing a follow-up runs `open-pr`; the heartbeat that observes that PR **merged** runs `merged`. The
-heartbeat that observes it **closed** first applies the pending-ruling sensor, then runs `closed-unmerged`
-only when no pending rejection exists. A follow-up whose PR landed three heartbeats ago and still sits in
-`in-pr` is a queue nobody can trust to say what is left to do.
+heartbeat that observes it **closed** runs `closed-unmerged`: it reopens ordinary work and records the
+completed disposition for a pending rejection. A follow-up whose PR landed three heartbeats ago and still
+sits in `in-pr` is a queue nobody can trust to say what is left to do.
 
 **AND REJECTIONS ARE KEPT.** A `rejected` entry stays in the store — hidden from the default view (nobody
 has anything left to do about it), **never deleted**. This is not an exception to the rule above; it is
@@ -357,11 +365,11 @@ followups.py --file <store> corroborate --id fuN --finding F   # TIER 1 — free
 followups.py --file <store> refute      --id fuN --finding F   # TIER 1 — free. And it stays in the store
 followups.py --file <store> take-up     --id fuN --act-...     # TIER 2 — only with EVERY condition evidenced
 followups.py --file <store> accept  --id fuN        # THE USER AGREED — the only edge into `accepted`
-followups.py --file <store> reject-pending --id fuN # user rejected an `in-pr` entry; stamp BEFORE PR disposition
-followups.py --file <store> reject  --id fuN        # user ruled against it; `in-pr` follows "Rejecting an `in-pr` follow-up"
+followups.py --file <store> reject-pending --id fuN # user rejected an `in-pr` entry; record typed pending state
+followups.py --file <store> reject  --id fuN        # user ruled against it; `in-pr` requires a disposed PR result
 followups.py --file <store> open-pr --id fuN --pr <ref>    # a PR is addressing it — the entry STAYS
 followups.py --file <store> merged  --id fuN        # that PR LANDED — it is the record now, so the entry is DELETED
-followups.py --file <store> closed-unmerged --id fuN       # unmarked PR died — back to OPEN WORK
+followups.py --file <store> closed-unmerged --id fuN       # ordinary PR died → OPEN WORK; pending rejection → disposed
 followups.py --file <store> publish --id fuN --ref <issue> # TIER 3 — only AFTER the user's accept. The ISSUE
                                                            # is the record now, so the entry is DELETED
 followups.py --file <store> set --id fuN --<field> <value>      # edit the PROSE of the claim — never EMPTY it
@@ -422,7 +430,7 @@ stamp that is **supplied** and shows nothing is refused like anything else.
 **And a flag exists on a subcommand only where that subcommand consumes it.** `--at` is offered by the steps
 that **stamp** a ruling and by no others; passing it elsewhere is an argparse **error**, not a value that
 silently vanishes. Terminal `reject` is the one completed-disposition case: it accepts a later `--at` but
-preserves the existing `reject@<iso>` ruling time. `<cmd> --help` names every flag a command takes.
+preserves the existing `decided` ruling time. `<cmd> --help` names every flag a command takes.
 
 **The claim's `evidence` and the investigation's `finding` are DIFFERENT FIELDS, and both matter.** One is
 why the driver **raised** it; the other is what happened when somebody actually **looked**. A finding never

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -312,8 +312,9 @@ def t_transition_graph(tmp: Path) -> None:
     must not move. A new state or edge is covered the moment it is added to `TRANSITIONS`: this fixture
     reads the graph rather than restating it, so it cannot go stale behind it.
 
-    The `in-pr` → `rejected` edge has one additional ordering precondition: campaign disposition starts
-    only after `reject-pending` writes its marker. Its allowed-state case therefore carries that marker.
+    Two `in-pr` edges have pending-ruling preconditions. `reject` requires the marker because campaign
+    disposition must start only after `reject-pending` writes it. `closed-unmerged` requires no marker
+    because a pending rejection must finish disposition and become `rejected`, never `reopened`.
 
     A DELETING edge is checked the same way, on its own terms: from an allowed state the entry is GONE (and
     the store still LOADS); from a forbidden one it is untouched. Nothing else may remove an entry.
@@ -778,14 +779,13 @@ def t_deletion_needs_a_durable_record(tmp: Path) -> None:
 
 
 def t_a_closed_pr_returns_the_entry_to_open_work(tmp: Path) -> None:
-    """A PR CLOSED WITHOUT MERGING RETURNS THE ENTRY TO OPEN WORK — it does not vanish, and it does not sit
-    in `in-pr` forever.
+    """A PR CLOSED WITHOUT MERGING AND WITHOUT A PENDING REJECTION RETURNS TO OPEN WORK.
 
     This is what buys the right to delete on the merge. A PR can be closed, abandoned or rejected in review,
     and the work is then exactly as undone as it was before anyone touched it — so the entry goes back to
     being work, with its history (the finding, the ACT grounds or the user's ruling, and the PR that DIED)
-    intact. Two failure modes are both refused here: the entry silently VANISHING with the PR, and the entry
-    STUCK in "being worked on" with no way out.
+    intact. The pending-rejection path is covered separately: its PR disposition must finish before terminal
+    `reject`, so `closed-unmerged` must not reopen it.
     """
     reopened = TRANSITIONS["closed-unmerged"][1]
     check(reopened != DELETED,
@@ -1057,6 +1057,14 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
           f"`reject-pending` lost the resumable PR record: {pending!r}")
     check(pending["decided"] == marker,
           f"`reject-pending` did not leave a distinct durable routing marker: {pending!r}")
+    code, _, err = run(["--file", str(store), "closed-unmerged", "--id", fid])
+    check(code == 1,
+          f"`closed-unmerged` reopened a pending rejection before campaign disposition (exit {code})")
+    check("finish campaign disposition" in err and "`reject`" in err,
+          f"`closed-unmerged` refused the pending rejection without naming its required next step: {err!r}")
+    after_close_refusal = json.loads(run(["--file", str(store), "get", "--id", fid])[1])
+    check(after_close_refusal == pending,
+          f"refused `closed-unmerged` changed the pending rejection: {after_close_refusal!r}")
     code, out, err = run(["--file", str(store), "reject", "--id", fid])
     check(code == 0, f"terminal `reject` exited {code}: {err!r}")
     rejected = json.loads(out)
@@ -1158,13 +1166,34 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     check("If an existing ledger row already records" in open_branch
           and "terminal `aborted`, NEVER re-adopt" in open_branch,
           f"{heading!r} does not preserve terminal disposition during interrupted rejection")
-    closed_branch = ordered("- **CLOSED WITHOUT MERGING**", "- **MERGED**", "`merge.py run`",
-                            "terminal close-out", "`followups.py --file <store> reject --id fuN`")
+    closed_branch = ordered(
+        "- **CLOSED WITHOUT MERGING**", "- **MERGED**",
+        "inspect this run's ledger",
+        "If no row names the recorded\n  PR",
+        "live **CLOSED**",
+        "complete campaign disposition",
+        "NEVER run `merge.py` or `pr-adopt.py`",
+        "`followups.py --file <store> reject --id fuN`",
+        "If a row exists",
+        "`merge.py run`",
+        "terminal close-out",
+        "`followups.py --file <store> reject --id fuN`",
+    )
     check("closed-unmerged" not in closed_branch,
           f"{heading!r} parks a rejected closed PR in resumable open work before recording the ruling")
-    ordered("- **MERGED**", "\n\nThe existing", "`merge.py run`",
-            "`followups.py --file <store> merged --id fuN`",
-            "Do not record `reject`")
+    ordered(
+        "- **MERGED**", "\n\nThe existing",
+        "inspect this run's ledger",
+        "If no row names the recorded PR",
+        "live **MERGED**",
+        "complete\n  campaign disposition",
+        "NEVER run `merge.py` or `pr-adopt.py`",
+        "`followups.py --file <store> merged --id fuN`",
+        "If a row exists",
+        "`merge.py run`",
+        "`followups.py --file <store> merged --id fuN`",
+        "Do not record\n  `reject`",
+    )
 
 
 def t_ids_are_assigned_and_never_reused(tmp: Path) -> None:
@@ -1542,7 +1571,7 @@ def t_fields_and_lookup(tmp: Path) -> None:
 CASES = [
     ("user-step-unskippable", "no driver-only path reaches `accepted`, nor any state `publish` leaves from — proved on the graph", t_user_ruling_is_unskippable),
     ("delete-needs-a-record", "an entry is deleted only once a DURABLE RECORD exists elsewhere — never on take-up", t_deletion_needs_a_durable_record),
-    ("closed-pr-reopens", "a PR closed WITHOUT merging returns the entry to open work — it never vanishes with it", t_a_closed_pr_returns_the_entry_to_open_work),
+    ("closed-pr-reopens", "an unmarked PR closed WITHOUT merging returns to open work; pending rejection does not", t_a_closed_pr_returns_the_entry_to_open_work),
     ("rejection-kept", "a REJECTED follow-up is kept — deleting it is how the next run re-raises it", t_a_rejection_is_never_deleted),
     ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1019,7 +1019,8 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     reopens, or replaces the PR. Terminal `reject` preserves the original ruling stamp after disposition.
 
     This fixture also pins the resume sensor and the disposition order for both interruption outcomes:
-    OPEN after abort must not be re-adopted, and CLOSED must not become `reopened`.
+    OPEN after a marked rejection must not be re-adopted, and CLOSED after a marked rejection must not
+    become `reopened`. An unmarked CLOSED PR follows the ordinary `closed-unmerged` edge to `reopened`.
     """
     check(TRANSITIONS["reject-pending"] == (("in-pr",), "in-pr"),
           "`reject-pending` must durably mark the ruling without inventing another follow-up state")
@@ -1051,6 +1052,20 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     check(rejected["state"] == "rejected" and rejected["decided"] == marker,
           f"terminal `reject` did not preserve when the user first ruled: {rejected!r}")
 
+    ordinary_store = tmp / "ordinary-closed.jsonl"
+    (ordinary_fid,) = seed(ordinary_store)
+    decided = "2026-07-14T11:00:00Z"
+    run(["--file", str(ordinary_store), "accept", "--id", ordinary_fid, "--at", decided])
+    run(["--file", str(ordinary_store), "open-pr", "--id", ordinary_fid, "--pr", "#1000"])
+    before_close = json.loads(run(["--file", str(ordinary_store), "get", "--id", ordinary_fid])[1])
+    check(before_close["decided"] == decided and not before_close["decided"].startswith(PENDING_REJECTION_PREFIX),
+          f"ordinary accepted follow-up unexpectedly carries a pending-rejection marker: {before_close!r}")
+    code, out, err = run(["--file", str(ordinary_store), "closed-unmerged", "--id", ordinary_fid])
+    check(code == 0, f"ordinary `closed-unmerged` exited {code}: {err!r}")
+    reopened = json.loads(out)
+    check(reopened["state"] == "reopened" and reopened["pr"] == "#1000" and reopened["decided"] == decided,
+          f"an unmarked closed PR did not return to ordinary open work: {reopened!r}")
+
     doc = Path(__file__).resolve().parent.parent / "references" / "followups.md"
     text = doc.read_text()
     resume_start = text.find("   - **`in-pr`**")
@@ -1058,17 +1073,21 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     check(resume_start >= 0 and resume_end > resume_start,
           f"{doc.name} has no bounded `in-pr` resume rule")
     resume_body = text[resume_start:resume_end]
-    guard = "**Before reconciliation, adoption,\n     or `closed-unmerged`, read"
+    guard = "**Before reconciliation, adoption,\n     or `closed-unmerged`, apply"
     check(guard in resume_body,
           "the `in-pr` resume rule does not inspect rejection sensors before every ordinary resume action")
-    marker_pos = resume_body.find("`reject@`")
-    ledger_pos = resume_body.find("`aborted`/`merged`")
-    route_pos = resume_body.find("route to **Rejecting")
-    ordinary_pos = resume_body.find("Otherwise, reconcile the recorded")
-    check(min(marker_pos, ledger_pos, route_pos) >= 0,
-          "the `in-pr` resume rule cannot sense a pending ruling or terminal campaign disposition")
-    check(max(marker_pos, ledger_pos) < route_pos < ordinary_pos,
+    sensor_pos = resume_body.find("pending-ruling sensor owned by Rejecting")
+    route_pos = resume_body.find("If it\n     selects rejection, route there")
+    ordinary_pos = resume_body.find("Otherwise, reconcile the\n     recorded")
+    check(min(sensor_pos, route_pos, ordinary_pos) >= 0,
+          "the `in-pr` resume rule cannot apply its pending-ruling sensor before ordinary processing")
+    check(sensor_pos < route_pos < ordinary_pos,
           "the `in-pr` resume rule reconciles, adopts, or reopens before routing the pending rejection")
+    check("`aborted`/`merged`" not in resume_body[:ordinary_pos],
+          "the `in-pr` resume rule still treats terminal ledger status as proof of user rejection")
+    check("A bare terminal `aborted`/`merged` ledger row records campaign\n"
+          "     disposition, not a user ruling, so it never selects rejection." in resume_body,
+          "the `in-pr` resume rule does not preserve ordinary handling for an unmarked terminal ledger row")
 
     heading = "#### Rejecting an `in-pr` follow-up"
     match = re.search(
@@ -1086,6 +1105,10 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
           f"{heading!r} starts PR disposition before writing the pending-ruling marker")
     resume_rule = "**If this procedure is interrupted, the `in-pr` resume rule routes back here.**"
     check(resume_rule in body, f"{heading!r} does not preserve a pending rejection across interruption")
+    sensor_rule = "**`reject@<iso>` is the only campaign-owned pending-rejection sensor.**"
+    check(sensor_rule in body, f"{heading!r} does not own an unambiguous pending-rejection sensor")
+    check("A terminal\nledger row records PR disposition, not a user ruling, and MUST NOT route here by itself." in body,
+          f"{heading!r} treats an ambiguous terminal ledger row as a user rejection")
 
     def ordered(branch: str, next_branch: str, *needles: str) -> str:
         start = body.find(branch)

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -312,13 +312,18 @@ def t_transition_graph(tmp: Path) -> None:
     must not move. A new state or edge is covered the moment it is added to `TRANSITIONS`: this fixture
     reads the graph rather than restating it, so it cannot go stale behind it.
 
+    The `in-pr` → `rejected` edge has one additional ordering precondition: campaign disposition starts
+    only after `reject-pending` writes its marker. Its allowed-state case therefore carries that marker.
+
     A DELETING edge is checked the same way, on its own terms: from an allowed state the entry is GONE (and
     the store still LOADS); from a forbidden one it is untouched. Nothing else may remove an entry.
     """
     for cmd, (frm, to) in TRANSITIONS.items():
         for state in STATES:
             path = tmp / f"{cmd}-{state}.jsonl"
-            write_lines(path, entry_line(id="fu1", state=state))
+            decided = (PENDING_REJECTION_PREFIX + "2026-07-14T08:00:00Z"
+                       if cmd == "reject" and state == "in-pr" else "<decided>")
+            write_lines(path, entry_line(id="fu1", state=state, decided=decided))
             code, _, err = run(["--file", str(path), cmd, "--id", "fu1", *transition_args(cmd)])
             if state in frm:
                 check(code == 0, f"`{cmd}` was refused from the ALLOWED state {state!r}: {err!r}")
@@ -380,10 +385,14 @@ def t_ruling_is_recorded(tmp: Path) -> None:
           f"`open-pr` overwrote the USER's ruling timestamp: {after!r}")
     check(after["pr"] == "#77", f"open-pr did not record WHICH PR is addressing it: {after!r}")
 
-    # …and so does the step that DELETES it: the record it prints is the handoff, and it still says the
-    # user ruled, and when.
+    # …and changing that ruling while a PR is open first records a pending rejection before terminal
+    # `reject`. The marker makes campaign disposition resumable.
+    code, _, err = run([
+        "--file", str(path), "reject-pending", "--id", a, "--at", "2026-07-14T10:30:00Z",
+    ])
+    check(code == 0, f"reject-pending exited {code}: {err!r}")
     code, out, err = run(["--file", str(path), "reject", "--id", a, "--at", "2026-07-14T11:00:00Z"])
-    check(code == 0, f"reject exited {code}: {err!r}")  # the user changed their mind while the PR was open
+    check(code == 0, f"reject exited {code}: {err!r}")
     (b2,) = seed(path)
     run(["--file", str(path), "accept", "--id", b2, "--at", "2026-07-14T12:00:00Z"])
     code, out, _ = run(["--file", str(path), "publish", "--id", b2, "--ref", "#88"])
@@ -1015,11 +1024,13 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     """REJECTING AN `in-pr` FOLLOW-UP PERSISTS THE RULING BEFORE CAMPAIGN DISPOSITION STARTS.
 
     `reject-pending` keeps the entry resumable as `in-pr`, but marks the user's ruling distinctly from an
-    earlier acceptance. A fresh heartbeat can therefore route to the rejection procedure before it adopts,
-    reopens, or replaces the PR. Terminal `reject` preserves the original ruling stamp after disposition.
+    earlier acceptance. A fresh heartbeat can therefore route to the rejection procedure before ordinary
+    adoption, reopening, or replacement. Terminal `reject` preserves the original ruling stamp after
+    disposition.
 
-    This fixture also pins the resume sensor and the disposition order for both interruption outcomes:
-    OPEN after a marked rejection must not be re-adopted, and CLOSED after a marked rejection must not
+    This fixture also pins the resume sensor and disposition order for both interruption outcomes. OPEN
+    after `open-pr` but before adoption completes missing adoption only to create the permanent-abort
+    records; an existing terminal abort is never re-adopted. CLOSED after a marked rejection must not
     become `reopened`. An unmarked CLOSED PR follows the ordinary `closed-unmerged` edge to `reopened`.
     """
     check(TRANSITIONS["reject-pending"] == (("in-pr",), "in-pr"),
@@ -1060,6 +1071,14 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     before_close = json.loads(run(["--file", str(ordinary_store), "get", "--id", ordinary_fid])[1])
     check(before_close["decided"] == decided and not before_close["decided"].startswith(PENDING_REJECTION_PREFIX),
           f"ordinary accepted follow-up unexpectedly carries a pending-rejection marker: {before_close!r}")
+    code, _, err = run(["--file", str(ordinary_store), "reject", "--id", ordinary_fid])
+    check(code == 1,
+          f"direct `reject` hid an ordinary live PR without disposition (exit {code})")
+    check("run `reject-pending` before campaign disposition" in err,
+          f"direct `reject` failed without naming the required disposition order: {err!r}")
+    after_refusal = json.loads(run(["--file", str(ordinary_store), "get", "--id", ordinary_fid])[1])
+    check(after_refusal == before_close,
+          f"refused direct `reject` changed the ordinary live PR entry: {after_refusal!r}")
     code, out, err = run(["--file", str(ordinary_store), "closed-unmerged", "--id", ordinary_fid])
     check(code == 0, f"ordinary `closed-unmerged` exited {code}: {err!r}")
     reopened = json.loads(out)
@@ -1078,11 +1097,13 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
           "the `in-pr` resume rule does not inspect rejection sensors before every ordinary resume action")
     sensor_pos = resume_body.find("pending-ruling sensor owned by Rejecting")
     route_pos = resume_body.find("If it\n     selects rejection, route there")
-    ordinary_pos = resume_body.find("Otherwise, reconcile the\n     recorded")
+    ordinary_pos = resume_body.find("Otherwise,\n     reconcile the recorded")
     check(min(sensor_pos, route_pos, ordinary_pos) >= 0,
           "the `in-pr` resume rule cannot apply its pending-ruling sensor before ordinary processing")
     check(sensor_pos < route_pos < ordinary_pos,
           "the `in-pr` resume rule reconciles, adopts, or reopens before routing the pending rejection")
+    check("NEVER re-adopt" not in resume_body[:ordinary_pos],
+          "the `in-pr` resume rule blocks the rejection procedure from completing interrupted adoption")
     check("`aborted`/`merged`" not in resume_body[:ordinary_pos],
           "the `in-pr` resume rule still treats terminal ledger status as proof of user rejection")
     check("A bare terminal `aborted`/`merged` ledger row records campaign\n"
@@ -1124,8 +1145,19 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
             cursor = found + len(needle)
         return branch_body
 
-    ordered("- **OPEN**", "- **CLOSED WITHOUT MERGING**", "permanent-abort procedure",
-            "`followups.py --file <store> reject --id fuN`")
+    open_branch = ordered(
+        "- **OPEN**", "- **CLOSED WITHOUT MERGING**",
+        "If the PR lacks this run's",
+        "owner label or ledger row",
+        "complete the existing",
+        "idempotent ADOPTION",
+        "solely to establish the ownership records",
+        "permanent-abort procedure",
+        "`followups.py --file <store> reject --id fuN`",
+    )
+    check("If an existing ledger row already records" in open_branch
+          and "terminal `aborted`, NEVER re-adopt" in open_branch,
+          f"{heading!r} does not preserve terminal disposition during interrupted rejection")
     closed_branch = ordered("- **CLOSED WITHOUT MERGING**", "- **MERGED**", "`merge.py run`",
                             "terminal close-out", "`followups.py --file <store> reject --id fuN`")
     check("closed-unmerged" not in closed_branch,

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -48,9 +48,9 @@ import followups  # noqa: E402
 from followups import (  # noqa: E402
     ACT_CMD, ACT_CONDITIONS, ACT_FLAGS, ACT_WITNESSES, BLANK_WHY, DEFAULTS, DELETED, DELETING,
     DRIVER_STEPS, DURABLE_RECORD, EDITABLE, ENTRY_TYPE, EVIDENCE_FIELDS, FIELDS, FLAG, INTAKE,
-    INVESTIGATION, OPTIONAL, PLACEHOLDER, REQUIRED, SEQ_TYPE, STATES, TABLE_ALL_HIDDEN_MARKER,
-    TABLE_DEFAULT_FIELDS, TABLE_EMPTY_MARKER, TABLE_HIDDEN_STATES, TABLE_MARKERS, TERMINAL, TRANSITIONS,
-    USER_RULINGS, WRITE_CMDS, WRITES, build_parser, deletable, find, is_blank, load,
+    INVESTIGATION, OPTIONAL, PENDING_REJECTION_PREFIX, PLACEHOLDER, REQUIRED, SEQ_TYPE, STATES,
+    TABLE_ALL_HIDDEN_MARKER, TABLE_DEFAULT_FIELDS, TABLE_EMPTY_MARKER, TABLE_HIDDEN_STATES, TABLE_MARKERS,
+    TERMINAL, TRANSITIONS, USER_RULINGS, WRITE_CMDS, WRITES, build_parser, deletable, find, is_blank, load,
 )
 
 
@@ -704,7 +704,10 @@ def t_deletion_needs_a_durable_record(tmp: Path) -> None:
         if set(WRITES[cmd]) & set(DURABLE_RECORD):
             continue  # the deleting step itself records where the follow-up now lives
         for state in frm:
-            ins = [c for c, (_, to) in TRANSITIONS.items() if to == state]
+            # A self-loop preserves a state whose durable record already exists; only edges arriving from
+            # another state must establish that record.
+            ins = [c for c, (sources, to) in TRANSITIONS.items()
+                   if to == state and any(source != state for source in sources)]
             check(ins, f"`{cmd}` deletes a {state!r} entry, and NOTHING reaches {state!r} — an entry that "
                        f"is there was hand-written, and carries no record of anything")
             for into in ins:
@@ -1009,23 +1012,64 @@ def t_the_doc_and_the_code_agree(tmp: Path) -> None:
 
 
 def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
-    """REJECTING AN `in-pr` FOLLOW-UP FINISHES ITS RECORDED PR'S CAMPAIGN DISPOSITION FIRST.
+    """REJECTING AN `in-pr` FOLLOW-UP PERSISTS THE RULING BEFORE CAMPAIGN DISPOSITION STARTS.
 
-    `reject` remains a legal store edge from `in-pr`: the graph preserves the PR reference and the durable
-    user ruling. But `rejected` is terminal, so the active loop will never return to finish an adopted PR
-    after that edge. The campaign procedure must therefore finish the PR before recording the rejection.
+    `reject-pending` keeps the entry resumable as `in-pr`, but marks the user's ruling distinctly from an
+    earlier acceptance. A fresh heartbeat can therefore route to the rejection procedure before it adopts,
+    reopens, or replaces the PR. Terminal `reject` preserves the original ruling stamp after disposition.
 
-    This fixture pins the order in the driver's canonical procedure for each live PR outcome. It does not
-    invent another store state or move the campaign disposition into `followups.py`.
+    This fixture also pins the resume sensor and the disposition order for both interruption outcomes:
+    OPEN after abort must not be re-adopted, and CLOSED must not become `reopened`.
     """
+    check(TRANSITIONS["reject-pending"] == (("in-pr",), "in-pr"),
+          "`reject-pending` must durably mark the ruling without inventing another follow-up state")
+    check("reject-pending" in USER_RULINGS,
+          "`reject-pending` is not a user ruling — the driver could manufacture a rejection marker")
     check("in-pr" in TRANSITIONS["reject"][0] and "reopened" in TRANSITIONS["reject"][0],
           "the rejection procedure changed the store graph instead of preserving the `in-pr`/`reopened` "
           "edges and their PR history")
     check("rejected" in TERMINAL,
           "`rejected` is not terminal — this fixture's ordering requirement no longer describes the graph")
 
+    store = tmp / "pending-rejection.jsonl"
+    (fid,) = seed(store)
+    run(["--file", str(store), "accept", "--id", fid, "--at", "2026-07-14T09:00:00Z"])
+    run(["--file", str(store), "open-pr", "--id", fid, "--pr", "#999"])
+    code, out, err = run([
+        "--file", str(store), "reject-pending", "--id", fid, "--at", "2026-07-14T10:00:00Z",
+    ])
+    check(code == 0, f"`reject-pending` exited {code}: {err!r}")
+    pending = json.loads(out)
+    marker = PENDING_REJECTION_PREFIX + "2026-07-14T10:00:00Z"
+    check(pending["state"] == "in-pr" and pending["pr"] == "#999",
+          f"`reject-pending` lost the resumable PR record: {pending!r}")
+    check(pending["decided"] == marker,
+          f"`reject-pending` did not leave a distinct durable routing marker: {pending!r}")
+    code, out, err = run(["--file", str(store), "reject", "--id", fid])
+    check(code == 0, f"terminal `reject` exited {code}: {err!r}")
+    rejected = json.loads(out)
+    check(rejected["state"] == "rejected" and rejected["decided"] == marker,
+          f"terminal `reject` did not preserve when the user first ruled: {rejected!r}")
+
     doc = Path(__file__).resolve().parent.parent / "references" / "followups.md"
     text = doc.read_text()
+    resume_start = text.find("   - **`in-pr`**")
+    resume_end = text.find("   - **`reopened`**", resume_start)
+    check(resume_start >= 0 and resume_end > resume_start,
+          f"{doc.name} has no bounded `in-pr` resume rule")
+    resume_body = text[resume_start:resume_end]
+    guard = "**Before reconciliation, adoption,\n     or `closed-unmerged`, read"
+    check(guard in resume_body,
+          "the `in-pr` resume rule does not inspect rejection sensors before every ordinary resume action")
+    marker_pos = resume_body.find("`reject@`")
+    ledger_pos = resume_body.find("`aborted`/`merged`")
+    route_pos = resume_body.find("route to **Rejecting")
+    ordinary_pos = resume_body.find("Otherwise, reconcile the recorded")
+    check(min(marker_pos, ledger_pos, route_pos) >= 0,
+          "the `in-pr` resume rule cannot sense a pending ruling or terminal campaign disposition")
+    check(max(marker_pos, ledger_pos) < route_pos < ordinary_pos,
+          "the `in-pr` resume rule reconciles, adopts, or reopens before routing the pending rejection")
+
     heading = "#### Rejecting an `in-pr` follow-up"
     match = re.search(
         rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^#{{1,4}} |\Z)",
@@ -1035,9 +1079,12 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     if match is None:
         raise SelfTestFailure(f"{doc.name} has no canonical {heading!r} procedure")
     body = match.group("body")
-    rule = "**Finish the recorded PR's campaign disposition BEFORE recording `reject`.**"
-    check(rule in body, f"{heading!r} does not require the PR disposition before the durable rejection")
-    resume_rule = "**If this procedure is interrupted, resume here, not through the state-resume list.**"
+    rule = "**Record `reject-pending` BEFORE starting campaign disposition, then finish disposition BEFORE recording\nterminal `reject`.**"
+    check(rule in body, f"{heading!r} does not persist the ruling before PR disposition")
+    marker_cmd = "`followups.py --file <store> reject-pending --id fuN`"
+    check(0 <= body.find(marker_cmd) < body.find("Then resolve the recorded PR's live state"),
+          f"{heading!r} starts PR disposition before writing the pending-ruling marker")
+    resume_rule = "**If this procedure is interrupted, the `in-pr` resume rule routes back here.**"
     check(resume_rule in body, f"{heading!r} does not preserve a pending rejection across interruption")
 
     def ordered(branch: str, next_branch: str, *needles: str) -> str:
@@ -1445,7 +1492,7 @@ CASES = [
     ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
-    ("in-pr-reject-orders-pr", "an `in-pr` rejection finishes the recorded PR's campaign disposition before becoming terminal", t_in_pr_rejection_finishes_campaign_disposition_first),
+    ("in-pr-reject-orders-pr", "an `in-pr` rejection is durable before PR disposition and terminal only after it", t_in_pr_rejection_finishes_campaign_disposition_first),
     ("investigation-evidence", "an investigation shows its work; the finding APPENDS and never clobbers", t_investigation_shows_its_work),
     ("refutation-stays", "a refuted follow-up stays in the store, stays visible, and stays overturnable", t_refutation_stays_in_the_store),
     ("state-not-settable", "`set` writes neither `state` nor any evidence a transition left behind", t_state_and_evidence_are_not_settable),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1008,6 +1008,59 @@ def t_the_doc_and_the_code_agree(tmp: Path) -> None:
               f"step it has not been told exists")
 
 
+def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
+    """REJECTING AN `in-pr` FOLLOW-UP FINISHES ITS RECORDED PR'S CAMPAIGN DISPOSITION FIRST.
+
+    `reject` remains a legal store edge from `in-pr`: the graph preserves the PR reference and the durable
+    user ruling. But `rejected` is terminal, so the active loop will never return to finish an adopted PR
+    after that edge. The campaign procedure must therefore finish the PR before recording the rejection.
+
+    This fixture pins the order in the driver's canonical procedure for each live PR outcome. It does not
+    invent another store state or move the campaign disposition into `followups.py`.
+    """
+    check("in-pr" in TRANSITIONS["reject"][0] and "reopened" in TRANSITIONS["reject"][0],
+          "the rejection procedure changed the store graph instead of preserving the `in-pr`/`reopened` "
+          "edges and their PR history")
+    check("rejected" in TERMINAL,
+          "`rejected` is not terminal — this fixture's ordering requirement no longer describes the graph")
+
+    doc = Path(__file__).resolve().parent.parent / "references" / "followups.md"
+    text = doc.read_text()
+    heading = "#### Rejecting an `in-pr` follow-up"
+    match = re.search(
+        rf"^{re.escape(heading)}\n(?P<body>.*?)(?=^#{{1,4}} |\Z)",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise SelfTestFailure(f"{doc.name} has no canonical {heading!r} procedure")
+    body = match.group("body")
+    rule = "**Finish the recorded PR's campaign disposition BEFORE recording `reject`.**"
+    check(rule in body, f"{heading!r} does not require the PR disposition before the durable rejection")
+
+    def ordered(branch: str, next_branch: str, *needles: str) -> None:
+        start = body.find(branch)
+        check(start >= 0, f"{heading!r} has no {branch!r} branch")
+        end = body.find(next_branch, start + len(branch))
+        check(end > start, f"{heading!r} has no end marker {next_branch!r} after {branch!r}")
+        branch_body = body[start:end]
+        cursor = 0
+        for needle in needles:
+            found = branch_body.find(needle, cursor)
+            check(found >= 0,
+                  f"{heading!r} does not place {needle!r} after {branch!r}; the disposition order is lost")
+            cursor = found + len(needle)
+
+    ordered("- **OPEN**", "- **CLOSED WITHOUT MERGING**", "permanent-abort procedure",
+            "`followups.py --file <store> reject --id fuN`")
+    ordered("- **CLOSED WITHOUT MERGING**", "- **MERGED**", "`merge.py run`", "terminal close-out",
+            "`followups.py --file <store> closed-unmerged --id fuN`",
+            "`followups.py --file <store> reject --id fuN`")
+    ordered("- **MERGED**", "\n\nThe existing", "`merge.py run`",
+            "`followups.py --file <store> merged --id fuN`",
+            "Do not record `reject`")
+
+
 def t_ids_are_assigned_and_never_reused(tmp: Path) -> None:
     """`id` is assigned by the STORE (`fu<N>`, one past the highest EVER HANDED OUT) — never by the caller,
     and NEVER REUSED, not even after the entry that held it was DELETED.
@@ -1388,6 +1441,7 @@ CASES = [
     ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
+    ("in-pr-reject-orders-pr", "an `in-pr` rejection finishes the recorded PR's campaign disposition before becoming terminal", t_in_pr_rejection_finishes_campaign_disposition_first),
     ("investigation-evidence", "an investigation shows its work; the finding APPENDS and never clobbers", t_investigation_shows_its_work),
     ("refutation-stays", "a refuted follow-up stays in the store, stays visible, and stays overturnable", t_refutation_stays_in_the_store),
     ("state-not-settable", "`set` writes neither `state` nor any evidence a transition left behind", t_state_and_evidence_are_not_settable),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1037,8 +1037,10 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     body = match.group("body")
     rule = "**Finish the recorded PR's campaign disposition BEFORE recording `reject`.**"
     check(rule in body, f"{heading!r} does not require the PR disposition before the durable rejection")
+    resume_rule = "**If this procedure is interrupted, resume here, not through the state-resume list.**"
+    check(resume_rule in body, f"{heading!r} does not preserve a pending rejection across interruption")
 
-    def ordered(branch: str, next_branch: str, *needles: str) -> None:
+    def ordered(branch: str, next_branch: str, *needles: str) -> str:
         start = body.find(branch)
         check(start >= 0, f"{heading!r} has no {branch!r} branch")
         end = body.find(next_branch, start + len(branch))
@@ -1050,12 +1052,14 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
             check(found >= 0,
                   f"{heading!r} does not place {needle!r} after {branch!r}; the disposition order is lost")
             cursor = found + len(needle)
+        return branch_body
 
     ordered("- **OPEN**", "- **CLOSED WITHOUT MERGING**", "permanent-abort procedure",
             "`followups.py --file <store> reject --id fuN`")
-    ordered("- **CLOSED WITHOUT MERGING**", "- **MERGED**", "`merge.py run`", "terminal close-out",
-            "`followups.py --file <store> closed-unmerged --id fuN`",
-            "`followups.py --file <store> reject --id fuN`")
+    closed_branch = ordered("- **CLOSED WITHOUT MERGING**", "- **MERGED**", "`merge.py run`",
+                            "terminal close-out", "`followups.py --file <store> reject --id fuN`")
+    check("closed-unmerged" not in closed_branch,
+          f"{heading!r} parks a rejected closed PR in resumable open work before recording the ruling")
     ordered("- **MERGED**", "\n\nThe existing", "`merge.py run`",
             "`followups.py --file <store> merged --id fuN`",
             "Do not record `reject`")

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1065,11 +1065,13 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     after_close_refusal = json.loads(run(["--file", str(store), "get", "--id", fid])[1])
     check(after_close_refusal == pending,
           f"refused `closed-unmerged` changed the pending rejection: {after_close_refusal!r}")
-    code, out, err = run(["--file", str(store), "reject", "--id", fid])
+    code, out, err = run([
+        "--file", str(store), "reject", "--id", fid, "--at", "2026-07-14T11:00:00Z",
+    ])
     check(code == 0, f"terminal `reject` exited {code}: {err!r}")
     rejected = json.loads(out)
     check(rejected["state"] == "rejected" and rejected["decided"] == marker,
-          f"terminal `reject` did not preserve when the user first ruled: {rejected!r}")
+          f"terminal `reject --at` replaced when the user first ruled: {rejected!r}")
 
     ordinary_store = tmp / "ordinary-closed.jsonl"
     (ordinary_fid,) = seed(ordinary_store)
@@ -1175,8 +1177,11 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
         "NEVER run `merge.py` or `pr-adopt.py`",
         "`followups.py --file <store> reject --id fuN`",
         "If a row exists",
+        "nonterminal status",
         "`merge.py run`",
         "terminal close-out",
+        "terminal `aborted`",
+        "do\n  not run `merge.py`",
         "`followups.py --file <store> reject --id fuN`",
     )
     check("closed-unmerged" not in closed_branch,
@@ -1190,9 +1195,13 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
         "NEVER run `merge.py` or `pr-adopt.py`",
         "`followups.py --file <store> merged --id fuN`",
         "If a row exists",
+        "nonterminal status",
         "`merge.py run`",
         "`followups.py --file <store> merged --id fuN`",
-        "Do not record\n  `reject`",
+        "already terminal (`merged` or `aborted`)",
+        "do not run `merge.py`",
+        "`followups.py --file <store> merged --id fuN`",
+        "Do not record `reject`",
     )
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -47,8 +47,8 @@ check = ledger_test.check
 import followups  # noqa: E402
 from followups import (  # noqa: E402
     ACT_CMD, ACT_CONDITIONS, ACT_FLAGS, ACT_WITNESSES, BLANK_WHY, DEFAULTS, DELETED, DELETING,
-    DRIVER_STEPS, DURABLE_RECORD, EDITABLE, ENTRY_TYPE, EVIDENCE_FIELDS, FIELDS, FLAG, INTAKE,
-    INVESTIGATION, OPTIONAL, PENDING_REJECTION_PREFIX, PLACEHOLDER, REQUIRED, SEQ_TYPE, STATES,
+    DISPOSED_REJECTION, DRIVER_STEPS, DURABLE_RECORD, EDITABLE, ENTRY_TYPE, EVIDENCE_FIELDS, FIELDS, FLAG,
+    INTAKE, INVESTIGATION, NO_REJECTION, OPTIONAL, PENDING_REJECTION, PLACEHOLDER, REQUIRED, SEQ_TYPE, STATES,
     TABLE_ALL_HIDDEN_MARKER, TABLE_DEFAULT_FIELDS, TABLE_EMPTY_MARKER, TABLE_HIDDEN_STATES, TABLE_MARKERS,
     TERMINAL, TRANSITIONS, USER_RULINGS, WRITE_CMDS, WRITES, build_parser, deletable, find, is_blank, load,
 )
@@ -66,7 +66,7 @@ def entry_line(**over: object) -> str:
     once. A fixture that wants a DEFECTIVE entry blanks a field on purpose — that is what `**over` is for.
     """
     rec = {"type": ENTRY_TYPE, **DEFAULTS,
-           **{f: f"<{f}>" for f in FIELDS if f not in ("id", "state")}, **over}
+           **{f: f"<{f}>" for f in FIELDS if f not in ("id", "state", "rejection")}, **over}
     return json.dumps(rec)
 
 
@@ -312,9 +312,9 @@ def t_transition_graph(tmp: Path) -> None:
     must not move. A new state or edge is covered the moment it is added to `TRANSITIONS`: this fixture
     reads the graph rather than restating it, so it cannot go stale behind it.
 
-    Two `in-pr` edges have pending-ruling preconditions. `reject` requires the marker because campaign
-    disposition must start only after `reject-pending` writes it. `closed-unmerged` requires no marker
-    because a pending rejection must finish disposition and become `rejected`, never `reopened`.
+    Two `in-pr` edges have pending-ruling preconditions. `reject` requires a completed typed disposition;
+    `closed-unmerged` turns a genuine pending rejection into that completed disposition instead of reopening
+    work the user rejected.
 
     A DELETING edge is checked the same way, on its own terms: from an allowed state the entry is GONE (and
     the store still LOADS); from a forbidden one it is untouched. Nothing else may remove an entry.
@@ -322,9 +322,8 @@ def t_transition_graph(tmp: Path) -> None:
     for cmd, (frm, to) in TRANSITIONS.items():
         for state in STATES:
             path = tmp / f"{cmd}-{state}.jsonl"
-            decided = (PENDING_REJECTION_PREFIX + "2026-07-14T08:00:00Z"
-                       if cmd == "reject" and state == "in-pr" else "<decided>")
-            write_lines(path, entry_line(id="fu1", state=state, decided=decided))
+            rejection = DISPOSED_REJECTION if cmd == "reject" and state == "in-pr" else NO_REJECTION
+            write_lines(path, entry_line(id="fu1", state=state, decided="<decided>", rejection=rejection))
             code, _, err = run(["--file", str(path), cmd, "--id", "fu1", *transition_args(cmd)])
             if state in frm:
                 check(code == 0, f"`{cmd}` was refused from the ALLOWED state {state!r}: {err!r}")
@@ -386,12 +385,14 @@ def t_ruling_is_recorded(tmp: Path) -> None:
           f"`open-pr` overwrote the USER's ruling timestamp: {after!r}")
     check(after["pr"] == "#77", f"open-pr did not record WHICH PR is addressing it: {after!r}")
 
-    # …and changing that ruling while a PR is open first records a pending rejection before terminal
-    # `reject`. The marker makes campaign disposition resumable.
+    # …and changing that ruling while a PR is open first records a typed pending rejection before terminal
+    # `reject`. The completed disposition makes the rejection resumable without reusing user timestamp data.
     code, _, err = run([
         "--file", str(path), "reject-pending", "--id", a, "--at", "2026-07-14T10:30:00Z",
     ])
     check(code == 0, f"reject-pending exited {code}: {err!r}")
+    code, _, err = run(["--file", str(path), "closed-unmerged", "--id", a])
+    check(code == 0, f"closed-unmerged did not record the pending disposition: {err!r}")
     code, out, err = run(["--file", str(path), "reject", "--id", a, "--at", "2026-07-14T11:00:00Z"])
     check(code == 0, f"reject exited {code}: {err!r}")
     (b2,) = seed(path)
@@ -1023,10 +1024,10 @@ def t_the_doc_and_the_code_agree(tmp: Path) -> None:
 def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     """REJECTING AN `in-pr` FOLLOW-UP PERSISTS THE RULING BEFORE CAMPAIGN DISPOSITION STARTS.
 
-    `reject-pending` keeps the entry resumable as `in-pr`, but marks the user's ruling distinctly from an
-    earlier acceptance. A fresh heartbeat can therefore route to the rejection procedure before ordinary
-    adoption, reopening, or replacement. Terminal `reject` preserves the original ruling stamp after
-    disposition.
+    `reject-pending` keeps the entry resumable as `in-pr`, but records a typed pending rejection separately
+    from the user's timestamp. A fresh heartbeat can therefore route to the rejection procedure before
+    ordinary adoption, reopening, or replacement. Terminal `reject` needs that disposition to complete and
+    preserves the original ruling stamp.
 
     This fixture also pins the resume sensor and disposition order for both interruption outcomes. OPEN
     after `open-pr` but before adoption completes missing adoption only to create the permanent-abort
@@ -1052,23 +1053,27 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     ])
     check(code == 0, f"`reject-pending` exited {code}: {err!r}")
     pending = json.loads(out)
-    marker = PENDING_REJECTION_PREFIX + "2026-07-14T10:00:00Z"
+    marker = "2026-07-14T10:00:00Z"
     check(pending["state"] == "in-pr" and pending["pr"] == "#999",
           f"`reject-pending` lost the resumable PR record: {pending!r}")
-    check(pending["decided"] == marker,
-          f"`reject-pending` did not leave a distinct durable routing marker: {pending!r}")
-    code, _, err = run(["--file", str(store), "closed-unmerged", "--id", fid])
-    check(code == 1,
-          f"`closed-unmerged` reopened a pending rejection before campaign disposition (exit {code})")
-    check("finish campaign disposition" in err and "`reject`" in err,
-          f"`closed-unmerged` refused the pending rejection without naming its required next step: {err!r}")
-    after_close_refusal = json.loads(run(["--file", str(store), "get", "--id", fid])[1])
-    check(after_close_refusal == pending,
-          f"refused `closed-unmerged` changed the pending rejection: {after_close_refusal!r}")
+    check(pending["decided"] == marker and pending["rejection"] == PENDING_REJECTION,
+          f"`reject-pending` did not leave typed pending-rejection data: {pending!r}")
     code, out, err = run([
         "--file", str(store), "reject", "--id", fid, "--at", "2026-07-14T11:00:00Z",
     ])
-    check(code == 0, f"terminal `reject` exited {code}: {err!r}")
+    check(code == 1 and "disposition is unresolved" in err,
+          f"terminal `reject` accepted an unresolved pending rejection: code={code} err={err!r}")
+    unresolved = json.loads(run(["--file", str(store), "get", "--id", fid])[1])
+    check(unresolved == pending, f"refused terminal `reject` changed the pending entry: {unresolved!r}")
+    code, out, err = run(["--file", str(store), "closed-unmerged", "--id", fid])
+    check(code == 0, f"pending `closed-unmerged` exited {code}: {err!r}")
+    disposed = json.loads(out)
+    check(disposed["state"] == "in-pr" and disposed["rejection"] == DISPOSED_REJECTION,
+          f"closed PR did not record the completed rejection disposition: {disposed!r}")
+    code, out, err = run([
+        "--file", str(store), "reject", "--id", fid, "--at", "2026-07-14T11:00:00Z",
+    ])
+    check(code == 0, f"terminal `reject` after disposition exited {code}: {err!r}")
     rejected = json.loads(out)
     check(rejected["state"] == "rejected" and rejected["decided"] == marker,
           f"terminal `reject --at` replaced when the user first ruled: {rejected!r}")
@@ -1079,8 +1084,8 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     run(["--file", str(ordinary_store), "accept", "--id", ordinary_fid, "--at", decided])
     run(["--file", str(ordinary_store), "open-pr", "--id", ordinary_fid, "--pr", "#1000"])
     before_close = json.loads(run(["--file", str(ordinary_store), "get", "--id", ordinary_fid])[1])
-    check(before_close["decided"] == decided and not before_close["decided"].startswith(PENDING_REJECTION_PREFIX),
-          f"ordinary accepted follow-up unexpectedly carries a pending-rejection marker: {before_close!r}")
+    check(before_close["decided"] == decided and before_close["rejection"] == NO_REJECTION,
+          f"ordinary accepted follow-up unexpectedly carries a pending rejection: {before_close!r}")
     code, _, err = run(["--file", str(ordinary_store), "reject", "--id", ordinary_fid])
     check(code == 1,
           f"direct `reject` hid an ordinary live PR without disposition (exit {code})")
@@ -1095,6 +1100,46 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     check(reopened["state"] == "reopened" and reopened["pr"] == "#1000" and reopened["decided"] == decided,
           f"an unmarked closed PR did not return to ordinary open work: {reopened!r}")
 
+    # `decided` is user data. An accepted value that happens to begin with the former marker spelling is
+    # neither a pending rejection nor proof that this PR was disposed. It must take every ordinary PR path.
+    spoof_store = tmp / "spoofed-accept.jsonl"
+    (spoof_fid,) = seed(spoof_store)
+    spoofed = "reject@spoofed-accept"
+    run(["--file", str(spoof_store), "accept", "--id", spoof_fid, "--at", spoofed])
+    run(["--file", str(spoof_store), "open-pr", "--id", spoof_fid, "--pr", "#1001"])
+    spoof_entry = json.loads(run(["--file", str(spoof_store), "get", "--id", spoof_fid])[1])
+    check(spoof_entry["decided"] == spoofed and spoof_entry["rejection"] == NO_REJECTION,
+          f"accepted marker-shaped timestamp was classified as a pending rejection: {spoof_entry!r}")
+    code, _, err = run(["--file", str(spoof_store), "reject", "--id", spoof_fid])
+    check(code == 1 and "without a genuine pending rejection" in err,
+          f"marker-shaped accepted timestamp allowed terminal reject: code={code} err={err!r}")
+    code, out, err = run(["--file", str(spoof_store), "closed-unmerged", "--id", spoof_fid])
+    check(code == 0, f"marker-shaped accepted timestamp blocked ordinary close handling: {err!r}")
+    check(json.loads(out)["state"] == "reopened",
+          f"marker-shaped accepted timestamp did not reopen after the PR closed: {out!r}")
+    run(["--file", str(spoof_store), "open-pr", "--id", spoof_fid, "--pr", "#1002"])
+    code, _, err = run(["--file", str(spoof_store), "merged", "--id", spoof_fid])
+    check(code == 0 and load(spoof_store) == [],
+          f"marker-shaped accepted timestamp blocked normal merged deletion: code={code} err={err!r}")
+
+    merged_store = tmp / "pending-merged.jsonl"
+    (merged_fid,) = seed(merged_store)
+    run(["--file", str(merged_store), "accept", "--id", merged_fid, "--at", "2026-07-14T12:00:00Z"])
+    run(["--file", str(merged_store), "open-pr", "--id", merged_fid, "--pr", "#1003"])
+    run(["--file", str(merged_store), "reject-pending", "--id", merged_fid,
+         "--at", "2026-07-14T13:00:00Z"])
+    code, _, err = run(["--file", str(merged_store), "merged", "--id", merged_fid])
+    check(code == 0 and load(merged_store) == [],
+          f"a merged PR did not remain the durable record for a pending rejection: code={code} err={err!r}")
+
+    non_pr_store = tmp / "ordinary-reject.jsonl"
+    (non_pr_fid,) = seed(non_pr_store)
+    ordinary_stamp = "2026-07-14T14:00:00Z"
+    code, out, err = run(["--file", str(non_pr_store), "reject", "--id", non_pr_fid,
+                          "--at", ordinary_stamp])
+    check(code == 0 and json.loads(out)["decided"] == ordinary_stamp,
+          f"ordinary terminal reject no longer accepts and records a supplied timestamp: code={code} err={err!r}")
+
     doc = Path(__file__).resolve().parent.parent / "references" / "followups.md"
     text = doc.read_text()
     resume_start = text.find("   - **`in-pr`**")
@@ -1105,8 +1150,8 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     guard = "**Before reconciliation, adoption,\n     or `closed-unmerged`, apply"
     check(guard in resume_body,
           "the `in-pr` resume rule does not inspect rejection sensors before every ordinary resume action")
-    sensor_pos = resume_body.find("pending-ruling sensor owned by Rejecting")
-    route_pos = resume_body.find("If it\n     selects rejection, route there")
+    sensor_pos = resume_body.find("typed pending-ruling sensor owned by Rejecting")
+    route_pos = resume_body.find("it selects rejection, route there")
     ordinary_pos = resume_body.find("Otherwise,\n     reconcile the recorded")
     check(min(sensor_pos, route_pos, ordinary_pos) >= 0,
           "the `in-pr` resume rule cannot apply its pending-ruling sensor before ordinary processing")
@@ -1132,13 +1177,15 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
     rule = "**Record `reject-pending` BEFORE starting campaign disposition, then finish disposition BEFORE recording\nterminal `reject`.**"
     check(rule in body, f"{heading!r} does not persist the ruling before PR disposition")
     marker_cmd = "`followups.py --file <store> reject-pending --id fuN`"
-    check(0 <= body.find(marker_cmd) < body.find("Then resolve the recorded PR's live state"),
+    check(0 <= body.find(marker_cmd) < body.find("Then resolve the recorded PR's live"),
           f"{heading!r} starts PR disposition before writing the pending-ruling marker")
     resume_rule = "**If this procedure is interrupted, the `in-pr` resume rule routes back here.**"
     check(resume_rule in body, f"{heading!r} does not preserve a pending rejection across interruption")
-    sensor_rule = "**`reject@<iso>` is the only campaign-owned pending-rejection sensor.**"
-    check(sensor_rule in body, f"{heading!r} does not own an unambiguous pending-rejection sensor")
-    check("A terminal\nledger row records PR disposition, not a user ruling, and MUST NOT route here by itself." in body,
+    check("**Only the typed `rejection` phase is a campaign-owned\n"
+          "pending-rejection sensor.**" in body,
+          f"{heading!r} does not own an unambiguous pending-rejection sensor")
+    check("A terminal ledger row records PR disposition, not a user ruling, and MUST\n"
+          "NOT route here by itself." in body,
           f"{heading!r} treats an ambiguous terminal ledger row as a user rejection")
 
     def ordered(branch: str, next_branch: str, *needles: str) -> str:
@@ -1163,29 +1210,30 @@ def t_in_pr_rejection_finishes_campaign_disposition_first(tmp: Path) -> None:
         "idempotent ADOPTION",
         "solely to establish the ownership records",
         "permanent-abort procedure",
+        "status = aborted",
+        "records `rejection = disposed`",
         "`followups.py --file <store> reject --id fuN`",
     )
-    check("If an existing ledger row already records" in open_branch
-          and "terminal `aborted`, NEVER re-adopt" in open_branch,
+    check("If an existing ledger row already records terminal" in open_branch
+          and "refresh that row through `ledger.py set --pr <N> --status aborted`" in open_branch,
           f"{heading!r} does not preserve terminal disposition during interrupted rejection")
     closed_branch = ordered(
         "- **CLOSED WITHOUT MERGING**", "- **MERGED**",
         "inspect this run's ledger",
         "If no row names the recorded\n  PR",
-        "live **CLOSED**",
-        "complete campaign disposition",
         "NEVER run `merge.py` or `pr-adopt.py`",
-        "`followups.py --file <store> reject --id fuN`",
+        "`followups.py --file <store> closed-unmerged --id fuN`",
         "If a row exists",
         "nonterminal status",
         "`merge.py run`",
-        "terminal close-out",
-        "terminal `aborted`",
-        "do\n  not run `merge.py`",
+        "terminal `aborted` write",
+        "records the disposition",
+        "If its status is already terminal",
+        "ledger.py set --pr <N> --status aborted",
         "`followups.py --file <store> reject --id fuN`",
     )
-    check("closed-unmerged" not in closed_branch,
-          f"{heading!r} parks a rejected closed PR in resumable open work before recording the ruling")
+    check("closed-unmerged" in closed_branch,
+          f"{heading!r} does not record a rejected closed PR's completed disposition")
     ordered(
         "- **MERGED**", "\n\nThe existing",
         "inspect this run's ledger",

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -49,9 +49,9 @@ file that grows.
     did we do this"), or it was PUBLISHED as an issue (the issue is then the record).
   * NEVER DELETED ON TAKE-UP. An entry deleted when work STARTS is an entry a closed, abandoned or
     rejected PR takes down with it — the work still undone, and nothing left to remember it. So while a PR
-    is OPEN the entry STAYS and records which PR is addressing it (`in-pr`), and a PR CLOSED WITHOUT
-    MERGING returns it to OPEN WORK (`reopened`) — never a silent vanish, never stuck in "being worked on"
-    forever.
+    is OPEN the entry STAYS and records which PR is addressing it (`in-pr`). A PR CLOSED WITHOUT MERGING
+    returns it to OPEN WORK (`reopened`) only when no pending rejection exists; a pending rejection keeps
+    it `in-pr` until campaign disposition finishes and terminal `reject` records the ruling.
   * REJECTIONS STAY. A rejection is worth remembering PRECISELY so it is not re-raised: delete it and the
     next run rediscovers the same thing, records it again, and asks the user again. It is hidden from the
     default view; it is not deleted. (A published one CAN be deleted for the same test: the ISSUE is the
@@ -343,7 +343,8 @@ FLAG_HELP = {
     "published": "where it was published (issue ref or URL) — the ISSUE is now the record, so the entry "
                  "is DELETED",
     "pr": "the PR addressing it (#N or URL). The entry STAYS while that PR is open: `merged` then deletes "
-          "it (the PR is the record), `closed-unmerged` returns it to open work (nothing recorded it)",
+          "it (the PR is the record); without a pending rejection, `closed-unmerged` returns it to open "
+          "work (nothing recorded it)",
     **{w: f"ACT condition '{c}' — {why}" for c, w, why in ACT_CONDITIONS if w in ACT_FLAGS},
 }
 
@@ -756,6 +757,12 @@ def cmd_transition(path: Path, args) -> int:
             fail(
                 f"{args.id} is 'in-pr' without a pending rejection marker — run `reject-pending` before "
                 "campaign disposition, then run `reject` only after disposition finishes."
+            )
+        if (cmd == "closed-unmerged"
+                and entry["decided"].startswith(PENDING_REJECTION_PREFIX)):
+            fail(
+                f"{args.id} has a pending rejection marker — finish campaign disposition, then run "
+                "`reject`; `closed-unmerged` applies only when no pending rejection exists."
             )
         # WHEN this step was taken. The user's ruling is DURABLE DATA, exactly like the ledger's
         # `api_approval`: a later run — or a fresh agent that never saw the conversation — reads it and does

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -233,6 +233,7 @@ TRANSITIONS = {
     "refute":          (("candidate", "corroborated", "reopened"), "refuted"),
     "take-up":         (("corroborated",), "self-accepted"),
     "accept":          (("candidate", "corroborated", "refuted", "self-accepted", "reopened"), "accepted"),
+    "reject-pending":  (("in-pr",), "in-pr"),
     "reject":          (("candidate", "corroborated", "refuted", "self-accepted", "accepted", "in-pr",
                         "reopened"), "rejected"),
     "open-pr":         (("accepted", "self-accepted", "reopened"), "in-pr"),
@@ -243,7 +244,12 @@ TRANSITIONS = {
 
 # The transitions that are the USER'S RULING. They are the ones that stamp `decided`, and the ONLY ones —
 # a `decided` written by anything else would launder the driver's action into the user's consent.
-USER_RULINGS = ("accept", "reject")
+USER_RULINGS = ("accept", "reject-pending", "reject")
+
+# A rejection of an `in-pr` entry cannot become terminal until its recorded PR's campaign disposition is
+# finished. The tagged value makes that pending ruling distinguishable from the untagged `accept` stamp
+# an `in-pr` entry may already carry. It uses the existing durable `decided` field, not another state.
+PENDING_REJECTION_PREFIX = "reject@"
 
 # Everything else is the DRIVER's. Derived, never listed: whatever is not the user's ruling is a step the
 # driver can take on its own, and the closure over exactly these edges is what must not reach `accepted`,
@@ -277,6 +283,7 @@ WRITES = {
     "refute":          ("finding",),
     ACT_CMD:           ACT_FLAGS,
     "accept":          ("decided",),
+    "reject-pending":  ("decided",),
     "reject":          ("decided",),
     "open-pr":         ("pr",),
     "closed-unmerged": (),
@@ -398,7 +405,7 @@ WRITE_CMDS = tuple(INTAKE)
 INTAKE_HELP = {
     **FLAG_HELP,
     **{f: f"'{f}' — required on `add`, editable after, NEVER blankable: {BLANK_WHY[f]}" for f in REQUIRED},
-    "decided": "ISO timestamp of this step (default: now)",
+    "decided": "ISO timestamp of this ruling (default: now); `reject-pending` stores it as `reject@<iso>`",
     "found": "ISO timestamp it was found (default: now)",
     "found_run": "the run-id that found it",
 }
@@ -751,7 +758,15 @@ def cmd_transition(path: Path, args) -> int:
         stamp = values.get("decided") or now_iso()
         for field in WRITES[cmd]:
             if field in OPTIONAL:
-                entry[field] = stamp
+                if cmd == "reject-pending":
+                    entry[field] = PENDING_REJECTION_PREFIX + stamp
+                elif cmd == "reject" and entry[field].startswith(PENDING_REJECTION_PREFIX):
+                    # Preserve the moment the user ruled, not the later moment campaign cleanup finished.
+                    # An explicit --at remains meaningful: it replaces the tagged timestamp.
+                    if "decided" in values:
+                        entry[field] = PENDING_REJECTION_PREFIX + stamp
+                else:
+                    entry[field] = stamp
                 continue
             entry[field] = (append_finding(entry[field], to, stamp, values[field]) if field == "finding"
                             else values[field])

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -751,6 +751,12 @@ def cmd_transition(path: Path, args) -> int:
                 f"{args.id} is '{entry['state']}' — `{cmd}` applies only to: {', '.join(frm)}. "
                 f"A follow-up reaches '{to}' only along the transition graph; nothing else moves `state`."
             )
+        if (cmd == "reject" and entry["state"] == "in-pr"
+                and not entry["decided"].startswith(PENDING_REJECTION_PREFIX)):
+            fail(
+                f"{args.id} is 'in-pr' without a pending rejection marker — run `reject-pending` before "
+                "campaign disposition, then run `reject` only after disposition finishes."
+            )
         # WHEN this step was taken. The user's ruling is DURABLE DATA, exactly like the ledger's
         # `api_approval`: a later run — or a fresh agent that never saw the conversation — reads it and does
         # not re-ask. OMITTED, the stamp defaults to now; SUPPLIED (`--at`), it is a value like any other and

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -138,8 +138,16 @@ SEQ_TYPE = "followup-seq"
 
 FIELDS = (
     "id", "title", "evidence", "deferred_why", "finding", *ACT_FLAGS,
-    "state", "found_run", "found", "decided", "pr", "published",
+    "state", "found_run", "found", "decided", "rejection", "pr", "published",
 )
+
+# `decided` is the user's timestamp. It is deliberately free-form input carried from the command line, so it
+# cannot also prove that campaign finished handling a PR. `rejection` is the accessor-owned, typed record of
+# that separate fact. It moves only from no rejection -> pending -> disposed; callers have no flag for it.
+NO_REJECTION = PLACEHOLDER
+PENDING_REJECTION = "pending"
+DISPOSED_REJECTION = "disposed"
+REJECTION_VALUES = (NO_REJECTION, PENDING_REJECTION, DISPOSED_REJECTION)
 
 # The fields that name a record OUTSIDE this store — the PR that addresses it, or the issue it was
 # published as. THEY ARE WHAT MAKES DELETION SAFE, and the rule is enforced, not assumed: an entry is
@@ -246,11 +254,6 @@ TRANSITIONS = {
 # a `decided` written by anything else would launder the driver's action into the user's consent.
 USER_RULINGS = ("accept", "reject-pending", "reject")
 
-# A rejection of an `in-pr` entry cannot become terminal until its recorded PR's campaign disposition is
-# finished. The tagged value makes that pending ruling distinguishable from the untagged `accept` stamp
-# an `in-pr` entry may already carry. It uses the existing durable `decided` field, not another state.
-PENDING_REJECTION_PREFIX = "reject@"
-
 # Everything else is the DRIVER's. Derived, never listed: whatever is not the user's ruling is a step the
 # driver can take on its own, and the closure over exactly these edges is what must not reach `accepted`,
 # nor any state `publish` leaves from. Add an edge tomorrow and it lands in this set automatically —
@@ -311,9 +314,9 @@ OPTIONAL = ("decided",)
 STAMPED = ("decided", "finding")
 
 # …so those are the ONLY steps that may OFFER `--at`, and which ones they are is DERIVED from what each edge
-# WRITES — never listed. A terminal `reject` of an existing pending-rejection marker is the one special
-# case: it completes campaign disposition but preserves that marker's original ruling time. `--at` used to
-# be offered by EVERY transition and read by only these:
+# WRITES — never listed. A terminal `reject` of a completed pending rejection is the one special case: it
+# completes the follow-up state but preserves the original ruling time. `--at` used to be offered by EVERY
+# transition and read by only these:
 # `open-pr --at 1999-01-01T00:00:00Z` exited 0, and that timestamp appeared NOWHERE — not in the entry, not
 # on stdout. The caller believes they set a value; the tool tells them it worked; the value is gone. On a
 # step that stamps nothing, `--at` is therefore not a flag at all, and argparse refuses it.
@@ -408,8 +411,8 @@ WRITE_CMDS = tuple(INTAKE)
 INTAKE_HELP = {
     **FLAG_HELP,
     **{f: f"'{f}' — required on `add`, editable after, NEVER blankable: {BLANK_WHY[f]}" for f in REQUIRED},
-    "decided": "ISO timestamp of this ruling (default: now); `reject-pending` stores it as `reject@<iso>`, "
-               "which terminal `reject` preserves",
+    "decided": "timestamp of this ruling (default: now); terminal `reject` preserves the original "
+               "`reject-pending` timestamp after campaign disposition",
     "found": "ISO timestamp it was found (default: now)",
     "found_run": "the run-id that found it",
 }
@@ -479,6 +482,14 @@ def entry_error(entry: dict) -> "str | None":
         return f"malformed id {entry['id']!r} (expected fu<N>)"
     if entry["state"] not in STATES:
         return f"unknown state {entry['state']!r}; valid: {', '.join(STATES)}"
+    if entry["rejection"] not in REJECTION_VALUES:
+        return (f"unknown rejection phase {entry['rejection']!r}; valid: "
+                f"{', '.join(REJECTION_VALUES)}")
+    if entry["state"] not in ("in-pr", "rejected") and entry["rejection"] != NO_REJECTION:
+        return (f"rejection phase {entry['rejection']!r} is only valid while an entry is `in-pr` or after "
+                "terminal `reject`")
+    if entry["state"] == "rejected" and entry["rejection"] == PENDING_REJECTION:
+        return "a rejected entry cannot retain an unresolved rejection disposition"
     empty = [f for f in REQUIRED if is_blank(entry[f])]
     if empty:
         return f"{entry['id']} carries no {', '.join(empty)} — {BLANK_WHY[empty[0]]}"
@@ -634,6 +645,49 @@ def find(entries: "list[dict]", fid: str) -> "dict | None":
     return None
 
 
+def rejection_phase(entry: dict) -> str:
+    """The one classifier for an `in-pr` rejection's durable state.
+
+    `decided` is user data and never participates. Only the accessor-owned `rejection` field may prove a
+    genuine pending ruling or that campaign has completed its disposition. A non-`in-pr` entry has no active
+    rejection procedure even when its terminal record retains `disposed` for audit history.
+    """
+    if entry["state"] != "in-pr":
+        return NO_REJECTION
+    return entry["rejection"]
+
+
+PR_REF_RE = re.compile(r"^(?:#|https://github\\.com/[^/]+/[^/]+/pull/)([1-9][0-9]*)/?$")
+
+
+def pr_number(ref: str) -> "str | None":
+    """The PR number in the two documented follow-up reference forms, or None for an opaque legacy value."""
+    match = PR_REF_RE.match(ref)
+    return match.group(1) if match is not None else None
+
+
+def record_completed_rejection_disposition(path: Path, pr: str) -> "tuple[str, ...]":
+    """Record campaign's completed abort/close-out for every matching pending follow-up.
+
+    The ledger owns when an adopted PR reaches terminal abort. It calls this helper after that durable result
+    exists. A missing store means no follow-up has been recorded yet, so it is a no-op; a matching ordinary
+    `in-pr` entry is also untouched. The store lock and atomic dump remain the only write path.
+    """
+    if not path.exists():
+        return ()
+    recorded: list[str] = []
+    with locked(path):
+        entries, high = read_store(path)
+        for entry in entries:
+            if pr_number(entry["pr"]) != pr or rejection_phase(entry) != PENDING_REJECTION:
+                continue
+            entry["rejection"] = DISPOSED_REJECTION
+            recorded.append(entry["id"])
+        if recorded:
+            dump(path, entries, high)
+    return tuple(recorded)
+
+
 def next_id(high: int) -> str:
     """`fu<N>`, one past the highest N EVER HANDED OUT — assigned HERE, never by the caller.
 
@@ -755,38 +809,49 @@ def cmd_transition(path: Path, args) -> int:
                 f"{args.id} is '{entry['state']}' — `{cmd}` applies only to: {', '.join(frm)}. "
                 f"A follow-up reaches '{to}' only along the transition graph; nothing else moves `state`."
             )
-        if (cmd == "reject" and entry["state"] == "in-pr"
-                and not entry["decided"].startswith(PENDING_REJECTION_PREFIX)):
+        phase = rejection_phase(entry)
+        if cmd == "reject" and entry["state"] == "in-pr":
+            if phase == NO_REJECTION:
+                fail(
+                    f"{args.id} is 'in-pr' without a genuine pending rejection — run `reject-pending` before "
+                    "campaign disposition, then run `reject` only after disposition finishes."
+                )
+            if phase == PENDING_REJECTION:
+                fail(
+                    f"{args.id} has a pending rejection whose recorded PR disposition is unresolved — finish "
+                    "campaign disposition before terminal `reject`."
+                )
+        if cmd == "closed-unmerged" and phase == DISPOSED_REJECTION:
             fail(
-                f"{args.id} is 'in-pr' without a pending rejection marker — run `reject-pending` before "
-                "campaign disposition, then run `reject` only after disposition finishes."
-            )
-        if (cmd == "closed-unmerged"
-                and entry["decided"].startswith(PENDING_REJECTION_PREFIX)):
-            fail(
-                f"{args.id} has a pending rejection marker — finish campaign disposition, then run "
-                "`reject`; `closed-unmerged` applies only when no pending rejection exists."
+                f"{args.id} already has a completed rejection disposition — run terminal `reject`; do not "
+                "reopen the entry."
             )
         # WHEN this step was taken. The user's ruling is DURABLE DATA, exactly like the ledger's
         # `api_approval`: a later run — or a fresh agent that never saw the conversation — reads it and does
         # not re-ask. OMITTED, the stamp defaults to now; SUPPLIED (`--at`), it is a value like any other and
         # `taken()` has already refused a blank. It is offered ONLY where it stamps a ruling (`STAMPS`),
-        # except terminal `reject`, which preserves an existing pending-rejection marker.
+        # except terminal `reject`, which preserves a completed pending rejection's original ruling time.
         stamp = values.get("decided") or now_iso()
         for field in WRITES[cmd]:
             if field in OPTIONAL:
                 if cmd == "reject-pending":
-                    entry[field] = PENDING_REJECTION_PREFIX + stamp
-                elif cmd == "reject" and entry[field].startswith(PENDING_REJECTION_PREFIX):
-                    # The marker records WHEN the user rejected the follow-up. Terminal `reject` records
-                    # only that the required campaign disposition has finished, so it must preserve that
-                    # ruling even when a later caller supplies --at for the completion attempt.
+                    entry[field] = stamp
+                    entry["rejection"] = PENDING_REJECTION
+                elif cmd == "reject" and phase == DISPOSED_REJECTION:
+                    # The typed disposition records that campaign completed the recorded PR. Terminal `reject`
+                    # records only that the user's ruling is now final, so its later `--at` cannot replace the
+                    # time the user originally supplied to `reject-pending`.
                     pass
                 else:
                     entry[field] = stamp
                 continue
             entry[field] = (append_finding(entry[field], to, stamp, values[field]) if field == "finding"
                             else values[field])
+        if cmd == "closed-unmerged" and phase == PENDING_REJECTION:
+            # This transition is the local proof that the recorded PR closed without merging. Do not reopen
+            # work the user rejected: leave it `in-pr` until terminal `reject` consumes the disposition.
+            entry["rejection"] = DISPOSED_REJECTION
+            to = "in-pr"
         if to == DELETED:
             if not deletable(entry):
                 fail(f"{args.id} names no durable record ({', '.join(DURABLE_RECORD)}) — deleting it would "

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -311,7 +311,9 @@ OPTIONAL = ("decided",)
 STAMPED = ("decided", "finding")
 
 # …so those are the ONLY steps that may OFFER `--at`, and which ones they are is DERIVED from what each edge
-# WRITES — never listed. `--at` used to be offered by EVERY transition and read by only these:
+# WRITES — never listed. A terminal `reject` of an existing pending-rejection marker is the one special
+# case: it completes campaign disposition but preserves that marker's original ruling time. `--at` used to
+# be offered by EVERY transition and read by only these:
 # `open-pr --at 1999-01-01T00:00:00Z` exited 0, and that timestamp appeared NOWHERE — not in the entry, not
 # on stdout. The caller believes they set a value; the tool tells them it worked; the value is gone. On a
 # step that stamps nothing, `--at` is therefore not a flag at all, and argparse refuses it.
@@ -406,7 +408,8 @@ WRITE_CMDS = tuple(INTAKE)
 INTAKE_HELP = {
     **FLAG_HELP,
     **{f: f"'{f}' — required on `add`, editable after, NEVER blankable: {BLANK_WHY[f]}" for f in REQUIRED},
-    "decided": "ISO timestamp of this ruling (default: now); `reject-pending` stores it as `reject@<iso>`",
+    "decided": "ISO timestamp of this ruling (default: now); `reject-pending` stores it as `reject@<iso>`, "
+               "which terminal `reject` preserves",
     "found": "ISO timestamp it was found (default: now)",
     "found_run": "the run-id that found it",
 }
@@ -767,17 +770,18 @@ def cmd_transition(path: Path, args) -> int:
         # WHEN this step was taken. The user's ruling is DURABLE DATA, exactly like the ledger's
         # `api_approval`: a later run — or a fresh agent that never saw the conversation — reads it and does
         # not re-ask. OMITTED, the stamp defaults to now; SUPPLIED (`--at`), it is a value like any other and
-        # `taken()` has already refused a blank. It is offered ONLY where it lands somewhere (`STAMPS`).
+        # `taken()` has already refused a blank. It is offered ONLY where it stamps a ruling (`STAMPS`),
+        # except terminal `reject`, which preserves an existing pending-rejection marker.
         stamp = values.get("decided") or now_iso()
         for field in WRITES[cmd]:
             if field in OPTIONAL:
                 if cmd == "reject-pending":
                     entry[field] = PENDING_REJECTION_PREFIX + stamp
                 elif cmd == "reject" and entry[field].startswith(PENDING_REJECTION_PREFIX):
-                    # Preserve the moment the user ruled, not the later moment campaign cleanup finished.
-                    # An explicit --at remains meaningful: it replaces the tagged timestamp.
-                    if "decided" in values:
-                        entry[field] = PENDING_REJECTION_PREFIX + stamp
+                    # The marker records WHEN the user rejected the follow-up. Terminal `reject` records
+                    # only that the required campaign disposition has finished, so it must preserve that
+                    # ruling even when a later caller supplies --at for the completion attempt.
+                    pass
                 else:
                     entry[field] = stamp
                 continue

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -34,6 +34,42 @@ DESCRIPTION = "Schema-owning accessor for the campaign ledger (state.jsonl)."
 
 HERE = Path(__file__).resolve().parent
 TEST_PY = HERE / "ledger-test.py"     # the fixture suite — this accessor's executable contract
+FOLLOWUPS_PY = HERE / "followups.py"
+
+
+def _followup_store_for(path: Path) -> "Path | None":
+    """The shared follow-up store for a standard `<project>/.gauntlet/runs/<id>/state.jsonl` ledger.
+
+    A ledger CLI may also operate on an arbitrary fixture or recovery file. Those paths have no documented
+    relationship to a follow-up store, so they deliberately receive no side effect. The campaign's durable
+    layout is the one place the relationship is defined.
+    """
+    run_dir = path.parent
+    if (path.name != "state.jsonl" or run_dir.parent.name != "runs"
+            or run_dir.parent.parent.name != ".gauntlet"):
+        return None
+    return run_dir.parent.parent / "followups.jsonl"
+
+
+def _complete_aborted_followups(path: Path, rows: "list[dict]") -> None:
+    """Let an aborted ledger row complete matching genuine pending follow-up rejections.
+
+    `status = aborted` is campaign's durable completion of the OPEN abort and CLOSED close-out workflows.
+    The follow-up accessor owns its own store and lock, so this bridge only derives the standard store path
+    and asks that accessor to record the typed disposition. A missing store is normal: no follow-up was
+    recorded for this project yet.
+    """
+    store = _followup_store_for(path)
+    if store is None or not store.exists() or not any(r["status"] == "aborted" for r in rows):
+        return
+    spec = importlib.util.spec_from_file_location("ledger_followups", FOLLOWUPS_PY)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load follow-up accessor at {FOLLOWUPS_PY}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    for row in rows:
+        if row["status"] == "aborted":
+            module.record_completed_rejection_disposition(store, row["pr"])
 
 # --- schema (owned here, once) ------------------------------------------------
 
@@ -727,6 +763,7 @@ def save(path: Path, header: dict, rows: list[dict], *, activity: bool) -> None:
     if activity:
         header["last_activity"] = now_activity()
     dump(path, header, rows)
+    _complete_aborted_followups(path, rows)
 
 
 def find_row(rows: list[dict], pr: str) -> "dict | None":

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 import sys
 import tempfile
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
@@ -33,11 +35,20 @@ def _load_reconcile():
     return mod
 
 
+def _load_followups():
+    path = OWNER.parent / "followups.py"
+    mod = load_module_from_path("merge_test_followups", path)
+    if mod is None:
+        raise RuntimeError(f"cannot load {path}")
+    return mod
+
+
 M = _load_owner()
 L = M.L
 # The reconcile detector. The routing-decision fixture drives BOTH tools: the fact reconcile emits, and the
 # `merge.py run` finalizer that fact routes to.
 RECON = _load_reconcile()
+F = _load_followups()
 
 SHA = "a" * 40
 
@@ -333,6 +344,13 @@ def status(ledger: Path) -> str:
     if row is None:
         raise M.SelfTestFailure("fixture ledger lost PR 9")
     return row["status"]
+
+
+def followup(argv: list[str]) -> tuple[int, str, str]:
+    out, err = StringIO(), StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        code = F.main(argv)
+    return code, out.getvalue(), err.getvalue()
 
 
 def t_happy_owned_cleanup_and_command():
@@ -864,6 +882,42 @@ def t_absent_snapshot_closed_row_terminates():
               "the close-out issued a merge command")
         check(not any("worktree" in argv and "remove" in argv for argv, _ in f.calls),
               "the close-out removed a worktree")
+    finally:
+        finish(td, real)
+
+
+def t_closed_out_ledger_disposes_matching_pending_followup():
+    """The terminal abort write, not a caller-supplied timestamp, completes a pending rejection.
+
+    This drives the real close-out branch through the standard `.gauntlet/runs/<id>/state.jsonl` layout. The
+    ledger accessor must update the sibling follow-up store after it records `aborted`; only then may terminal
+    `reject` consume the result. No GitHub call is needed beyond the fake CLOSED fact this fixture supplies.
+    """
+    td, root, f, _unused, real = scenario(state="CLOSED")
+    try:
+        ledger = root / ".gauntlet" / "runs" / "g1" / "state.jsonl"
+        f.ledger(ledger)
+        store = root / ".gauntlet" / "followups.jsonl"
+        for argv in (
+            ["--file", str(store), "add", "--title", "pending", "--evidence", "proof",
+             "--deferred-why", "scope"],
+            ["--file", str(store), "accept", "--id", "fu1", "--at", "2026-07-14T09:00:00Z"],
+            ["--file", str(store), "open-pr", "--id", "fu1", "--pr", "#9"],
+            ["--file", str(store), "reject-pending", "--id", "fu1", "--at", "2026-07-14T10:00:00Z"],
+        ):
+            code, _out, err = followup(argv)
+            check(code == 0, f"follow-up setup failed: {argv!r}: {err!r}")
+        code, result, err = invoke(f, ledger, root)
+        check(code == 0 and result is not None and result["status"] == "closed-unmerged", err)
+        entry = json.loads(followup(["--file", str(store), "get", "--id", "fu1"])[1])
+        check(entry["rejection"] == F.DISPOSED_REJECTION,
+              f"terminal ledger close-out did not record the completed follow-up disposition: {entry!r}")
+        code, out, err = followup(["--file", str(store), "reject", "--id", "fu1",
+                                   "--at", "2026-07-14T11:00:00Z"])
+        rejected = json.loads(out) if out else {}
+        check(code == 0 and rejected.get("state") == "rejected"
+              and rejected.get("decided") == "2026-07-14T10:00:00Z",
+              f"terminal reject did not consume the ledger disposition and preserve its ruling: {code} {err!r}")
     finally:
         finish(td, real)
 
@@ -1672,6 +1726,7 @@ CASES = [
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),
     ("absent-closed", "an absent-but-unfinalized CLOSED-without-merge row terminates as aborted with no cleanup", t_absent_snapshot_closed_row_terminates),
+    ("closed-followup-disposition", "a terminal CLOSED close-out records the matching pending follow-up disposition before terminal reject", t_closed_out_ledger_disposes_matching_pending_followup),
     ("half-adopted-closed", "a half-adopted CLOSED row closes out to aborted without requiring the cleanup-ownership fields", t_half_adopted_closed_row_closes_out_without_cleanup_fields),
     ("closed-out-moved-refs", "the CLOSED close-out terminates as aborted despite a moved head, base, or branch", t_closed_out_terminates_despite_moved_head_base_or_branch),
     ("closed-out-held-statuses", "a CLOSED PR closes out every held status to aborted; merged+CLOSED stays refused", t_closed_out_terminates_every_held_status),

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -45,6 +45,16 @@ def _load_finding_audit():
 
 FA = _load_finding_audit()
 
+
+def _load_followups():
+    mod = load_module_from_path("repair_pass_test_followups", OWNER.parent / "followups.py")
+    if mod is None:
+        raise RuntimeError(f"cannot load {OWNER.parent / 'followups.py'}")
+    return mod
+
+
+F = _load_followups()
+
 SHA = "c" * 40
 
 
@@ -292,6 +302,44 @@ def t_abort_is_terminal_and_leaves_the_pr_open(tmp: Path) -> None:
     check(field(path, "status") == "aborted", "abort is terminal")
     check("LEAVE THE PR OPEN" in err, f"the abort message must say the PR stays open: {err!r}")
     check("bailout-and-final-report" in err, f"the abort must route into the EXISTING procedure: {err!r}")
+
+
+def t_abort_decision_disposes_matching_pending_followup(tmp: Path) -> None:
+    """A reassessment abort records the completed PR disposition before terminal follow-up reject.
+
+    The abort decision is the OPEN permanent-abort path's durable terminal ledger write. It uses the standard
+    run layout, so the ledger must update the matching shared follow-up store after that write. A terminal
+    follow-up reject may then preserve the original user timestamp; without this bridge it remains unresolved.
+    """
+    root = tmp / "project"
+    run_dir = root / ".gauntlet" / "runs" / "g1"
+    run_dir.mkdir(parents=True)
+    ledger, record = setup(run_dir, decision="abort", pr="9", pr_origin="gauntlet")
+    store = root / ".gauntlet" / "followups.jsonl"
+    for argv in (
+        ["--file", str(store), "add", "--title", "pending", "--evidence", "proof",
+         "--deferred-why", "scope"],
+        ["--file", str(store), "accept", "--id", "fu1", "--at", "2026-07-14T09:00:00Z"],
+        ["--file", str(store), "open-pr", "--id", "fu1", "--pr", "#9"],
+        ["--file", str(store), "reject-pending", "--id", "fu1", "--at", "2026-07-14T10:00:00Z"],
+    ):
+        code, _out, err = capture_cli(F.main, argv)
+        check(code == 0, f"follow-up setup failed: {argv!r}: {err!r}")
+
+    code, _, err = decide(ledger, record, "abort", pr="9")
+    check(code == 0, f"abort decision failed: {err!r}")
+    code, out, err = capture_cli(F.main, ["--file", str(store), "get", "--id", "fu1"])
+    check(code == 0, f"get pending follow-up failed: {err!r}")
+    entry = json.loads(out)
+    check(entry["rejection"] == F.DISPOSED_REJECTION,
+          f"abort decision did not record the completed follow-up disposition: {entry!r}")
+    code, out, err = capture_cli(F.main, [
+        "--file", str(store), "reject", "--id", "fu1", "--at", "2026-07-14T11:00:00Z",
+    ])
+    rejected = json.loads(out) if out else {}
+    check(code == 0 and rejected.get("state") == "rejected"
+          and rejected.get("decided") == "2026-07-14T10:00:00Z",
+          f"terminal reject did not consume the abort disposition and preserve its ruling: {code} {err!r}")
 
 
 # --- the decision is real, recorded, and only for a PR that needs one ----------
@@ -1637,6 +1685,7 @@ CASES = [
     ("unknown-is-external", "an unset origin is EXTERNAL — the fail-safe direction", t_unknown_origin_is_treated_as_external),
     ("budget-spent", "at REPAIR_CAP the only decision left is abort", t_repair_budget_is_spent),
     ("abort-leaves-it-open", "abort is terminal, leaves the PR OPEN, and reuses the existing procedure", t_abort_is_terminal_and_leaves_the_pr_open),
+    ("abort-followup-disposition", "an abort decision records matching pending follow-up disposition before terminal reject", t_abort_decision_disposes_matching_pending_followup),
     ("only-a-capped-pr", "a PR that never hit a cap cannot be reassessed", t_only_a_capped_pr_may_be_reassessed),
     ("decision-needs-record", "no decision without its reasoning on disk", t_a_decision_needs_a_record),
     ("record-decision-binds", "the record's DECISION field must be well-formed and equal --decision", t_record_decision_must_match_the_argument),

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -1115,7 +1115,10 @@ def cmd_decide(path: Path, args) -> int:
         # Terminal. The driver still runs the abort PROCEDURE (leave the PR OPEN, drop this run's labels,
         # write abort-<id>.md) — `bailout-and-final-report.md` owns it, and this does not replace it.
         row["status"] = "aborted"
-    L.dump(path, header, rows)
+    # A recorded decision is real campaign activity. `save()` is also the ledger's single completion hook
+    # for a terminal abort, which records the matching pending follow-up's PR disposition before terminal
+    # `reject` may consume it.
+    L.save(path, header, rows, activity=True)
     print(json.dumps({f: row[f] for f in L.ROW_FIELDS}))
 
     if args.decision == "abort":


### PR DESCRIPTION
- require an `in-pr` rejection to finish the recorded PR's abort or close-out first
- preserve the follow-up graph and PR history, with a fixture covering every live PR outcome
- verify the follow-up contract and both isolated host plugin installs
