### PR TITLE
fix gauntlet repair-history parking

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -184,9 +184,10 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 18. Any campaign commit is PR content: it resets the gate, re-triages the tier, and is re-reviewed on
     the new SHA.
 19. At a review-loop cap -> `repair-pass.py bundle` / `decide`: STOP dispatching targeted fixes — a cap
-    is a **mode switch, not a doorbell**. Build and dispatch the exact reassessment bundle, then execute
-    its bundle-bound decision without asking the user (`references/repair-pass.md`). The tool derives and
-    enforces the permitted decision set from PR ownership and remaining repair budget.
+    is a **mode switch, not a doorbell**. Build the exact reassessment bundle. If it names unreconcilable
+    capped history and directs a park, use `references/repair-pass.md`, **Unreconcilable capped history**;
+    otherwise dispatch it and execute its bundle-bound decision without asking the user. The tool derives
+    and enforces the permitted decision set from PR ownership and remaining repair budget.
 
 **CI — stage 2b** (`references/stage-2-ci.md`)
 
@@ -209,7 +210,8 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 
 23. A HELD PR is FROZEN — take no action that MUTATES it. Two kinds: **parked** (`awaiting-user` /
     `awaiting-api` — waits on a HUMAN) and **`repairing`** (waits on the reassessment pass, which is
-    machine work due NOW). The test is "does this mutate the PR?", **not** "is it on a list";
+    machine work due NOW; its unreconcilable-history exception is in `repair-pass.md`). The test is "does
+    this mutate the PR?", **not** "is it on a list";
     `HELD_STATUSES` in `scripts/ledger.py` is the one enumeration — never retype it. Sole exception:
     the CI watch — observing is not mutating, so it follows the normal policy. Keep driving the other
     PRs. Unpark only on the user's answer, recorded DURABLY per park class; a ruling is durable and

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -98,10 +98,11 @@ LOCAL state against that same PR / its head; the PR itself is left in place.
   What replaces it is a **counter with a cap**, on disk, evaluated by the tool that records the verdict:
   `ledger.py verdict` bumps `review_rounds` / `ns_streak`, and at a cap it sets `status = repairing` and
   **exits non-zero**. The driver runs `repair-pass.md`, **"Build the complete reassessment bundle"**, and
