### PR TITLE
add session-scoped external review failure classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,15 @@ Optional when Claude Code is the orchestrator:
 - **Codex CLI (`codex`)** — the default independent reviewer for `gauntlet:campaign` under Claude Code.
   When Codex is installed, campaign reviews with it (`codex exec`) for engine diversity — a different
   engine catches defects a same-model re-roll misses. It launches at native-limitation level; engine
-  diversity needs no OS sandbox. When Codex is absent, or a cross-engine process fails after one retry,
-  campaign falls back to a fresh native worker under the documented native limitations, so the campaign
-  runs with or without Codex. An explicit selection or saved preference overrides the default (you can
+  diversity needs no OS sandbox. Before retry or fallback, use the campaign runtime adapter's
+  classification and fallback contract. Transient failures may use the one retry. A valid timer waits only
+  while that retry is unspent and the current time is before its deadline; after the retry is spent, fall
+  back immediately while retaining session backoff for other launches. Permanent failures, including
+  malformed or unsupported timer text, disable that external route for the current session. Opaque or
+  unrecognized failures fall back to a fresh native worker without disabling the route under the documented
+  native limitations.
+  Session backoff is never durable, so the campaign runs with or without Codex. An explicit selection or
+  saved preference overrides the default (you can
   force a native reviewer). Missing native filesystem/startup controls alone never park a pass.
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Optional when Claude Code is the orchestrator:
   back immediately while retaining session backoff for other launches. Permanent failures, including
   malformed or unsupported timer text, disable that external route for the current session. Opaque or
   unrecognized failures fall back to a fresh native worker without disabling the route under the documented
-  native limitations.
+  native limitations. A reviewer that refuses the task outright stops that PR and reports it to you instead
+  of falling back — the fallback would review with the same engine that is driving the campaign.
   Session backoff is never durable, so the campaign runs with or without Codex. An explicit selection or
   saved preference overrides the default (you can
   force a native reviewer). Missing native filesystem/startup controls alone never park a pass.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -14,7 +14,7 @@ adapter; keep workflow rules shared.
 | Agent dispatch | Agent tool and configured agent types | Available Codex multi-agent controls | Describe worker scope, permissions, model class, and output; do not require a host tool name. |
 | Model selection | Claude model aliases may be available | Session model or configured Codex agents | State required capability; map named models only inside host adapter. |
 | Heartbeat/resume | `ScheduleWakeup` where available | wakes its thread where available; bounded foreground wait otherwise | Persist state before waiting and provide an exact resume path. |
-| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Fall back to a fresh native worker when it is absent or fails. Explicit or saved user choice overrides. |
+| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Classify failures before retry or fallback: a valid timer waits only while the retry is unspent and the current time is before its deadline; after the retry is spent, fall back immediately while retaining session backoff. Disable the external route only for permanent failures, including malformed or unsupported timer text; unrecognized failures use a fresh native worker without disabling it. Explicit or saved user choice overrides. |
 
 Campaign's exact cross-agent command lines live in
 [`plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md`](../plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md).
@@ -34,7 +34,13 @@ Campaign's exact cross-agent command lines live in
 - Evaluate cross-engine reviewers through the runtime adapter's `ReviewIsolationCapability` transition.
   A cross-engine route launches at native-limitation level whenever the paired CLI is present; the three
   `os_filesystem_isolation` properties are an optional stronger-boundary claim that never blocks launch.
-  When the paired CLI is absent, or the process fails after its retry, fall back to a fresh native worker.
+  When the paired CLI is absent, use a fresh native worker. When the process fails, use the campaign
+  runtime adapter's classification and fallback contract: transient failures may use the one retry. A valid
+  timer waits for the exact provider deadline only while the retry is unspent and the current time is before
+  that deadline; after the retry is spent, fall back immediately while retaining session backoff for other
+  launches. Permanent failures, including malformed or unsupported timer text, disable that external route
+  for the current session before falling back to a fresh native worker. Opaque or unrecognized failures fall
+  back to a fresh native worker without disabling that route. Session backoff is never durable.
   The existing external Codex retry uses the typed `codex-recovery` prompt profile from **Review
   preparation mapping**; every other launch uses `standard`. Profiles never add attempts, resume a failed
   session, weaken the shared review contract, or require a model switch.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -14,7 +14,7 @@ adapter; keep workflow rules shared.
 | Agent dispatch | Agent tool and configured agent types | Available Codex multi-agent controls | Describe worker scope, permissions, model class, and output; do not require a host tool name. |
 | Model selection | Claude model aliases may be available | Session model or configured Codex agents | State required capability; map named models only inside host adapter. |
 | Heartbeat/resume | `ScheduleWakeup` where available | wakes its thread where available; bounded foreground wait otherwise | Persist state before waiting and provide an exact resume path. |
-| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Classify failures before retry or fallback: a valid timer waits only while the retry is unspent and the current time is before its deadline; after the retry is spent, fall back immediately while retaining session backoff. Disable the external route only for permanent failures, including malformed or unsupported timer text; unrecognized failures use a fresh native worker without disabling it. Explicit or saved user choice overrides. |
+| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Classify failures before retry or fallback: a valid timer waits only while the retry is unspent and the current time is before its deadline; after the retry is spent, fall back immediately while retaining session backoff. Disable the external route only for permanent failures, including malformed or unsupported timer text; unrecognized failures use a fresh native worker without disabling it. A reviewer refusal never falls back — it stops and asks the operator, since the fallback would be the driving engine itself. Explicit or saved user choice overrides. |
 
 Campaign's exact cross-agent command lines live in
 [`plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md`](../plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md).
@@ -40,7 +40,9 @@ Campaign's exact cross-agent command lines live in
   that deadline; after the retry is spent, fall back immediately while retaining session backoff for other
   launches. Permanent failures, including malformed or unsupported timer text, disable that external route
   for the current session before falling back to a fresh native worker. Opaque or unrecognized failures fall
-  back to a fresh native worker without disabling that route. Session backoff is never durable.
+  back to a fresh native worker without disabling that route. A refusal never falls back: it stops and asks
+  the operator, because the native fallback runs the driving engine and would silently end cross-engine
+  review. Session backoff is never durable.
   The existing external Codex retry uses the typed `codex-recovery` prompt profile from **Review
   preparation mapping**; every other launch uses `standard`. Profiles never add attempts, resume a failed
   session, weaken the shared review contract, or require a model switch.

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -68,10 +68,17 @@ native-limitation level whenever the paired CLI is present — engine diversity 
 You can override the default: name a reviewer when you invoke the campaign (including a native worker), or
 record a preference in the orchestrator's own trusted state — never in the checkout under review
 (`skills/campaign/references/reviewer.md`, "Selecting the reviewer", owns which sources count). If the paired CLI is absent, or a cross-engine
-reviewer can't return a verdict because of a system problem (quota, auth, timeout), the pipeline retries
-once and then falls back to a fresh native worker. The existing Codex retry uses repository-maintenance
-framing with the same full review contract and process command; it does not resume the failed session or
-switch models. Campaign therefore runs with or without the other engine.
+reviewer can't return a verdict, use the classification and fallback contract owned by
+`skills/campaign/references/runtime-adapter.md`, "Review failure classification and session backoff".
+That contract permits one retry for transient failures. A valid timer waits at the exact provider deadline
+only while the retry is unspent and the current time is before that deadline; after the retry is spent,
+native fallback is immediate while session backoff is retained for other launches. Malformed or unsupported
+timer text is permanent and disables the external route for this session before native fallback. Opaque or
+unrecognized typed failure kinds use native fallback without disabling the route.
+Session backoff and disabled state are never durable. The retry uses the same full review contract and process
+command; only the mapped Codex recovery
+profile adds repository-maintenance framing. It never resumes the failed session or requires a model
+switch. Campaign therefore runs with or without the other engine.
 The cross-engine and native routes both keep fresh conversational context and disclose the host's
 filesystem/startup-instruction limitations; a future adapter that proves an OS boundary can claim more.
 

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -74,7 +74,9 @@ That contract permits one retry for transient failures. A valid timer waits at t
 only while the retry is unspent and the current time is before that deadline; after the retry is spent,
 native fallback is immediate while session backoff is retained for other launches. Malformed or unsupported
 timer text is permanent and disables the external route for this session before native fallback. Opaque or
-unrecognized typed failure kinds use native fallback without disabling the route.
+unrecognized typed failure kinds use native fallback without disabling the route. A reviewer that refuses
+the task outright is never recovered automatically: the campaign stops that PR and tells you, because
+falling back would hand the review to the same engine that is driving the campaign.
 Session backoff and disabled state are never durable. The retry uses the same full review contract and process
 command; only the mapped Codex recovery
 profile adds repository-maintenance framing. It never resumes the failed session or requires a model

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -238,7 +238,10 @@ never the place to look them up.
   current time is before that deadline; after the retry is spent, native fallback is immediate while session
   backoff is retained for other launches. Permanent failures, including malformed or unsupported timer text,
   go to native fallback and disable the external route for this session. Opaque or unrecognized typed failure
-  kinds use native fallback without disabling it. Session backoff and disabled state are never durable. The
+  kinds use native fallback without disabling it. A reviewer that refuses the task outright is never
+  recovered automatically: the campaign stops that PR and tells you, because falling back would review the
+  code with the same engine that is driving the campaign and quietly cost you the second opinion.
+  Session backoff and disabled state are never durable. The
   retry uses the same complete review contract and process command; only the
   mapped Codex recovery profile adds repository-maintenance framing. It never resumes the failed session
   or requires a model switch. Campaign therefore runs with or without the other engine. The fallback uses

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -232,8 +232,11 @@ never the place to look them up.
   (for example, “review with claude”, or a native worker) or record a preference in the orchestrator's own
   trusted state — never in the checkout under review (`references/reviewer.md`, "Selecting the reviewer", owns which sources count).
   If the paired CLI is absent, or a cross-engine reviewer
-  can't return a verdict because of a system problem — quota or rate limits, auth, a timeout — it
-  retries once and then falls back to a fresh native worker. The existing Codex retry uses
+  can't return a verdict because of a system problem — quota or rate limits, auth, a timeout — follow
+  [`references/runtime-adapter.md`](./references/runtime-adapter.md), "Review failure classification and session backoff".
+  That owner classifies the failure as transient for one immediate retry, timer for an exact-deadline wait
+  before retrying, permanent for immediate native fallback with session disable, or unrecognized for native
+  fallback without session disable. The existing Codex retry uses
   repository-maintenance framing with the same complete review contract and process command; it never
   resumes the failed session or requires a model switch. Campaign therefore runs with or without the other
   engine. The fallback uses the disclosed native isolation contract. A reviewer that never

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -231,15 +231,18 @@ never the place to look them up.
   reviewer when you invoke the campaign
   (for example, “review with claude”, or a native worker) or record a preference in the orchestrator's own
   trusted state — never in the checkout under review (`references/reviewer.md`, "Selecting the reviewer", owns which sources count).
-  If the paired CLI is absent, or a cross-engine reviewer
-  can't return a verdict because of a system problem — quota or rate limits, auth, a timeout — follow
-  [`references/runtime-adapter.md`](./references/runtime-adapter.md), "Review failure classification and session backoff".
-  That owner classifies the failure as transient for one immediate retry, timer for an exact-deadline wait
-  before retrying, permanent for immediate native fallback with session disable, or unrecognized for native
-  fallback without session disable. The existing Codex retry uses
-  repository-maintenance framing with the same complete review contract and process command; it never
-  resumes the failed session or requires a model switch. Campaign therefore runs with or without the other
-  engine. The fallback uses the disclosed native isolation contract. A reviewer that never
+  If the paired CLI is absent, or a cross-engine reviewer can't return a verdict, follow the classification
+  and fallback contract owned by [`references/runtime-adapter.md`](./references/runtime-adapter.md),
+  "Review failure classification and session backoff". That contract permits one retry for transient
+  failures. A valid timer waits at the exact provider deadline only while the retry is unspent and the
+  current time is before that deadline; after the retry is spent, native fallback is immediate while session
+  backoff is retained for other launches. Permanent failures, including malformed or unsupported timer text,
+  go to native fallback and disable the external route for this session. Opaque or unrecognized typed failure
+  kinds use native fallback without disabling it. Session backoff and disabled state are never durable. The
+  retry uses the same complete review contract and process command; only the
+  mapped Codex recovery profile adds repository-maintenance framing. It never resumes the failed session
+  or requires a model switch. Campaign therefore runs with or without the other engine. The fallback uses
+  the disclosed native isolation contract. A reviewer that never
   gets going at all — hung on input, a bad path, a sandbox
   denial — is caught the same way: every review pass has to write *something* to its progress file
   within about five minutes of being dispatched, and one that writes nothing at all is killed and

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -30,11 +30,13 @@ At every entry/resume, before any other work:
 
 The **adversarial reviewer** is a selectable role: by default the cross-engine route (Claude Code
 reviews with `codex exec`, Codex reviews with `claude -p`), launched at native-limitation level
-whenever the paired CLI is present, falling back to a fresh native worker when it is absent or fails.
+whenever the paired CLI is present. Before retry or fallback, classify the external process failure
+through `references/runtime-adapter.md`'s session-only backoff contract; use a fresh native worker when
+that transition directs fallback.
 An explicit invocation or a TRUSTED saved preference (the orchestrator's own out-of-checkout user
 memory / global user instructions — NEVER a file inside the candidate checkout, including
 `.gauntlet/history/` carryover) overrides the default. `references/reviewer.md` owns selection and
-fallback; `references/runtime-adapter.md` owns the isolation contract. Every route guarantees fresh
+fallback; `references/runtime-adapter.md` owns isolation and external-failure transition state. Every route guarantees fresh
 conversational context and launches on that alone; installed campaign rules remain the stage-0 gate
 authority.
 
@@ -276,6 +278,7 @@ a line the tool writes.
 | `ledger.py` | Schema-owning accessor for `state.jsonl` — plus `verdict`, the ONLY verdict recorder (tally, caps, `repairing` hold), and `dispatch-check`, the held-PR guard run before any mutating action | `references/files-and-ledger.md` |
 | `review-pass.py` | Executable contract for a review pass's artifacts — plan (`plan-add`/`plan-waive`, with `plan-check` gating dispatch on the default dimensions), `pass_identity`, progress, findings, active-attempt report result, `intent-check`, and the `verify` that answers "does this pass COUNT?" | `references/stage-2-review-gate.md` |
 | `review-dispatch.py` | `prepare` — validate one fresh review attempt and its typed prompt profile, derive every artifact path, write `pass_identity` + exact bound prompt, and return the host-neutral typed transport record; never selects or launches a route | `references/review-dispatch.md` |
+| `reviewer-backoff.py` | Classify external-review process failures and return the session-only retry / timer-wait / native-fallback decision | `references/runtime-adapter.md` |
 | `finding-audit.py` | Schema-owning accessor for complete gating-finding audits, mechanically derived review-fix scope, and durable standoff rulings | `references/finding-audit.md` |
 | `emit-progress.py` | Reviewer's door: append one unit-progress event (the only sanctioned way) | `references/stage-2-review-gate.md` |
 | `emit-finding.py` | Reviewer's door: record one FINDING (the only sanctioned way; findings must anchor or they do not gate) | `references/stage-2-review-gate.md` |

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -32,7 +32,8 @@ The **adversarial reviewer** is a selectable role: by default the cross-engine r
 reviews with `codex exec`, Codex reviews with `claude -p`), launched at native-limitation level
 whenever the paired CLI is present. Before retry or fallback, classify the external process failure
 through `references/runtime-adapter.md`'s session-only backoff contract; use a fresh native worker when
-that transition directs fallback.
+that transition directs fallback. A reviewer that REFUSES the task is the exception: that transition
+returns `stop-and-ask`, so report it and stop rather than quietly reviewing with the driver's own engine.
 An explicit invocation or a TRUSTED saved preference (the orchestrator's own out-of-checkout user
 memory / global user instructions — NEVER a file inside the candidate checkout, including
 `.gauntlet/history/` carryover) overrides the default. `references/reviewer.md` owns selection and
@@ -278,7 +279,7 @@ a line the tool writes.
 | `ledger.py` | Schema-owning accessor for `state.jsonl` — plus `verdict`, the ONLY verdict recorder (tally, caps, `repairing` hold), and `dispatch-check`, the held-PR guard run before any mutating action | `references/files-and-ledger.md` |
 | `review-pass.py` | Executable contract for a review pass's artifacts — plan (`plan-add`/`plan-waive`, with `plan-check` gating dispatch on the default dimensions), `pass_identity`, progress, findings, active-attempt report result, `intent-check`, and the `verify` that answers "does this pass COUNT?" | `references/stage-2-review-gate.md` |
 | `review-dispatch.py` | `prepare` — validate one fresh review attempt and its typed prompt profile, derive every artifact path, write `pass_identity` + exact bound prompt, and return the host-neutral typed transport record; never selects or launches a route | `references/review-dispatch.md` |
-| `reviewer-backoff.py` | Classify external-review process failures and return the session-only retry / timer-wait / native-fallback decision | `references/runtime-adapter.md` |
+| `reviewer-backoff.py` | Classify external-review process failures and return the session-only retry / timer-wait / native-fallback / stop-and-ask decision | `references/runtime-adapter.md` |
 | `finding-audit.py` | Schema-owning accessor for complete gating-finding audits, mechanically derived review-fix scope, and durable standoff rulings | `references/finding-audit.md` |
 | `emit-progress.py` | Reviewer's door: append one unit-progress event (the only sanctioned way) | `references/stage-2-review-gate.md` |
 | `emit-finding.py` | Reviewer's door: record one FINDING (the only sanctioned way; findings must anchor or they do not gate) | `references/stage-2-review-gate.md` |

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -133,8 +133,9 @@ exactly what made it lethal. That case is the reassessment pass's, above, and no
 When the loop exits, summarize:
 
 - **Reviewer** — the ledger `reviewer` value the run used, every pass whose external Codex attempt `2`
-  used the `codex-recovery` prompt profile, plus any review pass where an external reviewer failed and
-  fell back to the active host's native workers (see "The reviewer").
+  used the `codex-recovery` prompt profile, any review pass where an external reviewer failed and
+  fell back to the active host's native workers, and any PR stopped because the external reviewer refused
+  the task (see "The reviewer").
 - **Which rules actually ran** — the ledger header's `skill_version`. **State it every time.** The harness
   loads this skill from the **installed plugin cache**, so a merged, version-bumped rule governs **nothing**
   until that cache refreshes — and one did not, for days, while every report in that window said "reviewer:

--- a/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
+++ b/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
@@ -7,6 +7,10 @@ This file defines the argv for that route, not review policy or the isolation ru
 Before preparing a record or prompt, evaluate `runtime-adapter.md`'s `ReviewIsolationCapability` and take
 its transition. Only `launch-external` or `retry-external` uses the commands below; every other action
 stays with the owner.
+When an external process returns without a usable verdict, classify its captured failure through
+`runtime-adapter.md`, "Review failure classification and session backoff", before taking any retry or
+fallback. Pass the typed `ExternalReviewFailure` and session state to the transition; provider text does
+not select an argv member or prompt profile here.
 A capable adapter runs `review-dispatch.py prepare` through the exact invocation in `review-dispatch.md`,
 then launches the process from its returned transport as a background task whose completion triggers a
 reconcile. Prompt bytes — including verbatim GitHub-derived intent — and dynamic paths never enter shell
@@ -98,8 +102,8 @@ This argv launches at the native-limitation level; it does not create a stronger
 - Limit built-in tools to `Read` and `Bash`. The review prompt forbids source changes; Bash is needed
   for git inspection and the two artifact emitters.
 - `--permission-mode dontAsk` makes an unapproved operation fail instead of opening an interactive
-  prompt. A permission or sandbox denial is a reviewer system failure; retry or fall back under
-  `reviewer.md`. Never switch to `--dangerously-skip-permissions`.
+  prompt. A permission or sandbox denial is a reviewer system failure; classify it through the runtime
+  adapter before retry or fallback. Never switch to `--dangerously-skip-permissions`.
 - Set `stdin_file` to `transport.prompt_path` and `stdout_file` to `transport.report.path`; the external
   process capture is the sole report producer. Prompt and path values remain data.
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -31,10 +31,10 @@ note it in the final report. Resolve in priority order:
    file can reach the selection.
 3. **Default — the cross-engine route for the active host.** No preference → Claude Code reviews with
    Codex (`codex exec`) and Codex reviews with Claude Code (`claude -p`), launched at native-limitation
-   level whenever the paired CLI is present. When the paired CLI is absent, or the cross-engine process
-   fails after its one retry, fall back to a fresh, context-isolated **native worker** on the active host,
-   disclosed in the final report. **No paired CLI is required for the campaign to run** — the native
-   fallback is always available.
+   level whenever the paired CLI is present. When the paired CLI is absent, or the runtime transition
+   directs fallback after classifying a process failure, use a fresh, context-isolated **native worker**
+   on the active host, disclosed in the final report. **No paired CLI is required for the campaign to run**
+   — the native fallback is always available.
 
 **Reviewer diversity is the default, not an add-on — and it also reduces native-worker cost.** The gate's
 passes are already fresh, context-isolated re-rolls, but two native workers share the orchestrator's model,
@@ -43,14 +43,15 @@ so they are less independent than a *different* engine would be. So the default 
 `claude -p`. It launches at native-limitation level whenever the paired CLI is present — engine diversity
 needs no OS sandbox. A same-engine process (Codex → another `codex exec`, Claude Code → another `claude
 -p`) provides fresh context only and must not be reported as diversity. A fresh native worker on the
