### PR TITLE
update CI watch consumer guidance

### DIFF
--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -115,10 +115,9 @@ it comes to **you** to settle — with the finding, the refutation, the evidence
 counter. It parks that PR while it waits and keeps driving the others. A parked PR is genuinely frozen:
 campaign changes nothing about it — no review, no fix, no merge, and no rebase, even if another PR
 merges and leaves it behind the base — until you answer. It stays behind rather than let a rebase
-rewrite the very content you're being asked to rule on. Parking doesn't change what it watches, though:
-observing isn't changing, so the CI watch stays alive exactly when a check can still move, and stops when
-CI has stopped moving — the same rule as any other PR. The same freeze applies to a PR parked for your
-approval of an API change.
+rewrite the very content you're being asked to rule on. Parking doesn't override `liveness`'s returned
+`watch_warranted` result, because observing isn't changing the PR. The same freeze applies to a PR parked
+for your approval of an API change.
 
 It also parks a PR when CI itself goes nowhere — checks that never register, a run that stops moving and
 never turns green, a status value GitHub added that it doesn't recognize, a merge GitHub blocks for a
@@ -161,7 +160,7 @@ anything it left for you to weigh in on.
 ```mermaid
 flowchart TD
     A(["invoke gauntlet:campaign #PRs"]) --> B{PR numbers, no args, or --new?}
-    B -- "#PRs / --new #PRs" --> C[adopt each PR: ledger row + run label,<br/>CI watch only if a check can still move]
+    B -- "#PRs / --new #PRs" --> C[adopt each PR: ledger row + run label,<br/>run liveness<br/>act on watch_warranted]
     B -- "no args" --> D{PRs already under this run?}
     D -- yes --> C
     D -- no --> E([prompt: run gauntlet:review<br/>or pass PR numbers])
@@ -187,9 +186,9 @@ flowchart TD
     P -- yes --> M
     N -- yes --> R{CI status on current SHA?}
     R -- red --> S[scoped CI-fix subagent: commit + push, new SHA]
-    R -- "pending / unreadable" --> CM{can any check still move?}
-    CM -- "yes: a check is still running" --> CW[keep a CI watch alive<br/>relaunch it if it exited] --> M
-    CM -- "no: CI has stopped moving" --> CB{still within its bounds?}
+    R -- "pending / unreadable" --> CM[run liveness] --> WW{watch_warranted?}
+    WW -- true --> CW[keep a CI watch alive<br/>relaunch it if it exited] --> M
+    WW -- false --> CB{still within its bounds?}
     CB -- yes --> M
     CB -- "no: bound reached" --> CP[park the PR: name the blocker,<br/>ask the user to retry or abort]
     CP -- retry --> M

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -106,7 +106,7 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
    default Non-goals into its managed block — the row must exist FIRST, because `intent-sync` REFUSES a PR
    with no ledger row (`pr-adoption.md`). Before gate work, follow
    `references/stage-2-review-gate.md`, "2a-triage", for the complete adoption-time procedure.
-   Start a CI watch only if a check can still move.
+   Apply item 21, "CI watch action".
 7. `review-pass.py intent-check --file <rundir>/intent-<pr>.md --ledger <rundir>/state.jsonl`: run
    immediately after writing an intent artifact and syncing it, before dispatching the PR's first review —
    the same parser every pass later loads, plus a check that the managed block is in sync with the run
@@ -132,10 +132,11 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that
     mutates a PR — it exits non-zero for a HELD one.
-11. Follow `references/stage-2-review-gate.md`, "2a-triage", for each non-held PR's complete heartbeat
-    triage procedure, then launch ALL due work up to caps — reviews,
-    CI watches/fixes, precondition clearing, base refresh — skipping HELD PRs, and stop in-flight
-    reviews doomed by a content change.
+11. **Due-work dispatch.** Follow `references/stage-2-review-gate.md`, "2a-triage", for each non-held
+    PR's complete heartbeat triage procedure, then launch ALL due work up to caps — reviews, CI fixes,
+    precondition clearing, base refresh — with mutating actions skipping HELD PRs, and stop in-flight
+    reviews doomed by a content change. CI watches follow item 21's returned `watch_warranted` action,
+    including for HELD PRs.
 12. Before sleeping, audit: re-run the dispatch scan across both concurrency pools and confirm every
     due launch actually happened, every PR at a liveness cap was escalated rather than left spinning,
     and the loop continues per `references/loop-control.md`, "Primary continuity", whenever non-terminal
@@ -196,9 +197,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     NEVER by reading command output and judging it by eye. `ci-status.py liveness` then RECORDS that
     JSON — `ci`, the fingerprint, the strike/stall/refetch counters, and any cap park ("THE BOOKKEEPING
     IS A COMMAND" owns the invocation): the arithmetic is never applied by hand.
-21. A PR with a still-RUNNING check (`derive`'s `buckets.RUNNING > 0`) always has a live watch; a PR
-    whose CI has SETTLED never does
-    ("WATCH ONLY WHAT CAN MOVE"). Completions are heartbeats — the driver never blocks. The bounded
+21. **CI watch action.** Run `liveness`, then ensure or relaunch a watch only when returned
+    `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not
+    override that result. Completions are heartbeats — the driver never blocks. The bounded
     CI waits and their caps are named in ONE place ("THE LIVENESS COUNTERS"); at any cap, escalate or
     park — never leave a PR spinning on a watch that will never wake anyone.
 22. CI fixes: a formatting/lint failure goes to the `economy` tier (Worker Dispatch below); everything
