### PR TITLE
pin merge ancestry to reviewed sha

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -34,7 +34,8 @@ resolves the row's **effective base** (its explicit `base_branch`, else the lega
 base into the PR worktree, and prints `{"verdict":"merge"|"not-yet","reason":…}`.
 It crosses — in ONE place — the held/open/draft/**base-retarget**/stale-head/ci/reviews preconditions and then **BOTH** GitHub enums (`.mergeable` first — `CONFLICTING`
 and `UNKNOWN` decide on their own, `MERGEABLE` falls through — then `.mergeStateStatus`, which alone
-yields `merge`), then confirms `origin/<effective-base>` is an ancestor of `HEAD`. Both enums are crossed
+yields `merge`), then confirms `origin/<effective-base>` is an ancestor of the ledger's reviewed
+`head_sha`. Both enums are crossed
 **TOTALLY**: a value GitHub's schema does not declare **parks**, never guesses. A live `baseRefName` that no
 longer matches the row's recorded base is an unsupported retarget: it fails closed with the shared
 machine-blocker reason (`base changed from <recorded> to <live>; not supported mid-run`), and the next

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -491,6 +491,51 @@ def t_dash_leading_stale_base_refreshes_and_rebases():
               "the dash-leading base fetch must refresh its remote-tracking ref before the stale verdict")
 
 
+def t_candidate_revision_is_checked_instead_of_moved_head():
+    """Stage 3 may check a reviewed SHA after the local worktree moves to a different, base-current HEAD."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        remote = root / "remote.git"
+        seed = root / "seed"
+        candidate = root / "candidate"
+
+        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
+        result = subprocess.run(["git", "clone", str(remote), str(seed)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
+        _configure_repo(seed)
+        (seed / "f").write_text("base\n", encoding="utf-8")
+        _git(seed, "add", "f")
+        _git(seed, "commit", "-m", "base")
+        _git(seed, "push", "origin", "main")
+
+        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
+                                capture_output=True, text=True, check=False)
+        check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
+        _configure_repo(candidate)
+        _git(candidate, "checkout", "-b", "reviewed")
+        (candidate / "reviewed").write_text("reviewed\n", encoding="utf-8")
+        _git(candidate, "add", "reviewed")
+        _git(candidate, "commit", "-m", "reviewed candidate")
+        reviewed = _git(candidate, "rev-parse", "HEAD").stdout.strip()
+
+        (seed / "advanced").write_text("advanced\n", encoding="utf-8")
+        _git(seed, "add", "advanced")
+        _git(seed, "commit", "-m", "advance base")
+        _git(seed, "push", "origin", "main")
+        _git(candidate, "fetch", "origin", "main")
+        _git(candidate, "checkout", "-B", "moved-local-head", "origin/main")
+        local_head = _git(candidate, "rev-parse", "HEAD").stdout.strip()
+        check(local_head != reviewed, "fixture requires local HEAD to differ from the reviewed SHA")
+
+        check(M.check_base_ancestry(str(candidate), "main", "origin") == ("current", ""),
+              "fixture requires the moved local HEAD to contain the advanced base")
+        check(M.check_base_ancestry(str(candidate), "main", "origin", reviewed) == ("stale", ""),
+              "the reviewed SHA lacks the advanced base and must be reported stale")
+
+
 # --- `--file`: a real `proceed` RECORDS base_ok_sha on the ledger (the precondition `verdict` enforces) -----
 # base-preflight is the ONLY sanctioned writer of `base_ok_sha`: on a final `proceed`, and only when a ledger
 # is named, it resolves the worktree's HEAD and shells out to `ledger.py base-ok`. `decide()` stays pure;
@@ -829,6 +874,8 @@ CASES = [
      t_dash_leading_current_base_refreshes_and_proceeds),
     ("dash-base-stale", "a dash-leading base refreshes its tracking ref and reports stale ancestry",
      t_dash_leading_stale_base_refreshes_and_rebases),
+    ("candidate-revision-not-head", "an explicit candidate revision is checked instead of a moved local HEAD",
+     t_candidate_revision_is_checked_instead_of_moved_head),
     ("proceed-file-records-base-ok", "a proceed with --file stamps base_ok_sha = HEAD; without --file writes nothing",
      t_proceed_with_file_records_base_ok),
     ("non-proceed-file-no-stamp", "rebase-first/recheck never stamp base_ok_sha, even with --file",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -116,15 +116,17 @@ def _verdict(verdict: str, reason: str) -> dict:
     return {"verdict": verdict, "reason": reason}
 
 
-def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str) -> tuple[str, str]:
-    """Return ``current``, ``stale``, or ``unverified`` for the fetched base against a PR worktree.
+def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str,
+                        candidate_revision: str = "HEAD") -> tuple[str, str]:
+    """Return ``current``, ``stale``, or ``unverified`` for the fetched base against a candidate revision.
 
     GitHub may keep reporting ``MERGEABLE/CLEAN`` after another campaign PR advances an unprotected base.
     The merge-state enums alone therefore cannot prove that a candidate contains the current base. Fetch the
-    named base through a fully qualified source:tracking-ref refspec and ask Git's ancestry graph directly.
-    A symbolic remote-tracking destination is replaced with a private ref so the fetch cannot update the
-    symbolic ref's target. The qualified source prevents a legal dash-leading base name from being parsed
-    as a Git option. Callers treat ``unverified`` as fail-closed.
+    named base through a fully qualified source:local-ref refspec and ask Git's ancestry graph directly
+    against ``candidate_revision`` (the worktree's ``HEAD`` by default). A symbolic remote-tracking
+    destination is replaced with a private ref so the fetch cannot update the symbolic ref's target. The
+    qualified source prevents a legal dash-leading base name from being parsed as a Git option. The fetch
+    never updates the candidate branch. Callers treat ``unverified`` as fail-closed.
     """
     if not worktree or not base:
         return "unverified", "base ancestry requires --worktree and --base"