-active host is the complete, valid **fallback** when the paired CLI is absent or the cross-engine process
-fails after its retry. The cost benefit compounds the diversity one: review passes dominate campaign's
+active host is the complete, valid **fallback** when the paired CLI is absent or the runtime transition
+directs it after classifying a cross-engine process failure. The cost benefit compounds the diversity one:
+review passes dominate campaign's
 native-worker spend — each re-reads the **whole** `origin/<base>...HEAD` diff (where `<base>` is the
 selected PR row's **effective base** — its explicit `base_branch`, else the legacy header fallback,
 resolved through `ledger.py`'s `effective_base`, never the one header base), runs `required(tier)` times
 per SHA, and re-runs **from scratch** on every gate reset (a content change voids the tally), so a PR that
 takes several fix rounds can spend many full-diff passes — and the default cross-engine route moves all of
-that off the native-worker pool, while a native-worker fallback (paired CLI absent) does not. Both are
+that off the native-worker pool, while a native-worker fallback still uses that pool. Both are
 benefits of the default, not separate knobs — the reviewer choice is owned above.
 
 **A REVIEW PASS IS NEVER RUN ON A DOWNGRADED MODEL.** Whether the reviewer is a native worker or the
@@ -66,7 +67,7 @@ class or review contract.
 **A NATIVE-WORKER REVIEWER RUNS THE SAME REVIEW PASS AS EVERY OTHER REVIEWER — the one `stage-2-review-gate.md`
 defines, whole.** “Native worker” names **who executes it**, and nothing else. It does not name a
 lighter contract, a shorter prompt, or an older protocol, and there is no such thing to name. It is the
-**fallback** for an absent or failed cross-engine reviewer, and it is what an explicit user selection of a
+**fallback** for an absent or transition-failed cross-engine reviewer, and it is what an explicit user selection of a
 native reviewer runs.
 
 It is also a verdict renderer, so use `runtime-adapter.md`'s **native-worker** isolation contract, not the
@@ -83,7 +84,7 @@ RECORDS, not prose", "Does this pass COUNT?"), and the one time this section car
 the summary went stale: it still described a plan/progress/verdict protocol with **no intent, no findings
 artifact and no gating rule**, months after those became the contract. Following it recreated exactly the
 open-ended review — *"is anything wrong with this code?"* — that the intent block exists to kill, **on the
-native-worker path**, which is the fallback whenever a cross-engine reviewer is absent or fails. A stale
+native-worker path**, which is the fallback whenever the runtime transition selects native. A stale
 summary is worse than no summary: it is the version people actually read, and it is believed.
 
 **Prepare it with `review-dispatch.py prepare`, using the exact invocation in `review-dispatch.md`.** The
@@ -127,19 +128,24 @@ exhaustion, auth failures, timeouts, or other system errors. Distinguish this fr
 run that returns an actual finding list or a `VERDICT: …` line is a *result*, act on it. A *failure*
 is the absence of a verdict.
 
-**On a capable external process failure, retry once. If it still can't deliver a verdict, take
-`runtime-adapter.md`'s fresh native fallback transition** rather than stalling, looping, or skipping the
-gate. A pre-launch capability miss (the paired CLI is absent) has no process to retry and takes that
-fallback immediately. Note in the final report which cross-engine routes were unavailable and which passes
-used the recovery profile or ran on the native-worker fallback. The gate is unchanged: a worker pass is a fresh, context-isolated re-roll that counts toward
-the review gate exactly like an external pass. The runtime owner defines the native limitations and the
-only machine-blocker transition; do not restate them here.
+**Before any retry or fallback, classify the captured external-process failure through
+`runtime-adapter.md`, "Review failure classification and session backoff".** The helper returns
+`transient`, `timer`, or `permanent`; permanent markers and malformed or unsupported timer text are
+permanent, and an unrecognized failure is permanent. Apply the returned transition: transient failures may
+spend the one retry, valid timers wait for the exact provider deadline before retrying, and permanent
+failures disable that external route for this session before native fallback.
+The paired CLI absence is a pre-launch capability miss and takes native fallback without a retry. Keep
+the session backoff state in memory only; never write it to campaign artifacts.
+Note in the final report which cross-engine routes were unavailable and which passes used the recovery
+profile or ran on the native-worker fallback. The gate is unchanged: a worker pass is a fresh,
+context-isolated re-roll that counts toward the review gate exactly like an external pass. The runtime
+owner defines the native limitations and the only machine-blocker transition; do not restate them here.
 
 **Prepare every retry from `runtime-adapter.md`, "Review preparation mapping".** The transition does not
-inspect provider error text: it assigns `codex-recovery` to the existing external Codex attempt `2` and
-`standard` to every other route. The retry always starts a fresh process and never resumes the failed
-external session. The profile changes only the opening framing, does not require a model switch, and
-keeps the complete shared prompt contract, attempt budget, producer, and canonical argv. The shipped
+select a profile from provider output: it assigns `codex-recovery` to the existing external Codex attempt
+`2` and `standard` to every other route. The retry always starts a fresh process and never resumes the
+failed external session. The profile changes only the opening framing, does not require a model switch,
+and keeps the complete shared prompt contract, attempt budget, producer, and canonical argv. The shipped
 adapter has no trusted alternate-model mapping, so it passes no model-selection argument.
 
 A reviewer that **never starts** is a distinct failure — it produces not even a partial result — and

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -130,10 +130,11 @@ is the absence of a verdict.
 
 **Before any retry or fallback, classify the captured external-process failure through
 `runtime-adapter.md`, "Review failure classification and session backoff".** The helper returns
-`transient`, `timer`, or `permanent`; permanent markers and malformed or unsupported timer text are
-permanent, and an unrecognized failure is permanent. Apply the returned transition: transient failures may
-spend the one retry, valid timers wait for the exact provider deadline before retrying, and permanent
-failures disable that external route for this session before native fallback.
+`transient`, `timer`, `permanent`, or `unrecognized`; permanent markers and malformed or unsupported
+timer text are permanent, while opaque text is unrecognized. Apply the returned transition: transient
+failures may spend the one retry, valid timers wait for the exact provider deadline before retrying,
+permanent failures disable that external route for this session, and unrecognized failures use native
+fallback without disabling the external route.
 The paired CLI absence is a pre-launch capability miss and takes native fallback without a retry. Keep
 the session backoff state in memory only; never write it to campaign artifacts.
 Note in the final report which cross-engine routes were unavailable and which passes used the recovery
@@ -141,12 +142,14 @@ profile or ran on the native-worker fallback. The gate is unchanged: a worker pa
 context-isolated re-roll that counts toward the review gate exactly like an external pass. The runtime
 owner defines the native limitations and the only machine-blocker transition; do not restate them here.
 
-**Prepare every retry from `runtime-adapter.md`, "Review preparation mapping".** The transition does not
-select a profile from provider output: it assigns `codex-recovery` to the existing external Codex attempt
-`2` and `standard` to every other route. The retry always starts a fresh process and never resumes the
-failed external session. The profile changes only the opening framing, does not require a model switch,
-and keeps the complete shared prompt contract, attempt budget, producer, and canonical argv. The shipped
-adapter has no trusted alternate-model mapping, so it passes no model-selection argument.
+**Prepare every retry from `runtime-adapter.md`, "Review preparation mapping".** `reviewer-backoff.py`
+classifies provider text and owns the session retry or deadline decision. The transition never chooses a
+prompt profile from provider error text: it assigns `codex-recovery` to the existing external Codex
+attempt `2` and `standard` to every other route. The retry always starts a fresh process and never
+resumes the failed external session. The profile changes only the opening framing, does not require a
+model switch, and keeps the complete shared prompt contract, attempt budget, producer, and canonical
+argv. The shipped adapter has no trusted alternate-model mapping, so it passes no model-selection
+argument.
 
 A reviewer that **never starts** is a distinct failure — it produces not even a partial result — and
 has its own guard: the Stage 2a **launch check** kills any pass that has written **no launch evidence**

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -132,8 +132,10 @@ is the absence of a verdict.
 `runtime-adapter.md`, "Review failure classification and session backoff".** The helper returns
 `transient`, `timer`, `permanent`, or `unrecognized`; permanent markers and malformed or unsupported
 timer text are permanent, while opaque text is unrecognized. Apply the returned transition: transient
-failures may spend the one retry, valid timers wait for the exact provider deadline before retrying,
-permanent failures disable that external route for this session, and unrecognized failures use native
+failures may spend the one retry. A valid timer waits for the exact provider deadline only while the retry
+is unspent and the current time is before that deadline; after the retry is spent, fall back immediately
+while retaining session backoff for other launches. Permanent failures, including malformed or unsupported
+timer text, disable that external route for this session, and opaque or unrecognized failures use native
 fallback without disabling the external route.
 The paired CLI absence is a pre-launch capability miss and takes native fallback without a retry. Keep
 the session backoff state in memory only; never write it to campaign artifacts.

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -124,23 +124,29 @@ attempt-scoped prompt artifact.** Never pass the prompt as a command argument an
 the former puts untrusted bytes at the wrong boundary, while the latter can stay open forever.
 
 An external reviewer can fail in a way that yields **no usable verdict**: quota/rate-limit
-exhaustion, auth failures, timeouts, or other system errors. Distinguish this from a real review — a
+exhaustion, auth failures, timeouts, other system errors, or a refusal to perform the task at all.
+Distinguish this from a real review — a
 run that returns an actual finding list or a `VERDICT: …` line is a *result*, act on it. A *failure*
 is the absence of a verdict.
 
 **Before any retry or fallback, classify the captured external-process failure through
 `runtime-adapter.md`, "Review failure classification and session backoff".** The helper returns
-`transient`, `timer`, `permanent`, or `unrecognized`; permanent markers and malformed or unsupported
-timer text are permanent, while opaque text is unrecognized. Apply the returned transition: transient
+`transient`, `timer`, `permanent`, `refusal`, or `unrecognized`; permanent markers and malformed or unsupported
+timer text are permanent, a reviewer that declined the task on content or policy grounds is a refusal, and
+opaque text is unrecognized. Apply the returned transition: transient
 failures may spend the one retry. A valid timer waits for the exact provider deadline only while the retry
 is unspent and the current time is before that deadline; after the retry is spent, fall back immediately
 while retaining session backoff for other launches. Permanent failures, including malformed or unsupported
 timer text, disable that external route for this session, and opaque or unrecognized failures use native
-fallback without disabling the external route.
+fallback without disabling the external route. **A refusal is the one failure that never recovers on its
+own**: it returns `stop-and-ask`, so report the refusal and the PR under review to the operator and stop
+there. Never retry it and never let it fall back to the same-engine native reviewer — that would drop the
+engine diversity the gate relies on without anyone being told. The refusal marker set is deliberately not
+exhaustive, so refusal wording it does not match arrives as `unrecognized` and takes the native fallback.
 The paired CLI absence is a pre-launch capability miss and takes native fallback without a retry. Keep
 the session backoff state in memory only; never write it to campaign artifacts.
-Note in the final report which cross-engine routes were unavailable and which passes used the recovery
-profile or ran on the native-worker fallback. The gate is unchanged: a worker pass is a fresh,
+Note in the final report which cross-engine routes were unavailable, which passes used the recovery
+profile or ran on the native-worker fallback, and every reviewer refusal that stopped a PR for the operator. The gate is unchanged: a worker pass is a fresh,
 context-isolated re-roll that counts toward the review gate exactly like an external pass. The runtime
 owner defines the native limitations and the only machine-blocker transition; do not restate them here.
 

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -184,20 +184,41 @@ ReviewTransition {
 The classifier recognizes non-negative whole-second relative provider delays such as `retry after 90
 seconds` and `available in 90 seconds`, plus absolute provider reset timestamps such as `resets Jul 27,
 9pm (Asia/Tokyo)`. Construct an absolute timestamp in the provider-named timezone, then calculate elapsed
-time with timezone-aware arithmetic. Refusal markers take precedence over every other marker, because a
-reviewer that declined the task on content or policy grounds has not suffered a transport failure and must
-not be recovered by swapping in a same-engine native reviewer. That marker set is deliberately NOT
-exhaustive: refusal wording it does not match stays `unrecognized` and takes the disclosed native fallback.
+time with timezone-aware arithmetic.
+
+The classifier collects every marker, every parsed timer, and every timer attempt in the message
+FIRST, as a claim on a span of the text, and only then applies the class order. A marker whose span
+sits inside a strictly longer marker's span is a fragment of that longer one and is dropped before
+the class order runs, so `refused` inside `connection refused` never outranks it. Merely overlapping
+claims both survive, and only markers can drop markers: a timer span says nothing about the words
+inside it, so a timer attempt straddling refusal wording never swallows it.
+
+The class order over what survives is refusal, then permanent, then malformed timer, then valid
+timer, then transient, then unrecognized. Refusal markers take precedence over every other marker,
+because a reviewer that declined the task on content or policy grounds has not suffered a transport
+failure and must not be recovered by swapping in a same-engine native reviewer. That marker set is
+deliberately NOT exhaustive: refusal wording it does not match stays `unrecognized` and takes the
+disclosed native fallback.
 Permanent markers come next, taking precedence over timers and transient markers;
 valid timer text takes precedence over generic transient markers. Malformed or unsupported timer text,
 including fractional or unrepresentable delays, unknown zones, and a numeric offset that is invalid for
 the named zone at the target local time, is `permanent`, and because it is `permanent` it also outranks
 any transient marker in the same message. A named zone's valid offsets include both sides
-of a DST fold. Text is a timer attempt at all only when a retry, reset, or availability word actually
-introduces a value — a connector such as `after` or `in`, a colon, or a digit follows it. A retry word that
-introduces nothing, as in `please try again`, is not a broken timer and never reaches that `permanent`
-precedence: the message keeps the class its own markers give it, `transient` when a transient marker
-matches and `unrecognized` otherwise. An unrecognized failure is opaque text that falls back natively
+of a DST fold.
+
+Text is a timer attempt at all only when a retry, reset, or availability word actually introduces a
+value: a digit, a time-unit word, or a month name must follow it, with at most one intervening
+token, optionally through a connector such as `after` or `in` or through a colon. A connector or a
+colon on its own is NOT a value, so `service unavailable at this time` is not a broken timer. A value
+token that is itself a live digit transient marker is a status rather than a delay, so `retry: 429`
+is not one either. That one-token window is arbitrary and load-bearing — it is what separates
+`retry after never seconds`, a broken timer that fails closed, from `try again in a few minutes`,
+ordinary prose — and fixtures pin both sides of it. A trigger word that introduces nothing, as in
+`please try again`, never reaches that `permanent` precedence: the message keeps the class its own
+markers give it, `transient` when a transient marker matches and `unrecognized` otherwise. A number
+with no time unit behind it stays a broken timer, because nothing syntactic separates
+`retry after 3 requests` from `retry after 90 bananas` and a vocabulary of non-time nouns is a
+non-goal. An unrecognized failure is opaque text that falls back natively
 without disabling this external route for the current session.
 
 `ExternalReviewSessionState` is process/session memory owned by the active orchestrator. Update it only

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -210,8 +210,11 @@ Text is a timer attempt at all only when a retry, reset, or availability word ac
 value: a digit, a time-unit word, or a month name must follow it, with at most one intervening
 token, optionally through a connector such as `after` or `in` or through a colon. A connector or a
 colon on its own is NOT a value, so `service unavailable at this time` is not a broken timer. A value
-token that is itself a live digit transient marker is a status rather than a delay, so `retry: 429`
-is not one either. That one-token window is arbitrary and load-bearing — it is what separates
+token that carries NO time unit and is itself a live digit transient marker is a status rather than a
+delay, and that holds whether or not the timer text otherwise reads as complete: `retry: 429` is not a
+broken timer, and `retry after 429` is not a valid one either. Both keep the class their own markers
+give them, `transient` here. A stated unit settles the reading the other way, so `retry after 503
+seconds` is a timer of 503 seconds. That one-token window is arbitrary and load-bearing — it is what separates
 `retry after never seconds`, a broken timer that fails closed, from `try again in a few minutes`,
 ordinary prose — and fixtures pin both sides of it. A trigger word that introduces nothing, as in
 `please try again`, never reaches that `permanent` precedence: the message keeps the class its own

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -161,7 +161,7 @@ provider text never selects a route, profile, model, or argv member.
 
 ```text
 ExternalReviewFailure {
-  kind: "transient" | "timer" | "permanent",
+  kind: "transient" | "timer" | "permanent" | "unrecognized",
   retry_after_seconds: NonNegativeInt | null,
   retry_at: Timestamp | null,
   reason: Text,
@@ -188,8 +188,8 @@ time with timezone-aware arithmetic. Permanent markers take precedence over time
 valid timer text takes precedence over generic transient markers. Malformed or unsupported timer text,
 including fractional or unrepresentable delays, unknown zones, and a numeric offset that is invalid for
 the named zone at the target local time, is `permanent`. A named zone's valid offsets include both sides
-of a DST fold. An unrecognized failure is also `permanent` and disables this external route for the
-current session.
+of a DST fold. An unrecognized failure is opaque text that falls back natively without disabling this
+external route for the current session.
 
 `ExternalReviewSessionState` is process/session memory owned by the active orchestrator. Update it only
 from the returned transition or decision. **Never write `external_disabled` or
@@ -215,6 +215,15 @@ review_transition(
 ) -> ReviewTransition
 ```
 
+`ExternalReviewFailure` and `ExternalReviewSessionState` are the typed values owned by
+`reviewer-backoff.py`. On `external-system-failure`, capture provider text and run
+`reviewer-backoff.py classify(provider_text, now)`, then run
+`reviewer-backoff.py transition(failure, retry_spent=external_retry_spent, now=now,
+state=session, pr_number=pr_number)`. Replace `session` with the returned transition state before the next
+transition. The helper keeps `unrecognized` opaque failures separate from `permanent` failures:
+opaque text falls back natively without disabling the external route, while known permanent markers and
+malformed timers retain the session-disable path owned there.
+
 This operation owns every route change:
 
 | Input | Action |
@@ -224,9 +233,10 @@ This operation owns every route change:
 | external failure classified `transient`, retry not spent | `retry-external` immediately |
 | external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external` until the exact provider deadline; do not launch before it |
 | external failure classified `timer`, retry not spent, and `now` has reached its deadline | `retry-external` immediately |
-| external failure classified `permanent`, or classification is unrecognized | set session `external_disabled`, then `fallback-native` |
+| external failure classified `permanent` | set session `external_disabled`, then `fallback-native` |
+| external failure classified `unrecognized` | use `fallback-native` without setting session `external_disabled` |
 | timer transition without the current positive PR number, including initial empty state | treat as malformed, set session `external_disabled`, then `fallback-native` without storing a deadline or timer identity |
-| external failure after retry, regardless of class | `fallback-native`; retain any timer backoff for other launches in this session |
+| external failure after retry, regardless of class | `fallback-native`; preserve the helper's disable decision and retain any timer backoff for other launches in this session |
 | session timer backoff is active for another PR | use `fallback-native` for that PR; do not shorten or ignore the timer |
 | native route/fallback can follow the installed contract | `launch-native` with the native limitations below |
 | native attempts cannot follow the installed contract or produce valid artifacts and their budget is exhausted | `park-machine-blocker` |
@@ -236,8 +246,7 @@ no `review-dispatch.py prepare`. Use the heartbeat or another bounded wait to re
 timestamp, then re-enter this transition with the same typed failure, live session state, and current time;
 the active-deadline re-entry rule above decides whether the stored deadline is preserved. A pre-launch
 cross-engine capability miss has no process to relaunch, so it consumes no retry and takes the fresh
-native fallback immediately. A timer or permanent provider error does not change the policy in a later
-session.
+native fallback immediately. A provider error does not change the policy in a later session.
 Missing native OS/startup controls alone never select `park-machine-blocker`; only actual inability to
 complete the installed contract after its budget does. `reviewer.md` owns the retry budget, while this table owns the transition meaning.
 

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -161,7 +161,7 @@ provider text never selects a route, profile, model, or argv member.
 
 ```text
 ExternalReviewFailure {
-  kind: "transient" | "timer" | "permanent" | "unrecognized",
+  kind: "transient" | "timer" | "permanent" | "refusal" | "unrecognized",
   retry_after_seconds: NonNegativeInt | null,
   retry_at: Timestamp | null,
   reason: Text,
@@ -184,7 +184,11 @@ ReviewTransition {
 The classifier recognizes non-negative whole-second relative provider delays such as `retry after 90
 seconds` and `available in 90 seconds`, plus absolute provider reset timestamps such as `resets Jul 27,
 9pm (Asia/Tokyo)`. Construct an absolute timestamp in the provider-named timezone, then calculate elapsed
-time with timezone-aware arithmetic. Permanent markers take precedence over timers and transient markers;
+time with timezone-aware arithmetic. Refusal markers take precedence over every other marker, because a
+reviewer that declined the task on content or policy grounds has not suffered a transport failure and must
+not be recovered by swapping in a same-engine native reviewer. That marker set is deliberately NOT
+exhaustive: refusal wording it does not match stays `unrecognized` and takes the disclosed native fallback.
+Permanent markers come next, taking precedence over timers and transient markers;
 valid timer text takes precedence over generic transient markers. Malformed or unsupported timer text,
 including fractional or unrepresentable delays, unknown zones, and a numeric offset that is invalid for
 the named zone at the target local time, is `permanent`. A named zone's valid offsets include both sides
@@ -222,7 +226,8 @@ review_transition(
 state=session, pr_number=pr_number)`. Replace `session` with the returned transition state before the next
 transition. The helper keeps `unrecognized` opaque failures separate from `permanent` failures:
 opaque text falls back natively without disabling the external route, while known permanent markers and
-malformed timers retain the session-disable path owned there.
+malformed timers retain the session-disable path owned there. A `refusal` is neither: it returns
+`stop-and-ask` with the session state unchanged, so the operator decides what happens next.
 
 This operation owns every route change:
 
@@ -234,17 +239,22 @@ This operation owns every route change:
 | external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external` until the exact provider deadline; do not launch before it |
 | external failure classified `timer`, retry not spent, and `now` has reached its deadline | `retry-external` immediately |
 | external failure classified `permanent` | set session `external_disabled`, then `fallback-native` |
+| external failure classified `refusal` | `stop-and-ask`: report the reviewer's refusal and the PR it was reviewing to the operator and stop this PR's review there. Never retry, never fall back to the same-engine native reviewer, and leave session state unchanged |
 | external failure classified `unrecognized` | use `fallback-native` without setting session `external_disabled` |
 | timer transition without the current positive PR number, including initial empty state | treat as malformed, set session `external_disabled`, then `fallback-native` without storing a deadline or timer identity |
-| external failure after retry, regardless of class | `fallback-native`; preserve the helper's disable decision and retain any timer backoff for other launches in this session |
+| external failure after retry, any class except `refusal` | `fallback-native`; preserve the helper's disable decision and retain any timer backoff for other launches in this session |
 | session timer backoff is active for another PR | use `fallback-native` for that PR; do not shorten or ignore the timer |
 | native route/fallback can follow the installed contract | `launch-native` with the native limitations below |
 | native attempts cannot follow the installed contract or produce valid artifacts and their budget is exhausted | `park-machine-blocker` |
 
-`wait-external` is a session action, not a process launch: it consumes no `launch_attempt` and calls
-no `review-dispatch.py prepare`. Use the heartbeat or another bounded wait to reach the returned
+`wait-external` and `stop-and-ask` are session actions, not process launches: they consume no
+`launch_attempt` and call no `review-dispatch.py prepare`. For `wait-external`, use the heartbeat or
+another bounded wait to reach the returned
 timestamp, then re-enter this transition with the same typed failure, live session state, and current time;
-the active-deadline re-entry rule above decides whether the stored deadline is preserved. A pre-launch
+the active-deadline re-entry rule above decides whether the stored deadline is preserved.
+`stop-and-ask` instead ends the campaign's autonomous handling of that PR and waits for the operator:
+engine diversity is a property of the gate, so a reviewer that refused the task is an operator decision,
+never a silent downgrade to a same-engine reviewer. A pre-launch
 cross-engine capability miss has no process to relaunch, so it consumes no retry and takes the fresh
 native fallback immediately. A provider error does not change the policy in a later session.
 Missing native OS/startup controls alone never select `park-machine-blocker`; only actual inability to
@@ -261,6 +271,7 @@ are different enums:
 | `retry-external` + `external-codex` | `external-codex` | `external-process-capture` | `codex-recovery` |
 | `retry-external` + `external-claude` | `external-claude` | `external-process-capture` | `standard` |
 | `wait-external` | no preparation | no preparation | no preparation |
+| `stop-and-ask` | no preparation | no preparation | no preparation |
 | `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |
 | `park-machine-blocker` | no preparation | no preparation | no preparation |
 

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -191,9 +191,14 @@ exhaustive: refusal wording it does not match stays `unrecognized` and takes the
 Permanent markers come next, taking precedence over timers and transient markers;
 valid timer text takes precedence over generic transient markers. Malformed or unsupported timer text,
 including fractional or unrepresentable delays, unknown zones, and a numeric offset that is invalid for
-the named zone at the target local time, is `permanent`. A named zone's valid offsets include both sides
-of a DST fold. An unrecognized failure is opaque text that falls back natively without disabling this
-external route for the current session.
+the named zone at the target local time, is `permanent`, and because it is `permanent` it also outranks
+any transient marker in the same message. A named zone's valid offsets include both sides
+of a DST fold. Text is a timer attempt at all only when a retry, reset, or availability word actually
+introduces a value — a connector such as `after` or `in`, a colon, or a digit follows it. A retry word that
+introduces nothing, as in `please try again`, is not a broken timer and never reaches that `permanent`
+precedence: the message keeps the class its own markers give it, `transient` when a transient marker
+matches and `unrecognized` otherwise. An unrecognized failure is opaque text that falls back natively
+without disabling this external route for the current session.
 
 `ExternalReviewSessionState` is process/session memory owned by the active orchestrator. Update it only
 from the returned transition or decision. **Never write `external_disabled` or
@@ -203,8 +208,11 @@ preferences, run artifacts, or any other durable campaign record. `timer_identit
 timer for the same PR owns its `retry_at`, even when earlier; a timer for another PR falls back natively
 and retains the existing deadline and owner. Matching timer text and deadline alone never prove re-entry.
 A new session starts with an empty state. **Require the current positive `pr_number` before storing any
-timer, including on the initial empty-state transition.** A missing or malformed PR owner is permanent,
-disables the external route for the session, and stores no deadline or timer identity.
+timer, including on the initial empty-state transition.** A malformed PR owner is permanent for every
+failure class: it disables the external route for the session and stores no deadline or timer identity. An
+omitted PR owner is permanent the same way for every class except `refusal` — a refusal stores no deadline
+or timer identity and owns no timer, so there is no owner to require, and its `stop-and-ask` (the `refusal`
+row below) outranks the requirement.
 
 ```text
 review_transition(

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -152,27 +152,92 @@ startup/cwd/mount/sandbox controls. A cross-engine record is identical in shape:
 true`, `launch_mechanism_present = true` when the paired CLI is present, the three properties false, no
 stronger-boundary claim. Both are available routes with the disclosed behavioral constraints below.
 
+### Review failure classification and session backoff
+
+**Classify every external process failure before choosing retry or fallback.** Feed the captured
+process error text to `reviewer-backoff.py`'s typed classifier, or to an equivalent host adapter that
+implements this same contract. A returned `ExternalReviewFailure` is data passed to the transition; raw
+provider text never selects a route, profile, model, or argv member.
+
+```text
+ExternalReviewFailure {
+  kind: "transient" | "timer" | "permanent",
+  retry_after_seconds: NonNegativeInt | null,
+  retry_at: Timestamp | null,
+  reason: Text,
+  timer_identity: Text | null
+}
+
+ExternalReviewSessionState {
+  external_disabled: Bool,
+  external_backoff_until: Timestamp | null,
+  external_backoff_timer_id: Text | null,
+  external_backoff_pr: PositiveInt | null
+}
+
+ReviewTransition {
+  action: ReviewAction,
+  session: ExternalReviewSessionState
+}
+```
+
+The classifier recognizes non-negative whole-second relative provider delays such as `retry after 90
+seconds` and `available in 90 seconds`, plus absolute provider reset timestamps such as `resets Jul 27,
+9pm (Asia/Tokyo)`. Construct an absolute timestamp in the provider-named timezone, then calculate elapsed
+time with timezone-aware arithmetic. Permanent markers take precedence over timers and transient markers;
+valid timer text takes precedence over generic transient markers. Malformed or unsupported timer text,
+including fractional or unrepresentable delays, unknown zones, and a numeric offset that is invalid for
+the named zone at the target local time, is `permanent`. A named zone's valid offsets include both sides
+of a DST fold. An unrecognized failure is also `permanent` and disables this external route for the
+current session.
+
+`ExternalReviewSessionState` is process/session memory owned by the active orchestrator. Update it only
+from the returned transition or decision. **Never write `external_disabled` or
+`external_backoff_until` or `external_backoff_timer_id` or `external_backoff_pr` to the ledger, history,
+preferences, run artifacts, or any other durable campaign record. `timer_identity` and
+`external_backoff_timer_id` are opaque session-memory values. While a session deadline is active, a new
+timer for the same PR owns its `retry_at`, even when earlier; a timer for another PR falls back natively
+and retains the existing deadline and owner. Matching timer text and deadline alone never prove re-entry.
+A new session starts with an empty state. **Require the current positive `pr_number` before storing any
+timer, including on the initial empty-state transition.** A missing or malformed PR owner is permanent,
+disables the external route for the session, and stores no deadline or timer identity.
+
 ```text
 review_transition(
   capability: ReviewIsolationCapability,
+  pr_number: PositiveInt,
   event: "selected" | "external-system-failure" | "native-system-failure",
+  failure: ExternalReviewFailure | null,
+  session: ExternalReviewSessionState,
   external_retry_spent: Bool,
+  now: Timestamp,
   native_attempts_exhausted: Bool
-) -> ReviewAction
+) -> ReviewTransition
 ```
 
 This operation owns every route change:
 
 | Input | Action |
 |---|---|
-| selected cross-engine route, paired CLI available | `launch-external` at native-limitation level (no stronger-boundary claim) |
-| `external-system-failure`, external retry not spent | re-evaluate capability, then `retry-external` only if still available |
-| selected cross-engine route unavailable before launch (paired CLI absent), or `external-system-failure` after retry | report the failure, then `fallback-native` (disclosed) |
+| selected cross-engine route, paired CLI available, and session state clear | `launch-external` at native-limitation level (no stronger-boundary claim) |
+| selected cross-engine route unavailable before launch, or session `external_disabled` is true | report the boundary, then `fallback-native` (disclosed) |
+| external failure classified `transient`, retry not spent | `retry-external` immediately |
+| external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external` until the exact provider deadline; do not launch before it |
+| external failure classified `timer`, retry not spent, and `now` has reached its deadline | `retry-external` immediately |
+| external failure classified `permanent`, or classification is unrecognized | set session `external_disabled`, then `fallback-native` |
+| timer transition without the current positive PR number, including initial empty state | treat as malformed, set session `external_disabled`, then `fallback-native` without storing a deadline or timer identity |
+| external failure after retry, regardless of class | `fallback-native`; retain any timer backoff for other launches in this session |
+| session timer backoff is active for another PR | use `fallback-native` for that PR; do not shorten or ignore the timer |
 | native route/fallback can follow the installed contract | `launch-native` with the native limitations below |
 | native attempts cannot follow the installed contract or produce valid artifacts and their budget is exhausted | `park-machine-blocker` |
 
-A pre-launch cross-engine capability miss (the paired CLI is absent) has no process to relaunch, so it
-consumes no retry and takes the fresh native fallback immediately.
+`wait-external` is a session action, not a process launch: it consumes no `launch_attempt` and calls
+no `review-dispatch.py prepare`. Use the heartbeat or another bounded wait to reach the returned
+timestamp, then re-enter this transition with the same typed failure, live session state, and current time;
+the active-deadline re-entry rule above decides whether the stored deadline is preserved. A pre-launch
+cross-engine capability miss has no process to relaunch, so it consumes no retry and takes the fresh
+native fallback immediately. A timer or permanent provider error does not change the policy in a later
+session.
 Missing native OS/startup controls alone never select `park-machine-blocker`; only actual inability to
 complete the installed contract after its budget does. `reviewer.md` owns the retry budget, while this table owns the transition meaning.
 
@@ -186,16 +251,19 @@ are different enums:
 | `launch-external` | selected capability's external route | `external-process-capture` | `standard` |
 | `retry-external` + `external-codex` | `external-codex` | `external-process-capture` | `codex-recovery` |
 | `retry-external` + `external-claude` | `external-claude` | `external-process-capture` | `standard` |
+| `wait-external` | no preparation | no preparation | no preparation |
 | `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |
 | `park-machine-blocker` | no preparation | no preparation | no preparation |
 
 Selected capability's external route is exactly `external-codex` or `external-claude`; never pass the
 `ReviewAction` string as `--route`.
 
-**Allocate `launch_attempt` monotonically for every reviewer launch passed to `prepare`.** An unavailable
-external route is never prepared and consumes no number, so its immediate native fallback takes the
-current next number. Once an attempt exists, recovery is fixed: attempt `1` fails → prepare the selected route's
-one retry as attempt `2`; attempt `2` fails → prepare fresh native fallback attempt `3`.
+**Allocate `launch_attempt` monotonically for every reviewer launch passed to `prepare`.** A
+`wait-external` action is not a launch and consumes no number. An unavailable external route is never
+prepared and consumes no number, so its native fallback takes the current next number. Once an attempt
+exists, recovery is fixed: attempt `1` fails → classify it, then prepare the selected route's one retry
+only when the transition permits it; a timer retry waits for its exact `retry_at`; attempt `2` fails →
+prepare fresh native fallback attempt `3`.
 **A dead or unusable attempt `3` → `park-machine-blocker`.** Never reuse an attempt's artifacts, and never
 allocate attempt `4`.
 
@@ -474,6 +542,6 @@ section states only the per-host default and where the transport pieces live:
 
 The cross-engine route launches at the **same native-limitation level** as a native worker whenever the
 paired CLI is present ("Review isolation capability and transition" above). Capability-gated cross-engine
-argv lives in `cross-agent-reviewers.md`; the external-reviewer retry budget in `reviewer.md`; the
-transition itself in `ReviewIsolationCapability` above. “Fallback” always means a fresh native worker on
-the active host.
+argv lives in `cross-agent-reviewers.md`; failure classification and session backoff in "Review failure
+classification and session backoff" above; the retry budget in `reviewer.md`; the transition itself in
+`ReviewIsolationCapability` above. “Fallback” always means a fresh native worker on the active host.

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -189,7 +189,7 @@ time with timezone-aware arithmetic.
 The classifier collects every marker, every parsed timer, and every timer attempt in the message
 FIRST, as a claim on a span of the text, and only then applies the class order. A marker whose span
 sits inside a strictly longer marker's span is a fragment of that longer one and is dropped before
-the class order runs, so `refused` inside `connection refused` never outranks it. Merely overlapping
+the class order runs, so `timeout` inside `gateway timeout` never stands in for it. Merely overlapping
 claims both survive, and only markers can drop markers: a timer span says nothing about the words
 inside it, so a timer attempt straddling refusal wording never swallows it.
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -31,6 +32,14 @@ D = _load_owner()
 def check(condition: bool, message: str) -> None:
     if not condition:
         raise D.SelfTestFailure(message)
+
+
+def has_attempt_two_fresh_native_attempt_three(text: str) -> bool:
+    return re.search(
+        r"attempt `2` fails[ \t]*→[ \t]*(?:\r?\n[ \t]*)?"
+        r"prepare fresh native fallback attempt `3`(?:[.!?]|$)",
+        text,
+    ) is not None
 
 
 SHA = "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c"
@@ -684,8 +693,8 @@ def t_external_attempt_two_has_native_attempt_three_recovery() -> None:
     runtime = (refs / "runtime-adapter.md").read_text(encoding="utf-8")
     stage = (refs / "stage-2-review-gate.md").read_text(encoding="utf-8")
     loop = (refs / "loop-control.md").read_text(encoding="utf-8")
-    check("attempt `2` fails → prepare fresh native fallback attempt `3`" in runtime,
-          "runtime owner does not allocate attempt 3 after failed attempt 2")
+    check(has_attempt_two_fresh_native_attempt_three(runtime),
+          "runtime owner does not relate attempt 2 failure to fresh native attempt 3")
     check("dead or unusable attempt `3` → `park-machine-blocker`" in runtime,
           "runtime owner does not terminate failed native fallback attempt 3")
     stale_attempt_two_terminal = "`2` → " + "fresh-worker fallback"
@@ -694,6 +703,21 @@ def t_external_attempt_two_has_native_attempt_three_recovery() -> None:
               f"{name} recovery does not point to the attempt-3 owner")
         check(stale_attempt_two_terminal not in text,
               f"{name} recovery retains the stale attempt-2 terminal rule")
+
+
+def t_attempt_two_recovery_relation_rejects_wrong_attempt() -> None:
+    valid = "attempt `2` fails →\nprepare fresh native fallback attempt `3`."
+    invalid = "attempt `2` fails → classify it, then prepare fresh native fallback attempt `4`."
+    separated = (
+        "attempt `2` fails → classify it, but do not prepare a native fallback for this path.\n\n"
+        "A separate unavailable-route paragraph says prepare fresh native fallback attempt `3`."
+    )
+    check(has_attempt_two_fresh_native_attempt_three(valid),
+          "attempt-2 recovery assertion does not allow the direct fallback clause")
+    check(not has_attempt_two_fresh_native_attempt_three(invalid),
+          "attempt-2 recovery assertion accepts the wrong native fallback attempt")
+    check(not has_attempt_two_fresh_native_attempt_three(separated),
+          "attempt-2 recovery assertion joins separated failure and fallback clauses")
 
 
 def t_transition_actions_map_directly_to_prepare_inputs() -> None:
@@ -939,6 +963,8 @@ CASES = [
     ("hard-stop-recovery", "both-files and identity-only hard-stop residue is recoverable", t_hard_stop_residue_is_recoverable),
     ("malformed-identity-refused", "a malformed lone identity is refused, not reclaimed", t_malformed_lone_identity_is_refused_not_reclaimed),
     ("fallback-attempt-three", "external retry failure has a terminal native attempt-3 path", t_external_attempt_two_has_native_attempt_three_recovery),
+    ("attempt-three-contract", "attempt-2 recovery requires fresh native attempt 3",
+     t_attempt_two_recovery_relation_rejects_wrong_attempt),
     ("transition-mapping", "review actions map directly to route, producer, and prompt profile",
      t_transition_actions_map_directly_to_prepare_inputs),
     ("unicode-delivery", "a Unicode path is delivered as UTF-8 bytes under ASCII stdout", t_unicode_worktree_delivers_under_ascii_stdout),

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -729,6 +729,7 @@ def t_transition_actions_map_directly_to_prepare_inputs() -> None:
         "`external-process-capture` | `codex-recovery` |",
         "| `retry-external` + `external-claude` | `external-claude` | "
         "`external-process-capture` | `standard` |",
+        "| `wait-external` | no preparation | no preparation | no preparation |",
         "| `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |",
         "| `park-machine-blocker` | no preparation | no preparation | no preparation |",
     ):

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -730,6 +730,7 @@ def t_transition_actions_map_directly_to_prepare_inputs() -> None:
         "| `retry-external` + `external-claude` | `external-claude` | "
         "`external-process-capture` | `standard` |",
         "| `wait-external` | no preparation | no preparation | no preparation |",
+        "| `stop-and-ask` | no preparation | no preparation | no preparation |",
         "| `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |",
         "| `park-machine-blocker` | no preparation | no preparation | no preparation |",
     ):

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -918,7 +918,7 @@ def test_reviewer_refusal_stops_and_asks() -> None:
 def test_reviewer_refusal_precedes_other_markers() -> None:
     now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
     for message in (
-        "I can't assist with that. usage: codex exec [OPTIONS] [PROMPT]",
+        "I can't assist with that.\nusage: codex exec [OPTIONS] [PROMPT]",
         "Sorry, I can't provide assistance with that. Please try again with a different request.",
         "I must decline; retry after 90 seconds is not applicable here.",
     ):
@@ -927,6 +927,44 @@ def test_reviewer_refusal_precedes_other_markers() -> None:
               f"another marker outranked the reviewer refusal: {message!r}")
         check(result.action == MODULE.STOP_AND_ASK,
               f"refusal with a competing marker did not stop and ask: {message!r}")
+
+
+def test_positive_capability_wording_is_not_a_refusal() -> None:
+    """Prose that says the reviewer COULD help must never manufacture a refusal or a dead route."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "I am able to help with this review",
+        "the assistant was able to assist and finished the review",
+        "happy to provide assistance",
+        "token usage: 41234",
+        "memory usage: 82%",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind != MODULE.REFUSAL,
+              f"positive wording was read as a reviewer refusal: {message!r}")
+        check(result.kind != MODULE.PERMANENT,
+              f"neutral wording was read as a permanent failure: {message!r}")
+        check(result.state.external_disabled is False,
+              f"neutral wording disabled the session route: {message!r}")
+
+
+def test_negated_capability_wording_is_still_a_refusal() -> None:
+    """The negation is what the marker must carry, so every negated form still reaches the operator."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "I'm unable to help with that",
+        "I am not able to help with that",
+        "I am not able to assist with this request",
+        "unable to provide assistance",
+        "I won't provide assistance here",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.REFUSAL,
+              f"a negated refusal form was not classified: {message!r}")
+        check(result.action == MODULE.STOP_AND_ASK,
+              f"a negated refusal form did not stop and ask: {message!r}")
 
 
 def test_reviewer_refusal_after_retry_still_stops_and_asks() -> None:
@@ -1124,12 +1162,35 @@ def test_status_code_after_a_trigger_word_is_not_a_timer_value() -> None:
         "connection reset: 503",
         "retry: 429",
         "too many requests; retry: 429",
+        "rate limited; retry after 429",
+        "retry after 429",
+        "retry after 503",
+        "retry-after: 502",
+        "retry after 504",
     ):
         result = MODULE.decide(message, now=now, pr_number=188)
         check(result.kind == MODULE.TRANSIENT,
               f"a status code was read as a broken timer value: {message!r}")
         check(result.state.external_disabled is False,
               f"a status code disabled the session route: {message!r}")
+
+
+def test_unit_bearing_timer_survives_the_status_value_rule() -> None:
+    """The status rule keys on a MISSING unit, so a stated unit must still yield the exact delay."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message, delay in (
+        ("retry after 503 seconds", 503),
+        ("retry after 429 seconds", 429),
+        ("retry after 30", 30),
+        ("retry after 1429", 1429),
+        ("http 429; retry after 60 seconds", 60),
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TIMER,
+              f"the status value rule swallowed a real timer: {message!r}")
+        check(result.retry_after_seconds == delay,
+              f"a surviving timer lost the provider delay: {message!r}")
 
 
 def test_free_standing_retry_word_without_a_value_keeps_the_transient_class() -> None:
@@ -1334,6 +1395,8 @@ CASES = [
     ("zero-delay-timer", "zero-delay timer retries immediately", test_zero_delay_timer_retries_immediately),
     ("refusal-stop-and-ask", "reviewer refusal stops and asks the operator", test_reviewer_refusal_stops_and_asks),
     ("refusal-marker-precedence", "refusal precedes permanent and timer markers", test_reviewer_refusal_precedes_other_markers),
+    ("positive-wording-not-refusal", "positive capability wording is not a reviewer refusal", test_positive_capability_wording_is_not_a_refusal),
+    ("negated-wording-still-refusal", "negated capability wording still stops and asks", test_negated_capability_wording_is_still_a_refusal),
     ("refusal-after-retry", "spent retry never downgrades a refusal to fallback", test_reviewer_refusal_after_retry_still_stops_and_asks),
     ("refusal-keeps-backoff", "refusal preserves an active session deadline", test_reviewer_refusal_preserves_active_session_backoff),
     ("refusal-missing-pr", "refusal without a PR number still stops and asks", test_reviewer_refusal_without_pr_still_stops_and_asks),
@@ -1344,6 +1407,7 @@ CASES = [
     ("refusal-survives-timer-attempt", "a timer attempt never swallows refusal wording", test_refusal_wording_survives_a_longer_timer_attempt),
     ("valueless-trigger-transient", "a valueless trigger word keeps the transient class", test_trigger_word_without_a_value_keeps_the_transient_class),
     ("status-code-not-timer-value", "a status code after a trigger word is not a timer value", test_status_code_after_a_trigger_word_is_not_a_timer_value),
+    ("unit-bearing-timer-survives", "a unit-bearing timer survives the status value rule", test_unit_bearing_timer_survives_the_status_value_rule),
     ("valueless-retry-word-transient", "a free-standing valueless retry word keeps the transient class", test_free_standing_retry_word_without_a_value_keeps_the_transient_class),
     ("timer-not-poisoned", "a valueless trigger word never poisons a valid timer", test_valueless_trigger_word_never_poisons_a_valid_timer),
     ("valueless-trigger-unrecognized", "a valueless trigger word without a marker stays unrecognized", test_valueless_trigger_word_without_a_marker_stays_unrecognized),

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -956,6 +956,103 @@ def test_reviewer_refusal_preserves_active_session_backoff() -> None:
           "reviewer refusal changed the active timer owner")
 
 
+def test_reviewer_refusal_without_pr_still_stops_and_asks() -> None:
+    """A refusal writes no session state and owns no timer, so an omitted PR must not downgrade it."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    result = MODULE.transition(
+        MODULE.Failure(MODULE.REFUSAL, None, None, "refusal marker: cannot assist"),
+        now=now,
+        state=MODULE.SessionState(),
+        pr_number=None,
+    )
+    check(result.kind == MODULE.REFUSAL,
+          "an omitted PR number rewrote a reviewer refusal")
+    check(result.action == MODULE.STOP_AND_ASK,
+          "a refusal without a PR number did not stop and ask")
+    check(result.external_disabled is False,
+          "a refusal without a PR number disabled the session route")
+    check(result.state.external_backoff_until is None,
+          "a refusal without a PR number stored a session deadline")
+
+    payload = run_cli(
+        "decide",
+        "--message",
+        "I'm sorry, but I can't help with that.",
+        "--now",
+        "2026-07-25T12:00:00Z",
+    )
+    check(payload["kind"] == MODULE.REFUSAL, "CLI without --pr did not report the refusal kind")
+    check(payload["action"] == MODULE.STOP_AND_ASK,
+          "CLI without --pr did not report the stop-and-ask action")
+    check(payload["external_disabled"] is False,
+          "CLI refusal without --pr disabled the session route")
+
+
+def test_refusal_pr_exemption_keeps_other_guards_closed() -> None:
+    """The refusal exemption at the PR-owner guard must not reach any other fail-closed path."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    refusal = MODULE.Failure(MODULE.REFUSAL, None, None, "refusal marker: cannot assist")
+
+    class UntypedFailure:
+        kind = MODULE.REFUSAL
+
+    for label, failure, state, pr_number in (
+        ("refusal with malformed session state",
+         refusal, MODULE.SessionState(external_disabled="yes"), None),
+        ("untyped failure claiming the refusal kind",
+         UntypedFailure(), MODULE.SessionState(), None),
+        ("failure object without a kind attribute",
+         object(), MODULE.SessionState(), None),
+        ("refusal with a malformed PR number",
+         refusal, MODULE.SessionState(), -5),
+        ("timer without a PR owner",
+         MODULE.Failure(MODULE.TIMER, 90, now, "retry after 90 seconds"),
+         MODULE.SessionState(), None),
+    ):
+        result = MODULE.transition(failure, now=now, state=state, pr_number=pr_number)
+        check(result.kind == MODULE.PERMANENT, f"{label} was not normalized to permanent")
+        check(result.action == MODULE.FALLBACK_NATIVE, f"{label} did not fall back natively")
+        check(result.external_disabled, f"{label} left the external route enabled")
+
+
+def test_retry_phrase_without_a_value_keeps_transient_classification() -> None:
+    """A bare retry phrase carries no timer value, so it must not outrank a transient marker."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "Request timed out, please try again.",
+        "Gateway timeout. The server is temporarily unavailable, please retry.",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TRANSIENT,
+              f"a bare retry phrase overrode a transient marker: {message!r}")
+        check(result.action == MODULE.RETRY_EXTERNAL,
+              f"a recognized transient failure did not retry: {message!r}")
+        check(result.external_disabled is False,
+              f"a bare retry phrase disabled the external route: {message!r}")
+        check(result.state.external_disabled is False,
+              f"a bare retry phrase disabled the session route: {message!r}")
+
+
+def test_retry_phrase_without_a_value_falls_back_without_disabling() -> None:
+    """Unmatched wording carrying a bare retry phrase stays unrecognized, not permanent."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "error sending request; retrying",
+        "retry later",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.UNRECOGNIZED,
+              f"a bare retry phrase forced the malformed-timer path: {message!r}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"unrecognized wording did not fall back natively: {message!r}")
+        check(result.external_disabled is False,
+              f"unrecognized wording disabled the external route: {message!r}")
+
+
 def test_cli_reports_reviewer_refusal() -> None:
     payload = run_cli(
         "decide",
@@ -1035,6 +1132,10 @@ CASES = [
     ("refusal-marker-precedence", "refusal precedes permanent and timer markers", test_reviewer_refusal_precedes_other_markers),
     ("refusal-after-retry", "spent retry never downgrades a refusal to fallback", test_reviewer_refusal_after_retry_still_stops_and_asks),
     ("refusal-keeps-backoff", "refusal preserves an active session deadline", test_reviewer_refusal_preserves_active_session_backoff),
+    ("refusal-missing-pr", "refusal without a PR number still stops and asks", test_reviewer_refusal_without_pr_still_stops_and_asks),
+    ("refusal-pr-exemption-bounds", "the refusal PR exemption leaves every other guard closed", test_refusal_pr_exemption_keeps_other_guards_closed),
+    ("valueless-retry-phrase-transient", "a valueless retry phrase keeps a transient classification", test_retry_phrase_without_a_value_keeps_transient_classification),
+    ("valueless-retry-phrase-unrecognized", "a valueless retry phrase falls back without disabling", test_retry_phrase_without_a_value_falls_back_without_disabling),
     ("cli-refusal", "CLI reports the refusal kind and stop-and-ask action", test_cli_reports_reviewer_refusal),
 ]
 

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -686,12 +686,12 @@ def test_numeric_transient_marker_requires_complete_token() -> None:
         "opaque provider error 1429",
         now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
     )
-    check(result.kind == MODULE.PERMANENT,
-          "numeric substring was classified as transient")
+    check(result.kind == MODULE.UNRECOGNIZED,
+          "numeric substring was classified as a transient marker")
     check(result.action == MODULE.FALLBACK_NATIVE,
-          "numeric substring selected an external retry")
-    check(result.state.external_disabled,
-          "numeric substring did not disable the session route")
+          "numeric substring did not fall back natively")
+    check(not result.state.external_disabled,
+          "numeric substring incorrectly disabled the session route")
 
 
 def test_permanent_disables_external_route_for_session() -> None:
@@ -702,18 +702,27 @@ def test_permanent_disables_external_route_for_session() -> None:
           "permanent failure did not disable the session route")
 
 
-def test_unknown_fails_closed_as_permanent() -> None:
-    result = MODULE.decide("opaque provider failure")
-    check(result.kind == MODULE.PERMANENT, "unknown failure was not permanent")
+def test_unknown_falls_back_as_unrecognized() -> None:
+    result = MODULE.decide(
+        "opaque provider failure",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        pr_number=188,
+    )
+    check(result.kind == MODULE.UNRECOGNIZED, "unknown failure was reported as permanent")
     check(result.action == MODULE.FALLBACK_NATIVE, "unknown failure did not fall back")
-    check(result.state.external_disabled, "unknown failure did not disable the session route")
+    check(not result.state.external_disabled,
+          "unknown failure incorrectly disabled the session route")
 
 
-def test_unrecognized_typed_failure_fails_closed() -> None:
+def test_unrecognized_typed_failure_falls_back() -> None:
     failure = MODULE.Failure("future-kind", None, None, "future provider classification")
     result = MODULE.transition(failure)
-    check(result.kind == MODULE.PERMANENT, "unknown typed failure was not normalized to permanent")
-    check(result.state.external_disabled, "unknown typed failure did not disable the session route")
+    check(result.kind == MODULE.UNRECOGNIZED,
+          "unknown typed failure was not normalized to unrecognized")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "unknown typed failure did not fall back natively")
+    check(not result.state.external_disabled,
+          "unknown typed failure incorrectly disabled the session route")
 
 
 def test_malformed_typed_timer_fails_closed() -> None:
@@ -888,8 +897,8 @@ CASES = [
     ("fractional-timer", "fractional timer fails closed", test_fractional_timer_fails_closed),
     ("numeric-marker-token", "numeric transient markers require complete tokens", test_numeric_transient_marker_requires_complete_token),
     ("permanent-session-disable", "permanent failure disables only this session", test_permanent_disables_external_route_for_session),
-    ("unknown-permanent", "unknown failure fails closed", test_unknown_fails_closed_as_permanent),
-    ("unknown-typed-permanent", "unknown typed failure fails closed", test_unrecognized_typed_failure_fails_closed),
+    ("unknown-unrecognized", "unknown failure falls back without permanent classification", test_unknown_falls_back_as_unrecognized),
+    ("unknown-typed-unrecognized", "unknown typed failure falls back without disabling the route", test_unrecognized_typed_failure_falls_back),
     ("malformed-typed-timer", "malformed typed timer fails closed", test_malformed_typed_timer_fails_closed),
     ("malformed-typed-state", "malformed typed state fails closed", test_malformed_typed_state_fails_closed),
     ("session-state", "disabled state blocks later launches in this session", test_disabled_state_is_session_only_and_blocks_new_launches),

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -1,0 +1,901 @@
+#!/usr/bin/env python3
+"""Focused fixtures for ``reviewer-backoff.py``."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+from _gauntlet.modules import load_module_from_path
+
+
+OWNER = Path(__file__).resolve().with_name("reviewer-backoff.py")
+MODULE = load_module_from_path("reviewer_backoff_owner", OWNER, register=True)
+if MODULE is None:
+    raise RuntimeError(f"cannot load the reviewer backoff helper at {OWNER}")
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def run_cli(*args: str) -> dict[str, object]:
+    completed = subprocess.run(
+        [sys.executable, str(OWNER), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    check(completed.returncode == 0,
+          f"reviewer-backoff CLI failed ({completed.returncode}): {completed.stderr!r}")
+    payload = json.loads(completed.stdout)
+    check(isinstance(payload, dict), f"reviewer-backoff CLI returned non-object JSON: {payload!r}")
+    return payload
+
+
+def test_absolute_timer_uses_provider_timezone() -> None:
+    tokyo_now = datetime(2026, 7, 25, 12, 0, tzinfo=MODULE.ZoneInfo("Asia/Tokyo"))
+    result = MODULE.classify("quota exhausted; resets Jul 27, 9pm (Asia/Tokyo)", tokyo_now)
+    check(result.kind == MODULE.TIMER, "absolute reset was not classified as a timer")
+    check(result.retry_after_seconds == 205200, "Tokyo absolute reset delay changed")
+
+    utc_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    utc_result = MODULE.classify("quota exhausted; resets Jul 27, 9pm (Asia/Tokyo)", utc_now)
+    check(utc_result.retry_after_seconds == 172800,
+          "absolute reset was not converted from the provider timezone")
+
+
+def test_absolute_timer_uses_elapsed_time_across_dst() -> None:
+    now = datetime(2026, 3, 8, 1, 30, tzinfo=MODULE.ZoneInfo("America/New_York"))
+    result = MODULE.classify("quota exhausted; resets Mar 8, 3:30am (America/New_York)", now)
+    check(result.kind == MODULE.TIMER, "DST deadline was not classified as a timer")
+    check(result.retry_after_seconds == 3600,
+          "absolute deadline was subtracted as wall-clock time across DST")
+
+
+def test_timer_wait_uses_elapsed_time_across_dst() -> None:
+    now = datetime(2026, 3, 8, 1, 30, tzinfo=MODULE.ZoneInfo("America/New_York"))
+    failure = MODULE.classify("quota exhausted; resets Mar 8, 3:30am (America/New_York)", now)
+    result = MODULE.transition(failure, now=now, pr_number=188)
+    check(result.action == MODULE.WAIT_EXTERNAL, "DST timer did not wait")
+    check(result.retry_after_seconds == 3600,
+          "timer wait was subtracted as wall-clock time across DST")
+
+
+def test_absolute_timer_dst_gap_fails_closed() -> None:
+    now = datetime(2026, 3, 1, 12, 0, tzinfo=MODULE.ZoneInfo("America/New_York"))
+    result = MODULE.decide("quota exhausted; resets Mar 8, 2:30am (America/New_York)", now=now)
+    check(result.kind == MODULE.PERMANENT, "DST gap was accepted as an absolute timer")
+    check(result.action == MODULE.FALLBACK_NATIVE, "DST gap did not fall back natively")
+    check(result.external_disabled, "DST gap did not disable the external route")
+
+
+def test_absolute_timer_dst_fold_fails_closed() -> None:
+    now = datetime(2026, 3, 1, 12, 0, tzinfo=MODULE.ZoneInfo("America/New_York"))
+    result = MODULE.decide("quota exhausted; resets Nov 1, 1:30am (America/New_York)", now=now)
+    check(result.kind == MODULE.PERMANENT, "DST fold was accepted without an explicit offset")
+    check(result.action == MODULE.FALLBACK_NATIVE, "DST fold did not fall back natively")
+    check(result.external_disabled, "DST fold did not disable the external route")
+
+
+def test_absolute_timer_explicit_offset_resolves_dst_fold() -> None:
+    now = datetime(2026, 3, 1, 12, 0, tzinfo=MODULE.ZoneInfo("America/New_York"))
+    result = MODULE.decide(
+        "quota exhausted; resets Nov 1, 1:30am -05:00 (America/New_York)",
+        now=now,
+        pr_number=188,
+    )
+    check(result.kind == MODULE.TIMER, "explicit offset did not resolve the DST fold")
+    check(result.retry_at == "2026-11-01T01:30:00-05:00",
+          "explicit offset changed the absolute provider deadline")
+
+
+def test_absolute_timer_explicit_offset_resolves_both_dst_fold_offsets() -> None:
+    now = datetime(2026, 3, 1, 12, 0, tzinfo=MODULE.ZoneInfo("America/New_York"))
+    for offset in ("-04:00", "-05:00"):
+        result = MODULE.decide(
+            f"quota exhausted; resets Nov 1, 1:30am {offset} (America/New_York)",
+            now=now,
+            pr_number=188,
+        )
+        check(result.kind == MODULE.TIMER,
+              f"valid DST fold offset {offset} was rejected")
+
+
+def test_absolute_timer_rejects_contradictory_named_zone_offset() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    result = MODULE.decide(
+        "rate limit; resets Jul 27, 9pm +14:00 (Asia/Tokyo)",
+        now=now,
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "contradictory named-zone offset was accepted as a timer")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "contradictory named-zone offset did not fall back natively")
+    check(result.external_disabled,
+          "contradictory named-zone offset did not disable the external route")
+
+
+def test_malformed_absolute_12_hour_field_fails_closed() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for clock in ("0pm", "13am"):
+        result = MODULE.decide(f"rate limit; resets Jul 27, {clock}", now=now)
+        check(result.kind == MODULE.PERMANENT,
+              f"malformed 12-hour field was accepted as a timer: {clock}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"malformed 12-hour field did not fall back: {clock}")
+        check(result.state.external_disabled,
+              f"malformed 12-hour field did not disable the session route: {clock}")
+
+
+def test_relative_timer_waits_exactly() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    result = MODULE.decide("rate limited; retry after 90 seconds", now=now, pr_number=188)
+    check(result.action == MODULE.WAIT_EXTERNAL, "relative timer did not wait")
+    check(result.retry_after_seconds == 90, "relative timer delay changed")
+    check(result.retry_at == "2026-07-25T12:01:30+00:00", "relative retry timestamp changed")
+    check(result.state.external_backoff_until == datetime(2026, 7, 25, 12, 1, 30,
+                                                           tzinfo=timezone.utc),
+          "timer state was not returned for the live session")
+
+
+def test_unitless_relative_timer_defaults_to_seconds() -> None:
+    result = MODULE.classify(
+        "rate limited; retry after 90",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.TIMER,
+          "unitless relative timer was not classified as a timer")
+    check(result.retry_after_seconds == 90,
+          "unitless relative timer did not default to seconds")
+
+
+def test_colon_after_unitless_timer_fails_closed() -> None:
+    result = MODULE.decide(
+        "rate limited; retry after 90:00",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "colon-formatted unitless timer was accepted")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "colon-formatted unitless timer did not fall back")
+    check(result.state.external_disabled,
+          "colon-formatted unitless timer did not disable the session route")
+
+
+def test_comma_grouped_relative_timer_fails_closed() -> None:
+    result = MODULE.decide(
+        "rate limited; retry after 90,000 seconds",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "comma-grouped relative timer was accepted")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "comma-grouped relative timer did not fall back")
+    check(result.state.external_disabled,
+          "comma-grouped relative timer did not disable the session route")
+
+
+def test_unsupported_relative_timer_unit_fails_closed() -> None:
+    result = MODULE.decide(
+        "rate limited; retry after 90 bananas",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "unsupported relative timer unit was accepted")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "unsupported relative timer unit did not fall back")
+    check(result.state.external_disabled,
+          "unsupported relative timer unit did not disable the session route")
+
+
+def test_unsupported_relative_timer_punctuation_fails_closed() -> None:
+    for message in (
+        "rate limited; retry after 90%",
+        "rate limited; retry after 90 seconds%",
+        "rate limited; available in 90 seconds%",
+    ):
+        result = MODULE.decide(
+            message,
+            now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        )
+        check(result.kind == MODULE.PERMANENT,
+              f"unsupported relative timer punctuation was accepted: {message!r}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"unsupported relative timer punctuation did not fall back: {message!r}")
+        check(result.state.external_disabled,
+              f"unsupported relative timer punctuation did not disable the session route: {message!r}")
+
+
+def test_incomplete_absolute_reset_fails_closed() -> None:
+    result = MODULE.decide(
+        "rate limit; resets Jul 27",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "incomplete absolute reset was accepted as a transient failure")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "incomplete absolute reset did not fall back")
+    check(result.state.external_disabled,
+          "incomplete absolute reset did not disable the session route")
+
+
+def test_absolute_timer_suffix_fails_closed() -> None:
+    result = MODULE.decide(
+        "rate limit; resets Jul 27, 9pm (Asia/Tokyo)%",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "absolute timer with an unsupported suffix was accepted")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "absolute timer with an unsupported suffix did not fall back")
+    check(result.state.external_disabled,
+          "absolute timer with an unsupported suffix did not disable the session route")
+
+
+def test_malformed_timer_before_valid_timer_fails_closed() -> None:
+    result = MODULE.decide(
+        "rate limit; retry after never seconds; retry after 90 seconds",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "malformed earlier timer clause was ignored")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "mixed malformed and valid timers did not fall back")
+    check(result.state.external_disabled,
+          "mixed malformed and valid timers did not disable the session route")
+
+
+def test_malformed_reset_timer_fails_closed() -> None:
+    for message in (
+        "temporarily unavailable; reset after 90 bananas",
+        "temporarily unavailable; reset after 1.5 seconds",
+    ):
+        result = MODULE.decide(
+            message,
+            now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        )
+        check(result.kind == MODULE.PERMANENT,
+              f"malformed reset timer was accepted: {message!r}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"malformed reset timer did not fall back: {message!r}")
+        check(result.state.external_disabled,
+              f"malformed reset timer did not disable the session route: {message!r}")
+
+
+def test_session_timer_deadline_is_not_extended_on_reentry() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    failure = MODULE.classify("retry after 90 seconds", now=first_now)
+    first = MODULE.transition(failure, now=first_now, pr_number=188)
+    second = MODULE.transition(
+        failure,
+        now=first_now.replace(second=30),
+        state=first.state,
+        pr_number=188,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 1, 30, tzinfo=timezone.utc)
+    check(first.state.external_backoff_until == expected_deadline,
+          "initial timer did not create the expected session deadline")
+    check(second.action == MODULE.WAIT_EXTERNAL,
+          "active session timer did not keep the external route waiting")
+    check(second.retry_after_seconds == 60,
+          "re-entry did not wait for the remaining session timer")
+    check(second.state.external_backoff_until == expected_deadline,
+          "re-entry extended the active session deadline")
+
+
+def test_active_identical_new_timer_replaces_deadline() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now, pr_number=188)
+    later_now = first_now.replace(second=30)
+    later_failure = MODULE.classify("retry after 90 seconds", later_now)
+    result = MODULE.transition(later_failure, now=later_now, state=first.state, pr_number=188)
+    expected_deadline = datetime(2026, 7, 25, 12, 2, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "active identical fresh timer did not keep the external route waiting")
+    check(result.retry_after_seconds == 90,
+          "active identical fresh timer was shortened to the old deadline")
+    check(result.state.external_backoff_until == expected_deadline,
+          "active identical fresh timer did not replace the old deadline")
+
+
+def test_active_later_timer_replaces_deadline_and_identity() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now, pr_number=188)
+    later_now = first_now.replace(second=10)
+    later_failure = MODULE.classify("retry after 2 minutes", later_now)
+    result = MODULE.transition(later_failure, now=later_now, state=first.state, pr_number=188)
+    expected_deadline = datetime(2026, 7, 25, 12, 2, 10, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "active later timer did not keep the external route waiting")
+    check(result.retry_after_seconds == 120,
+          "active later timer was shortened to the earlier deadline")
+    check(result.state.external_backoff_until == expected_deadline,
+          "active later timer did not replace the earlier deadline")
+    check(result.state.external_backoff_timer_id == later_failure.timer_identity,
+          "active later timer did not retain its timer identity")
+
+
+def test_active_earlier_timer_replaces_deadline_for_same_pr() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 120 seconds", now=first_now, pr_number=188)
+    later_now = first_now.replace(second=10)
+    result = MODULE.decide(
+        "retry after 30 seconds",
+        now=later_now,
+        state=first.state,
+        pr_number=188,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 0, 40, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "same-PR earlier timer did not keep the external route waiting")
+    check(result.retry_after_seconds == 30,
+          "same-PR earlier timer retained the old delay")
+    check(result.state.external_backoff_until == expected_deadline,
+          "same-PR earlier timer retained the old deadline")
+    check(result.state.external_backoff_pr == 188,
+          "same-PR timer did not retain its PR owner")
+
+
+def test_active_timer_for_another_pr_falls_back_and_retains_owner() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 120 seconds", now=first_now, pr_number=188)
+    later_now = first_now.replace(second=10)
+    result = MODULE.decide(
+        "retry after 30 seconds",
+        now=later_now,
+        state=first.state,
+        pr_number=189,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 2, tzinfo=timezone.utc)
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "another PR was allowed to use the active external timer")
+    check(result.retry_after_seconds == 30,
+          "another PR lost its provider timer while falling back")
+    check(result.state.external_backoff_until == expected_deadline,
+          "another PR changed the existing session backoff")
+    check(result.state.external_backoff_pr == 188,
+          "another PR replaced the existing session timer owner")
+
+
+def test_expired_timer_for_another_pr_replaces_deadline_and_waits() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 120 seconds", now=first_now, pr_number=188)
+    later_now = datetime(2026, 7, 25, 12, 2, 1, tzinfo=timezone.utc)
+    result = MODULE.decide(
+        "retry after 30 seconds",
+        now=later_now,
+        state=first.state,
+        pr_number=189,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 2, 31, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "another PR did not wait on its timer after the prior deadline expired")
+    check(result.retry_after_seconds == 30,
+          "another PR did not retain its provider timer after the prior deadline expired")
+    check(result.state.external_backoff_until == expected_deadline,
+          "another PR retained the expired session backoff")
+    check(result.state.external_backoff_timer_id != first.state.external_backoff_timer_id,
+          "another PR reused the expired session timer identity")
+    check(result.state.external_backoff_pr == 189,
+          "another PR did not become the owner after the prior deadline expired")
+
+
+def test_exactly_expiring_timer_for_another_pr_replaces_deadline_and_waits() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now, pr_number=188)
+    deadline = datetime(2026, 7, 25, 12, 1, 30, tzinfo=timezone.utc)
+    result = MODULE.decide(
+        "retry after 30 seconds",
+        now=deadline,
+        state=first.state,
+        pr_number=189,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 2, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "another PR did not wait when the prior deadline expired exactly")
+    check(result.retry_after_seconds == 30,
+          "another PR did not retain its provider timer at exact expiry")
+    check(result.state.external_backoff_until == expected_deadline,
+          "another PR did not replace the exactly expired session deadline")
+    check(result.state.external_backoff_pr == 189,
+          "another PR did not become the owner at exact expiry")
+
+
+def test_session_timer_retries_at_exact_reentry_deadline() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    failure = MODULE.classify("retry after 90 seconds", now=first_now)
+    first = MODULE.transition(failure, now=first_now, pr_number=188)
+    deadline = first_now.replace(minute=1, second=30)
+    result = MODULE.transition(failure, now=deadline, state=first.state, pr_number=188)
+    check(result.action == MODULE.RETRY_EXTERNAL,
+          "re-entry at the session deadline did not retry")
+    check(result.retry_after_seconds == 0,
+          "exact-deadline re-entry retained a stale timer delay")
+    check(result.state.external_backoff_until == deadline,
+          "exact-deadline re-entry changed the stored deadline")
+    check(result.state.external_backoff_timer_id == first.state.external_backoff_timer_id,
+          "exact-deadline re-entry changed the session timer identity")
+
+
+def test_cli_preserves_typed_timer_across_reentry() -> None:
+    first_now = "2026-07-25T12:00:00+00:00"
+    deadline = "2026-07-25T12:01:30+00:00"
+    failure = run_cli(
+        "classify",
+        "--message", "rate limited; retry after 90 seconds",
+        "--now", first_now,
+    )
+    check(failure["kind"] == MODULE.TIMER, "CLI classifier did not return a timer failure")
+    check(failure["retry_at"] == deadline, "CLI classifier changed the provider deadline")
+    timer_id = failure["timer_identity"]
+    check(isinstance(timer_id, str) and timer_id, "CLI classifier lost the timer identity")
+
+    with tempfile.TemporaryDirectory(prefix="reviewer backoff ") as directory:
+        failure_file = Path(directory) / "failure.json"
+        failure_file.write_text(json.dumps(failure), encoding="utf-8")
+        waiting = run_cli(
+            "decide",
+            "--failure-file", str(failure_file),
+            "--now", first_now,
+            "--backoff-until", deadline,
+            "--backoff-timer-id", timer_id,
+            "--backoff-pr", "188",
+            "--pr", "188",
+        )
+        check(waiting["action"] == MODULE.WAIT_EXTERNAL,
+              "CLI typed timer did not wait before its deadline")
+        check(waiting["state"]["external_backoff_timer_id"] == timer_id,
+              "CLI wait dropped the timer identity")
+        check(waiting["state"]["external_backoff_pr"] == 188,
+              "CLI wait dropped the timer PR owner")
+
+        raw_reentry = subprocess.run(
+            [sys.executable, str(OWNER), "decide",
+             "--message", "rate limited; retry after 90 seconds",
+             "--now", deadline, "--backoff-until", deadline,
+             "--backoff-timer-id", timer_id, "--backoff-pr", "188", "--pr", "188"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        check(raw_reentry.returncode != 0 and "--failure-file" in raw_reentry.stderr,
+              "CLI allowed raw-message re-entry to reclassify the timer")
+
+        reentry = run_cli(
+            "decide",
+            "--failure-file", str(failure_file),
+            "--now", deadline,
+            "--backoff-until", deadline,
+            "--backoff-timer-id", timer_id,
+            "--backoff-pr", "188",
+            "--pr", "188",
+        )
+    check(reentry["action"] == MODULE.RETRY_EXTERNAL,
+          "CLI exact-deadline re-entry did not retry immediately")
+    check(reentry["retry_after_seconds"] == 0,
+          "CLI exact-deadline re-entry retained a stale timer delay")
+    check(reentry["retry_at"] == deadline,
+          "CLI exact-deadline re-entry changed the typed provider deadline")
+    check(reentry["state"]["external_backoff_timer_id"] == timer_id,
+          "CLI exact-deadline re-entry changed the timer identity")
+
+
+def test_cli_invalid_utf8_message_file_falls_back() -> None:
+    with tempfile.TemporaryDirectory(prefix="reviewer backoff ") as directory:
+        message_file = Path(directory) / "message.bin"
+        message_file.write_bytes(b"rate limited; retry after 90 seconds \xff")
+        completed = subprocess.run(
+            [sys.executable, str(OWNER), "decide", "--message-file", str(message_file),
+             "--now", "2026-07-25T12:00:00+00:00"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    check(completed.returncode == 0,
+          f"invalid UTF-8 message file was not handled: {completed.stderr!r}")
+    result = json.loads(completed.stdout)
+    check(result["kind"] == MODULE.PERMANENT,
+          "invalid UTF-8 message file was not classified as permanent")
+    check(result["action"] == MODULE.FALLBACK_NATIVE,
+          "invalid UTF-8 message file did not fall back")
+    check(result["external_disabled"],
+          "invalid UTF-8 message file did not disable the external route")
+    check("Traceback" not in completed.stderr,
+          "invalid UTF-8 message file emitted a traceback")
+
+
+def test_identical_text_new_timer_replaces_expired_session_deadline() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now, pr_number=188)
+    deadline = first_now.replace(minute=1, second=30)
+    result = MODULE.decide(
+        "retry after 90 seconds",
+        now=deadline,
+        state=first.state,
+        pr_number=188,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 3, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "identical-text new timer at the exact old deadline did not wait")
+    check(result.retry_after_seconds == 90,
+          "identical-text new timer did not use its new delay")
+    check(result.state.external_backoff_until == expected_deadline,
+          "identical-text new timer did not replace the expired session deadline")
+
+
+def test_new_timer_replaces_expired_session_deadline() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now, pr_number=188)
+    deadline = first_now.replace(minute=1, second=30)
+    result = MODULE.decide(
+        "retry after 45 seconds",
+        now=deadline,
+        state=first.state,
+        pr_number=188,
+    )
+    expected_deadline = datetime(2026, 7, 25, 12, 2, 15, tzinfo=timezone.utc)
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "new timer at the exact old deadline did not wait")
+    check(result.retry_after_seconds == 45,
+          "new timer at the exact old deadline was discarded")
+    check(result.state.external_backoff_until == expected_deadline,
+          "new timer did not replace the expired session deadline")
+    check(result.state.external_backoff_timer_id != first.state.external_backoff_timer_id,
+          "new timer reused the expired session timer identity")
+
+
+def test_timer_retries_at_deadline() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    deadline = datetime(2026, 7, 25, 12, 1, 30, tzinfo=timezone.utc)
+    failure = MODULE.classify("retry after 90 seconds", now=now)
+    result = MODULE.transition(failure, now=deadline,
+                               state=MODULE.SessionState(external_backoff_until=deadline,
+                                                          external_backoff_pr=188),
+                               pr_number=188)
+    check(result.action == MODULE.RETRY_EXTERNAL, "timer did not retry at the exact deadline")
+
+
+def test_transient_retries_immediately() -> None:
+    result = MODULE.decide("upstream timeout")
+    check(result.kind == MODULE.TRANSIENT, "timeout was not transient")
+    check(result.action == MODULE.RETRY_EXTERNAL, "transient failure did not retry")
+
+
+def test_connection_reset_by_peer_retries_immediately() -> None:
+    result = MODULE.decide(
+        "connection reset by peer",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        pr_number=188,
+    )
+    check(result.kind == MODULE.TRANSIENT,
+          "connection reset by peer was not classified as transient")
+    check(result.action == MODULE.RETRY_EXTERNAL,
+          "connection reset by peer did not spend the one retry")
+    check(not result.external_disabled,
+          "connection reset by peer disabled the external route")
+
+
+def test_standalone_availability_timer_waits() -> None:
+    result = MODULE.decide(
+        "available in 90 seconds",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        pr_number=188,
+    )
+    check(result.kind == MODULE.TIMER, "standalone availability was not classified as a timer")
+    check(result.action == MODULE.WAIT_EXTERNAL, "standalone availability did not wait")
+    check(result.retry_after_seconds == 90, "standalone availability delay changed")
+
+
+def test_transient_wrapped_availability_timer_waits() -> None:
+    result = MODULE.decide(
+        "temporarily unavailable; available in 90 seconds",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        pr_number=188,
+    )
+    check(result.kind == MODULE.TIMER,
+          "transient-wrapped availability was not classified as a timer")
+    check(result.action == MODULE.WAIT_EXTERNAL,
+          "transient-wrapped availability retried immediately")
+    check(result.retry_after_seconds == 90,
+          "transient-wrapped availability delay changed")
+
+
+def test_malformed_availability_timer_fails_closed() -> None:
+    result = MODULE.decide(
+        "temporarily unavailable; available in 90 bananas",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "malformed availability timer was accepted")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "malformed availability timer retried")
+    check(result.state.external_disabled,
+          "malformed availability timer did not disable the session route")
+
+
+def test_permanent_marker_precedes_transient_marker() -> None:
+    result = MODULE.classify("permission denied after upstream timeout")
+    check(result.kind == MODULE.PERMANENT,
+          "permanent marker lost to a transient marker")
+
+
+def test_oversized_relative_timer_fails_closed() -> None:
+    result = MODULE.classify("rate limit; retry after " + "9" * 400 + " seconds")
+    check(result.kind == MODULE.PERMANENT,
+          "oversized relative timer did not fail closed")
+
+
+def test_malformed_timer_text_fails_closed() -> None:
+    result = MODULE.classify("rate limit; retry after never seconds")
+    check(result.kind == MODULE.PERMANENT,
+          "malformed timer text selected an immediate retry")
+
+
+def test_unknown_timer_zone_fails_closed() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    result = MODULE.classify("rate limit; resets Jul 27, 9pm (Unknown/Zone)", now)
+    check(result.kind == MODULE.PERMANENT,
+          "unknown timer zone selected an immediate retry")
+
+
+def test_unrepresentable_absolute_timer_disables_external_route() -> None:
+    now = datetime(9999, 12, 30, 0, 0, tzinfo=timezone.utc)
+    result = MODULE.decide("rate limit; resets Dec 31, 11pm (Pacific/Pago_Pago)", now=now)
+    check(result.kind == MODULE.PERMANENT,
+          "unrepresentable absolute deadline was not permanent")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "unrepresentable absolute deadline did not fall back")
+    check(result.state.external_disabled,
+          "unrepresentable absolute deadline did not disable the session route")
+
+
+def test_fractional_timer_fails_closed() -> None:
+    result = MODULE.classify("rate limit; retry after 1.5 seconds")
+    check(result.kind == MODULE.PERMANENT,
+          "fractional timer was rounded into a retry delay")
+
+
+def test_numeric_transient_marker_requires_complete_token() -> None:
+    result = MODULE.decide(
+        "opaque provider error 1429",
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "numeric substring was classified as transient")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "numeric substring selected an external retry")
+    check(result.state.external_disabled,
+          "numeric substring did not disable the session route")
+
+
+def test_permanent_disables_external_route_for_session() -> None:
+    result = MODULE.decide("permission denied by provider")
+    check(result.kind == MODULE.PERMANENT, "permission failure was not permanent")
+    check(result.action == MODULE.FALLBACK_NATIVE, "permanent failure did not fall back")
+    check(result.external_disabled and result.state.external_disabled,
+          "permanent failure did not disable the session route")
+
+
+def test_unknown_fails_closed_as_permanent() -> None:
+    result = MODULE.decide("opaque provider failure")
+    check(result.kind == MODULE.PERMANENT, "unknown failure was not permanent")
+    check(result.action == MODULE.FALLBACK_NATIVE, "unknown failure did not fall back")
+    check(result.state.external_disabled, "unknown failure did not disable the session route")
+
+
+def test_unrecognized_typed_failure_fails_closed() -> None:
+    failure = MODULE.Failure("future-kind", None, None, "future provider classification")
+    result = MODULE.transition(failure)
+    check(result.kind == MODULE.PERMANENT, "unknown typed failure was not normalized to permanent")
+    check(result.state.external_disabled, "unknown typed failure did not disable the session route")
+
+
+def test_malformed_typed_timer_fails_closed() -> None:
+    deadline = datetime(2026, 7, 25, 12, 1, 30, tzinfo=timezone.utc)
+    failure = MODULE.Failure(MODULE.TIMER, -1, deadline, "malformed timer")
+    result = MODULE.transition(failure, now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc))
+    check(result.kind == MODULE.PERMANENT, "malformed typed timer was not normalized")
+    check(result.action == MODULE.FALLBACK_NATIVE, "malformed typed timer was retried")
+    check(result.state.external_disabled, "malformed typed timer did not disable the session route")
+
+
+def test_malformed_typed_state_fails_closed() -> None:
+    state = MODULE.SessionState(external_disabled="false", external_backoff_until="not-a-timestamp")
+    failure = MODULE.Failure(MODULE.TRANSIENT, None, None, "temporary failure")
+    result = MODULE.transition(
+        failure,
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        state=state,
+        pr_number=188,
+    )
+    check(result.kind == MODULE.PERMANENT, "malformed typed state was not normalized")
+    check(result.action == MODULE.FALLBACK_NATIVE, "malformed typed state was retried")
+    check(result.state.external_disabled, "malformed typed state did not disable the session route")
+
+
+def test_disabled_state_is_session_only_and_blocks_new_launches() -> None:
+    state = MODULE.SessionState(external_disabled=True)
+    result = MODULE.decide("temporary failure", now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+                           state=state, pr_number=188)
+    check(result.action == MODULE.FALLBACK_NATIVE, "disabled session route was retried")
+    check(result.state == state, "disabled state was changed outside the caller's session state")
+
+
+def test_timer_after_retry_falls_back_but_keeps_timer() -> None:
+    result = MODULE.decide(
+        "retry after 2 minutes",
+        retry_spent=True,
+        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        pr_number=188,
+    )
+    check(result.action == MODULE.FALLBACK_NATIVE, "spent timer retry did not fall back")
+    check(result.kind == MODULE.TIMER and result.retry_after_seconds == 120,
+          "spent timer classification changed")
+    check(result.state.external_backoff_until is not None,
+          "spent timer did not retain session backoff")
+    check(not result.external_disabled, "timer failure incorrectly disabled external review")
+
+
+def test_active_timer_without_pr_fails_closed() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now, pr_number=188)
+    result = MODULE.decide(
+        "retry after 2 minutes",
+        now=first_now.replace(second=10),
+        state=first.state,
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "session transition without a PR number was not malformed")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "session transition without a PR number did not fall back natively")
+    check(result.external_disabled,
+          "session transition without a PR number did not disable the external route")
+    check(result.state.external_backoff_pr == 188,
+          "malformed session transition lost the existing timer owner")
+
+
+def test_initial_timer_without_pr_fails_closed_before_storage() -> None:
+    first_now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    first = MODULE.decide("retry after 90 seconds", now=first_now)
+    check(first.kind == MODULE.PERMANENT,
+          "initial timer without a PR owner was not classified as permanent")
+    check(first.action == MODULE.FALLBACK_NATIVE,
+          "initial timer without a PR owner did not fall back natively")
+    check(first.external_disabled,
+          "initial timer without a PR owner did not disable the external route")
+    check(first.state.external_backoff_until is None,
+          "initial ownerless timer stored a session deadline")
+    check(first.state.external_backoff_timer_id is None,
+          "initial ownerless timer stored a timer identity")
+    check(first.state.external_backoff_pr is None,
+          "initial ownerless timer stored an ownerless PR field")
+
+    later = MODULE.decide(
+        "retry after 30 seconds",
+        now=first_now.replace(second=10),
+        state=first.state,
+        pr_number=189,
+    )
+    check(later.action == MODULE.FALLBACK_NATIVE,
+          "later PR inherited the failed ownerless session transition")
+    check(later.state.external_backoff_until is None,
+          "later PR inherited an ownerless session deadline")
+
+
+def test_ownerless_state_fails_closed_before_cross_pr_use() -> None:
+    deadline = datetime(2026, 7, 25, 12, 1, 30, tzinfo=timezone.utc)
+    ownerless = MODULE.SessionState(
+        external_backoff_until=deadline,
+        external_backoff_timer_id="retry after 90 seconds",
+    )
+    result = MODULE.decide(
+        "retry after 30 seconds",
+        now=datetime(2026, 7, 25, 12, 0, 10, tzinfo=timezone.utc),
+        state=ownerless,
+        pr_number=189,
+    )
+    check(result.kind == MODULE.PERMANENT,
+          "ownerless session state was accepted for a later PR")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "ownerless session state did not fail closed")
+    check(result.external_disabled,
+          "ownerless session state did not disable the external route")
+    check(result.state.external_backoff_until is None,
+          "ownerless session deadline survived state validation")
+    check(result.state.external_backoff_timer_id is None,
+          "ownerless timer identity survived state validation")
+    check(result.state.external_backoff_pr is None,
+          "ownerless PR survived state validation")
+
+
+def test_zero_delay_timer_retries_immediately() -> None:
+    result = MODULE.decide("retry-after: 0", now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+                           pr_number=188)
+    check(result.kind == MODULE.TIMER and result.action == MODULE.RETRY_EXTERNAL,
+          "zero-delay timer was not an immediate retry")
+
+
+CASES = [
+    ("absolute-provider-timezone", "absolute reset uses provider timezone", test_absolute_timer_uses_provider_timezone),
+    ("absolute-dst-elapsed-time", "absolute deadline uses elapsed time across DST", test_absolute_timer_uses_elapsed_time_across_dst),
+    ("timer-wait-dst-elapsed-time", "timer wait uses elapsed time across DST", test_timer_wait_uses_elapsed_time_across_dst),
+    ("absolute-dst-gap", "DST gap fails closed", test_absolute_timer_dst_gap_fails_closed),
+    ("absolute-dst-fold", "DST fold fails closed without an offset", test_absolute_timer_dst_fold_fails_closed),
+    ("absolute-dst-explicit-offset", "explicit offset resolves a DST fold", test_absolute_timer_explicit_offset_resolves_dst_fold),
+    ("absolute-dst-both-explicit-offsets", "both valid DST fold offsets are accepted", test_absolute_timer_explicit_offset_resolves_both_dst_fold_offsets),
+    ("absolute-contradictory-offset", "contradictory named-zone offsets fail closed", test_absolute_timer_rejects_contradictory_named_zone_offset),
+    ("malformed-12-hour-field", "malformed 12-hour fields fail closed", test_malformed_absolute_12_hour_field_fails_closed),
+    ("relative-exact-wait", "relative delay is preserved exactly", test_relative_timer_waits_exactly),
+    ("unitless-relative-timer", "unitless timers default to seconds", test_unitless_relative_timer_defaults_to_seconds),
+    ("unitless-colon-timer", "colon-formatted unitless timers fail closed", test_colon_after_unitless_timer_fails_closed),
+    ("comma-grouped-relative-timer", "comma-grouped timers fail closed", test_comma_grouped_relative_timer_fails_closed),
+    ("unsupported-relative-unit", "unsupported timer units fail closed", test_unsupported_relative_timer_unit_fails_closed),
+    ("unsupported-relative-punctuation", "unsupported timer punctuation fails closed", test_unsupported_relative_timer_punctuation_fails_closed),
+    ("incomplete-absolute-reset", "incomplete absolute reset fails closed", test_incomplete_absolute_reset_fails_closed),
+    ("absolute-timer-suffix", "absolute timer suffix fails closed", test_absolute_timer_suffix_fails_closed),
+    ("malformed-before-valid-timer", "malformed timer before valid timer fails closed", test_malformed_timer_before_valid_timer_fails_closed),
+    ("malformed-reset-timer", "malformed reset timer fails closed", test_malformed_reset_timer_fails_closed),
+    ("session-deadline-reentry", "active session deadline is preserved on re-entry", test_session_timer_deadline_is_not_extended_on_reentry),
+    ("active-identical-timer", "active identical fresh timer replaces deadline", test_active_identical_new_timer_replaces_deadline),
+    ("active-later-deadline", "active later timer replaces deadline and identity", test_active_later_timer_replaces_deadline_and_identity),
+    ("active-earlier-same-pr", "active earlier timer replaces deadline for the same PR", test_active_earlier_timer_replaces_deadline_for_same_pr),
+    ("active-timer-other-pr", "active timer for another PR falls back and retains ownership", test_active_timer_for_another_pr_falls_back_and_retains_owner),
+    ("expired-timer-other-pr", "expired timer for another PR replaces deadline and waits", test_expired_timer_for_another_pr_replaces_deadline_and_waits),
+    ("exact-expiry-timer-other-pr", "exactly expired timer for another PR replaces deadline and waits", test_exactly_expiring_timer_for_another_pr_replaces_deadline_and_waits),
+    ("session-deadline-exact-reentry", "exact deadline re-entry retries without extension", test_session_timer_retries_at_exact_reentry_deadline),
+    ("cli-typed-reentry", "CLI preserves typed timer re-entry", test_cli_preserves_typed_timer_across_reentry),
+    ("cli-invalid-utf8", "CLI invalid UTF-8 message file falls back", test_cli_invalid_utf8_message_file_falls_back),
+    ("expired-deadline-identical-timer", "identical-text new timer replaces an expired session deadline", test_identical_text_new_timer_replaces_expired_session_deadline),
+    ("expired-deadline-new-timer", "new timer replaces an expired session deadline", test_new_timer_replaces_expired_session_deadline),
+    ("timer-deadline-retry", "timer retries at its exact deadline", test_timer_retries_at_deadline),
+    ("transient-immediate-retry", "transient failure retries immediately", test_transient_retries_immediately),
+    ("connection-reset-transient", "connection reset by peer retries immediately", test_connection_reset_by_peer_retries_immediately),
+    ("standalone-availability", "standalone availability timer waits", test_standalone_availability_timer_waits),
+    ("wrapped-availability", "transient-wrapped availability timer waits", test_transient_wrapped_availability_timer_waits),
+    ("malformed-availability", "malformed availability timer fails closed", test_malformed_availability_timer_fails_closed),
+    ("permanent-marker-precedence", "permanent marker precedes transient marker", test_permanent_marker_precedes_transient_marker),
+    ("oversized-relative-timer", "oversized timer fails closed", test_oversized_relative_timer_fails_closed),
+    ("malformed-timer", "malformed timer fails closed", test_malformed_timer_text_fails_closed),
+    ("unknown-timer-zone", "unknown timer zone fails closed", test_unknown_timer_zone_fails_closed),
+    ("unrepresentable-absolute-timer", "unrepresentable absolute timer disables the session route", test_unrepresentable_absolute_timer_disables_external_route),
+    ("fractional-timer", "fractional timer fails closed", test_fractional_timer_fails_closed),
+    ("numeric-marker-token", "numeric transient markers require complete tokens", test_numeric_transient_marker_requires_complete_token),
+    ("permanent-session-disable", "permanent failure disables only this session", test_permanent_disables_external_route_for_session),
+    ("unknown-permanent", "unknown failure fails closed", test_unknown_fails_closed_as_permanent),
+    ("unknown-typed-permanent", "unknown typed failure fails closed", test_unrecognized_typed_failure_fails_closed),
+    ("malformed-typed-timer", "malformed typed timer fails closed", test_malformed_typed_timer_fails_closed),
+    ("malformed-typed-state", "malformed typed state fails closed", test_malformed_typed_state_fails_closed),
+    ("session-state", "disabled state blocks later launches in this session", test_disabled_state_is_session_only_and_blocks_new_launches),
+    ("spent-timer-fallback", "spent timer falls back and retains session backoff", test_timer_after_retry_falls_back_but_keeps_timer),
+    ("active-timer-missing-pr", "active timer without a PR number fails closed", test_active_timer_without_pr_fails_closed),
+    ("initial-timer-missing-pr", "initial timer without a PR owner is never stored", test_initial_timer_without_pr_fails_closed_before_storage),
+    ("ownerless-state", "ownerless session state fails closed before cross-PR use", test_ownerless_state_fails_closed_before_cross_pr_use),
+    ("zero-delay-timer", "zero-delay timer retries immediately", test_zero_delay_timer_retries_immediately),
+]
+
+
+def main() -> int:
+    failures = 0
+    for name, description, function in CASES:
+        try:
+            function()
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:32} -> {description}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:32} -> {description}")
+    if failures:
+        print(f"{failures} fixture(s) FAILED")
+        return 1
+    print(f"reviewer-backoff fixtures: {len(CASES)} passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -1053,6 +1053,210 @@ def test_retry_phrase_without_a_value_falls_back_without_disabling() -> None:
               f"unrecognized wording disabled the external route: {message!r}")
 
 
