### PR TITLE
fix CI verdict liveness terminology

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -753,18 +753,22 @@ the intended behavior, and it costs nothing:
 **Why NO ORDER here can produce a false green:** `green` is the **last** bullet and demands that **EVERY**
 evidence row classify `PASS`. An `UNKNOWN_VALUE` row is **not** `PASS`, so **while any unknown value is in
 the snapshot the `green` bullet cannot match — no matter which bullet is evaluated first.** Every earlier
-bullet (`UNUSABLE`, `red`, `UNKNOWN_VALUE`, `pending`) is a **non-merging** outcome. So the ordering can
-only decide *which non-green state* is recorded and *how fast the PR moves*; it can **never** decide
-*green*. That is what makes `red`-first safe, and it is the property to preserve if these bullets are
-ever re-ordered again.
+bullet (`UNUSABLE`, `UNVERIFIABLE`, `red`, `UNKNOWN_VALUE`, `pending`) is a **non-merging** outcome. So the
+ordering can only decide *which non-green state* is recorded and *how fast the PR moves*; it can **never**
+decide *green*. That is what makes `red`-first safe, and it is the property to preserve if these bullets
+are ever re-ordered again.
 
 - **UNUSABLE → `ci = pending`, refetch** → no usable snapshot: any fetch failed, the file is absent, or it