@@ -210,10 +211,11 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     `awaiting-api` — waits on a HUMAN) and **`repairing`** (waits on the reassessment pass, which is
     machine work due NOW; its unreconcilable-history exception is in `repair-pass.md`). The test is "does
     this mutate the PR?", **not** "is it on a list";
-    `HELD_STATUSES` in `scripts/ledger.py` is the one enumeration — never retype it. Sole exception:
+    `HELD_STATUSES` in `scripts/ledger.py` is the one enumeration — never retype it. Sole mutating exception:
     a non-legacy recorded repair's required clean base-only rebase, owned by `repair-pass.md`, **A non-legacy
-    recorded repair may first take its required clean base-only rebase**. The CI watch is not a mutation, so it follows the normal policy. Keep driving the other
-    PRs. Unpark only on the user's answer, recorded DURABLY per park class; a ruling is durable and
+    recorded repair may first take its required clean base-only rebase**. The CI watch is not a mutation, so
+    parked status does not override item 21's returned `watch_warranted` action. Keep driving the other PRs.
+    Unpark only on the user's answer, recorded DURABLY per park class; a ruling is durable and
     consumed exactly once (`references/stage-2-ci.md`, "THE RULING IS CONSUMED EXACTLY ONCE").
 
 **Merge — stage 3** (`references/stage-3-merge.md`)

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -792,21 +792,21 @@ are ever re-ordered again.
   - **An unknown value parks the PR AS SOON AS no `FAIL` outranks it** — on this derivation if there is
     no `FAIL`, otherwise on the next one, once the CI fix has cleared the failure. **It is deferred, never
     dropped**, and it outranks `pending`: a still-running row does **not** postpone the park.