+def test_longer_marker_outranks_the_fragment_inside_it() -> None:
+    """`refused` is a fragment of `connection refused`; the marker explaining more text wins."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "dial tcp 10.0.0.1:443: connect: connection refused",
+        "connection refused",
+        "TLS handshake: connection refused",
+        "connection refused; 503 service unavailable",
+        "upstream connection reset; connection refused",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TRANSIENT,
+              f"a transport refusal was read as a reviewer refusal: {message!r}")
+        check(result.action == MODULE.RETRY_EXTERNAL,
+              f"a transport refusal did not spend the one retry: {message!r}")
+
+    timed = MODULE.decide("connection refused; retry after 90 seconds", now=now, pr_number=188)
+    check(timed.kind == MODULE.TIMER and timed.retry_after_seconds == 90,
+          "a transport refusal threw away the provider's 90-second delay")
+    permanent = MODULE.decide("permission denied; connection refused", now=now, pr_number=188)
+    check(permanent.kind == MODULE.PERMANENT,
+          "a permanent marker lost to a transport refusal")
+
+
+def test_refusal_wording_survives_a_longer_timer_attempt() -> None:
+    """Only markers can eat markers: a timer attempt straddling a refusal must never swallow it."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "retry: decline 5",
+        "the model refused to comply",
+        "I must decline; retry after 90 seconds is not applicable here.",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.REFUSAL,
+              f"a timer attempt swallowed the reviewer refusal: {message!r}")
+        check(result.action == MODULE.STOP_AND_ASK,
+              f"a swallowed refusal skipped the operator: {message!r}")
+
+
+def test_trigger_word_without_a_value_keeps_the_transient_class() -> None:
+    """A connector or colon alone introduces no value, so a live transient marker keeps the class."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for carrier in ("service unavailable", "temporarily unavailable", "connection reset"):
+        for tail in (": please stand by", " in us-east-1", " at this time", " for this account",
+                     " on this endpoint", " after maintenance"):
+            message = carrier + tail
+            result = MODULE.decide(message, now=now, pr_number=188)
+            check(result.kind == MODULE.TRANSIENT,
+                  f"a valueless trigger word forced the malformed-timer path: {message!r}")
+            check(result.state.external_disabled is False,
+                  f"a valueless trigger word disabled the session route: {message!r}")
+
+
+def test_status_code_after_a_trigger_word_is_not_a_timer_value() -> None:
+    """`503` is a status the transient list explains whole, not a delay the timer detector guesses."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "service unavailable: 503",
+        "service unavailable:503",
+        "service unavailable : 503",
+        "service unavailable 503",
+        "service unavailable  503",
+        "service unavailable\n503",
+        "temporarily unavailable: 503",
+        "connection reset: 503",
+        "retry: 429",
+        "too many requests; retry: 429",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TRANSIENT,
+              f"a status code was read as a broken timer value: {message!r}")
+        check(result.state.external_disabled is False,
+              f"a status code disabled the session route: {message!r}")
+
+
+def test_free_standing_retry_word_without_a_value_keeps_the_transient_class() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "503; retry: yes",
+        "503; retry in a moment",
+        "503; retry after the maintenance window",
+        "502 bad gateway; please retry in a bit",
+        "gateway timeout; retry at your convenience",
+        "gateway timeout; wait for the upstream to recover",
+        "gateway timeout; wait: upstream is down",
+        "internal server error; backoff in effect",
+        "internal server error; backoff: enabled",
+        "429; retrying in background",
+        "rate limit; try again at a later time",
+        "rate limit; resets at midnight",
+        "rate limit; resets on the first of the month",
+        "temporary failure; available in region eu-west",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TRANSIENT,
+              f"a valueless retry word forced the malformed-timer path: {message!r}")
+        check(result.action == MODULE.RETRY_EXTERNAL,
+              f"a recognized transient failure did not retry: {message!r}")
+
+
+def test_valueless_trigger_word_never_poisons_a_valid_timer() -> None:
+    """A stray trigger elsewhere in the message must not throw away a real provider deadline."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "rate limit; retry after 90 seconds; service unavailable at this time",
+        "service unavailable at this time; retry after 90 seconds",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TIMER,
+              f"a valueless trigger word poisoned a valid timer: {message!r}")
+        check(result.retry_after_seconds == 90,
+              f"a poisoned timer lost the provider delay: {message!r}")
+
+    absolute = MODULE.decide(
+        "quota exhausted; resets Jul 27, 9pm (Asia/Tokyo); service unavailable in us-east-1",
+        now=now,
+        pr_number=188,
+    )
+    check(absolute.kind == MODULE.TIMER and absolute.retry_after_seconds == 172800,
+          "a valueless trigger word poisoned a valid absolute timer")
+
+
+def test_valueless_trigger_word_without_a_marker_stays_unrecognized() -> None:
+    """With no marker at all the message is opaque, and opaque text never disables the route."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "quota exceeded; resets: soon",
+        "please retry at your leisure",
+        "job failed; wait for operator",
+        "upstream busy; try again in a while",
+        "aborted; retry: manual",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.UNRECOGNIZED,
+              f"opaque wording was classified permanent: {message!r}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"opaque wording did not fall back natively: {message!r}")
+        check(result.state.external_disabled is False,
+              f"opaque wording disabled the session route: {message!r}")
+
+
+def test_trigger_word_with_a_number_and_a_non_time_noun_fails_closed() -> None:
+    """`retry after 3 requests` is the shape of `retry after 90 bananas`; both must fail closed.
+
+    No syntactic rule separates `requests`, `attempts`, `times`, or a bare count from `bananas`.
+    Only a vocabulary of non-time nouns would, and that vocabulary is a declared non-goal, so these
+    stay `permanent` deliberately. The last three rows are the same shape reached through a
+    transient carrier, and they fail closed for the same reason.
+    """
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "rate limit exceeded, retry after 3 requests",
+        "retry: 3 attempts failed, gateway timeout",
+        "504 gateway timeout; retry 3 times",
+        "429; retrying: attempt 2",
+        "timed out; wait 30",
+        "service unavailable 30",
+        "temporarily unavailable 30",
+        "connection reset 30",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.PERMANENT,
+              f"a countable non-time noun was accepted as a timer: {message!r}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"a countable non-time noun did not fall back: {message!r}")
+        check(result.state.external_disabled,
+              f"a countable non-time noun did not disable the session route: {message!r}")
+
+
+def test_one_intervening_token_bounds_the_timer_attempt_window() -> None:
+    """The one-token window between a connector and a value is arbitrary and load-bearing.
+
+    Inside the window the text is a broken timer and fails closed; outside it the text is ordinary
+    prose that never reaches the `permanent` precedence. Both sides are pinned so the boundary
+    cannot drift silently.
+    """
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "rate limit; retry after never seconds",
+        "temporarily unavailable; reset after every 90 seconds",
+    ):
+        inside = MODULE.decide(message, now=now, pr_number=188)
+        check(inside.kind == MODULE.PERMANENT,
+              f"a value one token past the connector stopped failing closed: {message!r}")
+
+    for message, expected in (
+        ("upstream busy; try again in a few minutes", MODULE.UNRECOGNIZED),
+        ("service unavailable; try again in a few minutes", MODULE.TRANSIENT),
+    ):
+        outside = MODULE.decide(message, now=now, pr_number=188)
+        check(outside.kind == expected,
+              f"a value three tokens past the connector was read as a timer: {message!r}")
+        check(outside.state.external_disabled is False,
+              f"prose past the attempt window disabled the session route: {message!r}")
+
+
 def test_cli_reports_reviewer_refusal() -> None:
     payload = run_cli(
         "decide",
@@ -1136,6 +1340,15 @@ CASES = [
     ("refusal-pr-exemption-bounds", "the refusal PR exemption leaves every other guard closed", test_refusal_pr_exemption_keeps_other_guards_closed),
     ("valueless-retry-phrase-transient", "a valueless retry phrase keeps a transient classification", test_retry_phrase_without_a_value_keeps_transient_classification),
     ("valueless-retry-phrase-unrecognized", "a valueless retry phrase falls back without disabling", test_retry_phrase_without_a_value_falls_back_without_disabling),
+    ("marker-fragment-precedence", "a longer marker outranks the fragment inside it", test_longer_marker_outranks_the_fragment_inside_it),
+    ("refusal-survives-timer-attempt", "a timer attempt never swallows refusal wording", test_refusal_wording_survives_a_longer_timer_attempt),
+    ("valueless-trigger-transient", "a valueless trigger word keeps the transient class", test_trigger_word_without_a_value_keeps_the_transient_class),
+    ("status-code-not-timer-value", "a status code after a trigger word is not a timer value", test_status_code_after_a_trigger_word_is_not_a_timer_value),
+    ("valueless-retry-word-transient", "a free-standing valueless retry word keeps the transient class", test_free_standing_retry_word_without_a_value_keeps_the_transient_class),
+    ("timer-not-poisoned", "a valueless trigger word never poisons a valid timer", test_valueless_trigger_word_never_poisons_a_valid_timer),
+    ("valueless-trigger-unrecognized", "a valueless trigger word without a marker stays unrecognized", test_valueless_trigger_word_without_a_marker_stays_unrecognized),
+    ("non-time-noun-fails-closed", "a number with a non-time noun stays permanent", test_trigger_word_with_a_number_and_a_non_time_noun_fails_closed),
+    ("attempt-window-bounds", "one intervening token bounds the timer attempt window", test_one_intervening_token_bounds_the_timer_attempt_window),
     ("cli-refusal", "CLI reports the refusal kind and stop-and-ask action", test_cli_reports_reviewer_refusal),
 ]
 

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -664,6 +664,17 @@ def test_unknown_timer_zone_fails_closed() -> None:
           "unknown timer zone selected an immediate retry")
 
 