-  dispatches its exact prompt to a context-isolated reassessment worker. The driver executes the returned
-  bundle-bound decision **without asking the user**. **A cap is a MODE SWITCH, not a doorbell.** The
-  root-cause pass remains available through the closed decision set rather than through an unevaluable
-  history rule.
+  dispatches its exact prompt to a context-isolated reassessment worker. A bundle that names
+  unreconcilable capped history and directs a park follows **"Unreconcilable capped history"** there;
+  otherwise the driver executes the returned bundle-bound decision without asking the user. **A cap is a
+  MODE SWITCH, not a doorbell.** The root-cause pass remains available through the closed decision set
+  rather than through an unevaluable history rule.
 
   **ABORT is the only decision that ends the PR, and it lands on the procedure below** (leave the PR OPEN,
   drop this run's labels, write `abort-<id>.md`) — reused, not reinvented. A **second failed repair**
@@ -161,11 +162,14 @@ When the loop exits, summarize:
   unobserved. **NEVER report `unknown` as "no required checks"**: it means campaign **could not read** them
   **for that base**, nothing merged on it, and any PR that reached it **escalated** — say which base's read
   failed, so the user can fix the access rather than wonder why those PRs stalled.
-- **Repaired** — every PR that reached a review-loop cap: its `review_rounds`, the decision the
-  reassessment pass returned, and a pointer to `repair-<pr>-<k>.md` (`repair-pass.md`). For a legacy
+- **Repaired** — every PR that reached a review-loop cap and recorded a reassessment decision: its
+  `review_rounds`, the decision, and a pointer to `repair-<pr>-<k>.md` (`repair-pass.md`). For a legacy
   `demote@…` row, **report each demoted finding explicitly** — they are true findings that were deliberately
   **not fixed**, and burying that is how a report becomes a false claim of cleanliness. This is the run
   telling the user, in the one place they will read, that it stopped whacking moles and what it did instead.
+- **Blocked reassessment history** — every capped PR whose bundle entered the machine-blocker park before
+  recording a decision: the durable `ci_reason` and the `awaiting-user` action. `repair-pass.md`,
+  **Unreconcilable capped history**, owns the transition.
 - **Aborted** — PR number + slug, why, pointer to `abort-<id>.md`.
 - **Skipped (API-declined)** — any PR whose API-changing fix the user was asked about and declined,
   with the change each would have needed.

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -19,9 +19,12 @@ LOCAL state against that same PR / its head; the PR itself is left in place.
   - **a REPAIR — `status == repairing`** (`repair-pass.md`). The PR has reached a review-loop cap and is
     being reassessed and repaired. It is **bounded by `repair_count`/`REPAIR_CAP`**, and its exit is
     **declared**: the reassessment's decision, and — at the cap — **ABORT**, which lands on this very
-    procedure. **Firing the 1-hour cap here would PRE-EMPT the repair the cap exists to reach**, aborting a
+    procedure. The third exit is an unreconcilable-history machine-blocker park before a decision, when
+    `bundle` directs it; `repair-pass.md`, **Unreconcilable capped history**, owns that `awaiting-user`
+    transition. **Firing the 1-hour cap here would PRE-EMPT the repair the cap exists to reach**, aborting a
     PR that the mechanism was in the middle of saving — the same mistake as firing it inside a live CI
-    liveness bound, for the same reason. A repairing PR always terminates: it repairs, or it aborts.
+    liveness bound, for the same reason. A repairing PR exits by a decision, ABORT, or that machine-blocker
+    park.
   - **a LIVE Stage 2 CI LIVENESS BOUND, still below its cap.** **Read the bounds from their owner —
     `stage-2-ci.md`, "THE LIVENESS COUNTERS", which is the ONE enumeration of the bounded CI waits and
     names each one's cap. NEVER re-list them here, and NEVER key this exemption on a `ci` value.** A bound

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -253,9 +253,9 @@
 - **A HELD PR IS FROZEN — TAKE NO ACTION THAT MUTATES IT. ASK THE TOOL: `ledger.py … dispatch-check --pr
   <N>` exits non-zero.** A PR is **HELD** when it is **parked on a HUMAN** (`status = awaiting-user`, a
   standoff; `awaiting-api`, API approval) **or `repairing`** — it reached a review-loop cap, has stopped
-  converging, and is being reassessed and repaired (`repair-pass.md`; **that one waits on no human — do
-  NOT prompt the user**). `HELD_STATUSES` in `scripts/ledger.py` is the **one** enumeration; never retype
-  it. The test is **"does this MUTATE the
+  converging, and is normally reassessed and repaired without a human. `repair-pass.md`,
+  **Unreconcilable capped history**, owns the narrow machine-blocker exception. `HELD_STATUSES` in
+  `scripts/ledger.py` is the **one** enumeration; never retype it. The test is **"does this MUTATE the
   PR?"** — **not** "is this action named in a list", because an enumeration will miss a site (it did:
   the guard once named four dispatch sites and missed `stage-3-merge.md` step 6's post-merge rebase).
   **NEVER** launch a review pass, a CI fix, a review fix, or a merge for it; **NEVER** rebase it,
@@ -369,8 +369,9 @@
 - **A PR THAT STOPS CONVERGING IS REPAIRED, NOT PROMPTED.** At a review-loop cap `ledger.py verdict` sets
   `status = repairing` and **exits non-zero**: dispatch **no** further targeted fix and **no** further
   review pass. Run `repair-pass.md`, **"Build the complete reassessment bundle"**, dispatch its exact
-  prompt to the reassessment worker, and execute its bundle-bound decision **without asking the user**.
-  **A cap is a MODE SWITCH, not a doorbell.**
+  prompt to the reassessment worker, and execute its bundle-bound decision. A bundle that explicitly names
+  unreconcilable history and directs a park follows **"Unreconcilable capped history"** there. **A cap is a
+  MODE SWITCH, not a doorbell.**
 - **AUTONOMOUS REPAIR NEVER REWRITES A PR CAMPAIGN DOES NOT OWN.** On a PR with `pr_origin = external` —
   the user's, a teammate's, any PR adopted by number, **and the DEFAULT** — the permitted decisions are
   **only REPAIR-INTENT / ABORT**. RESCOPE and ROOT-CAUSE reshape branch content wholesale, and

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -439,11 +439,13 @@
   the review gate's own reset rules are owned by `stage-2-review-gate.md`, "Status labels mirror the
   review gate". Neither is restated here.
 - **A `blocker_ruling` is DURABLE *and* SPENT EXACTLY ONCE** (`stage-2-ci.md`, "THE RULING IS CONSUMED
-  EXACTLY ONCE"): set to `-` when a machine-blocker park is **ENTERED** and when a `retry` is **CONSUMED**,
-  each in the same `ledger.py … set` call as the `status` write. A ruling left on the row answers the
-  **next** park too — the blocker silently self-clears with **no fresh user answer**, which is exactly what
-  the durable record exists to prevent. `abort` is never cleared: it is terminal, and a terminal row is
-  never re-parked.
+  EXACTLY ONCE"): enter every machine-blocker park through `ledger.py … park --pr <N> --reason "<blocker>"`;
+  it atomically clears the ruling. Consume a `retry` through the matching `ledger.py … unpark` transition
+  (`files-and-ledger.md`, "`park`/`unpark` are the sanctioned writers of the machine-blocker park/unpark
+  TRANSITIONS"). Use `set` only to record the user's ruling; the separate review-standoff path also owns its
+  `set` transition (`finding-audit.md`). A ruling left on the row answers the **next** park too — the blocker
+  silently self-clears with **no fresh user answer**, which is exactly what the durable record exists to
+  prevent. `abort` is never cleared: it is terminal, and a terminal row is never re-parked.
 - **The three materializer roles — both CI tiers and review-fix — use the fix-subagent materializer.** Follow
   `fix-subagent-contract.md`; never rebuild its shared contract or role block from this lookup. The
   follow-up fixer that opens a new PR is a separate workflow it names, outside these roles.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -516,10 +516,10 @@ Header field notes (the header fields above; per-row fields follow):
      below — and `loop-control.md` step 3, "Only the user's answer unparks a PR", owns the mapping.
   2. **`repairing` — waiting on the REASSESSMENT PASS, not on a human.** The PR reached a review-loop cap
      (`review_rounds` or `ns_streak`), so it has stopped converging and **must not take another targeted
-     fix or another review pass**. `ledger.py verdict` sets it, and it is **NOT a park**: campaign clears it
-     itself, by reassessing the PR and executing the one decision that comes back (`repair-pass.md` — the
-     owner). **A cap is a MODE SWITCH, not a doorbell**: the driver repairs the PR autonomously and asks the
-     user nothing. Only the ABORT decision involves a human at all, and it is the last resort of five.
+     fix or another review pass**. `ledger.py verdict` sets it, and campaign normally clears it by
+     reassessing the PR and executing the one decision that comes back. A capped history that the bundle
+     cannot reconcile is the one exception: `repair-pass.md`, **Unreconcilable capped history**, owns its
+     machine-blocker park and its `repair_decision` guard. **A cap is a MODE SWITCH, not a doorbell**.
   - `awaiting-api` — parked for the user to approve an API-changing fix. Resolves via `api_approval`:
     `approved` returns the PR to the normal flow, `declined` makes it `aborted` (terminal).
   - `awaiting-user` — parked for the user to adjudicate. **Two CLASSES, each with its OWN durable answer
@@ -632,8 +632,9 @@ way `verdict` owns the review counters: a park (`status = awaiting-user`, `ci_re
 `blocker_ruling = -`) and a retry unpark (`status = in_review`, ruling spent, the four liveness counters
 reset) are each MULTI-FIELD writes coherent only together, so each is ONE atomic call rather than a
 hand-assembled string of `set`s. `park` is for every **non-CI** machine-blocker park (the merge-precondition
-park, `stage-3-merge.md`); the **CI** parks stay `ci-status.py liveness`'s, which writes the same three
-fields itself (`stage-2-ci.md`, "ESCALATE"). `unpark` consumes a `retry@<iso>` ruling only — it refuses a
+park, `stage-3-merge.md`) plus the narrow capped-history transition owned by `repair-pass.md`,
+**Unreconcilable capped history**; the **CI** parks stay `ci-status.py liveness`'s, which writes the same
+three fields itself (`stage-2-ci.md`, "ESCALATE"). `unpark` consumes a `retry@<iso>` ruling only — it refuses a
 bare `retry`, an unanswered park, an `abort` (that goes terminal through the abort procedure), and a row
 that is not parked. **`set` still writes `status` and `blocker_ruling` and is NOT gated:** the
 review-standoff park/unpark (`finding-audit.md`) is answered through `finding-audit.py rule-standoff`, not

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -636,10 +636,12 @@ park, `stage-3-merge.md`) plus the narrow capped-history transition owned by `re
 **Unreconcilable capped history**; the **CI** parks stay `ci-status.py liveness`'s, which writes the same
 three fields itself (`stage-2-ci.md`, "ESCALATE"). `unpark` consumes a `retry@<iso>` ruling only — it refuses a
 bare `retry`, an unanswered park, an `abort` (that goes terminal through the abort procedure), and a row
-that is not parked. **`set` still writes `status` and `blocker_ruling` and is NOT gated:** the
-review-standoff park/unpark (`finding-audit.md`) is answered through `finding-audit.py rule-standoff`, not
-`blocker_ruling`, so park/unpark cannot serve it and it stays on `set`; and `blocker_ruling` is where the user's **answer** is
-recorded (`set --blocker-ruling retry@<iso>`), which `unpark` then consumes.
+that is not parked. **`set` still writes `status` and `blocker_ruling`, with one decided-repair guard:** it
+refuses `repairing` → `awaiting-user` when `repair_decision` is recorded, so a manual park cannot strand the
+repair that `dispatch-check --action repair` permits. The review-standoff park/unpark (`finding-audit.md`) is
+answered through `finding-audit.py rule-standoff`, not `blocker_ruling`, so its transition stays on `set`; and
+`blocker_ruling` is where the user's **answer** is recorded (`set --blocker-ruling retry@<iso>`), which
+`unpark` then consumes.
 
 `table` is the user-facing status view: the end-of-heartbeat report renders it whenever the run goes back
 to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and makes NO gate decisions; its

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -281,11 +281,12 @@ the worker returns, and what never moves into it. The steps below are unchanged 
 
    - **PARKED** (`awaiting-user`, `awaiting-api`) — waiting on a **HUMAN**. No amount of machine work can
      resolve it; only the user's answer unparks it (below).
-   - **`repairing`** — the PR reached a **review-loop cap** and has stopped converging. It is **NOT waiting
-     on a human**: campaign clears it **itself**, by running the reassessment pass and executing the one
-     decision that comes back (`repair-pass.md`). **A cap is a mode switch, not a doorbell — do NOT prompt
-     the user.** Ordinary gate work is refused for it; the **decided repair** is the one thing that may be
-     dispatched, and only once the decision is recorded (`dispatch-check --action repair`).
+   - **`repairing`** — the PR reached a **review-loop cap** and has stopped converging. It normally is **NOT
+     waiting on a human**: campaign clears it by running the reassessment pass and executing its decision.
+     An unreconcilable capped history is the narrow exception; `repair-pass.md`, **Unreconcilable capped
+     history**, owns its machine-blocker park. Ordinary gate work is refused for it; the **decided repair**
+     is the one thing that may be dispatched, and only once the decision is recorded
+     (`dispatch-check --action repair`).
 
    **The test is "does this MUTATE the PR?" — NOT "is this action named in a list?"** *Mutate* = change
    the PR or dispatch work that will: its content, its head commit, its base, its labels, its
@@ -362,8 +363,9 @@ the worker returns, and what never moves into it. The steps below are unchanged 
    other bullets describe.** Do not skip it and do not prompt the user; drive its repair to completion:
 
    - **no `repair_decision` yet** → run `repair-pass.md`, **"Build the complete reassessment bundle"**.
-     Dispatch its exact prompt to one context-isolated **`session`** worker. Record the returned decision
-     through that section's bundle-bound `repair-pass.py decide` command.
+     If it explicitly reports unreconcilable history and directs a park, follow **"Unreconcilable capped
+     history"** there. Otherwise dispatch its exact prompt to one context-isolated **`session`** worker and
+     record the returned decision through that section's bundle-bound `repair-pass.py decide` command.
    - **a `repair_decision` is recorded** → `ledger.py dispatch-check --pr <N> --action repair`, then
      execute **that** decision and no other work. When the repair has landed, return the row to the gate
      (`ledger.py … set --pr <N> --status in_review`). `review_rounds` is **not** reset — it never is. A

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -57,9 +57,9 @@ to say. Do not look for a bug in the reviewer. The bug is that nothing could **c
 
 ### A cap is a MODE SWITCH, not a doorbell
 
-**It does not stop and ask the user.** The driver stops dispatching targeted fixes and **repairs the PR
-itself, autonomously.** Asking a human is one of the four outcomes, and it is the last resort — not the
-first.
+**It does not stop and ask the user for a valid reassessment.** The driver stops dispatching targeted fixes
+and **repairs the PR itself, autonomously.** A bundle that cannot reconcile the capped history is a separate
+machine blocker; its narrow park transition is defined below.
 
 ### The reassessment pass — give the loop the memory it never had
 
@@ -108,6 +108,25 @@ an older enum fails this match. Delete both refused stale artifacts and rerun `b
 hash. Dispatch the exact prompt file to the reassessment worker; NEVER rebuild, reorder, summarize, or splice
 its inputs by hand.
 
+### Unreconcilable capped history
+
+**When `bundle` refuses capped history and explicitly tells the driver to park, record its named blocker through
+the sanctioned transition:**
+
+```text
+ledger.py --file <state.jsonl> park --pr <N> --reason "<named bundle blocker>"
+```
+
+This is the sole machine-blocker exit from `repairing`: `ledger.py park` admits it only while
+`repair_decision = -`, then atomically sets `status = awaiting-user`, records the blocker in `ci_reason`, and
+clears `blocker_ruling`. A bundled history cannot be repaired by guessing missing artifacts or editing the
+ledger. A refusal that names retry, relaunch, rebuild, or another recovery stays `repairing`; follow that
+recovery instead.
+
+**A recorded repair decision is never replaced by this park.** If `repair_decision` is present, execute that
+decision through `dispatch-check --action repair`; `ledger.py park` refuses the transition so a machine
+blocker cannot erase a decision already bound to the reassessment record.
+
 It returns **exactly ONE decision from a CLOSED enum**, and the driver executes it **without asking the
 user**:
 
@@ -152,10 +171,12 @@ Use this fail-closed procedure:
 4. Record one follow-up for every row in that recovered final-cap list, leave every row unfixed, and use the
    same list in the final report. Then return the row to `in_review`.
 
-**Park the PR with a machine-blocker reason when any binding, hash, identity, artifact, or schema check fails,
-or when the final-cap list cannot be recovered.** Never infer missing findings from generic record prose,
-another round, or the current diff. Existing review-learning entries produced by the legacy decision remain
-valid data and stay readable through `review-learnings.py`.
+**Leave a legacy-DEMOTE row `repairing` when any binding, hash, identity, artifact, or schema check fails,
+or when the final-cap list cannot be recovered.** It already has a recorded `repair_decision`, so the
+unreconcilable-history park above is unavailable and `ledger.py park` correctly refuses it. Surface the
+blocker without editing the ledger or inferring missing findings from generic record prose, another round, or
+the current diff. Existing review-learning entries produced by the legacy decision remain valid data and stay
+readable through `review-learnings.py`.
 
 The final report's **Repaired** entry names the legacy DEMOTE, links its `repair-<pr>-<k>.md`, and lists
 each true finding deliberately left unfixed (`bailout-and-final-report.md`).

--- a/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/root-cause-pass.md
@@ -22,8 +22,9 @@ different instance — is the same signal arriving late; treat it identically.)
 restore it.** It triggered on a fact about history that nothing recorded, evaluated by a heartbeat that
 remembers nothing, and it **never fired once** across 35 review rounds on two PRs
 (`bailout-and-final-report.md`). What backstops this pass now is a **counter with a cap**: at a review-loop
-cap the PR goes `repairing` and a reassessment pass sees **every round at once** and returns one decision —
-and **ROOT-CAUSE is one of the four** (`repair-pass.md`). So this pass is now reached by **two** doors: the
+cap the PR goes `repairing`. A valid reassessment bundle sees **every round at once** and returns one
+decision — and **ROOT-CAUSE is one of the four**; unreconcilable capped history follows
+`repair-pass.md`, **Unreconcilable capped history**. So this pass is now reached by **two** doors: the
 shape trigger above, which is still the fast one and still the one you should be using, and the
 reassessment, which is the backstop that actually fires. **This file remains the definition of the pass
 itself; the reassessment REUSES it and never reimplements it.**

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -638,7 +638,7 @@ exactly two kinds of site, and the two RESET THEMSELVES DIFFERENTLY:
    **outside** the PR (they re-ran the workflow, killed the hung runner, registered the missing check), so
    the strikes and the stall clock that measured the old attempt are void. **This reset stays EXPLICIT** —
    there is NO `head_sha` change for the door to fire on, so the unpark writes the counters back to their
-   defaults itself, in the same `ledger.py … set` call that spends the ruling.
+   defaults itself, in the same `ledger.py … unpark --pr <N>` call that spends the ruling.
 
 **`liveness`'s stale-derivation refusal ("THE BOOKKEEPING IS A COMMAND", above) is NOT a substitute for
 the head write doing it — it is the seam that makes that reset SAFE.** The sites above **write the new

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -842,8 +842,9 @@ the counters mean and why the reader is fused into the door that cannot be skipp
 
 **At a review-loop cap, `verdict` sets `status = repairing` and EXITS NON-ZERO.** The PR has stopped
 converging: **do NOT dispatch a fix subagent and do NOT launch another review pass for it.** Run
-`repair-pass.md`, **"Build the complete reassessment bundle"**, and execute the bundle-bound decision the
-reassessment worker returns. Ordinary work on that PR is refused by
+`repair-pass.md`, **"Build the complete reassessment bundle"**. If it explicitly reports unreconcilable
+history and directs a park, follow **"Unreconcilable capped history"** there; otherwise execute the
+bundle-bound decision the reassessment worker returns. Ordinary work on that PR is refused by
 `ledger.py … dispatch-check --pr <N>` until the repair lands, so this is not a rule you have to remember.
 
 **A `SATISFIED` NEVER trips a cap.** The gate is moving, and a PR one corroborating pass from merging must

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -844,8 +844,9 @@ the counters mean and why the reader is fused into the door that cannot be skipp
 converging: **do NOT dispatch a fix subagent and do NOT launch another review pass for it.** Run
 `repair-pass.md`, **"Build the complete reassessment bundle"**. If it explicitly reports unreconcilable
 history and directs a park, follow **"Unreconcilable capped history"** there; otherwise execute the
-bundle-bound decision the reassessment worker returns. Ordinary work on that PR is refused by
-`ledger.py … dispatch-check --pr <N>` until the repair lands, so this is not a rule you have to remember.
+bundle-bound decision the reassessment worker returns. `ledger.py … dispatch-check --pr <N>` refuses ordinary
+work while the row is held: a recorded decision keeps it held until its repair lands, and an
+unreconcilable-history park keeps it held for a user resolution. This is not a rule you have to remember.
 
 **A `SATISFIED` NEVER trips a cap.** The gate is moving, and a PR one corroborating pass from merging must
 never be torn up for a repair.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2143,6 +2143,41 @@ def t_park_writes_all_three(L: ModuleType, tmp: Path) -> None:
     check(json.loads(got)["status"] == "awaiting-user", f"the park did not land on disk: {got!r}")
 
 
+def t_park_recovers_an_unreconcilable_repair_history(L: ModuleType, tmp: Path) -> None:
+    """An undecided `repairing` row may atomically become the machine-blocker park bundle recovery needs.
+
+    `repair-pass.py bundle` may prove that the capped history cannot be reconciled. It has no decision to
+    execute, so the only truthful next state is the same durable machine-blocker park every other impossible
+    campaign state uses. This fixture drives the real CLI and counts writes: the special entry keeps the
+    unreconciled history visible in `ci_reason`, clears a stale ruling, preserves `repair_decision = -`, and
+    is still one atomic ledger write.
+    """
+    path = write_lines(tmp / "repair-history.jsonl", header_line(L),
+                       row_line(L, status=L.REPAIR_STATUS, repair_decision="-",
+                                blocker_ruling="retry@2026-07-01T00:00:00Z",
+                                **{k: v for k, v in PARK_ROW.items() if k not in ("status",)}))
+    captured: dict = {}
+    reason = "review history cannot be reconciled from the capped artifacts"
+
+    def run() -> None:
+        captured["r"] = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", reason])
+
+    dumps = count_dumps(L, run)
+    code, out, err = captured["r"]
+    check(code == 0, f"unreconcilable repair history was not parkable: {err!r}")
+    check(dumps == 1, f"repair-history park wrote the store {dumps} times, not once")
+    row = json.loads(out)
+    check((row["status"], row["ci_reason"], row["blocker_ruling"], row["repair_decision"])
+          == ("awaiting-user", reason, "-", "-"),
+          f"repair-history park did not make the required atomic transition: {row!r}")
+    code, got, err = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    check(code == 0, f"repair-history park did not persist: {err!r}")
+    saved = json.loads(got)
+    check((saved["status"], saved["ci_reason"], saved["blocker_ruling"], saved["repair_decision"])
+          == ("awaiting-user", reason, "-", "-"),
+          f"repair-history park is not durable: {saved!r}")
+
+
 def t_park_refusals(L: ModuleType, tmp: Path) -> None:
     """Every park refusal writes NOTHING, and the double-park STOPS with the OPEN question surfaced."""
     # no row
@@ -2164,12 +2199,28 @@ def t_park_refusals(L: ModuleType, tmp: Path) -> None:
         check(code == 1 and "name its blocker" in err, f"[{reason!r}] park with no blocker: exit {code}, {err!r}")
         check("awaiting-user" not in path.read_text(), f"[{reason!r}] a refused park still wrote the store")
 
-    # conflicting-owner held states — each names the conflicting status, exit 1, nothing written
-    for status in ("awaiting-api", L.REPAIR_STATUS):
+    # conflicting-owner held state — it names the conflicting status, exits 1, and writes nothing
+    for status in ("awaiting-api",):
         path = write_lines(tmp / f"o-{status}.jsonl", header_line(L), row_line(L, pr="1", status=status))
         code, _, err = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", "x"])
         check(code == 1 and status in err, f"[{status}] park did not name the conflicting owner: exit {code}, {err!r}")
         check("awaiting-user" not in path.read_text(), f"[{status}] a refused park still wrote the store")
+
+    # A recorded reassessment decision owns a repairing row. The narrow history-recovery park exists only
+    # before a decision, so it cannot discard a decision and replace it with a different question for the user.
+    decision = "root-cause@2026-07-14T00:00:00Z"
+    path = write_lines(tmp / "repair-decided.jsonl", header_line(L),
+                       row_line(L, pr="1", status=L.REPAIR_STATUS, repair_count="1",
+                                repair_decision=decision))
+    code, _, err = cli(L, ["--file", str(path), "park", "--pr", "1", "--reason", "x"])
+    check(code == 1 and decision in err and "recorded reassessment decision" in err,
+          f"a decided repairing row was parkable: exit {code}, {err!r}")
+    code, got, err = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    check(code == 0, f"could not read decided repairing row after refusal: {err!r}")
+    row = json.loads(got)
+    check((row["status"], row["repair_decision"], row["ci_reason"], row["blocker_ruling"])
+          == (L.REPAIR_STATUS, decision, "-", "-"),
+          f"a refused decided repair-history park changed the row: {row!r}")
 
     # DOUBLE PARK — a park is already open. STOP (EXIT_STOP), surface the OPEN ci_reason, overwrite NOTHING.
     open_q = "SETTLED at the STRIKE CAP — nobody is coming"
@@ -2795,7 +2846,8 @@ CASES = [
     ("repair-decision-cleared", "re-entering a cap CLEARS the stale reassessment decision — the repair budget binds", t_stale_repair_decision_cleared_at_cap),
     ("pr-origin-default", "an unknown origin is `external` — the fail-safe direction", t_pr_origin_defaults_to_external),
     ("park-writes-three", "`park` writes status/ci_reason/blocker_ruling atomically, counters untouched", t_park_writes_all_three),
-    ("park-refusals", "park refuses no-row/terminal/blank-reason/held-owner, and a double-park STOPs", t_park_refusals),
+    ("park-repair-history", "an undecided repairing row parks unreconcilable history atomically", t_park_recovers_an_unreconcilable_repair_history),
+    ("park-refusals", "park refuses no-row/terminal/blank-reason/held-owner/recorded-repair, and a double-park STOPs", t_park_refusals),
     ("unpark-spends-resets", "`unpark` flips status, spends the ruling, resets all four counters — one write", t_unpark_spends_and_resets),
     ("unpark-refusals", "unpark refuses not-parked/unanswered/abort/malformed — writing nothing", t_unpark_refusals),
     ("set-status-stays-open", "set may still write the standoff park/unpark transitions — park/unpark can't serve them", t_set_status_transitions_stay_open),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2177,6 +2177,18 @@ def t_park_recovers_an_unreconcilable_repair_history(L: ModuleType, tmp: Path) -
           == ("awaiting-user", reason, "-", "-"),
           f"repair-history park is not durable: {saved!r}")
 
+    # This park has no repair that can land. Ordinary work remains refused while it awaits the user.
+    code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == L.EXIT_STOP,
+          f"ordinary work ran while unreconcilable repair history awaited the user: exit {code}, {err!r}")
+    code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--blocker-ruling",
+                           "retry@2026-07-14T00:00:00Z"])
+    check(code == 0, f"the user could not record the retry ruling: {err!r}")
+    code, _, err = cli(L, ["--file", str(path), "unpark", "--pr", "1"])
+    check(code == 0, f"the user's retry ruling did not resolve the repair-history park: {err!r}")
+    code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == 0, f"ordinary work remained frozen after the user resolved the repair-history park: {err!r}")
+
 
 def t_park_refusals(L: ModuleType, tmp: Path) -> None:
     """Every park refusal writes NOTHING, and the double-park STOPS with the OPEN question surfaced."""

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2347,6 +2347,32 @@ def t_set_status_transitions_stay_open(L: ModuleType, tmp: Path) -> None:
           f"`set --blocker-ruling` was refused — the user's answer cannot be recorded: exit {code}, {err!r}")
 
 
+def t_set_cannot_park_a_decided_repair(L: ModuleType, tmp: Path) -> None:
+    """`set` cannot move a decided `repairing` row to `awaiting-user` and strand its repair dispatch.
+
+    The review-standoff route must retain its `set` transition, but a reassessment decision owns a
+    `repairing` row's next action. Drive the documented bypass through the real CLI, then prove the row
+    remains dispatchable for exactly that recorded repair.
+    """
+    decision = "root-cause@2026-07-14T00:00:00Z"
+    path = capped_row(L, tmp, "set-decided-repair.jsonl", status=L.REPAIR_STATUS,
+                      repair_decision=decision)
+    code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", "awaiting-user",
+                         "--ci-reason", "manual park", "--blocker-ruling", "-"])
+    check(code == 1 and decision in err and "dispatch-check --action repair" in err,
+          f"a decided repair was parkable through `set`: exit {code}, {err!r}")
+
+    code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1", "--action", "repair"])
+    check(code == 0 and decision in out,
+          f"a rejected set transition stranded the decided repair: exit {code}, {err!r}, {out!r}")
+    code, out, err = cli(L, ["--file", str(path), "get", "--pr", "1"])
+    check(code == 0, f"could not read decided repair after set refusal: {err!r}")
+    row = json.loads(out)
+    check((row["status"], row["repair_decision"], row["ci_reason"], row["blocker_ruling"])
+          == (L.REPAIR_STATUS, decision, "-", "-"),
+          f"a refused set transition changed the decided repair: {row!r}")
+
+
 # --- last_activity: the run's durable "when did anything last move?" sensor -----
 #
 # Two frozen instants, so a stamp is DETERMINISTIC and a no-op write can be PROVEN not to re-stamp (the
@@ -2863,6 +2889,7 @@ CASES = [
     ("unpark-spends-resets", "`unpark` flips status, spends the ruling, resets all four counters — one write", t_unpark_spends_and_resets),
     ("unpark-refusals", "unpark refuses not-parked/unanswered/abort/malformed — writing nothing", t_unpark_refusals),
     ("set-status-stays-open", "set may still write the standoff park/unpark transitions — park/unpark can't serve them", t_set_status_transitions_stay_open),
+    ("set-decided-repair-guard", "set cannot park a decided repair and strand its dispatch", t_set_cannot_park_a_decided_repair),
     ("replay-the-record", "the REAL #42/#43 verdict sequences: it fires, never too early, and says what it costs", t_replay_the_real_record),
     ("activity-stamped-on-change", "a value-changing set stamps last_activity; a no-op set does not", t_activity_stamped_on_a_real_change),
     ("verdict-stamps-activity", "a landed verdict stamps last_activity — it always moves review_rounds", t_verdict_stamps_activity),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -361,7 +361,9 @@ CREATE_ONLY = ("base_branch",)
 #   * `blocker_ruling` is where the USER'S ANSWER is recorded (`set --pr N --blocker-ruling retry@<iso>`);
 #     park/unpark own only the park-ENTRY clear and the retry SPEND, never the answer itself.
 # The CI-bound parks are `ci-status.py liveness`'s (it writes the same three fields itself and does NOT call
-# `park`); `park` is the writer for every OTHER machine-blocker park.
+# `park`); `park` is the writer for every OTHER machine-blocker park. One narrow recovery starts from
+# `repairing`: if `repair-pass.py bundle` cannot reconcile the capped history BEFORE a decision exists,
+# `park` converts that machine blocker to `awaiting-user`. A recorded `repair_decision` is never replaced.
 
 # (`unpark` resets every LIVENESS_COUNTERS member — the set defined once, above — to its ROW_DEFAULTS
 # value, never a retyped literal, so a counter added to the set is reset by the retry unpark with NO edit
@@ -1290,8 +1292,9 @@ def held_reason(status: str) -> str:
     DERIVED from the status, so a new member of HELD_STATUSES cannot silently inherit a wrong explanation.
     """
     if status == REPAIR_STATUS:
-        return ("at a review-loop cap and awaiting its REASSESSMENT PASS — the reassessment's decision and "
-                "the repair it dispatches clear it (`repair-pass.md`); NO human is waited on")
+        return ("at a review-loop cap and awaiting its REASSESSMENT PASS — its decision and the repair it "
+                "dispatches clear it (`repair-pass.md`), except an unreconcilable bundle history before a "
+                "decision becomes a machine-blocker park")
     if status == "awaiting-api":
         return "parked for the user to approve an API-changing fix — only the user's answer unparks it"
     if status == "awaiting-user":
@@ -1365,7 +1368,10 @@ def cmd_park(path: Path, args) -> int:
     Refusals, none of which write anything:
       * no row, or a TERMINAL row (`merged`/`aborted`) — nothing waits on a human for it — `fail` (exit 1);
       * an empty or `-` reason — a park that cannot name its blocker is not actionable (ESCALATE) — exit 1;
-      * `awaiting-api` / `repairing` — those held states have their OWN owners (`held_reason`) — exit 1;
+      * `awaiting-api` — that held state has its OWN owner (`held_reason`) — exit 1;
+      * `repairing` with a recorded `repair_decision` — the decision owns the next action and may not be
+        replaced by a park — exit 1. With `repair_decision = -`, `repair-pass.py bundle` may convert an
+        unreconcilable capped history into this machine-blocker park;
       * ALREADY `awaiting-user` — a park is open and a SECOND may not overwrite the open question. That is a
         STOP, not an input error: `EXIT_STOP`, and the EXISTING `ci_reason` is surfaced so the driver knows
         which question is already outstanding.
@@ -1387,9 +1393,14 @@ def cmd_park(path: Path, args) -> int:
         print(f"ledger: pr {pr} is ALREADY awaiting-user — a park is open and NOT yet answered, so a second "
               f"park may not overwrite its question. Open blocker: {row['ci_reason']}", file=sys.stderr)
         return EXIT_STOP
-    if status in ("awaiting-api", REPAIR_STATUS):
+    if status == "awaiting-api":
         fail(f"pr {pr} is {status}, not parkable as a machine blocker — that state has its own owner "
              f"({held_reason(status)}). Resolve it through its own path, not a park")
+    if status == REPAIR_STATUS and row["repair_decision"] != "-":
+        fail(f"pr {pr} is {REPAIR_STATUS} with recorded reassessment decision {row['repair_decision']} — "
+             "a machine-blocker park may replace `repairing` only before a decision exists, when "
+             "`repair-pass.py bundle` cannot reconcile capped history. Execute the recorded decision "
+             "through `dispatch-check --action repair`; never overwrite it with a park")
 
     row.update({"status": "awaiting-user", "ci_reason": reason, "blocker_ruling": "-"})
     save(path, header, rows, activity=True)  # a park changes `status` — a non-exempt field, so it is activity
@@ -1684,7 +1695,8 @@ def build_parser() -> argparse.ArgumentParser:
                         "`repairing` row accepts (and only once its decision is recorded)")
 
     pk = sub.add_parser("park", help="park a PR on the user for a MACHINE BLOCKER: status=awaiting-user, "
-                                     "ci_reason=<blocker>, blocker_ruling=- — atomically")
+                                     "ci_reason=<blocker>, blocker_ruling=- — atomically; an undecided "
+                                     "repairing row may park only for unreconcilable reassessment history")
     pk.add_argument("--pr", required=True, help="PR number (row key)")
     pk.add_argument("--reason", required=True,
                     help="the machine blocker, NAMED — the question the user is asked to rule on; becomes "

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -399,8 +399,10 @@ ROUND_CAP = 11
 NS_STREAK_CAP = 6
 REPAIR_CAP = 2
 
-# Where a PR goes when it reaches a cap. It is NOT a park: a park waits on a HUMAN and only the user's
-# answer leaves it, while this waits on the reassessment pass and the driver clears it itself.
+# Where a PR goes when it reaches a cap. `repairing` normally is NOT a park: it waits on the reassessment
+# pass and the driver clears it itself. Before a decision, unreconcilable capped history that `bundle`
+# directs to park becomes `awaiting-user`; `repair-pass.md`, "Unreconcilable capped history", owns that
+# machine-blocker transition.
 REPAIR_STATUS = "repairing"
 
 # HELD — the statuses in which campaign MUST NOT dispatch ordinary gate work on a PR (a review pass, a
@@ -411,7 +413,9 @@ REPAIR_STATUS = "repairing"
 #
 #   awaiting-api / awaiting-user   parked on a HUMAN. Only the user's answer unparks.
 #   repairing                      at a review-loop cap. The reassessment pass and the repair it decides
-#                                  clear it — no human is waited on.
+#                                  normally clear it. Before a decision, unreconcilable capped history may
+#                                  enter the `awaiting-user` machine-blocker park; `repair-pass.md`,
+#                                  "Unreconcilable capped history", owns that exception.
 #
 # The ONE exception, for every member alike: OBSERVING a PR is not mutating it, so the CI watch follows
 # its normal policy, and reconcile still READS a held PR and records what it read.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -353,7 +353,9 @@ CREATE_ONLY = ("base_branch",)
 # those two transitions (stage-2-ci.md, "ESCALATE" / "THE RULING IS CONSUMED EXACTLY ONCE" / "THE LIVENESS
 # COUNTERS"; loop-control.md step 3; stage-3-merge.md).
 #
-# `set` is DELIBERATELY left able to write `status` and `blocker_ruling` — the guard is NOT closed, because:
+# `set` is DELIBERATELY left able to write `status` and `blocker_ruling` — except that a decided
+# `repairing` row may not be hand-parked through `set`, because that would strand the decision its
+# `dispatch-check --action repair` must execute. The guard is otherwise NOT closed, because:
 #   * the REVIEW-STANDOFF park (finding-audit.md) writes `status = awaiting-user` through `set` and is
 #     answered through `finding-audit.py rule-standoff`, NOT `blocker_ruling`; its unpark is a plain `set --status
 #     in_review` carrying no `retry@<iso>` ruling for `unpark` to validate. park/unpark cannot serve that
@@ -1116,6 +1118,14 @@ def cmd_set(path: Path, args) -> int:
     updates = _named_field_values(args, creating=False)
     if not updates:
         fail("set requires at least one --<field> <value>")
+    # The review-standoff park still uses `set --status awaiting-user`, but a recorded repair decision owns
+    # a repairing row's next action. `park` already refuses this transition; keep the same guard at the
+    # generic write door so a hand-assembled `set` cannot strand a repair that dispatch-check permits.
+    if (row["status"] == REPAIR_STATUS and row["repair_decision"] != "-"
+            and updates.get("status") == "awaiting-user"):
+        fail(f"pr {pr} is {REPAIR_STATUS} with recorded reassessment decision {row['repair_decision']} — "
+             "a decided repair may not transition to awaiting-user through `set`. Execute the recorded "
+             "decision through `dispatch-check --action repair`")
     check_tally(updates, row)
     # Decide activity from the updates against the row AS LOADED — before `apply_head_sha`/`row.update`
     # mutate it. A head MOVE counts (head_sha is non-exempt and changes), and the liveness counters that

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -767,6 +767,30 @@ def t_bundle_refuses_unreconcilable_pass_histories(tmp: Path) -> None:
           f"the unparseable-surplus refusal names no recovery action: {err!r}")
 
 
+def t_unreconcilable_history_park_is_documented_at_each_boundary(tmp: Path) -> None:
+    """The cap, held-status, and bailout guidance name the bundle-directed machine-blocker park.
+
+    The functional seam is covered by `t_bundle_refuses_unreconcilable_pass_histories`; this pins the three
+    summaries that a driver reads before it reaches that seam. They must preserve the owner and the fact that
+    an undecided repairing row can become `awaiting-user` instead of claiming repair always self-clears.
+    """
+    del tmp
+    owner = OWNER.read_text(encoding="utf-8")
+    ledger = (OWNER.parent / "ledger.py").read_text(encoding="utf-8")
+    bailout = (OWNER.parent.parent / "references" / "bailout-and-final-report.md").read_text(encoding="utf-8")
+    owner_pointer = '`repair-pass.md`, **Unreconcilable capped history**'
+
+    check("unreconcilable capped history before\na decision" in owner
+          and "required `ledger.py park` command" in owner,
+          "repair-pass.py's cap guide lost the bundle-directed machine-blocker park")
+    check(ledger.count('"Unreconcilable capped history"') == 2
+          and "enter the `awaiting-user` machine-blocker park" in ledger,
+          "ledger.py's REPAIR_STATUS and HELD_STATUSES comments lost the undecided-history exception")
+    check(owner_pointer in bailout and "third exit is an unreconcilable-history machine-blocker park" in bailout
+          and "`awaiting-user`\n    transition" in bailout,
+          "bailout guidance lost repairing's third exit to the owner-defined park")
+
+
 def t_bundle_is_deterministic_and_payloads_are_data(tmp: Path) -> None:
     """Identical inputs produce identical prompt bytes/hash; hostile payload and paths remain JSON data."""
     case = bundle_setup(tmp, origin="external", hostile_names=True)
@@ -1616,6 +1640,7 @@ CASES = [
     ("bundle-order-active", "bundle orders rounds numerically and selects only the active relaunch", t_bundle_orders_rounds_and_selects_active_attempt),
     ("bundle-skips-deferred-pass", "a verdictless (DEFERRED) surplus pass is excluded, listed, and never wedges", t_bundle_skips_an_explicitly_deferred_pass),
     ("bundle-pass-history-refusals", "every other pass-numbering drift is refused with the mismatch and recovery named", t_bundle_refuses_unreconcilable_pass_histories),
+    ("unreconcilable-history-park-docs", "the cap, ledger, and bailout guidance retain the machine-blocker park", t_unreconcilable_history_park_is_documented_at_each_boundary),
     ("bundle-deterministic", "bundle bytes/hash are deterministic and hostile payloads stay data", t_bundle_is_deterministic_and_payloads_are_data),
     ("bundle-refusals", "missing, stale, and duplicate active inputs fail before output", t_bundle_refuses_missing_stale_and_duplicate_inputs),
     ("bundle-old-intent", "old intent anchors survive; the cap round may have no audit yet", t_bundle_preserves_findings_from_an_older_intent),

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -768,9 +768,9 @@ def t_bundle_refuses_unreconcilable_pass_histories(tmp: Path) -> None:
 
 
 def t_unreconcilable_history_park_is_documented_at_each_boundary(tmp: Path) -> None:
-    """The cap, held-status, and bailout guidance name the bundle-directed machine-blocker park.
+    """The stage-two, cap, held-status, and bailout guidance name the machine-blocker park.
 
-    The functional seam is covered by `t_bundle_refuses_unreconcilable_pass_histories`; this pins the three
+    The functional seam is covered by `t_bundle_refuses_unreconcilable_pass_histories`; this pins the four
     summaries that a driver reads before it reaches that seam. They must preserve the owner and the fact that
     an undecided repairing row can become `awaiting-user` instead of claiming repair always self-clears.
     """
@@ -778,6 +778,7 @@ def t_unreconcilable_history_park_is_documented_at_each_boundary(tmp: Path) -> N
     owner = OWNER.read_text(encoding="utf-8")
     ledger = (OWNER.parent / "ledger.py").read_text(encoding="utf-8")
     bailout = (OWNER.parent.parent / "references" / "bailout-and-final-report.md").read_text(encoding="utf-8")
+    stage_two = (OWNER.parent.parent / "references" / "stage-2-review-gate.md").read_text(encoding="utf-8")
     owner_pointer = '`repair-pass.md`, **Unreconcilable capped history**'
 
     check("unreconcilable capped history before\na decision" in owner
@@ -789,6 +790,10 @@ def t_unreconcilable_history_park_is_documented_at_each_boundary(tmp: Path) -> N
     check(owner_pointer in bailout and "third exit is an unreconcilable-history machine-blocker park" in bailout
           and "`awaiting-user`\n    transition" in bailout,
           "bailout guidance lost repairing's third exit to the owner-defined park")
+    check("`ledger.py … dispatch-check --pr <N>` refuses ordinary\nwork while the row is held" in stage_two
+          and "recorded decision keeps it held until its repair lands" in stage_two
+          and "unreconcilable-history park keeps it held for a user resolution" in stage_two,
+          "stage-two cap guidance lost the user-resolved unreconcilable-history exit")
 
 
 def t_bundle_is_deterministic_and_payloads_are_data(tmp: Path) -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -648,6 +648,16 @@ def t_bundle_refuses_unreconcilable_pass_histories(tmp: Path) -> None:
     check(code == 1 and "disagree about" in err, f"a landed surplus pass was not refused: {err!r}")
     check("park the PR for the user" in err,
           f"the landed-surplus refusal names no recovery action: {err!r}")
+    # The bundle's named recovery must reach the sanctioned atomic transition. This is the integration
+    # seam: bundle sees unreconcilable capped history, and ledger.py moves its still-undecided repairing row
+    # to the durable machine-blocker park without hand-editing any campaign state.
+    reason = "review history cannot be reconciled from the capped artifacts"
+    code, out, err = ledger_cli(["--file", str(surplus["ledger"]), "park", "--pr", "1", "--reason", reason])
+    check(code == 0, f"the bundle-directed repair-history park was refused: {err!r}")
+    parked = json.loads(out)
+    check((parked["status"], parked["ci_reason"], parked["blocker_ruling"], parked["repair_decision"])
+          == ("awaiting-user", reason, "-", "-"),
+          f"the bundle-directed machine-blocker park was incomplete: {parked!r}")
 
     # A hole in the artifact pass numbering is lost history, never a skip. Another machine blocker.
     hole = bundle_setup(tmp / "hole", rounds=4)
@@ -911,7 +921,8 @@ def t_docs_recover_legacy_demote_findings_from_the_bound_cap_artifact(tmp: Path)
         "load_historical_findings",
         "one follow-up for every row",
         "same list in the final report",
-        "Park the PR with a machine-blocker reason",
+        "Leave a legacy-DEMOTE row `repairing`",
+        "`ledger.py park` correctly refuses it",
     ):
         check(needle in legacy, f"legacy DEMOTE recovery lost required rule {needle!r}")
 

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -19,11 +19,13 @@ CLOSED enum. `references/repair-pass.md` is the definition; this is its enforcem
 `DECISION: <enum>` field, the same decision `--decision` records — so the ledger can never disagree with the
 audit artifact.
 
-**A CAP IS A MODE SWITCH, NOT A DOORBELL.** It does not stop and ask the user. The driver stops dispatching
-targeted fixes and REPAIRS THE PR ITSELF — rescopes it back to its stated purpose, re-authors the intent the
-reviewer had nothing to measure against, fixes at the chokepoint instead of playing whack-a-mole, or gives
-up and leaves the PR open for a human. Only the last of those involves the user at all, and it is the last
-resort, not the first.
+**A CAP IS A MODE SWITCH, NOT A DOORBELL.** It does not normally stop and ask the user. The driver stops
+dispatching targeted fixes and REPAIRS THE PR ITSELF — rescopes it back to its stated purpose, re-authors the
+intent the reviewer had nothing to measure against, fixes at the chokepoint instead of playing whack-a-mole,
+or gives up and leaves the PR open for a human. The narrow exception is unreconcilable capped history before
+a decision: if `bundle` directs a park, follow `references/repair-pass.md`, **Unreconcilable capped history**,
+and run its required `ledger.py park` command. Other than that machine-blocker park, only the last decision
+involves the user, and it is the last resort, not the first.
 
 Three refusals this tool exists to make, all of them things a well-meaning driver would otherwise do:
 


### PR DESCRIPTION
- Allow an undecided repair cap to park unreconcilable review history atomically.
- Keep recorded reassessment decisions protected from replacement by a park.
- Cover the recovery path and align campaign lifecycle guidance.