@@ -137,13 +139,14 @@ def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str)
     if fetch.returncode != 0:
         return "unverified", f"could not fetch {selected.refspec}: {fetch.stderr.strip()}"
     probe = subprocess.run(  # noqa: S603
-        ["git", "-C", worktree, "merge-base", "--is-ancestor", selected.local_ref, "HEAD"],
+        ["git", "-C", worktree, "merge-base", "--is-ancestor", selected.local_ref, candidate_revision],
         capture_output=True, text=True, check=False)
     if probe.returncode == 0:
         return "current", ""
     if probe.returncode == 1:
         return "stale", ""
-    return "unverified", f"could not compare HEAD with {selected.local_ref}: {probe.stderr.strip()}"
+    return ("unverified",
+            f"could not compare {candidate_revision} with {selected.local_ref}: {probe.stderr.strip()}")
 
 
 def decide(view: dict) -> dict:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -13,6 +13,7 @@ check outranks the enums.
 from __future__ import annotations
 
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -63,6 +64,14 @@ def decide(r: dict, v: dict) -> dict:
 def check(cond: bool, msg: str) -> None:
     if not cond:
         raise M.SelfTestFailure(msg)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    proc = subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=False)
+    check(proc.returncode == 0,
+          f"git {' '.join(args)} failed in {cwd}: {proc.stderr.strip()}")
+    return proc
 
 
 def expect(r: dict, v: dict, verdict: str, reason: "str | None" = None) -> dict:
@@ -236,6 +245,50 @@ def t_cli_stale_base_blocks_merge():
     check(code == 0, f"a stale base is a computed not-yet result (stderr: {err})")
     check(json.loads(out) == {"verdict": "not-yet", "reason": "base moved ahead — rebase"},
           f"a CLEAN candidate behind the base must not merge, got {out!r}")
