### PR TITLE
fix follow-up pr reference parsing

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1408,6 +1408,11 @@ def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
         "https://github.com/../repo/pull/42",
         "https://github.com/acme/./pull/42",
         "https://github.com/acme/../pull/42",
+        "https://github.com/%2e/repo/pull/42",
+        "https://github.com/%2E%2e/repo/pull/42",
+        "https://github.com/acme/%2e/pull/42",
+        "https://github.com/acme%2frepo/repo/pull/42",
+        "https://github.com/acme/repo%2F/pull/42",
         "https://github.com/acme/repo/issues/42",
         "PR 42",
     )

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1397,7 +1397,17 @@ def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
     for ref, expected in accepted.items():
         check(followups.pr_number(ref) == expected,
               f"PR reference {ref!r} parsed as {followups.pr_number(ref)!r}, not {expected!r}")
-    for ref in ("0", "#0", "42/", "https://github.com/acme/repo/issues/42", "PR 42"):
+    for ref in (
+        "0",
+        "#0",
+        "42/",
+        "#42\n",
+        "https://github.com/acme/repo/pull/42\n",
+        "https://github.com/acme?x/repo/pull/42",
+        "https://github.com/acme/repo#fragment/pull/42",
+        "https://github.com/acme/repo/issues/42",
+        "PR 42",
+    ):
         check(followups.pr_number(ref) is None,
               f"non-PR reference {ref!r} was guessed as {followups.pr_number(ref)!r}")
 

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -379,7 +379,7 @@ def t_ruling_is_recorded(tmp: Path) -> None:
     after = json.loads(run(["--file", str(path), "get", "--id", a])[1])
     check(after["decided"] == "2026-07-14T09:00:00Z",
           f"`open-pr` overwrote the USER's ruling timestamp: {after!r}")
-    check(after["pr"] == "#77", f"open-pr did not record WHICH PR is addressing it: {after!r}")
+    check(after["pr"] == "77", f"open-pr did not record WHICH PR is addressing it: {after!r}")
 
     # …and so does the step that DELETES it: the record it prints is the handoff, and it still says the
     # user ruled, and when.
@@ -752,12 +752,12 @@ def t_deletion_needs_a_durable_record(tmp: Path) -> None:
     check(code == 0, f"open-pr exited {code}: {err!r}")
     entry = json.loads(run(["--file", str(path), "get", "--id", fid])[1])
     check(entry["state"] == "in-pr", f"an open PR did not put the entry in `in-pr`: {entry!r}")
-    check(entry["pr"] == "#123", f"the entry does not say WHICH PR is addressing it: {entry!r}")
+    check(entry["pr"] == "123", f"the entry does not say WHICH PR is addressing it: {entry!r}")
 
     # ON THE MERGE it goes — and it is REALLY gone: not hidden, not tombstoned. Gone from the file.
     code, out, err = run(["--file", str(path), "merged", "--id", fid])
     check(code == 0, f"merged exited {code}: {err!r}")