-  **fails ANY rule in VERIFY above** — misnamed, header not first or not alone, a line that does not parse
+  fails a structural, source-completeness, SHA, or exact-containment rule in VERIFY above — misnamed,
+  header not first or not alone, a line that does not parse
   as JSON, an unknown row type, a missing or unexpected field, a field whose **value is not a string**, a
   `.sha` (the `header` row's, **any** evidence row's, or the filename's) that does not match the ledger's
   `head_sha`, **a mandatory `source` marker missing, duplicated, mis-counted, or carrying a sha that is not
-  GitHub's** — or containment **cannot be established**: it fails, **or** a `witness` `.id` is
-  null/duplicated so the test proves nothing.
+  GitHub's** — or containment **fails** because REST is missing a witnessed run.
+- **UNVERIFIABLE → `ci = pending`, refetch** → the snapshot's shape is usable, but containment cannot be
+  decided: a `witness` `.id` is null or duplicated, so the test cannot prove which run was present. This
+  exact verdict remains distinct in `derive` output; it shares only the not-verified liveness policy with
+  `UNUSABLE` (`stage-2-ci.md`, "NOT VERIFIED — the refetch is BOUNDED").
 - **red** → **any** evidence row classifies `FAIL`. Other rows still `RUNNING` does **not** change this —
   a failure is actionable now. The driver's response — the held-PR guard, stopping an in-flight review,
   classifying the failure, the fix dispatch, the gate reset — is `stage-2-ci.md`, "ACT ON THE VERDICT".

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -712,8 +712,9 @@ block a merge, this is the line that was wrong.
 
 #### DECIDE — first match wins
 
-> **`ci-status.py derive` EVALUATES THESE BULLETS** — its JSON's `verdict` and `reason` name the bullet
-> that matched and the row that made it match. The bullet LOGIC is the **SPECIFICATION THE TOOL
+> **`ci-status.py derive` EVALUATES THESE BULLETS** — its JSON's `verdict` names the bullet that matched,
+> and `reason` preserves that outcome's exact diagnostic detail. Not every outcome has an evidence row.
+> The bullet LOGIC is the **SPECIFICATION THE TOOL
 > IMPLEMENTS** (`doc-check` pins the bullet order; the `*-outranks-*` fixtures pin it behaviourally):
 > keep it correct, and **NEVER re-evaluate it by hand against a snapshot** — a hand evaluation that
 > disagrees with the JSON is the by-eye derivation this file exists to kill. **The DRIVER ACTION for

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -443,10 +443,9 @@ Header field notes (the header fields above; per-row fields follow):
   historical and **understates** the field: it is also written at machine-blocker parks where **`ci` is
   `green`**. The name is kept — renaming it would churn the schema and every write site for cosmetics —
   so the definition, not the name, is what binds. Its two write mechanisms:
-  - **CI blockers** (`stage-2-ci.md`, "ESCALATE" — `ci` is `red` or `pending`): the DECIDE bullet that
-    matched and the row that made it match — which required check never registered, which check has been
-    `RUNNING` since when without the check set moving, which enum value was unrecognized, which VERIFY
-    rule the snapshot failed, which read was denied. Written by `ci-status.py liveness`.
+  - **CI blockers** (`stage-2-ci.md`, "ESCALATE" — `ci` is `red` or `pending`): the exact actionable
+    detail for the matched DECIDE outcome. `stage-2-ci.md`'s liveness-bound sections own each diagnostic
+    shape; never reconstruct those shapes here. Written by `ci-status.py liveness`.
   - **NON-CI machine blockers**: every caller writes through `ledger.py … park --pr <N> --reason
     <blocker>`. This includes `base-preflight.py`'s unknown-enum park (`stage-2-review-gate.md`,
     "Preconditions — clear Copilot items, CI, and conflicts before reviewing") and every `— park` reason

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -415,7 +415,7 @@ Header field notes (the header fields above; per-row fields follow):
   naming the blocker. Reset to `0` on any `head_sha` change (the ledger `set --head-sha` accessor does this
   itself — ledger.py's `apply_head_sha`) or fingerprint change (by `ci-status.py liveness`).
 - `unusable_refetches` — durable refetch-bound state, written only by `ci-status.py liveness` or the
-  `head_sha` accessor. `stage-2-ci.md`, "UNUSABLE — the refetch is BOUNDED", owns the machine-checked
+  `head_sha` accessor. `stage-2-ci.md`, "NOT VERIFIED — the refetch is BOUNDED", owns the machine-checked
   increment/reset contract and the **REFETCH CAP**. Do not infer this field from artifact presence or
   verification; hand `derive`'s unedited result to `liveness`.
 - `ci_stalled_since` — `-`, or the **UTC ISO-8601 timestamp** of the first derivation that saw the check
@@ -536,7 +536,7 @@ Header field notes (the header fields above; per-row fields follow):
        refetch bound that reached its cap (`unusable_refetches`), a check carrying an **unrecognized enum
        value**, or **any merge precondition `merge-check.py` parks** (any `— park` reason it emits)
        (`stage-2-ci.md`, "SETTLED", "RUNNING-STALL"
-       and "UNUSABLE — the refetch is BOUNDED"; `stage-3-merge.md`, "The merge precondition"). **This is
+       and "NOT VERIFIED — the refetch is BOUNDED"; `stage-3-merge.md`, "The merge precondition"). **This is
        the exit from `pending` — in BOTH of its shapes**, the settled one and the forever-`RUNNING` one;
        without it, a stuck PR spins forever and no one is ever told. **Answered into**
        `blocker_ruling`: `retry@<iso>` → **`ledger.py … unpark --pr <N>`**, which returns the row to

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -337,7 +337,7 @@ the worker returns, and what never moves into it. The steps below are unchanged 
 
      **The counter reset is part of the unpark, not an optimization**: a `retry` that clears nothing
      re-escalates on its first derivation (`stage-2-ci.md`, "THE LIVENESS COUNTERS" / "SETTLED" /
-     "UNUSABLE — the refetch is BOUNDED", own why). The loop is bounded by the **human**: campaign never
+     "NOT VERIFIED — the refetch is BOUNDED", own why). The loop is bounded by the **human**: campaign never
      re-asks unprompted, and every park is a fresh question backed by a fresh snapshot.
 
      **A `retry` is SPENT when it is consumed — one ruling answers exactly ONE park.** `ledger.py … unpark

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -148,7 +148,7 @@ wins") and is never re-evaluated by hand.
 | `red` | `red` | **If the row is HELD (`liveness` reports it), dispatch nothing** — a held PR dispatches nothing until its question is answered (`loop-control.md` step 3, "held-status guard"); the watch still follows "WATCH ONLY WHAT CAN MOVE" below. Otherwise: **stop any review pass in flight on this PR** (the fix will replace its SHA — `loop-control.md` step 3; free the slot), **CLASSIFY the failure from the check logs** ("Classify, then set the model class", below) **before dispatching anything**, and dispatch a **scoped CI-fix subagent** into `<worktree>` — the row's ledger `worktree` value, the single source of truth for this PR's checkout path (`pr-adoption.md`). Its fix commits + pushes to the PR's **own head branch** → apply the gate reset ("Any campaign commit to the PR head resets the gate", below). Watch only while `liveness` reports `watch_warranted` (a still-RUNNING row — "WATCH ONLY WHAT CAN MOVE", below). |
 | `unclassified` | `pending` | `liveness` has parked the PR (`status = awaiting-user`). **Prompt the user** per ESCALATE ("THE PARK MUST DECLARE ITS OWN EXIT", below), naming the offending value from `reason`. Never guess a bucket for it. No watch — the park is the resolution. |
 | `pending` | `pending` | `liveness` reports `watch_warranted` → ensure a live watch ("WATCH ONLY WHAT CAN MOVE", below). Otherwise nothing can move — no watch; the liveness bounds own the wait and `liveness` escalates at a cap. The `pending` sub-cases that waiting can never green (`nothing registered`, `required set unreadable`, `required check missing` — each named in `reason`) resolve through those same bounds; while `required_set` is `unknown`, keep running `required-set` each heartbeat ("WHAT WERE WE EXPECTING TO SEE?", below). |
-| `unusable` / `unverifiable` | `pending` | **Refetch on the next heartbeat** — the heartbeat is the backoff ("UNUSABLE — the refetch is BOUNDED", below); `liveness` counted the attempt and escalates at the REFETCH CAP. `head_moved: true` → refresh the row's `head_sha` (`pr-adoption.md`) and re-derive pinned to it. No watch. |
+| `unusable` / `unverifiable` | `pending` | **Refetch on the next heartbeat** — the heartbeat is the backoff ("NOT VERIFIED — the refetch is BOUNDED", below); `liveness` counted the attempt and escalates at the REFETCH CAP. `head_moved: true` → refresh the row's `head_sha` (`pr-adoption.md`) and re-derive pinned to it. No watch. |
 
 #### WHAT WERE WE EXPECTING TO SEE? — the required-check set
 
@@ -331,10 +331,10 @@ fingerprint = sha256( head_sha + "\n" + <those lines, sorted bytewise, one per l
 - **A derivation with no trusted evidence for the PR's current head has NO fingerprint** — `derive` prints
   `fingerprint: null` for it. `UNUSABLE` and `UNVERIFIABLE` never yield one. A moved-head derivation keeps
   its promoted old-commit artifact for audit but still yields none, because those rows are not evidence
-  about the current PR. **Nothing rejected or stale is ever hashed**, and an `UNUSABLE` derivation
-  **NEVER touches `settled_strikes`**: a strike is a claim that *trusted* evidence did not move, and
-  `UNUSABLE` is the **absence** of trusted current-head evidence — the two cannot be counted on the same
-  dial. It gets its **own** persisted counter and its **own** bound: "UNUSABLE — the refetch is BOUNDED"
+  about the current PR. **Nothing rejected or stale is ever hashed**, and a not-verified derivation
+  **NEVER touches `settled_strikes`**: a strike is a claim that *trusted* evidence did not move, while
+  both exact verdicts mean trusted current-head evidence was not obtained — the two cannot be counted on
+  the same dial. They share one persisted counter and one bound: "NOT VERIFIED — the refetch is BOUNDED"
   below.
 
 ```