+def test_unknown_timer_month_fails_closed() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    result = MODULE.decide("rate limit; resets Jax 27, 9pm", now=now, pr_number=188)
+    check(result.kind == MODULE.PERMANENT,
+          "unknown timer month selected an immediate retry")
+    check(result.action == MODULE.FALLBACK_NATIVE,
+          "unknown timer month did not fall back natively")
+    check(result.state.external_disabled,
+          "unknown timer month did not disable the session route")
+
+
 def test_unrepresentable_absolute_timer_disables_external_route() -> None:
     now = datetime(9999, 12, 30, 0, 0, tzinfo=timezone.utc)
     result = MODULE.decide("rate limit; resets Dec 31, 11pm (Pacific/Pago_Pago)", now=now)
@@ -893,6 +904,7 @@ CASES = [
     ("oversized-relative-timer", "oversized timer fails closed", test_oversized_relative_timer_fails_closed),
     ("malformed-timer", "malformed timer fails closed", test_malformed_timer_text_fails_closed),
     ("unknown-timer-zone", "unknown timer zone fails closed", test_unknown_timer_zone_fails_closed),
+    ("unknown-timer-month", "unknown timer month fails closed", test_unknown_timer_month_fails_closed),
     ("unrepresentable-absolute-timer", "unrepresentable absolute timer disables the session route", test_unrepresentable_absolute_timer_disables_external_route),
     ("fractional-timer", "fractional timer fails closed", test_fractional_timer_fails_closed),
     ("numeric-marker-token", "numeric transient markers require complete tokens", test_numeric_transient_marker_requires_complete_token),

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -50,6 +50,21 @@ def test_absolute_timer_uses_provider_timezone() -> None:
           "absolute reset was not converted from the provider timezone")
 
 
+def test_absolute_timer_accepts_at_and_on_connectors() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "rate limit; resets at Jul 27, 9pm (Asia/Tokyo)",
+        "rate limit; available on Jul 27, 9pm (Asia/Tokyo)",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.TIMER,
+              f"absolute timer connector was not classified as a timer: {message!r}")
+        check(result.action == MODULE.WAIT_EXTERNAL,
+              f"absolute timer connector did not wait: {message!r}")
+        check(result.retry_after_seconds == 172800,
+              f"absolute timer connector delay changed: {message!r}")
+
+
 def test_absolute_timer_uses_elapsed_time_across_dst() -> None:
     now = datetime(2026, 3, 8, 1, 30, tzinfo=MODULE.ZoneInfo("America/New_York"))
     result = MODULE.classify("quota exhausted; resets Mar 8, 3:30am (America/New_York)", now)
@@ -213,16 +228,21 @@ def test_unsupported_relative_timer_punctuation_fails_closed() -> None:
 
 
 def test_incomplete_absolute_reset_fails_closed() -> None:
-    result = MODULE.decide(
+    for message in (
         "rate limit; resets Jul 27",
-        now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
-    )
-    check(result.kind == MODULE.PERMANENT,
-          "incomplete absolute reset was accepted as a transient failure")
-    check(result.action == MODULE.FALLBACK_NATIVE,
-          "incomplete absolute reset did not fall back")
-    check(result.state.external_disabled,
-          "incomplete absolute reset did not disable the session route")
+        "rate limit; resets at Jul 27",
+        "rate limit; available on Jul 27",
+    ):
+        result = MODULE.decide(
+            message,
+            now=datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc),
+        )
+        check(result.kind == MODULE.PERMANENT,
+              f"incomplete absolute timer was accepted as transient: {message!r}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"incomplete absolute timer did not fall back: {message!r}")
+        check(result.state.external_disabled,
+              f"incomplete absolute timer did not disable the session route: {message!r}")
 
 
 def test_absolute_timer_suffix_fails_closed() -> None:
@@ -823,6 +843,7 @@ def test_zero_delay_timer_retries_immediately() -> None:
 
 CASES = [
     ("absolute-provider-timezone", "absolute reset uses provider timezone", test_absolute_timer_uses_provider_timezone),
+    ("absolute-at-on-connectors", "absolute timers accept at/on connectors", test_absolute_timer_accepts_at_and_on_connectors),
     ("absolute-dst-elapsed-time", "absolute deadline uses elapsed time across DST", test_absolute_timer_uses_elapsed_time_across_dst),
     ("timer-wait-dst-elapsed-time", "timer wait uses elapsed time across DST", test_timer_wait_uses_elapsed_time_across_dst),
     ("absolute-dst-gap", "DST gap fails closed", test_absolute_timer_dst_gap_fails_closed),

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -894,6 +894,83 @@ def test_zero_delay_timer_retries_immediately() -> None:
           "zero-delay timer was not an immediate retry")
 
 
+def test_reviewer_refusal_stops_and_asks() -> None:
+    """A content/safety refusal must reach the operator, never a silent same-engine fallback."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "I'm sorry, but I can't help with that.",
+        "ERROR: I'm unable to assist with a request of this kind.",
+        "codex: turn aborted: refusal",
+        "The reviewer declined this task on policy grounds.",
+        "response blocked: safety policy violation",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.REFUSAL, f"reviewer refusal was not classified: {message!r}")
+        check(result.action == MODULE.STOP_AND_ASK,
+              f"reviewer refusal did not stop and ask: {message!r}")
+        check(not result.state.external_disabled,
+              f"reviewer refusal disabled the session route: {message!r}")
+        check(result.state.external_backoff_until is None,
+              f"reviewer refusal stored a session deadline: {message!r}")
+
+
+def test_reviewer_refusal_precedes_other_markers() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "I can't assist with that. usage: codex exec [OPTIONS] [PROMPT]",
+        "Sorry, I can't provide assistance with that. Please try again with a different request.",
+        "I must decline; retry after 90 seconds is not applicable here.",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.REFUSAL,
+              f"another marker outranked the reviewer refusal: {message!r}")
+        check(result.action == MODULE.STOP_AND_ASK,
+              f"refusal with a competing marker did not stop and ask: {message!r}")
+
+
+def test_reviewer_refusal_after_retry_still_stops_and_asks() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    result = MODULE.decide(
+        "I'm sorry, but I can't help with that.", retry_spent=True, now=now, pr_number=188
+    )
+    check(result.action == MODULE.STOP_AND_ASK,
+          "spent retry turned a reviewer refusal into a native fallback")
+
+
+def test_reviewer_refusal_preserves_active_session_backoff() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    deadline = datetime(2026, 7, 25, 12, 5, tzinfo=timezone.utc)
+    state = MODULE.SessionState(False, deadline, "retry after 300 seconds", 188)
+    result = MODULE.transition(
+        MODULE.Failure(MODULE.REFUSAL, None, None, "refusal marker: decline"),
+        now=now,
+        state=state,
+        pr_number=188,
+    )
+    check(result.action == MODULE.STOP_AND_ASK,
+          "active session backoff swallowed a reviewer refusal")
+    check(result.state.external_backoff_until == deadline,
+          "reviewer refusal changed the active session deadline")
+    check(result.state.external_backoff_timer_id == "retry after 300 seconds",
+          "reviewer refusal changed the active timer owner")
+
+
+def test_cli_reports_reviewer_refusal() -> None:
+    payload = run_cli(
+        "decide",
+        "--message",
+        "I'm sorry, but I can't help with that.",
+        "--now",
+        "2026-07-25T12:00:00Z",
+        "--pr",
+        "188",
+    )
+    check(payload["kind"] == MODULE.REFUSAL, "CLI did not report the refusal kind")
+    check(payload["action"] == MODULE.STOP_AND_ASK, "CLI did not report the stop-and-ask action")
+    check(payload["external_disabled"] is False, "CLI refusal disabled the session route")
+
+
 CASES = [
     ("absolute-provider-timezone", "absolute reset uses provider timezone", test_absolute_timer_uses_provider_timezone),
     ("absolute-at-on-connectors", "absolute timers accept at/on connectors", test_absolute_timer_accepts_at_and_on_connectors),
@@ -954,6 +1031,11 @@ CASES = [
     ("initial-timer-missing-pr", "initial timer without a PR owner is never stored", test_initial_timer_without_pr_fails_closed_before_storage),
     ("ownerless-state", "ownerless session state fails closed before cross-PR use", test_ownerless_state_fails_closed_before_cross_pr_use),
     ("zero-delay-timer", "zero-delay timer retries immediately", test_zero_delay_timer_retries_immediately),
+    ("refusal-stop-and-ask", "reviewer refusal stops and asks the operator", test_reviewer_refusal_stops_and_asks),
+    ("refusal-marker-precedence", "refusal precedes permanent and timer markers", test_reviewer_refusal_precedes_other_markers),
+    ("refusal-after-retry", "spent retry never downgrades a refusal to fallback", test_reviewer_refusal_after_retry_still_stops_and_asks),
+    ("refusal-keeps-backoff", "refusal preserves an active session deadline", test_reviewer_refusal_preserves_active_session_backoff),
+    ("cli-refusal", "CLI reports the refusal kind and stop-and-ask action", test_cli_reports_reviewer_refusal),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -626,6 +626,24 @@ def test_transient_wrapped_availability_timer_waits() -> None:
           "transient-wrapped availability delay changed")
 
 
+def test_service_unavailable_timer_waits_until_exact_deadline() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for connector in ("for", "in"):
+        result = MODULE.decide(
+            f"service unavailable {connector} 90 seconds",
+            now=now,
+            pr_number=188,
+        )
+        check(result.kind == MODULE.TIMER,
+              f"service-unavailable timer was not classified as a timer: {connector}")
+        check(result.action == MODULE.WAIT_EXTERNAL,
+              f"service-unavailable timer did not wait: {connector}")
+        check(result.retry_after_seconds == 90,
+              f"service-unavailable timer delay changed: {connector}")
+        check(result.retry_at == "2026-07-25T12:01:30+00:00",
+              f"service-unavailable timer deadline changed: {connector}")
+
+
 def test_malformed_availability_timer_fails_closed() -> None:
     result = MODULE.decide(
         "temporarily unavailable; available in 90 bananas",
@@ -637,6 +655,21 @@ def test_malformed_availability_timer_fails_closed() -> None:
           "malformed availability timer retried")
     check(result.state.external_disabled,
           "malformed availability timer did not disable the session route")
+
+
+def test_malformed_service_unavailable_timer_fails_closed() -> None:
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for connector in ("for", "in"):
+        result = MODULE.decide(
+            f"service unavailable {connector} 90 bananas",
+            now=now,
+        )
+        check(result.kind == MODULE.PERMANENT,
+              f"malformed service-unavailable timer was accepted: {connector}")
+        check(result.action == MODULE.FALLBACK_NATIVE,
+              f"malformed service-unavailable timer did not fall back: {connector}")
+        check(result.state.external_disabled,
+              f"malformed service-unavailable timer did not disable the session route: {connector}")
 
 
 def test_permanent_marker_precedes_transient_marker() -> None:
@@ -899,7 +932,9 @@ CASES = [
     ("connection-reset-transient", "connection reset by peer retries immediately", test_connection_reset_by_peer_retries_immediately),
     ("standalone-availability", "standalone availability timer waits", test_standalone_availability_timer_waits),
     ("wrapped-availability", "transient-wrapped availability timer waits", test_transient_wrapped_availability_timer_waits),
+    ("service-unavailable-timer", "service unavailable timers wait until their exact deadline", test_service_unavailable_timer_waits_until_exact_deadline),
     ("malformed-availability", "malformed availability timer fails closed", test_malformed_availability_timer_fails_closed),
+    ("malformed-service-unavailable", "malformed service unavailable timers fail closed", test_malformed_service_unavailable_timer_fails_closed),
     ("permanent-marker-precedence", "permanent marker precedes transient marker", test_permanent_marker_precedes_transient_marker),
     ("oversized-relative-timer", "oversized timer fails closed", test_oversized_relative_timer_fails_closed),
     ("malformed-timer", "malformed timer fails closed", test_malformed_timer_text_fails_closed),

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff-test.py
@@ -1092,7 +1092,11 @@ def test_retry_phrase_without_a_value_falls_back_without_disabling() -> None:
 
 
 def test_longer_marker_outranks_the_fragment_inside_it() -> None:
-    """`refused` is a fragment of `connection refused`; the marker explaining more text wins."""
+    """Transport connection-refused text stays transient: the marker explaining more text wins.
+
+    The live containment pair the rule now turns on is `timeout` inside `gateway timeout`, pinned by
+    reason string in ``test_longest_marker_supplies_the_reported_reason``.
+    """
 
     now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
     for message in (
@@ -1114,6 +1118,62 @@ def test_longer_marker_outranks_the_fragment_inside_it() -> None:
     permanent = MODULE.decide("permission denied; connection refused", now=now, pr_number=188)
     check(permanent.kind == MODULE.PERMANENT,
           "a permanent marker lost to a transport refusal")
+
+
+def test_longest_marker_supplies_the_reported_reason() -> None:
+    """The surviving containment pair is pinned by reason, not only by class.
+
+    `gateway timeout` contains `timeout` and both are transient, so the class alone cannot show that
+    the fragment was dropped. Without the fragment rule both messages report `transient marker:
+    timeout`, because `timeout` sits earlier in TRANSIENT_MARKERS.
+    """
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in ("gateway timeout", "504 gateway timeout"):
+        result = MODULE.classify(message, now)
+        check(result.kind == MODULE.TRANSIENT,
+              f"a gateway timeout was not classified transient: {message!r}")
+        check(result.reason == "transient marker: gateway timeout",
+              f"a fragment marker supplied the reason: {message!r} -> {result.reason!r}")
+
+
+def test_transport_wording_is_never_a_reviewer_refusal() -> None:
+    """Transport and telemetry text carrying the bare `refused` stem never stops the campaign.
+
+    Asserted as safe-outcome PROPERTIES, not as a specific kind: today these land unrecognized and
+    take the native fallback, and a later transient marker covering them must not move this fixture.
+    """
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "The connection was refused by the upstream.",
+        "connection actively refused by the remote host",
+        "the peer refused the connection",
+        "the merge was refused by the branch ruleset",
+        "Error: connect ECONNREFUSED 127.0.0.1:443",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind != MODULE.REFUSAL,
+              f"transport wording was read as a reviewer refusal: {message!r}")
+        check(result.action != MODULE.STOP_AND_ASK,
+              f"transport wording manufactured a stop-and-ask: {message!r}")
+        check(result.external_disabled is False,
+              f"transport wording disabled the external route: {message!r}")
+
+
+def test_infinitive_anchored_refusal_still_stops_and_asks() -> None:
+    """Narrowing the stem to `refused to` keeps the agent sense reaching the operator."""
+
+    now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+    for message in (
+        "the model refused to comply",
+        "the reviewer refused to continue this review",
+    ):
+        result = MODULE.decide(message, now=now, pr_number=188)
+        check(result.kind == MODULE.REFUSAL,
+              f"an agent refusal lost the refusal class: {message!r}")
+        check(result.action == MODULE.STOP_AND_ASK,
+              f"an agent refusal skipped the operator: {message!r}")
 
 
 def test_refusal_wording_survives_a_longer_timer_attempt() -> None:
@@ -1404,6 +1464,9 @@ CASES = [
     ("valueless-retry-phrase-transient", "a valueless retry phrase keeps a transient classification", test_retry_phrase_without_a_value_keeps_transient_classification),
     ("valueless-retry-phrase-unrecognized", "a valueless retry phrase falls back without disabling", test_retry_phrase_without_a_value_falls_back_without_disabling),
     ("marker-fragment-precedence", "a longer marker outranks the fragment inside it", test_longer_marker_outranks_the_fragment_inside_it),
+    ("marker-fragment-reason", "the longest marker supplies the reported reason", test_longest_marker_supplies_the_reported_reason),
+    ("transport-wording-not-refusal", "transport wording is never a reviewer refusal", test_transport_wording_is_never_a_reviewer_refusal),
+    ("infinitive-anchored-refusal", "infinitive-anchored refusal wording still stops and asks", test_infinitive_anchored_refusal_still_stops_and_asks),
     ("refusal-survives-timer-attempt", "a timer attempt never swallows refusal wording", test_refusal_wording_survives_a_longer_timer_attempt),
     ("valueless-trigger-transient", "a valueless trigger word keeps the transient class", test_trigger_word_without_a_value_keeps_the_transient_class),
     ("status-code-not-timer-value", "a status code after a trigger word is not a timer value", test_status_code_after_a_trigger_word_is_not_a_timer_value),

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -53,6 +53,7 @@ DURATION_RE = re.compile(
 )
 TIMER_PHRASE_RE = re.compile(
     r"\b(?:retry(?:ing)?|try\s+again|backoff|wait)\b"
+    r"(?=\s*(?:after|in|for|at|on)\b|\s*:\s*|\s+\d)"
     r"|\b(?:reset(?:s)?|available|unavailable)\b"
     r"(?=\s*(?:after|in|for|at|on)\b|\s*:\s*|\s+\d)",
     re.IGNORECASE,
@@ -634,7 +635,11 @@ def transition(
     if not _valid_state(prior):
         prior = ExternalReviewSessionState(external_disabled=True)
         failure = _permanent("external session state was malformed")
-    elif state is not None and pr_number is None:
+    elif (
+        state is not None
+        and pr_number is None
+        and not (isinstance(failure, ExternalReviewFailure) and failure.kind == REFUSAL)
+    ):
         failure = _permanent("external review PR number was omitted for a session transition")
     elif pr_number is not None and (type(pr_number) is not int or pr_number <= 0):
         failure = _permanent("external review PR number was malformed")

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -58,9 +58,7 @@ TIMER_PHRASE_RE = re.compile(
 ABSOLUTE_TIMER_PREFIX_RE = re.compile(
     r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
     r"(?:(?:at|on)\s+)?"
-    r"(?:(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
-    r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
-    r"nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}|\d{1,2}\b)",
+    r"(?:[A-Za-z]+\s+\d{1,2}|\d{1,2}\b)",
     re.IGNORECASE,
 )
 MONTHS = {
@@ -80,9 +78,7 @@ MONTHS = {
 ABSOLUTE_RE = re.compile(
     r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
     r"(?:(?:at|on)\s+)?"
-    r"(?P<month>jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
-    r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
-    r"nov(?:ember)?|dec(?:ember)?)\s+"
+    r"(?P<month>[A-Za-z]+)\s+"
     r"(?P<day>\d{1,2})(?:,\s*|\s+)"
     r"(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<ampm>am|pm)"
     r"(?:\s*(?P<offset>Z|[+-]\d{2}:?\d{2}))?"

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -26,6 +26,7 @@ SIBLING = HERE / "reviewer-backoff-test.py"
 TRANSIENT = "transient"
 TIMER = "timer"
 PERMANENT = "permanent"
+UNRECOGNIZED = "unrecognized"
 
 RETRY_EXTERNAL = "retry-external"
 WAIT_EXTERNAL = "wait-external"
@@ -427,10 +428,14 @@ def _permanent(reason: str) -> ExternalReviewFailure:
     return ExternalReviewFailure(PERMANENT, None, None, reason)
 
 
+def _unrecognized(reason: str) -> ExternalReviewFailure:
+    return ExternalReviewFailure(UNRECOGNIZED, None, None, reason)
+
+
 def _valid_failure(value: object) -> bool:
     if not isinstance(value, ExternalReviewFailure) or not isinstance(value.reason, str):
         return False
-    if value.kind in (TRANSIENT, PERMANENT):
+    if value.kind in (TRANSIENT, PERMANENT, UNRECOGNIZED):
         return (
             value.retry_after_seconds is None
             and value.retry_at is None
@@ -524,8 +529,9 @@ def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure
     """Classify every external-process error before route selection.
 
     Permanent markers take precedence. Valid whole-second timer text wins over transient markers;
-    malformed or unsupported timer text is permanent for this session. A numeric offset paired with
-    a named timezone must match that zone's valid offset for the target local time.
+    malformed or unsupported timer text is permanent for this session. Opaque text is unrecognized
+    and falls back without disabling the external route. A numeric offset paired with a named timezone
+    must match that zone's valid offset for the target local time.
     """
 
     if not isinstance(message, str):
@@ -551,7 +557,7 @@ def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure
     for marker in TRANSIENT_MARKERS:
         if _contains_transient_marker(lowered, marker):
             return ExternalReviewFailure(TRANSIENT, None, None, f"transient marker: {marker}")
-    return _permanent("no safe retry class or timer was identified")
+    return _unrecognized("no recognized retry class or timer was identified")
 
 
 def _iso(value: datetime | None) -> str | None:
@@ -605,8 +611,8 @@ def transition(
         pr_number = None
     elif not isinstance(failure, ExternalReviewFailure):
         failure = _permanent("external failure classification was malformed")
-    elif failure.kind not in (TRANSIENT, TIMER, PERMANENT):
-        failure = _permanent("unrecognized external failure classification")
+    elif failure.kind not in (TRANSIENT, TIMER, PERMANENT, UNRECOGNIZED):
+        failure = _unrecognized("unrecognized external failure classification")
     elif not _valid_failure(failure):
         failure = _permanent("external failure classification was malformed")
     elif failure.kind == TIMER and pr_number is None:

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -51,11 +51,12 @@ DURATION_RE = re.compile(
 TIMER_PHRASE_RE = re.compile(
     r"\b(?:retry(?:ing)?|try\s+again|backoff|wait)\b"
     r"|\b(?:reset(?:s)?|available)\b"
-    r"(?=\s*(?:after|in|for)\b|\s*:\s*|\s+\d)",
+    r"(?=\s*(?:after|in|for|at|on)\b|\s*:\s*|\s+\d)",
     re.IGNORECASE,
 )
 ABSOLUTE_TIMER_PREFIX_RE = re.compile(
     r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
+    r"(?:(?:at|on)\s+)?"
     r"(?:(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
     r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
     r"nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}|\d{1,2}\b)",
@@ -77,6 +78,7 @@ MONTHS = {
 }
 ABSOLUTE_RE = re.compile(
     r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
+    r"(?:(?:at|on)\s+)?"
     r"(?P<month>jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
     r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
     r"nov(?:ember)?|dec(?:ember)?)\s+"

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -42,7 +42,7 @@ RETRY_AFTER_RE = re.compile(
     re.IGNORECASE,
 )
 DURATION_RE = re.compile(
-    r"\b(?:retry(?:ing)?|try\s+again|backoff|wait|reset(?:s)?|available)"
+    r"\b(?:retry(?:ing)?|try\s+again|backoff|wait|reset(?:s)?|available|unavailable)"
     r"\s*(?:after|in|for|:)?\s*"
     r"(?P<value>\d+)(?![\d.])\s*"
     r"(?P<unit>seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d)"
@@ -51,7 +51,7 @@ DURATION_RE = re.compile(
 )
 TIMER_PHRASE_RE = re.compile(
     r"\b(?:retry(?:ing)?|try\s+again|backoff|wait)\b"
-    r"|\b(?:reset(?:s)?|available)\b"
+    r"|\b(?:reset(?:s)?|available|unavailable)\b"
     r"(?=\s*(?:after|in|for|at|on)\b|\s*:\s*|\s+\d)",
     re.IGNORECASE,
 )

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -140,7 +140,17 @@ REFUSAL_MARKERS = (
     "won't provide assistance",
     "decline",
     "refusal",
-    "refused",
+    # The agent sense of this stem is anchored by the following infinitive. The bare stem `refused`
+    # also matched transport and telemetry wording -- a connection that "was refused by the
+    # upstream", a peer that "refused the connection", a merge "refused by the branch ruleset" --
+    # and, because a non-digit marker compiles with no word boundary, it matched as a pure substring
+    # inside `ECONNREFUSED`. Each of those manufactured a stop-and-ask and ended autonomous handling
+    # of the PR. Transport wording the marker no longer matches lands in `unrecognized` and takes
+    # the native fallback; it is deliberately NOT added to TRANSIENT_MARKERS.
+    # Disclosed residual, deliberately not excluded: browser wording of the form `<host> refused to
+    # connect` still classifies refusal. That is a browser page, not external-reviewer process
+    # output, and separating it from an agent refusal would need an exclusion list.
+    "refused to",
     "content filter",
     "content policy",
     "safety policy",
@@ -582,8 +592,10 @@ def _surviving_candidates(candidates: list[_ClassCandidate]) -> list[_ClassCandi
 
     A marker whose span sits inside a strictly longer marker's span explained less of the message
     than that longer one did, so it is discarded before any class ordering happens. This is what
-    stops the refusal marker `refused` from outranking the transient marker `connection refused`
-    that contains it.
+    stops the marker `timeout` from standing in for the longer marker `gateway timeout` that
+    contains it, so the reported reason names the marker that explained the whole phrase. The rule
+    is written on SPANS, not on classes: a containment pair that crosses two classes is dropped the
+    same way, and the drop decides which class survives to be ordered.
 
     Two bounds are deliberate. Merely OVERLAPPING claims are both kept: `service unavailable for 90
     bananas` must stay a broken timer, and its attempt span overlaps but does not sit inside the

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -51,13 +51,6 @@ DURATION_RE = re.compile(
     rf"(?=\s*{_TIMER_END})",
     re.IGNORECASE,
 )
-TIMER_PHRASE_RE = re.compile(
-    r"\b(?:retry(?:ing)?|try\s+again|backoff|wait)\b"
-    r"(?=\s*(?:after|in|for|at|on)\b|\s*:\s*|\s+\d)"
-    r"|\b(?:reset(?:s)?|available|unavailable)\b"
-    r"(?=\s*(?:after|in|for|at|on)\b|\s*:\s*|\s+\d)",
-    re.IGNORECASE,
-)
 ABSOLUTE_TIMER_PREFIX_RE = re.compile(
     r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
     r"(?:(?:at|on)\s+)?"
@@ -88,6 +81,24 @@ ABSOLUTE_RE = re.compile(
     r"(?:\s+(?P<year>\d{4}))?\s*"
     r"(?:\s*\((?P<zone>[^)\s,]+)(?:\s*,?\s*(?P<zone_offset>Z|[+-]\d{2}:?\d{2}))?\))?"
     rf"(?=\s*{_TIMER_END})",
+    re.IGNORECASE,
+)
+
+# A trigger word claims text only when it actually INTRODUCES A VALUE. The trigger and the connector
+# alphabet are exactly the ones a timer detector already recognises, so this can only ever match a
+# subset of the trigger words themselves; what it adds is the requirement that a digit, a time-unit
+# word, or a month name follow, with AT MOST ONE INTERVENING TOKEN. That one-token window is the only
+# thing separating `retry after never seconds` (one intervening token, a broken timer that must fail
+# closed) from `try again in a few minutes` (three, ordinary prose that is not a timer at all); it is
+# arbitrary, load-bearing, and pinned by fixtures on both sides.
+_TIMER_TRIGGER = r"(?:retry(?:ing)?|try\s+again|backoff|wait|reset(?:s)?|unavailable|available)"
+_TIMER_CONNECTOR = r"(?:\s*(?:after|in|for|at|on)\b|\s*:\s*|(?=\s+\d))"
+_TIMER_UNIT_WORD = r"(?:seconds?|secs?|minutes?|mins?|hours?|hrs?|days?|[smhd])"
+_TIMER_MONTH_WORD = "(?:%s)" % "|".join(sorted(MONTHS, key=len, reverse=True))
+TIMER_ATTEMPT_RE = re.compile(
+    rf"\b{_TIMER_TRIGGER}\b{_TIMER_CONNECTOR}\s*"
+    r"(?:\S+\s+)?"
+    rf"(?P<value>\d+|(?:{_TIMER_UNIT_WORD}|{_TIMER_MONTH_WORD})\b)",
     re.IGNORECASE,
 )
 
@@ -137,6 +148,25 @@ PERMANENT_MARKERS = (
     "command not found",
     "no such file or directory",
     "usage:",
+)
+
+
+def _marker_pattern(marker: str) -> re.Pattern[str]:
+    if marker.isdigit():
+        return re.compile(rf"(?<![\w.]){re.escape(marker)}(?![\w.])", re.IGNORECASE)
+    return re.compile(re.escape(marker), re.IGNORECASE)
+
+
+def _marker_patterns(markers: tuple[str, ...]) -> tuple[tuple[int, str, re.Pattern[str]], ...]:
+    return tuple((index, marker, _marker_pattern(marker)) for index, marker in enumerate(markers))
+
+
+_REFUSAL_PATTERNS = _marker_patterns(REFUSAL_MARKERS)
+_PERMANENT_PATTERNS = _marker_patterns(PERMANENT_MARKERS)
+_TRANSIENT_PATTERNS = _marker_patterns(TRANSIENT_MARKERS)
+_STATUS_VALUE_RE = re.compile(
+    r"(?<![\w.])(?:%s)(?![\w.])"
+    % "|".join(re.escape(marker) for marker in TRANSIENT_MARKERS if marker.isdigit())
 )
 
 
@@ -316,24 +346,12 @@ class _TimerCandidate:
     identity: str
 
 
-def _relative_candidates(text: str, now: datetime) -> list[_TimerCandidate] | object:
-    matches = list(RETRY_AFTER_RE.finditer(text)) + list(DURATION_RE.finditer(text))
-    candidates: list[_TimerCandidate] = []
-    seen_spans: set[tuple[int, int]] = set()
-    for match in sorted(matches, key=lambda item: item.start()):
-        span = (match.start(), match.end())
-        if span in seen_spans:
-            continue
-        seen_spans.add(span)
-        try:
-            delay = int(match.group("value")) * _unit_seconds(match.groupdict().get("unit"))
-            retry_at = (_utc(now) + timedelta(seconds=delay)).astimezone(now.tzinfo)
-        except (OverflowError, ValueError):
-            return _MALFORMED_TIMER
-        candidates.append(_TimerCandidate(
-            match.start(), match.end(), delay, retry_at, _timer_identity(match.group(0))
-        ))
-    return candidates
+@dataclass(frozen=True)
+class _TimerScan:
+    """Every timer claim in one message: the spans that parsed, and the spans that only tried."""
+
+    parsed: tuple[_TimerCandidate, ...]
+    attempts: tuple[tuple[int, int], ...]
 
 
 def _absolute_timer_match(match: re.Match[str] | None, now: datetime) -> tuple[int, datetime, str] | None:
@@ -387,45 +405,69 @@ def _absolute_timer(text: str, now: datetime) -> tuple[int, datetime, str] | Non
     return _absolute_timer_match(ABSOLUTE_RE.search(text), now)
 
 
-def _timer_candidates(text: str, now: datetime) -> list[_TimerCandidate] | object:
-    relative = _relative_candidates(text, now)
-    if relative is _MALFORMED_TIMER:
-        return _MALFORMED_TIMER
+def _is_status_value(text: str, start: int, end: int) -> bool:
+    """Report whether the claimed timer value is really a live digit transient marker.
 
-    candidates = list(relative)
+    ``503`` in ``service unavailable: 503`` is a status, not a delay: the transient marker explains
+    the whole token while the timer detector explains only part of it, so the longer claim wins.
+    Value PARSING never consults this — a genuinely parsed ``retry after 503 seconds`` stays a timer.
+    """
+
+    match = _STATUS_VALUE_RE.match(text, start)
+    return match is not None and match.end() == end
+
+
+def _scan_timers(text: str, now: datetime) -> _TimerScan:
+    parsed: list[_TimerCandidate] = []
+    attempts: list[tuple[int, int]] = []
+    seen_spans: set[tuple[int, int]] = set()
+    relative = list(RETRY_AFTER_RE.finditer(text)) + list(DURATION_RE.finditer(text))
+    for match in sorted(relative, key=lambda item: item.start()):
+        span = (match.start(), match.end())
+        if span in seen_spans:
+            continue
+        seen_spans.add(span)
+        try:
+            delay = int(match.group("value")) * _unit_seconds(match.groupdict().get("unit"))
+            retry_at = (_utc(now) + timedelta(seconds=delay)).astimezone(now.tzinfo)
+        except (OverflowError, ValueError):
+            attempts.append(span)
+            continue
+        parsed.append(_TimerCandidate(
+            span[0], span[1], delay, retry_at, _timer_identity(match.group(0))
+        ))
     for match in ABSOLUTE_RE.finditer(text):
         absolute = _absolute_timer_match(match, now)
         if absolute is None:
-            return _MALFORMED_TIMER
+            attempts.append(match.span())
+            continue
         delay, retry_at, identity = absolute
-        candidates.append(_TimerCandidate(
+        parsed.append(_TimerCandidate(
             match.start(), match.end(), delay, retry_at, identity
         ))
 
-    valid_spans = [(candidate.start, candidate.end) for candidate in candidates]
-    for match in TIMER_PHRASE_RE.finditer(text):
-        if not any(start <= match.start() < end for start, end in valid_spans):
-            return _MALFORMED_TIMER
+    valid_spans = [(candidate.start, candidate.end) for candidate in parsed]
+    for match in TIMER_ATTEMPT_RE.finditer(text):
+        if any(start <= match.start() < end for start, end in valid_spans):
+            continue
+        if _is_status_value(text, match.start("value"), match.end("value")):
+            continue
+        attempts.append(match.span())
     for match in ABSOLUTE_TIMER_PREFIX_RE.finditer(text):
-        if not any(start <= match.start() < end for start, end in valid_spans):
-            return _MALFORMED_TIMER
-    return candidates
+        if any(start <= match.start() < end for start, end in valid_spans):
+            continue
+        attempts.append(match.span())
+    return _TimerScan(tuple(parsed), tuple(attempts))
 
 
 def _timer(text: str, now: datetime) -> tuple[int, datetime, str] | None | object:
-    candidates = _timer_candidates(text, now)
-    if candidates is _MALFORMED_TIMER:
+    scan = _scan_timers(text, now)
+    if scan.attempts:
         return _MALFORMED_TIMER
-    if not candidates:
+    if not scan.parsed:
         return None
-    candidate = min(candidates, key=lambda item: item.start)
+    candidate = min(scan.parsed, key=lambda item: item.start)
     return candidate.delay, candidate.retry_at, candidate.identity
-
-
-def _contains_transient_marker(text: str, marker: str) -> bool:
-    if marker.isdigit():
-        return re.search(rf"(?<![\w.]){re.escape(marker)}(?![\w.])", text) is not None
-    return marker in text
 
 
 def timer_seconds(message: str, now: datetime) -> int | None:
@@ -450,6 +492,87 @@ def _refusal(reason: str) -> ExternalReviewFailure:
 
 def _unrecognized(reason: str) -> ExternalReviewFailure:
     return ExternalReviewFailure(UNRECOGNIZED, None, None, reason)
+
+
+_RANK_REFUSAL = 0
+_RANK_PERMANENT = 1
+_RANK_MALFORMED_TIMER = 2
+_RANK_TIMER = 3
+_RANK_TRANSIENT = 4
+
+
+@dataclass(frozen=True)
+class _ClassCandidate:
+    """One class's claim on a span of the failure text, with how much of it that claim explains."""
+
+    start: int
+    end: int
+    rank: int
+    order: int
+    reason: str
+    marker: bool
+    timer: _TimerCandidate | None = None
+
+
+def _marker_candidates(
+    text: str,
+    patterns: tuple[tuple[int, str, re.Pattern[str]], ...],
+    rank: int,
+    label: str,
+) -> list[_ClassCandidate]:
+    candidates: list[_ClassCandidate] = []
+    for order, marker, pattern in patterns:
+        for match in pattern.finditer(text):
+            candidates.append(_ClassCandidate(
+                match.start(), match.end(), rank, order, f"{label} marker: {marker}", True
+            ))
+    return candidates
+
+
+def _classification_candidates(text: str, now: datetime) -> list[_ClassCandidate]:
+    scan = _scan_timers(text, now)
+    candidates = _marker_candidates(text, _REFUSAL_PATTERNS, _RANK_REFUSAL, "refusal")
+    candidates += _marker_candidates(text, _PERMANENT_PATTERNS, _RANK_PERMANENT, "permanent")
+    candidates += _marker_candidates(text, _TRANSIENT_PATTERNS, _RANK_TRANSIENT, "transient")
+    for start, end in scan.attempts:
+        candidates.append(_ClassCandidate(
+            start, end, _RANK_MALFORMED_TIMER, 0, "provider supplied an invalid retry timer", False
+        ))
+    for timer in scan.parsed:
+        candidates.append(_ClassCandidate(
+            timer.start, timer.end, _RANK_TIMER, 0, "provider supplied a retry timer", False, timer
+        ))
+    return candidates
+
+
+def _surviving_candidates(candidates: list[_ClassCandidate]) -> list[_ClassCandidate]:
+    """Drop every MARKER that is only a FRAGMENT of a longer marker on the same text.
+
+    A marker whose span sits inside a strictly longer marker's span explained less of the message
+    than that longer one did, so it is discarded before any class ordering happens. This is what
+    stops the refusal marker `refused` from outranking the transient marker `connection refused`
+    that contains it.
+
+    Two bounds are deliberate. Merely OVERLAPPING claims are both kept: `service unavailable for 90
+    bananas` must stay a broken timer, and its attempt span overlaps but does not sit inside the
+    transient marker's span. And only MARKERS take part — a timer span is not evidence about the
+    words inside it, so a timer attempt that happens to straddle a refusal marker must never swallow
+    it. Silently losing a refusal is the exact failure this classifier exists to prevent.
+    """
+
+    survivors: list[_ClassCandidate] = []
+    for candidate in candidates:
+        length = candidate.end - candidate.start
+        if candidate.marker and any(
+            other.marker
+            and other.start <= candidate.start
+            and candidate.end <= other.end
+            and (other.end - other.start) > length
+            for other in candidates
+        ):
+            continue
+        survivors.append(candidate)
+    return survivors
 
 
 def _valid_failure(value: object) -> bool:
@@ -548,6 +671,11 @@ def _read_failure(path: Path) -> ExternalReviewFailure:
 def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure:
     """Classify every external-process error before route selection.
 
+    Every marker, parsed timer, and timer ATTEMPT in the message is collected first, as a claim on a
+    span of the text. A claim that sits inside a strictly longer one is a fragment and is discarded
+    (`_surviving_candidates`). Only then does the class order decide, and it is unchanged: refusal,
+    then permanent, then malformed timer, then valid timer, then transient, then unrecognized.
+
     Refusal markers take precedence over every other marker: a reviewer that declined the task on
     content or policy grounds is not a transport failure, and swapping in a same-engine native
     reviewer would silently drop the engine diversity the gate relies on. That marker set is
@@ -556,6 +684,11 @@ def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure
     malformed or unsupported timer text is permanent for this session. Opaque text is unrecognized
     and falls back without disabling the external route. A numeric offset paired with a named timezone
     must match that zone's valid offset for the target local time.
+
+    Text is a broken timer only when a retry, reset, or availability word actually INTRODUCES A VALUE
+    (`TIMER_ATTEMPT_RE`), and a value token that is itself a live digit transient marker is a status
+    rather than a delay (`_is_status_value`). A trigger word that introduces nothing keeps the class
+    its own markers give it.
     """
 
     if not isinstance(message, str):
@@ -566,25 +699,20 @@ def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure
         return _permanent("external failure classification had an invalid timestamp")
     if not text:
         return _permanent("external process returned no error text")
-    lowered = text.lower()
-    for marker in REFUSAL_MARKERS:
-        if marker in lowered:
-            return _refusal(f"refusal marker: {marker}")
-    for marker in PERMANENT_MARKERS:
-        if marker in lowered:
-            return _permanent(f"permanent marker: {marker}")
-    timer = _timer(text, current)
-    if timer is _MALFORMED_TIMER:
-        return _permanent("provider supplied an invalid retry timer")
-    if timer is not None:
-        delay, retry_at, timer_identity = timer
-        return ExternalReviewFailure(
-            TIMER, delay, retry_at, "provider supplied a retry timer", timer_identity
-        )
-    for marker in TRANSIENT_MARKERS:
-        if _contains_transient_marker(lowered, marker):
-            return ExternalReviewFailure(TRANSIENT, None, None, f"transient marker: {marker}")
-    return _unrecognized("no recognized retry class or timer was identified")
+    survivors = _surviving_candidates(_classification_candidates(text, current))
+    if not survivors:
+        return _unrecognized("no recognized retry class or timer was identified")
+    winner = min(survivors, key=lambda item: (item.rank, item.order, item.start))
+    if winner.rank == _RANK_REFUSAL:
+        return _refusal(winner.reason)
+    if winner.rank in (_RANK_PERMANENT, _RANK_MALFORMED_TIMER):
+        return _permanent(winner.reason)
+    timer = winner.timer
+    if timer is None:
+        return ExternalReviewFailure(TRANSIENT, None, None, winner.reason)
+    return ExternalReviewFailure(
+        TIMER, timer.delay, timer.retry_at, winner.reason, timer.identity
+    )
 
 
 def _iso(value: datetime | None) -> str | None:

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -1,0 +1,826 @@
+#!/usr/bin/env python3
+"""Classify external-review failures and choose a session-only recovery action.
+
+The caller keeps ``Decision.state`` in memory for the current campaign session. This helper never
+reads or writes a ledger, run artifact, history entry, cache, or preference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import NoReturn
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from _gauntlet.modules import load_module_from_path
+
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE / "reviewer-backoff-test.py"
+
+TRANSIENT = "transient"
+TIMER = "timer"
+PERMANENT = "permanent"
+
+RETRY_EXTERNAL = "retry-external"
+WAIT_EXTERNAL = "wait-external"
+FALLBACK_NATIVE = "fallback-native"
+
+_TIMER_END = r"(?:\Z|[.;:!?]|,(?!\d))"
+_UNITLESS_TIMER_END = r"(?:\Z|[.;!?]|,(?!\d))"
+RETRY_AFTER_RE = re.compile(
+    r"\bretry[\s-]+after\s*:?[\s]*(?P<value>\d+)(?![\d.])"
+    rf"(?:\s*(?P<unit>seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d)"
+    rf"(?=\s*{_TIMER_END})"
+    rf"|(?=\s*{_UNITLESS_TIMER_END}))",
+    re.IGNORECASE,
+)
+DURATION_RE = re.compile(
+    r"\b(?:retry(?:ing)?|try\s+again|backoff|wait|reset(?:s)?|available)"
+    r"\s*(?:after|in|for|:)?\s*"
+    r"(?P<value>\d+)(?![\d.])\s*"
+    r"(?P<unit>seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d)"
+    rf"(?=\s*{_TIMER_END})",
+    re.IGNORECASE,
+)
+TIMER_PHRASE_RE = re.compile(
+    r"\b(?:retry(?:ing)?|try\s+again|backoff|wait)\b"
+    r"|\b(?:reset(?:s)?|available)\b"
+    r"(?=\s*(?:after|in|for)\b|\s*:\s*|\s+\d)",
+    re.IGNORECASE,
+)
+ABSOLUTE_TIMER_PREFIX_RE = re.compile(
+    r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
+    r"(?:(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
+    r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
+    r"nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}|\d{1,2}\b)",
+    re.IGNORECASE,
+)
+MONTHS = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}
+ABSOLUTE_RE = re.compile(
+    r"\b(?:reset(?:s)?|available|retry(?:ing)?|try\s+again)\s+"
+    r"(?P<month>jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|"
+    r"jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|"
+    r"nov(?:ember)?|dec(?:ember)?)\s+"
+    r"(?P<day>\d{1,2})(?:,\s*|\s+)"
+    r"(?P<hour>\d{1,2})(?::(?P<minute>\d{2}))?\s*(?P<ampm>am|pm)"
+    r"(?:\s*(?P<offset>Z|[+-]\d{2}:?\d{2}))?"
+    r"(?:\s+(?P<year>\d{4}))?\s*"
+    r"(?:\s*\((?P<zone>[^)\s,]+)(?:\s*,?\s*(?P<zone_offset>Z|[+-]\d{2}:?\d{2}))?\))?"
+    rf"(?=\s*{_TIMER_END})",
+    re.IGNORECASE,
+)
+
+TRANSIENT_MARKERS = (
+    "timed out",
+    "timeout",
+    "connection reset",
+    "connection refused",
+    "temporarily unavailable",
+    "temporary failure",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "internal server error",
+    "rate limit",
+    "too many requests",
+    "429",
+    "502",
+    "503",
+    "504",
+)
+PERMANENT_MARKERS = (
+    "authentication failed",
+    "unauthorized",
+    "forbidden",
+    "permission denied",
+    "invalid api key",
+    "invalid token",
+    "unknown option",
+    "command not found",
+    "no such file or directory",
+    "usage:",
+)
+
+
+class BackoffError(ValueError):
+    """A caller supplied an invalid backoff input."""
+
+
+class InvalidMessageFile(BackoffError):
+    """The message file could not be decoded as UTF-8."""
+
+
+_MALFORMED_TIMER = object()
+
+
+@dataclass(frozen=True)
+class ExternalReviewFailure:
+    """The closed, typed result of classifying one external-process failure."""
+
+    kind: str
+    retry_after_seconds: int | None
+    retry_at: datetime | None
+    reason: str
+    timer_identity: str | None = None
+
+
+@dataclass(frozen=True)
+class ExternalReviewSessionState:
+    """State retained only by the live campaign session."""
+
+    external_disabled: bool = False
+    external_backoff_until: datetime | None = None
+    external_backoff_timer_id: str | None = None
+    external_backoff_pr: int | None = None
+
+
+# Keep the short name used by the runtime-adapter contract and existing callers.
+Failure = ExternalReviewFailure
+SessionState = ExternalReviewSessionState
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: str
+    kind: str
+    retry_after_seconds: int | None
+    retry_at: str | None
+    external_disabled: bool
+    external_backoff_until: str | None
+    reason: str
+    state: ExternalReviewSessionState
+
+
+def _fail(message: str) -> NoReturn:
+    raise BackoffError(message)
+
+
+def _is_aware(value: object) -> bool:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        return False
+    try:
+        return value.utcoffset() is not None
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _require_aware(value: datetime) -> datetime:
+    if not _is_aware(value):
+        _fail("timestamps must include a timezone offset")
+    return value
+
+
+def _as_aware(value: object) -> datetime | None:
+    return value if _is_aware(value) else None
+
+
+def _utc(value: datetime) -> datetime:
+    return value.astimezone(timezone.utc)
+
+
+def _ceil_seconds(delta: timedelta) -> int:
+    seconds = delta.days * 86400 + delta.seconds
+    return seconds + (1 if delta.microseconds else 0)
+
+
+def parse_now(value: str | None) -> datetime:
+    if value is None:
+        return datetime.now(timezone.utc)
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        result = datetime.fromisoformat(text)
+    except ValueError:
+        _fail(f"invalid timestamp: {value!r}")
+    return _require_aware(result)
+
+
+def _unit_seconds(unit: str | None) -> int:
+    if unit is None:
+        return 1
+    unit = unit.lower()
+    if unit.startswith("s"):
+        return 1
+    if unit.startswith("m"):
+        return 60
+    if unit.startswith("h"):
+        return 3600
+    if unit.startswith("d"):
+        return 86400
+    raise ValueError(f"unsupported retry timer unit: {unit}")
+
+
+def _timer_identity(value: str) -> str:
+    return " ".join(value.casefold().split())
+
+
+def _parse_offset(value: str | None) -> timezone | None | object:
+    if value is None:
+        return None
+    if value.upper() == "Z":
+        return timezone.utc
+    match = re.fullmatch(r"([+-])(\d{2}):?(\d{2})", value)
+    if match is None:
+        return _MALFORMED_TIMER
+    hours = int(match.group(2))
+    minutes = int(match.group(3))
+    if hours > 23 or minutes > 59:
+        return _MALFORMED_TIMER
+    delta = timedelta(hours=hours, minutes=minutes)
+    if match.group(1) == "-":
+        delta = -delta
+    try:
+        return timezone(delta)
+    except ValueError:
+        return _MALFORMED_TIMER
+
+
+def _resolve_local_deadline(
+    local: datetime,
+    zone: object,
+    explicit_offset: timezone | None,
+    *,
+    validate_explicit_offset: bool = False,
+) -> datetime | None:
+    if explicit_offset is not None:
+        if validate_explicit_offset:
+            valid_offsets: set[timedelta] = set()
+            for fold in (0, 1):
+                candidate = local.replace(tzinfo=zone, fold=fold)
+                candidate_utc = candidate.astimezone(timezone.utc)
+                round_trip = candidate_utc.astimezone(zone)
+                if round_trip.replace(tzinfo=None) == local:
+                    candidate_offset = candidate.utcoffset()
+                    if candidate_offset is not None:
+                        valid_offsets.add(candidate_offset)
+            if explicit_offset.utcoffset(None) not in valid_offsets:
+                return None
+        return local.replace(tzinfo=explicit_offset)
+    candidates: dict[datetime, datetime] = {}
+    for fold in (0, 1):
+        candidate = local.replace(tzinfo=zone, fold=fold)
+        candidate_utc = candidate.astimezone(timezone.utc)
+        round_trip = candidate_utc.astimezone(zone)
+        if round_trip.replace(tzinfo=None) == local:
+            candidates.setdefault(candidate_utc, candidate)
+    if len(candidates) != 1:
+        return None
+    return next(iter(candidates.values()))
+
+
+@dataclass(frozen=True)
+class _TimerCandidate:
+    start: int
+    end: int
+    delay: int
+    retry_at: datetime
+    identity: str
+
+
+def _relative_candidates(text: str, now: datetime) -> list[_TimerCandidate] | object:
+    matches = list(RETRY_AFTER_RE.finditer(text)) + list(DURATION_RE.finditer(text))
+    candidates: list[_TimerCandidate] = []
+    seen_spans: set[tuple[int, int]] = set()
+    for match in sorted(matches, key=lambda item: item.start()):
+        span = (match.start(), match.end())
+        if span in seen_spans:
+            continue
+        seen_spans.add(span)
+        try:
+            delay = int(match.group("value")) * _unit_seconds(match.groupdict().get("unit"))
+            retry_at = (_utc(now) + timedelta(seconds=delay)).astimezone(now.tzinfo)
+        except (OverflowError, ValueError):
+            return _MALFORMED_TIMER
+        candidates.append(_TimerCandidate(
+            match.start(), match.end(), delay, retry_at, _timer_identity(match.group(0))
+        ))
+    return candidates
+
+
+def _absolute_timer_match(match: re.Match[str] | None, now: datetime) -> tuple[int, datetime, str] | None:
+    if match is None:
+        return None
+    zone_name = match.group("zone")
+    try:
+        offset = _parse_offset(match.group("offset"))
+        zone_offset = _parse_offset(match.group("zone_offset"))
+        if offset is _MALFORMED_TIMER or zone_offset is _MALFORMED_TIMER:
+            return None
+        if offset is not None and zone_offset is not None and offset != zone_offset:
+            return None
+        explicit_offset = zone_offset if zone_offset is not None else offset
+        zone = ZoneInfo(zone_name) if zone_name else (explicit_offset or _require_aware(now).tzinfo)
+        if zone is None:
+            return None
+        local_now = now.astimezone(zone)
+        month = MONTHS[match.group("month").lower()]
+        year = int(match.group("year") or local_now.year)
+        minute = int(match.group("minute") or 0)
+        hour = int(match.group("hour"))
+        if not 1 <= hour <= 12:
+            return None
+        ampm = match.group("ampm").lower()
+        if ampm == "pm" and hour != 12:
+            hour += 12
+        if ampm == "am" and hour == 12:
+            hour = 0
+        target_local = datetime(year, month, int(match.group("day")), hour, minute)
+        if not match.group("year") and target_local < local_now.replace(tzinfo=None):
+            target_local = target_local.replace(year=target_local.year + 1)
+        target = _resolve_local_deadline(
+            target_local,
+            zone,
+            explicit_offset,
+            validate_explicit_offset=zone_name is not None,
+        )
+        if target is None:
+            return None
+        target_utc = target.astimezone(timezone.utc)
+        local_now_utc = local_now.astimezone(timezone.utc)
+        if target_utc < local_now_utc and match.group("year"):
+            return None
+        return max(0, _ceil_seconds(target_utc - local_now_utc)), target, _timer_identity(match.group(0))
+    except (KeyError, OverflowError, ValueError, TypeError, ZoneInfoNotFoundError):
+        return None
+
+
+def _absolute_timer(text: str, now: datetime) -> tuple[int, datetime, str] | None:
+    return _absolute_timer_match(ABSOLUTE_RE.search(text), now)
+
+
+def _timer_candidates(text: str, now: datetime) -> list[_TimerCandidate] | object:
+    relative = _relative_candidates(text, now)
+    if relative is _MALFORMED_TIMER:
+        return _MALFORMED_TIMER
+
+    candidates = list(relative)
+    for match in ABSOLUTE_RE.finditer(text):
+        absolute = _absolute_timer_match(match, now)
+        if absolute is None:
+            return _MALFORMED_TIMER
+        delay, retry_at, identity = absolute
+        candidates.append(_TimerCandidate(
+            match.start(), match.end(), delay, retry_at, identity
+        ))
+
+    valid_spans = [(candidate.start, candidate.end) for candidate in candidates]
+    for match in TIMER_PHRASE_RE.finditer(text):
+        if not any(start <= match.start() < end for start, end in valid_spans):
+            return _MALFORMED_TIMER
+    for match in ABSOLUTE_TIMER_PREFIX_RE.finditer(text):
+        if not any(start <= match.start() < end for start, end in valid_spans):
+            return _MALFORMED_TIMER
+    return candidates
+
+
+def _timer(text: str, now: datetime) -> tuple[int, datetime, str] | None | object:
+    candidates = _timer_candidates(text, now)
+    if candidates is _MALFORMED_TIMER:
+        return _MALFORMED_TIMER
+    if not candidates:
+        return None
+    candidate = min(candidates, key=lambda item: item.start)
+    return candidate.delay, candidate.retry_at, candidate.identity
+
+
+def _contains_transient_marker(text: str, marker: str) -> bool:
+    if marker.isdigit():
+        return re.search(rf"(?<![\w.]){re.escape(marker)}(?![\w.])", text) is not None
+    return marker in text
+
+
+def timer_seconds(message: str, now: datetime) -> int | None:
+    """Return the provider-supplied delay, or ``None`` when no timer is present."""
+
+    if not isinstance(message, str):
+        return None
+    current = _as_aware(now)
+    if current is None:
+        return None
+    result = _timer(message, current)
+    return None if result is None or result is _MALFORMED_TIMER else result[0]
+
+
+def _permanent(reason: str) -> ExternalReviewFailure:
+    return ExternalReviewFailure(PERMANENT, None, None, reason)
+
+
+def _valid_failure(value: object) -> bool:
+    if not isinstance(value, ExternalReviewFailure) or not isinstance(value.reason, str):
+        return False
+    if value.kind in (TRANSIENT, PERMANENT):
+        return (
+            value.retry_after_seconds is None
+            and value.retry_at is None
+            and value.timer_identity is None
+        )
+    if value.kind != TIMER:
+        return False
+    return (
+        type(value.retry_after_seconds) is int
+        and value.retry_after_seconds >= 0
+        and _is_aware(value.retry_at)
+        and (
+            value.timer_identity is None
+            or (type(value.timer_identity) is str and bool(value.timer_identity))
+        )
+    )
+
+
+def _valid_state(value: object) -> bool:
+    return (
+        isinstance(value, ExternalReviewSessionState)
+        and type(value.external_disabled) is bool
+        and (value.external_backoff_until is None or _is_aware(value.external_backoff_until))
+        and (
+            value.external_backoff_timer_id is None
+            or (type(value.external_backoff_timer_id) is str and bool(value.external_backoff_timer_id))
+        )
+        and (
+            value.external_backoff_pr is None
+            or (type(value.external_backoff_pr) is int and value.external_backoff_pr > 0)
+        )
+        and (
+            (
+                value.external_backoff_until is None
+                and value.external_backoff_timer_id is None
+                and value.external_backoff_pr is None
+            )
+            or (
+                value.external_backoff_until is not None
+                and type(value.external_backoff_pr) is int
+                and value.external_backoff_pr > 0
+            )
+        )
+    )
+
+
+def _read_failure(path: Path) -> ExternalReviewFailure:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _fail(f"cannot read --failure-file: {exc}")
+    except UnicodeDecodeError as exc:
+        _fail(f"--failure-file is not valid UTF-8: {exc}")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _fail(f"--failure-file is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        _fail("--failure-file must contain one ExternalReviewFailure object")
+    expected = {"kind", "retry_after_seconds", "retry_at", "reason", "timer_identity"}
+    if set(payload) != expected:
+        _fail("--failure-file has the wrong ExternalReviewFailure fields")
+
+    kind = payload["kind"]
+    retry_after_seconds = payload["retry_after_seconds"]
+    retry_at_value = payload["retry_at"]
+    reason = payload["reason"]
+    timer_identity = payload["timer_identity"]
+    if not isinstance(kind, str) or not isinstance(reason, str):
+        _fail("--failure-file has non-text kind or reason")
+    if retry_after_seconds is not None and type(retry_after_seconds) is not int:
+        _fail("--failure-file has a non-integer retry_after_seconds")
+    if retry_at_value is not None and not isinstance(retry_at_value, str):
+        _fail("--failure-file has a non-text retry_at")
+    if timer_identity is not None and not isinstance(timer_identity, str):
+        _fail("--failure-file has a non-text timer_identity")
+    retry_at = parse_now(retry_at_value) if retry_at_value is not None else None
+    failure = ExternalReviewFailure(
+        kind,
+        retry_after_seconds,
+        retry_at,
+        reason,
+        timer_identity,
+    )
+    if not _valid_failure(failure):
+        _fail("--failure-file contains a malformed ExternalReviewFailure")
+    return failure
+
+
+def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure:
+    """Classify every external-process error before route selection.
+
+    Permanent markers take precedence. Valid whole-second timer text wins over transient markers;
+    malformed or unsupported timer text is permanent for this session. A numeric offset paired with
+    a named timezone must match that zone's valid offset for the target local time.
+    """
+
+    if not isinstance(message, str):
+        return _permanent("external process error text was not a string")
+    text = message.strip()
+    current = _as_aware(now if now is not None else datetime.now(timezone.utc))
+    if current is None:
+        return _permanent("external failure classification had an invalid timestamp")
+    if not text:
+        return _permanent("external process returned no error text")
+    lowered = text.lower()
+    for marker in PERMANENT_MARKERS:
+        if marker in lowered:
+            return _permanent(f"permanent marker: {marker}")
+    timer = _timer(text, current)
+    if timer is _MALFORMED_TIMER:
+        return _permanent("provider supplied an invalid retry timer")
+    if timer is not None:
+        delay, retry_at, timer_identity = timer
+        return ExternalReviewFailure(
+            TIMER, delay, retry_at, "provider supplied a retry timer", timer_identity
+        )
+    for marker in TRANSIENT_MARKERS:
+        if _contains_transient_marker(lowered, marker):
+            return ExternalReviewFailure(TRANSIENT, None, None, f"transient marker: {marker}")
+    return _permanent("no safe retry class or timer was identified")
+
+
+def _iso(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()
+
+
+def _max_deadline(first: datetime | None, second: datetime | None) -> datetime | None:
+    if first is None:
+        return second
+    if second is None:
+        return first
+    return first if _utc(first) >= _utc(second) else second
+
+
+def _decision(
+    action: str,
+    failure: ExternalReviewFailure,
+    state: ExternalReviewSessionState,
+    reason: str,
+) -> Decision:
+    return Decision(
+        action=action,
+        kind=failure.kind,
+        retry_after_seconds=failure.retry_after_seconds,
+        retry_at=_iso(failure.retry_at),
+        external_disabled=state.external_disabled,
+        external_backoff_until=_iso(state.external_backoff_until),
+        reason=reason,
+        state=state,
+    )
+
+
+def transition(
+    failure: ExternalReviewFailure,
+    *,
+    retry_spent: bool = False,
+    now: datetime | None = None,
+    state: ExternalReviewSessionState | None = None,
+    pr_number: int | None = None,
+) -> Decision:
+    """Apply one typed failure to session state and return the next recovery action."""
+
+    prior = state if state is not None else ExternalReviewSessionState()
+    if not _valid_state(prior):
+        prior = ExternalReviewSessionState(external_disabled=True)
+        failure = _permanent("external session state was malformed")
+    elif state is not None and pr_number is None:
+        failure = _permanent("external review PR number was omitted for a session transition")
+    elif pr_number is not None and (type(pr_number) is not int or pr_number <= 0):
+        failure = _permanent("external review PR number was malformed")
+        pr_number = None
+    elif not isinstance(failure, ExternalReviewFailure):
+        failure = _permanent("external failure classification was malformed")
+    elif failure.kind not in (TRANSIENT, TIMER, PERMANENT):
+        failure = _permanent("unrecognized external failure classification")
+    elif not _valid_failure(failure):
+        failure = _permanent("external failure classification was malformed")
+    elif failure.kind == TIMER and pr_number is None:
+        failure = _permanent("external review PR number is required for a timer transition")
+    current = _as_aware(now if now is not None else datetime.now(timezone.utc))
+    if current is None:
+        failure = _permanent("external transition had an invalid timestamp")
+        current = datetime.now(timezone.utc)
+    if prior.external_disabled:
+        return _decision(FALLBACK_NATIVE, failure, prior, "external route is disabled for this session")
+    prior_deadline_active = (
+        prior.external_backoff_until is not None
+        and _utc(prior.external_backoff_until) > _utc(current)
+    )
+    same_timer_identity = (
+        failure.kind == TIMER
+        and failure.timer_identity is not None
+        and failure.timer_identity == prior.external_backoff_timer_id
+    )
+    same_timer_owner = (
+        failure.kind == TIMER
+        and prior.external_backoff_pr == pr_number
+    )
+    different_timer_owner = (
+        failure.kind == TIMER
+        and prior.external_backoff_pr is not None
+        and pr_number is not None
+        and prior.external_backoff_pr != pr_number
+    )
+    same_timer_reentry = (
+        same_timer_owner
+        and same_timer_identity
+        and failure.retry_at is not None
+        and _utc(failure.retry_at) == _utc(prior.external_backoff_until)
+    )
+    deadline = _max_deadline(prior.external_backoff_until, failure.retry_at if failure.kind == TIMER else None)
+    timer_id = failure.timer_identity if failure.kind == TIMER else prior.external_backoff_timer_id
+    timer_pr = prior.external_backoff_pr
+    if failure.kind == TIMER and pr_number is not None:
+        timer_pr = pr_number
+    if failure.kind == TIMER and prior.external_backoff_until is not None:
+        incoming_deadline = failure.retry_at
+        if same_timer_reentry:
+            deadline = prior.external_backoff_until
+            timer_id = prior.external_backoff_timer_id
+            failure = ExternalReviewFailure(
+                TIMER, 0, prior.external_backoff_until, failure.reason, failure.timer_identity
+            )
+        elif same_timer_owner and incoming_deadline is not None:
+            deadline = incoming_deadline
+            timer_id = failure.timer_identity
+        elif different_timer_owner and prior_deadline_active:
+            deadline = prior.external_backoff_until
+            timer_id = prior.external_backoff_timer_id
+            timer_pr = prior.external_backoff_pr
+        elif (
+            incoming_deadline is not None
+            and _utc(incoming_deadline) <= _utc(prior.external_backoff_until)
+        ):
+            deadline = prior.external_backoff_until
+            if prior.external_backoff_timer_id is not None:
+                timer_id = prior.external_backoff_timer_id
+    next_state = ExternalReviewSessionState(prior.external_disabled, deadline, timer_id, timer_pr)
+
+    if failure.kind == PERMANENT:
+        next_state = ExternalReviewSessionState(True, deadline, timer_id, timer_pr)
+        return _decision(FALLBACK_NATIVE, failure, next_state, failure.reason)
+
+    if different_timer_owner and prior_deadline_active:
+        return _decision(FALLBACK_NATIVE, failure, next_state,
+                         "session external backoff belongs to another PR")
+
+    if deadline is not None and _utc(deadline) > _utc(current):
+        if retry_spent or failure.kind != TIMER:
+            return _decision(FALLBACK_NATIVE, failure, next_state, "session external backoff is active")
+        wait_seconds = max(0, _ceil_seconds(_utc(deadline) - _utc(current)))
+        waiting_failure = ExternalReviewFailure(TIMER, wait_seconds, deadline, failure.reason)
+        return _decision(WAIT_EXTERNAL, waiting_failure, next_state, failure.reason)
+
+    if failure.kind in (TRANSIENT, TIMER) and not retry_spent:
+        return _decision(RETRY_EXTERNAL, failure, next_state, failure.reason)
+
+    return _decision(FALLBACK_NATIVE, failure, next_state, failure.reason)
+
+
+def decide(
+    message: str,
+    *,
+    retry_spent: bool = False,
+    now: datetime | None = None,
+    state: ExternalReviewSessionState | None = None,
+    pr_number: int | None = None,
+) -> Decision:
+    """Classify one failure, then return retry, exact-timer wait, or native fallback."""
+
+    current = now if now is not None else datetime.now(timezone.utc)
+    return transition(
+        classify(message, current), retry_spent=retry_spent, now=current, state=state,
+        pr_number=pr_number,
+    )
+
+
+def sibling_cases() -> list[tuple[str, str, object]]:
+    if not SIBLING.is_file():
+        raise BackoffError(f"the fixture file {SIBLING} is missing")
+    module = load_module_from_path("reviewer_backoff_test", SIBLING, register=True)
+    if module is None:
+        raise BackoffError(f"the fixture file {SIBLING} cannot be loaded")
+    cases = getattr(module, "CASES", None)
+    if not cases:
+        raise BackoffError(f"the fixture file {SIBLING} exports no CASES")
+    return list(cases)
+
+
+def self_test() -> int:
+    failures = 0
+    try:
+        cases = sibling_cases()
+    except BackoffError as exc:
+        print(f"FAIL     sibling-fixtures -> {exc}")
+        return 1
+    for name, description, function in cases:
+        try:
+            function()
+        except Exception as exc:  # noqa: BLE001
+            print(f"FAIL     {name:32} -> {description}\n         {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:32} -> {description}")
+    if failures:
+        print(f"{failures} fixture(s) FAILED — reviewer backoff contract is broken.")
+        return 1
+    print(f"all {len(cases)} fixtures hold — reviewer backoff contract is intact.")
+    return 0
+
+
+def _message(args: argparse.Namespace, parser: argparse.ArgumentParser) -> str:
+    if (args.message is not None) == (args.message_file is not None):
+        parser.error("provide exactly one of --message or --message-file")
+    try:
+        return args.message if args.message is not None else args.message_file.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise InvalidMessageFile(f"--message-file is not valid UTF-8: {exc}") from exc
+    except OSError as exc:
+        _fail(f"cannot read --message-file: {exc}")
+
+
+def _state_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> ExternalReviewSessionState:
+    if args.backoff_timer_id is not None and args.backoff_until is None:
+        parser.error("--backoff-timer-id requires --backoff-until")
+    if args.backoff_pr is not None and args.backoff_until is None:
+        parser.error("--backoff-pr requires --backoff-until")
+    return ExternalReviewSessionState(
+        external_disabled=args.external_disabled,
+        external_backoff_until=parse_now(args.backoff_until) if args.backoff_until else None,
+        external_backoff_timer_id=args.backoff_timer_id,
+        external_backoff_pr=args.backoff_pr,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    classify_parser = sub.add_parser("classify")
+    classify_parser.add_argument("--message")
+    classify_parser.add_argument("--message-file", type=Path)
+    classify_parser.add_argument("--now")
+    decide_parser = sub.add_parser("decide")
+    decide_parser.add_argument("--message")
+    decide_parser.add_argument("--message-file", type=Path)
+    decide_parser.add_argument("--now")
+    decide_parser.add_argument("--retry-spent", action="store_true")
+    decide_parser.add_argument("--external-disabled", action="store_true")
+    decide_parser.add_argument("--backoff-until")
+    decide_parser.add_argument("--backoff-timer-id")
+    decide_parser.add_argument("--backoff-pr", type=int)
+    decide_parser.add_argument("--pr", "--pr-number", dest="pr_number", type=int)
+    decide_parser.add_argument("--failure-file", type=Path)
+    sub.add_parser("self-test")
+    args = parser.parse_args(argv)
+    if args.command == "self-test":
+        return self_test()
+    now = parse_now(args.now)
+    if args.command == "classify":
+        try:
+            result = classify(_message(args, parser), now)
+        except InvalidMessageFile as exc:
+            result = _permanent(str(exc))
+    else:
+        if args.failure_file is not None and (args.message is not None or args.message_file is not None):
+            parser.error("provide --failure-file instead of --message or --message-file")
+        if args.backoff_until is not None and args.failure_file is None:
+            parser.error("--backoff-until requires --failure-file to preserve the typed failure")
+        state = _state_from_args(args, parser)
+        try:
+            failure = (
+                _read_failure(args.failure_file)
+                if args.failure_file is not None
+                else classify(_message(args, parser), now)
+            )
+        except InvalidMessageFile as exc:
+            failure = _permanent(str(exc))
+        result = transition(
+            failure,
+            retry_spent=args.retry_spent,
+            now=now,
+            state=state,
+            pr_number=args.pr_number,
+        )
+    print(json.dumps(asdict(result), default=lambda value: value.isoformat(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BackoffError as exc:
+        print(f"reviewer-backoff: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -126,9 +126,18 @@ REFUSAL_MARKERS = (
     "can't assist",
     "cannot assist",
     "won't help",
-    "able to help",
-    "able to assist",
-    "provide assistance",
+    # Every refusal marker must carry its own negation. A positive stem like `able to help` matches
+    # both "I am able to help" and "I'm unable to help with that", so it cannot tell a refusal from
+    # ordinary prose, and a manufactured refusal ends autonomous handling with stop-and-ask.
+    "unable to help",
+    "not able to help",
+    "unable to assist",
+    "not able to assist",
+    "unable to provide assistance",
+    "not able to provide assistance",
+    "cannot provide assistance",
+    "can't provide assistance",
+    "won't provide assistance",
     "decline",
     "refusal",
     "refused",
@@ -151,9 +160,18 @@ PERMANENT_MARKERS = (
 )
 
 
+# Markers that are a line-leading banner rather than a phrase. `usage:` identifies a CLI help dump
+# only when it opens a line; anywhere else it is ordinary telemetry prose (`token usage: 41234`,
+# `memory usage: 82%`), and matching that would classify permanent and disable the external reviewer
+# for the whole session.
+_LINE_ANCHORED_MARKERS = frozenset({"usage:"})
+
+
 def _marker_pattern(marker: str) -> re.Pattern[str]:
     if marker.isdigit():
         return re.compile(rf"(?<![\w.]){re.escape(marker)}(?![\w.])", re.IGNORECASE)
+    if marker in _LINE_ANCHORED_MARKERS:
+        return re.compile(rf"(?m)^[ \t]*{re.escape(marker)}", re.IGNORECASE)
     return re.compile(re.escape(marker), re.IGNORECASE)
 
 
@@ -410,7 +428,10 @@ def _is_status_value(text: str, start: int, end: int) -> bool:
 
     ``503`` in ``service unavailable: 503`` is a status, not a delay: the transient marker explains
     the whole token while the timer detector explains only part of it, so the longer claim wins.
-    Value PARSING never consults this — a genuinely parsed ``retry after 503 seconds`` stays a timer.
+    A UNIT is what separates the two readings, so both stages consult this. Value PARSING consults it
+    for a UNITLESS value only: ``retry after 429`` names no unit, so its ``429`` is the status the
+    transient list already explains, and `_scan_timers` suppresses that span outright. A unit-bearing
+    ``retry after 503 seconds`` states a delay and stays a timer.
     """
 
     match = _STATUS_VALUE_RE.match(text, start)
@@ -420,6 +441,11 @@ def _is_status_value(text: str, start: int, end: int) -> bool:
 def _scan_timers(text: str, now: datetime) -> _TimerScan:
     parsed: list[_TimerCandidate] = []
     attempts: list[tuple[int, int]] = []
+    # Spans a status token owns: neither a timer nor a broken one. Suppressing the span, rather than
+    # only dropping the candidate, is load-bearing. `ABSOLUTE_TIMER_PREFIX_RE` would otherwise read
+    # `retry after 42` out of `retry after 429` and register a malformed-timer attempt, which is
+    # permanent and disables the external reviewer for the session — worse than the timer it fixes.
+    status_spans: list[tuple[int, int]] = []
     seen_spans: set[tuple[int, int]] = set()
     relative = list(RETRY_AFTER_RE.finditer(text)) + list(DURATION_RE.finditer(text))
     for match in sorted(relative, key=lambda item: item.start()):
@@ -427,6 +453,11 @@ def _scan_timers(text: str, now: datetime) -> _TimerScan:
         if span in seen_spans:
             continue
         seen_spans.add(span)
+        if match.groupdict().get("unit") is None and _is_status_value(
+            text, match.start("value"), match.end("value")
+        ):
+            status_spans.append(span)
+            continue
         try:
             delay = int(match.group("value")) * _unit_seconds(match.groupdict().get("unit"))
             retry_at = (_utc(now) + timedelta(seconds=delay)).astimezone(now.tzinfo)
@@ -447,14 +478,15 @@ def _scan_timers(text: str, now: datetime) -> _TimerScan:
         ))
 
     valid_spans = [(candidate.start, candidate.end) for candidate in parsed]