-    check(json.loads(out)["pr"] == "#123",
+    check(json.loads(out)["pr"] == "123",
           f"the deletion record does not name the PR that is now the record: {out!r}")
     check(load(path) == [], "a MERGED follow-up was KEPT — the queue is an archive, and it only grows")
     check(fid not in path.read_text(),
@@ -800,7 +800,7 @@ def t_a_closed_pr_returns_the_entry_to_open_work(tmp: Path) -> None:
         entry = json.loads(run(["--file", str(path), "get", "--id", fid])[1])
         check(entry["state"] == reopened,
               f"[{lineage}] a PR closed without merging left the entry in {entry['state']!r}: {entry!r}")
-        check(entry["pr"] == "#9", f"[{lineage}] the PR that died was forgotten: {entry!r}")
+        check(entry["pr"] == "9", f"[{lineage}] the PR that died was forgotten: {entry!r}")
         code, out, err = run(["--file", str(path), "list"])
         check((code, out) == (0, f"{fid}\n"),
               f"[{lineage}] the entry left the store when its PR was closed — the work is undone and there "
@@ -1382,11 +1382,10 @@ def t_fields_and_lookup(tmp: Path) -> None:
 
 
 def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
-    """The follow-up store recognises all PR forms it has historically recorded.
+    """`open-pr` stores recognised PR forms as their canonical number.
 
-    `open-pr` accepts a caller-provided reference, so older stores can hold a bare number as well as the
-    current `#N` spelling. GitHub pull-request URLs are also accepted, including their optional trailing
-    slash. Other references remain opaque instead of being guessed from a number embedded in free text.
+    The command accepts legacy bare numbers, current `#N` spelling, and GitHub pull-request URLs, including
+    an optional trailing slash. It preserves unrecognised text rather than guessing a number embedded in it.
     """
     accepted = {
         "42": "42",
@@ -1397,7 +1396,7 @@ def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
     for ref, expected in accepted.items():
         check(followups.pr_number(ref) == expected,
               f"PR reference {ref!r} parsed as {followups.pr_number(ref)!r}, not {expected!r}")
-    for ref in (
+    opaque = (
         "0",
         "#0",
         "42/",
@@ -1407,9 +1406,24 @@ def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
         "https://github.com/acme/repo#fragment/pull/42",
         "https://github.com/acme/repo/issues/42",
         "PR 42",
-    ):
+    )
+    for ref in opaque:
         check(followups.pr_number(ref) is None,
               f"non-PR reference {ref!r} was guessed as {followups.pr_number(ref)!r}")
+
+    # Drive every accepted and opaque form through the only transition that writes `pr`; a parser-only
+    # fixture would still pass if `open-pr` stored its raw argument.
+    expected_refs = {**accepted, **{ref: ref for ref in opaque}}
+    for i, (ref, expected) in enumerate(expected_refs.items()):
+        path = tmp / f"pr-reference-{i}.jsonl"
+        (fid,) = seed(path)
+        code, _, err = run(["--file", str(path), "accept", "--id", fid])
+        check(code == 0, f"setup `accept` for {ref!r} exited {code}: {err!r}")
+        code, _, err = run(["--file", str(path), "open-pr", "--id", fid, "--pr", ref])
+        check(code == 0, f"`open-pr` for {ref!r} exited {code}: {err!r}")
+        entry = json.loads(run(["--file", str(path), "get", "--id", fid])[1])
+        check(entry["pr"] == expected,
+              f"`open-pr` stored {entry['pr']!r} for {ref!r}, not {expected!r}")
 
 
 CASES = [
@@ -1420,7 +1434,7 @@ CASES = [
     ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
-    ("pr-reference-parser", "legacy bare numbers, #N, and GitHub pull-request URLs identify the same PR", t_pr_references_keep_legacy_bare_numbers_and_github_urls),
+    ("pr-reference-parser", "open-pr canonicalises recognised PR references and preserves opaque text", t_pr_references_keep_legacy_bare_numbers_and_github_urls),
     ("investigation-evidence", "an investigation shows its work; the finding APPENDS and never clobbers", t_investigation_shows_its_work),
     ("refutation-stays", "a refuted follow-up stays in the store, stays visible, and stays overturnable", t_refutation_stays_in_the_store),
     ("state-not-settable", "`set` writes neither `state` nor any evidence a transition left behind", t_state_and_evidence_are_not_settable),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1381,6 +1381,27 @@ def t_fields_and_lookup(tmp: Path) -> None:
     check(out == "", f"--where matched a state the entry has left: {out!r}")
 
 
+def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
+    """The follow-up store recognises all PR forms it has historically recorded.
+
+    `open-pr` accepts a caller-provided reference, so older stores can hold a bare number as well as the
+    current `#N` spelling. GitHub pull-request URLs are also accepted, including their optional trailing
+    slash. Other references remain opaque instead of being guessed from a number embedded in free text.
+    """
+    accepted = {
+        "42": "42",
+        "#42": "42",
+        "https://github.com/acme/repo/pull/42": "42",
+        "https://github.com/acme/repo/pull/42/": "42",
+    }
+    for ref, expected in accepted.items():
+        check(followups.pr_number(ref) == expected,
+              f"PR reference {ref!r} parsed as {followups.pr_number(ref)!r}, not {expected!r}")
+    for ref in ("0", "#0", "42/", "https://github.com/acme/repo/issues/42", "PR 42"):
+        check(followups.pr_number(ref) is None,
+              f"non-PR reference {ref!r} was guessed as {followups.pr_number(ref)!r}")
+
+
 CASES = [
     ("user-step-unskippable", "no driver-only path reaches `accepted`, nor any state `publish` leaves from — proved on the graph", t_user_ruling_is_unskippable),
     ("delete-needs-a-record", "an entry is deleted only once a DURABLE RECORD exists elsewhere — never on take-up", t_deletion_needs_a_durable_record),
@@ -1389,6 +1410,7 @@ CASES = [
     ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
+    ("pr-reference-parser", "legacy bare numbers, #N, and GitHub pull-request URLs identify the same PR", t_pr_references_keep_legacy_bare_numbers_and_github_urls),
     ("investigation-evidence", "an investigation shows its work; the finding APPENDS and never clobbers", t_investigation_shows_its_work),
     ("refutation-stays", "a refuted follow-up stays in the store, stays visible, and stays overturnable", t_refutation_stays_in_the_store),
     ("state-not-settable", "`set` writes neither `state` nor any evidence a transition left behind", t_state_and_evidence_are_not_settable),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1404,6 +1404,10 @@ def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
         "https://github.com/acme/repo/pull/42\n",
         "https://github.com/acme?x/repo/pull/42",
         "https://github.com/acme/repo#fragment/pull/42",
+        "https://github.com/./repo/pull/42",
+        "https://github.com/../repo/pull/42",
+        "https://github.com/acme/./pull/42",
+        "https://github.com/acme/../pull/42",
         "https://github.com/acme/repo/issues/42",
         "PR 42",
     )

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1413,6 +1413,11 @@ def t_pr_references_keep_legacy_bare_numbers_and_github_urls(tmp: Path) -> None:
         "https://github.com/acme/%2e/pull/42",
         "https://github.com/acme%2frepo/repo/pull/42",
         "https://github.com/acme/repo%2F/pull/42",
+        "https://github.com/acme%3Fbad/repo/pull/42",
+        "https://github.com/acme%23bad/repo/pull/42",
+        "https://github.com/acme%0Abad/repo/pull/42",
+        "https://github.com/acme%20bad/repo/pull/42",
+        "https://github.com/acme%5Cbad/repo/pull/42",
         "https://github.com/acme/repo/issues/42",
         "PR 42",
     )

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -643,7 +643,11 @@ def pr_number(ref: str) -> "str | None":
         return None
     if match.group("url"):
         decoded_path = (unquote(component) for component in urlsplit(ref).path.split("/"))
-        if any(component in (".", "..") or "/" in component for component in decoded_path):
+        if any(
+            component in (".", "..")
+            or any(char in "/?#\\" or char.isspace() for char in component)
+            for component in decoded_path
+        ):
             return None
     return match.group("short") or match.group("url")
 

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -624,7 +624,7 @@ def find(entries: "list[dict]", fid: str) -> "dict | None":
     return None
 
 
-GITHUB_PATH_COMPONENT = r"[^/?#\s]+"
+GITHUB_PATH_COMPONENT = r"(?!(?:\.{1,2})/)[^/?#\s]+"
 
 
 PR_REF_RE = re.compile(

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -83,6 +83,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
+from urllib.parse import unquote, urlsplit
 
 # The grid is NOT reimplemented here. The private campaign package owns escaping, layout, and omission
 # notices; this file owns only the follow-up schema, lifecycle, and store lifetime.
@@ -638,7 +639,13 @@ PR_REF_RE = re.compile(
 def pr_number(ref: str) -> "str | None":
     """Return the number from a legacy bare, `#N`, or GitHub pull-request reference."""
     match = PR_REF_RE.fullmatch(ref)
-    return None if match is None else (match.group("short") or match.group("url"))
+    if match is None:
+        return None
+    if match.group("url"):
+        decoded_path = (unquote(component) for component in urlsplit(ref).path.split("/"))
+        if any(component in (".", "..") or "/" in component for component in decoded_path):
+            return None
+    return match.group("short") or match.group("url")
 
 
 def next_id(high: int) -> str:

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -752,6 +752,10 @@ def cmd_transition(path: Path, args) -> int:
     cmd = args.cmd
     frm, to = TRANSITIONS[cmd]
     values = taken(cmd, args)  # THE one door — every caller value, validated (see `taken()`)
+    if cmd == "open-pr":
+        # A PR number is the durable key other campaign tools consume. Keep an opaque caller reference
+        # untouched, but collapse every recognised legacy spelling to that one key before storing it.
+        values["pr"] = pr_number(values["pr"]) or values["pr"]
     with locked(path):
         entries, high = read_store(path)
         entry = find(entries, args.id)

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -624,6 +624,20 @@ def find(entries: "list[dict]", fid: str) -> "dict | None":
     return None
 
 
+PR_REF_RE = re.compile(
+    r"^(?:"
+    r"(?:#)?(?P<short>[1-9][0-9]*)"
+    r"|https://github\.com/[^/]+/[^/]+/pull/(?P<url>[1-9][0-9]*)/?"
+    r")$"
+)
+
+
+def pr_number(ref: str) -> "str | None":
+    """Return the number from a legacy bare, `#N`, or GitHub pull-request reference."""
+    match = PR_REF_RE.match(ref)
+    return None if match is None else (match.group("short") or match.group("url"))
+
+
 def next_id(high: int) -> str:
     """`fu<N>`, one past the highest N EVER HANDED OUT — assigned HERE, never by the caller.
 

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -624,17 +624,20 @@ def find(entries: "list[dict]", fid: str) -> "dict | None":
     return None
 
 
+GITHUB_PATH_COMPONENT = r"[^/?#\s]+"
+
+
 PR_REF_RE = re.compile(
-    r"^(?:"
+    r"(?:"
     r"(?:#)?(?P<short>[1-9][0-9]*)"
-    r"|https://github\.com/[^/]+/[^/]+/pull/(?P<url>[1-9][0-9]*)/?"
-    r")$"
+    rf"|https://github\.com/{GITHUB_PATH_COMPONENT}/{GITHUB_PATH_COMPONENT}/pull/(?P<url>[1-9][0-9]*)/?"
+    r")"
 )
 
 
 def pr_number(ref: str) -> "str | None":
     """Return the number from a legacy bare, `#N`, or GitHub pull-request reference."""
-    match = PR_REF_RE.match(ref)
+    match = PR_REF_RE.fullmatch(ref)
     return None if match is None else (match.group("short") or match.group("url"))
 
 


### PR DESCRIPTION
- parse bare numbers, `#N`, and GitHub pull-request URLs
- cover accepted and opaque PR reference forms