@@ -389,9 +389,9 @@ Two rules the tool enforces that the block's lines cannot show:
   `ci_reason` is the **open question** a human is being asked, and no second park may overwrite it.
 
 Per derivation **with trusted current-head evidence** — `fp` below is **the `fingerprint` field of
-`derive`'s JSON**
-(an `UNUSABLE` one prints `fingerprint: null`, has no `fp` at all, is handled entirely by "UNUSABLE — the
-refetch is BOUNDED" below, and touches **no liveness counter but its own**) — in this order:
+`derive`'s JSON** (an `UNUSABLE` or `UNVERIFIABLE` one prints `fingerprint: null`, has no `fp` at all, is
+handled entirely by "NOT VERIFIED — the refetch is BOUNDED" below, and touches **no liveness counter but
+its own**) — in this order:
 
 ```
 fp != ci_fingerprint      -> ci_fingerprint = fp ; settled_strikes = 0 ; ci_stalled_since = -
@@ -606,7 +606,7 @@ VALUE lives at its own single defining site, named here and never retyped:
 | `ci_fingerprint` | CI is genuinely **MOVING** (the fingerprint CHANGED since the last derivation) | *none — motion is not a wait* | — |
 | `settled_strikes` | CI has **SETTLED** and is still not green | **the STRIKE CAP** | "SETTLED", the derivation block above |
 | `ci_stalled_since` | a row still says **RUNNING** but nothing in the check set moves | **the CI STALL CAP** | "RUNNING-STALL", below |
-| `unusable_refetches` | the final derivation has no trusted current-head evidence | **the REFETCH CAP** | "UNUSABLE — the refetch is BOUNDED", below |
+| `unusable_refetches` | the final derivation has no trusted current-head evidence | **the REFETCH CAP** | "NOT VERIFIED — the refetch is BOUNDED", below |
 
 Each ends by itself — in a bounded number of derivations, or a bounded amount of time — and each ends in
 the **same** place: **ESCALATE** (above), the park a human answers. That is what makes every one of them a
@@ -730,13 +730,14 @@ heartbeat; a scheduler-less host keeps the invocation alive and loops after each
 (`loop-control.md` step 5). **A bound that could only be reached by the event it is waiting for would not
 be a bound at all.**
 
-#### UNUSABLE — the refetch is BOUNDED: `unusable_refetches`, the REFETCH CAP
+#### NOT VERIFIED — the refetch is BOUNDED: `unusable_refetches`, the REFETCH CAP
 
 `UNUSABLE` and `UNVERIFIABLE` are final derivation outcomes with **no trusted current-head evidence** and
 therefore no fingerprint, so `settled_strikes` can say nothing about them — and "refetch until it works" is
-an absorbing state with no exit, which the invariant forbids. They get their own counter, on the same
-shape — **applied by the same `liveness` command** ("THE BOOKKEEPING IS A COMMAND", above), except the
-`head_sha changed` line, which belongs to the sites that write a new head ("THE LIVENESS COUNTERS").
+an absorbing state with no exit, which the invariant forbids. Their exact verdicts remain distinct in
+`derive` and `liveness` output, while they share one counter and bound — **applied by the same `liveness`
+command** ("THE BOOKKEEPING IS A COMMAND", above), except the `head_sha changed` line, which belongs to the
+sites that write a new head ("THE LIVENESS COUNTERS").
 
 This is the machine-checked owner block for that counter:
 
@@ -757,18 +758,19 @@ liveness.refetch_cap = unusable_refetches >= 3
   obtained trusted evidence at all"*, not *"trusted evidence stopped moving"*. Each bound's own question is
   stated at its own defining site, and the owner's table ("THE LIVENESS COUNTERS" above) maps every member
   to that site: **read them there, never restated here.**
-- **The REFETCH CAP is HIGHER than the STRIKE CAP, on purpose.** UNUSABLE is dominated by **transient**
-  causes — a `gh` call failed, the check set changed mid-fetch so a `source` count no longer matches, the
-  snapshot raced a push — and a fresh fetch usually clears them; a SETTLED-but-not-green snapshot is,
-  by construction, **not** transient. The extra headroom buys the transient case free retries, and it
-  still terminates.
-- **The HEARTBEAT is the backoff — never tight-loop inside one.** UNUSABLE gets **no watch** ("WATCH ONLY WHAT
-  CAN MOVE" below), so the next attempt arrives on the scheduled heartbeat, after one bounded wait, or
-  on another task's completion. At most **one** refetch per reconcile.
-- On escalation `ci_reason` names **the VERIFY rule (`ci-derivation-spec.md`) that failed and the line/row that failed it** (not
-  "unusable") — a snapshot campaign could not read once in the REFETCH CAP's worth of consecutive attempts
-  is a real, actionable blocker: a
-  denied read, a wrong-SHA artifact, a fetch that never succeeds.
+- **The REFETCH CAP is HIGHER than the STRIKE CAP, on purpose.** Not-verified outcomes can be
+  **transient**: a `gh` call failed, the check set changed mid-fetch so a `source` count no longer matches,
+  the snapshot raced a push, or a rerun replaced an ambiguous witness identity. A fresh fetch can clear
+  them; a SETTLED-but-not-green snapshot is, by construction, **not** transient. The extra headroom buys
+  the transient case free retries, and it still terminates.
+- **The HEARTBEAT is the backoff — never tight-loop inside one.** Both not-verified verdicts get **no
+  watch** ("WATCH ONLY WHAT CAN MOVE" below), so the next attempt arrives on the scheduled heartbeat,
+  after one bounded wait, or on another task's completion. At most **one** refetch per reconcile.
+- On escalation `ci_reason` names **the actual verdict and refusal reason**: `UNUSABLE` or `UNVERIFIABLE`,
+  plus the VERIFY rule (`ci-derivation-spec.md`) and line/row that refused the snapshot. A snapshot
+  campaign could not trust current-head evidence once in the REFETCH CAP's worth of consecutive attempts
+  is a real, actionable blocker: a denied read, a wrong-SHA artifact, an ambiguous witness identity, or a
+  fetch that never succeeds.
 
 #### WATCH ONLY WHAT CAN MOVE — the relaunch is not free
 
@@ -793,7 +795,7 @@ ranks `UNKNOWN_VALUE` above plain `pending`), yet the park — not a check finis
 | **red** — but some row still `RUNNING` | **YES** — that row can still move; the CI fix runs regardless. |
 | **red** — every row terminal | **NO.** The CI fix moves it, not the watch. |
 | **UNKNOWN_VALUE** | **NO.** The park is the resolution. |
-| **UNUSABLE** | **NO.** Refetch on the **next heartbeat** (the heartbeat *is* the backoff), **bounded by the REFETCH CAP** — then ESCALATE ("UNUSABLE — the refetch is BOUNDED"). |
+| **UNUSABLE** / **UNVERIFIABLE** | **NO.** Preserve the exact verdict, refetch on the **next heartbeat** (the heartbeat *is* the backoff), and bound both through the REFETCH CAP ("NOT VERIFIED — the refetch is BOUNDED"). |
 | **green** | **NO.** |
 
 **NEVER relaunch the watch merely because `ci == pending`.** On a settled PR `gh pr checks --watch`

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -509,8 +509,9 @@ blank reason, a terminal row, and a second park over an open question). The non-
 park missing its `ci_reason` is a question nobody can read. Telling the user is the half that stays with
 the driver. It does **not**
 abort the run or close the PR — the run's other PRs keep going. At **this** park — a CI one — `ci_reason` is
-**the DECIDE reason for this snapshot**: the bullet that matched and the row that made it match, never a
-bare restatement of `ci`. (The field itself is **wider than CI**: it is the durable machine-blocker reason,
+**the exact actionable detail for the matched DECIDE outcome**, never a bare restatement of `ci`. Each
+liveness bound's owning section below defines its diagnostic shape. (The field itself is **wider than CI**:
+it is the durable machine-blocker reason,
 and `stage-3-merge.md`'s merge-precondition parks write it with `ci` **green**. `files-and-ledger.md` owns
 that definition.) A park that cannot name its blocker is not actionable.
 
@@ -521,7 +522,7 @@ too.** A park whose exit event never comes is the same wedge, one level up. So t
 
 - **PROMPTS with the blocker and what campaign already spent on it** — the PR, its `ci_reason`, the
   evidence (the fingerprint that did not change; **how long it has not changed** (`ci_stalled_since` →
-  now) when a `RUNNING` row is what stalled; the row, value, or VERIFY rule that made the bullet match),
+  now) when a `RUNNING` row is what stalled; the exact detail in the matched outcome's diagnostic shape),
   and what was already tried (CI-fix attempts, strikes, refetches). **Never a bare "CI is stuck".**
 - **Asks for exactly ONE of two answers, and names them:**
   - **`retry`** — "I changed something **outside** the PR (re-ran the workflow, registered the missing
@@ -748,6 +749,9 @@ liveness.trusted_current_head_action = unusable_refetches = 0
 liveness.retained_moved_head_artifact = untrusted
 liveness.head_sha_changed_action = reset by ledger accessor
 liveness.refetch_cap = unusable_refetches >= 3
+liveness.refetch_diagnostic = exact verdict + exact derive refusal reason
+liveness.unusable_refusal = snapshot/fetch/head-trust failure; may name VERIFY rule and line/row
+liveness.unverifiable_refusal = witness-identity containment failure; line/row not required
 ```
 
 - **The counter follows the final derivation's trust for the current head, never artifact verification.**