+    claimed_spans = valid_spans + status_spans
     for match in TIMER_ATTEMPT_RE.finditer(text):
-        if any(start <= match.start() < end for start, end in valid_spans):
+        if any(start <= match.start() < end for start, end in claimed_spans):
             continue
         if _is_status_value(text, match.start("value"), match.end("value")):
             continue
         attempts.append(match.span())
     for match in ABSOLUTE_TIMER_PREFIX_RE.finditer(text):
-        if any(start <= match.start() < end for start, end in valid_spans):
+        if any(start <= match.start() < end for start, end in claimed_spans):
             continue
         attempts.append(match.span())
     return _TimerScan(tuple(parsed), tuple(attempts))
@@ -686,9 +718,11 @@ def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure
     must match that zone's valid offset for the target local time.
 
     Text is a broken timer only when a retry, reset, or availability word actually INTRODUCES A VALUE
-    (`TIMER_ATTEMPT_RE`), and a value token that is itself a live digit transient marker is a status
-    rather than a delay (`_is_status_value`). A trigger word that introduces nothing keeps the class
-    its own markers give it.
+    (`TIMER_ATTEMPT_RE`). A value token that is itself a live digit transient marker is a status
+    rather than a delay (`_is_status_value`), and that holds at BOTH stages: a value carrying no unit
+    is suppressed even when the timer regexes parsed it, so `retry after 429` yields neither a timer
+    nor a broken one and the transient marker keeps the class. A trigger word that introduces nothing
+    keeps the class its own markers give it.
     """
 
     if not isinstance(message, str):

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-backoff.py
@@ -26,11 +26,13 @@ SIBLING = HERE / "reviewer-backoff-test.py"
 TRANSIENT = "transient"
 TIMER = "timer"
 PERMANENT = "permanent"
+REFUSAL = "refusal"
 UNRECOGNIZED = "unrecognized"
 
 RETRY_EXTERNAL = "retry-external"
 WAIT_EXTERNAL = "wait-external"
 FALLBACK_NATIVE = "fallback-native"
+STOP_AND_ASK = "stop-and-ask"
 
 _TIMER_END = r"(?:\Z|[.;:!?]|,(?!\d))"
 _UNITLESS_TIMER_END = r"(?:\Z|[.;!?]|,(?!\d))"
@@ -105,6 +107,23 @@ TRANSIENT_MARKERS = (
     "502",
     "503",
     "504",
+)
+REFUSAL_MARKERS = (
+    "can't help",
+    "cannot help",
+    "can't assist",
+    "cannot assist",
+    "won't help",
+    "able to help",
+    "able to assist",
+    "provide assistance",
+    "decline",
+    "refusal",
+    "refused",
+    "content filter",
+    "content policy",
+    "safety policy",
+    "usage policy",
 )
 PERMANENT_MARKERS = (
     "authentication failed",
@@ -424,6 +443,10 @@ def _permanent(reason: str) -> ExternalReviewFailure:
     return ExternalReviewFailure(PERMANENT, None, None, reason)
 
 
+def _refusal(reason: str) -> ExternalReviewFailure:
+    return ExternalReviewFailure(REFUSAL, None, None, reason)
+
+
 def _unrecognized(reason: str) -> ExternalReviewFailure:
     return ExternalReviewFailure(UNRECOGNIZED, None, None, reason)
 
@@ -431,7 +454,7 @@ def _unrecognized(reason: str) -> ExternalReviewFailure:
 def _valid_failure(value: object) -> bool:
     if not isinstance(value, ExternalReviewFailure) or not isinstance(value.reason, str):
         return False
-    if value.kind in (TRANSIENT, PERMANENT, UNRECOGNIZED):
+    if value.kind in (TRANSIENT, PERMANENT, REFUSAL, UNRECOGNIZED):
         return (
             value.retry_after_seconds is None
             and value.retry_at is None
@@ -524,7 +547,11 @@ def _read_failure(path: Path) -> ExternalReviewFailure:
 def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure:
     """Classify every external-process error before route selection.
 
