### PR TITLE
fix lease precondition refusal guidance

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -149,6 +149,30 @@ def t_argparse_must_not_steal_the_refusal(work: Path) -> None:
     L.check(err.startswith("lease: REFUSED"), "the refusal must be OUR message")
 
 
+def t_no_acquire_preconditions_give_complete_recovery(work: Path) -> None:
+    """Neither acquire input still yields complete recovery in one refusal."""
+    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+    before = p.read_bytes()
+    code, out, err = run_before_lease_access(["--file", str(p), "acquire"])
+    assert_precondition_refusal(code, out, err, p, before,
+                                "acquire without --token or --heartbeat-id")
+    L.check("requires both --token and --heartbeat-id" in err,
+            "the combined refusal must identify both missing inputs")
+    L.check("if YOU already hold this run" in err and "recover YOUR OWN token" in err and
+            "Do NOT mint a replacement" in err,
+            "a current owner must recover its own token without minting a replacement")
+    L.check("NEVER from `lease.json` or `lease.py read`" in err,
+            "the combined refusal must reject run-scoped token sources")
+    L.check("including when adopting an absent" in err and "or stale run" in err and
+            "lease.py mint" in err,
+            "an absent or stale-run adopter must mint its token")
+    L.check("Arm a new heartbeat for this run with that token" in err and
+            "runtime-adapter.md" in err and "record the id for that arming as the proof" in err,
+            "every caller must be told how to obtain a newly armed heartbeat proof")
+    L.check("acquire --token <tok> --heartbeat-id <proof>" in err,
+            "the combined refusal must name the exact retry with both values")
+
+
 def t_no_token_refuses_with_caller_scoped_recovery(work: Path) -> None:
     """A missing token must distinguish owner recovery from stale-run adoption."""
     p = put(work, {
@@ -778,6 +802,8 @@ CASES = [
      t_empty_heartbeat_is_not_a_proof),
     ("refusal-is-ours", "argparse must not steal the refusal — the instruction IS the mechanism",
      t_argparse_must_not_steal_the_refusal),
+    ("no-acquire-preconditions", "neither acquire input gets complete recovery in one refusal",
+     t_no_acquire_preconditions_give_complete_recovery),
     ("no-token", "no token, no ownership check — owner recovery and stale adoption stay separate",
      t_no_token_refuses_with_caller_scoped_recovery),
     ("refresh-no-token", "refresh without a token checks no ownership and preserves the lease",

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -149,17 +149,27 @@ def t_argparse_must_not_steal_the_refusal(work: Path) -> None:
     L.check(err.startswith("lease: REFUSED"), "the refusal must be OUR message")
 
 
-def t_no_token_refuses_and_never_mints(work: Path) -> None:
-    """A live owner missing its token must recover it, never mint a replacement."""
-    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+def t_no_token_refuses_with_caller_scoped_recovery(work: Path) -> None:
+    """A missing token must distinguish owner recovery from stale-run adoption."""
+    p = put(work, {
+        "agent": "previous-owner-token",
+        "heartbeat": "w0",
+        "updated": L.now() - L.LEASE_STALE_AFTER - 1,
+    })
     before = p.read_bytes()
     code, out, err = run_before_lease_access(
         ["--file", str(p), "acquire", "--heartbeat-id", "hb-1"])
     assert_precondition_refusal(code, out, err, p, before, "acquire without --token")
-    L.check("SAME token" in err and "do NOT mint a replacement" in err,
-            "an existing owner must be told to recover its token, never mint a replacement")
-    L.check("first acquire" in err and "lease.py mint" in err,
-            "the acquire refusal must separately explain recovery when no token exists yet")
+    L.check("if YOU already hold this run" in err and "YOUR OWN token" in err,
+            "owner recovery must be scoped to the caller, not a token found in run state")
+    L.check("session or from the heartbeat prompt" in err,
+            "owner recovery must name caller-scoped sources for the token")
+    L.check("NEVER from `lease.json` or `lease.py read`" in err,
+            "owner recovery must reject run-scoped sources that may identify the previous holder")
+    L.check("adopting an absent or stale run" in err and "lease.py mint" in err,
+            "a stale-run adopter without its own token must be routed through mint")
+    L.check("do NOT mint a replacement" in err,
+            "a current owner must be told to recover its own token, never mint a replacement")
     L.check("acquire --token <tok> --heartbeat-id <proof>" in err,
             "the acquire refusal must name the exact retry")
 
@@ -182,8 +192,8 @@ def t_release_without_token_refuses_before_ownership_check(work: Path) -> None:
     before = p.read_bytes()
     code, out, err = run_before_lease_access(["--file", str(p), "release"])
     assert_precondition_refusal(code, out, err, p, before, "release without --token")
-    L.check("release --token <tok>" in err and "SAME owner token" in err,
-            "release must tell the owner to recover the matching token and name the exact retry")
+    L.check("release --token <tok>" in err and "your own token from your session" in err,
+            "release must name the caller-scoped token source and the exact retry")
     L.check("do NOT delete or alter the lease" in err,
             "release without the owner token must say to leave the lease untouched")
 
@@ -768,8 +778,8 @@ CASES = [
      t_empty_heartbeat_is_not_a_proof),
     ("refusal-is-ours", "argparse must not steal the refusal — the instruction IS the mechanism",
      t_argparse_must_not_steal_the_refusal),
-    ("no-token", "no token, no ownership check — an existing owner never mints a replacement",
-     t_no_token_refuses_and_never_mints),
+    ("no-token", "no token, no ownership check — owner recovery and stale adoption stay separate",
+     t_no_token_refuses_with_caller_scoped_recovery),
     ("refresh-no-token", "refresh without a token checks no ownership and preserves the lease",
      t_refresh_without_token_refuses_before_ownership_check),
     ("release-no-token", "release without a token checks no ownership and preserves the lease",

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -57,6 +57,39 @@ def acquire(work: Path, **kw):
     return L.run(argv)
 
 
+def run_before_lease_access(argv: "list[str]"):
+    """A missing precondition must refuse before both the claim lock and lease read."""
+    original_lock = L.claim_lock
+    original_read = L.read_lease
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("a precondition refusal reached the claim lock or lease read")
+
+    setattr(L, "claim_lock", forbidden)
+    setattr(L, "read_lease", forbidden)
+    try:
+        return L.run(argv)
+    finally:
+        setattr(L, "claim_lock", original_lock)
+        setattr(L, "read_lease", original_read)
+
+
+def assert_precondition_refusal(code: int, out: str, err: str, path: Path, before: bytes,
+                                command: str) -> None:
+    """Pin the common no-read/no-write contract without replacing command-specific guidance checks."""
+    L.check(code == L.EXIT_REFUSED,
+            f"{command} with a missing precondition must exit {L.EXIT_REFUSED}, got {code}")
+    L.check(out == "", f"{command}'s precondition refusal must print no stdout, got {out!r}")
+    L.check("ownership was NOT checked" in err,
+            f"{command}'s precondition refusal must say it made no ownership decision")
+    L.check("UNDRIVEN" not in err,
+            f"{command}'s precondition refusal must not invent an ownership state")
+    L.check(path.read_bytes() == before,
+            f"{command}'s precondition refusal must leave the lease BYTE-UNCHANGED")
+    L.check(not (path.parent / L.LOCK_NAME).exists(),
+            f"{command}'s precondition refusal must stop before taking the claim lock")
+
+
 def verdict_of(out: str) -> str:
     return json.loads(out)["verdict"]
 
@@ -64,14 +97,19 @@ def verdict_of(out: str) -> str:
 # --- the heartbeat precondition -----------------------------------------------
 
 def t_no_heartbeat_refuses(work: Path) -> None:
-    """The whole point: no proof of arming, no lease."""
-    code, _out, err = acquire(work, token="t1")
-    L.check(code != 0, "acquire with NO --heartbeat-id must REFUSE — that is the entire mechanism")
-    L.check(not lease_path(work).exists(), "a refused acquire must write NOTHING")
+    """No proof stops before ownership is checked, even when the caller already owns a live lease."""
+    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+    before = p.read_bytes()
+    code, out, err = run_before_lease_access(
+        ["--file", str(p), "acquire", "--token", "t1"])
+    assert_precondition_refusal(code, out, err, p, before, "acquire without --heartbeat-id")
     L.check("--heartbeat-id" in err and "ALREADY armed" in err,
             "the refusal must say the proof names something ALREADY armed, not something intended")
     L.check("IN THIS ORDER" in err, "the refusal must teach the order (arm, THEN acquire) — an "
                                     "instruction, not a diagnosis")
+    L.check("keep the token you already have" in err and
+            "acquire --token <tok> --heartbeat-id <proof>" in err,
+            "the missing-proof refusal must preserve the existing token and name the exact acquire retry")
     L.check("runtime-adapter" in err, "the refusal must point at the doc that owns the host mapping")
     for host_specific in ("ScheduleWakeup", "CronCreate", "bounded wait"):
         L.check(host_specific not in err,
@@ -112,12 +150,42 @@ def t_argparse_must_not_steal_the_refusal(work: Path) -> None:
 
 
 def t_no_token_refuses_and_never_mints(work: Path) -> None:
-    """A caller with no token never armed a heartbeat that identifies it: its proof cannot be real."""
-    code, _out, err = acquire(work, heartbeat="hb-1")
-    L.check(code != 0, "acquire with NO --token must REFUSE")
-    L.check(not lease_path(work).exists(), "a refused acquire must write NOTHING — and must NOT mint a "
-                                           "token to make itself succeed")
-    L.check("mint" in err, "the refusal must point at `mint` as step one")
+    """A live owner missing its token must recover it, never mint a replacement."""
+    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+    before = p.read_bytes()
+    code, out, err = run_before_lease_access(
+        ["--file", str(p), "acquire", "--heartbeat-id", "hb-1"])
+    assert_precondition_refusal(code, out, err, p, before, "acquire without --token")
+    L.check("SAME token" in err and "do NOT mint a replacement" in err,
+            "an existing owner must be told to recover its token, never mint a replacement")
+    L.check("first acquire" in err and "lease.py mint" in err,
+            "the acquire refusal must separately explain recovery when no token exists yet")
+    L.check("acquire --token <tok> --heartbeat-id <proof>" in err,
+            "the acquire refusal must name the exact retry")
+
+
+def t_refresh_without_token_refuses_before_ownership_check(work: Path) -> None:
+    """Refresh recovers the heartbeat's owner token; it never mints or changes commands."""
+    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+    before = p.read_bytes()
+    code, out, err = run_before_lease_access(["--file", str(p), "refresh"])
+    assert_precondition_refusal(code, out, err, p, before, "refresh without --token")
+    L.check("refresh --token <tok>" in err and "heartbeat or owner session" in err,
+            "refresh must say where to recover the token and name the exact retry")
+    L.check("Do NOT mint a replacement or switch to acquire" in err,
+            "refresh must not redirect a missing-token owner into a different ownership path")
+
+
+def t_release_without_token_refuses_before_ownership_check(work: Path) -> None:
+    """Release recovers the exact owner token or leaves the lease untouched."""
+    p = put(work, {"agent": "t1", "heartbeat": "w0", "updated": L.now()})
+    before = p.read_bytes()
+    code, out, err = run_before_lease_access(["--file", str(p), "release"])
+    assert_precondition_refusal(code, out, err, p, before, "release without --token")
+    L.check("release --token <tok>" in err and "SAME owner token" in err,
+            "release must tell the owner to recover the matching token and name the exact retry")
+    L.check("do NOT delete or alter the lease" in err,
+            "release without the owner token must say to leave the lease untouched")
 
 
 # --- the proof is recorded, never interpreted ---------------------------------
@@ -692,15 +760,20 @@ def t_lost_race_readback_refuses(work: Path) -> None:
 
 
 CASES = [
-    ("no-heartbeat", "no proof of arming, no lease — the entire mechanism", t_no_heartbeat_refuses),
+    ("no-heartbeat", "no proof of arming, no ownership check — the entire mechanism",
+     t_no_heartbeat_refuses),
     ("no-heartbeat-absent", "an ABSENT lease refuses too — a fresh run has no heartbeat yet",
      t_no_heartbeat_refuses_on_an_absent_lease),
     ("blank-heartbeat", "a whitespace proof is refused, never trimmed into a value",
      t_empty_heartbeat_is_not_a_proof),
     ("refusal-is-ours", "argparse must not steal the refusal — the instruction IS the mechanism",
      t_argparse_must_not_steal_the_refusal),
-    ("no-token", "no token, no lease — and acquire never mints one to save itself",
+    ("no-token", "no token, no ownership check — an existing owner never mints a replacement",
      t_no_token_refuses_and_never_mints),
+    ("refresh-no-token", "refresh without a token checks no ownership and preserves the lease",
+     t_refresh_without_token_refuses_before_ownership_check),
+    ("release-no-token", "release without a token checks no ownership and preserves the lease",
+     t_release_without_token_refuses_before_ownership_check),
     ("proof-verbatim", "the proof is recorded, never parsed or normalized", t_proof_is_stored_verbatim),
     ("proof-not-a-generation", "a new proof is a record, not a generation mismatch",
      t_a_new_proof_is_not_a_generation_mismatch),

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -335,6 +335,20 @@ def emit(verdict: str, rec: "dict | None", **extra) -> None:
 # THIS command recovers. The heartbeat refusal names no host mechanism — `runtime-adapter.md` owns that
 # mapping — and offers no way to acquire before arming.
 
+NO_ACQUIRE_PRECONDITIONS = """\
+lease: REFUSED — acquire stopped before the lease read, so ownership was NOT checked. Nothing was written;
+       the lease and ownership state are unchanged.
+lease: acquire requires both --token and --heartbeat-id. The token identifies you; the heartbeat id proves
+       you have ALREADY armed this run's heartbeat with that token.
+lease: DO THIS, IN THIS ORDER: (1) if YOU already hold this run, recover YOUR OWN token from your session
+       or from the heartbeat prompt that carries it — NEVER from `lease.json` or `lease.py read`, which show
+       whoever held the run before. Do NOT mint a replacement. Otherwise, including when adopting an absent
+       or stale run, run `lease.py mint`. (2) Arm a new heartbeat for this run with that token via your host's
+       mechanism (`runtime-adapter.md` owns it, and `heartbeat.py callback` prints the exact wake prompt);
+       record the id for that arming as the proof. (3) Re-run
+       `acquire --token <tok> --heartbeat-id <proof>` with both recorded values.
+lease: DO NOT take the lease first and arm afterwards."""
+
 NO_HEARTBEAT = """\
 lease: REFUSED — acquire stopped before the lease read, so ownership was NOT checked. Nothing was written;
        the lease and ownership state are unchanged.
@@ -386,9 +400,13 @@ def cmd_mint(_path, _args) -> int:
 
 
 def cmd_acquire(path: Path, args) -> int:
-    if not (args.token or "").strip():
+    has_token = bool((args.token or "").strip())
+    has_heartbeat = bool((args.heartbeat_id or "").strip())
+    if not has_token and not has_heartbeat:
+        fail(NO_ACQUIRE_PRECONDITIONS)
+    if not has_token:
         fail(NO_TOKEN_ACQUIRE)
-    if not (args.heartbeat_id or "").strip():
+    if not has_heartbeat:
         fail(NO_HEARTBEAT)
     token = args.token
     with claim_lock(path):
@@ -605,9 +623,9 @@ def build_parser() -> argparse.ArgumentParser:
     # NOTE: --token and --heartbeat-id are deliberately NOT argparse-`required`. They ARE required, and
     # this file refuses without them — but argparse's "the following arguments are required:
     # --heartbeat-id" is a DIAGNOSIS, and the whole mechanism here is the INSTRUCTION the refusal carries
-    # (NO_HEARTBEAT / NO_TOKEN_*). Letting argparse win the race would keep the exit code and throw away the
-    # only part that says ownership was not checked and teaches command-specific recovery. The
-    # NO_HEARTBEAT / NO_TOKEN_* messages own that contract; `lease-test.py` pins it.
+    # (the NO_* messages below). Letting argparse win the race would keep the exit code and throw away the
+    # only part that says ownership was not checked and teaches command-specific recovery. Those messages
+    # own that contract; `lease-test.py` pins it.
     a = sub.add_parser("acquire", help="take or refresh ownership of this run — the door every heartbeat goes "
                                        "through first")
     a.add_argument("--token", help="REQUIRED. A current owner reuses its own token from its session or "

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -21,13 +21,15 @@ would otherwise do:
    wrongly refusing an orphan stalls a run, which staleness and a human both recover.
 2. **`release` refuses unless the token matches.** The prose once said "delete lease.json on normal
    exit" — a superseded driver following that literally deletes the LIVE OWNER'S lease.
-3. **No `--heartbeat-id`, no lease.** The caller must hand over its proof that it has ALREADY armed the
-   heartbeat. This tool never inspects the proof and takes the caller's word for it — which is exactly why
-   it must name something already done. Arming was step 6 of the heartbeat skeleton, after all the interesting
-   work, when an agent believes it is finished; it was skipped for an entire session and nothing noticed.
-   Requiring it here moves the failure from "forgot at the end", which nothing catches, to "cannot start".
-4. **No `--token`, no lease** — and `acquire` never mints one. The heartbeat carries `--token`, so a caller
-   without one demonstrably never armed a heartbeat that identifies it: its proof cannot be real.
+3. **No `--heartbeat-id`, no ownership check.** The caller must hand over its proof that it has ALREADY
+   armed the heartbeat. This tool never inspects the proof and takes the caller's word for it — which is
+   exactly why it must name something already done. Arming was step 6 of the heartbeat skeleton, after all
+   the interesting work, when an agent believes it is finished; it was skipped for an entire session and
+   nothing noticed. Requiring it here moves the failure from "forgot at the end", which nothing catches, to
+   "cannot start". The refusal happens before the lock or lease read, so it cannot claim who drives the run.
+4. **No `--token`, no ownership check.** `acquire`, `refresh`, and `release` all refuse before the lock or
+   lease read, produce no stdout, preserve lease bytes, and say how to recover for that command. `acquire` never
+   mints a token: a first acquire must mint and arm, while an existing owner must reuse its token.
 
 A future `updated` (clock skew) reads as FRESH, not stale — fail closed, same direction as (1).
 """
@@ -325,33 +327,50 @@ def emit(verdict: str, rec: "dict | None", **extra) -> None:
     print(json.dumps(out))
 
 
-# --- the refusal that carries the contract ------------------------------------
+# --- the precondition refusals that carry the contract ------------------------
 #
-# The proof cannot be verified, so the ENFORCEMENT is this refusal and its value is the INSTRUCTION it
-# carries. Modelled on `ledger.py verdict` at a review-loop cap, the strongest rule in the campaign: it
-# exits non-zero and its stderr says what happened, WHAT STATE CHANGED, what NOT to do, and what to do
-# instead. It names no host mechanism — `runtime-adapter.md` owns that mapping — and it offers NO
-# alternative, because the moment it names a way to proceed without a proof, that way becomes the default.
+# These checks run before the lock and lease read, so they decide NO ownership state. Each refusal exits
+# non-zero with no stdout and says that ownership was not checked, that lease state is unchanged, and how
+# THIS command recovers. The heartbeat refusal names no host mechanism — `runtime-adapter.md` owns that
+# mapping — and offers no way to acquire before arming.
 
 NO_HEARTBEAT = """\
-lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.
-lease: acquire requires --heartbeat-id: your PROOF that you have ALREADY armed the heartbeat for this
-       run. This tool never inspects it and takes your word for it — which is exactly why it must be
-       something you already did, not something you intend to do.
-lease: DO THIS, IN THIS ORDER: (1) arm the heartbeat for this run — schedule its wake via your host's
-       mechanism (`runtime-adapter.md` owns it, and `heartbeat.py callback` prints the exact wake prompt). The
-       wake carries ONLY --run <id> --token <tok>; a resuming heartbeat REFRESHES and needs no proof,
-       so --heartbeat-id is NOT part of it. (2) Re-run THIS command with --heartbeat-id <proof> — the id you
-       recorded for that arming, presented to acquire here, never carried in the wake.
+lease: REFUSED — acquire stopped before the lease read, so ownership was NOT checked. Nothing was written;
+       the lease and ownership state are unchanged.
+lease: acquire requires --heartbeat-id: your PROOF that you have ALREADY armed the heartbeat for this run.
+       This tool never inspects it and takes your word for it — which is exactly why it must be something
+       you already did, not something you intend to do.
+lease: DO THIS, IN THIS ORDER: (1) keep the token you already have and arm the heartbeat for this run —
+       schedule its wake via your host's mechanism (`runtime-adapter.md` owns it, and `heartbeat.py callback`
+       prints the exact wake prompt). The wake carries ONLY --run <id> --token <tok>; a resuming heartbeat
+       REFRESHES and needs no proof, so --heartbeat-id is NOT part of it. (2) Re-run
+       `acquire --token <tok> --heartbeat-id <proof>` with the token and the id recorded for that arming;
+       the proof is presented only to acquire.
 lease: DO NOT take the lease first and arm afterwards. An arm at the end of a heartbeat is the step that gets
        forgotten — that is the entire reason this door refuses."""
 
-NO_TOKEN = """\
-lease: REFUSED — the lease was NOT taken. Nothing was written, and this run is still UNDRIVEN.
-lease: acquire requires --token, and it does NOT mint one for you. The heartbeat carries `--token <tok>`, so
-       the token must exist BEFORE you arm: a caller without one cannot have armed a heartbeat that identifies
-       it, which means its --heartbeat-id cannot name a real heartbeat.
-lease: DO THIS: run `lease.py mint` for a token, arm the heartbeat with it, then acquire with both."""
+NO_TOKEN_ACQUIRE = """\
+lease: REFUSED — acquire stopped before the lease read, so ownership was NOT checked. Nothing was written;
+       the lease and ownership state are unchanged.
+lease: acquire requires --token, and it does NOT mint one for you.
+lease: DO THIS: if this run already has an owner token, recover that SAME token and re-run
+       `acquire --token <tok> --heartbeat-id <proof>`; do NOT mint a replacement. For a first acquire with
+       no token yet, run `lease.py mint`, arm the heartbeat with that token, then acquire with both values."""
+
+NO_TOKEN_REFRESH = """\
+lease: REFUSED — refresh stopped before the lease read, so ownership was NOT checked. Nothing was written;
+       the lease and ownership state are unchanged.
+lease: refresh requires --token.
+lease: DO THIS: recover the SAME owner token carried by this heartbeat or owner session, then re-run
+       `refresh --token <tok>`. Do NOT mint a replacement or switch to acquire; if the owner token is
+       unavailable, stand down and use the documented manual `--run` resume flow."""
+
+NO_TOKEN_RELEASE = """\
+lease: REFUSED — release stopped before the lease read, so ownership was NOT checked. Nothing was written;
+       the lease and ownership state are unchanged.
+lease: release requires --token.
+lease: DO THIS: recover the SAME owner token and re-run `release --token <tok>`. If that token is unavailable,
+       do NOT delete or alter the lease; leave it for the owner or the documented adoption flow."""
 
 
 # --- commands -----------------------------------------------------------------
@@ -363,7 +382,7 @@ def cmd_mint(_path, _args) -> int:
 
 def cmd_acquire(path: Path, args) -> int:
     if not (args.token or "").strip():
-        fail(NO_TOKEN)
+        fail(NO_TOKEN_ACQUIRE)
     if not (args.heartbeat_id or "").strip():
         fail(NO_HEARTBEAT)
     token = args.token
@@ -426,7 +445,7 @@ def cmd_acquire(path: Path, args) -> int:
 def cmd_refresh(path: Path, args) -> int:
     """The heartbeat bump — 'still alive'. It does NOT re-arm, so it takes no proof."""
     if not (args.token or "").strip():
-        fail(NO_TOKEN)
+        fail(NO_TOKEN_REFRESH)
     with claim_lock(path):
         try:
             rec = read_lease(path)
@@ -458,7 +477,7 @@ def cmd_release(path: Path, args) -> int:
     release refuses unless the token matches".
     """
     if not (args.token or "").strip():
-        fail(NO_TOKEN)
+        fail(NO_TOKEN_RELEASE)
     with claim_lock(path):
         try:
             rec = read_lease(path)
@@ -581,24 +600,28 @@ def build_parser() -> argparse.ArgumentParser:
     # NOTE: --token and --heartbeat-id are deliberately NOT argparse-`required`. They ARE required, and
     # this file refuses without them — but argparse's "the following arguments are required:
     # --heartbeat-id" is a DIAGNOSIS, and the whole mechanism here is the INSTRUCTION the refusal carries
-    # (NO_HEARTBEAT / NO_TOKEN). Letting argparse win the race would keep the exit code and throw away the
-    # only part that teaches the caller what to do. `lease-test.py` pins this.
+    # (NO_HEARTBEAT / NO_TOKEN_*). Letting argparse win the race would keep the exit code and throw away the
+    # only part that says ownership was not checked and teaches command-specific recovery. The
+    # NO_HEARTBEAT / NO_TOKEN_* messages own that contract; `lease-test.py` pins it.
     a = sub.add_parser("acquire", help="take or refresh ownership of this run — the door every heartbeat goes "
                                        "through first")
-    a.add_argument("--token", help="REQUIRED. Your agent token (from `mint`). NEVER minted here: a caller "
-                                   "without one cannot have armed a heartbeat that names it")
+    a.add_argument("--token", help="REQUIRED. Existing owners reuse their token; only first-acquire setup "
+                                   "should mint one. Without it, acquire stops before checking ownership")
     a.add_argument("--heartbeat-id",
                    help="REQUIRED. Your PROOF that you have ALREADY armed the heartbeat. Never inspected — "
                         "taken on your word, which is why it must name something already done. "
-                        "`runtime-adapter.md` tells you what your proof is")
+                        "Without it, acquire stops before checking ownership. `runtime-adapter.md` tells "
+                        "you what your proof is")
     a.add_argument("--allow-takeover", action="store_true",
                    help="adopt a run a DIFFERENT live agent holds. Only after a human has agreed to it")
 
     r = sub.add_parser("refresh", help="heartbeat the lease ('still alive'). Does not re-arm, takes no proof")
-    r.add_argument("--token", help="REQUIRED. Your agent token")
+    r.add_argument("--token", help="REQUIRED. The existing owner's token. Without it, refresh stops before "
+                                   "checking ownership; recover the same token and retry")
 
     d = sub.add_parser("release", help="release on normal exit. Refuses unless the token matches")
-    d.add_argument("--token", help="REQUIRED. Your agent token")
+    d.add_argument("--token", help="REQUIRED. The existing owner's token. Without it, release stops before "
+                                   "checking ownership; recover the same token and retry")
 
     sub.add_parser("read", help="ADVISORY read-only status (no lock — may race a write). For discovery "
                                 "bucketing; never decide ownership from it")

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -29,7 +29,8 @@ would otherwise do:
    "cannot start". The refusal happens before the lock or lease read, so it cannot claim who drives the run.
 4. **No `--token`, no ownership check.** `acquire`, `refresh`, and `release` all refuse before the lock or
    lease read, produce no stdout, preserve lease bytes, and say how to recover for that command. `acquire` never
-   mints a token: a first acquire must mint and arm, while an existing owner must reuse its token.
+   mints a token: fresh starts and absent/stale adopters mint and arm, while a current owner recovers its own
+   token from its session or heartbeat prompt.
 
 A future `updated` (clock skew) reads as FRESH, not stale — fail closed, same direction as (1).
 """
@@ -353,9 +354,12 @@ NO_TOKEN_ACQUIRE = """\
 lease: REFUSED — acquire stopped before the lease read, so ownership was NOT checked. Nothing was written;
        the lease and ownership state are unchanged.
 lease: acquire requires --token, and it does NOT mint one for you.
-lease: DO THIS: if this run already has an owner token, recover that SAME token and re-run
-       `acquire --token <tok> --heartbeat-id <proof>`; do NOT mint a replacement. For a first acquire with
-       no token yet, run `lease.py mint`, arm the heartbeat with that token, then acquire with both values."""
+lease: DO THIS: if YOU already hold this run and only lost your token, recover YOUR OWN token from your
+       session or from the heartbeat prompt that carries it — NEVER from `lease.json` or `lease.py read`,
+       which show whoever held the run before — then re-run
+       `acquire --token <tok> --heartbeat-id <proof>`; do NOT mint a replacement. Otherwise, including when
+       adopting an absent or stale run, run `lease.py mint`, arm the heartbeat with that token, then acquire
+       with both values."""
 
 NO_TOKEN_REFRESH = """\
 lease: REFUSED — refresh stopped before the lease read, so ownership was NOT checked. Nothing was written;
@@ -369,8 +373,9 @@ NO_TOKEN_RELEASE = """\
 lease: REFUSED — release stopped before the lease read, so ownership was NOT checked. Nothing was written;
        the lease and ownership state are unchanged.
 lease: release requires --token.
-lease: DO THIS: recover the SAME owner token and re-run `release --token <tok>`. If that token is unavailable,
-       do NOT delete or alter the lease; leave it for the owner or the documented adoption flow."""
+lease: DO THIS: recover your own token from your session and re-run `release --token <tok>`. If your token
+       is unavailable, do NOT delete or alter the lease; leave it for the owner or the documented adoption
+       flow."""
 
 
 # --- commands -----------------------------------------------------------------
@@ -605,8 +610,9 @@ def build_parser() -> argparse.ArgumentParser:
     # NO_HEARTBEAT / NO_TOKEN_* messages own that contract; `lease-test.py` pins it.
     a = sub.add_parser("acquire", help="take or refresh ownership of this run — the door every heartbeat goes "
                                        "through first")
-    a.add_argument("--token", help="REQUIRED. Existing owners reuse their token; only first-acquire setup "
-                                   "should mint one. Without it, acquire stops before checking ownership")
+    a.add_argument("--token", help="REQUIRED. A current owner reuses its own token from its session or "
+                                   "heartbeat prompt; fresh starts and absent/stale adopters mint a new "
+                                   "token. Without it, acquire stops before checking ownership")
     a.add_argument("--heartbeat-id",
                    help="REQUIRED. Your PROOF that you have ALREADY armed the heartbeat. Never inspected — "
                         "taken on your word, which is why it must name something already done. "
@@ -621,7 +627,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     d = sub.add_parser("release", help="release on normal exit. Refuses unless the token matches")
     d.add_argument("--token", help="REQUIRED. The existing owner's token. Without it, release stops before "
-                                   "checking ownership; recover the same token and retry")
+                                   "checking ownership; recover your own token from your session and retry")
 
     sub.add_parser("read", help="ADVISORY read-only status (no lock — may race a write). For discovery "
                                 "bucketing; never decide ownership from it")


### PR DESCRIPTION
- report unchecked ownership when lease arguments are missing
- give acquire, refresh, and release distinct recovery steps
- pin empty stdout and unchanged lease state in fixtures
