### PR TITLE
document external review transition and native fallback

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
+++ b/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
@@ -7,6 +7,10 @@ This file defines the argv for that route, not review policy or the isolation ru
 Before preparing a record or prompt, evaluate `runtime-adapter.md`'s `ReviewIsolationCapability` and take
 its transition. Only `launch-external` or `retry-external` uses the commands below; every other action
 stays with the owner.
+When an external process returns without a usable verdict, classify its captured failure through
+`runtime-adapter.md`, "Review failure classification and session backoff", before taking any retry or
+fallback. Pass the typed `ExternalReviewFailure` and session state to the transition; provider text does
+not select an argv member or prompt profile here.
 A capable adapter runs `review-dispatch.py prepare` through the exact invocation in `review-dispatch.md`,
 then launches the process from its returned transport as a background task whose completion triggers a
 reconcile. Prompt bytes — including verbatim GitHub-derived intent — and dynamic paths never enter shell
@@ -98,8 +102,8 @@ This argv launches at the native-limitation level; it does not create a stronger
 - Limit built-in tools to `Read` and `Bash`. The review prompt forbids source changes; Bash is needed
   for git inspection and the two artifact emitters.
 - `--permission-mode dontAsk` makes an unapproved operation fail instead of opening an interactive
-  prompt. A permission or sandbox denial is a reviewer system failure; retry or fall back under
-  `reviewer.md`. Never switch to `--dangerously-skip-permissions`.
+  prompt. A permission or sandbox denial is a reviewer system failure; classify it through the runtime
+  adapter before retry or fallback. Never switch to `--dangerously-skip-permissions`.
 - Set `stdin_file` to `transport.prompt_path` and `stdout_file` to `transport.report.path`; the external
   process capture is the sole report producer. Prompt and path values remain data.
 

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -31,10 +31,10 @@ note it in the final report. Resolve in priority order:
    file can reach the selection.
 3. **Default — the cross-engine route for the active host.** No preference → Claude Code reviews with
    Codex (`codex exec`) and Codex reviews with Claude Code (`claude -p`), launched at native-limitation
-   level whenever the paired CLI is present. When the paired CLI is absent, or the cross-engine process
-   fails after its one retry, fall back to a fresh, context-isolated **native worker** on the active host,
-   disclosed in the final report. **No paired CLI is required for the campaign to run** — the native
-   fallback is always available.
+   level whenever the paired CLI is present. When the paired CLI is absent, or the runtime transition
+   directs fallback after classifying a process failure, use a fresh, context-isolated **native worker**
+   on the active host, disclosed in the final report. **No paired CLI is required for the campaign to run**
+   — the native fallback is always available.
 
 **Reviewer diversity is the default, not an add-on — and it also reduces native-worker cost.** The gate's
 passes are already fresh, context-isolated re-rolls, but two native workers share the orchestrator's model,
@@ -43,14 +43,15 @@ so they are less independent than a *different* engine would be. So the default 
 `claude -p`. It launches at native-limitation level whenever the paired CLI is present — engine diversity
 needs no OS sandbox. A same-engine process (Codex → another `codex exec`, Claude Code → another `claude
 -p`) provides fresh context only and must not be reported as diversity. A fresh native worker on the