-- **pending** → any evidence row classifies `RUNNING` → leave `ci = pending`. **This outcome warrants a
-  watch** (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE", owns the whole policy — a `red` verdict with a
-  still-`RUNNING` row is watched too): a row can still move on its own, so if the
-  watch task has exited, **relaunch it in this same heartbeat** — a PR with a still-RUNNING row must never sit
-  unwatched waiting for the fallback heartbeat. **It is also BOUNDED**: "a row can still move" is a claim the row
+- **pending** → any evidence row classifies `RUNNING` → leave `ci = pending`.
+
+  **CI watch action.** Run `liveness`, then ensure or relaunch a watch only when returned
+  `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not
+  override that result.
+
+  **This outcome is also BOUNDED**: "a row can still move" is a claim the row
   makes, not a promise it keeps, so if the whole check set then sits unchanged for the CI STALL CAP, the
   PR escalates (`stage-2-ci.md`, "RUNNING-STALL"). `pending` is not a place a PR may live forever.
 - **pending (nothing registered)** → the snapshot lists **zero evidence rows**. **Zero evidence rows is NOT
-  green** — it means nothing has registered yet. **Do NOT watch it**: there is no row that could move, so
-  there is nothing to block on. If nothing ever registers, SETTLED (`stage-2-ci.md`) escalates it instead of letting it
-  spin.
+  green** — it means nothing has registered yet. If nothing ever registers, SETTLED (`stage-2-ci.md`)
+  escalates it instead of letting it spin.
 - **pending (required set unreadable)** → `required_set` is **CANNOT READ** (`stage-2-ci.md`, "WHAT WERE WE EXPECTING TO
   SEE?"). We do not know what this commit was supposed to show, so **no snapshot of it can be
-  green** — not even an all-`PASS` one. **Do NOT watch it**: no row moving would answer the question that
-  is open. It is **bounded like every other `pending`**: nothing is RUNNING, so SETTLED (`stage-2-ci.md`) strikes it
+  green** — not even an all-`PASS` one. It is **bounded like every other `pending`**: nothing is RUNNING, so SETTLED (`stage-2-ci.md`) strikes it
   and escalates at the STRIKE CAP, naming the read that failed. Re-attempt the read each heartbeat while it is
   `unknown` — a transient failure clears itself well inside that budget.
 - **pending (required check missing)** → `required_set` is **DECLARED** and a declared required check has
@@ -815,7 +815,7 @@ are ever re-ordered again.
   truth about this commit**. **NEVER green.** Bounded the same way: if it never registers, SETTLED (`stage-2-ci.md`)
   escalates with the check **named** (that is exactly the "which check never registered" ESCALATE already
   promises). A declared check that IS present but still running is not this bullet — it is a `RUNNING` row,
-  so plain `pending` above already caught it, and it is watched, as it should be.
+  so plain `pending` above already caught it.
 - **green** → **all three `source` markers are present and hold** (VERIFY above — otherwise you do not know
   what you did not read); **≥1 evidence row**; **every** evidence row classifies `PASS`; containment
   holds **on a usable identity** (every `witness` `.id` non-null and unique); **and the required set is

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -69,19 +69,9 @@
 - Work-conserving dispatch is mandatory: every heartbeat scans all PRs and launches every due
   action that fits a free slot before returning. Waiting is allowed only when no useful action is
   launchable anywhere in the run.
-- A PR whose snapshot can still move must ALWAYS have a live watch: if **`liveness` reports
-  `watch_warranted`** — its mechanical reduction of "WATCH ONLY WHAT CAN MOVE": `verified AND verdict !=
-  UNCLASSIFIED AND buckets.RUNNING > 0`, where `buckets.RUNNING` is the CLASSIFY tally
-  (`ci-derivation-spec.md`, "CLASSIFY every row"), an EXPLICIT membership test and
-  **NEVER** "any row is not yet terminal" / `.status != COMPLETED`, which is a negated test: it sweeps up
-  every value GitHub adds tomorrow and silently watches it instead of letting it fall to the
-  `UNKNOWN_VALUE` escalation — and the watch task has exited (including after any rebase/push), relaunch
-  the watch in this same heartbeat — never wait for the next heartbeat.
-- **But NEVER relaunch a watch merely because `ci == pending`.** Once CI has **SETTLED** (no row can
-  still move) there is nothing to block on: `gh pr checks --watch` returns in about **a second**, and a
-  task completion is **itself a heartbeat** — so a settled-but-not-green PR would burn a fresh-context heartbeat
-  **every second, forever**, and observe nothing. A settled PR is resolved by the **`settled_strikes`
-  escalation** (`stage-2-ci.md`, "SETTLED"), not by watching it harder.
+- **CI watch action.** Run `liveness`, then ensure or relaunch a watch only when returned
+  `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not
+  override that result. When a warranted watch has exited, relaunch it in the same heartbeat.
 - **And the watch is NEVER the bound.** A row that stays `RUNNING` forever (a hung runner, a dead
   reporter) keeps `gh pr checks --watch` blocked forever, so the watch wakes no one and `pending` would
   absorb the PR — the exact wedge. **RUNNING-STALL** ends it: a `RUNNING` row plus a fingerprint that has
