### PR TITLE
fix ci-status equals-form documentation checks

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1291,6 +1291,12 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
             "ci-status.py derive --pr=1 --required-set=unknown",
             "ci-status.py derive --pr=1",
             "--practical",
+            (
+                "--pr/foo=1",
+                "--pr:1",
+                "--pr=1 --required-set/foo=unknown",
+                "--pr=1 --required-set:unknown",
+            ),
         ),
         (
             "liveness",
@@ -1298,6 +1304,12 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
             "ci-status.py liveness --ledger=run/state.jsonl --pr=1 --machine-action=none",
             "ci-status.py liveness --ledger=run/state.jsonl --pr=1",
             "--ledger-file",
+            (
+                "--ledger/run/state.jsonl --pr=1 --machine-action=none",
+                "--ledger:run/state.jsonl --pr=1 --machine-action=none",
+                "--ledger=run/state.jsonl --pr=1 --machine-action/foo=none",
+                "--ledger=run/state.jsonl --pr=1 --machine-action:none",
+            ),
         ),
         (
             "required-set",
@@ -1305,9 +1317,13 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
             "ci-status.py required-set --ledger=run/state.jsonl",
             "ci-status.py required-set --ledger=",
             "--ledger-file",
+            (
+                "--ledger/run/state.jsonl",
+                "--ledger:run/state.jsonl",
+            ),
         ),
     ]
-    for name, check, valid, missing, lookalike in cases:
+    for name, check, valid, missing, lookalike, invalid_forms in cases:
         valid_root = tmp / f"documentation-options-{name}-valid"
         valid_root.mkdir()
         (valid_root / "commands.md").write_text(f"`{valid}`\n", encoding="utf-8")
@@ -1339,6 +1355,19 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
                 f"[documentation options {name}:lookalike] expected no accepted copy; "
                 f"got copies={copies!r}, problems={found!r}"
             )
+
+        for invalid in invalid_forms:
+            invalid_root = tmp / f"documentation-options-{name}-{invalid.replace('/', '-')}"
+            invalid_root.mkdir()
+            (invalid_root / "commands.md").write_text(
+                f"`ci-status.py {name} {invalid}`\n", encoding="utf-8"
+            )
+            found, copies = check(invalid_root)
+            if not found:
+                problems.append(
+                    f"[documentation options {name}:invalid-boundary {invalid!r}] expected the "
+                    f"punctuation-separated form to be rejected; got copies={copies!r}, problems={found!r}"
+                )
     return problems
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1281,6 +1281,67 @@ def verdict_doc_cases(ci) -> list[str]:
     return problems
 
 
+def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
+    """Pin standalone and ``--name=value`` forms in all three documentation validators."""
+    problems: list[str] = []
+    cases = [
+        (
+            "derive",
+            ci.check_derive_copies,
+            "ci-status.py derive --pr=1 --required-set=unknown",
+            "ci-status.py derive --pr=1",
+            "--practical",
+        ),
+        (
+            "liveness",
+            ci.check_liveness_copies,
+            "ci-status.py liveness --ledger=run/state.jsonl --pr=1 --machine-action=none",
+            "ci-status.py liveness --ledger=run/state.jsonl --pr=1",
+            "--ledger-file",
+        ),
+        (
+            "required-set",
+            ci.check_required_set_copies,
+            "ci-status.py required-set --ledger=run/state.jsonl",
+            "ci-status.py required-set --ledger=",
+            "--ledger-file",
+        ),
+    ]
+    for name, check, valid, missing, lookalike in cases:
+        valid_root = tmp / f"documentation-options-{name}-valid"
+        valid_root.mkdir()
+        (valid_root / "commands.md").write_text(f"`{valid}`\n", encoding="utf-8")
+        found, copies = check(valid_root)
+        if found or copies != ["commands.md:1"]:
+            problems.append(
+                f"[documentation options {name}:valid] expected one accepted copy; "
+                f"got copies={copies!r}, problems={found!r}"
+            )
+
+        missing_root = tmp / f"documentation-options-{name}-missing"
+        missing_root.mkdir()
+        (missing_root / "commands.md").write_text(f"`{missing}`\n", encoding="utf-8")
+        found, copies = check(missing_root)
+        if len(found) != 1 or copies != ["commands.md:1"]:
+            problems.append(
+                f"[documentation options {name}:missing] expected one reported copy; "
+                f"got copies={copies!r}, problems={found!r}"
+            )
+
+        lookalike_root = tmp / f"documentation-options-{name}-lookalike"
+        lookalike_root.mkdir()
+        (lookalike_root / "commands.md").write_text(
+            f"`ci-status.py {name} {lookalike}=value`\n", encoding="utf-8"
+        )
+        found, copies = check(lookalike_root)
+        if len(found) != 1 or copies:
+            problems.append(
+                f"[documentation options {name}:lookalike] expected no accepted copy; "
+                f"got copies={copies!r}, problems={found!r}"
+            )
+    return problems
+
+
 def run(ci, tmp: Path) -> int:
     """Every fixture, then the seams, then `doc-check`. Non-zero on any failure.
 
@@ -1347,6 +1408,14 @@ def run(ci, tmp: Path) -> int:
     if not verdict_doc_problems:
         print(f"ok       {'DECIDE verdict terminology':32} -> UNUSABLE and UNVERIFIABLE both remain explicit "
               f"before liveness groups them")
+
+    documentation_option_problems = documentation_option_form_cases(ci, tmp)
+    for problem in documentation_option_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not documentation_option_problems:
+        print(f"ok       {'documentation option forms':32} -> standalone and --name=value forms are "
+              f"recognized without accepting option-name lookalikes")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2249,7 +2249,7 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
 
 def _has_long_option(command: str, option: str) -> bool:
     """Recognize one long-option token, including argparse's ``--name=value`` form."""