@@ -766,11 +770,11 @@ liveness.refetch_cap = unusable_refetches >= 3
 - **The HEARTBEAT is the backoff — never tight-loop inside one.** Both not-verified verdicts get **no
   watch** ("WATCH ONLY WHAT CAN MOVE" below), so the next attempt arrives on the scheduled heartbeat,
   after one bounded wait, or on another task's completion. At most **one** refetch per reconcile.
-- On escalation `ci_reason` names **the actual verdict and refusal reason**: `UNUSABLE` or `UNVERIFIABLE`,
-  plus the VERIFY rule (`ci-derivation-spec.md`) and line/row that refused the snapshot. A snapshot
-  campaign could not trust current-head evidence once in the REFETCH CAP's worth of consecutive attempts
-  is a real, actionable blocker: a denied read, a wrong-SHA artifact, an ambiguous witness identity, or a
-  fetch that never succeeds.
+- On escalation `ci_reason` preserves **the exact verdict and exact `derive` refusal reason**. An
+  `UNUSABLE` refusal reports the snapshot, fetch, or head-trust failure and may name a VERIFY rule
+  (`ci-derivation-spec.md`) with its offending line/row. An `UNVERIFIABLE` refusal reports the
+  witness-identity containment failure; it may identify a missing or duplicate witness without any
+  line/row. Reaching the REFETCH CAP without trusted current-head evidence is an actionable blocker.
 
 #### WATCH ONLY WHAT CAN MOVE — the relaunch is not free
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -855,24 +855,26 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
          (True, "awaiting-user", True),
          (out["escalated"], r["status"], "STALL CAP" in r["ci_reason"]))
 
-    # UNUSABLE/UNVERIFIABLE: their own counter and cap. Only a trusted current-head result resets it.
+    # NOT VERIFIED: UNUSABLE and UNVERIFIABLE keep their exact verdicts while sharing one neutral
+    # liveness state, one persisted counter, and one cap. Only a trusted current-head result resets it.
     reset()
