### PR TITLE
fix status-based watch maintenance checks

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -62,12 +62,12 @@ WATCH_STATUS_CONDITION = (
     r"\b(?:ci(?:\s+status)?|status)\b\s*(?:is|=|==|:)\s*"
     r"(?:[`\"']\s*)?(?:quoted\s+)?"
     + WATCH_STATUS_VALUES
-    + r"\b\s*[`\"']?(?=\s|[.!?;|,)\]}]|$)"
+    + r"\b\s*[`\"']?(?=\s|[.!?;:|,)\]}]|$)"
 )
 WATCH_ACTIVE_MAINTENANCE_ACTION = (
     r"\b"
     + WATCH_MAINTENANCE_VERBS
-    + r"\b(?:\s+[\w-]+){0,8}\s+\bwatch(?:es|ed|ing)?\b"
+    + r"\b(?:\s+[\w-]+){0,8}?\s+\bwatch(?:es|ed|ing)?\b(?:\s+alive)?"
 )
 WATCH_PASSIVE_MAINTENANCE_ACTION = (
     r"\bwatch(?:es|ed|ing)?\b"
@@ -87,17 +87,32 @@ WATCH_WARRANTED_TRUE_GUARD_RE = re.compile(
     r"`?watch_warranted`?\s*(?:is|=|==|:)\s*`?true`?\b",
     re.IGNORECASE,
 )
-WATCH_NEGATED_ACTION_RE = re.compile(
-    r"\b(?:never|do\s+not|don't|doesn't|no\s+need\s+to|"
-    r"unnecessary\s+to|not\s+(?:required|necessary)\s+to)\b",
+WATCH_NEGATED_BEFORE_ACTION_RE = re.compile(
+    r"(?:\bnever\b|\bdo\s+not\b|\bdon't\b|\bdoesn't\b|"
+    r"\bno\s+need\s+to\b|\bunnecessary\s+to\b|"
+    r"\bnot(?:\s+(?:required|necessary))?\s+to\b|\bnot\b)\s*$",
     re.IGNORECASE,
 )
 WATCH_NEGATED_AFTER_ACTION_RE = re.compile(
-    r"\b(?:is|are|becomes?|seems?)\s+(?:unnecessary|"
+    r"^\s*(?:is|are|becomes?|seems?)\s+(?:unnecessary|"
     r"not\s+(?:required|necessary))\b",
     re.IGNORECASE,
 )
-WATCH_QUOTED_SPAN_RE = re.compile(r"`[^`\n]*`|\"[^\"\n]*\"|“[^”\n]*”|‘[^’\n]*’")
+WATCH_QUOTED_SPAN_RE = re.compile(
+    r"`[^`\n]*`|\"[^\"\n]*\"|(?<!\w)'[^'\n]*'(?!\w)|“[^”\n]*”|‘[^’\n]*’"
+)
+WATCH_GUARD_BEFORE_ACTION_GAP_RE = re.compile(
+    r"^\s*[,;:()\[\]-]*(?:(?:then|and)\s+)?[,;:()\[\]-]*\s*$",
+    re.IGNORECASE,
+)
+WATCH_GUARD_AFTER_ACTION_GAP_RE = re.compile(
+    r"^\s*[,;:()\[\]-]*(?:only|then|and)?[,;:()\[\]-]*\s*$",
+    re.IGNORECASE,
+)
+WATCH_STATUS_GUARD_AFTER_ACTION_GAP_RE = re.compile(
+    rf"^\s*(?:when|if|while)\s+{WATCH_STATUS_CONDITION}(?:\s+only)?\s*$",
+    re.IGNORECASE,
+)
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
 )
@@ -428,19 +443,47 @@ def watch_action_is_negated(clause: str, action: re.Match[str]) -> bool:
     before = clause[:action.start()]
     after = clause[action.end():]
     return (
-        WATCH_NEGATED_ACTION_RE.search(before) is not None
-        or WATCH_NEGATED_AFTER_ACTION_RE.search(after) is not None
+        WATCH_NEGATED_BEFORE_ACTION_RE.search(before) is not None
+        or WATCH_NEGATED_AFTER_ACTION_RE.match(after) is not None
     )
+
+
+def watch_guard_prefix_is_conditional(clause: str, guard: re.Match[str]) -> bool:
+    prefix = clause[:guard.start()]
+    prefix = WATCH_STATUS_CONDITION_RE.sub("", prefix)
+    return re.fullmatch(
+        r"\s*[,;:()\[\]-]*(?:(?:then|and|only)\s+)?[,;:()\[\]-]*\s*",
+        prefix,
+        re.IGNORECASE,
+    ) is not None
 
 
 def watch_action_has_true_warrant_guard(
     clause: str,
     action: re.Match[str],
 ) -> bool:
-    return any(
-        guard.end() <= action.start() or action.end() <= guard.start()
-        for guard in WATCH_WARRANTED_TRUE_GUARD_RE.finditer(clause)
-    )
+    quoted_spans = list(WATCH_QUOTED_SPAN_RE.finditer(clause))
+    for guard in WATCH_WARRANTED_TRUE_GUARD_RE.finditer(clause):
+        if any(
+            quoted.start() <= guard.start() and guard.end() <= quoted.end()
+            for quoted in quoted_spans
+        ):
+            continue
+        if guard.end() <= action.start():
+            gap = clause[guard.end():action.start()]
+            if (
+                WATCH_GUARD_BEFORE_ACTION_GAP_RE.fullmatch(gap)
+                and watch_guard_prefix_is_conditional(clause, guard)
+            ):
+                return True
+        elif action.end() <= guard.start():
+            gap = clause[action.end():guard.start()]
+            if (
+                WATCH_GUARD_AFTER_ACTION_GAP_RE.fullmatch(gap)
+                or WATCH_STATUS_GUARD_AFTER_ACTION_GAP_RE.fullmatch(gap)
+            ):
+                return True
+    return False
 
 
 def check_status_watch_maintenance_docs(root: Path = ROOT) -> list[str]:
@@ -451,12 +494,13 @@ def check_status_watch_maintenance_docs(root: Path = ROOT) -> list[str]:
         for clause, line in markdown_watch_clauses(text):
             if WATCH_STATUS_CONDITION_RE.search(clause) is None:
                 continue
-            action = WATCH_MAINTENANCE_ACTION_RE.search(clause)
-            if action is None or watch_action_is_quoted(clause, action):
-                continue
-            if watch_action_is_negated(clause, action):
-                continue
-            if watch_action_has_true_warrant_guard(clause, action):
+            actions = WATCH_MAINTENANCE_ACTION_RE.finditer(clause)
+            if all(
+                watch_action_is_quoted(clause, action)
+                or watch_action_is_negated(clause, action)
+                or watch_action_has_true_warrant_guard(clause, action)
+                for action in actions
+            ):
                 continue
             relative = document.relative_to(root).as_posix()
             problems.append(
@@ -514,6 +558,16 @@ def run_watch_action_fixtures() -> None:
             True,
         ),
         (
+            "quoted-warrant-guard-mention",
+            'CI status is pending, ensure a watch as documented by "when watch_warranted is true".',
+            True,
+        ),
+        (
+            "explanatory-warrant-guard-mention",
+            "CI status is pending, ensure a watch as documented by when watch_warranted is true.",
+            True,
+        ),
+        (
             "true-watch-warranted-guard",
             "Ensure a watch when CI status is pending only when returned watch_warranted is true.",
             False,
@@ -528,6 +582,8 @@ def run_watch_action_fixtures() -> None:
         ("quoted-status", 'Ensure a watch when CI status is "pending".', True),
         ("code-status", "Ensure a watch when CI status is `pending`.", True),
         ("quoted-word-status", "Ensure a watch when CI status is quoted pending.", True),
+        ("colon-status", "CI status is pending: keep a watch.", True),
+        ("quoted-action", "CI status is pending, 'keep a watch'.", False),
         ("no-need-negation", "No need to keep a watch when CI status is pending.", False),
         (
             "unnecessary-negation",
@@ -538,6 +594,21 @@ def run_watch_action_fixtures() -> None:
             "not-required-negation",
             "It is not required to keep a watch when CI status is pending.",
             False,
+        ),
+        (
+            "unrelated-negation",
+            "It is not required to merge, but keep a watch when CI status is pending.",
+            True,
+        ),
+        (
+            "negated-then-positive-action",
+            "CI status is pending, do not keep a watch but ensure a watch.",
+            True,
+        ),
+        (
+            "contractions-are-not-quotes",
+            "CI status is pending, don't keep a watch, ensure a watch, don't stop.",
+            True,
         ),
         ("separate-list-items", "- CI status is pending\n- Keep a watch.", False),
         ("separate-sentences", "CI status is pending. Keep a watch.", False),

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -54,6 +55,23 @@ TRIAGE_TIER_BINDING = ("--tier", "<your decided tier>")
 WATCH_ACTION = (
     "Run `liveness`, then ensure or relaunch a watch only when returned "
     "`watch_warranted` is `true`"
+)
+WATCH_MAINTENANCE_VERBS = r"(?:keep|maintain|start|launch|relaunch|ensure)(?:s|ed|ing)?"
+WATCH_STATUS_VALUES = r"(?:pending|red|green|unknown|unusable|unverifiable)"
+WATCH_STATUS_CONDITION = (
+    r"\b(?:ci(?:\s+status)?|status)\b\s*(?:is|=|==|:)\s*"
+    + WATCH_STATUS_VALUES
+    + r"\b"
+)
+WATCH_MAINTENANCE_ACTION = (
+    r"\b"
+    + WATCH_MAINTENANCE_VERBS
+    + r"\b(?:\s+\w+){0,6}\s+\bwatch(?:es|ed|ing)?\b"
+)
+STATUS_WATCH_MAINTENANCE = re.compile(
+    rf"(?:{WATCH_MAINTENANCE_ACTION}[^.!?;|]{{0,120}}{WATCH_STATUS_CONDITION}|"
+    rf"{WATCH_STATUS_CONDITION}[^.!?;|]{{0,120}}{WATCH_MAINTENANCE_ACTION})",
+    re.IGNORECASE,
 )
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
@@ -335,6 +353,69 @@ def check_watch_consumers(adoption: str, loop_control: str) -> None:
     ):
         require(WATCH_ACTION in normalized(region),
                 f"{name} lost the liveness/watch_warranted gate")
+
+
+def check_status_watch_maintenance_docs(root: Path = ROOT) -> list[str]:
+    """Reject status-conditioned watch maintenance that does not use `watch_warranted`."""
+    problems: list[str] = []
+    for document in sorted(root.rglob("*.md")):
+        text = document.read_text(encoding="utf-8")
+        for match in STATUS_WATCH_MAINTENANCE.finditer(text):
+            clause_start = max(text.rfind(boundary, 0, match.start())
+                               for boundary in ".!?;|") + 1
+            clause_end_candidates = [text.find(boundary, match.end())
+                                     for boundary in ".!?;|"
+                                     if text.find(boundary, match.end()) >= 0]
+            clause_end = min(clause_end_candidates) if clause_end_candidates else len(text)
+            clause = text[clause_start:clause_end]
+            action = re.search(WATCH_MAINTENANCE_ACTION, clause, re.IGNORECASE)
+            if action is None:
+                continue
+            if re.search(r"\b(?:never|do not|don't|not)\b", clause[:action.start()], re.IGNORECASE):
+                continue
+            if re.search(r"\bLIVELOCKS\b", clause, re.IGNORECASE):
+                continue
+            if "watch_warranted" in clause:
+                continue
+            line = text.count("\n", 0, match.start()) + 1
+            relative = document.relative_to(root).as_posix()
+            problems.append(
+                f"{relative}:{line} adds status-based watch maintenance without `watch_warranted`"
+            )
+    return problems
+
+
+def run_watch_action_fixtures() -> None:
+    require(not check_status_watch_maintenance_docs(),
+            "current campaign docs contain an unregistered status-based watch action")
+
+    fixture_parent = ROOT.parents[4] / ".tmp"
+    fixture_parent.mkdir(exist_ok=True)
+    allowed = (
+        "Run liveness and keep a watch alive while CI is pending only when "
+        "`watch_warranted` is `true`."
+    )
+    for name, addition, expected in (
+        ("unregistered-keep", "Run liveness and keep a watch alive while CI is pending.", True),
+        ("unregistered-maintain", "Run liveness and maintain a watch while CI is pending.", True),
+        ("registered", allowed, False),
+    ):
+        with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
+            fixture_root = Path(temporary) / "campaign"
+            shutil.copytree(ROOT, fixture_root)
+            document = fixture_root / "references" / "stage-2-review-gate.md"
+            document.write_text(
+                document.read_text(encoding="utf-8") + "\n\n" + addition + "\n",
+                encoding="utf-8",
+            )
+            problems = check_status_watch_maintenance_docs(fixture_root)
+            found = any(
+                "stage-2-review-gate.md" in problem
+                and "status-based watch maintenance" in problem
+                for problem in problems
+            )
+            require(found is expected,
+                    f"{name} status-based watch maintenance fixture had the wrong result")
 
 
 def require_rejected(callback, expected: str, message: str) -> None:
@@ -662,6 +743,8 @@ def check_document_contract() -> None:
 
     check_campaign_triage_contract(stage, adoption, loop_control, skill)
     check_watch_consumers(adoption, loop_control)
+    require(not check_status_watch_maintenance_docs(),
+            "campaign docs contain an unregistered status-based watch action")
     new_row_summary = delimited_region(
         adoption,
         "   - **On a NEW row only, initialize:**",
@@ -1191,6 +1274,7 @@ def run_isolation_transition_fixtures() -> None:
 
 def main() -> int:
     check_document_contract()
+    run_watch_action_fixtures()
     run_triage_contract_fixtures()
     run_hostile_fixtures()
     run_repository_context_fixtures()

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -58,8 +58,12 @@ WATCH_ACTION = (
 )
 WATCH_MAINTENANCE_VERBS = r"(?:keep|maintain|start|launch|relaunch|ensure)(?:s|ed|ing)?"
 WATCH_STATUS_VALUES = r"(?:pending|red|green|unknown|unusable|unverifiable)"
+WATCH_STATUS_MARKUP = r"[`*_]{0,2}"
 WATCH_STATUS_CONDITION = (
-    r"\b(?:ci(?:\s+status)?|status)\b\s*(?:is|=|==|:)\s*"
+    WATCH_STATUS_MARKUP
+    + r"\b(?:ci(?:`?\s+`?status)?|status)\b"
+    + WATCH_STATUS_MARKUP
+    + r"\s*(?:is|=|==|:)\s*"
     r"(?:[`\"']\s*)?(?:quoted\s+)?"
     + WATCH_STATUS_VALUES
     + r"\b\s*[`\"']?(?=\s|[.!?;:|,)\]}]|$)"
@@ -80,11 +84,28 @@ WATCH_MAINTENANCE_ACTION = (
 )
 WATCH_STATUS_CONDITION_RE = re.compile(WATCH_STATUS_CONDITION, re.IGNORECASE)
 WATCH_MAINTENANCE_ACTION_RE = re.compile(WATCH_MAINTENANCE_ACTION, re.IGNORECASE)
+WATCH_WARRANTED_REPORTER = (
+    r"(?:`?liveness`?(?:\s+result)?|it)\s+(?:has|reports?|returns?)\s+"
+)
+WATCH_WARRANTED_TOKEN = r"`?watch_warranted`?"
+WATCH_WARRANTED_IS_TRUE = r"\s*(?:is|=|==|:)\s*`?true`?"
 WATCH_WARRANTED_TRUE_GUARD_RE = re.compile(
     r"\b(?:only\s+)?(?:when|if|provided(?:\s+that)?|as\s+long\s+as)\s+"
-    r"(?:(?:the|a)\s+)?(?:returned\s+)?"
-    r"(?:liveness\s+result\s+(?:has|reports?)\s+)?"
-    r"`?watch_warranted`?\s*(?:is|=|==|:)\s*`?true`?\b",
+    # The same introducer may carry the status condition first, as in
+    # "when CI status is pending and `liveness` reports `watch_warranted`".
+    + rf"(?:{WATCH_STATUS_CONDITION}\s*[,;:-]*\s*(?:and|but)?\s*(?:only\s+)?)?"
+    + r"(?:(?:the|a)\s+)?(?:returned\s+)?"
+    r"(?:"
+    # A named reporter (`liveness`, the liveness result, or a pronoun) makes the
+    # trailing `is true` optional: it is the docs' own house phrasing.
+    + WATCH_WARRANTED_REPORTER
+    + WATCH_WARRANTED_TOKEN
+    + rf"(?:{WATCH_WARRANTED_IS_TRUE})?"
+    r"|"
+    # Without a reporter, a bare token is not a guard: `is true` stays required.
+    + WATCH_WARRANTED_TOKEN
+    + WATCH_WARRANTED_IS_TRUE
+    + r")\b",
     re.IGNORECASE,
 )
 WATCH_NEGATED_BEFORE_ACTION_RE = re.compile(
@@ -110,7 +131,8 @@ WATCH_GUARD_AFTER_ACTION_GAP_RE = re.compile(
     re.IGNORECASE,
 )
 WATCH_STATUS_GUARD_AFTER_ACTION_GAP_RE = re.compile(
-    rf"^\s*(?:when|if|while)\s+{WATCH_STATUS_CONDITION}(?:\s+only)?\s*$",
+    rf"^\s*(?:when|if|while)\s+{WATCH_STATUS_CONDITION}"
+    r"\s*[,;:-]*\s*(?:but\s+)?(?:only\s*)?$",
     re.IGNORECASE,
 )
 MARKDOWN_LIST_ITEM = re.compile(
@@ -504,7 +526,8 @@ def check_status_watch_maintenance_docs(root: Path = ROOT) -> list[str]:
                 continue
             relative = document.relative_to(root).as_posix()
             problems.append(
-                f"{relative}:{line} adds status-based watch maintenance without `watch_warranted`"
+                f"{relative}:{line} adds status-based watch maintenance "
+                f"without a `watch_warranted` guard"
             )
     return problems
 
@@ -577,10 +600,55 @@ def run_watch_action_fixtures() -> None:
             "When watch_warranted is true, ensure a watch when CI status is pending.",
             False,
         ),
+        (
+            "named-reporter-guard",
+            "Ensure a live watch when CI status is pending and `liveness` reports "
+            "`watch_warranted`.",
+            False,
+        ),
+        (
+            "pronoun-reporter-guard",
+            "When CI status is pending, run `liveness` and ensure a watch only when it "
+            "reports `watch_warranted`.",
+            False,
+        ),
+        (
+            "named-reporter-true-guard",
+            "Ensure a watch when CI status is pending only when `liveness` reports "
+            "`watch_warranted` is `true`.",
+            False,
+        ),
+        (
+            "comma-before-guard",
+            "Ensure a watch when CI status is pending, only when returned "
+            "watch_warranted is true.",
+            False,
+        ),
+        (
+            "comma-and-but-before-guard",
+            "Ensure a watch when CI status is pending, but only when the returned "
+            "`watch_warranted` is `true`.",
+            False,
+        ),
+        (
+            "reporterless-bare-token-guard",
+            "Ensure a watch when CI status is pending only when watch_warranted changes.",
+            True,
+        ),
         ("passive-action", "A watch should be launched when CI status is pending.", True),
         ("hyphenated-action", "Keep a long-running watch alive when CI status is pending.", True),
         ("quoted-status", 'Ensure a watch when CI status is "pending".', True),
         ("code-status", "Ensure a watch when CI status is `pending`.", True),
+        ("code-field-and-status", "`ci` is `pending`, ensure a watch.", True),
+        ("code-field-plain-status", "`ci` is pending, ensure a watch.", True),
+        ("emphasis-field", "**ci** is pending, ensure a watch.", True),
+        ("code-field-phrase", "`ci status` is pending, ensure a watch.", True),
+        (
+            "code-field-relaunch",
+            "While `ci` is `pending`, relaunch the watch each heartbeat.",
+            True,
+        ),
+        ("field-substring-not-a-status", "Ensure a watch when sci is pending.", False),
         ("quoted-word-status", "Ensure a watch when CI status is quoted pending.", True),
         ("colon-status", "CI status is pending: keep a watch.", True),
         ("quoted-action", "CI status is pending, 'keep a watch'.", False),

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -60,19 +60,44 @@ WATCH_MAINTENANCE_VERBS = r"(?:keep|maintain|start|launch|relaunch|ensure)(?:s|e
 WATCH_STATUS_VALUES = r"(?:pending|red|green|unknown|unusable|unverifiable)"
 WATCH_STATUS_CONDITION = (
     r"\b(?:ci(?:\s+status)?|status)\b\s*(?:is|=|==|:)\s*"
+    r"(?:[`\"']\s*)?(?:quoted\s+)?"
     + WATCH_STATUS_VALUES
+    + r"\b\s*[`\"']?(?=\s|[.!?;|,)\]}]|$)"
+)
+WATCH_ACTIVE_MAINTENANCE_ACTION = (
+    r"\b"
+    + WATCH_MAINTENANCE_VERBS
+    + r"\b(?:\s+[\w-]+){0,8}\s+\bwatch(?:es|ed|ing)?\b"
+)
+WATCH_PASSIVE_MAINTENANCE_ACTION = (
+    r"\bwatch(?:es|ed|ing)?\b"
+    r"(?:\s+(?:should|must|may|can|will|is|are|be)){0,3}\s+"
+    + WATCH_MAINTENANCE_VERBS
     + r"\b"
 )
 WATCH_MAINTENANCE_ACTION = (
-    r"\b"
-    + WATCH_MAINTENANCE_VERBS
-    + r"\b(?:\s+\w+){0,6}\s+\bwatch(?:es|ed|ing)?\b"
+    rf"(?:{WATCH_ACTIVE_MAINTENANCE_ACTION}|{WATCH_PASSIVE_MAINTENANCE_ACTION})"
 )
-STATUS_WATCH_MAINTENANCE = re.compile(
-    rf"(?:{WATCH_MAINTENANCE_ACTION}[^.!?;|]{{0,120}}{WATCH_STATUS_CONDITION}|"
-    rf"{WATCH_STATUS_CONDITION}[^.!?;|]{{0,120}}{WATCH_MAINTENANCE_ACTION})",
+WATCH_STATUS_CONDITION_RE = re.compile(WATCH_STATUS_CONDITION, re.IGNORECASE)
+WATCH_MAINTENANCE_ACTION_RE = re.compile(WATCH_MAINTENANCE_ACTION, re.IGNORECASE)
+WATCH_WARRANTED_TRUE_GUARD_RE = re.compile(
+    r"\b(?:only\s+)?(?:when|if|provided(?:\s+that)?|as\s+long\s+as)\s+"
+    r"(?:(?:the|a)\s+)?(?:returned\s+)?"
+    r"(?:liveness\s+result\s+(?:has|reports?)\s+)?"
+    r"`?watch_warranted`?\s*(?:is|=|==|:)\s*`?true`?\b",
     re.IGNORECASE,
 )
+WATCH_NEGATED_ACTION_RE = re.compile(
+    r"\b(?:never|do\s+not|don't|doesn't|no\s+need\s+to|"
+    r"unnecessary\s+to|not\s+(?:required|necessary)\s+to)\b",
+    re.IGNORECASE,
+)
+WATCH_NEGATED_AFTER_ACTION_RE = re.compile(
+    r"\b(?:is|are|becomes?|seems?)\s+(?:unnecessary|"
+    r"not\s+(?:required|necessary))\b",
+    re.IGNORECASE,
+)
+WATCH_QUOTED_SPAN_RE = re.compile(r"`[^`\n]*`|\"[^\"\n]*\"|“[^”\n]*”|‘[^’\n]*’")
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
 )
@@ -355,29 +380,84 @@ def check_watch_consumers(adoption: str, loop_control: str) -> None:
                 f"{name} lost the liveness/watch_warranted gate")
 
 
+def markdown_watch_clauses(body: str) -> list[tuple[str, int]]:
+    """Return sentence-sized Markdown blocks without crossing list-item boundaries."""
+    blocks: list[tuple[str, int]] = []
+    current: list[str] = []
+    current_line = 0
+
+    def flush() -> None:
+        nonlocal current, current_line
+        if current:
+            blocks.append((" ".join(current), current_line))
+        current = []
+        current_line = 0
+
+    for line_number, line in enumerate(body.splitlines(), start=1):
+        item = MARKDOWN_LIST_ITEM.match(line)
+        if item is not None:
+            flush()
+            current = [line[item.end():].strip()]
+            current_line = line_number
+        elif not line.strip():
+            flush()
+        else:
+            if not current:
+                current_line = line_number
+            current.append(line.strip())
+    flush()
+
+    clauses: list[tuple[str, int]] = []
+    for block, line_number in blocks:
+        clauses.extend(
+            (clause.strip(), line_number)
+            for clause in re.split(r"(?<=[.!?;|])\s+", block)
+            if clause.strip()
+        )
+    return clauses
+
+
+def watch_action_is_quoted(clause: str, action: re.Match[str]) -> bool:
+    return any(
+        quoted.start() < action.start() and action.end() <= quoted.end()
+        for quoted in WATCH_QUOTED_SPAN_RE.finditer(clause)
+    )
+
+
+def watch_action_is_negated(clause: str, action: re.Match[str]) -> bool:
+    before = clause[:action.start()]
+    after = clause[action.end():]
+    return (
+        WATCH_NEGATED_ACTION_RE.search(before) is not None
+        or WATCH_NEGATED_AFTER_ACTION_RE.search(after) is not None
+    )
+
+
+def watch_action_has_true_warrant_guard(
+    clause: str,
+    action: re.Match[str],
+) -> bool:
+    return any(
+        guard.end() <= action.start() or action.end() <= guard.start()
+        for guard in WATCH_WARRANTED_TRUE_GUARD_RE.finditer(clause)
+    )
+
+
 def check_status_watch_maintenance_docs(root: Path = ROOT) -> list[str]:
-    """Reject status-conditioned watch maintenance that does not use `watch_warranted`."""
+    """Reject status-conditioned watch maintenance without a true `watch_warranted` guard."""
     problems: list[str] = []
     for document in sorted(root.rglob("*.md")):
         text = document.read_text(encoding="utf-8")
-        for match in STATUS_WATCH_MAINTENANCE.finditer(text):
-            clause_start = max(text.rfind(boundary, 0, match.start())
-                               for boundary in ".!?;|") + 1
-            clause_end_candidates = [text.find(boundary, match.end())
-                                     for boundary in ".!?;|"
-                                     if text.find(boundary, match.end()) >= 0]
-            clause_end = min(clause_end_candidates) if clause_end_candidates else len(text)
-            clause = text[clause_start:clause_end]
-            action = re.search(WATCH_MAINTENANCE_ACTION, clause, re.IGNORECASE)
-            if action is None:
+        for clause, line in markdown_watch_clauses(text):
+            if WATCH_STATUS_CONDITION_RE.search(clause) is None:
                 continue
-            if re.search(r"\b(?:never|do not|don't|not)\b", clause[:action.start()], re.IGNORECASE):
+            action = WATCH_MAINTENANCE_ACTION_RE.search(clause)
+            if action is None or watch_action_is_quoted(clause, action):
                 continue
-            if re.search(r"\bLIVELOCKS\b", clause, re.IGNORECASE):
+            if watch_action_is_negated(clause, action):
                 continue
-            if "watch_warranted" in clause:
+            if watch_action_has_true_warrant_guard(clause, action):
                 continue
-            line = text.count("\n", 0, match.start()) + 1
             relative = document.relative_to(root).as_posix()
             problems.append(
                 f"{relative}:{line} adds status-based watch maintenance without `watch_warranted`"
@@ -414,6 +494,61 @@ def run_watch_action_fixtures() -> None:
                 and "status-based watch maintenance" in problem
                 for problem in problems
             )
+            require(found is expected,
+                    f"{name} status-based watch maintenance fixture had the wrong result")
+
+    parser_fixtures = (
+        (
+            "unguarded-watch-warranted-token",
+            "CI status is pending, ensure a watch, and read watch_warranted from liveness.",
+            True,
+        ),
+        (
+            "unguarded-true-watch-warranted-token",
+            "CI status is pending, ensure a watch, and watch_warranted is true.",
+            True,
+        ),
+        (
+            "unguarded-livelocks-token",
+            "CI status is pending, ensure a watch, and investigate LIVELOCKS.",
+            True,
+        ),
+        (
+            "true-watch-warranted-guard",
+            "Ensure a watch when CI status is pending only when returned watch_warranted is true.",
+            False,
+        ),
+        (
+            "guard-before-action",
+            "When watch_warranted is true, ensure a watch when CI status is pending.",
+            False,
+        ),
+        ("passive-action", "A watch should be launched when CI status is pending.", True),
+        ("hyphenated-action", "Keep a long-running watch alive when CI status is pending.", True),
+        ("quoted-status", 'Ensure a watch when CI status is "pending".', True),
+        ("code-status", "Ensure a watch when CI status is `pending`.", True),
+        ("quoted-word-status", "Ensure a watch when CI status is quoted pending.", True),
+        ("no-need-negation", "No need to keep a watch when CI status is pending.", False),
+        (
+            "unnecessary-negation",
+            "It is unnecessary to ensure a watch when CI status is pending.",
+            False,
+        ),
+        (
+            "not-required-negation",
+            "It is not required to keep a watch when CI status is pending.",
+            False,
+        ),
+        ("separate-list-items", "- CI status is pending\n- Keep a watch.", False),
+        ("separate-sentences", "CI status is pending. Keep a watch.", False),
+        ("same-list-item", "- CI status is pending and keep a watch.", True),
+    )
+    for name, fixture, expected in parser_fixtures:
+        with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
+            fixture_root = Path(temporary) / "campaign"
+            fixture_root.mkdir()
+            (fixture_root / "fixture.md").write_text(fixture + "\n", encoding="utf-8")
+            found = bool(check_status_watch_maintenance_docs(fixture_root))
             require(found is expected,
                     f"{name} status-based watch maintenance fixture had the wrong result")
 

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -56,153 +56,88 @@ WATCH_ACTION = (
     "Run `liveness`, then ensure or relaunch a watch only when returned "
     "`watch_warranted` is `true`"
 )
-# --- Shared token-edge primitives -------------------------------------------
-# Every site below asks the same question -- "what may sit at this token's
-# edge?" -- and answers it here, once. Hand-rolling it per site is what made the
-# identical missing markup tolerance surface as a false negative on the accuse
-# path (status condition, maintenance action) and a false positive on the excuse
-# path (guard, negation, gaps).
+# --- The watch-directive warrant convention ---------------------------------
+# The rule these docs already keep: every passage that tells the driver to
+# start, keep or relaunch a CI watch NAMES `watch_warranted` in that same
+# passage. Watching on the `ci` value alone livelocks a settled PR
+# (`stage-3-merge.md`, "`BLOCKED` and `UNSTABLE` -- what each merge state
+# means"), so citing the warrant is the whole point of the directive.
 #
-# `\b` cannot be part of that answer: it is RELATIVE, so its meaning flips with
-# whatever the engine just consumed, and it therefore cannot compose with an
-# optional markup delimiter. WATCH_LEFT/WATCH_RIGHT are absolute.
-WATCH_MARKUP = r"[`*_~]{0,3}"
-WATCH_LEFT = r"(?<![0-9A-Za-z])"
-WATCH_RIGHT = r"(?![0-9A-Za-z])"
-# The one gap vocabulary: whitespace, clause punctuation, table cell bars,
-# inline markup, dashes and arrows.
-WATCH_GAP_CHARS = r"(?:[\s,;:()\[\]{}|`*_~—–-]|->|→)"
-# What may follow a matched token: whitespace, sentence or clause punctuation,
-# a table cell bar, a dash, or end of clause.
-WATCH_TOKEN_END = r"(?=\s|[.!?;:|,)\]}]|[-—–]|$)"
-
-
-def watch_token(inner: str) -> str:
-    """Wrap a vocabulary alternation in the shared markup-tolerant token edges.
-
-    The builder decides EDGES only. Which words count as verbs, introducers or
-    connectives stays with the caller.
-    """
-    return rf"{WATCH_MARKUP}{WATCH_LEFT}(?:{inner}){WATCH_RIGHT}{WATCH_MARKUP}"
-
-
-def watch_gap(connectives: str) -> str:
-    """Return the one gap pattern: gap characters around named connectives."""
-    return rf"{WATCH_GAP_CHARS}*(?:{watch_token(connectives)}{WATCH_GAP_CHARS}*)*"
-
-
-WATCH_MAINTENANCE_VERBS = r"(?:keep|maintain|start|launch|relaunch|ensure)(?:s|ed|ing)?"
-WATCH_STATUS_VALUES = r"(?:pending|red|green|unknown|unusable|unverifiable)"
-# `is`/`=`/`==`/`:` may carry markup, but a bare symbol must not demand a
-# non-word character after it: `ci=pending` has none.
-WATCH_COPULA = (
-    rf"\s*(?:{watch_token('is')}|{WATCH_MARKUP}(?:==|=|:){WATCH_MARKUP})\s*"
+# This is a CONVENTION check, and deliberately NOT a grammar. It never decides
+# what an English sentence MEANS. It has two finite, explicit inputs:
+#
+#   * WATCH_DIRECTIVE_PHRASES -- literal imperatives. They only ACCUSE.
+#   * WATCH_DIRECTIVE_EXEMPTIONS -- named passages. They only EXCUSE.
+#
+# The two never trade against each other, and THAT is this check's closure
+# condition. A regex grammar over prose has none: every widening on the accuse
+# side manufactures a false positive on the excuse side and the reverse, so it
+# converges on nothing. Here, adding a phrase can only add accusations, and
+# excusing one costs an entry naming the document, the exact passage, and the
+# reason -- which a reviewer reads.
+#
+# What this check does NOT prove: that a directive is genuinely CONDITIONED on
+# the warrant rather than merely next to it. Deciding that is the grammar this
+# check refuses to have. Naming the field is the mechanical part; whether the
+# sentence uses it correctly is the reviewer's.
+WATCH_WARRANT_FIELD = "watch_warranted"
+# Inline markup is not vocabulary: `ensure a **live** watch` is the same
+# directive as `ensure a live watch`. Underscore is NOT stripped -- it is a
+# character of the warrant's own name.
+WATCH_MARKUP_CHARS = str.maketrans("", "", "`*~")
+# Every phrase names a WATCH as the object of a maintenance verb -- that is the
+# whole bound on this list, and it is what keeps "watch the review budget" out.
+# Matched against markup-normalized text, so each entry stays lowercase and
+# markup-free. Order is irrelevant: nesting is resolved by longest span.
+WATCH_DIRECTIVE_PHRASES = (
+    "ensure or relaunch a watch",
+    "ensure a live watch",
+    "ensure a watch task",
+    "ensure a watch",
+    "launch a watch",
+    "launch the watch",
+    "relaunch a watch",
+    "relaunch the ci watch",
+    "relaunch the watch",
+    "keep a ci watch alive",
+    "keep a watch alive",
+    "keep a watch",
+    "maintain a watch",
+    "start a watch",
 )
-WATCH_STATUS_FIELD = (
-    rf"(?:{watch_token('ci')}(?:\s+{watch_token('status')})?"
-    rf"|{watch_token('status')})"
+# (document, anchor, the maximal directive phrases that passage may carry, why)
+# The anchor must occur exactly once in the document and select exactly one
+# passage, and that passage must carry exactly the declared phrases. So editing
+# an excused passage re-opens the judgement instead of inheriting it silently.
+WATCH_DIRECTIVE_EXEMPTIONS = (
+    (
+        "references/stage-2-ci.md",
+        "**YES** — ensure a watch task is alive",
+        ("ensure a watch task",),
+        "The WATCH ONLY WHAT CAN MOVE table IS the specification of "
+        "`watch_warranted`. Its rows state that predicate rather than cite it; "
+        "the section names the field above the table.",
+    ),
+    (
+        "references/stage-2-ci.md",
+        "**NEVER relaunch the watch merely because `ci == pending`.**",
+        ("relaunch the watch",),
+        "A prohibition on the `ci`-only watch. It quotes the anti-pattern in "
+        "order to forbid it.",
+    ),
+    (
+        "references/stage-3-merge.md",
+        '→ "relaunch the CI watch" therefore **LIVELOCKS**',
+        ("relaunch the ci watch",),
+        "Quotes the BLOCKED-to-watch mapping in order to reject it as the "
+        "livelock this convention exists to prevent.",
+    ),
 )
-WATCH_STATUS_CONDITION = (
-    WATCH_STATUS_FIELD
-    + WATCH_COPULA
-    + r"(?:[\"']\s*)?(?:quoted\s+)?"
-    + watch_token(WATCH_STATUS_VALUES)
-    + r"\s*[\"']?"
-    + WATCH_TOKEN_END
-)
-# Filler words between a maintenance verb and its object may themselves be
-# marked up: `ensure a **live** watch`.
-WATCH_ACTION_FILLER = rf"(?:\s+{WATCH_MARKUP}[\w-]+{WATCH_MARKUP}){{0,8}}?"
-WATCH_ACTIVE_MAINTENANCE_ACTION = (
-    watch_token(WATCH_MAINTENANCE_VERBS)
-    + WATCH_ACTION_FILLER
-    + r"\s+"
-    + watch_token(r"watch(?:es|ed|ing)?")
-    + rf"(?:\s+{watch_token('alive')})?"
-)
-WATCH_PASSIVE_MAINTENANCE_ACTION = (
-    watch_token(r"watch(?:es|ed|ing)?")
-    + rf"(?:\s+{watch_token('should|must|may|can|will|is|are|be')}){{0,3}}\s+"
-    + watch_token(WATCH_MAINTENANCE_VERBS)
-)
-WATCH_MAINTENANCE_ACTION = (
-    rf"(?:{WATCH_ACTIVE_MAINTENANCE_ACTION}|{WATCH_PASSIVE_MAINTENANCE_ACTION})"
-)
-WATCH_STATUS_CONDITION_RE = re.compile(WATCH_STATUS_CONDITION, re.IGNORECASE)
-WATCH_MAINTENANCE_ACTION_RE = re.compile(WATCH_MAINTENANCE_ACTION, re.IGNORECASE)
-WATCH_WARRANTED_REPORTER = (
-    rf"(?:{watch_token('liveness')}(?:\s+{watch_token('result')})?"
-    rf"|{watch_token('it')})"
-    rf"\s+{watch_token('has|reports?|returns?')}\s+"
-)
-WATCH_WARRANTED_TOKEN = watch_token("watch_warranted")
-WATCH_WARRANTED_IS_TRUE = WATCH_COPULA + watch_token("true")
-WATCH_WARRANTED_TRUE_GUARD_RE = re.compile(
-    rf"(?:{watch_token('only')}\s+)?"
-    + watch_token(r"when|if|provided(?:\s+that)?|as\s+long\s+as")
-    + r"\s+"
-    # The same introducer may carry the status condition first, as in
-    # "when CI status is pending and `liveness` reports `watch_warranted`".
-    + rf"(?:{WATCH_STATUS_CONDITION}{watch_gap('and|but|only')})?"
-    + rf"(?:{watch_token('the|a')}\s+)?(?:{watch_token('returned')}\s+)?"
-    r"(?:"
-    # A named reporter (`liveness`, the liveness result, or a pronoun) makes the
-    # trailing `is true` optional: it is the docs' own house phrasing.
-    + WATCH_WARRANTED_REPORTER
-    + WATCH_WARRANTED_TOKEN
-    + rf"(?:{WATCH_WARRANTED_IS_TRUE})?"
-    r"|"
-    # Without a reporter, a bare token is not a guard: `is true` stays required.
-    + WATCH_WARRANTED_TOKEN
-    + WATCH_WARRANTED_IS_TRUE
-    + r")",
-    # No trailing `\b`: the final atom may be a closing markup delimiter, which
-    # `\b` can never satisfy, so it would backtrack that delimiter out of the
-    # guard and into the gap. watch_token's WATCH_RIGHT already pins the word.
-    re.IGNORECASE,
-)
-WATCH_NEGATED_BEFORE_ACTION_RE = re.compile(
-    watch_token(
-        r"never|do\s+not|don't|doesn't|no\s+need\s+to|unnecessary\s+to|"
-        r"not(?:\s+(?:required|necessary))?\s+to|not"
-    )
-    + r"\s*$",
-    re.IGNORECASE,
-)
-WATCH_NEGATED_AFTER_ACTION_RE = re.compile(
-    # The negating copula need not be adjacent to the action: "ensure a watch
-    # when CI status is pending is unnecessary" negates it just as plainly.
-    rf"^{WATCH_ACTION_FILLER}\s*"
-    + watch_token("is|are|becomes?|seems?")
-    + r"\s+"
-    + watch_token(r"unnecessary|not\s+(?:required|necessary)"),
-    re.IGNORECASE,
-)
-# NOT routed through watch_token: here the backticks are SEMANTIC -- they mark a
-# quotation, which is itself the excuse. Making markup skippable inside this
-# pattern would turn every backticked example into a quotation.
-WATCH_QUOTED_SPAN_RE = re.compile(
-    r"`[^`\n]*`|\"[^\"\n]*\"|(?<!\w)'[^'\n]*'(?!\w)|“[^”\n]*”|‘[^’\n]*’"
-)
-WATCH_GUARD_BEFORE_ACTION_GAP_RE = re.compile(
-    rf"^{watch_gap('then|and|only')}$",
-    re.IGNORECASE,
-)
-WATCH_GUARD_AFTER_ACTION_GAP_RE = re.compile(
-    rf"^{watch_gap('only|then|and|but')}$",
-    re.IGNORECASE,
-)
-WATCH_STATUS_GUARD_AFTER_ACTION_GAP_RE = re.compile(
-    rf"^{WATCH_GAP_CHARS}*{watch_token('when|if|while')}\s+"
-    rf"{WATCH_STATUS_CONDITION}{watch_gap('but|only|and|then')}$",
-    re.IGNORECASE,
-)
-WATCH_GUARD_PREFIX_RE = re.compile(watch_gap("then|and|only"), re.IGNORECASE)
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
 )
 MARKDOWN_TABLE_ROW = re.compile(r"^[ \t>]*\|.*\|[ \t]*$")
-MARKDOWN_TABLE_DELIMITER = re.compile(r"^[ \t>]*\|[\s:|-]*\|[ \t]*$")
+MARKDOWN_HEADING = re.compile(r"^[ \t>]*#{1,6} ")
 
 
 def markdown_section(body: str, heading: str) -> str:
@@ -482,27 +417,35 @@ def check_watch_consumers(adoption: str, loop_control: str) -> None:
                 f"{name} lost the liveness/watch_warranted gate")
 
 
-def markdown_watch_clauses(body: str) -> list[tuple[str, int]]:
-    """Return sentence-sized Markdown blocks without crossing list-item boundaries."""
-    blocks: list[tuple[str, int]] = []
+def markdown_watch_passages(body: str) -> list[tuple[str, int]]:
+    """Split Markdown into passages: one table row, one list item, one paragraph.
+
+    A table row is ONE passage: its cell bars must not sever it, or the check
+    goes structurally inert inside every watch-policy table -- which is exactly
+    where this repository's watch policy is written.
+
+    Nothing below this splits a passage further. Sentence segmentation is what
+    let a semicolon put a directive and its warrant into different units while
+    the reader sees one instruction.
+    """
+    passages: list[tuple[str, int]] = []
     current: list[str] = []
     current_line = 0
 
     def flush() -> None:
         nonlocal current, current_line
         if current:
-            blocks.append((" ".join(current), current_line))
+            passages.append((" ".join(current), current_line))
         current = []
         current_line = 0
 
     for line_number, line in enumerate(body.splitlines(), start=1):
         item = MARKDOWN_LIST_ITEM.match(line)
         if MARKDOWN_TABLE_ROW.match(line) is not None:
-            # A table row is ONE clause. Its cell bars must not sever it, or the
-            # check goes structurally inert inside every watch-policy table.
             flush()
-            if MARKDOWN_TABLE_DELIMITER.match(line) is None:
-                blocks.append((line.strip(), line_number))
+            passages.append((line.strip(), line_number))
+        elif MARKDOWN_HEADING.match(line) is not None:
+            flush()
         elif item is not None:
             flush()
             current = [line[item.end():].strip()]
@@ -514,405 +457,265 @@ def markdown_watch_clauses(body: str) -> list[tuple[str, int]]:
                 current_line = line_number
             current.append(line.strip())
     flush()
+    return passages
 
-    clauses: list[tuple[str, int]] = []
-    for block, line_number in blocks:
-        clauses.extend(
-            (clause.strip(), line_number)
-            for clause in re.split(r"(?<=[.!?;])\s+", block)
-            if clause.strip()
+
+def watch_text(passage: str) -> str:
+    """Return the passage with inline markup and line wrapping normalized away."""
+    return " ".join(passage.translate(WATCH_MARKUP_CHARS).lower().split())
+
+
+def watch_directive_phrases(passage: str) -> list[str]:
+    """Return the MAXIMAL directive phrases this passage carries.
+
+    Maximal: "ensure a watch" sits inside "ensure a watch task", and one
+    directive must count once, or an exemption would have to declare every
+    nested spelling of the imperative it excuses.
+    """
+    text = watch_text(passage)
+    spans: list[tuple[int, int, str]] = []
+    for phrase in WATCH_DIRECTIVE_PHRASES:
+        start = text.find(phrase)
+        while start != -1:
+            spans.append((start, start + len(phrase), phrase))
+            start = text.find(phrase, start + 1)
+    return sorted({
+        phrase
+        for start, end, phrase in spans
+        if not any(
+            (other_start, other_end) != (start, end)
+            and other_start <= start
+            and end <= other_end
+            for other_start, other_end, _ in spans
         )
-    return clauses
+    })
 
 
-def watch_action_is_quoted(clause: str, action: re.Match[str]) -> bool:
-    # `<=` on both ends, not `<`: the action's own markup edges may now consume
-    # the quotation's opening delimiter, so a fully quoted action starts exactly
-    # where its quotation does. Containment is what excuses it, either way.
-    return any(
-        quoted.start() <= action.start() and action.end() <= quoted.end()
-        for quoted in WATCH_QUOTED_SPAN_RE.finditer(clause)
-    )
-
-
-def watch_action_is_negated(clause: str, action: re.Match[str]) -> bool:
-    before = clause[:action.start()]
-    after = clause[action.end():]
-    return (
-        WATCH_NEGATED_BEFORE_ACTION_RE.search(before) is not None
-        or WATCH_NEGATED_AFTER_ACTION_RE.match(after) is not None
-    )
-
-
-def watch_guard_prefix_is_conditional(clause: str, guard: re.Match[str]) -> bool:
-    prefix = clause[:guard.start()]
-    prefix = WATCH_STATUS_CONDITION_RE.sub("", prefix)
-    return WATCH_GUARD_PREFIX_RE.fullmatch(prefix) is not None
-
-
-def watch_action_has_true_warrant_guard(
-    clause: str,
-    action: re.Match[str],
+def watch_directive_is_exempt(
+    document: str,
+    passage: str,
+    registry: tuple[tuple[str, str, tuple[str, ...], str], ...] =
+        WATCH_DIRECTIVE_EXEMPTIONS,
 ) -> bool:
-    quoted_spans = list(WATCH_QUOTED_SPAN_RE.finditer(clause))
-    for guard in WATCH_WARRANTED_TRUE_GUARD_RE.finditer(clause):
-        if any(
-            quoted.start() <= guard.start() and guard.end() <= quoted.end()
-            for quoted in quoted_spans
-        ):
-            continue
-        if guard.end() <= action.start():
-            gap = clause[guard.end():action.start()]
-            if (
-                WATCH_GUARD_BEFORE_ACTION_GAP_RE.fullmatch(gap)
-                and watch_guard_prefix_is_conditional(clause, guard)
-            ):
-                return True
-        elif action.end() <= guard.start():
-            gap = clause[action.end():guard.start()]
-            if (
-                WATCH_GUARD_AFTER_ACTION_GAP_RE.fullmatch(gap)
-                or WATCH_STATUS_GUARD_AFTER_ACTION_GAP_RE.fullmatch(gap)
-            ):
-                return True
+    for exempt_document, anchor, excused, _ in registry:
+        if exempt_document == document and anchor in passage:
+            # An entry excuses the directives it was reviewed against, never
+            # whatever the passage grows afterwards.
+            return watch_directive_phrases(passage) == sorted(set(excused))
     return False
 
 
-def check_status_watch_maintenance_docs(root: Path = ROOT) -> list[str]:
-    """Reject status-conditioned watch maintenance without a true `watch_warranted` guard."""
+def check_watch_directive_warrants(root: Path = ROOT) -> list[str]:
+    """Reject a watch directive that does not name `watch_warranted`."""
     problems: list[str] = []
     for document in sorted(root.rglob("*.md")):
+        relative = document.relative_to(root).as_posix()
         text = document.read_text(encoding="utf-8")
-        for clause, line in markdown_watch_clauses(text):
-            if WATCH_STATUS_CONDITION_RE.search(clause) is None:
+        for passage, line in markdown_watch_passages(text):
+            phrases = watch_directive_phrases(passage)
+            if not phrases:
                 continue
-            actions = WATCH_MAINTENANCE_ACTION_RE.finditer(clause)
-            if all(
-                watch_action_is_quoted(clause, action)
-                or watch_action_is_negated(clause, action)
-                or watch_action_has_true_warrant_guard(clause, action)
-                for action in actions
-            ):
+            if WATCH_WARRANT_FIELD in watch_text(passage):
                 continue
-            relative = document.relative_to(root).as_posix()
+            if watch_directive_is_exempt(relative, passage):
+                continue
             problems.append(
-                f"{relative}:{line} adds status-based watch maintenance "
-                f"without a `watch_warranted` guard"
+                f"{relative}:{line} directs watch maintenance "
+                f"({', '.join(phrases)}) without naming "
+                f"`{WATCH_WARRANT_FIELD}`"
             )
     return problems
 
 
-def run_watch_action_fixtures() -> None:
-    require(not check_status_watch_maintenance_docs(),
-            "current campaign docs contain an unregistered status-based watch action")
+def check_watch_directive_exemptions(root: Path = ROOT) -> None:
+    """Every exemption must still name one live passage, and only its own."""
+    for document, anchor, excused, reason in WATCH_DIRECTIVE_EXEMPTIONS:
+        require(bool(reason.strip()),
+                f"watch directive exemption carries no reason: {anchor!r}")
+        path = root / document
+        require(path.is_file(),
+                f"watch directive exemption names a missing document: {document}")
+        text = path.read_text(encoding="utf-8")
+        require(text.count(anchor) == 1,
+                f"watch directive exemption anchor is not unique in {document}: "
+                f"{anchor!r}")
+        selected = [
+            passage
+            for passage, _ in markdown_watch_passages(text)
+            if anchor in passage
+        ]
+        require(len(selected) == 1,
+                f"watch directive exemption anchor selects {len(selected)} "
+                f"passages in {document}: {anchor!r}")
+        require(watch_directive_phrases(selected[0]) == sorted(set(excused)),
+                f"watch directive exemption in {document} no longer excuses "
+                f"exactly {sorted(set(excused))}: {anchor!r}")
 
+
+def run_watch_action_fixtures() -> None:
+    # The clean-corpus assertion lives with the other document contracts
+    # (`check_document_contract`). It is NOT evidence that this check works: a
+    # blind check passes a clean corpus too. The mutation fixtures below are the
+    # evidence, and they run against the real documents.
     fixture_parent = ROOT.parents[4] / ".tmp"
     fixture_parent.mkdir(exist_ok=True)
-    allowed = (
-        "Run liveness and keep a watch alive while CI is pending only when "
-        "`watch_warranted` is `true`."
+    run_watch_corpus_mutation_fixtures(fixture_parent)
+    run_watch_passage_fixtures(fixture_parent)
+    run_watch_exemption_fixtures(fixture_parent)
+
+
+def run_watch_corpus_mutation_fixtures(fixture_parent: Path) -> None:
+    """Mutate the REAL corpus: the check must catch its own motivating case.
+
+    A synthetic sentence appended to a document proves only that the parser
+    recognises a sentence written for the parser. The case this check exists for
+    is a contributor deleting the warrant from the tables and bullets that tell
+    the driver when to watch, so that is what these fixtures do.
+    """
+    mutations = (
+        (
+            # The motivating anti-pattern: the `pending` verdict row of the
+            # driver's own table, with its guard deleted.
+            "verdict-row-guard-deleted",
+            "references/stage-2-ci.md",
+            (("`liveness` reports `watch_warranted` → ensure a live watch",
+              "Ensure a live watch"),),
+            "references/stage-2-ci.md:150",
+        ),
+        (
+            # The head-move bullet names the warrant twice. Strip both and it
+            # still says "launch a watch".
+            "head-move-bullet-guard-deleted",
+            "references/stage-2-ci.md",
+            (("`liveness` then reports `watch_warranted`**", "**"),
+             ("watch only if `liveness` reports `watch_warranted`",
+              "watch on the push")),
+            "references/stage-2-ci.md:821",
+        ),
+        (
+            # An excused passage that grows a second, unreviewed directive must
+            # stop inheriting its exemption.
+            "exempt-passage-grew-a-directive",
+            "references/stage-2-ci.md",
+            (("**YES** — ensure a watch task is alive",
+              "**YES** — ensure a watch task is alive, and keep a watch alive"),),
+            "references/stage-2-ci.md:795",
+        ),
     )
-    for name, addition, expected in (
-        ("unregistered-keep", "Run liveness and keep a watch alive while CI is pending.", True),
-        ("unregistered-maintain", "Run liveness and maintain a watch while CI is pending.", True),
-        ("registered", allowed, False),
-    ):
+    for name, document, edits, expected in mutations:
         with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
             fixture_root = Path(temporary) / "campaign"
             shutil.copytree(ROOT, fixture_root)
-            document = fixture_root / "references" / "stage-2-review-gate.md"
-            document.write_text(
-                document.read_text(encoding="utf-8") + "\n\n" + addition + "\n",
-                encoding="utf-8",
-            )
-            problems = check_status_watch_maintenance_docs(fixture_root)
-            found = any(
-                "stage-2-review-gate.md" in problem
-                and "status-based watch maintenance" in problem
-                for problem in problems
-            )
-            require(found is expected,
-                    f"{name} status-based watch maintenance fixture had the wrong result")
+            target = fixture_root / document
+            body = target.read_text(encoding="utf-8")
+            for before, after in edits:
+                require(body.count(before) == 1,
+                        f"{name} watch corpus mutation no longer applies: "
+                        f"{before!r}")
+                body = body.replace(before, after, 1)
+            target.write_text(body, encoding="utf-8")
+            problems = check_watch_directive_warrants(fixture_root)
+            require(any(problem.startswith(expected) for problem in problems),
+                    f"{name} watch corpus mutation was not caught: {problems}")
 
-    parser_fixtures = (
-        (
-            "unguarded-watch-warranted-token",
-            "CI status is pending, ensure a watch, and read watch_warranted from liveness.",
-            True,
-        ),
-        (
-            "unguarded-true-watch-warranted-token",
-            "CI status is pending, ensure a watch, and watch_warranted is true.",
-            True,
-        ),
-        (
-            "unguarded-livelocks-token",
-            "CI status is pending, ensure a watch, and investigate LIVELOCKS.",
-            True,
-        ),
-        (
-            "quoted-warrant-guard-mention",
-            'CI status is pending, ensure a watch as documented by "when watch_warranted is true".',
-            True,
-        ),
-        (
-            "explanatory-warrant-guard-mention",
-            "CI status is pending, ensure a watch as documented by when watch_warranted is true.",
-            True,
-        ),
-        (
-            "true-watch-warranted-guard",
-            "Ensure a watch when CI status is pending only when returned watch_warranted is true.",
-            False,
-        ),
-        (
-            "guard-before-action",
-            "When watch_warranted is true, ensure a watch when CI status is pending.",
-            False,
-        ),
-        (
-            "named-reporter-guard",
-            "Ensure a live watch when CI status is pending and `liveness` reports "
-            "`watch_warranted`.",
-            False,
-        ),
-        (
-            "pronoun-reporter-guard",
-            "When CI status is pending, run `liveness` and ensure a watch only when it "
-            "reports `watch_warranted`.",
-            False,
-        ),
-        (
-            "named-reporter-true-guard",
-            "Ensure a watch when CI status is pending only when `liveness` reports "
-            "`watch_warranted` is `true`.",
-            False,
-        ),
-        (
-            "comma-before-guard",
-            "Ensure a watch when CI status is pending, only when returned "
-            "watch_warranted is true.",
-            False,
-        ),
-        (
-            "comma-and-but-before-guard",
-            "Ensure a watch when CI status is pending, but only when the returned "
-            "`watch_warranted` is `true`.",
-            False,
-        ),
-        (
-            "reporterless-bare-token-guard",
-            "Ensure a watch when CI status is pending only when watch_warranted changes.",
-            True,
-        ),
-        ("passive-action", "A watch should be launched when CI status is pending.", True),
-        ("hyphenated-action", "Keep a long-running watch alive when CI status is pending.", True),
-        ("quoted-status", 'Ensure a watch when CI status is "pending".', True),
-        ("code-status", "Ensure a watch when CI status is `pending`.", True),
-        ("code-field-and-status", "`ci` is `pending`, ensure a watch.", True),
-        ("code-field-plain-status", "`ci` is pending, ensure a watch.", True),
-        ("emphasis-field", "**ci** is pending, ensure a watch.", True),
-        ("code-field-phrase", "`ci status` is pending, ensure a watch.", True),
-        (
-            "code-field-relaunch",
-            "While `ci` is `pending`, relaunch the watch each heartbeat.",
-            True,
-        ),
-        ("field-substring-not-a-status", "Ensure a watch when sci is pending.", False),
-        ("quoted-word-status", "Ensure a watch when CI status is quoted pending.", True),
-        ("colon-status", "CI status is pending: keep a watch.", True),
-        ("quoted-action", "CI status is pending, 'keep a watch'.", False),
-        ("no-need-negation", "No need to keep a watch when CI status is pending.", False),
-        (
-            "unnecessary-negation",
-            "It is unnecessary to ensure a watch when CI status is pending.",
-            False,
-        ),
-        (
-            "not-required-negation",
-            "It is not required to keep a watch when CI status is pending.",
-            False,
-        ),
-        (
-            "unrelated-negation",
-            "It is not required to merge, but keep a watch when CI status is pending.",
-            True,
-        ),
-        (
-            "negated-then-positive-action",
-            "CI status is pending, do not keep a watch but ensure a watch.",
-            True,
-        ),
-        (
-            "contractions-are-not-quotes",
-            "CI status is pending, don't keep a watch, ensure a watch, don't stop.",
-            True,
-        ),
-        ("separate-list-items", "- CI status is pending\n- Keep a watch.", False),
-        ("separate-sentences", "CI status is pending. Keep a watch.", False),
-        ("same-list-item", "- CI status is pending and keep a watch.", True),
-        # Gap content, not markup form: the guard-to-action and action-to-guard
-        # gaps carry arrows, dashes and more than one connective.
-        (
-            "arrow-guard-to-action-gap",
-            "When `liveness` reports `watch_warranted` → ensure a watch while "
-            "CI status is pending.",
-            False,
-        ),
-        (
-            "ascii-arrow-guard-to-action-gap",
-            "When `liveness` reports `watch_warranted` -> ensure a watch while "
-            "CI status is pending.",
-            False,
-        ),
-        (
-            "multi-connective-action-to-guard-gap",
-            "Ensure a watch when CI status is pending, and only if returned "
-            "watch_warranted is true.",
-            False,
-        ),
-        (
-            "em-dash-status-terminator",
-            "`ci` is `pending`—ensure a watch.",
-            True,
-        ),
-        (
-            "non-adjacent-negation-after-action",
-            "To ensure a watch when CI status is pending is unnecessary.",
-            False,
-        ),
-        # A table row is one clause; its cell bars must not sever the condition
-        # from the action, or the check goes inert inside watch-policy tables.
-        (
-            "table-row-condition-and-action",
-            "| condition | policy |\n|---|---|\n"
-            "| When `ci` is `pending` | ensure a live watch |",
-            True,
-        ),
-        (
-            "table-row-guarded-action",
-            "| condition | policy |\n|---|---|\n"
-            "| When `ci` is `pending` | ensure a live watch only when "
-            "`liveness` reports `watch_warranted` |",
-            False,
-        ),
-        (
-            "table-delimiter-row-is-not-a-clause",
-            "| CI status is pending | keep a watch |\n|---|---|",
-            True,
-        ),
-        # ...and one clause per row, not one clause per table: a condition in
-        # one row must not bind to an action in another.
-        (
-            "separate-table-rows",
-            "| verdict | policy |\n|---|---|\n"
-            "| `ci` is `pending` | wait for the liveness bounds |\n"
-            "| `red` | keep a watch |",
-            False,
-        ),
-        # The quotation excuse must survive the action's own markup edges in
-        # both directions: a wholly quoted action stays excused, and a merely
-        # marked-up object does not become a quotation.
-        ("code-span-quoted-action", "CI status is pending, `keep a watch`.", False),
-        ("code-span-action-object", "`ci` is `pending`, ensure a `watch`.", True),
+
+def run_watch_passage_fixtures(fixture_parent: Path) -> None:
+    """Pin the passage boundaries and the directive vocabulary."""
+    warrant = "`liveness` reports `watch_warranted`"
+    fixtures = (
+        # The directive vocabulary: accused, then discharged.
+        ("unguarded-paragraph", "While `ci` is `pending`, ensure a live watch.", True),
+        ("guarded-paragraph",
+         f"While `ci` is `pending` and {warrant}, ensure a live watch.", False),
+        ("markup-inside-the-directive",
+         "While `ci` is `pending`, ensure a **live** watch.", True),
+        ("marked-up-warrant",
+         "Ensure a live watch only when **`watch_warranted`** is true.", False),
+        # Quoting a watch directive does not excuse it. Deciding from
+        # punctuation whether a quotation rejects or endorses what it quotes is
+        # the grammar this check refuses to have, so the corpus's two real
+        # anti-pattern quotations are registry entries instead.
+        ("code-span-directive", "While `ci` is `pending`, `keep a watch`.", True),
+        ("passive-mention-is-not-a-directive", "The watch is not the bound.", False),
+        ("warrant-read-is-not-a-directive",
+         "Read `watch_warranted` from `liveness`.", False),
+        ("unrelated-watch-word", "Watch the review budget.", False),
+        # Passage boundaries: what may carry a warrant to a directive.
+        ("semicolon-does-not-sever", f"{warrant}; ensure a live watch.", False),
+        ("semicolon-unguarded", "`ci` is `pending`; keep a watch alive.", True),
+        ("sentence-boundary-does-not-sever",
+         f"{warrant}. Ensure a live watch.", False),
+        ("blank-line-severs", f"{warrant}.\n\nEnsure a live watch.", True),
+        # A section title is not a warrant for what the section says: the
+        # directive itself has to name the field.
+        ("heading-severs",
+         "## When `watch_warranted` is true\nEnsure a live watch.", True),
+        ("list-items-are-separate", f"- {warrant}\n- Ensure a live watch.", True),
+        ("list-item-continuation-joins",
+         f"- {warrant}\n  and only then ensure a live watch.", False),
+        ("wrapped-directive-joins",
+         "While `ci` is `pending`, ensure or\nrelaunch a watch.", True),
+        # Tables: one passage per ROW, and a row is never severed by its bars.
+        ("table-row-unguarded",
+         "| verdict | move |\n|---|---|\n| `pending` | Ensure a live watch. |", True),
+        ("table-row-guarded",
+         "| verdict | move |\n|---|---|\n"
+         f"| `pending` | {warrant} → ensure a live watch |", False),
+        ("table-cell-bars-do-not-sever",
+         "| condition | move |\n|---|---|\n"
+         f"| {warrant} | ensure a live watch |", False),
+        ("table-rows-are-separate",
+         f"| verdict | move |\n|---|---|\n| `pending` | {warrant} |\n"
+         "| `red` | Ensure a live watch. |", True),
+        # A fenced diagram is one passage, so a decision node can carry the
+        # warrant to the node that acts on it.
+        ("fenced-diagram-guarded",
+         "```mermaid\nflowchart TD\n    R --> WW{watch_warranted?}\n"
+         "    WW -- true --> CW[keep a CI watch alive]\n```", False),
+        ("fenced-diagram-unguarded",
+         "```mermaid\nflowchart TD\n"
+         "    R -- pending --> CW[keep a CI watch alive]\n```", True),
     )
-    for name, fixture, expected in parser_fixtures:
+    for name, fixture, expected in fixtures:
         with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
             fixture_root = Path(temporary) / "campaign"
             fixture_root.mkdir()
             (fixture_root / "fixture.md").write_text(fixture + "\n", encoding="utf-8")
-            found = bool(check_status_watch_maintenance_docs(fixture_root))
+            found = bool(check_watch_directive_warrants(fixture_root))
             require(found is expected,
-                    f"{name} status-based watch maintenance fixture had the wrong result")
-
-    run_watch_markup_grid_fixtures(fixture_parent)
+                    f"{name} watch directive fixture had the wrong result")
 
 
-def run_watch_markup_grid_fixtures(fixture_parent: Path) -> None:
-    """Sweep every token position against every inline-markup form.
+def run_watch_exemption_fixtures(fixture_parent: Path) -> None:
+    """The registry excuses only what it names, and it may not go stale."""
+    document, anchor, excused, _ = WATCH_DIRECTIVE_EXEMPTIONS[0]
+    passage = f"| {anchor}; relaunch it in this same heartbeat. |"
+    require(watch_directive_is_exempt(document, passage,
+                                      (WATCH_DIRECTIVE_EXEMPTIONS[0],)),
+            "the registry entry under test does not excuse its own passage")
+    for name, entry in (
+        ("other-document",
+         ("references/stage-3-merge.md", anchor, excused, "fixture")),
+        ("anchor-absent", (document, "an anchor nobody wrote", excused, "fixture")),
+        ("declared-phrases-drifted", (document, anchor, ("keep a watch",), "fixture")),
+    ):
+        require(not watch_directive_is_exempt(document, passage, (entry,)),
+                f"{name} watch exemption fixture excused a passage it does not name")
 
-    A FLAT list of sentences is what let the guard-before/guard-after asymmetry
-    survive four review rounds: one missing markup tolerance shows up as a false
-    NEGATIVE at an accuse position and a false POSITIVE at an excuse position,
-    so a list that happens to spell one position plainly proves nothing about
-    the other. The grid forces both directions at every position.
-    """
-    markup_forms = (
-        ("plain", "{}"),
-        ("code", "`{}`"),
-        ("bold", "**{}**"),
-        ("italic", "*{}*"),
-        ("underscore", "_{}_"),
-        ("strikethrough", "~~{}~~"),
-        ("code-in-bold", "**`{}`**"),
-        ("code-in-italic", "*`{}`*"),
-    )
-    # (position, token, clause template with one slot, expected to be flagged)
-    token_positions = (
-        # Accuse path: the marked-up token must still be recognised, or a real
-        # anti-pattern escapes.
-        ("condition-field", "ci", "{} is pending, ensure a watch.", True),
-        ("condition-field-phrase", "ci status",
-         "{} is pending, ensure a watch.", True),
-        ("condition-copula", "is", "`ci` {} pending, ensure a watch.", True),
-        ("condition-value", "pending", "`ci` is {}, ensure a watch.", True),
-        ("condition-whole", "ci = pending", "{}, ensure a watch.", True),
-        ("active-verb", "ensure", "`ci` is `pending`, {} a watch.", True),
-        ("active-object", "watch", "`ci` is `pending`, ensure a {}.", True),
-        ("active-filler", "live", "`ci` is `pending`, ensure a {} watch.", True),
-        ("passive-object", "watch",
-         "`ci` is `pending`, a {} should be maintained.", True),
-        ("passive-verb", "maintained",
-         "`ci` is `pending`, a watch should be {}.", True),
-        # Excuse path: the same marked-up token must still be recognised, or a
-        # correct sentence is flagged.
-        ("guard-introducer", "When",
-         "{} `watch_warranted` is `true`, ensure a watch when CI status "
-         "is pending.", False),
-        ("guard-introducer-provided", "provided",
-         "Ensure a watch when CI status is pending, {} returned "
-         "watch_warranted is true.", False),
-        ("guard-reporter", "liveness",
-         "Ensure a watch when CI status is pending only when {} reports "
-         "`watch_warranted`.", False),
-        ("guard-reporter-verb", "reports",
-         "Ensure a watch when CI status is pending only when `liveness` {} "
-         "`watch_warranted`.", False),
-        ("guard-token", "watch_warranted",
-         "Ensure a watch when CI status is pending only when `liveness` "
-         "reports {}.", False),
-        ("guard-copula", "is",
-         "Ensure a watch when CI status is pending only when returned "
-         "watch_warranted {} true.", False),
-        ("guard-true", "true",
-         "Ensure a watch when CI status is pending only when returned "
-         "watch_warranted is {}.", False),
-        ("guard-to-action-connective", "then",
-         "When `watch_warranted` is `true`, {} ensure a watch when CI status "
-         "is pending.", False),
-        ("action-to-guard-connective", "and",
-         "Ensure a watch when CI status is pending, {} only when returned "
-         "watch_warranted is true.", False),
-        ("negator-before-action", "Never",
-         "{} ensure a watch when CI status is pending.", False),
-        ("negator-after-copula", "is",
-         "When CI status is pending, to ensure a watch {} unnecessary.", False),
-        ("negator-after-word", "unnecessary",
-         "When CI status is pending, to ensure a watch is {}.", False),
-    )
-    for position, token, template, expected in token_positions:
-        for form_name, form in markup_forms:
-            clause = template.format(form.format(token))
-            with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
-                fixture_root = Path(temporary) / "campaign"
-                fixture_root.mkdir()
-                (fixture_root / "fixture.md").write_text(
-                    clause + "\n", encoding="utf-8"
-                )
-                found = bool(check_status_watch_maintenance_docs(fixture_root))
-                require(found is expected,
-                        f"{position}/{form_name} watch markup grid cell had the "
-                        f"wrong result: {clause!r}")
+    with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
+        fixture_root = Path(temporary) / "campaign"
+        shutil.copytree(ROOT, fixture_root)
+        target = fixture_root / document
+        target.write_text(
+            target.read_text(encoding="utf-8").replace(
+                anchor, "**YES** — ensure a live watch", 1),
+            encoding="utf-8",
+        )
+        require_rejected(
+            lambda: check_watch_directive_exemptions(fixture_root),
+            "watch directive exemption anchor is not unique",
+            "a stale watch directive exemption anchor must be rejected",
+        )
 
 
 def require_rejected(callback, expected: str, message: str) -> None:
@@ -1240,8 +1043,11 @@ def check_document_contract() -> None:
 
     check_campaign_triage_contract(stage, adoption, loop_control, skill)
     check_watch_consumers(adoption, loop_control)
-    require(not check_status_watch_maintenance_docs(),
-            "campaign docs contain an unregistered status-based watch action")
+    check_watch_directive_exemptions()
+    unwarranted = check_watch_directive_warrants()
+    require(not unwarranted,
+            "campaign docs direct a watch without naming `watch_warranted`: "
+            + "; ".join(unwarranted))
     new_row_summary = delimited_region(
         adoption,
         "   - **On a NEW row only, initialize:**",

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -56,28 +56,74 @@ WATCH_ACTION = (
     "Run `liveness`, then ensure or relaunch a watch only when returned "
     "`watch_warranted` is `true`"
 )
+# --- Shared token-edge primitives -------------------------------------------
+# Every site below asks the same question -- "what may sit at this token's
+# edge?" -- and answers it here, once. Hand-rolling it per site is what made the
+# identical missing markup tolerance surface as a false negative on the accuse
+# path (status condition, maintenance action) and a false positive on the excuse
+# path (guard, negation, gaps).
+#
+# `\b` cannot be part of that answer: it is RELATIVE, so its meaning flips with
+# whatever the engine just consumed, and it therefore cannot compose with an
+# optional markup delimiter. WATCH_LEFT/WATCH_RIGHT are absolute.
+WATCH_MARKUP = r"[`*_~]{0,3}"
+WATCH_LEFT = r"(?<![0-9A-Za-z])"
+WATCH_RIGHT = r"(?![0-9A-Za-z])"
+# The one gap vocabulary: whitespace, clause punctuation, table cell bars,
+# inline markup, dashes and arrows.
+WATCH_GAP_CHARS = r"(?:[\s,;:()\[\]{}|`*_~—–-]|->|→)"
+# What may follow a matched token: whitespace, sentence or clause punctuation,
+# a table cell bar, a dash, or end of clause.
+WATCH_TOKEN_END = r"(?=\s|[.!?;:|,)\]}]|[-—–]|$)"
+
+
+def watch_token(inner: str) -> str:
+    """Wrap a vocabulary alternation in the shared markup-tolerant token edges.
+
+    The builder decides EDGES only. Which words count as verbs, introducers or
+    connectives stays with the caller.
+    """
+    return rf"{WATCH_MARKUP}{WATCH_LEFT}(?:{inner}){WATCH_RIGHT}{WATCH_MARKUP}"
+
+
+def watch_gap(connectives: str) -> str:
+    """Return the one gap pattern: gap characters around named connectives."""
+    return rf"{WATCH_GAP_CHARS}*(?:{watch_token(connectives)}{WATCH_GAP_CHARS}*)*"
+
+
 WATCH_MAINTENANCE_VERBS = r"(?:keep|maintain|start|launch|relaunch|ensure)(?:s|ed|ing)?"
 WATCH_STATUS_VALUES = r"(?:pending|red|green|unknown|unusable|unverifiable)"
-WATCH_STATUS_MARKUP = r"[`*_]{0,2}"
-WATCH_STATUS_CONDITION = (
-    WATCH_STATUS_MARKUP
-    + r"\b(?:ci(?:`?\s+`?status)?|status)\b"
-    + WATCH_STATUS_MARKUP
-    + r"\s*(?:is|=|==|:)\s*"
-    r"(?:[`\"']\s*)?(?:quoted\s+)?"
-    + WATCH_STATUS_VALUES
-    + r"\b\s*[`\"']?(?=\s|[.!?;:|,)\]}]|$)"
+# `is`/`=`/`==`/`:` may carry markup, but a bare symbol must not demand a
+# non-word character after it: `ci=pending` has none.
+WATCH_COPULA = (
+    rf"\s*(?:{watch_token('is')}|{WATCH_MARKUP}(?:==|=|:){WATCH_MARKUP})\s*"
 )
+WATCH_STATUS_FIELD = (
+    rf"(?:{watch_token('ci')}(?:\s+{watch_token('status')})?"
+    rf"|{watch_token('status')})"
+)
+WATCH_STATUS_CONDITION = (
+    WATCH_STATUS_FIELD
+    + WATCH_COPULA
+    + r"(?:[\"']\s*)?(?:quoted\s+)?"
+    + watch_token(WATCH_STATUS_VALUES)
+    + r"\s*[\"']?"
+    + WATCH_TOKEN_END
+)
+# Filler words between a maintenance verb and its object may themselves be
+# marked up: `ensure a **live** watch`.
+WATCH_ACTION_FILLER = rf"(?:\s+{WATCH_MARKUP}[\w-]+{WATCH_MARKUP}){{0,8}}?"
 WATCH_ACTIVE_MAINTENANCE_ACTION = (
-    r"\b"
-    + WATCH_MAINTENANCE_VERBS
-    + r"\b(?:\s+[\w-]+){0,8}?\s+\bwatch(?:es|ed|ing)?\b(?:\s+alive)?"
+    watch_token(WATCH_MAINTENANCE_VERBS)
+    + WATCH_ACTION_FILLER
+    + r"\s+"
+    + watch_token(r"watch(?:es|ed|ing)?")
+    + rf"(?:\s+{watch_token('alive')})?"
 )
 WATCH_PASSIVE_MAINTENANCE_ACTION = (
-    r"\bwatch(?:es|ed|ing)?\b"
-    r"(?:\s+(?:should|must|may|can|will|is|are|be)){0,3}\s+"
-    + WATCH_MAINTENANCE_VERBS
-    + r"\b"
+    watch_token(r"watch(?:es|ed|ing)?")
+    + rf"(?:\s+{watch_token('should|must|may|can|will|is|are|be')}){{0,3}}\s+"
+    + watch_token(WATCH_MAINTENANCE_VERBS)
 )
 WATCH_MAINTENANCE_ACTION = (
     rf"(?:{WATCH_ACTIVE_MAINTENANCE_ACTION}|{WATCH_PASSIVE_MAINTENANCE_ACTION})"
@@ -85,16 +131,20 @@ WATCH_MAINTENANCE_ACTION = (
 WATCH_STATUS_CONDITION_RE = re.compile(WATCH_STATUS_CONDITION, re.IGNORECASE)
 WATCH_MAINTENANCE_ACTION_RE = re.compile(WATCH_MAINTENANCE_ACTION, re.IGNORECASE)
 WATCH_WARRANTED_REPORTER = (
-    r"(?:`?liveness`?(?:\s+result)?|it)\s+(?:has|reports?|returns?)\s+"
+    rf"(?:{watch_token('liveness')}(?:\s+{watch_token('result')})?"
+    rf"|{watch_token('it')})"
+    rf"\s+{watch_token('has|reports?|returns?')}\s+"
 )
-WATCH_WARRANTED_TOKEN = r"`?watch_warranted`?"
-WATCH_WARRANTED_IS_TRUE = r"\s*(?:is|=|==|:)\s*`?true`?"
+WATCH_WARRANTED_TOKEN = watch_token("watch_warranted")
+WATCH_WARRANTED_IS_TRUE = WATCH_COPULA + watch_token("true")
 WATCH_WARRANTED_TRUE_GUARD_RE = re.compile(
-    r"\b(?:only\s+)?(?:when|if|provided(?:\s+that)?|as\s+long\s+as)\s+"
+    rf"(?:{watch_token('only')}\s+)?"
+    + watch_token(r"when|if|provided(?:\s+that)?|as\s+long\s+as")
+    + r"\s+"
     # The same introducer may carry the status condition first, as in
     # "when CI status is pending and `liveness` reports `watch_warranted`".
-    + rf"(?:{WATCH_STATUS_CONDITION}\s*[,;:-]*\s*(?:and|but)?\s*(?:only\s+)?)?"
-    + r"(?:(?:the|a)\s+)?(?:returned\s+)?"
+    + rf"(?:{WATCH_STATUS_CONDITION}{watch_gap('and|but|only')})?"
+    + rf"(?:{watch_token('the|a')}\s+)?(?:{watch_token('returned')}\s+)?"
     r"(?:"
     # A named reporter (`liveness`, the liveness result, or a pronoun) makes the
     # trailing `is true` optional: it is the docs' own house phrasing.
@@ -105,39 +155,54 @@ WATCH_WARRANTED_TRUE_GUARD_RE = re.compile(
     # Without a reporter, a bare token is not a guard: `is true` stays required.
     + WATCH_WARRANTED_TOKEN
     + WATCH_WARRANTED_IS_TRUE
-    + r")\b",
+    + r")",
+    # No trailing `\b`: the final atom may be a closing markup delimiter, which
+    # `\b` can never satisfy, so it would backtrack that delimiter out of the
+    # guard and into the gap. watch_token's WATCH_RIGHT already pins the word.
     re.IGNORECASE,
 )
 WATCH_NEGATED_BEFORE_ACTION_RE = re.compile(
-    r"(?:\bnever\b|\bdo\s+not\b|\bdon't\b|\bdoesn't\b|"
-    r"\bno\s+need\s+to\b|\bunnecessary\s+to\b|"
-    r"\bnot(?:\s+(?:required|necessary))?\s+to\b|\bnot\b)\s*$",
+    watch_token(
+        r"never|do\s+not|don't|doesn't|no\s+need\s+to|unnecessary\s+to|"
+        r"not(?:\s+(?:required|necessary))?\s+to|not"
+    )
+    + r"\s*$",
     re.IGNORECASE,
 )
 WATCH_NEGATED_AFTER_ACTION_RE = re.compile(
-    r"^\s*(?:is|are|becomes?|seems?)\s+(?:unnecessary|"
-    r"not\s+(?:required|necessary))\b",
+    # The negating copula need not be adjacent to the action: "ensure a watch
+    # when CI status is pending is unnecessary" negates it just as plainly.
+    rf"^{WATCH_ACTION_FILLER}\s*"
+    + watch_token("is|are|becomes?|seems?")
+    + r"\s+"
+    + watch_token(r"unnecessary|not\s+(?:required|necessary)"),
     re.IGNORECASE,
 )
+# NOT routed through watch_token: here the backticks are SEMANTIC -- they mark a
+# quotation, which is itself the excuse. Making markup skippable inside this
+# pattern would turn every backticked example into a quotation.
 WATCH_QUOTED_SPAN_RE = re.compile(
     r"`[^`\n]*`|\"[^\"\n]*\"|(?<!\w)'[^'\n]*'(?!\w)|“[^”\n]*”|‘[^’\n]*’"
 )
 WATCH_GUARD_BEFORE_ACTION_GAP_RE = re.compile(
-    r"^\s*[,;:()\[\]-]*(?:(?:then|and)\s+)?[,;:()\[\]-]*\s*$",
+    rf"^{watch_gap('then|and|only')}$",
     re.IGNORECASE,
 )
 WATCH_GUARD_AFTER_ACTION_GAP_RE = re.compile(
-    r"^\s*[,;:()\[\]-]*(?:only|then|and)?[,;:()\[\]-]*\s*$",
+    rf"^{watch_gap('only|then|and|but')}$",
     re.IGNORECASE,
 )
 WATCH_STATUS_GUARD_AFTER_ACTION_GAP_RE = re.compile(
-    rf"^\s*(?:when|if|while)\s+{WATCH_STATUS_CONDITION}"
-    r"\s*[,;:-]*\s*(?:but\s+)?(?:only\s*)?$",
+    rf"^{WATCH_GAP_CHARS}*{watch_token('when|if|while')}\s+"
+    rf"{WATCH_STATUS_CONDITION}{watch_gap('but|only|and|then')}$",
     re.IGNORECASE,
 )
+WATCH_GUARD_PREFIX_RE = re.compile(watch_gap("then|and|only"), re.IGNORECASE)
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
 )
+MARKDOWN_TABLE_ROW = re.compile(r"^[ \t>]*\|.*\|[ \t]*$")
+MARKDOWN_TABLE_DELIMITER = re.compile(r"^[ \t>]*\|[\s:|-]*\|[ \t]*$")
 
 
 def markdown_section(body: str, heading: str) -> str:
@@ -432,7 +497,13 @@ def markdown_watch_clauses(body: str) -> list[tuple[str, int]]:
 
     for line_number, line in enumerate(body.splitlines(), start=1):
         item = MARKDOWN_LIST_ITEM.match(line)
-        if item is not None:
+        if MARKDOWN_TABLE_ROW.match(line) is not None:
+            # A table row is ONE clause. Its cell bars must not sever it, or the
+            # check goes structurally inert inside every watch-policy table.
+            flush()
+            if MARKDOWN_TABLE_DELIMITER.match(line) is None:
+                blocks.append((line.strip(), line_number))
+        elif item is not None:
             flush()
             current = [line[item.end():].strip()]
             current_line = line_number
@@ -448,15 +519,18 @@ def markdown_watch_clauses(body: str) -> list[tuple[str, int]]:
     for block, line_number in blocks:
         clauses.extend(
             (clause.strip(), line_number)
-            for clause in re.split(r"(?<=[.!?;|])\s+", block)
+            for clause in re.split(r"(?<=[.!?;])\s+", block)
             if clause.strip()
         )
     return clauses
 
 
 def watch_action_is_quoted(clause: str, action: re.Match[str]) -> bool:
+    # `<=` on both ends, not `<`: the action's own markup edges may now consume
+    # the quotation's opening delimiter, so a fully quoted action starts exactly
+    # where its quotation does. Containment is what excuses it, either way.
     return any(
-        quoted.start() < action.start() and action.end() <= quoted.end()
+        quoted.start() <= action.start() and action.end() <= quoted.end()
         for quoted in WATCH_QUOTED_SPAN_RE.finditer(clause)
     )
 
@@ -473,11 +547,7 @@ def watch_action_is_negated(clause: str, action: re.Match[str]) -> bool:
 def watch_guard_prefix_is_conditional(clause: str, guard: re.Match[str]) -> bool:
     prefix = clause[:guard.start()]
     prefix = WATCH_STATUS_CONDITION_RE.sub("", prefix)
-    return re.fullmatch(
-        r"\s*[,;:()\[\]-]*(?:(?:then|and|only)\s+)?[,;:()\[\]-]*\s*",
-        prefix,
-        re.IGNORECASE,
-    ) is not None
+    return WATCH_GUARD_PREFIX_RE.fullmatch(prefix) is not None
 
 
 def watch_action_has_true_warrant_guard(
@@ -681,6 +751,70 @@ def run_watch_action_fixtures() -> None:
         ("separate-list-items", "- CI status is pending\n- Keep a watch.", False),
         ("separate-sentences", "CI status is pending. Keep a watch.", False),
         ("same-list-item", "- CI status is pending and keep a watch.", True),
+        # Gap content, not markup form: the guard-to-action and action-to-guard
+        # gaps carry arrows, dashes and more than one connective.
+        (
+            "arrow-guard-to-action-gap",
+            "When `liveness` reports `watch_warranted` → ensure a watch while "
+            "CI status is pending.",
+            False,
+        ),
+        (
+            "ascii-arrow-guard-to-action-gap",
+            "When `liveness` reports `watch_warranted` -> ensure a watch while "
+            "CI status is pending.",
+            False,
+        ),
+        (
+            "multi-connective-action-to-guard-gap",
+            "Ensure a watch when CI status is pending, and only if returned "
+            "watch_warranted is true.",
+            False,
+        ),
+        (
+            "em-dash-status-terminator",
+            "`ci` is `pending`—ensure a watch.",
+            True,
+        ),
+        (
+            "non-adjacent-negation-after-action",
+            "To ensure a watch when CI status is pending is unnecessary.",
+            False,
+        ),
+        # A table row is one clause; its cell bars must not sever the condition
+        # from the action, or the check goes inert inside watch-policy tables.
+        (
+            "table-row-condition-and-action",
+            "| condition | policy |\n|---|---|\n"
+            "| When `ci` is `pending` | ensure a live watch |",
+            True,
+        ),
+        (
+            "table-row-guarded-action",
+            "| condition | policy |\n|---|---|\n"
+            "| When `ci` is `pending` | ensure a live watch only when "
+            "`liveness` reports `watch_warranted` |",
+            False,
+        ),
+        (
+            "table-delimiter-row-is-not-a-clause",
+            "| CI status is pending | keep a watch |\n|---|---|",
+            True,
+        ),
+        # ...and one clause per row, not one clause per table: a condition in
+        # one row must not bind to an action in another.
+        (
+            "separate-table-rows",
+            "| verdict | policy |\n|---|---|\n"
+            "| `ci` is `pending` | wait for the liveness bounds |\n"
+            "| `red` | keep a watch |",
+            False,
+        ),
+        # The quotation excuse must survive the action's own markup edges in
+        # both directions: a wholly quoted action stays excused, and a merely
+        # marked-up object does not become a quotation.
+        ("code-span-quoted-action", "CI status is pending, `keep a watch`.", False),
+        ("code-span-action-object", "`ci` is `pending`, ensure a `watch`.", True),
     )
     for name, fixture, expected in parser_fixtures:
         with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
@@ -690,6 +824,95 @@ def run_watch_action_fixtures() -> None:
             found = bool(check_status_watch_maintenance_docs(fixture_root))
             require(found is expected,
                     f"{name} status-based watch maintenance fixture had the wrong result")
+
+    run_watch_markup_grid_fixtures(fixture_parent)
+
+
+def run_watch_markup_grid_fixtures(fixture_parent: Path) -> None:
+    """Sweep every token position against every inline-markup form.
+
+    A FLAT list of sentences is what let the guard-before/guard-after asymmetry
+    survive four review rounds: one missing markup tolerance shows up as a false
+    NEGATIVE at an accuse position and a false POSITIVE at an excuse position,
+    so a list that happens to spell one position plainly proves nothing about
+    the other. The grid forces both directions at every position.
+    """
+    markup_forms = (
+        ("plain", "{}"),
+        ("code", "`{}`"),
+        ("bold", "**{}**"),
+        ("italic", "*{}*"),
+        ("underscore", "_{}_"),
+        ("strikethrough", "~~{}~~"),
+        ("code-in-bold", "**`{}`**"),
+        ("code-in-italic", "*`{}`*"),
+    )
+    # (position, token, clause template with one slot, expected to be flagged)
+    token_positions = (
+        # Accuse path: the marked-up token must still be recognised, or a real
+        # anti-pattern escapes.
+        ("condition-field", "ci", "{} is pending, ensure a watch.", True),
+        ("condition-field-phrase", "ci status",
+         "{} is pending, ensure a watch.", True),
+        ("condition-copula", "is", "`ci` {} pending, ensure a watch.", True),
+        ("condition-value", "pending", "`ci` is {}, ensure a watch.", True),
+        ("condition-whole", "ci = pending", "{}, ensure a watch.", True),
+        ("active-verb", "ensure", "`ci` is `pending`, {} a watch.", True),
+        ("active-object", "watch", "`ci` is `pending`, ensure a {}.", True),
+        ("active-filler", "live", "`ci` is `pending`, ensure a {} watch.", True),
+        ("passive-object", "watch",
+         "`ci` is `pending`, a {} should be maintained.", True),
+        ("passive-verb", "maintained",
+         "`ci` is `pending`, a watch should be {}.", True),
+        # Excuse path: the same marked-up token must still be recognised, or a
+        # correct sentence is flagged.
+        ("guard-introducer", "When",
+         "{} `watch_warranted` is `true`, ensure a watch when CI status "
+         "is pending.", False),
+        ("guard-introducer-provided", "provided",
+         "Ensure a watch when CI status is pending, {} returned "
+         "watch_warranted is true.", False),
+        ("guard-reporter", "liveness",
+         "Ensure a watch when CI status is pending only when {} reports "
+         "`watch_warranted`.", False),
+        ("guard-reporter-verb", "reports",
+         "Ensure a watch when CI status is pending only when `liveness` {} "
+         "`watch_warranted`.", False),
+        ("guard-token", "watch_warranted",
+         "Ensure a watch when CI status is pending only when `liveness` "
+         "reports {}.", False),
+        ("guard-copula", "is",
+         "Ensure a watch when CI status is pending only when returned "
+         "watch_warranted {} true.", False),
+        ("guard-true", "true",
+         "Ensure a watch when CI status is pending only when returned "
+         "watch_warranted is {}.", False),
+        ("guard-to-action-connective", "then",
+         "When `watch_warranted` is `true`, {} ensure a watch when CI status "
+         "is pending.", False),
+        ("action-to-guard-connective", "and",
+         "Ensure a watch when CI status is pending, {} only when returned "
+         "watch_warranted is true.", False),
+        ("negator-before-action", "Never",
+         "{} ensure a watch when CI status is pending.", False),
+        ("negator-after-copula", "is",
+         "When CI status is pending, to ensure a watch {} unnecessary.", False),
+        ("negator-after-word", "unnecessary",
+         "When CI status is pending, to ensure a watch is {}.", False),
+    )
+    for position, token, template, expected in token_positions:
+        for form_name, form in markup_forms:
+            clause = template.format(form.format(token))
+            with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
+                fixture_root = Path(temporary) / "campaign"
+                fixture_root.mkdir()
+                (fixture_root / "fixture.md").write_text(
+                    clause + "\n", encoding="utf-8"
+                )
+                found = bool(check_status_watch_maintenance_docs(fixture_root))
+                require(found is expected,
+                        f"{position}/{form_name} watch markup grid cell had the "
+                        f"wrong result: {clause!r}")
 
 
 def require_rejected(callback, expected: str, message: str) -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import os
 import re
@@ -13,6 +14,7 @@ import sys
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
+from typing import NamedTuple
 
 from _gauntlet.modules import load_module_from_path
 
@@ -81,13 +83,9 @@ WATCH_ACTION = (
 # check refuses to have. Naming the field is the mechanical part; whether the
 # sentence uses it correctly is the reviewer's.
 WATCH_WARRANT_FIELD = "watch_warranted"
-# Inline markup is not vocabulary: `ensure a **live** watch` is the same
-# directive as `ensure a live watch`. Underscore is NOT stripped -- it is a
-# character of the warrant's own name.
-WATCH_MARKUP_CHARS = str.maketrans("", "", "`*~")
 # Every phrase names a WATCH as the object of a maintenance verb -- that is the
 # whole bound on this list, and it is what keeps "watch the review budget" out.
-# Matched against markup-normalized text, so each entry stays lowercase and
+# Matched against `inline_text`'s projection, so each entry stays lowercase and
 # markup-free. Order is irrelevant: nesting is resolved by longest span.
 WATCH_DIRECTIVE_PHRASES = (
     "ensure or relaunch a watch",
@@ -136,8 +134,71 @@ WATCH_DIRECTIVE_EXEMPTIONS = (
 MARKDOWN_LIST_ITEM = re.compile(
     r"^(?P<prefix>[ \t>]*)(?:[-*+]|\d+[.)]) "
 )
-MARKDOWN_TABLE_ROW = re.compile(r"^[ \t>]*\|.*\|[ \t]*$")
 MARKDOWN_HEADING = re.compile(r"^[ \t>]*#{1,6} ")
+# --- The Markdown view: ONE producer, four consumers -------------------------
+# `document_passages` is the only thing that turns a Markdown document into the
+# units this check judges, and `inline_text` is the only thing that says what a
+# passage's text amounts to. Before them, the block splitter and the inline
+# projection were two independent, partial re-implementations of Markdown, so
+# the check judged a document that did not exist: a fenced diagram was severed
+# by its own blank lines -- a FALSE accusation, because the warrant and the
+# directive landed in different halves -- and a `# comment` inside that fence
+# was deleted outright as a heading, a missed one.
+#
+# This is deliberately NOT CommonMark. The check needs exactly two facts about
+# a document: where a passage begins and ends, and what plain text it amounts
+# to. It never needs link destinations, nesting depth, HTML semantics or
+# reference resolution. So the residue is bounded -- it is the set of
+# constructs that MOVE A BLOCK BOUNDARY or ERASE INLINE TEXT, nothing else --
+# and every cell of it is pinned by a fixture in `run_watch_passage_fixtures`.
+# Unpinned, a bigger hand-rolled parser is just the same trap at larger size.
+#
+# THREE POLICY CALLS, made once, here, rather than falling out of a regex:
+#
+#   1. RAW, not rendered. These documents are read by an agent consuming raw
+#      Markdown, not by a browser, so AN HTML COMMENT IS TEXT: its content both
+#      accuses and discharges, exactly like visible prose. Under the rendered
+#      reading a warrant hidden in a comment would silently excuse a visible
+#      directive -- a suppression vector -- while a directive hidden in a
+#      comment would escape entirely. Reading comments as ordinary text closes
+#      both, and it is what the actual consumer of these documents does.
+#   2. A FENCED BLOCK IS ONE PASSAGE, never skipped. The corpus already forced
+#      this: the campaign's own mermaid flowchart carries the warrant on one
+#      node and the directive on the next.
+#   3. INDENTED CODE IS ORDINARY TEXT -- the same call as (2), stated rather
+#      than inferred. See `document_passages`.
+#
+# These regexes are PRIVATE to this section. `MARKDOWN_LIST_ITEM` and
+# `MARKDOWN_HEADING` above are shared with the triage-contract checks, which
+# judge literal pointer strings and must not move when this view changes.
+WATCH_BLOCKQUOTE = re.compile(r"^ {0,3}(?:> ?)+")
+WATCH_FENCE_OPEN = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+# `#` alone is an empty ATX heading; `#foo` is not a heading at all.
+WATCH_ATX_HEADING = re.compile(r"^ {0,3}#{1,6}(?:[ \t].*)?$")
+WATCH_SETEXT_UNDERLINE = re.compile(r"^ {0,3}(?:=+|-+)[ \t]*$")
+WATCH_THEMATIC_BREAK = re.compile(r"^ {0,3}(?P<rule>[-*_])(?:[ \t]*(?P=rule)){2,}[ \t]*$")
+WATCH_LIST_MARKER = re.compile(r"^(?P<indent>[ \t]*)(?:[-*+]|\d{1,9}[.)])(?:[ \t]+|$)")
+WATCH_TABLE_DELIMITER = re.compile(
+    r"^ {0,3}\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)*\|?[ \t]*$"
+)
+WATCH_HTML_COMMENT = re.compile(r"<!--|-->")
+WATCH_HTML_TAG = re.compile(r"</?[A-Za-z][A-Za-z0-9-]*(?:\s[^<>]*)?/?>")
+WATCH_INLINE_LINK = re.compile(r"!?\[(?P<label>[^\[\]]*)\]\([^()]*\)")
+WATCH_REFERENCE_LINK = re.compile(r"!?\[(?P<label>[^\[\]]*)\]\[[^\[\]]*\]")
+WATCH_BACKSLASH_ESCAPE = re.compile(r"\\([!-/:-@\[-`{-~])")
+# An emphasis run, and ONLY an emphasis run: a `_` with a word character on
+# both sides is part of a name (`watch_warranted`) and is left alone.
+WATCH_EMPHASIS_UNDERSCORE = re.compile(r"(?<![0-9A-Za-z])_+|_+(?![0-9A-Za-z])")
+# `_` is deliberately absent here -- see `inline_text`.
+WATCH_MARKUP_CHARS = str.maketrans("", "", "`*~")
+
+
+class Passage(NamedTuple):
+    """One judged unit of a Markdown document."""
+
+    line: int
+    raw: str
+    text: str
 
 
 def markdown_section(body: str, heading: str) -> str:
@@ -417,62 +478,201 @@ def check_watch_consumers(adoption: str, loop_control: str) -> None:
                 f"{name} lost the liveness/watch_warranted gate")
 
 
-def markdown_watch_passages(body: str) -> list[tuple[str, int]]:
-    """Split Markdown into passages: one table row, one list item, one paragraph.
+def inline_text(source: str) -> str:
+    """Project Markdown source onto the plain text it amounts to.
 
-    A table row is ONE passage: its cell bars must not sever it, or the check
-    goes structurally inert inside every watch-policy table -- which is exactly
-    where this repository's watch policy is written.
+    Inline markup is not vocabulary: `ensure a **live** watch` is the same
+    directive as `ensure a live watch`, and so is `ensure a [live](x.md) watch`.
+    This is the ONLY inline projection in the watch check -- the accusing side,
+    the warrant test and the exemption anchors all read it, so the two halves of
+    one decision can never disagree about what a passage says.
 
-    Nothing below this splits a passage further. Sentence segmentation is what
-    let a semicolon put a directive and its warrant into different units while
-    the reader sees one instruction.
+    UNDERSCORE IS SPECIAL AND MUST STAY SO. `_` is a character of the warrant's
+    own name, so it is stripped only where it CANNOT be part of a word --
+    emphasis-run position. Adding `_` to the markup translate table would delete
+    `watch_warranted` from every passage that names it, converting a class of
+    missed accusations into a far worse class of false ones.
     """
-    passages: list[tuple[str, int]] = []
-    current: list[str] = []
-    current_line = 0
+    text = html.unescape(source)
+    text = WATCH_BACKSLASH_ESCAPE.sub(r"\1", text)
+    # RAW reading, policy call 1: keep what a comment SAYS, drop only its
+    # delimiters. A tag carries no prose, so it becomes a space.
+    text = WATCH_HTML_COMMENT.sub(" ", text)
+    text = WATCH_HTML_TAG.sub(" ", text)
+    text = WATCH_INLINE_LINK.sub(r"\1", text)
+    text = WATCH_REFERENCE_LINK.sub(r"\1", text)
+    # Remaining brackets become SPACES, never nothing: `CW[keep a watch alive]`
+    # must not fuse its node id onto the directive it labels.
+    text = text.replace("[", " ").replace("]", " ")
+    text = WATCH_EMPHASIS_UNDERSCORE.sub("", text)
+    text = text.translate(WATCH_MARKUP_CHARS)
+    return " ".join(text.lower().split())
+
+
+def document_passages(body: str) -> list[Passage]:
+    """Split a Markdown document into the units this check judges.
+
+    One table row, one list item (with its loose continuation), one fenced
+    block, one paragraph. Nothing below this splits a passage further: sentence
+    segmentation is what let a semicolon put a directive and its warrant into
+    different units while the reader sees one instruction.
+    """
+    passages: list[Passage] = []
+    raw_lines: list[str] = []
+    text_lines: list[str] = []
+    # Blank lines inside a list are held here, not committed: they belong to
+    # the item's source span only if the item turns out to continue past them.
+    held_blanks: list[str] = []
+    start = 0
+    item_indent: int | None = None
+    fence_close: re.Pattern[str] | None = None
+    in_table = False
+
+    def add(number: int, raw: str, text: str) -> None:
+        nonlocal start
+        if not raw_lines:
+            start = number
+        raw_lines.append(raw)
+        text_lines.append(text)
+
+    def drop() -> None:
+        """Discard the open passage: a setext underline retitled it."""
+        nonlocal start, item_indent
+        raw_lines.clear()
+        text_lines.clear()
+        held_blanks.clear()
+        start = 0
+        item_indent = None
 
     def flush() -> None:
-        nonlocal current, current_line
-        if current:
-            passages.append((" ".join(current), current_line))
-        current = []
-        current_line = 0
+        if raw_lines:
+            passages.append(Passage(start, "\n".join(raw_lines),
+                                    inline_text(" ".join(text_lines))))
+        drop()
 
-    for line_number, line in enumerate(body.splitlines(), start=1):
-        item = MARKDOWN_LIST_ITEM.match(line)
-        if MARKDOWN_TABLE_ROW.match(line) is not None:
+    lines = body.splitlines()
+    index = 0
+    # YAML front matter is metadata, but it is scanned like a fence -- one
+    # passage, never skipped -- so a directive cannot hide in it.
+    if lines and lines[0].rstrip() == "---":
+        for offset in range(1, len(lines)):
+            if lines[offset].rstrip() in ("---", "..."):
+                for number in range(1, offset + 2):
+                    add(number, lines[number - 1], lines[number - 1])
+                flush()
+                index = offset + 1
+                break
+
+    while index < len(lines):
+        number = index + 1
+        line = lines[index]
+        index += 1
+        content = WATCH_BLOCKQUOTE.sub("", line)
+
+        # Policy call 2: a fenced block is ONE passage and is never skipped, so
+        # a decision node can carry the warrant to the node that acts on it and
+        # a `#` comment inside the fence is not mistaken for a heading.
+        if fence_close is not None:
+            add(number, line, content)
+            if fence_close.match(content) is not None:
+                fence_close = None
+                flush()
+            continue
+
+        opener = WATCH_FENCE_OPEN.match(content)
+        if opener is not None and not (
+            opener.group("fence").startswith("`") and "`" in opener.group("info")
+        ):
             flush()
-            passages.append((line.strip(), line_number))
-        elif MARKDOWN_HEADING.match(line) is not None:
+            in_table = False
+            marker = opener.group("fence")
+            fence_close = re.compile(
+                rf"^ {{0,3}}{re.escape(marker[0])}{{{len(marker)},}}[ \t]*$")
+            add(number, line, content)
+            continue
+
+        if not content.strip():
+            # A blank line inside a list may be a LOOSE item, not its end. A
+            # `>`-only line reaches here too: it is a blank line in the quote.
+            if item_indent is not None and raw_lines:
+                held_blanks.append(line)
+            else:
+                flush()
+            in_table = False
+            continue
+
+        if WATCH_ATX_HEADING.match(content) is not None:
             flush()
-        elif item is not None:
+            in_table = False
+            continue
+
+        if (raw_lines and not held_blanks and item_indent is None
+                and not in_table
+                and WATCH_SETEXT_UNDERLINE.match(content) is not None):
+            # A setext underline makes the open paragraph a TITLE, and a title
+            # is never a warrant for what the section under it says -- the same
+            # call the ATX spelling above already makes.
+            drop()
+            continue
+
+        if WATCH_THEMATIC_BREAK.match(content) is not None:
             flush()
-            current = [line[item.end():].strip()]
-            current_line = line_number
-        elif not line.strip():
+            in_table = False
+            continue
+
+        if in_table:
+            if "|" in content:
+                flush()
+                add(number, line, content)
+                flush()
+                continue
+            in_table = False
+
+        # A table is a header row plus a delimiter row; outer pipes are
+        # OPTIONAL. Each row is one passage -- its cell bars must not sever it,
+        # or the check goes structurally inert inside every watch-policy table,
+        # which is exactly where this repository's watch policy is written.
+        if "|" in content and index < len(lines):
+            following = WATCH_BLOCKQUOTE.sub("", lines[index])
+            if "|" in following and WATCH_TABLE_DELIMITER.match(following) is not None:
+                flush()
+                add(number, line, content)
+                flush()
+                in_table = True
+                index += 1  # the delimiter row carries no prose
+                continue
+
+        item = WATCH_LIST_MARKER.match(content)
+        if item is not None:
             flush()
-        else:
-            if not current:
-                current_line = line_number
-            current.append(line.strip())
+            add(number, line, content[item.end():])
+            item_indent = item.end()
+            continue
+
+        indent = len(content) - len(content.lstrip(" \t"))
+        if held_blanks:
+            if item_indent is not None and indent >= item_indent:
+                raw_lines.extend(held_blanks)  # the item continues past them
+                held_blanks.clear()
+            else:
+                flush()  # not a continuation: the item ended at the blank line
+        # Policy call 3: indented code is ORDINARY TEXT. A shell transcript that
+        # says "keep a watch alive" is a directive whether or not it is
+        # indented, and an indented block is just as often a loose list item's
+        # own continuation, which must stay joined to the item.
+        add(number, line, content)
+
     flush()
     return passages
 
 
-def watch_text(passage: str) -> str:
-    """Return the passage with inline markup and line wrapping normalized away."""
-    return " ".join(passage.translate(WATCH_MARKUP_CHARS).lower().split())
-
-
-def watch_directive_phrases(passage: str) -> list[str]:
-    """Return the MAXIMAL directive phrases this passage carries.
+def watch_directive_phrases(text: str) -> list[str]:
+    """Return the MAXIMAL directive phrases this projected text carries.
 
     Maximal: "ensure a watch" sits inside "ensure a watch task", and one
     directive must count once, or an exemption would have to declare every
     nested spelling of the imperative it excuses.
     """
-    text = watch_text(passage)
     spans: list[tuple[int, int, str]] = []
     for phrase in WATCH_DIRECTIVE_PHRASES:
         start = text.find(phrase)
@@ -493,15 +693,18 @@ def watch_directive_phrases(passage: str) -> list[str]:
 
 def watch_directive_is_exempt(
     document: str,
-    passage: str,
+    passage: Passage,
     registry: tuple[tuple[str, str, tuple[str, ...], str], ...] =
         WATCH_DIRECTIVE_EXEMPTIONS,
 ) -> bool:
     for exempt_document, anchor, excused, _ in registry:
-        if exempt_document == document and anchor in passage:
+        # The anchor is projected through the SAME view as the passage, so the
+        # excusing side and the accusing side cannot disagree about what the
+        # passage says.
+        if exempt_document == document and inline_text(anchor) in passage.text:
             # An entry excuses the directives it was reviewed against, never
             # whatever the passage grows afterwards.
-            return watch_directive_phrases(passage) == sorted(set(excused))
+            return watch_directive_phrases(passage.text) == sorted(set(excused))
     return False
 
 
@@ -511,16 +714,16 @@ def check_watch_directive_warrants(root: Path = ROOT) -> list[str]:
     for document in sorted(root.rglob("*.md")):
         relative = document.relative_to(root).as_posix()
         text = document.read_text(encoding="utf-8")
-        for passage, line in markdown_watch_passages(text):
-            phrases = watch_directive_phrases(passage)
+        for passage in document_passages(text):
+            phrases = watch_directive_phrases(passage.text)
             if not phrases:
                 continue
-            if WATCH_WARRANT_FIELD in watch_text(passage):
+            if WATCH_WARRANT_FIELD in passage.text:
                 continue
             if watch_directive_is_exempt(relative, passage):
                 continue
             problems.append(
-                f"{relative}:{line} directs watch maintenance "
+                f"{relative}:{passage.line} directs watch maintenance "
                 f"({', '.join(phrases)}) without naming "
                 f"`{WATCH_WARRANT_FIELD}`"
             )
@@ -539,15 +742,16 @@ def check_watch_directive_exemptions(root: Path = ROOT) -> None:
         require(text.count(anchor) == 1,
                 f"watch directive exemption anchor is not unique in {document}: "
                 f"{anchor!r}")
+        projected = inline_text(anchor)
         selected = [
             passage
-            for passage, _ in markdown_watch_passages(text)
-            if anchor in passage
+            for passage in document_passages(text)
+            if projected in passage.text
         ]
         require(len(selected) == 1,
                 f"watch directive exemption anchor selects {len(selected)} "
                 f"passages in {document}: {anchor!r}")
-        require(watch_directive_phrases(selected[0]) == sorted(set(excused)),
+        require(watch_directive_phrases(selected[0].text) == sorted(set(excused)),
                 f"watch directive exemption in {document} no longer excuses "
                 f"exactly {sorted(set(excused))}: {anchor!r}")
 
@@ -557,11 +761,66 @@ def run_watch_action_fixtures() -> None:
     # (`check_document_contract`). It is NOT evidence that this check works: a
     # blind check passes a clean corpus too. The mutation fixtures below are the
     # evidence, and they run against the real documents.
-    fixture_parent = ROOT.parents[4] / ".tmp"
+    # `ROOT.parents` is [skills, gauntlet, plugins, <checkout>, <checkout's
+    # parent>]. Index 3 is the CHECKOUT ROOT -- the `.tmp/` that
+    # `scripts/validate-plugins.sh` already creates and `.gitignore` already
+    # covers. Index 4 escapes the checkout: it litters the directory holding it
+    # and dies on an uncaught OSError wherever that is not writable, skipping
+    # every watch fixture below.
+    fixture_parent = ROOT.parents[3] / ".tmp"
     fixture_parent.mkdir(exist_ok=True)
+    run_watch_view_fixtures()
     run_watch_corpus_mutation_fixtures(fixture_parent)
     run_watch_passage_fixtures(fixture_parent)
     run_watch_exemption_fixtures(fixture_parent)
+
+
+def run_watch_view_fixtures() -> None:
+    """Pin the Markdown view itself: where a passage starts, ends and says what.
+
+    The passage fixtures below judge the CHECK's VERDICT, and a wrong boundary
+    can still produce the right verdict by luck -- the campaign's own flowchart
+    passed for exactly that reason, until a blank line moved. These assert the
+    boundaries and the projection directly, so luck is not a passing grade.
+    """
+    fixtures = (
+        # A fence is one passage, delimiters and internal blank line included.
+        ("fence-is-one-passage",
+         "```mermaid\nA{watch_warranted?}\n\nB[keep a watch]\n```",
+         [(1, "```mermaid\nA{watch_warranted?}\n\nB[keep a watch]\n```",
+           "mermaid a{watch_warranted?} b keep a watch")]),
+        # A heading is a title: it severs and contributes no text of its own.
+        ("heading-is-dropped-not-emitted",
+         "## Title\nBody one.\n\nBody two.",
+         [(2, "Body one.", "body one."), (4, "Body two.", "body two.")]),
+        # One passage per table row; the delimiter row carries no prose.
+        ("table-rows-are-one-passage-each",
+         "verdict | move\n---|---\n`pending` | watch it\n`red` | fix it",
+         [(1, "verdict | move", "verdict | move"),
+          (3, "`pending` | watch it", "pending | watch it"),
+          (4, "`red` | fix it", "red | fix it")]),
+        # A loose list item is ONE passage: the blank line does not end it, and
+        # the passage is reported at the item's own line.
+        ("loose-list-item-is-one-passage",
+         "- first line\n\n  continued here\n\nnext paragraph",
+         [(1, "- first line\n\n  continued here", "first line continued here"),
+          (5, "next paragraph", "next paragraph")]),
+        # A `>`-only line is a blank line inside the quote.
+        ("blockquote-blank-line-severs",
+         "> one\n>\n> two",
+         [(1, "> one", "one"), (3, "> two", "two")]),
+        # The projection: link text survives, emphasis and tags do not, and an
+        # HTML comment's CONTENT survives because an agent reads it (policy 1).
+        ("projection-keeps-text-drops-markup",
+         "See [the *rules*](x.md) <br/> now. <!-- and this -->",
+         [(1, "See [the *rules*](x.md) <br/> now. <!-- and this -->",
+           "see the rules now. and this")]),
+    )
+    for name, body, expected in fixtures:
+        actual = [(passage.line, passage.raw, passage.text)
+                  for passage in document_passages(body)]
+        require(actual == [tuple(item) for item in expected],
+                f"{name} markdown view fixture produced {actual}")
 
 
 def run_watch_corpus_mutation_fixtures(fixture_parent: Path) -> None:
@@ -675,6 +934,100 @@ def run_watch_passage_fixtures(fixture_parent: Path) -> None:
         ("fenced-diagram-unguarded",
          "```mermaid\nflowchart TD\n"
          "    R -- pending --> CW[keep a CI watch alive]\n```", True),
+        # --- Inline projection: markup may not hide a directive, and may not
+        # hide the warrant either. The second direction is the dangerous one:
+        # an erased warrant is a FALSE accusation against correct content.
+        ("inline-link-does-not-hide-a-directive",
+         "While `ci` is `pending`, ensure a [live](watch.md) watch.", True),
+        ("reference-link-does-not-hide-a-directive",
+         "While `ci` is `pending`, ensure a [live][watch] watch.", True),
+        ("image-alt-does-not-hide-a-directive",
+         "![keep a watch alive](diagram.png)", True),
+        ("html-tag-does-not-hide-a-directive",
+         "While `ci` is `pending`, ensure a <b>live</b> watch.", True),
+        ("underscore-emphasis-does-not-hide-a-directive",
+         "While `ci` is `pending`, ensure a _live_ watch.", True),
+        ("escaped-markup-does-not-hide-a-directive",
+         "While `ci` is `pending`, ensure a \\*live\\* watch.", True),
+        # The three ways `_` reaches the warrant's own name. Each of these
+        # would be a false accusation if `_` were stripped unconditionally,
+        # which is why emphasis is parsed as a RUN and not translated away.
+        ("emphasized-warrant-still-names-the-field",
+         "Ensure a live watch only when _watch_warranted_ is true.", False),
+        ("intraword-underscore-is-never-emphasis",
+         "Ensure a live watch only when the watch_warranted field is true.",
+         False),
+        ("escaped-underscore-in-the-warrant",
+         "Ensure a live watch only when watch\\_warranted is true.", False),
+        ("entity-reference-in-the-warrant",
+         "Ensure a live watch only when watch&#95;warranted is true.", False),
+        # POLICY CALL 1, both sides: these documents are read RAW, so an HTML
+        # comment is text. It discharges a directive and it is accused for one.
+        ("html-comment-warrant-discharges",
+         "<!-- only when `watch_warranted` -->\nEnsure a live watch.", False),
+        ("html-comment-directive-is-accused",
+         "<!-- Ensure a live watch. -->", True),
+        # POLICY CALL 2, both sides: a fence is ONE passage and is never
+        # skipped. Neither a blank line nor a list marker nor a `#` comment
+        # inside it means what it would mean outside.
+        ("fenced-blank-line-does-not-sever",
+         "```mermaid\nflowchart TD\n    R --> WW{watch_warranted?}\n\n"
+         "    WW -- true --> CW[keep a CI watch alive]\n```", False),
+        ("fenced-list-marker-does-not-sever",
+         "```yaml\nwatch_warranted: true\n- keep a watch alive\n```", False),
+        ("fenced-comment-is-not-a-heading",
+         "```bash\n# keep a watch alive while ci is pending\ngh pr checks\n```",
+         True),
+        ("tilde-fence-is-one-passage",
+         "~~~text\n`liveness` reports `watch_warranted`\n\n"
+         "then keep a watch alive\n~~~", False),
+        ("fence-closes-only-on-its-own-length",
+         "````mermaid\n`liveness` reports `watch_warranted`\n```\n\n"
+         "    CW[keep a CI watch alive]\n````", False),
+        ("backtick-in-the-info-string-is-not-a-fence",
+         "```sh`x\nkeep a watch alive\n\n`liveness` reports `watch_warranted`.",
+         True),
+        # POLICY CALL 3, both sides: indented code is ordinary text -- scanned
+        # like a fence, and still part of the list item it continues.
+        ("indented-code-is-scanned",
+         "    gh pr checks --watch  # keep a watch alive while ci is pending",
+         True),
+        ("indented-code-continues-its-list-item",
+         f"- Only when {warrant}\n\n      ensure a live watch", False),
+        # --- Block boundaries the old splitter never had. Inventing a boundary
+        # is what severs a directive from the warrant discharging it.
+        ("setext-heading-severs",
+         f"When {warrant}\n===\nEnsure a live watch.", True),
+        ("setext-dash-heading-severs",
+         f"{warrant}\n---\nEnsure a live watch.", True),
+        ("thematic-break-severs", f"{warrant}.\n***\nEnsure a live watch.", True),
+        ("empty-heading-severs", f"{warrant}.\n#\nEnsure a live watch.", True),
+        ("hash-without-a-space-is-not-a-heading",
+         f"#{warrant}\nEnsure a live watch.", False),
+        ("blockquote-blank-line-severs",
+         f"> {warrant}.\n>\n> Ensure a live watch.", True),
+        ("blockquote-line-wrap-joins",
+         f"> {warrant}\n> and only then ensure a live watch.", False),
+        ("table-without-outer-pipes-rows-are-separate",
+         f"verdict | move\n---|---\n`pending` | {warrant}\n"
+         "`red` | Ensure a live watch.", True),
+        ("table-without-outer-pipes-row-is-not-severed",
+         f"condition | move\n---|---\n{warrant} | ensure a live watch", False),
+        ("pipe-in-prose-is-not-a-table",
+         f"{warrant} | ensure a live watch\nand that is the whole rule.", False),
+        ("loose-list-item-continuation-joins",
+         f"- Ensure a live watch.\n\n  Only when {warrant}.", False),
+        ("unindented-line-after-a-blank-ends-the-item",
+         f"- Ensure a live watch.\n\nOnly when {warrant}.", True),
+        ("ordered-list-items-are-separate",
+         f"1. {warrant}\n2. Ensure a live watch.", True),
+        # Front matter is metadata, and it is scanned like a fence: one
+        # passage, never skipped.
+        ("front-matter-is-one-passage",
+         f"---\ntitle: watching\nwhen: {warrant}\nthen: keep a watch alive\n---",
+         False),
+        ("front-matter-is-not-skipped",
+         "---\ntitle: watching\nthen: keep a watch alive\n---", True),
     )
     for name, fixture, expected in fixtures:
         with tempfile.TemporaryDirectory(dir=fixture_parent) as temporary:
@@ -689,7 +1042,8 @@ def run_watch_passage_fixtures(fixture_parent: Path) -> None:
 def run_watch_exemption_fixtures(fixture_parent: Path) -> None:
     """The registry excuses only what it names, and it may not go stale."""
     document, anchor, excused, _ = WATCH_DIRECTIVE_EXEMPTIONS[0]
-    passage = f"| {anchor}; relaunch it in this same heartbeat. |"
+    row = f"| {anchor}; relaunch it in this same heartbeat. |"
+    passage = Passage(1, row, inline_text(row))
     require(watch_directive_is_exempt(document, passage,
                                       (WATCH_DIRECTIVE_EXEMPTIONS[0],)),
             "the registry entry under test does not excuse its own passage")


### PR DESCRIPTION
- Reject status-conditioned watch maintenance that omits `watch_warranted`.
- Add regression fixtures for `keep` and `maintain` wording, including guarded forms.
- Replace only PR #170's final confirmed gap; PR #170 remains unchanged.