-active host is the complete, valid **fallback** when the paired CLI is absent or the cross-engine process
-fails after its retry. The cost benefit compounds the diversity one: review passes dominate campaign's
+active host is the complete, valid **fallback** when the paired CLI is absent or the runtime transition
+directs it after classifying a cross-engine process failure. The cost benefit compounds the diversity one:
+review passes dominate campaign's
 native-worker spend — each re-reads the **whole** `origin/<base>...HEAD` diff (where `<base>` is the
 selected PR row's **effective base** — its explicit `base_branch`, else the legacy header fallback,
 resolved through `ledger.py`'s `effective_base`, never the one header base), runs `required(tier)` times
 per SHA, and re-runs **from scratch** on every gate reset (a content change voids the tally), so a PR that
 takes several fix rounds can spend many full-diff passes — and the default cross-engine route moves all of
-that off the native-worker pool, while a native-worker fallback (paired CLI absent) does not. Both are
+that off the native-worker pool, while a native-worker fallback still uses that pool. Both are
 benefits of the default, not separate knobs — the reviewer choice is owned above.
 
 **A REVIEW PASS IS NEVER RUN ON A DOWNGRADED MODEL.** Whether the reviewer is a native worker or the
@@ -66,7 +67,7 @@ class or review contract.
 **A NATIVE-WORKER REVIEWER RUNS THE SAME REVIEW PASS AS EVERY OTHER REVIEWER — the one `stage-2-review-gate.md`
 defines, whole.** “Native worker” names **who executes it**, and nothing else. It does not name a
 lighter contract, a shorter prompt, or an older protocol, and there is no such thing to name. It is the
-**fallback** for an absent or failed cross-engine reviewer, and it is what an explicit user selection of a
+**fallback** for an absent or transition-failed cross-engine reviewer, and it is what an explicit user selection of a
 native reviewer runs.
 
 It is also a verdict renderer, so use `runtime-adapter.md`'s **native-worker** isolation contract, not the
@@ -83,7 +84,7 @@ RECORDS, not prose", "Does this pass COUNT?"), and the one time this section car
 the summary went stale: it still described a plan/progress/verdict protocol with **no intent, no findings
 artifact and no gating rule**, months after those became the contract. Following it recreated exactly the
 open-ended review — *"is anything wrong with this code?"* — that the intent block exists to kill, **on the
-native-worker path**, which is the fallback whenever a cross-engine reviewer is absent or fails. A stale
+native-worker path**, which is the fallback whenever the runtime transition selects native. A stale
 summary is worse than no summary: it is the version people actually read, and it is believed.
 
 **Prepare it with `review-dispatch.py prepare`, using the exact invocation in `review-dispatch.md`.** The
@@ -127,19 +128,24 @@ exhaustion, auth failures, timeouts, or other system errors. Distinguish this fr
 run that returns an actual finding list or a `VERDICT: …` line is a *result*, act on it. A *failure*
 is the absence of a verdict.
 
-**On a capable external process failure, retry once. If it still can't deliver a verdict, take
-`runtime-adapter.md`'s fresh native fallback transition** rather than stalling, looping, or skipping the
-gate. A pre-launch capability miss (the paired CLI is absent) has no process to retry and takes that
-fallback immediately. Note in the final report which cross-engine routes were unavailable and which passes
-used the recovery profile or ran on the native-worker fallback. The gate is unchanged: a worker pass is a fresh, context-isolated re-roll that counts toward
-the review gate exactly like an external pass. The runtime owner defines the native limitations and the
-only machine-blocker transition; do not restate them here.
+**Before any retry or fallback, classify the captured external-process failure through
+`runtime-adapter.md`, "Review failure classification and session backoff".** The helper returns
+`transient`, `timer`, or `permanent`; permanent markers and malformed or unsupported timer text are
+permanent, and an unrecognized failure is permanent. Apply the returned transition: transient failures may
+spend the one retry, valid timers wait for the exact provider deadline before retrying, and permanent
+failures disable that external route for this session before native fallback.
+The paired CLI absence is a pre-launch capability miss and takes native fallback without a retry. Keep
+the session backoff state in memory only; never write it to campaign artifacts.
+Note in the final report which cross-engine routes were unavailable and which passes used the recovery
+profile or ran on the native-worker fallback. The gate is unchanged: a worker pass is a fresh,
+context-isolated re-roll that counts toward the review gate exactly like an external pass. The runtime
+owner defines the native limitations and the only machine-blocker transition; do not restate them here.
 
 **Prepare every retry from `runtime-adapter.md`, "Review preparation mapping".** The transition does not
-inspect provider error text: it assigns `codex-recovery` to the existing external Codex attempt `2` and
-`standard` to every other route. The retry always starts a fresh process and never resumes the failed
-external session. The profile changes only the opening framing, does not require a model switch, and
-keeps the complete shared prompt contract, attempt budget, producer, and canonical argv. The shipped
+select a profile from provider output: it assigns `codex-recovery` to the existing external Codex attempt
+`2` and `standard` to every other route. The retry always starts a fresh process and never resumes the
+failed external session. The profile changes only the opening framing, does not require a model switch,
+and keeps the complete shared prompt contract, attempt budget, producer, and canonical argv. The shipped
 adapter has no trusted alternate-model mapping, so it passes no model-selection argument.
 
 A reviewer that **never starts** is a distinct failure — it produces not even a partial result — and

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -152,27 +152,92 @@ startup/cwd/mount/sandbox controls. A cross-engine record is identical in shape:
 true`, `launch_mechanism_present = true` when the paired CLI is present, the three properties false, no
 stronger-boundary claim. Both are available routes with the disclosed behavioral constraints below.
 
+### Review failure classification and session backoff
+
+**Classify every external process failure before choosing retry or fallback.** Feed the captured
+process error text to `reviewer-backoff.py`'s typed classifier, or to an equivalent host adapter that
+implements this same contract. A returned `ExternalReviewFailure` is data passed to the transition; raw
+provider text never selects a route, profile, model, or argv member.
+
+```text
+ExternalReviewFailure {
+  kind: "transient" | "timer" | "permanent",
+  retry_after_seconds: NonNegativeInt | null,
+  retry_at: Timestamp | null,
+  reason: Text,
+  timer_identity: Text | null
+}
+
+ExternalReviewSessionState {
+  external_disabled: Bool,
+  external_backoff_until: Timestamp | null,
+  external_backoff_timer_id: Text | null,
+  external_backoff_pr: PositiveInt | null
+}
+
+ReviewTransition {
+  action: ReviewAction,
+  session: ExternalReviewSessionState
+}
+```
+
+The classifier recognizes non-negative whole-second relative provider delays such as `retry after 90
+seconds` and `available in 90 seconds`, plus absolute provider reset timestamps such as `resets Jul 27,
+9pm (Asia/Tokyo)`. Construct an absolute timestamp in the provider-named timezone, then calculate elapsed
+time with timezone-aware arithmetic. Permanent markers take precedence over timers and transient markers;
+valid timer text takes precedence over generic transient markers. Malformed or unsupported timer text,
+including fractional or unrepresentable delays, unknown zones, and a numeric offset that is invalid for
+the named zone at the target local time, is `permanent`. A named zone's valid offsets include both sides
+of a DST fold. An unrecognized failure is also `permanent` and disables this external route for the
+current session.
+
+`ExternalReviewSessionState` is process/session memory owned by the active orchestrator. Update it only
+from the returned transition or decision. **Never write `external_disabled` or
+`external_backoff_until` or `external_backoff_timer_id` or `external_backoff_pr` to the ledger, history,
+preferences, run artifacts, or any other durable campaign record. `timer_identity` and
+`external_backoff_timer_id` are opaque session-memory values. While a session deadline is active, a new
+timer for the same PR owns its `retry_at`, even when earlier; a timer for another PR falls back natively
+and retains the existing deadline and owner. Matching timer text and deadline alone never prove re-entry.
+A new session starts with an empty state. **Require the current positive `pr_number` before storing any
+timer, including on the initial empty-state transition.** A missing or malformed PR owner is permanent,
+disables the external route for the session, and stores no deadline or timer identity.
+
 ```text
 review_transition(
   capability: ReviewIsolationCapability,
+  pr_number: PositiveInt,
   event: "selected" | "external-system-failure" | "native-system-failure",
+  failure: ExternalReviewFailure | null,
+  session: ExternalReviewSessionState,
   external_retry_spent: Bool,
+  now: Timestamp,
   native_attempts_exhausted: Bool
-) -> ReviewAction
+) -> ReviewTransition
 ```
 
 This operation owns every route change:
 
 | Input | Action |
 |---|---|
-| selected cross-engine route, paired CLI available | `launch-external` at native-limitation level (no stronger-boundary claim) |
-| `external-system-failure`, external retry not spent | re-evaluate capability, then `retry-external` only if still available |
-| selected cross-engine route unavailable before launch (paired CLI absent), or `external-system-failure` after retry | report the failure, then `fallback-native` (disclosed) |
+| selected cross-engine route, paired CLI available, and session state clear | `launch-external` at native-limitation level (no stronger-boundary claim) |
+| selected cross-engine route unavailable before launch, or session `external_disabled` is true | report the boundary, then `fallback-native` (disclosed) |
+| external failure classified `transient`, retry not spent | `retry-external` immediately |
+| external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external` until the exact provider deadline; do not launch before it |
+| external failure classified `timer`, retry not spent, and `now` has reached its deadline | `retry-external` immediately |
+| external failure classified `permanent`, or classification is unrecognized | set session `external_disabled`, then `fallback-native` |
+| timer transition without the current positive PR number, including initial empty state | treat as malformed, set session `external_disabled`, then `fallback-native` without storing a deadline or timer identity |
+| external failure after retry, regardless of class | `fallback-native`; retain any timer backoff for other launches in this session |
+| session timer backoff is active for another PR | use `fallback-native` for that PR; do not shorten or ignore the timer |
 | native route/fallback can follow the installed contract | `launch-native` with the native limitations below |
 | native attempts cannot follow the installed contract or produce valid artifacts and their budget is exhausted | `park-machine-blocker` |
 