-    for expect in ("1", "2"):
-        out = ci.liveness(ledger, "35", derived(verdict="unusable"), "none", now)
-        case(f"unusable refetch {expect} does not escalate", (expect, False),
-             (row()["unusable_refetches"], out["escalated"]))
     out = ci.liveness(ledger, "35", derived(verdict="unusable"), "none", now)
+    case("UNUSABLE enters the neutral liveness class without losing its verdict",
+         ("not-verified", "unusable", "1", False),
+         (out["state"], out["verdict"], row()["unusable_refetches"], out["escalated"]))
+    out = ci.liveness(ledger, "35", derived(verdict="unverifiable"), "none", now)
+    case("UNVERIFIABLE shares the counter without losing its verdict",
+         ("not-verified", "unverifiable", "2", False),
+         (out["state"], out["verdict"], row()["unusable_refetches"], out["escalated"]))
+    out = ci.liveness(ledger, "35", derived(verdict="unverifiable"), "none", now)
     r = row()
-    case("the REFETCH CAP escalates",
-         (True, "3", True), (out["escalated"], r["unusable_refetches"], "REFETCH CAP" in r["ci_reason"]))
+    case("UNVERIFIABLE at the REFETCH CAP names the exact verdict",
+         ("not-verified", "unverifiable", True, "3", True),
+         (out["state"], out["verdict"], out["escalated"], r["unusable_refetches"],
+          "UNVERIFIABLE at the REFETCH CAP" in r["ci_reason"]))
     reset(unusable_refetches="2")
     out = ci.liveness(ledger, "35", derived(), "none", now)
     case("trusted current-head evidence resets the refetch counter", "0", row()["unusable_refetches"])
-
-    reset()
-    out = ci.liveness(ledger, "35", derived(verdict="unverifiable"), "none", now)
-    case("an unverifiable derivation increments the refetch counter",
-         ("unusable", "1"), (out["state"], row()["unusable_refetches"]))
 
     # The cross-step case a synthesized liveness result cannot prove: derive retains a verified artifact
     # for the requested head, then the moved-head override makes the final result untrusted. Liveness must
@@ -890,7 +892,7 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
     r = row()
     moved_snapshot = Path(moved["snapshot"]) if moved["snapshot"] is not None else None
     case("a retained moved-head artifact reaches the refetch cap without changing bytes",
-         (True, True, None, None, "unusable",
+         (True, True, None, None, "not-verified",
           [("1", False, moved_artifacts), ("2", False, moved_artifacts),
            ("3", True, moved_artifacts)]),
          (moved["head_moved"], moved_snapshot is not None and moved_snapshot.is_file(),
@@ -957,6 +959,8 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
           derived(verdict="green", ci_value="green", running=0), ci_fingerprint=fp1)
     watch("an unusable derivation warrants no watch — no trusted current-head evidence",
           False, "no trusted current-head evidence", derived(verdict="unusable"))
+    watch("an unverifiable derivation warrants no watch — no trusted current-head evidence",
+          False, "no trusted current-head evidence", derived(verdict="unverifiable"))
     # THE COUNTEREXAMPLE the exclusion exists for: `decide()` ranks UNKNOWN_VALUE above plain `pending`,
     # so an UNCLASSIFIED verdict can carry a still-RUNNING row (buckets RUNNING>0 AND UNKNOWN_VALUE>0). A
     # bare RUNNING>0 reading would warrant a watch; the park is the resolution, so watch_warranted is
@@ -969,6 +973,21 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
     watch("a held row with a RUNNING row still warrants a watch", True, "still RUNNING",
           derived(running=1), status="awaiting-user", ci_reason="the open question", ci_fingerprint=fp1)
 
+    return problems
+
+
+def verdict_doc_cases(ci) -> list[str]:
+    """Pin both no-fingerprint verdicts in the DECIDE doc order independently of `doc-check`."""
+    problems: list[str] = []
+    order = ci.parse_decide_order(ci.SPEC_DOC.read_text(encoding="utf-8"))
+    if order != ci.DECIDE_ORDER:
+        problems.append(f"[verdict docs] parsed DECIDE order {order!r}, expected {ci.DECIDE_ORDER!r}")
+    got = tuple(name for name in order if name in ci.NOT_VERIFIED_DECIDE_NAMES)
+    if got != ci.NOT_VERIFIED_DECIDE_NAMES:
+        problems.append(
+            f"[verdict docs] not-verified outcomes are {got!r}, expected "
+            f"{ci.NOT_VERIFIED_DECIDE_NAMES!r}"
+        )
     return problems
 
 
@@ -1019,8 +1038,16 @@ def run(ci, tmp: Path) -> int:
     if not liveness_problems:
         print(f"ok       {'liveness bookkeeping':32} -> every transition of the derivation block: strikes "
               f"to the cap, the stall clock, the refetch cap, machine-action stop, held observation, "
-              f"stale-head refusal, retained moved-head artifact, and the watch_warranted reduction "
-              f"(incl. the UNCLASSIFIED exclusion)")
+              f"both exact not-verified verdicts, stale-head refusal, retained moved-head artifact, and "
+              f"the watch_warranted reduction (incl. the UNCLASSIFIED exclusion)")
+
+    verdict_doc_problems = verdict_doc_cases(ci)
+    for problem in verdict_doc_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not verdict_doc_problems:
+        print(f"ok       {'DECIDE verdict terminology':32} -> UNUSABLE and UNVERIFIABLE both remain explicit "
+              f"before liveness groups them")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -872,6 +872,38 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
          ("not-verified", "unverifiable", True, "3", True),
          (out["state"], out["verdict"], out["escalated"], r["unusable_refetches"],
           "UNVERIFIABLE at the REFETCH CAP" in r["ci_reason"]))