-    return re.search(rf"(?<![\w-]){re.escape(option)}(?![\w-])", command) is not None
+    return re.search(rf"(?<![\w-]){re.escape(option)}(?=[=\s]|$)", command) is not None
 
 
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2247,6 +2247,11 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
     return problems
 
 
+def _has_long_option(command: str, option: str) -> bool:
+    """Recognize one long-option token, including argparse's ``--name=value`` form."""
+    return re.search(rf"(?<![\w-]){re.escape(option)}(?![\w-])", command) is not None
+
+
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
     """EVERY COPY OF THE DERIVE COMMAND, IN EVERY SKILL DOC — not just the one in the doc under test.
 
@@ -2271,11 +2276,11 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
         for m in re.finditer(r"ci-status\.py derive", text):
             end = text.find("\n\n", m.start())
             command = text[m.start(): end if end > 0 else len(text)]
-            if "--pr" not in command:
+            if not _has_long_option(command, "--pr"):
                 continue  # prose that NAMES the command, not a copy of it
             n = text.count("\n", 0, m.start()) + 1
             copies.append(f"{md.name}:{n}")
-            if "--ledger" not in command and "--required-set" not in command:
+            if not _has_long_option(command, "--ledger") and not _has_long_option(command, "--required-set"):
                 problems.append(
                     f"{md.name}:{n} runs `ci-status.py derive` WITHOUT `--ledger` OR `--required-set` — the "
                     f"flag that makes `green` mean the REQUIRED SET passed. A reader following this copy "
@@ -2306,11 +2311,11 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
             # `--ledger`, not `--pr`, is the runnable-copy gate here: prose about liveness routinely sits
             # in the same paragraph as a `ledger.py … set --pr` command, and `--pr` alone would condemn
             # every such mention as a flagless invocation.
-            if "--ledger" not in command:
+            if not _has_long_option(command, "--ledger"):
                 continue  # prose that names the subcommand, not a runnable copy
             line = text.count("\n", 0, match.start()) + 1
             copies.append(f"{md.name}:{line}")
-            if "--machine-action" not in command:
+            if not _has_long_option(command, "--machine-action"):
                 problems.append(
                     f"{md.name}:{line} runs `ci-status.py liveness` WITHOUT `--machine-action` — the one "
                     f"judgment the command asks of its caller. The tool refuses the invocation; a reader "
@@ -2332,7 +2337,7 @@ def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list
         for match in re.finditer(r"ci-status\.py required-set", text):
             end = text.find("\n\n", match.start())
             command = text[match.start(): end if end > 0 else len(text)]
-            if "--ledger" not in command:
+            if not _has_long_option(command, "--ledger"):
                 continue  # prose that names the subcommand, not a runnable copy
             line = text.count("\n", 0, match.start()) + 1
             copies.append(f"{md.name}:{line}")


### PR DESCRIPTION
- Support standalone and `--name=value` options in three CI-status documentation validators.
- Cover valid forms, missing inputs, and option-name lookalikes.
- Run 36 CI-status checks, self-test, doc-check, plugin validation, Python compilation, and diff checks.
