### PR TITLE
fix run-end non-goals report scope

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -144,13 +144,9 @@ When the loop exits, summarize:
   author's, and a wrong one silently **narrows** a review. It is a real cost and it is disclosed here rather
   than buried; a `stated@…` intent's **base sections** came from the PR body and need no flag (the managed
   run-default block is folded in mechanically either way, so `stated@` is not "wholly verbatim").
-- **The run's default Non-goals** — when `default_non_goals` is non-empty, state them explicitly. The
-  defaults **in force** are folded into each adopted PR's managed block at adoption/sync — both `stated@`
-  and `authored@` intents alike — so they narrow every review measured against a synced intent. A mid-run
-  change that **BROADENS** scope (drops a default) is **refused while any non-terminal PR still holds review
-  credit** (`files-and-ledger.md`, "default_non_goals"), so a banked SATISFIED can never outlive the
-  narrower scope it was earned under. Disclose the defaults in force here beside the per-PR `authored` flag,
-  never left implicit.
+- **Run-end default Non-goals snapshot** — **ALWAYS emit** the current terminal-ledger
+  `default_non_goals`. List each value; spell an empty array as `none`. Append this exact caveat:
+  `Run-end snapshot only. Defaults may have changed mid-run. This is not per-PR or per-pass history.`
 - **Merged** — PR number + slug, one-line description, tier, and the **base it merged into** (its
   `effective_base`), so a mixed-base run shows which release line each PR shipped to.
 - **Residual risk** — for each merged PR, each accepting SATISFIED pass's `RESIDUAL-RISK` line (the

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1118,7 +1118,8 @@ def t_default_non_goals_broadening_guard(L: ModuleType, tmp: Path) -> None:
     """A `default_non_goals` change that BROADENS scope (removes/shrinks a default) is REFUSED while any
     non-terminal PR still holds banked review credit (`reviews_ok > 0`) — the false-permissive-merge guard.
     A narrowing change (an ADD) is always allowed; a broadening change is allowed once no active row holds
-    credit (its crediting rows are at 0, or terminal)."""
+    credit (its crediting rows are at 0, or terminal). The final report therefore labels the header value
+    as a run-end snapshot, not historical scope."""
     def ledger(name: str, *rows: str) -> Path:
         return write_lines(tmp / name,
                            header_line(L, run_id="r", default_non_goals=json.dumps(["D", "E"])), *rows)
@@ -1146,6 +1147,19 @@ def t_default_non_goals_broadening_guard(L: ModuleType, tmp: Path) -> None:
         check(code == 0, f"a broadening change was refused with only {why}: {err!r}")
         code, out, _ = cli(L, ["--file", str(p), "header", "get", "default_non_goals"])
         check(out == '["E"]\n', f"the broadening change did not land with only {why}: {out!r}")
+
+    # The terminal-row allowance above means the final header can differ from a merged PR's dispatch-time
+    # scope. Pin the report contract beside the behavior that requires it: always emit the run-end value,
+    # spell empty explicitly, and never present the snapshot as per-PR or per-pass history.
+    report_path = HERE.parent / "references" / "bailout-and-final-report.md"
+    report_contract = """
+    - **Run-end default Non-goals snapshot** — **ALWAYS emit** the current terminal-ledger
+    `default_non_goals`. List each value; spell an empty array as `none`. Append this exact caveat:
+    `Run-end snapshot only. Defaults may have changed mid-run. This is not per-PR or per-pass history.`
+    """
+    report_text = report_path.read_text(encoding="utf-8")
+    check(" ".join(report_contract.split()) in " ".join(report_text.split()),
+          f"the final-report run-end default Non-goals contract drifted: {report_path}")
 
 
 def t_values_are_strings(L: ModuleType, tmp: Path) -> None:


### PR DESCRIPTION
- report default Non-goals as an always-emitted run-end snapshot with an explicit history caveat
- pin the report contract beside active-credit refusal and terminal-row allowance
- validate ledger fixtures, Python checks, and both isolated plugin install paths