@@ -230,8 +220,10 @@
   `<rundir>/audit-<pr>-<n>.jsonl` through `finding-audit.py`) and
   **commit it**. A refutation is a COMMIT, a commit is PR CONTENT, and PR content **RESETS THE GATE** and
   is **REVIEWED** — route it through the same "any campaign commit resets the gate" rule (`reviews_ok` →
-  0, restore `gauntlet-reviewing`, re-derive CI for the new tip and watch it only if `liveness` reports
-  `watch_warranted`, re-enter Stage 2a); never invent a second mechanism. Nothing is slipped past the reviewer: the argument is IN the diff, so a bogus refutation is
+  0, restore `gauntlet-reviewing`, re-derive CI for the new tip). **Refutation CI watch action.** Run
+  `liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`
+  (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not override that result. Re-enter
+  Stage 2a; never invent a second mechanism. Nothing is slipped past the reviewer: the argument is IN the diff, so a bogus refutation is
   a defect the next reviewer flags. The comment MUST be a **falsifiable claim with evidence** ("git has
   no hardlink mode — a PR cannot create one; verified: checkout recreates separate inodes"), NEVER an
   instruction to the reviewer ("ignore this", "do not re-raise", "already dismissed") — argue why the
@@ -270,10 +262,10 @@
   **merge** and the **post-merge reconcile** (`stage-3-merge.md`) — not merely recorded in the ledger.
   Only the user's answer unparks it (`status` → `in_review`, recorded durably per park class; a declined
   API change or a `blocker_ruling` of `abort` → `aborted`); a parked PR that fell behind its base stays
-  behind until then. **The park does not change the CI watch either way** — observing a PR is not mutating
-  it, so the watch follows the normal policy (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"): alive while a
-  row can still move, **not** relaunched once CI has SETTLED. Parking neither stops a warranted watch nor
-  starts an unwarranted one — and it dispatches no CI fix.
+  behind until then. **Held-PR watch action.** Observing a PR is not mutating it. Run
+  `liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`
+  (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not override that result. Do not
+  dispatch a CI fix.
 - Reviews are fresh, context-isolated re-rolls: a separate reviewer invocation each pass (the default
   cross-engine reviewer or the user's preferred reviewer, with a native-worker fallback), no shared
   context. `runtime-adapter.md`'s
@@ -432,10 +424,10 @@
   `reviews_ok` to 0 AND reconcile the label by running `label-mirror.py mirror` for the PR (it restores
   `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`); the new commit
   moves `head_sha`, so writing it through the accessor fires the head-move reset at the door
-  (`files-and-ledger.md`, the `head_sha` field, "What a genuine head move resets"); re-derive CI
-  for the new tip and watch it **only if `liveness` reports `watch_warranted`** (`stage-2-ci.md`, "WATCH
-  ONLY WHAT CAN MOVE" — a watch launched on a tip whose checks have not registered yet has nothing to
-  block on and exits in about a second), and re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
+  (`files-and-ledger.md`, the `head_sha` field, "What a genuine head move resets"); re-derive CI for the
+  new tip. **Campaign-commit CI watch action.** Run `liveness`, then ensure or relaunch a watch only when
+  returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does
+  not override that result. Re-enter Stage 2a. NEVER exempt a commit because it "only reformatted".
 - **A `head_sha` change and a gate reset are NOT the same event** — what a genuine head move voids at the
   write door is owned by `files-and-ledger.md`, the `head_sha` field, "What a genuine head move resets";
   the review gate's own reset rules are owned by `stage-2-review-gate.md`, "Status labels mirror the

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -505,10 +505,11 @@ Header field notes (the header fields above; per-row fields follow):
   enumerated. Never retype that list; ask the tool.** A status added to it is enforced everywhere with no
   edit to any of the sites that consult it.
 
-  **Holding does not change the watch policy either way** (observing is not mutating): the watch follows
-  `stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE" — alive while a row is still `RUNNING`, **not** relaunched
-  once CI has settled. Nor does it stop **reconcile** from reading the PR and recording what it read. The
-  other PRs keep being driven: **a held PR never blocks the loop.**
+  **Held-PR watch action.** Observing is not mutating. Run `liveness`, then ensure or
+  relaunch a watch only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN
+  MOVE"). Parked status does not override that result. Holding also does not stop **reconcile** from
+  reading the PR and recording what it read. The other PRs keep being driven: **a held PR never blocks
+  the loop.**
 
   Held statuses come in **two kinds, and they are cleared by DIFFERENT events — do not collapse them:**
 

--- a/plugins/gauntlet/skills/campaign/references/finding-audit.md
+++ b/plugins/gauntlet/skills/campaign/references/finding-audit.md
@@ -280,8 +280,10 @@ On REFUTED:
 - **Commit it.** The refutation commit is a **PR-content change**, so it **RESETS THE GATE** exactly like
   any other campaign commit: route it through the existing "any campaign commit to the PR head resets the
   gate" rule (`reviews_ok` → 0, restore `gauntlet-reviewing` — "Status labels mirror the review gate" —
-  re-derive CI for the new tip and watch it only if `liveness` reports `watch_warranted`, re-enter Stage 2a on the new
-  tip). Do **NOT** invent a second mechanism.
+  re-derive CI for the new tip). **Refutation CI watch action.** Run `liveness`, then ensure or relaunch
+  a watch only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE").
+  Parked status does not override that result. Re-enter Stage 2a on the new tip. Do **NOT** invent a
+  second mechanism.
 - CONFIRMED / ADJUSTED findings from the same round still go to the scoped fix subagent; the refutation
   comment rides along in the same round's work.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -157,8 +157,9 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      default** — the base is per-row now, recorded on each row at adoption from that PR's live
      `baseRefName`, never a run-wide header value (`files-and-ledger.md`, the row `base_branch` field).
      Then **adopt** each PR
-     (ledger row + labels + worktree, and a CI watch **only when one is due** — `pr-adoption.md` owns what
-     adoption produces and when the watch is warranted; adoption fetches **each PR's own base ref**, so a
+     (ledger row + labels + worktree, then **Run `liveness`, then ensure or relaunch a watch only when
+     returned `watch_warranted` is `true`** — `pr-adoption.md`, "Step 6 — Run liveness, then act on its
+     CI watch warrant"; adoption fetches **each PR's own base ref**, so a
      set spanning several bases fetches each of them once at its adoption). A death mid-adoption still
      leaves a discoverable, adoptable run. **When the whole requested set is adopted, clear the checkpoint —
      `ledger.py … header set pending_adoption -`** (this is adoption's final step; a later entry that

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -305,11 +305,9 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      applies only to `repairing` after `dispatch-check --action repair` succeeds; `repair-pass.md`, **A
      non-legacy recorded repair may first take its required clean base-only rebase**, owns it. It does not permit a
      conflict-resolving/diff-changing rebase or unhold the row.
-   - **The CI watch is not an exception: OBSERVING a PR is not mutating it.** The park **does not change
-     the watch either way** — it follows the normal policy, `stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE":
-     alive while an evidence row can still `RUN`, **not** relaunched once CI has SETTLED (relaunching a
-     settled PR's watch burns a heartbeat per second and observes nothing). Parking never stops a warranted
-     watch and never starts an unwarranted one. But do **NOT** dispatch a CI *fix*.
+   - **Held-PR watch action.** Observing a PR is not mutating it. Run `liveness`, then ensure
+     or relaunch a watch only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT
+     CAN MOVE"). Parked status does not override that result. Do **NOT** dispatch a CI *fix*.
    - **Recording ground truth is not mutating either.** Reconcile still READS a parked PR (live SHA, CI,
      labels) and writes what it read to the ledger — including a `reviews_ok` reset, and its label
      mirror, when **someone else** pushed to the PR (step 1). Recording a change campaign did not make is
@@ -481,16 +479,11 @@ the worker returns, and what never moves into it. The steps below are unchanged 
      resulting commit **resets the gate** (Stage 2b, "Any campaign commit to the PR head resets the gate").
      Materialize the selected role through `worker-prompt.py fix` (`fix-subagent-contract.md`); its
      template owns the job order and role rules. Different PRs may fix CI concurrently within the cap.
-   - `liveness` reports **`watch_warranted`** (its reduction of "WATCH ONLY WHAT CAN MOVE" — a verified
-     snapshot with a still-`RUNNING` evidence row that is not an `UNKNOWN_VALUE` park; the `RUNNING` is an
-     evidence row that classifies `RUNNING` under Stage 2b CLASSIFY, never "a row that is not terminal") for
-     a PR whose watch task has already exited →
-     **relaunch the watch in this same heartbeat**. A PR whose watch is warranted must never sit
-     unwatched until the fallback heartbeat; the fallback lifecycle is not the mechanism. **But NEVER relaunch
-     it merely because `ci == pending`** — once CI has SETTLED nothing can move, `gh pr checks --watch`
-     exits in about a second, and its completion is itself a heartbeat: that is a heartbeat per second, forever
-     (Stage 2b, "WATCH ONLY WHAT CAN MOVE"). A settled PR is resolved by the `settled_strikes`
-     escalation, not by watching it harder. **And a row that never leaves `RUNNING` is resolved by
+   - **CI watch action.** Run `liveness`, then ensure or relaunch a watch only when returned
+     `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not
+     override that result. When a warranted watch has exited, relaunch it in this same heartbeat. A
+     warranted watch must never sit unwatched until the fallback heartbeat; the fallback lifecycle is not
+     the mechanism. **A row that never leaves `RUNNING` is resolved by
      RUNNING-STALL** (Stage 2b): its watch blocks forever and completes never, so the escalation lands on
      **this fallback heartbeat**, once `ci_stalled_since` has stood at the same fingerprint for the CI STALL
      CAP. **A watch is never a bound.**
@@ -613,8 +606,8 @@ resume. This block OWNS when the loop continues; every other site points here, n
      - **any in-flight review pass** → `review-pass.py status --run <rundir> --verify`, then apply the
        **Stage 2a launch-deadline and meaningful-progress rules** to it (`stage-2-review-gate.md`) — a
        review that died mid-flight is exactly what a quiet streak hides.
-     - **any row that can still move** → **re-derive CI** (Stage 2b) and apply the CI watch / RUNNING-STALL
-       rules — a watch that wedged wakes no one, and only a swept heartbeat notices.
+     - **each active PR's CI** → **re-derive CI and run `liveness`** (Stage 2b), then apply its returned
+       watch warrant and liveness state. A wedged watch wakes no one; only a swept heartbeat notices.
      - **every parked PR** → **re-surface its question to the user, WITH how long it has waited.** The park
        is not a stall to "fix" (the held-status guard still binds — step 3), but a forgotten question is
        the single most likely reason a run went quiet, so it is what the user needs put back in front of

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -534,15 +534,12 @@ mirror is a guaranteed no-op.
 python3 <skill-dir>/scripts/label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name
 ```
 
-#### Step 6 — Ensure a live CI watch when — and ONLY when — a check can still move
+#### Step 6 — Run liveness, then act on its CI watch warrant
 
-6. **Ensure a live CI watch when — and ONLY when — a check can still move.** The warrant for a watch is a
-   **still-RUNNING evidence row** in the PR's snapshot, **never the `ci` value** (Stage 2b, `stage-2-ci.md`
-   — "WATCH ONLY WHAT CAN MOVE"): a PR whose CI has **SETTLED** gets **no watch**, because
-   `gh pr checks --watch` on it exits in about a second and its completion is itself a heartbeat — a heartbeat per
-   second, forever, observing nothing. A watch on a run that is still moving wakes the driver when it
-   settles. **The backgrounded command is the watch and NOTHING ELSE** — its **ONLY** job is to **block**
-   until the run settles, so that **its completion becomes a heartbeat**:
+6. **CI watch action.** Run `liveness`, then ensure or relaunch a watch only when returned
+   `watch_warranted` is `true` (Stage 2b, `stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does
+   not override that result. **The backgrounded command is the watch and NOTHING ELSE** — its **ONLY** job
+   is to **block** until the run settles, so that **its completion becomes a heartbeat**:
 
    ```
    # run in background. This is the WHOLE command: it BLOCKS, and that is all it does.

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -559,7 +559,8 @@ python3 <skill-dir>/scripts/label-mirror.py mirror --ledger <state.jsonl> --pr <
    Don't launch a duplicate watch for a PR that already has a live one (Loop control tracks in-flight
    watches).
 
-Adoption produces only the registered, labelled row (and a CI watch when due). Reviews, CI fixes, and
-merges are driven by Loop control on later heartbeats — this file just gets each PR **into** the run.
+Adoption produces only the registered, labelled row and the CI watch action: **Run `liveness`, then ensure
+or relaunch a watch only when returned `watch_warranted` is `true`**. Reviews, CI fixes, and merges are
+driven by Loop control on later heartbeats — this file just gets each PR **into** the run.
 
 ---

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -106,9 +106,10 @@ are only examples). Held leaves
 `reviews_ok < required(tier)`, so the review-launch rule MUST read `status` too — otherwise the next
 heartbeat re-reviews a PR that is **waiting on a HUMAN** (a park) and a `SATISFIED` verdict merges it **without
 the user's ruling**, or re-reviews a PR that has **stopped converging** (`repairing`) and spends round 22
-of a loop that has already been told to stop. The park does **not** change its CI watch either way — observing is not mutating, so the
-watch follows the normal policy (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE": alive while a row can still
-move, **not** relaunched once CI has SETTLED). Everything else waits for the user's answer.
+of a loop that has already been told to stop. **Held-PR watch action.** Observing is not mutating. Run
+`liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`
+(`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not override that result. Everything
+else waits for the user's answer.
 
 The non-legacy recorded repair's required clean base-only rebase is not a review precondition:
 `repair-pass.md`, **A non-legacy recorded repair may first take its required clean base-only rebase**, owns

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -180,12 +180,12 @@ ownership checks and phase order remain in force.
    `reviews_ok`, relabel, and relaunch work — and would **change the PR's content**, which can invalidate
    the very refutation or API change the user was parked to adjudicate. **A parked PR that has fallen
    behind simply STAYS behind** until the user answers; it is re-reconciled normally on the heartbeat after it
-   unparks. **Do NOT drop its row** — it stays in the run, and the park **does not change its CI watch
-   either way** (observation, not mutation): the watch follows the normal policy (`stage-2-ci.md`, "WATCH
-   ONLY WHAT CAN MOVE") — relaunched while a row is still RUNNING, **not** relaunched once CI has settled.
-   This merge-stage reconcile is ordinary work, never the non-legacy recorded repair's required clean base-only
-   rebase; `repair-pass.md`, **A non-legacy recorded repair may first take its required clean base-only rebase**,
-   owns that separate path.
+   unparks. **Do NOT drop its row** — it stays in the run. This merge-stage reconcile is ordinary work,
+   never the non-legacy recorded repair's required clean base-only rebase; `repair-pass.md`, **A non-legacy
+   recorded repair may first take its required clean base-only rebase**, owns that separate path.
+   **Held-PR watch action.** Observation is not mutation. Run `liveness`, then ensure or relaunch a watch
+   only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked
+   status does not override that result.
 
    For each **non-parked** open PR, run `python3 scripts/base-preflight.py check --pr <pr> --worktree
    <worktree> --base <base> --file <state.jsonl>`, where `<base>` is that row's **effective base** (its
@@ -203,11 +203,11 @@ ownership checks and phase order remain in force.
      "What a genuine head move resets"), `ci = pending`. **Exit 3 means it was NOT
      clean** — a conflict, or a rebase that changed the PR's own diff — and it has already aborted/reset to
      the original head; the judgment-path bullet below then owns **both** exit-3 subcases. On a clean (exit 0) rebase,
-     **re-derive CI from a snapshot of the new tip in the same heartbeat, launching a watch only if `liveness`
-     then reports `watch_warranted`** ("WATCH ONLY WHAT CAN MOVE"). A rebased PR must not sit unwatched
-     until the heartbeat while its checks are running — but it must not be watched when **nothing** is
-     running either, which right after a push is the common case (no check has registered yet). CI must
-     return green before merging.
+     re-derive CI from a snapshot of the new tip in the same heartbeat. **Clean-rebase watch action.** Run
+     `liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`
+     (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not override that result. CI must return
+     green before merging.
+
    - Judgment-path rebase — a conflict resolved by hand, OR a no-conflict rebase that reshaped the PR's own
      diff (both `clean-rebase.py` exit-3 subcases) → PR content changed → **reset `reviews_ok` to 0 AND, in that
      same step, reconcile the label by running `label-mirror.py mirror` for the PR** (it restores
@@ -217,9 +217,10 @@ ownership checks and phase order remain in force.
      `head_sha` to the
      new tip through the accessor, which fires the head-move reset (a new head is new evidence — `files-and-ledger.md`,
      the `head_sha` field, "What a genuine head move resets"; the clean-rebase branch above does the same, and this branch is no different in
-     that respect). Then re-derive CI for
-     the new tip — watching it only if `liveness` reports `watch_warranted` ("WATCH ONLY WHAT CAN MOVE") — and re-enter
-     Stage 2.
+     that respect). Then re-derive CI for the new tip. **Judgment-rebase watch action.** Run `liveness`, then
+     ensure or relaunch a watch only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY
+     WHAT CAN MOVE"). Parked status does not override that result. Re-enter Stage 2.
+
    - `proceed` with the same live `head_sha`, `reviews_ok >= required(tier)`, and `ci == green` → return
      to **"Resumable merge execution"** in the same heartbeat; `merge.py` imports `merge-check.py` and
      repeats the ancestry check before merging.

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -51,6 +51,10 @@ TRIAGE_INPUT_BINDINGS = (
     ("--pr", "<pr>"),
 )
 TRIAGE_TIER_BINDING = ("--tier", "<your decided tier>")
+WATCH_ACTION = (
+    "Run `liveness`, then ensure or relaunch a watch only when returned "
+    "`watch_warranted` is `true`"
+)
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
 )
@@ -89,6 +93,10 @@ def delimited_region(body: str, start_marker: str, end_marker: str, name: str) -
     start = body.index(start_marker)
     end = body.index(end_marker, start + len(start_marker))
     return body[start:end]
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.split())
 
 
 def command_argvs(block: str) -> list[list[str]]:
@@ -310,6 +318,23 @@ def check_additional_triage_consumers(root_cause: str, pr_adopt: str) -> None:
         ("pr-adopt.py", pr_adopt, SKILL_TRIAGE_OWNER),
     ):
         check_consumer_triage_region(name, body, expected_owner)
+
+
+def check_watch_consumers(adoption: str, loop_control: str) -> None:
+    loop_start = loop_control.index("Then **adopt** each PR")
+    loop_end = loop_control.index("A death mid-adoption still", loop_start)
+    loop_adoption = loop_control[loop_start:loop_end]
+
+    summary_start = adoption.index("Adoption produces only")
+    summary_end = adoption.index("\n\n", summary_start)
+    adoption_summary = adoption[summary_start:summary_end]
+
+    for name, region in (
+        ("loop-control.md adoption consumer", loop_adoption),
+        ("pr-adoption.md summary consumer", adoption_summary),
+    ):
+        require(WATCH_ACTION in normalized(region),
+                f"{name} lost the liveness/watch_warranted gate")
 
 
 def require_rejected(callback, expected: str, message: str) -> None:
@@ -636,6 +661,7 @@ def check_document_contract() -> None:
     copilot = (COPILOT / "SKILL.md").read_text(encoding="utf-8")
 
     check_campaign_triage_contract(stage, adoption, loop_control, skill)
+    check_watch_consumers(adoption, loop_control)
     new_row_summary = delimited_region(
         adoption,
         "   - **On a NEW row only, initialize:**",


### PR DESCRIPTION
- route watch launches and relaunches through liveness and `watch_warranted`
- align README, skill, lifecycle references, and held-PR guidance
- preserve observation-only handling while PR mutations remain frozen
