### PR TITLE
release gauntlet 0.5.1

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- Bump both Gauntlet manifests to 0.5.1.
- Make the merged repair flow available to installed campaign runs.