-    Permanent markers take precedence. Valid whole-second timer text wins over transient markers;
+    Refusal markers take precedence over every other marker: a reviewer that declined the task on
+    content or policy grounds is not a transport failure, and swapping in a same-engine native
+    reviewer would silently drop the engine diversity the gate relies on. That marker set is
+    deliberately NOT exhaustive; refusal wording it does not match stays unrecognized.
+    Permanent markers come next. Valid whole-second timer text wins over transient markers;
     malformed or unsupported timer text is permanent for this session. Opaque text is unrecognized
     and falls back without disabling the external route. A numeric offset paired with a named timezone
     must match that zone's valid offset for the target local time.
@@ -539,6 +566,9 @@ def classify(message: str, now: datetime | None = None) -> ExternalReviewFailure
     if not text:
         return _permanent("external process returned no error text")
     lowered = text.lower()
+    for marker in REFUSAL_MARKERS:
+        if marker in lowered:
+            return _refusal(f"refusal marker: {marker}")
     for marker in PERMANENT_MARKERS:
         if marker in lowered:
             return _permanent(f"permanent marker: {marker}")
@@ -594,7 +624,11 @@ def transition(
     state: ExternalReviewSessionState | None = None,
     pr_number: int | None = None,
 ) -> Decision:
-    """Apply one typed failure to session state and return the next recovery action."""
+    """Apply one typed failure to session state and return the next recovery action.
+
+    A refusal never recovers automatically: it returns ``stop-and-ask`` with the session state
+    unchanged, before any retry, timer wait, or native fallback can consume it.
+    """
 
     prior = state if state is not None else ExternalReviewSessionState()
     if not _valid_state(prior):
@@ -607,7 +641,7 @@ def transition(
         pr_number = None
     elif not isinstance(failure, ExternalReviewFailure):
         failure = _permanent("external failure classification was malformed")
-    elif failure.kind not in (TRANSIENT, TIMER, PERMANENT, UNRECOGNIZED):
+    elif failure.kind not in (TRANSIENT, TIMER, PERMANENT, REFUSAL, UNRECOGNIZED):
         failure = _unrecognized("unrecognized external failure classification")
     elif not _valid_failure(failure):
         failure = _permanent("external failure classification was malformed")
@@ -617,6 +651,8 @@ def transition(
     if current is None:
         failure = _permanent("external transition had an invalid timestamp")
         current = datetime.now(timezone.utc)
+    if failure.kind == REFUSAL:
+        return _decision(STOP_AND_ASK, failure, prior, failure.reason)
     if prior.external_disabled:
         return _decision(FALLBACK_NATIVE, failure, prior, "external route is disabled for this session")
     prior_deadline_active = (
@@ -702,7 +738,7 @@ def decide(
     state: ExternalReviewSessionState | None = None,
     pr_number: int | None = None,
 ) -> Decision:
-    """Classify one failure, then return retry, exact-timer wait, or native fallback."""
+    """Classify one failure, then return retry, exact-timer wait, native fallback, or stop-and-ask."""
 
     current = now if now is not None else datetime.now(timezone.utc)
     return transition(

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -1198,6 +1198,7 @@ def review_action(capability: Mapping[str, object], *, event: str = "selected",
                 BACKOFF.RETRY_EXTERNAL,
                 BACKOFF.WAIT_EXTERNAL,
                 BACKOFF.FALLBACK_NATIVE,
+                BACKOFF.STOP_AND_ASK,
             ), f"reviewer backoff returned an unmapped action: {decision.action}")
             return decision.action
         require(event == "selected", f"unsupported external review event: {event}")
@@ -1333,6 +1334,33 @@ def run_isolation_transition_fixtures() -> None:
             current_time=now,
             pr=188,
         ) == "fallback-native", f"{route} opaque provider failure did not fall back")
+
+        # A reviewer refusal is the one transition() action that never reaches the operator through
+        # any other route: no retry, no wait, and no native fallback that would swap in a same-engine
+        # reviewer for a task the reviewer declined on content or policy grounds.
+        refusal = BACKOFF.classify("I'm sorry, but I can't help with that.", now)
+        require(refusal.kind == BACKOFF.REFUSAL,
+                f"{route} fixture text was not classified as a reviewer refusal")
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=refusal,
+            session=BACKOFF.SessionState(),
+            current_time=now,
+            pr=188,
+        ) == "stop-and-ask", f"{route} reviewer refusal did not reach the operator")
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=refusal,
+            session=BACKOFF.SessionState(),
+            current_time=now,
+            pr=188,
+            external_retry_spent=True,
+        ) == "stop-and-ask", f"{route} spent retry downgraded a reviewer refusal to native fallback")
+        clear = BACKOFF.SessionState()
+        require(BACKOFF.transition(refusal, now=now, state=clear, pr_number=188).state == clear,
+                f"{route} reviewer refusal changed the session state")
 
         # Paired CLI absent -> unavailable -> immediate native fallback, no retry consumed.
         absent = dict(shipped, launch_mechanism_present=False)

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -1202,9 +1202,9 @@ def review_action(capability: Mapping[str, object], *, event: str = "selected",
         if session is not None and session.external_backoff_until is not None:
             require(current_time is not None, "active session backoff did not carry current time")
             require(pr is not None, "active session backoff did not carry PR ownership")
-            if session.external_backoff_pr != pr:
-                return "fallback-native"
             if BACKOFF._utc(session.external_backoff_until) > BACKOFF._utc(current_time):
+                if session.external_backoff_pr != pr:
+                    return "fallback-native"
                 return "wait-external"
         return "launch-external"
     # Native is the last-resort route: if it cannot launch (unavailable — no fresh conversation or no
@@ -1300,6 +1300,13 @@ def run_isolation_transition_fixtures() -> None:
             current_time=now,
             pr=189,
         ) == "fallback-native", f"{route} selected other PR ignored the timer owner")
+        require(review_action(
+            shipped,
+            event="selected",
+            session=timer_state.state,
+            current_time=deadline + timedelta(seconds=1),
+            pr=189,
+        ) == "launch-external", f"{route} selected other PR remained blocked after timer expiry")
 
         other_pr_failure = BACKOFF.classify("rate limited; retry after 30 seconds", now)
         require(review_action(

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -99,6 +99,14 @@ def normalized(text: str) -> str:
     return " ".join(text.split())
 
 
+def has_attempt_two_fresh_native_attempt_three(text: str) -> bool:
+    return re.search(
+        r"attempt `2` fails[ \t]*→[ \t]*(?:\r?\n[ \t]*)?"
+        r"prepare fresh native fallback attempt `3`(?:[.!?]|$)",
+        text,
+    ) is not None
+
+
 def command_argvs(block: str) -> list[list[str]]:
     logical_lines = re.sub(r"\\\r?\n", " ", block).splitlines()
     commands: list[list[str]] = []
@@ -736,12 +744,29 @@ def check_document_contract() -> None:
         "<TRANSPORT-RECORD>",
         '"native-worker-write" | "external-process-capture"',
         "ReviewIsolationCapability",
+        "ExternalReviewFailure",
+        "ExternalReviewSessionState",
+        "reviewer-backoff.py",
+        "retry_after_seconds: NonNegativeInt | null",
+        "external_backoff_until: Timestamp | null",
+        "external_backoff_timer_id: Text | null",
+        "external_backoff_pr: PositiveInt | null",
+        "timer_identity: Text | null",
         "external_retry_spent: Bool",
+        "pr_number: PositiveInt",
         'event: "selected" | "external-system-failure" | "native-system-failure"',
         "current Claude Code and Codex adapters",
         "launch_mechanism_present",
         "Their absence NEVER blocks launch",
-        "selected cross-engine route, paired CLI available | `launch-external`",
+        "selected cross-engine route, paired CLI available, and session state clear | `launch-external`",
+        "external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external`",
+        "external failure classified `permanent`, or classification is unrecognized",
+        "timer transition without the current positive PR number, including initial empty state | treat as malformed",
+        "numeric offset that is invalid for",
+        "A named zone's valid offsets include both sides",
+        "of a DST fold.",
+        "Never write `external_disabled` or",
+        "wait-external",
         "Missing native OS/startup controls alone never select",
         "### Review preparation mapping",
         "| `launch-external` | selected capability's external route | "
@@ -750,12 +775,24 @@ def check_document_contract() -> None:
         "`external-process-capture` | `codex-recovery` |",
         "| `retry-external` + `external-claude` | `external-claude` | "
         "`external-process-capture` | `standard` |",
+        "| `wait-external` | no preparation | no preparation | no preparation |",
         "| `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |",
-        "attempt `2` fails → prepare fresh native fallback attempt `3`",
         "dead or unusable attempt `3` → `park-machine-blocker`",
         'prompt_profile: "standard" | "codex-recovery"',
     ):
         require(needle in runtime, f"runtime adapter lost typed owner: {needle}")
+    require(has_attempt_two_fresh_native_attempt_three(runtime),
+            "runtime adapter does not relate attempt 2 failure to fresh native attempt 3")
+    require(has_attempt_two_fresh_native_attempt_three(
+        "attempt `2` fails →\nprepare fresh native fallback attempt `3`."
+    ), "attempt-2 recovery assertion does not allow the direct fallback clause")
+    require(not has_attempt_two_fresh_native_attempt_three(
+        "attempt `2` fails → classify it, then prepare fresh native fallback attempt `4`."
+    ), "attempt-2 recovery assertion accepts the wrong native fallback attempt")
+    require(not has_attempt_two_fresh_native_attempt_three(
+        "attempt `2` fails → classify it, but do not prepare a native fallback for this path.\n\n"
+        "A separate unavailable-route paragraph says prepare fresh native fallback attempt `3`."
+    ), "attempt-2 recovery assertion joins separated failure and fallback clauses")
 
     for needle in (
         '["python3", review_dispatch_script, "prepare"',
@@ -783,10 +820,11 @@ def check_document_contract() -> None:
     require("producer rule applies to initial launch, relaunch, and native fallback" in reviewer,
             "native report producer no longer covers every attempt state")
     reviewer_flat = " ".join(reviewer.split())
-    require("does not inspect provider error text" in reviewer_flat and
+    require("Before any retry or fallback, classify the captured external-process failure" in reviewer_flat and
+            "unrecognized failure is permanent" in reviewer_flat and
             "never resumes the failed external session" in reviewer_flat and
             "does not require a model switch" in reviewer_flat,
-            "reviewer retry recovered provider matching, session resume, or model switching")
+            "reviewer retry lost failure classification, session fallback, or model boundary")
     stage_flat = " ".join(stage.split())
     require('"--file", ledger_file' in stage_flat and
             '"--prompt-profile", prompt_profile' in stage_flat,
@@ -1107,7 +1145,9 @@ def run_repository_context_fixtures() -> None:
 
 
 def review_action(capability: Mapping[str, object], external_retry_spent: bool = False,
-                  external_failed: bool = False, native_exhausted: bool = False) -> str:
+                  external_failed: bool = False, external_failure_kind: str | None = None,
+                  session_disabled: bool = False, session_backoff_active: bool = False,
+                  timer_expired: bool = False, native_exhausted: bool = False) -> str:
     # Every route launches on `fresh_conversation` + `launch_mechanism_present` alone. The three
     # `os_filesystem_isolation` properties are an optional stronger-boundary CLAIM and MUST NOT gate
     # launch — the function deliberately never reads them.
@@ -1116,7 +1156,15 @@ def review_action(capability: Mapping[str, object], external_retry_spent: bool =
     if route.startswith("external-"):
         if not launchable:
             return "fallback-native"
+        if session_disabled or session_backoff_active:
+            return "fallback-native"
         if external_failed:
+            if external_failure_kind not in ("transient", "timer", "permanent"):
+                return "fallback-native"
+            if external_failure_kind == "permanent":
+                return "fallback-native"
+            if external_failure_kind == "timer" and not timer_expired:
+                return "wait-external" if not external_retry_spent else "fallback-native"
             return "fallback-native" if external_retry_spent else "retry-external"
         return "launch-external"
     # Native is the last-resort route: if it cannot launch (unavailable — no fresh conversation or no
@@ -1148,10 +1196,24 @@ def run_isolation_transition_fixtures() -> None:
         }
         require(review_action(shipped) == "launch-external",
                 f"shipped {route} did not launch cross-engine at native-limitation level")
-        require(review_action(shipped, external_failed=True) == "retry-external",
+        require(review_action(shipped, external_failed=True, external_failure_kind="transient") == "retry-external",
                 f"{route} first failure lost its retry")
-        require(review_action(shipped, external_failed=True, external_retry_spent=True) == "fallback-native",
+        require(review_action(shipped, external_failed=True, external_failure_kind="transient",
+                             external_retry_spent=True) == "fallback-native",
                 f"{route} retry failure did not fall back to native")
+        require(review_action(shipped, external_failed=True) == "fallback-native",
+                f"{route} retried an unclassified failure")
+        require(review_action(shipped, external_failed=True, external_failure_kind="timer") == "wait-external",
+                f"{route} timer failure did not wait")
+        require(review_action(shipped, external_failed=True, external_failure_kind="timer",
+                             timer_expired=True) == "retry-external",
+                f"{route} timer failure did not retry at its deadline")
+        require(review_action(shipped, external_failed=True, external_failure_kind="permanent") == "fallback-native",
+                f"{route} permanent failure did not fall back")
+        require(review_action(shipped, session_disabled=True) == "fallback-native",
+                f"{route} session-disabled state launched external review")
+        require(review_action(shipped, session_backoff_active=True) == "fallback-native",
+                f"{route} active session backoff launched external review")
 
         # Paired CLI absent -> unavailable -> immediate native fallback, no retry consumed.
         absent = dict(shipped, launch_mechanism_present=False)

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path
@@ -20,6 +21,7 @@ ROOT = Path(__file__).resolve().parents[1]
 REFS = ROOT / "references"
 COPILOT = ROOT.parent / "copilot-address-reviews"
 DISPATCH_PATH = ROOT / "scripts" / "review-dispatch.py"
+BACKOFF_PATH = ROOT / "scripts" / "reviewer-backoff.py"
 
 
 def _load_dispatch():
@@ -30,6 +32,16 @@ def _load_dispatch():
 
 
 DISPATCH = _load_dispatch()
+
+
+def _load_backoff():
+    mod = load_module_from_path("transport_contract_reviewer_backoff", BACKOFF_PATH, register=True)
+    if mod is None:
+        raise RuntimeError(f"cannot load reviewer backoff owner at {BACKOFF_PATH}")
+    return mod
+
+
+BACKOFF = _load_backoff()
 
 
 def require(condition: bool, message: str) -> None:
@@ -747,6 +759,7 @@ def check_document_contract() -> None:
         "ExternalReviewFailure",
         "ExternalReviewSessionState",
         "reviewer-backoff.py",
+        'kind: "transient" | "timer" | "permanent" | "unrecognized"',
         "retry_after_seconds: NonNegativeInt | null",
         "external_backoff_until: Timestamp | null",
         "external_backoff_timer_id: Text | null",
@@ -755,12 +768,17 @@ def check_document_contract() -> None:
         "external_retry_spent: Bool",
         "pr_number: PositiveInt",
         'event: "selected" | "external-system-failure" | "native-system-failure"',
+        "failure: ExternalReviewFailure | null",
+        "now: Timestamp",
+        "reviewer-backoff.py classify(provider_text, now)",
+        "reviewer-backoff.py transition(failure",
         "current Claude Code and Codex adapters",
         "launch_mechanism_present",
         "Their absence NEVER blocks launch",
         "selected cross-engine route, paired CLI available, and session state clear | `launch-external`",
         "external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external`",
-        "external failure classified `permanent`, or classification is unrecognized",
+        "external failure classified `permanent` | set session `external_disabled`",
+        "external failure classified `unrecognized` | use `fallback-native` without setting session `external_disabled`",
         "timer transition without the current positive PR number, including initial empty state | treat as malformed",
         "numeric offset that is invalid for",
         "A named zone's valid offsets include both sides",
@@ -821,10 +839,11 @@ def check_document_contract() -> None:
             "native report producer no longer covers every attempt state")
     reviewer_flat = " ".join(reviewer.split())
     require("Before any retry or fallback, classify the captured external-process failure" in reviewer_flat and
-            "unrecognized failure is permanent" in reviewer_flat and
+            "unrecognized failures use native fallback without disabling the external route" in reviewer_flat and
+            "never chooses a prompt profile from provider error text" in reviewer_flat and
             "never resumes the failed external session" in reviewer_flat and
             "does not require a model switch" in reviewer_flat,
-            "reviewer retry lost failure classification, session fallback, or model boundary")
+            "reviewer retry lost failure classification, session fallback, profile selection, session resume, or model boundary")
     stage_flat = " ".join(stage.split())
     require('"--file", ledger_file' in stage_flat and
             '"--prompt-profile", prompt_profile' in stage_flat,
@@ -1144,10 +1163,13 @@ def run_repository_context_fixtures() -> None:
                 "repository Git argv shifted a hostile ref")
 
 
-def review_action(capability: Mapping[str, object], external_retry_spent: bool = False,
-                  external_failed: bool = False, external_failure_kind: str | None = None,
-                  session_disabled: bool = False, session_backoff_active: bool = False,
-                  timer_expired: bool = False, native_exhausted: bool = False) -> str:
+def review_action(capability: Mapping[str, object], *, event: str = "selected",
+                  external_retry_spent: bool = False,
+                  native_attempts_exhausted: bool = False,
+                  external_failure: object | None = None,
+                  session: object | None = None,
+                  current_time: object | None = None,
+                  pr: object | None = None) -> str:
     # Every route launches on `fresh_conversation` + `launch_mechanism_present` alone. The three
     # `os_filesystem_isolation` properties are an optional stronger-boundary CLAIM and MUST NOT gate
     # launch — the function deliberately never reads them.
@@ -1156,22 +1178,35 @@ def review_action(capability: Mapping[str, object], external_retry_spent: bool =
     if route.startswith("external-"):
         if not launchable:
             return "fallback-native"
-        if session_disabled or session_backoff_active:
+        if event == "external-system-failure":
+            require(external_failure is not None, "external failure did not carry a typed failure")
+            require(session is not None, "external failure did not carry session state")
+            require(current_time is not None, "external failure did not carry current time")
+            require(pr is not None, "external failure did not carry PR ownership")
+            decision = BACKOFF.transition(
+                external_failure,
+                retry_spent=external_retry_spent,
+                now=current_time,
+                state=session,
+                pr_number=pr,
+            )
+            require(decision.action in (
+                BACKOFF.RETRY_EXTERNAL,
+                BACKOFF.WAIT_EXTERNAL,
+                BACKOFF.FALLBACK_NATIVE,
+            ), f"reviewer backoff returned an unmapped action: {decision.action}")
+            return decision.action
+        require(event == "selected", f"unsupported external review event: {event}")
+        if session is not None and session.external_disabled:
             return "fallback-native"
-        if external_failed:
-            if external_failure_kind not in ("transient", "timer", "permanent"):
-                return "fallback-native"
-            if external_failure_kind == "permanent":
-                return "fallback-native"
-            if external_failure_kind == "timer" and not timer_expired:
-                return "wait-external" if not external_retry_spent else "fallback-native"
-            return "fallback-native" if external_retry_spent else "retry-external"
         return "launch-external"
     # Native is the last-resort route: if it cannot launch (unavailable — no fresh conversation or no
     # launch mechanism), there is nothing left to fall back to, which is exactly `park-machine-blocker`.
     if not launchable:
         return "park-machine-blocker"
-    if native_exhausted:
+    require(event in ("selected", "native-system-failure"),
+            f"unsupported native review event: {event}")
+    if native_attempts_exhausted:
         return "park-machine-blocker"
     return "launch-native"
 
@@ -1196,24 +1231,75 @@ def run_isolation_transition_fixtures() -> None:
         }
         require(review_action(shipped) == "launch-external",
                 f"shipped {route} did not launch cross-engine at native-limitation level")
-        require(review_action(shipped, external_failed=True, external_failure_kind="transient") == "retry-external",
-                f"{route} first failure lost its retry")
-        require(review_action(shipped, external_failed=True, external_failure_kind="transient",
-                             external_retry_spent=True) == "fallback-native",
-                f"{route} retry failure did not fall back to native")
-        require(review_action(shipped, external_failed=True) == "fallback-native",
-                f"{route} retried an unclassified failure")
-        require(review_action(shipped, external_failed=True, external_failure_kind="timer") == "wait-external",
-                f"{route} timer failure did not wait")
-        require(review_action(shipped, external_failed=True, external_failure_kind="timer",
-                             timer_expired=True) == "retry-external",
-                f"{route} timer failure did not retry at its deadline")
-        require(review_action(shipped, external_failed=True, external_failure_kind="permanent") == "fallback-native",
-                f"{route} permanent failure did not fall back")
-        require(review_action(shipped, session_disabled=True) == "fallback-native",
-                f"{route} session-disabled state launched external review")
-        require(review_action(shipped, session_backoff_active=True) == "fallback-native",
-                f"{route} active session backoff launched external review")
+        require(review_action(
+            shipped,
+            session=BACKOFF.SessionState(external_disabled=True),
+            pr=188,
+        ) == "fallback-native", f"{route} ignored a disabled external session")
+        now = datetime(2026, 7, 25, 12, 0, tzinfo=timezone.utc)
+        transient = BACKOFF.classify("upstream timeout", now)
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=transient,
+            session=BACKOFF.SessionState(),
+            current_time=now,
+            pr=188,
+        ) == "retry-external", f"{route} first failure lost its retry")
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=transient,
+            session=BACKOFF.SessionState(),
+            current_time=now,
+            pr=188,
+            external_retry_spent=True,
+        ) == "fallback-native", f"{route} retry failure did not fall back to native")
+
+        timer_failure = BACKOFF.classify("rate limited; retry after 90 seconds", now)
+        timer_state = BACKOFF.transition(timer_failure, now=now, pr_number=188)
+        require(timer_state.action == "wait-external" and timer_state.retry_after_seconds == 90,
+                f"{route} fixture did not establish the provider deadline")
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=timer_failure,
+            session=BACKOFF.SessionState(),
+            current_time=now,
+            pr=188,
+        ) == "wait-external", f"{route} ignored the provider deadline")
+        deadline = timer_state.state.external_backoff_until
+        require(deadline is not None, f"{route} lost the provider deadline")
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=timer_failure,
+            session=timer_state.state,
+            current_time=deadline,
+            pr=188,
+        ) == "retry-external", f"{route} did not retry at the provider deadline")
+
+        other_pr_failure = BACKOFF.classify("rate limited; retry after 30 seconds", now)
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=other_pr_failure,
+            session=timer_state.state,
+            current_time=now + timedelta(seconds=10),
+            pr=189,
+        ) == "fallback-native", f"{route} ignored the session timer owner")
+
+        opaque = BACKOFF.classify("opaque provider failure", now)
+        require(opaque.kind == BACKOFF.UNRECOGNIZED,
+                f"{route} opaque provider failure was classified as permanent")
+        require(review_action(
+            shipped,
+            event="external-system-failure",
+            external_failure=opaque,
+            session=BACKOFF.SessionState(),
+            current_time=now,
+            pr=188,
+        ) == "fallback-native", f"{route} opaque provider failure did not fall back")
 
         # Paired CLI absent -> unavailable -> immediate native fallback, no retry consumed.
         absent = dict(shipped, launch_mechanism_present=False)
@@ -1238,7 +1324,7 @@ def run_isolation_transition_fixtures() -> None:
     }
     require(review_action(native) == "launch-native",
             "native limitations incorrectly parked an available pass")
-    require(review_action(native, native_exhausted=True) == "park-machine-blocker",
+    require(review_action(native, native_attempts_exhausted=True) == "park-machine-blocker",
             "exhausted invalid native route did not park")
 
     # A native route that is `unavailable` (no launch mechanism, or no fresh conversation) CANNOT launch.

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -759,7 +759,7 @@ def check_document_contract() -> None:
         "ExternalReviewFailure",
         "ExternalReviewSessionState",
         "reviewer-backoff.py",
-        'kind: "transient" | "timer" | "permanent" | "unrecognized"',
+        'kind: "transient" | "timer" | "permanent" | "refusal" | "unrecognized"',
         "retry_after_seconds: NonNegativeInt | null",
         "external_backoff_until: Timestamp | null",
         "external_backoff_timer_id: Text | null",
@@ -778,6 +778,7 @@ def check_document_contract() -> None:
         "selected cross-engine route, paired CLI available, and session state clear | `launch-external`",
         "external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external`",
         "external failure classified `permanent` | set session `external_disabled`",
+        "external failure classified `refusal` | `stop-and-ask`",
         "external failure classified `unrecognized` | use `fallback-native` without setting session `external_disabled`",
         "timer transition without the current positive PR number, including initial empty state | treat as malformed",
         "numeric offset that is invalid for",
@@ -794,6 +795,7 @@ def check_document_contract() -> None:
         "| `retry-external` + `external-claude` | `external-claude` | "
         "`external-process-capture` | `standard` |",
         "| `wait-external` | no preparation | no preparation | no preparation |",
+        "| `stop-and-ask` | no preparation | no preparation | no preparation |",
         "| `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |",
         "dead or unusable attempt `3` → `park-machine-blocker`",
         'prompt_profile: "standard" | "codex-recovery"',
@@ -840,6 +842,8 @@ def check_document_contract() -> None:
     reviewer_flat = " ".join(reviewer.split())
     require("Before any retry or fallback, classify the captured external-process failure" in reviewer_flat and
             "unrecognized failures use native fallback without disabling the external route" in reviewer_flat and
+            "refusal is the one failure that never recovers on its own" in reviewer_flat and
+            "it returns `stop-and-ask`" in reviewer_flat and
             "never chooses a prompt profile from provider error text" in reviewer_flat and
             "never resumes the failed external session" in reviewer_flat and
             "does not require a model switch" in reviewer_flat,

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -1199,6 +1199,13 @@ def review_action(capability: Mapping[str, object], *, event: str = "selected",
         require(event == "selected", f"unsupported external review event: {event}")
         if session is not None and session.external_disabled:
             return "fallback-native"
+        if session is not None and session.external_backoff_until is not None:
+            require(current_time is not None, "active session backoff did not carry current time")
+            require(pr is not None, "active session backoff did not carry PR ownership")
+            if session.external_backoff_pr != pr:
+                return "fallback-native"
+            if BACKOFF._utc(session.external_backoff_until) > BACKOFF._utc(current_time):
+                return "wait-external"
         return "launch-external"
     # Native is the last-resort route: if it cannot launch (unavailable — no fresh conversation or no
     # launch mechanism), there is nothing left to fall back to, which is exactly `park-machine-blocker`.
@@ -1278,6 +1285,21 @@ def run_isolation_transition_fixtures() -> None:
             current_time=deadline,
             pr=188,
         ) == "retry-external", f"{route} did not retry at the provider deadline")
+
+        require(review_action(
+            shipped,
+            event="selected",
+            session=timer_state.state,
+            current_time=now,
+            pr=188,
+        ) == "wait-external", f"{route} selected owner ignored the active session deadline")
+        require(review_action(
+            shipped,
+            event="selected",
+            session=timer_state.state,
+            current_time=now,
+            pr=189,
+        ) == "fallback-native", f"{route} selected other PR ignored the timer owner")
 
         other_pr_failure = BACKOFF.classify("rate limited; retry after 30 seconds", now)
         require(review_action(

--- a/scripts/validate-plugins.sh
+++ b/scripts/validate-plugins.sh
@@ -707,6 +707,8 @@ grep -Fq 'ReviewIsolationCapability' "$campaign/references/runtime-adapter.md" |
   fail "runtime adapter is missing the review-isolation capability owner"
 python3 "$campaign/scripts/review-dispatch.py" self-test || status=1
 python3 "$campaign/scripts/transport-contract-test.py" || status=1
+python3 "$campaign/scripts/reviewer-backoff.py" self-test || status=1
+python3 "$campaign/scripts/script-table-test.py" || status=1
 python3 "$campaign/scripts/worker-prompt.py" self-test || status=1
 
 campaign_host_leaks=$(


### PR DESCRIPTION
## Purpose

- Classify external reviewer process failures as transient, timer-based, permanent, or unrecognized.
- Preserve exact provider timer deadlines and positive PR ownership in session-only state.
- Provide focused executable fixtures and validation for the classifier.

## Non-goals

- Change review verdict acceptance, review-attempt budgets, or native-worker isolation.
- Change provider CLIs, credentials, or third-party service behavior.

## Threat model

- Repository contributors can change the bundled classifier and its fixtures.
- An external provider or process can return transient, timer-based, permanent, malformed, or unrecognized failure text.
- The classifier must not create unbounded external retries or durable state.

## Verification

- reviewer-backoff.py self-test: 55 fixtures
- scripts/validate-plugins.sh
- git diff --check

This is the first PR in the #188 rescope. Merge before #190 and #191.