+
+
+def t_cli_ancestry_uses_reviewed_sha_not_moved_worktree_head():
+    """The Stage 3 probe receives row.head_sha even when the worktree has moved to another commit."""
+    real_check = M.B.check_base_ancestry
+    seen: list[tuple[str, str, str, str]] = []
+
+    def probe(worktree: str, base: str, remote: str, candidate_revision: str) -> tuple[str, str]:
+        seen.append((worktree, base, remote, candidate_revision))
+        return "stale", ""
+
+    M.B.check_base_ancestry = probe
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            candidate = Path(d) / "candidate"
+            candidate.mkdir()
+            _git(candidate, "init", "-b", "main")
+            _git(candidate, "config", "user.email", "fixture@example.invalid")
+            _git(candidate, "config", "user.name", "Fixture")
+            (candidate / "f").write_text("reviewed\n", encoding="utf-8")
+            _git(candidate, "add", "f")
+            _git(candidate, "commit", "-m", "reviewed")
+            reviewed = _git(candidate, "rev-parse", "HEAD").stdout.strip()
+            (candidate / "f").write_text("moved\n", encoding="utf-8")
+            _git(candidate, "commit", "-am", "move local head")
+            local_head = _git(candidate, "rev-parse", "HEAD").stdout.strip()
+            check(local_head != reviewed, "fixture requires local HEAD to differ from row.head_sha")
+
+            candidate_row = row(head_sha=reviewed)
+            candidate_row["worktree"] = str(candidate)
+            led = Path(d) / "state.jsonl"
+            L.dump(
+                led, dict(L.HEADER_DEFAULTS, run_id="g1", base_branch="main"), [candidate_row])
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view(headRefOid=reviewed)), encoding="utf-8")
+            code, out, err = capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    finally:
+        M.B.check_base_ancestry = real_check
+    check(code == 0, f"a stale reviewed SHA is a computed not-yet result (stderr: {err})")
+    check(json.loads(out) == {"verdict": "not-yet", "reason": "base moved ahead — rebase"},
+          f"the stale reviewed SHA must block merge, got {out!r}")
+    check(seen == [(str(candidate), "main", "origin", reviewed)],
+          f"the ancestry probe must receive row.head_sha, not ambient HEAD: {seen!r}")
 
 
 def t_cli_unverified_base_blocks_merge():
