### PR TITLE
document external review backoff compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ Optional when Claude Code is the orchestrator:
 - **Codex CLI (`codex`)** — the default independent reviewer for `gauntlet:campaign` under Claude Code.
   When Codex is installed, campaign reviews with it (`codex exec`) for engine diversity — a different
   engine catches defects a same-model re-roll misses. It launches at native-limitation level; engine
-  diversity needs no OS sandbox. When Codex is absent, or a cross-engine process fails after one retry,
-  campaign falls back to a fresh native worker under the documented native limitations, so the campaign
-  runs with or without Codex. An explicit selection or saved preference overrides the default (you can
+  diversity needs no OS sandbox. Before retry or fallback, use the campaign runtime adapter's
+  classification and fallback contract. Transient failures may use the one retry, valid timers wait for
+  exact provider deadlines, and permanent, malformed, unsupported, or unrecognized failures disable that
+  external route for the current session before campaign falls back to a fresh native worker under the
+  documented native limitations.
+  Session backoff is never durable, so the campaign runs with or without Codex. An explicit selection or
+  saved preference overrides the default (you can
   force a native reviewer). Missing native filesystem/startup controls alone never park a pass.
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Optional when Claude Code is the orchestrator:
   engine catches defects a same-model re-roll misses. It launches at native-limitation level; engine
   diversity needs no OS sandbox. Before retry or fallback, use the campaign runtime adapter's
   classification and fallback contract. Transient failures may use the one retry, valid timers wait for
-  exact provider deadlines, and permanent, malformed, unsupported, or unrecognized failures disable that
-  external route for the current session before campaign falls back to a fresh native worker under the
-  documented native limitations.
+  exact provider deadlines, and permanent, malformed, or unsupported failures disable that external route
+  for the current session. Unrecognized failures fall back to a fresh native worker without disabling the
+  route under the documented native limitations.
   Session backoff is never durable, so the campaign runs with or without Codex. An explicit selection or
   saved preference overrides the default (you can
   force a native reviewer). Missing native filesystem/startup controls alone never park a pass.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ Optional when Claude Code is the orchestrator:
   When Codex is installed, campaign reviews with it (`codex exec`) for engine diversity — a different
   engine catches defects a same-model re-roll misses. It launches at native-limitation level; engine
   diversity needs no OS sandbox. Before retry or fallback, use the campaign runtime adapter's
-  classification and fallback contract. Transient failures may use the one retry, valid timers wait for
-  exact provider deadlines, and permanent, malformed, or unsupported failures disable that external route
-  for the current session. Unrecognized failures fall back to a fresh native worker without disabling the
-  route under the documented native limitations.
+  classification and fallback contract. Transient failures may use the one retry. A valid timer waits only
+  while that retry is unspent and the current time is before its deadline; after the retry is spent, fall
+  back immediately while retaining session backoff for other launches. Permanent failures, including
+  malformed or unsupported timer text, disable that external route for the current session. Opaque or
+  unrecognized failures fall back to a fresh native worker without disabling the route under the documented
+  native limitations.
   Session backoff is never durable, so the campaign runs with or without Codex. An explicit selection or
   saved preference overrides the default (you can
   force a native reviewer). Missing native filesystem/startup controls alone never park a pass.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -36,9 +36,10 @@ Campaign's exact cross-agent command lines live in
   `os_filesystem_isolation` properties are an optional stronger-boundary claim that never blocks launch.
   When the paired CLI is absent, use a fresh native worker. When the process fails, use the campaign
   runtime adapter's classification and fallback contract: transient failures may use the one retry, valid
-  timers wait for exact provider deadlines, and permanent, malformed, unsupported, or unrecognized
+  timers wait for exact provider deadlines, and permanent failures or malformed or unsupported timer
   failures disable that external route for the current session before falling back to a fresh native
-  worker. Session backoff is never durable.
+  worker. Unrecognized failures fall back to a fresh native worker without disabling that route. Session
+  backoff is never durable.
   The existing external Codex retry uses the typed `codex-recovery` prompt profile from **Review
   preparation mapping**; every other launch uses `standard`. Profiles never add attempts, resume a failed
   session, weaken the shared review contract, or require a model switch.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -14,7 +14,7 @@ adapter; keep workflow rules shared.
 | Agent dispatch | Agent tool and configured agent types | Available Codex multi-agent controls | Describe worker scope, permissions, model class, and output; do not require a host tool name. |
 | Model selection | Claude model aliases may be available | Session model or configured Codex agents | State required capability; map named models only inside host adapter. |
 | Heartbeat/resume | `ScheduleWakeup` where available | wakes its thread where available; bounded foreground wait otherwise | Persist state before waiting and provide an exact resume path. |
-| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Fall back to a fresh native worker when it is absent or fails. Explicit or saved user choice overrides. |
+| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Classify failures before retry or fallback: wait for valid timer deadlines, disable permanent or malformed external routes for the session, and use a fresh native worker. Explicit or saved user choice overrides. |
 
 Campaign's exact cross-agent command lines live in
 [`plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md`](../plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md).
@@ -34,7 +34,11 @@ Campaign's exact cross-agent command lines live in
 - Evaluate cross-engine reviewers through the runtime adapter's `ReviewIsolationCapability` transition.
   A cross-engine route launches at native-limitation level whenever the paired CLI is present; the three
   `os_filesystem_isolation` properties are an optional stronger-boundary claim that never blocks launch.
-  When the paired CLI is absent, or the process fails after its retry, fall back to a fresh native worker.
+  When the paired CLI is absent, use a fresh native worker. When the process fails, use the campaign
+  runtime adapter's classification and fallback contract: transient failures may use the one retry, valid
+  timers wait for exact provider deadlines, and permanent, malformed, unsupported, or unrecognized
+  failures disable that external route for the current session before falling back to a fresh native
+  worker. Session backoff is never durable.
   The existing external Codex retry uses the typed `codex-recovery` prompt profile from **Review
   preparation mapping**; every other launch uses `standard`. Profiles never add attempts, resume a failed
   session, weaken the shared review contract, or require a model switch.

--- a/docs/runtime-compatibility.md
+++ b/docs/runtime-compatibility.md
@@ -14,7 +14,7 @@ adapter; keep workflow rules shared.
 | Agent dispatch | Agent tool and configured agent types | Available Codex multi-agent controls | Describe worker scope, permissions, model class, and output; do not require a host tool name. |
 | Model selection | Claude model aliases may be available | Session model or configured Codex agents | State required capability; map named models only inside host adapter. |
 | Heartbeat/resume | `ScheduleWakeup` where available | wakes its thread where available; bounded foreground wait otherwise | Persist state before waiting and provide an exact resume path. |
-| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Classify failures before retry or fallback: wait for valid timer deadlines, disable permanent or malformed external routes for the session, and use a fresh native worker. Explicit or saved user choice overrides. |
+| Other-agent reviewer | Default: review with `codex exec` | Default: review with `claude -p` | Cross-engine is the default, launched at native-limitation level when the paired CLI is present. Classify failures before retry or fallback: a valid timer waits only while the retry is unspent and the current time is before its deadline; after the retry is spent, fall back immediately while retaining session backoff. Disable the external route only for permanent failures, including malformed or unsupported timer text; unrecognized failures use a fresh native worker without disabling it. Explicit or saved user choice overrides. |
 
 Campaign's exact cross-agent command lines live in
 [`plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md`](../plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md).
@@ -35,11 +35,12 @@ Campaign's exact cross-agent command lines live in
   A cross-engine route launches at native-limitation level whenever the paired CLI is present; the three
   `os_filesystem_isolation` properties are an optional stronger-boundary claim that never blocks launch.
   When the paired CLI is absent, use a fresh native worker. When the process fails, use the campaign
-  runtime adapter's classification and fallback contract: transient failures may use the one retry, valid
-  timers wait for exact provider deadlines, and permanent failures or malformed or unsupported timer
-  failures disable that external route for the current session before falling back to a fresh native
-  worker. Unrecognized failures fall back to a fresh native worker without disabling that route. Session
-  backoff is never durable.
+  runtime adapter's classification and fallback contract: transient failures may use the one retry. A valid
+  timer waits for the exact provider deadline only while the retry is unspent and the current time is before
+  that deadline; after the retry is spent, fall back immediately while retaining session backoff for other
+  launches. Permanent failures, including malformed or unsupported timer text, disable that external route
+  for the current session before falling back to a fresh native worker. Opaque or unrecognized failures fall
+  back to a fresh native worker without disabling that route. Session backoff is never durable.
   The existing external Codex retry uses the typed `codex-recovery` prompt profile from **Review
   preparation mapping**; every other launch uses `standard`. Profiles never add attempts, resume a failed
   session, weaken the shared review contract, or require a model switch.

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -70,10 +70,11 @@ record a preference in the orchestrator's own trusted state — never in the che
 (`skills/campaign/references/reviewer.md`, "Selecting the reviewer", owns which sources count). If the paired CLI is absent, or a cross-engine
 reviewer can't return a verdict, use the classification and fallback contract owned by
 `skills/campaign/references/runtime-adapter.md`, "Review failure classification and session backoff".
-That contract permits one retry for transient failures, waits for valid timers at exact provider
-deadlines, and treats malformed or unsupported timer text as permanent before sending it to native fallback
-and disabling the external route for this session. Unrecognized typed failure kinds use native fallback
-without disabling the route.
+That contract permits one retry for transient failures. A valid timer waits at the exact provider deadline
+only while the retry is unspent and the current time is before that deadline; after the retry is spent,
+native fallback is immediate while session backoff is retained for other launches. Malformed or unsupported
+timer text is permanent and disables the external route for this session before native fallback. Opaque or
+unrecognized typed failure kinds use native fallback without disabling the route.
 Session backoff and disabled state are never durable. The retry uses the same full review contract and process
 command; only the mapped Codex recovery
 profile adds repository-maintenance framing. It never resumes the failed session or requires a model

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -68,10 +68,14 @@ native-limitation level whenever the paired CLI is present — engine diversity 
 You can override the default: name a reviewer when you invoke the campaign (including a native worker), or
 record a preference in the orchestrator's own trusted state — never in the checkout under review
 (`skills/campaign/references/reviewer.md`, "Selecting the reviewer", owns which sources count). If the paired CLI is absent, or a cross-engine
-reviewer can't return a verdict because of a system problem (quota, auth, timeout), the pipeline retries
-once and then falls back to a fresh native worker. The existing Codex retry uses repository-maintenance
-framing with the same full review contract and process command; it does not resume the failed session or
-switch models. Campaign therefore runs with or without the other engine.
+reviewer can't return a verdict, use the classification and fallback contract owned by
+`skills/campaign/references/runtime-adapter.md`, "Review failure classification and session backoff".
+That contract permits one retry for transient failures, waits for valid timers at exact provider
+deadlines, and sends permanent, malformed, unsupported, or unrecognized failures to native fallback
+after disabling the external route for this session. Session backoff and disabled state are never
+durable. The retry uses the same full review contract and process command; only the mapped Codex recovery
+profile adds repository-maintenance framing. It never resumes the failed session or requires a model
+switch. Campaign therefore runs with or without the other engine.
 The cross-engine and native routes both keep fresh conversational context and disclose the host's
 filesystem/startup-instruction limitations; a future adapter that proves an OS boundary can claim more.
 

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -71,8 +71,9 @@ record a preference in the orchestrator's own trusted state — never in the che
 reviewer can't return a verdict, use the classification and fallback contract owned by
 `skills/campaign/references/runtime-adapter.md`, "Review failure classification and session backoff".
 That contract permits one retry for transient failures, waits for valid timers at exact provider
-deadlines, and sends permanent, malformed, or unsupported failures to native fallback after disabling the
-external route for this session. Unrecognized failures use native fallback without disabling the route.
+deadlines, and treats malformed or unsupported timer text as permanent before sending it to native fallback
+and disabling the external route for this session. Unrecognized typed failure kinds use native fallback
+without disabling the route.
 Session backoff and disabled state are never durable. The retry uses the same full review contract and process
 command; only the mapped Codex recovery
 profile adds repository-maintenance framing. It never resumes the failed session or requires a model

--- a/plugins/gauntlet/README.md
+++ b/plugins/gauntlet/README.md
@@ -71,9 +71,10 @@ record a preference in the orchestrator's own trusted state — never in the che
 reviewer can't return a verdict, use the classification and fallback contract owned by
 `skills/campaign/references/runtime-adapter.md`, "Review failure classification and session backoff".
 That contract permits one retry for transient failures, waits for valid timers at exact provider
-deadlines, and sends permanent, malformed, unsupported, or unrecognized failures to native fallback
-after disabling the external route for this session. Session backoff and disabled state are never
-durable. The retry uses the same full review contract and process command; only the mapped Codex recovery
+deadlines, and sends permanent, malformed, or unsupported failures to native fallback after disabling the
+external route for this session. Unrecognized failures use native fallback without disabling the route.
+Session backoff and disabled state are never durable. The retry uses the same full review contract and process
+command; only the mapped Codex recovery
 profile adds repository-maintenance framing. It never resumes the failed session or requires a model
 switch. Campaign therefore runs with or without the other engine.
 The cross-engine and native routes both keep fresh conversational context and disclose the host's

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -231,15 +231,16 @@ never the place to look them up.
   reviewer when you invoke the campaign
   (for example, “review with claude”, or a native worker) or record a preference in the orchestrator's own
   trusted state — never in the checkout under review (`references/reviewer.md`, "Selecting the reviewer", owns which sources count).
-  If the paired CLI is absent, or a cross-engine reviewer
-  can't return a verdict because of a system problem — quota or rate limits, auth, a timeout — follow
-  [`references/runtime-adapter.md`](./references/runtime-adapter.md), "Review failure classification and session backoff".
-  That owner classifies the failure as transient for one immediate retry, timer for an exact-deadline wait
-  before retrying, permanent for immediate native fallback with session disable, or unrecognized for native
-  fallback without session disable. The existing Codex retry uses
-  repository-maintenance framing with the same complete review contract and process command; it never
-  resumes the failed session or requires a model switch. Campaign therefore runs with or without the other
-  engine. The fallback uses the disclosed native isolation contract. A reviewer that never
+  If the paired CLI is absent, or a cross-engine reviewer can't return a verdict, follow the classification
+  and fallback contract owned by [`references/runtime-adapter.md`](./references/runtime-adapter.md),
+  "Review failure classification and session backoff". That contract permits one retry for transient
+  failures, waits for valid timers at exact provider deadlines, and sends permanent, malformed, unsupported,
+  or unrecognized failures to native fallback. Permanent failures disable the external route for this
+  session; unrecognized failures use native fallback without disabling it. Session backoff and disabled
+  state are never durable. The retry uses the same complete review contract and process command; only the
+  mapped Codex recovery profile adds repository-maintenance framing. It never resumes the failed session
+  or requires a model switch. Campaign therefore runs with or without the other engine. The fallback uses
+  the disclosed native isolation contract. A reviewer that never
   gets going at all — hung on input, a bad path, a sandbox
   denial — is caught the same way: every review pass has to write *something* to its progress file
   within about five minutes of being dispatched, and one that writes nothing at all is killed and

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -234,9 +234,9 @@ never the place to look them up.
   If the paired CLI is absent, or a cross-engine reviewer can't return a verdict, follow the classification
   and fallback contract owned by [`references/runtime-adapter.md`](./references/runtime-adapter.md),
   "Review failure classification and session backoff". That contract permits one retry for transient
-  failures, waits for valid timers at exact provider deadlines, and sends permanent, malformed, unsupported,
-  or unrecognized failures to native fallback. Permanent failures disable the external route for this
-  session; unrecognized failures use native fallback without disabling it. Session backoff and disabled
+  failures, waits for valid timers at exact provider deadlines, and treats malformed or unsupported timer
+  text as permanent. Permanent failures go to native fallback and disable the external route for this
+  session; unrecognized typed failure kinds use native fallback without disabling it. Session backoff and disabled
   state are never durable. The retry uses the same complete review contract and process command; only the
   mapped Codex recovery profile adds repository-maintenance framing. It never resumes the failed session
   or requires a model switch. Campaign therefore runs with or without the other engine. The fallback uses

--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -234,10 +234,12 @@ never the place to look them up.
   If the paired CLI is absent, or a cross-engine reviewer can't return a verdict, follow the classification
   and fallback contract owned by [`references/runtime-adapter.md`](./references/runtime-adapter.md),
   "Review failure classification and session backoff". That contract permits one retry for transient
-  failures, waits for valid timers at exact provider deadlines, and treats malformed or unsupported timer
-  text as permanent. Permanent failures go to native fallback and disable the external route for this
-  session; unrecognized typed failure kinds use native fallback without disabling it. Session backoff and disabled
-  state are never durable. The retry uses the same complete review contract and process command; only the
+  failures. A valid timer waits at the exact provider deadline only while the retry is unspent and the
+  current time is before that deadline; after the retry is spent, native fallback is immediate while session
+  backoff is retained for other launches. Permanent failures, including malformed or unsupported timer text,
+  go to native fallback and disable the external route for this session. Opaque or unrecognized typed failure
+  kinds use native fallback without disabling it. Session backoff and disabled state are never durable. The
+  retry uses the same complete review contract and process command; only the
   mapped Codex recovery profile adds repository-maintenance framing. It never resumes the failed session
   or requires a model switch. Campaign therefore runs with or without the other engine. The fallback uses
   the disclosed native isolation contract. A reviewer that never

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -132,8 +132,10 @@ is the absence of a verdict.
 `runtime-adapter.md`, "Review failure classification and session backoff".** The helper returns
 `transient`, `timer`, `permanent`, or `unrecognized`; permanent markers and malformed or unsupported
 timer text are permanent, while opaque text is unrecognized. Apply the returned transition: transient
-failures may spend the one retry, valid timers wait for the exact provider deadline before retrying,
-permanent failures disable that external route for this session, and unrecognized failures use native
+failures may spend the one retry. A valid timer waits for the exact provider deadline only while the retry
+is unspent and the current time is before that deadline; after the retry is spent, fall back immediately
+while retaining session backoff for other launches. Permanent failures, including malformed or unsupported
+timer text, disable that external route for this session, and opaque or unrecognized failures use native
 fallback without disabling the external route.
 The paired CLI absence is a pre-launch capability miss and takes native fallback without a retry. Keep
 the session backoff state in memory only; never write it to campaign artifacts.


### PR DESCRIPTION
## Purpose

- Restate the external review backoff contract in repository-facing documentation.
- Keep Claude Code and Codex compatibility guidance aligned with session-only native fallback behavior.

## Non-goals

- Change executable classifier or runtime transition behavior.
- Change review verdict acceptance, CI gating, or provider behavior.

## Threat model

- Repository contributors and users rely on these documents to select compatible review behavior.
- Documentation drift must not describe a retry or timer policy that differs from the runtime contract.

## Verification

- scripts/validate-plugins.sh
- git diff --check

Depends on #189 and follows #190. Merge #189 and #190 first. This PR is part of the #188 rescope.
