### PR TITLE
fix dash-leading base fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           # file here and the count updates itself, with no second edit and no literal to keep in sync.
           files=(
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -24,7 +24,7 @@ block. This file owns the dispatch procedure, not a second copy of prompt text.
 `<base>` is **this PR row's effective base** — its explicit `base_branch`, else the legacy header fallback
 (`ledger.py`'s `effective_base`), never the one header base. With `--file`, the ROW owns the base: `--base`
 is an **assertion** that must equal the row's effective base, and the helper also compares the PR's live
-`baseRefName` against it. It fetches `origin/<base>` and prints ONE of four verdicts, and the action
+`baseRefName` against it. It fetches the base and prints ONE of four verdicts, and the action
 **splits by verdict** — only `proceed` clears the dispatch:
 
 - **`proceed`** → the base is current; **dispatch the fix**. The `--file` makes the `proceed` record

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -136,7 +136,7 @@ review gate"), and the review re-starts on the clean tip:
   scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base> --file <state.jsonl>`. With
   `--file`, the ROW owns the base: `--base` is an **assertion** that must equal the row's effective base, and
   the helper also compares the PR's **live** `baseRefName` against it. It checks GitHub's merge states and
-  whether fetched `origin/<base>` is an ancestor of the PR worktree's `HEAD`. A `rebase-first` verdict covers
+  whether the fetched base is an ancestor of the PR worktree's `HEAD`. A `rebase-first` verdict covers
   a conflict, GitHub reporting behind, or a CLEAN PR whose branch lacks the refreshed base — a base that
   merely **ADVANCED** (same branch NAME, new commits). `recheck` covers an uncomputed GitHub value,
   ancestry the helper cannot verify, **or a live retarget** — the PR now targets a different branch

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -186,7 +186,7 @@ ownership checks and phase order remain in force.
    For each **non-parked** open PR, run `python3 scripts/base-preflight.py check --pr <pr> --worktree
    <worktree> --base <base> --file <state.jsonl>`, where `<base>` is that row's **effective base** (its
    explicit `base_branch`, else the legacy header — a run may hold PRs on different bases, so it is resolved
-   per PR, and `--base` is asserted against it). It fetches `origin/<base>` and requires it to be an ancestor
+   per PR, and `--base` is asserted against it). It fetches the base and requires it to be an ancestor
    of `HEAD` even when GitHub still reports CLEAN. On `recheck`, re-poll and leave the candidate alone. On
    `park`, the helper has already sent the unrecognized enum value through `ledger.py park`; leave the
    now-held candidate alone. On `rebase-first`, rebase before considering the candidate for another review or merge:

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
@@ -1,0 +1,27 @@
+"""Argument-vector helpers shared by Gauntlet campaign scripts."""
+
+from __future__ import annotations
+
+import sys
+
+
+def bind_separate_option_value(argv: "list[str] | None", option: str) -> "list[str]":
+    """Bind the argv member after ``option`` as its value, even when it begins with ``-``.
+
+    Campaign instructions construct selected data-bearing options as two argv members. ``argparse`` treats a
+    dash-leading second member as another option, so join only the named option and its immediate value into
+    the equivalent ``--option=value`` form before parsing. Leave a trailing option unchanged so ``argparse``
+    still reports its missing value.
+    """
+    source = list(sys.argv[1:] if argv is None else argv)
+    bound: list[str] = []
+    index = 0
+    while index < len(source):
+        token = source[index]
+        if token == option and index + 1 < len(source):
+            bound.append(f"{option}={source[index + 1]}")
+            index += 2
+            continue
+        bound.append(token)
+        index += 1
+    return bound

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/git_refs.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/git_refs.py
@@ -1,0 +1,49 @@
+"""Git ref selection shared by campaign base-fetch operations."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BaseFetchRefs:
+    """The fully qualified refspec and exact local ref for one fetched base."""
+
+    refspec: str
+    local_ref: str
+
+
+def select_base_fetch_refs(
+        worktree: str, remote: str, base: str) -> "tuple[BaseFetchRefs | None, str | None]":
+    """Select a safe destination for fetching ``refs/heads/<base>``.
+
+    The normal remote-tracking destination is retained unless it is symbolic. Git follows a symbolic
+    fetch destination and updates its target, so those cases use a private ref keyed by the exact remote
+    and branch names. Return a diagnostic instead of selecting any private candidate that is itself
+    symbolic.
+    """
+    tracking_ref = f"refs/remotes/{remote}/{base}"
+    probe = subprocess.run(  # noqa: S603
+        ["git", "-C", worktree, "symbolic-ref", "--quiet", tracking_ref],
+        capture_output=True, text=True, check=False)
+    if probe.returncode not in (0, 1):
+        return None, f"could not inspect fetch destination {tracking_ref}: {probe.stderr.strip()}"
+
+    local_ref = tracking_ref
+    if probe.returncode == 0:
+        key = hashlib.sha256(f"{remote}\0{base}".encode("utf-8")).hexdigest()
+        local_ref = f"refs/gauntlet/base-fetch/{key}"
+        private_probe = subprocess.run(  # noqa: S603
+            ["git", "-C", worktree, "symbolic-ref", "--quiet", local_ref],
+            capture_output=True, text=True, check=False)
+        if private_probe.returncode == 0:
+            return None, f"private fetch destination {local_ref} is symbolic"
+        if private_probe.returncode != 1:
+            return (
+                None,
+                f"could not inspect private fetch destination {local_ref}: {private_probe.stderr.strip()}",
+            )
+
+    return BaseFetchRefs(f"+refs/heads/{base}:{local_ref}", local_ref), None

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -362,6 +362,62 @@ def t_force_rewritten_base_refreshes_and_rebases():
               "the ancestry check must force-refresh origin/main to the rewritten remote base")
 
 
+def t_literal_head_base_does_not_follow_remote_head_symref():
+    """A branch literally named HEAD must not overwrite the default branch's tracking ref."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        remote = root / "remote.git"
+        seed = root / "seed"
+        candidate = root / "candidate"
+
+        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+        result = subprocess.run(["git", "clone", str(remote), str(seed)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+        _configure_repo(seed)
+        (seed / "f").write_text("main\n", encoding="utf-8")
+        _git(seed, "add", "f")
+        _git(seed, "commit", "-m", "main base")
+        _git(seed, "push", "origin", "main")
+        main_head = _git(seed, "rev-parse", "HEAD").stdout.strip()
+
+        (seed / "f").write_text("literal HEAD branch\n", encoding="utf-8")
+        _git(seed, "commit", "-am", "literal HEAD advance")
+        literal_head = _git(seed, "rev-parse", "HEAD").stdout.strip()
+        _git(seed, "push", "origin", "HEAD:refs/heads/HEAD")
+        check(main_head != literal_head, "fixture setup: main and the literal HEAD branch must differ")
+
+        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture candidate: {result.stderr.strip()}")
+        symbolic = _git(candidate, "symbolic-ref", "refs/remotes/origin/HEAD")
+        check(symbolic.returncode == 0
+              and symbolic.stdout.strip() == "refs/remotes/origin/main",
+              "fixture setup: origin/HEAD must be the normal symbolic ref to origin/main")
+        origin_main_before = _git(candidate, "rev-parse", "refs/remotes/origin/main").stdout.strip()
+        check(origin_main_before == main_head, "fixture setup: origin/main must track the remote main branch")
+
+        result = M.check_base_ancestry(str(candidate), "HEAD", "origin")
+        check(result == ("stale", ""),
+              f"a candidate behind the literal HEAD branch must be sent to rebase, got {result!r}")
+        check(_git(candidate, "rev-parse", "refs/remotes/origin/main").stdout.strip() == origin_main_before,
+              "fetching the literal HEAD branch must not follow origin/HEAD and overwrite origin/main")
+        private_refs = _git(
+            candidate, "for-each-ref", "--format=%(objectname)", "refs/gauntlet/base-fetch").stdout.splitlines()
+        check(private_refs == [literal_head],
+              f"the private fetched-base ref must resolve to the literal HEAD branch tip, got {private_refs!r}")
+
+        _git(remote, "update-ref", "-d", "refs/heads/HEAD")
+        result = M.check_base_ancestry(str(candidate), "HEAD", "origin")
+        check(result[0] == "unverified"
+              and result[1].startswith("could not fetch +refs/heads/HEAD:refs/gauntlet/base-fetch/"),
+              f"a failed literal HEAD fetch must name its exact private refspec, got {result!r}")
+        check(_git(candidate, "rev-parse", "refs/remotes/origin/main").stdout.strip() == origin_main_before,
+              "a failed literal HEAD fetch must leave origin/main unchanged")
+
+
 DASH_BASE = "--upload-pack=/bin/false"
 
 
@@ -766,6 +822,9 @@ CASES = [
      t_clean_view_with_current_base_proceeds),
     ("force-rewritten-base", "a rewritten remote base is refreshed before ancestry reports stale",
      t_force_rewritten_base_refreshes_and_rebases),
+    ("literal-head-base",
+     "a literal HEAD base uses a private ref and leaves the symbolic origin/HEAD target unchanged",
+     t_literal_head_base_does_not_follow_remote_head_symref),
     ("dash-base-current", "a dash-leading base refreshes its tracking ref and reports current ancestry",
      t_dash_leading_current_base_refreshes_and_proceeds),
     ("dash-base-stale", "a dash-leading base refreshes its tracking ref and reports stale ancestry",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -317,6 +317,69 @@ def t_clean_view_with_current_base_proceeds():
               f"a current base must permit the candidate, got {out!r}")
 
 
+DASH_BASE = "--upload-pack=/bin/false"
+
+
+def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[tuple[str, str], str, str]":
+    """Fetch a legal dash-leading base from a real bare remote with a deliberately stale tracking ref."""
+    remote, seed, candidate = root / "remote.git", root / "seed", root / "candidate"
+    result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                            capture_output=True, text=True, check=False)
+    check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+    result = subprocess.run(["git", "clone", str(remote), str(seed)],
+                            capture_output=True, text=True, check=False)
+    check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+    _configure_repo(seed)
+    (seed / "f").write_text("base\n", encoding="utf-8")
+    _git(seed, "add", "f")
+    _git(seed, "commit", "-m", "base")
+    _git(seed, "push", "origin", "main")
+    dash_head = f"refs/heads/{DASH_BASE}"
+    tracking_ref = f"refs/remotes/origin/{DASH_BASE}"
+    _git(seed, "update-ref", dash_head, "HEAD")
+    _git(seed, "push", "origin", f"{dash_head}:{dash_head}")
+
+    result = subprocess.run(["git", "clone", str(remote), str(candidate)],
+                            capture_output=True, text=True, check=False)
+    check(result.returncode == 0, f"could not clone fixture candidate: {result.stderr.strip()}")
+    _configure_repo(candidate)
+    old_base = _git(candidate, "rev-parse", tracking_ref).stdout.strip()
+
+    (seed / "f").write_text("advanced base\n", encoding="utf-8")
+    _git(seed, "commit", "-am", "advance dash base")
+    advanced_base = _git(seed, "rev-parse", "HEAD").stdout.strip()
+    _git(seed, "push", "origin", f"HEAD:{dash_head}")
+    check(old_base != advanced_base, "fixture setup: the candidate tracking ref must be stale")
+
+    if current:
+        # Import the advanced base through a separate local ref so HEAD contains it while origin/<base>
+        # stays stale until the operation under test refreshes that tracking ref.
+        _git(candidate, "fetch", "origin", f"{dash_head}:refs/heads/current-dash-base")
+        _git(candidate, "checkout", "current-dash-base")
+
+    result = M.check_base_ancestry(str(candidate), DASH_BASE, "origin")
+    refreshed_base = _git(candidate, "rev-parse", tracking_ref).stdout.strip()
+    return result, refreshed_base, advanced_base
+
+
+def t_dash_leading_current_base_refreshes_and_proceeds():
+    with tempfile.TemporaryDirectory() as d:
+        result, refreshed, remote_head = _dash_base_ancestry(Path(d), current=True)
+        check(result == ("current", ""),
+              f"a current candidate on a dash-leading base must pass ancestry, got {result!r}")
+        check(refreshed == remote_head,
+              "the dash-leading base fetch must refresh its remote-tracking ref before the current verdict")
+
+
+def t_dash_leading_stale_base_refreshes_and_rebases():
+    with tempfile.TemporaryDirectory() as d:
+        result, refreshed, remote_head = _dash_base_ancestry(Path(d), current=False)
+        check(result == ("stale", ""),
+              f"a stale candidate on a dash-leading base must fail ancestry, got {result!r}")
+        check(refreshed == remote_head,
+              "the dash-leading base fetch must refresh its remote-tracking ref before the stale verdict")
+
+
 # --- `--file`: a real `proceed` RECORDS base_ok_sha on the ledger (the precondition `verdict` enforces) -----
 # base-preflight is the ONLY sanctioned writer of `base_ok_sha`: on a final `proceed`, and only when a ledger
 # is named, it resolves the worktree's HEAD and shells out to `ledger.py base-ok`. `decide()` stays pure;
@@ -646,6 +709,10 @@ CASES = [
      t_clean_view_with_stale_base_rebases),
     ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",
      t_clean_view_with_current_base_proceeds),
+    ("dash-base-current", "a dash-leading base refreshes its tracking ref and reports current ancestry",
+     t_dash_leading_current_base_refreshes_and_proceeds),
+    ("dash-base-stale", "a dash-leading base refreshes its tracking ref and reports stale ancestry",
+     t_dash_leading_stale_base_refreshes_and_rebases),
     ("proceed-file-records-base-ok", "a proceed with --file stamps base_ok_sha = HEAD; without --file writes nothing",
      t_proceed_with_file_records_base_ok),
     ("non-proceed-file-no-stamp", "rebase-first/recheck never stamp base_ok_sha, even with --file",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -365,8 +365,8 @@ def t_force_rewritten_base_refreshes_and_rebases():
 DASH_BASE = "--upload-pack=/bin/false"
 
 
-def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[tuple[str, str], str, str]":
-    """Fetch a legal dash-leading base from a real bare remote with a deliberately stale tracking ref."""
+def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[int, dict, str, str, str]":
+    """Drive the documented CLI against a legal dash-leading base and a real bare remote."""
     remote, seed, candidate = root / "remote.git", root / "seed", root / "candidate"
     result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
                             capture_output=True, text=True, check=False)
@@ -402,25 +402,35 @@ def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[tuple[str, str],
         _git(candidate, "fetch", "origin", f"{dash_head}:refs/heads/current-dash-base")
         _git(candidate, "checkout", "current-dash-base")
 
-    result = M.check_base_ancestry(str(candidate), DASH_BASE, "origin")
+    vjson = root / "clean-view.json"
+    vjson.write_text(json.dumps(view()), encoding="utf-8")
+    code, out, err = capture_cli(
+        M.main,
+        ["check", "--pr", "9", "--view-json", str(vjson), "--worktree", str(candidate),
+         "--base", DASH_BASE],
+    )
     refreshed_base = _git(candidate, "rev-parse", tracking_ref).stdout.strip()
-    return result, refreshed_base, advanced_base
+    return code, json.loads(out), err, refreshed_base, advanced_base
 
 
 def t_dash_leading_current_base_refreshes_and_proceeds():
     with tempfile.TemporaryDirectory() as d:
-        result, refreshed, remote_head = _dash_base_ancestry(Path(d), current=True)
-        check(result == ("current", ""),
-              f"a current candidate on a dash-leading base must pass ancestry, got {result!r}")
+        code, result, err, refreshed, remote_head = _dash_base_ancestry(Path(d), current=True)
+        check(code == 0,
+              f"a current candidate on a dash-leading base must pass the CLI (code={code}, err={err!r})")
+        check(result == {"verdict": "proceed", "reason": "GitHub merge state permits base check"},
+              f"a current candidate on a dash-leading base must proceed, got {result!r}")
         check(refreshed == remote_head,
               "the dash-leading base fetch must refresh its remote-tracking ref before the current verdict")
 
 
 def t_dash_leading_stale_base_refreshes_and_rebases():
     with tempfile.TemporaryDirectory() as d:
-        result, refreshed, remote_head = _dash_base_ancestry(Path(d), current=False)
-        check(result == ("stale", ""),
-              f"a stale candidate on a dash-leading base must fail ancestry, got {result!r}")
+        code, result, err, refreshed, remote_head = _dash_base_ancestry(Path(d), current=False)
+        check(code != 0,
+              f"a stale candidate on a dash-leading base must stop the CLI (code={code}, err={err!r})")
+        check(result == {"verdict": "rebase-first", "reason": "base has moved ahead — rebase first"},
+              f"a stale candidate on a dash-leading base must request a rebase, got {result!r}")
         check(refreshed == remote_head,
               "the dash-leading base fetch must refresh its remote-tracking ref before the stale verdict")
 

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -317,6 +317,51 @@ def t_clean_view_with_current_base_proceeds():
               f"a current base must permit the candidate, got {out!r}")
 
 
+def t_force_rewritten_base_refreshes_and_rebases():
+    """A rewritten remote base is refreshed before ancestry is decided."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        remote = root / "remote.git"
+        seed = root / "seed"
+        candidate = root / "candidate"
+
+        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+        result = subprocess.run(["git", "clone", str(remote), str(seed)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+        _configure_repo(seed)
+        (seed / "f").write_text("base\n", encoding="utf-8")
+        _git(seed, "add", "f")
+        _git(seed, "commit", "-m", "base")
+        _git(seed, "push", "origin", "main")
+
+        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture candidate: {result.stderr.strip()}")
+
+        (seed / "f").write_text("first advance\n", encoding="utf-8")
+        _git(seed, "commit", "-am", "first advance")
+        _git(seed, "push", "origin", "main")
+        _git(candidate, "fetch", "origin", "main")
+        old_base = _git(candidate, "rev-parse", "refs/remotes/origin/main").stdout.strip()
+
+        (seed / "f").write_text("rewritten advance\n", encoding="utf-8")
+        _git(seed, "commit", "--amend", "-am", "rewritten base")
+        rewritten_base = _git(seed, "rev-parse", "HEAD").stdout.strip()
+        _git(seed, "push", "--force", "origin", "HEAD:refs/heads/main")
+        check(old_base != rewritten_base,
+              "fixture setup: the remote base rewrite must differ from the stale tracking ref")
+
+        result = M.check_base_ancestry(str(candidate), "main", "origin")
+        refreshed_base = _git(candidate, "rev-parse", "refs/remotes/origin/main").stdout.strip()
+        check(result == ("stale", ""),
+              f"a candidate based on the replaced base must be sent to rebase, got {result!r}")
+        check(refreshed_base == rewritten_base,
+              "the ancestry check must force-refresh origin/main to the rewritten remote base")
+
+
 DASH_BASE = "--upload-pack=/bin/false"
 
 
@@ -709,6 +754,8 @@ CASES = [
      t_clean_view_with_stale_base_rebases),
     ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",
      t_clean_view_with_current_base_proceeds),
+    ("force-rewritten-base", "a rewritten remote base is refreshed before ancestry reports stale",
+     t_force_rewritten_base_refreshes_and_rebases),
     ("dash-base-current", "a dash-leading base refreshes its tracking ref and reports current ancestry",
      t_dash_leading_current_base_refreshes_and_proceeds),
     ("dash-base-stale", "a dash-leading base refreshes its tracking ref and reports stale ancestry",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -46,6 +46,7 @@ import sys
 from pathlib import Path
 
 from _gauntlet.argv import bind_separate_option_value
+from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path
 
 _HERE = Path(__file__).resolve().parent
@@ -120,28 +121,29 @@ def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str)
 
     GitHub may keep reporting ``MERGEABLE/CLEAN`` after another campaign PR advances an unprotected base.
     The merge-state enums alone therefore cannot prove that a candidate contains the current base. Fetch the
-    named base through a fully qualified source:tracking-ref refspec and ask Git's ancestry graph directly;
-    this updates only the remote-tracking ref, never the candidate branch. The qualified source prevents a
-    legal dash-leading base name from being parsed as a Git option. Callers treat ``unverified`` as
-    fail-closed.
+    named base through a fully qualified source:tracking-ref refspec and ask Git's ancestry graph directly.
+    A symbolic remote-tracking destination is replaced with a private ref so the fetch cannot update the
+    symbolic ref's target. The qualified source prevents a legal dash-leading base name from being parsed
+    as a Git option. Callers treat ``unverified`` as fail-closed.
     """
     if not worktree or not base:
         return "unverified", "base ancestry requires --worktree and --base"
-    # Force-update the remote-tracking destination, matching Git's default remote fetch refspec.
-    tracking_refspec = f"+refs/heads/{base}:refs/remotes/{remote}/{base}"
+    selected, selection_problem = select_base_fetch_refs(worktree, remote, base)
+    if selection_problem is not None or selected is None:
+        return "unverified", selection_problem or "could not select a base fetch destination"
     fetch = subprocess.run(  # noqa: S603
-        ["git", "-C", worktree, "fetch", remote, tracking_refspec],
+        ["git", "-C", worktree, "fetch", remote, selected.refspec],
         capture_output=True, text=True, check=False)
     if fetch.returncode != 0:
-        return "unverified", f"could not fetch {remote}/{base}: {fetch.stderr.strip()}"
+        return "unverified", f"could not fetch {selected.refspec}: {fetch.stderr.strip()}"
     probe = subprocess.run(  # noqa: S603
-        ["git", "-C", worktree, "merge-base", "--is-ancestor", f"{remote}/{base}", "HEAD"],
+        ["git", "-C", worktree, "merge-base", "--is-ancestor", selected.local_ref, "HEAD"],
         capture_output=True, text=True, check=False)
     if probe.returncode == 0:
         return "current", ""
     if probe.returncode == 1:
         return "stale", ""
-    return "unverified", f"could not compare HEAD with {remote}/{base}: {probe.stderr.strip()}"
+    return "unverified", f"could not compare HEAD with {selected.local_ref}: {probe.stderr.strip()}"
 
 
 def decide(view: dict) -> dict:

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -119,13 +119,17 @@ def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str)
 
     GitHub may keep reporting ``MERGEABLE/CLEAN`` after another campaign PR advances an unprotected base.
     The merge-state enums alone therefore cannot prove that a candidate contains the current base. Fetch the
-    named base and ask Git's ancestry graph directly; this updates only the remote-tracking ref, never the
-    candidate branch. Callers treat ``unverified`` as fail-closed.
+    named base through a fully qualified source:tracking-ref refspec and ask Git's ancestry graph directly;
+    this updates only the remote-tracking ref, never the candidate branch. The qualified source prevents a
+    legal dash-leading base name from being parsed as a Git option. Callers treat ``unverified`` as
+    fail-closed.
     """
     if not worktree or not base:
         return "unverified", "base ancestry requires --worktree and --base"
+    tracking_refspec = f"refs/heads/{base}:refs/remotes/{remote}/{base}"
     fetch = subprocess.run(  # noqa: S603
-        ["git", "-C", worktree, "fetch", remote, base], capture_output=True, text=True, check=False)
+        ["git", "-C", worktree, "fetch", remote, tracking_refspec],
+        capture_output=True, text=True, check=False)
     if fetch.returncode != 0:
         return "unverified", f"could not fetch {remote}/{base}: {fetch.stderr.strip()}"
     probe = subprocess.run(  # noqa: S603

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -45,6 +45,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.modules import load_module_from_path
 
 _HERE = Path(__file__).resolve().parent
@@ -440,7 +441,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     sub.add_parser("self-test", help="run every fixture (base-preflight-test.py)")
 
-    args = p.parse_args(argv)
+    args = p.parse_args(bind_separate_option_value(argv, "--base"))
 
     if args.cmd == "self-test":
         return self_test()

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -126,7 +126,8 @@ def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str)
     """
     if not worktree or not base:
         return "unverified", "base ancestry requires --worktree and --base"
-    tracking_refspec = f"refs/heads/{base}:refs/remotes/{remote}/{base}"
+    # Force-update the remote-tracking destination, matching Git's default remote fetch refspec.
+    tracking_refspec = f"+refs/heads/{base}:refs/remotes/{remote}/{base}"
     fetch = subprocess.run(  # noqa: S603
         ["git", "-C", worktree, "fetch", remote, tracking_refspec],
         capture_output=True, text=True, check=False)

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -158,6 +158,17 @@ class Scenario:
         git(self.seed, "push", "origin", f"HEAD:refs/heads/{self.base}")
         git(self.seed, "checkout", PR_BRANCH)
 
+    def rewrite_base(self, overrides: "dict[int, str]"):
+        """Force-rewrite the remote base to a sibling of the worktree's tracked base."""
+        if self.base == "main":
+            git(self.seed, "checkout", "main")
+        else:
+            git(self.seed, "checkout", "--detach", f"refs/heads/{self.base}")
+        (self.seed / "f").write_text(_numbered(overrides), encoding="utf-8")
+        git(self.seed, "commit", "--amend", "-am", "rewritten base")
+        git(self.seed, "push", "--force", "origin", f"HEAD:refs/heads/{self.base}")
+        git(self.seed, "checkout", PR_BRANCH)
+
     def move_remote_pr(self):
         """A concurrent push moves remote `pr` past the worktree's stale tracking ref (breaks the lease)."""
         git(self.seed, "checkout", PR_BRANCH)
@@ -573,6 +584,28 @@ def t_variant_spelling_rebases_against_row_base():
               "the remote PR branch was force-with-lease pushed to the rebased head")
 
 
+def t_force_rewritten_base_refreshes_and_rebases():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        tracking_ref = "refs/remotes/origin/main"
+        s.advance_base({12: "12-FIRST"})
+        git(s.wt, "fetch", "origin", "main")
+        old_base = head(s.wt, tracking_ref)
+        s.rewrite_base({12: "12-REWRITTEN"})
+        rewritten_base = head(s.remote, "refs/heads/main")
+        check(old_base != rewritten_base,
+              "fixture setup: the remote base rewrite must differ from the stale tracking ref")
+
+        code, out, err = s.invoke()
+        check(code == M.EXIT_OK,
+              f"a clean rebase onto a force-rewritten base must succeed "
+              f"(code={code}, out={out!r}, err={err!r})")
+        check(head(s.wt, tracking_ref) == rewritten_base,
+              "the fetch must force-refresh origin/main to the rewritten remote base")
+        check(head(s.wt) != s.orig_head,
+              "the clean rebase onto the rewritten base must move HEAD")
+
+
 def t_dash_leading_base_fetch_refreshes_tracking_ref():
     with tempfile.TemporaryDirectory() as tmp:
         s = Scenario(Path(tmp), base=DASH_BASE).build()
@@ -585,7 +618,7 @@ def t_dash_leading_base_fetch_refreshes_tracking_ref():
         code, out, err = s.invoke("--dry-run")
         check(code == M.EXIT_OK, f"dash-leading base dry-run preconditions must pass (code={code}, err={err})")
         plan = json.loads(out.strip().splitlines()[-1])
-        refspec = f"refs/heads/{DASH_BASE}:refs/remotes/origin/{DASH_BASE}"
+        refspec = f"+refs/heads/{DASH_BASE}:refs/remotes/origin/{DASH_BASE}"
         check(plan["would"].startswith(f"fetch origin {refspec};"),
               f"the dry-run must show the fully qualified safe refspec, got {plan['would']!r}")
         check(head(s.wt, tracking_ref) == stale_base,
@@ -607,7 +640,7 @@ def t_dash_leading_fetch_failure_names_safe_refspec():
         check(code == M.EXIT_PRECONDITION,
               f"a missing dash-leading base must refuse at exit 2 (code={code}, err={err!r})")
         detail = json.loads(out.strip().splitlines()[-1])["detail"]
-        refspec = f"refs/heads/{DASH_BASE}:refs/remotes/origin/{DASH_BASE}"
+        refspec = f"+refs/heads/{DASH_BASE}:refs/remotes/origin/{DASH_BASE}"
         check(detail.startswith(f"`git fetch origin {refspec}` failed:"),
               f"the fetch diagnostic must show the safe fully qualified refspec, got {detail!r}")
 
@@ -660,6 +693,9 @@ CASES = [
     ("variant-spelling-rebases-row-base",
      "an accepted origin/main spelling rebases against the row's effective base 'main', not the raw arg",
      t_variant_spelling_rebases_against_row_base),
+    ("force-rewritten-base",
+     "a non-fast-forward base rewrite force-refreshes its tracking ref and rebases cleanly",
+     t_force_rewritten_base_refreshes_and_rebases),
     ("dash-base-safe-fetch",
      "a dash-leading base uses a fully qualified fetch, refreshes its tracking ref, and rebases cleanly",
      t_dash_leading_base_fetch_refreshes_tracking_ref),

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -181,7 +181,7 @@ class Scenario:
 
     def invoke(self, *extra):
         argv = ["run", "--ledger", str(self.ledger), "--pr", PR_NUMBER, "--worktree", str(self.wt)]
-        argv += [f"--base={self.base}"] if self.base.startswith("-") else ["--base", self.base]
+        argv += ["--base", self.base]
         argv += list(extra)
         return capture_cli(M.main, argv)
 

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -93,11 +93,13 @@ def _numbered(overrides: "dict[int, str]") -> str:
 
 PR_NUMBER = "12"
 PR_BRANCH = "pr"
+DASH_BASE = "--upload-pack=/bin/false"
 
 
 class Scenario:
-    def __init__(self, tmp: Path):
+    def __init__(self, tmp: Path, base: str = "main"):
         self.tmp = tmp
+        self.base = base
         self.remote = tmp / "remote.git"
         self.seed = tmp / "seed"
         self.wt = tmp / "wt"
@@ -113,6 +115,10 @@ class Scenario:
         git(self.seed, "add", "f")
         git(self.seed, "commit", "-m", "base")
         git(self.seed, "push", "origin", "main")
+        if self.base != "main":
+            base_ref = f"refs/heads/{self.base}"
+            git(self.seed, "update-ref", base_ref, "HEAD")
+            git(self.seed, "push", "origin", f"{base_ref}:{base_ref}")
         # PR branch: change line 3
         git(self.seed, "checkout", "-b", PR_BRANCH)
         (self.seed / "f").write_text(_numbered({3: "3-PR"}), encoding="utf-8")
@@ -126,9 +132,12 @@ class Scenario:
         check(head(self.wt) == self.orig_head, "precondition: the worktree is at the PR head")
         # ledger: header + row, with reviews_ok earned by real verdicts at the PR head
         _ledger("--file", str(self.ledger), "header", "set", "base_branch", "main")
-        _ledger("--file", str(self.ledger), "add-row", "--pr", PR_NUMBER, "--branch", PR_BRANCH,
-                "--head-sha", self.orig_head, "--worktree", str(self.wt), "--tier", "STANDARD",
-                "--status", status)
+        row_args = ["--file", str(self.ledger), "add-row", "--pr", PR_NUMBER, "--branch", PR_BRANCH,
+                    "--head-sha", self.orig_head, "--worktree", str(self.wt), "--tier", "STANDARD",
+                    "--status", status]
+        if self.base != "main":
+            row_args.append(f"--base-branch={self.base}")
+        _ledger(*row_args)
         # `verdict` refuses unless a base-preflight `proceed` is on record for this head
         # (base_ok_sha == head_sha); stamp it first, as the real flow does (base-preflight.py -> base-ok).
         if reviews_ok:
@@ -139,11 +148,14 @@ class Scenario:
         return self
 
     def advance_base(self, overrides: "dict[int, str]"):
-        """Move remote main ahead by one commit that rewrites the given lines."""
-        git(self.seed, "checkout", "main")
+        """Move the remote base ahead by one commit that rewrites the given lines."""
+        if self.base == "main":
+            git(self.seed, "checkout", "main")
+        else:
+            git(self.seed, "checkout", "--detach", f"refs/heads/{self.base}")
         (self.seed / "f").write_text(_numbered(overrides), encoding="utf-8")
         git(self.seed, "commit", "-am", "base advance")
-        git(self.seed, "push", "origin", "main")
+        git(self.seed, "push", "origin", f"HEAD:refs/heads/{self.base}")
         git(self.seed, "checkout", PR_BRANCH)
 
     def move_remote_pr(self):
@@ -157,8 +169,9 @@ class Scenario:
         return git(self.remote, "rev-parse", f"refs/heads/{PR_BRANCH}").stdout.strip()
 
     def invoke(self, *extra):
-        argv = ["run", "--ledger", str(self.ledger), "--pr", PR_NUMBER, "--worktree", str(self.wt),
-                "--base", "main", *extra]
+        argv = ["run", "--ledger", str(self.ledger), "--pr", PR_NUMBER, "--worktree", str(self.wt)]
+        argv += [f"--base={self.base}"] if self.base.startswith("-") else ["--base", self.base]
+        argv += list(extra)
         return capture_cli(M.main, argv)
 
 
@@ -540,10 +553,11 @@ def t_push_rejected_preserves_local_rebase():
 def t_variant_spelling_rebases_against_row_base():
     # `--base origin/main` against a row whose effective base is `main` is ACCEPTED by `base_agrees` (a
     # leading `origin/` on the argument is stripped). The operational fetch/rebase must target the ROW's
-    # resolved base, so this runs `git fetch origin main` / rebase onto `origin/main` — the SAME clean rebase
-    # as `--base main`, exit 0, remote pushed. Trusting the raw `--base` (the reverted bug) would instead run
-    # `git fetch origin origin/main`, which has no such remote ref → `fetch-failed`, refused at exit 2. This
-    # FAILS if the operational ref is taken from the raw `--base` rather than the row's effective base.
+    # resolved base, so its source/tracking refspec names `refs/heads/main`, then it rebases onto
+    # `origin/main` — the SAME clean rebase as `--base main`, exit 0, remote pushed. Trusting the raw
+    # `--base` (the reverted bug) would instead name the nonexistent source `refs/heads/origin/main` →
+    # `fetch-failed`, refused at exit 2. This FAILS if the operational ref is taken from the raw `--base`
+    # rather than the row's effective base.
     with tempfile.TemporaryDirectory() as tmp:
         s = _scenario(tmp)
         s.advance_base({12: "12-BASE"})  # a clean FAR edit — the rebase itself succeeds
@@ -557,6 +571,45 @@ def t_variant_spelling_rebases_against_row_base():
         check(new_head != s.orig_head, "the clean rebase moved the worktree HEAD")
         check(s.remote_pr_head() == new_head,
               "the remote PR branch was force-with-lease pushed to the rebased head")
+
+
+def t_dash_leading_base_fetch_refreshes_tracking_ref():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = Scenario(Path(tmp), base=DASH_BASE).build()
+        tracking_ref = f"refs/remotes/origin/{DASH_BASE}"
+        stale_base = head(s.wt, tracking_ref)
+        s.advance_base({12: "12-BASE"})
+        remote_base = head(s.remote, f"refs/heads/{DASH_BASE}")
+        check(stale_base != remote_base, "fixture setup: the dash-leading base tracking ref must be stale")
+
+        code, out, err = s.invoke("--dry-run")
+        check(code == M.EXIT_OK, f"dash-leading base dry-run preconditions must pass (code={code}, err={err})")
+        plan = json.loads(out.strip().splitlines()[-1])
+        refspec = f"refs/heads/{DASH_BASE}:refs/remotes/origin/{DASH_BASE}"
+        check(plan["would"].startswith(f"fetch origin {refspec};"),
+              f"the dry-run must show the fully qualified safe refspec, got {plan['would']!r}")
+        check(head(s.wt, tracking_ref) == stale_base,
+              "the dash-leading base dry-run must not refresh the tracking ref")
+
+        code, out, err = s.invoke()
+        check(code == M.EXIT_OK,
+              f"a clean rebase onto a dash-leading base must succeed (code={code}, out={out!r}, err={err!r})")
+        check(head(s.wt, tracking_ref) == remote_base,
+              "the clean-rebase fetch must refresh the dash-leading base tracking ref")
+        check(head(s.wt) != s.orig_head, "the clean rebase onto the refreshed dash-leading base must move HEAD")
+
+
+def t_dash_leading_fetch_failure_names_safe_refspec():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = Scenario(Path(tmp), base=DASH_BASE).build()
+        git(s.remote, "update-ref", "-d", f"refs/heads/{DASH_BASE}")
+        code, out, err = s.invoke()
+        check(code == M.EXIT_PRECONDITION,
+              f"a missing dash-leading base must refuse at exit 2 (code={code}, err={err!r})")
+        detail = json.loads(out.strip().splitlines()[-1])["detail"]
+        refspec = f"refs/heads/{DASH_BASE}:refs/remotes/origin/{DASH_BASE}"
+        check(detail.startswith(f"`git fetch origin {refspec}` failed:"),
+              f"the fetch diagnostic must show the safe fully qualified refspec, got {detail!r}")
 
 
 # --- --dry-run mutates nothing -----------------------------------------------
@@ -607,6 +660,12 @@ CASES = [
     ("variant-spelling-rebases-row-base",
      "an accepted origin/main spelling rebases against the row's effective base 'main', not the raw arg",
      t_variant_spelling_rebases_against_row_base),
+    ("dash-base-safe-fetch",
+     "a dash-leading base uses a fully qualified fetch, refreshes its tracking ref, and rebases cleanly",
+     t_dash_leading_base_fetch_refreshes_tracking_ref),
+    ("dash-base-fetch-diagnostic",
+     "a dash-leading fetch failure reports the fully qualified refspec used",
+     t_dash_leading_fetch_failure_names_safe_refspec),
     ("unresolved-base-refused", "a both-`-` ledger resolves to `-`; the unresolved base is refused as no-base at exit 2",
      t_unresolved_base_refused),
     ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -117,8 +117,13 @@ class Scenario:
         git(self.seed, "push", "origin", "main")
         if self.base != "main":
             base_ref = f"refs/heads/{self.base}"
-            git(self.seed, "update-ref", base_ref, "HEAD")
-            git(self.seed, "push", "origin", f"{base_ref}:{base_ref}")
+            # A local refs/heads/HEAD makes every later plain HEAD revision ambiguous. The real bug only
+            # needs the REMOTE branch with that name, so create it directly from the current commit.
+            if self.base == "HEAD":
+                git(self.seed, "push", "origin", "HEAD:refs/heads/HEAD")
+            else:
+                git(self.seed, "update-ref", base_ref, "HEAD")
+                git(self.seed, "push", "origin", f"{base_ref}:{base_ref}")
         # PR branch: change line 3
         git(self.seed, "checkout", "-b", PR_BRANCH)
         (self.seed / "f").write_text(_numbered({3: "3-PR"}), encoding="utf-8")
@@ -151,6 +156,12 @@ class Scenario:
         """Move the remote base ahead by one commit that rewrites the given lines."""
         if self.base == "main":
             git(self.seed, "checkout", "main")
+        elif self.base == "HEAD":
+            # Keep the literal HEAD branch out of the local heads namespace: a local refs/heads/HEAD would
+            # make the pseudoref HEAD ambiguous and prevent this fixture from reaching clean-rebase.
+            fixture_ref = "refs/heads/literal-head-fixture"
+            git(self.seed, "fetch", "origin", f"refs/heads/HEAD:{fixture_ref}")
+            git(self.seed, "checkout", "--detach", fixture_ref)
         else:
             git(self.seed, "checkout", "--detach", f"refs/heads/{self.base}")
         (self.seed / "f").write_text(_numbered(overrides), encoding="utf-8")
@@ -645,6 +656,57 @@ def t_dash_leading_fetch_failure_names_safe_refspec():
               f"the fetch diagnostic must show the safe fully qualified refspec, got {detail!r}")
 
 
+def t_literal_head_base_uses_private_ref_without_moving_origin_main():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = Scenario(Path(tmp), base="HEAD").build()
+        symbolic = git(s.wt, "symbolic-ref", "refs/remotes/origin/HEAD")
+        check(symbolic.stdout.strip() == "refs/remotes/origin/main",
+              "fixture setup: origin/HEAD must be the normal symbolic ref to origin/main")
+        origin_main_before = head(s.wt, "refs/remotes/origin/main")
+        s.advance_base({12: "12-LITERAL-HEAD"})
+        remote_base = head(s.remote, "refs/heads/HEAD")
+        check(origin_main_before != remote_base,
+              "fixture setup: main and the literal HEAD branch must point to different commits")
+
+        code, out, err = s.invoke("--dry-run")
+        check(code == M.EXIT_OK,
+              f"a literal HEAD dry-run must pass its preconditions (code={code}, out={out!r}, err={err!r})")
+        plan = json.loads(out.strip().splitlines()[-1])
+        check(":refs/remotes/origin/HEAD" not in plan["would"],
+              f"the dry-run must not plan a fetch into the symbolic origin/HEAD ref: {plan['would']!r}")
+        check(":refs/gauntlet/" in plan["would"],
+              f"the dry-run must name the private full destination ref: {plan['would']!r}")
+        check(head(s.wt, "refs/remotes/origin/main") == origin_main_before,
+              "the literal HEAD dry-run must not move origin/main")
+
+        code, out, err = s.invoke()
+        check(code == M.EXIT_OK,
+              f"a clean rebase onto a literal HEAD branch must succeed "
+              f"(code={code}, out={out!r}, err={err!r})")
+        check(head(s.wt, "refs/remotes/origin/main") == origin_main_before,
+              "fetching the literal HEAD branch must not follow origin/HEAD and overwrite origin/main")
+        check(git(s.wt, "merge-base", "--is-ancestor", remote_base, "HEAD").returncode == 0,
+              "the rebased PR must contain the literal HEAD branch tip")
+
+
+def t_literal_head_fetch_failure_names_private_refspec():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = Scenario(Path(tmp), base="HEAD").build()
+        origin_main_before = head(s.wt, "refs/remotes/origin/main")
+        git(s.remote, "update-ref", "-d", "refs/heads/HEAD")
+
+        code, out, err = s.invoke()
+        check(code == M.EXIT_PRECONDITION,
+              f"a missing literal HEAD branch must refuse at exit 2 "
+              f"(code={code}, out={out!r}, err={err!r})")
+        detail = json.loads(out.strip().splitlines()[-1])["detail"]
+        check(detail.startswith(
+            "`git fetch origin +refs/heads/HEAD:refs/gauntlet/base-fetch/"),
+            f"the fetch diagnostic must show the exact private refspec, got {detail!r}")
+        check(head(s.wt, "refs/remotes/origin/main") == origin_main_before,
+              "a failed literal HEAD fetch must leave origin/main unchanged")
+
+
 # --- --dry-run mutates nothing -----------------------------------------------
 
 def t_dry_run_mutates_nothing():
@@ -702,6 +764,12 @@ CASES = [
     ("dash-base-fetch-diagnostic",
      "a dash-leading fetch failure reports the fully qualified refspec used",
      t_dash_leading_fetch_failure_names_safe_refspec),
+    ("literal-head-base",
+     "a literal HEAD base uses one private full ref throughout and leaves origin/main unchanged",
+     t_literal_head_base_uses_private_ref_without_moving_origin_main),
+    ("literal-head-fetch-diagnostic",
+     "a failed literal HEAD fetch reports its exact private refspec and leaves origin/main unchanged",
+     t_literal_head_fetch_failure_names_private_refspec),
     ("unresolved-base-refused", "a both-`-` ledger resolves to `-`; the unresolved base is refused as no-base at exit 2",
      t_unresolved_base_refused),
     ("no-remote-refused", "an absent default remote is refused at exit 2", t_absent_remote_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -237,7 +237,8 @@ def run(args) -> int:
 
     # Fully qualify both sides of the refspec so a legal dash-leading base is ref data, never a Git option.
     # The destination is the same remote-tracking ref every later diff/rebase reads.
-    fetch_refspec = f"refs/heads/{base}:refs/remotes/{remote}/{base}"
+    # Force-update the remote-tracking destination, matching Git's default remote fetch refspec.
+    fetch_refspec = f"+refs/heads/{base}:refs/remotes/{remote}/{base}"
 
     # --- --dry-run STOPS HERE — before the first mutation (fetch moves a tracking ref) ------------------
     if args.dry_run:

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.modules import load_module_from_path
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
@@ -422,7 +423,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     sub.add_parser("self-test", help="run every fixture (clean-rebase-test.py)")
 
-    args = p.parse_args(argv)
+    args = p.parse_args(bind_separate_option_value(argv, "--base"))
     if args.cmd == "self-test":
         return self_test()
     return run(args)

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -44,6 +44,7 @@ import sys
 from pathlib import Path
 
 from _gauntlet.argv import bind_separate_option_value
+from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
@@ -99,14 +100,14 @@ def _git(worktree: str, *args: str) -> subprocess.CompletedProcess:
     return _run(["git", "-C", worktree, *args])
 
 
-def patch_identity(worktree: str, remote: str, base: str) -> "str | None":
-    """The PR's MERGE-BASE-relative patch identity: `git diff <remote>/<base>...HEAD` piped through
-    `git patch-id --verbatim`. Verbatim mode preserves whitespace, so an indentation-only context change
-    cannot carry review credit. Returns the 40-hex id, `EMPTY_DIFF` for an empty diff, or None if the diff
-    or patch identity could not be computed. Three-dot diff is measured from the merge base, so the SAME
-    value is produced whether the PR sits on the old or the new base — which is exactly what lets a
-    before/after comparison isolate what the REBASE did to the PR's content."""
-    diff = _git(worktree, "diff", f"{remote}/{base}...HEAD")
+def patch_identity(worktree: str, base_ref: str) -> "str | None":
+    """The PR's MERGE-BASE-relative patch identity: `git diff <base-ref>...HEAD` piped through `git patch-id
+    --verbatim`. Verbatim mode preserves whitespace, so an indentation-only context change cannot carry
+    review credit. Returns the 40-hex id, `EMPTY_DIFF` for an empty diff, or None if the diff or patch
+    identity could not be computed. Three-dot diff is measured from the merge base, so the SAME value is
+    produced whether the PR sits on the old or the new base — which is exactly what lets a before/after
+    comparison isolate what the REBASE did to the PR's content."""
+    diff = _git(worktree, "diff", f"{base_ref}...HEAD")
     if diff.returncode != 0:
         return None
     pid = _run(["git", "patch-id", "--verbatim"], cwd=worktree, stdin=diff.stdout)
@@ -237,15 +238,20 @@ def run(args) -> int:
                       EXIT_PRECONDITION)
 
     # Fully qualify both sides of the refspec so a legal dash-leading base is ref data, never a Git option.
-    # The destination is the same remote-tracking ref every later diff/rebase reads.
-    # Force-update the remote-tracking destination, matching Git's default remote fetch refspec.
-    fetch_refspec = f"+refs/heads/{base}:refs/remotes/{remote}/{base}"
+    # A symbolic normal destination gets a private ref; every later diff/rebase uses that exact full ref.
+    selected, selection_problem = select_base_fetch_refs(worktree, remote, base)
+    if selection_problem is not None or selected is None:
+        return refuse("fetch-ref",
+                      selection_problem or "could not select a base fetch destination",
+                      EXIT_PRECONDITION)
+    fetch_refspec = selected.refspec
+    base_ref = selected.local_ref
 
     # --- --dry-run STOPS HERE — before the first mutation (fetch moves a tracking ref) ------------------
     if args.dry_run:
         emit({"dry_run": True, "pr": pr, "worktree": worktree, "base": base, "remote": remote,
               "orig_head": orig_head, "branch": row_branch,
-              "would": f"fetch {remote} {fetch_refspec}; rebase onto {remote}/{base}; verify the PR diff is "
+              "would": f"fetch {remote} {fetch_refspec}; rebase onto {base_ref}; verify the PR diff is "
                        f"unchanged; push --force-with-lease; then set head_sha, ci=pending and reset the "
                        f"liveness counters in the ledger"})
         return EXIT_OK
@@ -262,14 +268,14 @@ def run(args) -> int:
 
     # The COMPARISON TARGET — the PR's patch identity as it stands now, measured against the fetched base.
     # (Three-dot is merge-base-relative, so this equals the PR's pre-rebase content; see patch_identity.)
-    target_id = patch_identity(worktree, remote, base)
+    target_id = patch_identity(worktree, base_ref)
     if target_id is None:
         return refuse("diff-failed",
-                      f"could not compute the patch identity for {remote}/{base}...HEAD in {worktree} "
+                      f"could not compute the patch identity for {base_ref}...HEAD in {worktree} "
                       f"(git diff or git patch-id failed) — nothing rebased", EXIT_PRECONDITION)
 
     # The rebase. ANY non-zero exit is a conflict this tool NEVER resolves: abort, restore HEAD, hand off.
-    rebase = _git(worktree, "rebase", f"{remote}/{base}")
+    rebase = _git(worktree, "rebase", base_ref)
     if rebase.returncode != 0:
         _git(worktree, "rebase", "--abort")
         after = _git(worktree, "rev-parse", "HEAD").stdout.strip()
@@ -280,12 +286,12 @@ def run(args) -> int:
             emit({"error": "abort-did-not-restore", "pr": pr, "orig_head": orig_head, "head_now": after})
             return EXIT_PARTIAL
         return refuse("conflict",
-                      f"rebase of pr {pr} onto {remote}/{base} conflicts — aborted, HEAD restored to "
+                      f"rebase of pr {pr} onto {base_ref} conflicts — aborted, HEAD restored to "
                       f"{orig_head}. Conflict resolution is the driver's call; this tool does the clean "
                       f"case only", EXIT_NOT_CLEAN)
 
     # Textually clean — but did it change the PR's OWN diff? Compare patch identities.
-    post_id = patch_identity(worktree, remote, base)
+    post_id = patch_identity(worktree, base_ref)
     if post_id != target_id:
         # NOT the clean case: the rebase re-wrote the PR's effective patch (e.g. a base edit next to the
         # PR's hunk), or its post-rebase identity could not be proved. Fail closed — reset to the original
@@ -299,8 +305,8 @@ def run(args) -> int:
             return EXIT_PARTIAL
         if post_id is None:
             return refuse("diff-failed",
-                          f"could not compute pr {pr}'s patch identity after rebasing onto "
-                          f"{remote}/{base} — reset to {orig_head}; nothing pushed and the ledger is "
+                          f"could not compute pr {pr}'s patch identity after rebasing onto {base_ref} — "
+                          f"reset to {orig_head}; nothing pushed and the ledger is "
                           f"untouched", EXIT_PRECONDITION)
         return refuse("diff-changed",
                       f"the rebase applied textually but CHANGED pr {pr}'s diff (patch identity "

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -173,9 +173,8 @@ def run(args) -> int:
                       f"--base {base!r} disagrees with pr {pr}'s ledger effective base {effective_base!r} — "
                       f"--base is an assertion, not a base source", EXIT_PRECONDITION)
     # Operate on the ROW's resolved base, never the raw `--base` spelling: two spellings `base_agrees`
-    # accepts (`main` vs `origin/main`) fetch/rebase against different refs (`git fetch origin main` vs
-    # `git fetch origin origin/main`), so every operational fetch/rebase/patch-identity below follows the
-    # row, not the caller's argument.
+    # accepts (`main` vs `origin/main`) produce different fully qualified source/tracking refspecs, so every
+    # operational fetch/rebase/patch-identity below follows the row, not the caller's argument.
     base = effective_base
 
     # 2. A HELD PR is FROZEN — no rebase (a mutation) is dispatched on it — and a TERMINAL PR is done.
@@ -236,11 +235,15 @@ def run(args) -> int:
                       f"(`pr-adopt.py adopt`) before rebasing",
                       EXIT_PRECONDITION)
 
+    # Fully qualify both sides of the refspec so a legal dash-leading base is ref data, never a Git option.
+    # The destination is the same remote-tracking ref every later diff/rebase reads.
+    fetch_refspec = f"refs/heads/{base}:refs/remotes/{remote}/{base}"
+
     # --- --dry-run STOPS HERE — before the first mutation (fetch moves a tracking ref) ------------------
     if args.dry_run:
         emit({"dry_run": True, "pr": pr, "worktree": worktree, "base": base, "remote": remote,
               "orig_head": orig_head, "branch": row_branch,
-              "would": f"fetch {remote} {base}; rebase onto {remote}/{base}; verify the PR diff is "
+              "would": f"fetch {remote} {fetch_refspec}; rebase onto {remote}/{base}; verify the PR diff is "
                        f"unchanged; push --force-with-lease; then set head_sha, ci=pending and reset the "
                        f"liveness counters in the ledger"})
         return EXIT_OK
@@ -249,9 +252,10 @@ def run(args) -> int:
 
     # Fetch the base BEFORE computing the comparison target, so both the target and the post-rebase
     # identity are measured against the SAME (updated) base ref.
-    fetch = _git(worktree, "fetch", remote, base)
+    fetch = _git(worktree, "fetch", remote, fetch_refspec)
     if fetch.returncode != 0:
-        return refuse("fetch-failed", f"`git fetch {remote} {base}` failed: {fetch.stderr.strip()}",
+        return refuse("fetch-failed",
+                      f"`git fetch {remote} {fetch_refspec}` failed: {fetch.stderr.strip()}",
                       EXIT_PRECONDITION)
 
     # The COMPARISON TARGET — the PR's patch identity as it stands now, measured against the fetched base.


### PR DESCRIPTION
- fetch base refs through fully qualified source-to-tracking refspecs
- align clean-rebase plans and failure details with the executed command
- cover dash-leading bases against real local bare remotes