+
+    # Reach the same cap from the checked-in witness-identity fixture, not a synthesized reason. This
+    # refusal identifies the duplicated witness and containment failure, but has no VERIFY rule or row.
+    duplicate_path = (ci.SNAPSHOT_PY.parent / "fixtures" / "ci-snapshot"
+                      / "duplicate-witness-id.jsonl")
+    duplicate_verdict, duplicate_refusal = ci.SNAP.evaluate(
+        duplicate_path, sha, required=ci.SNAP.NO_REQUIRED, expect_filename_sha=False
+    )
+    duplicate_derived = ci.derive_output({
+        "head_sha": sha,
+        "verdict": duplicate_verdict,
+        "ci": "pending",
+        "reason": duplicate_refusal,
+        "fingerprint": None,
+        "buckets": None,
+    })
+    reset(unusable_refetches="2")
+    out = ci.liveness(ledger, "35", duplicate_derived, "none", now)
+    r = row()
+    expected_refusal = (
+        "witness identity is not unique "
+        "(https://github.com/lestrrat-ai/claude-code-plugins/actions/runs/29263565055/job/1) "
+        "— containment cannot be proven"
+    )
+    expected_cap_reason = (
+        f"UNVERIFIABLE at the REFETCH CAP — 3 consecutive not-verified derivations at head {sha} "
+        f"yielded no trusted current-head evidence. Last refusal: {expected_refusal}"
+    )
+    case("witness-identity refusal reaches the cap without invented row detail",
+         ("unverifiable", expected_refusal, True, "awaiting-user", expected_cap_reason),
+         (duplicate_verdict, duplicate_refusal, out["escalated"], r["status"], r["ci_reason"]))
+
     reset(unusable_refetches="2")
     out = ci.liveness(ledger, "35", derived(), "none", now)
     case("trusted current-head evidence resets the refetch counter", "0", row()["unusable_refetches"])

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -242,7 +242,7 @@ BUCKET_KEYS = {PASS: "PASS", RUNNING: "RUNNING", FAIL: "FAIL", UNKNOWN_VALUE: "U
 # --- the liveness caps -----------------------------------------------------------------------------
 #
 # Each VALUE's one defining site is `stage-2-ci.md` — "SETTLED" (the derivation block) for the STRIKE CAP,
-# "UNUSABLE — the refetch is BOUNDED" for the REFETCH CAP, "THE CI STALL CAP = 6h" for the stall bound —
+# "NOT VERIFIED — the refetch is BOUNDED" for the REFETCH CAP, "THE CI STALL CAP = 6h" for the stall bound —
 # and `doc-check` compares these constants against those sites, so the doc and the tool cannot drift.
 # `liveness()` below is what fires them.
 STRIKE_CAP = 2
@@ -303,8 +303,8 @@ def bucket_counts(rows: list[dict]) -> dict[str, int]:
 # field is how "unusable" and "an enum value nobody has ever classified" would come to be recorded as the
 # same bland `pending` and lose the thing that made them worth escalating.
 #
-# EVERY NON-GREEN, NON-RED OUTCOME IS `pending`, and the doc says so outcome by outcome: UNUSABLE ->
-# "`ci = pending`, refetch"; containment unprovable -> "`ci = pending`"; UNKNOWN_VALUE -> escalate, and an
+# EVERY NON-GREEN, NON-RED OUTCOME IS `pending`, and the doc says so outcome by outcome: UNUSABLE /
+# UNVERIFIABLE -> "`ci = pending`, refetch"; UNKNOWN_VALUE -> escalate, and an
 # unrecognised value is by definition neither a pass nor a failure, so of the three legal column values only
 # `pending` is left. NEVER let an unmapped verdict fall through to a default here: an outcome this table does
 # not name is one nobody has thought about, and guessing `pending` for it is the same "close enough" that
@@ -318,20 +318,25 @@ LEDGER_CI = {
     SNAP.UNCLASSIFIED: "pending",
 }
 
+# These two exact derivation verdicts share one LIVENESS class because neither is trusted for the PR's
+# current head. They remain distinct in every derive/liveness JSON result and in a cap's diagnostic.
+NOT_VERIFIED_VERDICTS = (SNAP.UNUSABLE, SNAP.UNVERIFIABLE)
+NOT_VERIFIED_DECIDE_NAMES = tuple(verdict.upper() for verdict in NOT_VERIFIED_VERDICTS)
+
 
 def ledger_ci(verdict: str) -> str | None:
     """The ledger column this verdict maps to — or None, which `result()` refuses rather than guesses."""
     return LEDGER_CI.get(verdict)
 
 
-# The DECIDE order, as a NAME PER BULLET, in the order `ci-derivation-spec.md` evaluates them. This is a THIRD
-# statement of an order that is already owned twice (the doc's bullets; `ci-snapshot.decide()`'s branches),
+# The DECIDE order, as a NAME PER BULLET, in the order `ci-derivation-spec.md` evaluates them. This is a
+# THIRD statement of an order that is already owned twice (the doc's bullets; `ci-snapshot.evaluate()` /
+# `decide()`),
 # and it is only allowed to exist because it is MECHANICALLY CHECKED AGAINST BOTH:
 #
 #   * against the DOC, textually — `doc-check` parses the DECIDE bullets and asserts this exact sequence;
-#   * against the CODE, BEHAVIOURALLY — the `*-outranks-*` fixtures drive real evidence through the real
-#     `ci-snapshot.decide()` and assert the precedence holds at run time, which no amount of reading either
-#     copy could establish.
+#   * against the CODE, BEHAVIOURALLY — snapshot fixtures pin both refusal verdicts exactly, while the
+#     `*-outranks-*` fixtures drive real evidence through `decide()` and assert its branch precedence.
 #
 # A copy that is checked against both owners is a PIVOT. A copy that is merely written down beside them is
 # the stale restatement this repo keeps killing. Delete either check and this becomes the latter.
@@ -340,8 +345,10 @@ def ledger_ci(verdict: str) -> str | None:
 # the questions no ROW can answer, so they are asked once every row has already passed. `required-set-unreadable.json`
 # and `required-check-absent.json` drive them behaviourally; this line is what pins that the DOC still
 # evaluates them in that order.
-DECIDE_ORDER = ("UNUSABLE", "red", "UNKNOWN_VALUE", "pending", "pending (nothing registered)",
-                "pending (required set unreadable)", "pending (required check missing)", "green")
+DECIDE_ORDER = (
+    "UNUSABLE", "UNVERIFIABLE", "red", "UNKNOWN_VALUE", "pending", "pending (nothing registered)",
+    "pending (required set unreadable)", "pending (required check missing)", "green",
+)
 
 
 class FetchError(Exception):
@@ -1564,7 +1571,7 @@ def derive(fetch: Fetch, repo: str, pr: str, head_sha: str, rundir: Path, requir
     # come off the PROMOTED ARTIFACT, like the verdict — never from the dicts still in memory.
     fp = None
     buckets = None
-    if verdict not in (SNAP.UNUSABLE, SNAP.UNVERIFIABLE):
+    if verdict not in NOT_VERIFIED_VERDICTS:
         trusted = SNAP.parse(path)
         fp = SNAP.fingerprint(trusted, head_sha)
         buckets = bucket_counts(trusted)
@@ -1617,7 +1624,7 @@ def result(pr: str, head_sha: str, verdict: str, reason: str, path: Path | None,
         # exactly when the final derivation has no trusted evidence for the PR's current head (fetch failed,
         # unusable, unverifiable, or head moved). A moved-head artifact can remain on disk for audit, but
         # stale evidence has no fingerprint. A derivation that got none touches no liveness counter but
-        # `unusable_refetches`.
+        # `unusable_refetches`. That persisted field counts both exact not-verified verdicts.
         "fingerprint": fingerprint,
         # THE CLASSIFY TALLY of the trusted current-head evidence rows —
         # {"PASS","RUNNING","FAIL","UNKNOWN_VALUE"},
@@ -1635,7 +1642,7 @@ def result(pr: str, head_sha: str, verdict: str, reason: str, path: Path | None,
     }
 
 
-# --- liveness: the SETTLED / RUNNING-STALL / UNUSABLE bookkeeping, as a command -------------------
+# --- liveness: the SETTLED / RUNNING-STALL / NOT-VERIFIED bookkeeping, as a command ----------------
 
 MACHINE_ACTIONS = ("due", "in-flight", "none")
 LEDGER_CI_VALUES = ("green", "red", "pending")
@@ -1673,7 +1680,7 @@ def derive_output(raw: object) -> dict:
     if out["ci"] not in LEDGER_CI_VALUES:
         fail(f"liveness: derive JSON `ci` is {out['ci']!r}, not one of {'/'.join(LEDGER_CI_VALUES)}")
     fp, buckets = raw.get("fingerprint"), raw.get("buckets")
-    trusted_current_head = out["verdict"] not in (SNAP.UNUSABLE, SNAP.UNVERIFIABLE)
+    trusted_current_head = out["verdict"] not in NOT_VERIFIED_VERDICTS
     if trusted_current_head:
         if not isinstance(fp, str) or not re.fullmatch(r"[0-9a-f]{64}", fp):
             fail(f"liveness: a derivation with trusted current-head evidence must carry a 64-hex "
@@ -1693,7 +1700,7 @@ def derive_output(raw: object) -> dict:
 def liveness(ledger_path: Path, pr: str, derived: dict, machine_action: str, now: datetime) -> dict:
     """Apply the liveness rules to one derivation and write the row — ONE atomic row update.
 
-    THE SPEC IS THE DERIVATION BLOCK IN `stage-2-ci.md` ("SETTLED", "RUNNING-STALL", "UNUSABLE — the
+    THE SPEC IS THE DERIVATION BLOCK IN `stage-2-ci.md` ("SETTLED", "RUNNING-STALL", "NOT VERIFIED — the
     refetch is BOUNDED"). What stays the CALLER's: `--machine-action` — "is work that can move this PR's
     `head_sha` due or in flight?" is a property judgment about the run's dispatch state, which no ledger
     field records; the caller asserts it, this command does every piece of arithmetic that follows from it.
@@ -1734,9 +1741,10 @@ def liveness(ledger_path: Path, pr: str, derived: dict, machine_action: str, now
     elif not derived["trusted_current_head"]:
         refetches = LEDGER.counter(row, "unusable_refetches") + 1
         put("unusable_refetches", refetches)
-        state = "unusable"
+        state = "not-verified"
         if refetches >= REFETCH_CAP:
-            escalate_reason = (f"UNUSABLE at the REFETCH CAP — {refetches} consecutive derivations at "
+            escalate_reason = (f"{derived['verdict'].upper()} at the REFETCH CAP — {refetches} "
+                               f"consecutive not-verified derivations at "
                                f"head {row['head_sha']} yielded no trusted current-head evidence. "
                                f"Last refusal: "
                                f"{derived['reason']}")
@@ -1836,7 +1844,7 @@ def liveness(ledger_path: Path, pr: str, derived: dict, machine_action: str, now
         "head_sha": row["head_sha"],
         "ci": derived["ci"],
         "verdict": derived["verdict"],
-        "state": state,             # moving | settled | running-stall | machine-action | unusable | held
+        "state": state,             # moving | settled | running-stall | machine-action | not-verified | held
         "held": held,
         "machine_action": machine_action,
         "wrote": wrote,             # exactly the fields this call changed, with the values written
@@ -2384,6 +2392,10 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          enums.get("CheckStatusState"), "the doc and the script's own comment disagree"),
         ("DECIDE order", order, DECIDE_ORDER,
          "the doc evaluates the bullets in a different order than this tool pins"),
+        ("DECIDE not-verified outcomes",
+         tuple(name for name in order if name in NOT_VERIFIED_DECIDE_NAMES),
+         NOT_VERIFIED_DECIDE_NAMES,
+         "the doc must name both exact no-fingerprint verdicts before liveness groups them"),
         ("FINGERPRINT line: checkrun", fp_spec.get("checkrun"), SNAP.FINGERPRINT_FIELDS["checkrun"],
          "the doc's canonical line and the hash `derive` emits disagree — every driver comparing "
          "`fingerprint` against `ci_fingerprint` would see motion that never happened, or none that did"),
@@ -2585,7 +2597,7 @@ def main() -> int:
 
     lv = sub.add_parser(
         "liveness",
-        help="apply the SETTLED/RUNNING-STALL/UNUSABLE liveness rules to one derive result: update the "
+        help="apply the SETTLED/RUNNING-STALL/NOT-VERIFIED liveness rules to one derive result: update the "
              "row's counters through the ledger accessor, and escalate (park) at a cap",
     )
     lv.add_argument("--ledger", required=True, type=Path, help="the run's state.jsonl")
@@ -2662,8 +2674,9 @@ def main() -> int:
 
     out = derive(gh_fetch, repo, args.pr, args.head_sha, args.rundir, required)
     print(json.dumps(out, indent=2, ensure_ascii=False))
-    # green is the ONLY exit-0 verdict. Everything else — pending, red, unusable, an unclassified value —
-    # is NOT a green, and a caller that checks only the exit status must never be told otherwise.
+    # green is the ONLY exit-0 verdict. Everything else — pending, red, either not-verified verdict, an
+    # unclassified value — is NOT a green, and a caller that checks only the exit status must never be told
+    # otherwise.
     return 0 if out["verdict"] == SNAP.GREEN else 1
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2037,10 +2037,11 @@ def parse_moved_head_contract(blocks: list[str]) -> dict[str, str]:
 
 
 def parse_liveness_contract(blocks: list[str]) -> dict[str, str]:
-    """The refetch-counter owner block -> final-result trust, actions, head reset, and cap expression."""
+    """The refetch-counter owner block -> trust, actions, cap, and diagnostic shape."""
     keys = {
         "untrusted_verdicts", "untrusted_action", "trusted_current_head_action",
         "retained_moved_head_artifact", "head_sha_changed_action", "refetch_cap",
+        "refetch_diagnostic", "unusable_refusal", "unverifiable_refusal",
     }
     for block in blocks:
         if "liveness.untrusted_verdicts" not in block:
@@ -2431,6 +2432,15 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
         ("liveness refetch-cap expression", liveness_contract.get("refetch_cap"),
          f"unusable_refetches >= {REFETCH_CAP}",
          "the owner block and the refetch cap used by liveness must agree"),
+        ("liveness refetch diagnostic", liveness_contract.get("refetch_diagnostic"),
+         "exact verdict + exact derive refusal reason",
+         "the cap diagnostic must preserve both fields from the final not-verified derivation"),
+        ("liveness UNUSABLE refusal", liveness_contract.get("unusable_refusal"),
+         "snapshot/fetch/head-trust failure; may name VERIFY rule and line/row",
+         "UNUSABLE structural details may identify an offending row, but do not require one"),
+        ("liveness UNVERIFIABLE refusal", liveness_contract.get("unverifiable_refusal"),
+         "witness-identity containment failure; line/row not required",
+         "witness identity can prevent containment proof without identifying an evidence row"),
         ("the STRIKE CAP", caps.get("STRIKE"), STRIKE_CAP,
          "the bound `liveness` fires at and the bound the doc promises are different numbers"),
         ("the REFETCH CAP", caps.get("REFETCH"), REFETCH_CAP,

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -137,13 +137,13 @@ ROW_FIELDS = (
     "id", "slug", "branch", "worktree", "worktree_owned", "branch_owned", "pr",
     "head_sha", "reviews_ok", "ci", "tier", "attempts", "started",
     "api_approval", "status",
-    # Liveness (stage-2-ci.md, "SETTLED" and "UNUSABLE — the refetch is BOUNDED"). A non-green `ci` is
+    # Liveness (stage-2-ci.md, "SETTLED" and "NOT VERIFIED — the refetch is BOUNDED"). A non-green `ci` is
     # not enough to know whether CI is still MOVING or has STOPPED — these carry that, and they must
     # survive a context loss (a heartbeat may be a fresh agent instance), so they live on disk and not in the
     # driver's head. A counter that dies with the context never reaches its cap.
     "ci_fingerprint",     # digest of last trusted current-head evidence; unchanged + nothing running = SETTLED
     "settled_strikes",    # consecutive derivations seen SETTLED-but-not-green; at the cap -> escalate
-    "unusable_refetches", # consecutive untrusted final derivations (no fingerprint); at the cap -> escalate
+    "unusable_refetches", # consecutive not-verified final derivations; at the cap -> escalate
     # UNCHANGED + a row still RUNNING == RUNNING-STALL: something CLAIMS it can still move, and nothing in
     # the check set has. A TIMESTAMP, not a tally, and that is the point: SLOW and DEAD look identical on a
     # fingerprint, and derivations are driven by heartbeats whose cadence tracks the RUN'S LOAD, not this PR's


### PR DESCRIPTION
- preserve exact `unusable` and `unverifiable` derivation verdicts under neutral liveness reporting
- count both not-verified outcomes through the existing retry field and cap without changing gate decisions
- align DECIDE, watch, ledger docs and tests with the shared liveness class