@@ -452,6 +505,8 @@ CASES = [
     ("cli-unresolved-base", "a both-`-` unresolved base never merges — the finding #2 false-permissive fix",
      t_cli_unresolved_base_never_merges),
     ("cli-stale-base", "a CLEAN candidate behind refreshed base cannot merge", t_cli_stale_base_blocks_merge),
+    ("cli-pinned-base-ancestry", "Stage 3 checks base ancestry against row.head_sha, not moved worktree HEAD",
+     t_cli_ancestry_uses_reviewed_sha_not_moved_worktree_head),
     ("cli-unverified-base", "an unreadable base ancestry fails closed", t_cli_unverified_base_blocks_merge),
     ("cli-blocked-behind", "a BLOCKED PR behind its base routes to rebase (the #134 fix)",
      t_cli_blocked_behind_rebases),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -16,7 +16,7 @@ two enums are crossed, so nobody does it by hand and nobody does it wrong.
 
 `.mergeable = MERGEABLE` is NECESSARY BUT NOT SUFFICIENT: it falls THROUGH to `.mergeStateStatus`, which is
 the only field that yields a preliminary `merge`. Before emitting `merge`, the shared preflight helper
-fetches the ledger base and proves it is an ancestor of the candidate `HEAD`. `BLOCKED` runs that SAME
+fetches the ledger base and proves it is an ancestor of the ledger's reviewed `head_sha`. `BLOCKED` runs that SAME
 ancestry probe before it parks: a BLOCKED PR that is merely BEHIND its base is routed to a rebase (which the
 gate carries forward), not parked on the user; only a BLOCKED PR proven up-to-date is a genuine human/ruleset
 block and parks. The probe NEVER yields a new merge — it can only turn a park into a rebase. Both enums are mapped TOTALLY
@@ -308,7 +308,8 @@ def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None
     # unprotected base, and a BLOCKED PR may merely be BEHIND its base — a rebase fixes both. So re-fetch and
     # compare actual ancestry before the final decision; the shared preflight helper owns the graph check so
     # review dispatch and Stage 3 cannot disagree about what "current base" means.
-    ancestry, detail = B.check_base_ancestry(row.get("worktree"), effective_base, "origin")
+    ancestry, detail = B.check_base_ancestry(
+        row.get("worktree"), effective_base, "origin", row["head_sha"])
     if ancestry == "stale":                       # behind base -> rebase (BOTH paths; never a merge)
         print(json.dumps(_not_yet(REBASE_REASON)))
         return 0

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -58,6 +58,7 @@ class Fake:
                  repo_identity: str = "o/r", mergeable: str = "MERGEABLE",
                  merge_state_status: str = "CLEAN", header_base: "str | None" = None,
                  base_ff_blocked: bool = False, ancestor_ok: bool = True,
+                 worktree_head: str = SHA,
                  plumb_fail: "str | None" = None,
                  staged_paths: "list[str] | None" = None,
                  staged_incoming_paths: "list[str] | None" = None,
@@ -115,6 +116,9 @@ class Fake:
         # resolve through the SAME base-ancestry probe the MERGE path runs (behind -> rebase, current -> park).
         self.mergeable = mergeable
         self.merge_state_status = merge_state_status
+        # The worktree may move after review while the ledger and live PR remain pinned to SHA. Stage 3's
+        # base-ancestry probe must inspect the reviewed SHA, never this ambient checkout tip.
+        self.worktree_head = worktree_head
         # Post-merge base-sync diagnostic knobs, all modeled on checked[0] (the checkout holding the base,
         # which the fixtures set to root). `base_ff_blocked` forces the checked-out-base `merge --ff-only`
         # to fail as git does against uncommitted work. `ancestor_ok` is the `merge-base --is-ancestor HEAD
@@ -181,7 +185,7 @@ class Fake:
             entries.append(f"worktree {self.root}\0HEAD {'b' * 40}\0branch refs/heads/{self.base}\0\0")
         if self.worktree_present:
             entries.append(
-                f"worktree {self.worktree}\0HEAD {SHA}\0branch refs/heads/{self.branch}\0\0")
+                f"worktree {self.worktree}\0HEAD {self.worktree_head}\0branch refs/heads/{self.branch}\0\0")
         return "".join(entries)
 
     def run(self, argv: list[str], *, cwd: "str | None" = None,
@@ -410,6 +414,26 @@ def t_gate_refusals():
             check(f.merged_calls == 0, f"{kwargs} reached merge")
         finally:
             finish(td, real)
+
+
+def t_base_ancestry_uses_reviewed_sha_not_moved_worktree_head():
+    moved_head = "b" * 40
+    td, root, f, led, real = scenario(worktree_head=moved_head)
+    try:
+        check(f.worktree_head != SHA,
+              "fixture requires the local worktree HEAD to differ from the reviewed ledger SHA")
+        code, _result, err = invoke(f, led, root)
+        check(code == 0, f"a base-current reviewed SHA should merge: {err}")
+        expected = [
+            "git", "-C", str(f.worktree), "merge-base", "--is-ancestor",
+            f"origin/{f.base}", SHA,
+        ]
+        probes = [argv for argv, _ in f.calls
+                  if argv[:5] == ["git", "-C", str(f.worktree), "merge-base", "--is-ancestor"]]
+        check(probes == [expected],
+              f"the merge runner must probe the reviewed SHA, not moved local HEAD: {probes!r}")
+    finally:
+        finish(td, real)
 
 
 def t_blocked_probe_rebases_when_behind_parks_when_current():
@@ -1628,6 +1652,8 @@ CASES = [
     ("ownership-matrix", "all worktree/branch ownership combinations clean only owned resources", t_reused_resources_are_left),
     ("root-foreign", "root cleanup and foreign branch are refused before merge", t_root_and_foreign_targets_refused),
     ("gate-refusals", "held, stale, red, pending, and short-tally rows never merge", t_gate_refusals),
+    ("pinned-base-ancestry", "merge ancestry probes row.head_sha when the local worktree HEAD differs",
+     t_base_ancestry_uses_reviewed_sha_not_moved_worktree_head),
     ("blocked-probe-ancestry", "a BLOCKED PROBE resolves via the base-ancestry probe: behind rebases, up-to-date parks; neither merges", t_blocked_probe_rebases_when_behind_parks_when_current),
     ("stale-malformed", "stale live SHA and malformed ownership fail closed", t_stale_head_and_malformed_ownership_refused),
     ("owner-and-view", "another run and uncertain GitHub state fail closed", t_owner_label_and_uncertain_view_refused),

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -282,14 +282,14 @@ def _base_is_current(row: dict, header: dict) -> None:
         f"refresh of origin/{base} for merge-check",
     )
     probe = _run(
-        ["git", "-C", worktree, "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"])
+        ["git", "-C", worktree, "merge-base", "--is-ancestor", f"origin/{base}", row["head_sha"]])
     if probe.returncode == 1:
         raise Refusal("merge-check: base moved ahead — rebase")
     _require(probe, f"merge-check ancestry against origin/{base}")
 
 
 def _require_ready(row: dict, header: dict, view: dict) -> None:
-    """Delegate policy to merge-check.py, then supply its fetched-base ancestry phase.
+    """Delegate policy to merge-check.py, then check fetched-base ancestry against the reviewed SHA.
 
     merge-check.decide returns MERGE only for CLEAN/HAS_HOOKS; a BLOCKED PR is left as the PROBE sentinel
     because `decide` alone cannot tell a genuine block from one that is merely BEHIND its base. Mirror


### PR DESCRIPTION
- check Stage 3 base ancestry against the ledger's reviewed SHA
- cover moved-worktree cases in shared preflight, merge gate, and runner fixtures