-A pre-launch cross-engine capability miss (the paired CLI is absent) has no process to relaunch, so it
-consumes no retry and takes the fresh native fallback immediately.
+`wait-external` is a session action, not a process launch: it consumes no `launch_attempt` and calls
+no `review-dispatch.py prepare`. Use the heartbeat or another bounded wait to reach the returned
+timestamp, then re-enter this transition with the same typed failure, live session state, and current time;
+the active-deadline re-entry rule above decides whether the stored deadline is preserved. A pre-launch
+cross-engine capability miss has no process to relaunch, so it consumes no retry and takes the fresh
+native fallback immediately. A timer or permanent provider error does not change the policy in a later
+session.
 Missing native OS/startup controls alone never select `park-machine-blocker`; only actual inability to
 complete the installed contract after its budget does. `reviewer.md` owns the retry budget, while this table owns the transition meaning.
 
@@ -186,16 +251,19 @@ are different enums:
 | `launch-external` | selected capability's external route | `external-process-capture` | `standard` |
 | `retry-external` + `external-codex` | `external-codex` | `external-process-capture` | `codex-recovery` |
 | `retry-external` + `external-claude` | `external-claude` | `external-process-capture` | `standard` |
+| `wait-external` | no preparation | no preparation | no preparation |
 | `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |
 | `park-machine-blocker` | no preparation | no preparation | no preparation |
 
 Selected capability's external route is exactly `external-codex` or `external-claude`; never pass the
 `ReviewAction` string as `--route`.
 
-**Allocate `launch_attempt` monotonically for every reviewer launch passed to `prepare`.** An unavailable
-external route is never prepared and consumes no number, so its immediate native fallback takes the
-current next number. Once an attempt exists, recovery is fixed: attempt `1` fails → prepare the selected route's
-one retry as attempt `2`; attempt `2` fails → prepare fresh native fallback attempt `3`.
+**Allocate `launch_attempt` monotonically for every reviewer launch passed to `prepare`.** A
+`wait-external` action is not a launch and consumes no number. An unavailable external route is never
+prepared and consumes no number, so its native fallback takes the current next number. Once an attempt
+exists, recovery is fixed: attempt `1` fails → classify it, then prepare the selected route's one retry
+only when the transition permits it; a timer retry waits for its exact `retry_at`; attempt `2` fails →
+prepare fresh native fallback attempt `3`.
 **A dead or unusable attempt `3` → `park-machine-blocker`.** Never reuse an attempt's artifacts, and never
 allocate attempt `4`.
 
@@ -474,6 +542,6 @@ section states only the per-host default and where the transport pieces live:
 
 The cross-engine route launches at the **same native-limitation level** as a native worker whenever the
 paired CLI is present ("Review isolation capability and transition" above). Capability-gated cross-engine
-argv lives in `cross-agent-reviewers.md`; the external-reviewer retry budget in `reviewer.md`; the
-transition itself in `ReviewIsolationCapability` above. “Fallback” always means a fresh native worker on
-the active host.
+argv lives in `cross-agent-reviewers.md`; failure classification and session backoff in "Review failure
+classification and session backoff" above; the retry budget in `reviewer.md`; the transition itself in
+`ReviewIsolationCapability` above. “Fallback” always means a fresh native worker on the active host.

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -34,11 +35,11 @@ def check(condition: bool, message: str) -> None:
 
 
 def has_attempt_two_fresh_native_attempt_three(text: str) -> bool:
-    flat = " ".join(text.split())
-    attempt_two = "attempt `2` fails →"
-    fresh_native_attempt_three = "prepare fresh native fallback attempt `3`"
-    start = flat.find(attempt_two)
-    return start >= 0 and flat.find(fresh_native_attempt_three, start + len(attempt_two)) >= 0
+    return re.search(
+        r"attempt `2` fails[ \t]*→[ \t]*(?:\r?\n[ \t]*)?"
+        r"prepare fresh native fallback attempt `3`(?:[.!?]|$)",
+        text,
+    ) is not None
 
 
 SHA = "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c"
@@ -705,12 +706,18 @@ def t_external_attempt_two_has_native_attempt_three_recovery() -> None:
 
 
 def t_attempt_two_recovery_relation_rejects_wrong_attempt() -> None:
-    valid = "attempt `2` fails → classify it,\nthen prepare fresh native fallback attempt `3`."
+    valid = "attempt `2` fails →\nprepare fresh native fallback attempt `3`."
     invalid = "attempt `2` fails → classify it, then prepare fresh native fallback attempt `4`."
+    separated = (
+        "attempt `2` fails → classify it, but do not prepare a native fallback for this path.\n\n"
+        "A separate unavailable-route paragraph says prepare fresh native fallback attempt `3`."
+    )
     check(has_attempt_two_fresh_native_attempt_three(valid),
-          "attempt-2 recovery assertion does not allow normalized classification text")
+          "attempt-2 recovery assertion does not allow the direct fallback clause")
     check(not has_attempt_two_fresh_native_attempt_three(invalid),
           "attempt-2 recovery assertion accepts the wrong native fallback attempt")
+    check(not has_attempt_two_fresh_native_attempt_three(separated),
+          "attempt-2 recovery assertion joins separated failure and fallback clauses")
 
 
 def t_transition_actions_map_directly_to_prepare_inputs() -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -33,6 +33,14 @@ def check(condition: bool, message: str) -> None:
         raise D.SelfTestFailure(message)
 
 
+def has_attempt_two_fresh_native_attempt_three(text: str) -> bool:
+    flat = " ".join(text.split())
+    attempt_two = "attempt `2` fails →"
+    fresh_native_attempt_three = "prepare fresh native fallback attempt `3`"
+    start = flat.find(attempt_two)
+    return start >= 0 and flat.find(fresh_native_attempt_three, start + len(attempt_two)) >= 0
+
+
 SHA = "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c"
 STAMP = "2026-07-20T00:00:00Z"
 
@@ -684,8 +692,8 @@ def t_external_attempt_two_has_native_attempt_three_recovery() -> None:
     runtime = (refs / "runtime-adapter.md").read_text(encoding="utf-8")
     stage = (refs / "stage-2-review-gate.md").read_text(encoding="utf-8")
     loop = (refs / "loop-control.md").read_text(encoding="utf-8")
-    check("attempt `2` fails → prepare fresh native fallback attempt `3`" in runtime,
-          "runtime owner does not allocate attempt 3 after failed attempt 2")
+    check(has_attempt_two_fresh_native_attempt_three(runtime),
+          "runtime owner does not relate attempt 2 failure to fresh native attempt 3")
     check("dead or unusable attempt `3` → `park-machine-blocker`" in runtime,
           "runtime owner does not terminate failed native fallback attempt 3")
     stale_attempt_two_terminal = "`2` → " + "fresh-worker fallback"
@@ -694,6 +702,15 @@ def t_external_attempt_two_has_native_attempt_three_recovery() -> None:
               f"{name} recovery does not point to the attempt-3 owner")
         check(stale_attempt_two_terminal not in text,
               f"{name} recovery retains the stale attempt-2 terminal rule")
+
+
+def t_attempt_two_recovery_relation_rejects_wrong_attempt() -> None:
+    valid = "attempt `2` fails → classify it,\nthen prepare fresh native fallback attempt `3`."
+    invalid = "attempt `2` fails → classify it, then prepare fresh native fallback attempt `4`."
+    check(has_attempt_two_fresh_native_attempt_three(valid),
+          "attempt-2 recovery assertion does not allow normalized classification text")
+    check(not has_attempt_two_fresh_native_attempt_three(invalid),
+          "attempt-2 recovery assertion accepts the wrong native fallback attempt")
 
 
 def t_transition_actions_map_directly_to_prepare_inputs() -> None:
@@ -939,6 +956,8 @@ CASES = [
     ("hard-stop-recovery", "both-files and identity-only hard-stop residue is recoverable", t_hard_stop_residue_is_recoverable),
     ("malformed-identity-refused", "a malformed lone identity is refused, not reclaimed", t_malformed_lone_identity_is_refused_not_reclaimed),
     ("fallback-attempt-three", "external retry failure has a terminal native attempt-3 path", t_external_attempt_two_has_native_attempt_three_recovery),
+    ("attempt-three-contract", "attempt-2 recovery requires fresh native attempt 3",
+     t_attempt_two_recovery_relation_rejects_wrong_attempt),
     ("transition-mapping", "review actions map directly to route, producer, and prompt profile",
      t_transition_actions_map_directly_to_prepare_inputs),
     ("unicode-delivery", "a Unicode path is delivered as UTF-8 bytes under ASCII stdout", t_unicode_worktree_delivers_under_ascii_stdout),

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -100,11 +100,11 @@ def normalized(text: str) -> str:
 
 
 def has_attempt_two_fresh_native_attempt_three(text: str) -> bool:
-    flat = normalized(text)
-    attempt_two = "attempt `2` fails →"
-    fresh_native_attempt_three = "prepare fresh native fallback attempt `3`"
-    start = flat.find(attempt_two)
-    return start >= 0 and flat.find(fresh_native_attempt_three, start + len(attempt_two)) >= 0
+    return re.search(
+        r"attempt `2` fails[ \t]*→[ \t]*(?:\r?\n[ \t]*)?"
+        r"prepare fresh native fallback attempt `3`(?:[.!?]|$)",
+        text,
+    ) is not None
 
 
 def command_argvs(block: str) -> list[list[str]]:
@@ -784,11 +784,15 @@ def check_document_contract() -> None:
     require(has_attempt_two_fresh_native_attempt_three(runtime),
             "runtime adapter does not relate attempt 2 failure to fresh native attempt 3")
     require(has_attempt_two_fresh_native_attempt_three(
-        "attempt `2` fails → classify it,\nthen prepare fresh native fallback attempt `3`."
-    ), "attempt-2 recovery assertion does not allow normalized classification text")
+        "attempt `2` fails →\nprepare fresh native fallback attempt `3`."
+    ), "attempt-2 recovery assertion does not allow the direct fallback clause")
     require(not has_attempt_two_fresh_native_attempt_three(
         "attempt `2` fails → classify it, then prepare fresh native fallback attempt `4`."
     ), "attempt-2 recovery assertion accepts the wrong native fallback attempt")
+    require(not has_attempt_two_fresh_native_attempt_three(
+        "attempt `2` fails → classify it, but do not prepare a native fallback for this path.\n\n"
+        "A separate unavailable-route paragraph says prepare fresh native fallback attempt `3`."
+    ), "attempt-2 recovery assertion joins separated failure and fallback clauses")
 
     for needle in (
         '["python3", review_dispatch_script, "prepare"',

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -99,6 +99,14 @@ def normalized(text: str) -> str:
     return " ".join(text.split())
 
 
+def has_attempt_two_fresh_native_attempt_three(text: str) -> bool:
+    flat = normalized(text)
+    attempt_two = "attempt `2` fails →"
+    fresh_native_attempt_three = "prepare fresh native fallback attempt `3`"
+    start = flat.find(attempt_two)
+    return start >= 0 and flat.find(fresh_native_attempt_three, start + len(attempt_two)) >= 0
+
+
 def command_argvs(block: str) -> list[list[str]]:
     logical_lines = re.sub(r"\\\r?\n", " ", block).splitlines()
     commands: list[list[str]] = []
@@ -736,12 +744,29 @@ def check_document_contract() -> None:
         "<TRANSPORT-RECORD>",
         '"native-worker-write" | "external-process-capture"',
         "ReviewIsolationCapability",
+        "ExternalReviewFailure",
+        "ExternalReviewSessionState",
+        "reviewer-backoff.py",
+        "retry_after_seconds: NonNegativeInt | null",
+        "external_backoff_until: Timestamp | null",
+        "external_backoff_timer_id: Text | null",
+        "external_backoff_pr: PositiveInt | null",
+        "timer_identity: Text | null",
         "external_retry_spent: Bool",
+        "pr_number: PositiveInt",
         'event: "selected" | "external-system-failure" | "native-system-failure"',
         "current Claude Code and Codex adapters",
         "launch_mechanism_present",
         "Their absence NEVER blocks launch",
-        "selected cross-engine route, paired CLI available | `launch-external`",
+        "selected cross-engine route, paired CLI available, and session state clear | `launch-external`",
+        "external failure classified `timer`, retry not spent, and `now` is before its deadline | `wait-external`",
+        "external failure classified `permanent`, or classification is unrecognized",
+        "timer transition without the current positive PR number, including initial empty state | treat as malformed",
+        "numeric offset that is invalid for",
+        "A named zone's valid offsets include both sides",
+        "of a DST fold.",
+        "Never write `external_disabled` or",
+        "wait-external",
         "Missing native OS/startup controls alone never select",
         "### Review preparation mapping",
         "| `launch-external` | selected capability's external route | "
@@ -750,12 +775,20 @@ def check_document_contract() -> None:
         "`external-process-capture` | `codex-recovery` |",
         "| `retry-external` + `external-claude` | `external-claude` | "
         "`external-process-capture` | `standard` |",
+        "| `wait-external` | no preparation | no preparation | no preparation |",
         "| `launch-native` / `fallback-native` | `native` | `native-worker-write` | `standard` |",
-        "attempt `2` fails → prepare fresh native fallback attempt `3`",
         "dead or unusable attempt `3` → `park-machine-blocker`",
         'prompt_profile: "standard" | "codex-recovery"',
     ):
         require(needle in runtime, f"runtime adapter lost typed owner: {needle}")
+    require(has_attempt_two_fresh_native_attempt_three(runtime),
+            "runtime adapter does not relate attempt 2 failure to fresh native attempt 3")
+    require(has_attempt_two_fresh_native_attempt_three(
+        "attempt `2` fails → classify it,\nthen prepare fresh native fallback attempt `3`."
+    ), "attempt-2 recovery assertion does not allow normalized classification text")
+    require(not has_attempt_two_fresh_native_attempt_three(
+        "attempt `2` fails → classify it, then prepare fresh native fallback attempt `4`."
+    ), "attempt-2 recovery assertion accepts the wrong native fallback attempt")
 
     for needle in (
         '["python3", review_dispatch_script, "prepare"',
@@ -783,10 +816,11 @@ def check_document_contract() -> None:
     require("producer rule applies to initial launch, relaunch, and native fallback" in reviewer,
             "native report producer no longer covers every attempt state")
     reviewer_flat = " ".join(reviewer.split())
-    require("does not inspect provider error text" in reviewer_flat and
+    require("Before any retry or fallback, classify the captured external-process failure" in reviewer_flat and
+            "unrecognized failure is permanent" in reviewer_flat and
             "never resumes the failed external session" in reviewer_flat and
             "does not require a model switch" in reviewer_flat,
-            "reviewer retry recovered provider matching, session resume, or model switching")
+            "reviewer retry lost failure classification, session fallback, or model boundary")
     stage_flat = " ".join(stage.split())
     require('"--file", ledger_file' in stage_flat and
             '"--prompt-profile", prompt_profile' in stage_flat,
@@ -1107,7 +1141,9 @@ def run_repository_context_fixtures() -> None:
 
 
 def review_action(capability: Mapping[str, object], external_retry_spent: bool = False,
-                  external_failed: bool = False, native_exhausted: bool = False) -> str:
+                  external_failed: bool = False, external_failure_kind: str | None = None,
+                  session_disabled: bool = False, session_backoff_active: bool = False,
+                  timer_expired: bool = False, native_exhausted: bool = False) -> str:
     # Every route launches on `fresh_conversation` + `launch_mechanism_present` alone. The three
     # `os_filesystem_isolation` properties are an optional stronger-boundary CLAIM and MUST NOT gate
     # launch — the function deliberately never reads them.
@@ -1116,7 +1152,15 @@ def review_action(capability: Mapping[str, object], external_retry_spent: bool =
     if route.startswith("external-"):
         if not launchable:
             return "fallback-native"
+        if session_disabled or session_backoff_active:
+            return "fallback-native"
         if external_failed:
+            if external_failure_kind not in ("transient", "timer", "permanent"):
+                return "fallback-native"
+            if external_failure_kind == "permanent":
+                return "fallback-native"
+            if external_failure_kind == "timer" and not timer_expired:
+                return "wait-external" if not external_retry_spent else "fallback-native"
             return "fallback-native" if external_retry_spent else "retry-external"
         return "launch-external"
     # Native is the last-resort route: if it cannot launch (unavailable — no fresh conversation or no
@@ -1148,10 +1192,24 @@ def run_isolation_transition_fixtures() -> None:
         }
         require(review_action(shipped) == "launch-external",
                 f"shipped {route} did not launch cross-engine at native-limitation level")
-        require(review_action(shipped, external_failed=True) == "retry-external",
+        require(review_action(shipped, external_failed=True, external_failure_kind="transient") == "retry-external",
                 f"{route} first failure lost its retry")
-        require(review_action(shipped, external_failed=True, external_retry_spent=True) == "fallback-native",
+        require(review_action(shipped, external_failed=True, external_failure_kind="transient",
+                             external_retry_spent=True) == "fallback-native",
                 f"{route} retry failure did not fall back to native")
+        require(review_action(shipped, external_failed=True) == "fallback-native",
+                f"{route} retried an unclassified failure")
+        require(review_action(shipped, external_failed=True, external_failure_kind="timer") == "wait-external",
+                f"{route} timer failure did not wait")
+        require(review_action(shipped, external_failed=True, external_failure_kind="timer",
+                             timer_expired=True) == "retry-external",
+                f"{route} timer failure did not retry at its deadline")
+        require(review_action(shipped, external_failed=True, external_failure_kind="permanent") == "fallback-native",
+                f"{route} permanent failure did not fall back")
+        require(review_action(shipped, session_disabled=True) == "fallback-native",
+                f"{route} session-disabled state launched external review")
+        require(review_action(shipped, session_backoff_active=True) == "fallback-native",
+                f"{route} active session backoff launched external review")
 
         # Paired CLI absent -> unavailable -> immediate native fallback, no retry consumed.
         absent = dict(shipped, launch_mechanism_present=False)


### PR DESCRIPTION
## Purpose

- Make the campaign runtime transition use the external failure classifier before retry or fallback.
- Define session-only timer backoff, native fallback, attempt allocation, and Claude/Codex transport behavior.
- Keep the transition contract mechanically checked across runtime guidance and dispatch fixtures.

## Non-goals

- Change the classifier implementation or its provider parsing rules.
- Change review verdict acceptance, CI gating, native-worker isolation, or provider behavior.

## Threat model

- Repository contributors can change runtime guidance and contract fixtures.
- The classifier supplies typed failure and session state to the transition.
- The runtime must not relaunch a disabled or timer-blocked external route.

## Verification

- review-dispatch-test.py: 31 fixtures
- transport-contract-test.py
- scripts/validate-plugins.sh
- git diff --check

Depends on #189. Merge #189 first. This PR is part of the #188 rescope.
