### PR TITLE
hide aborted rows in ledger table by default

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -662,16 +662,23 @@ written into a real ledger, and a truncated SHA escape into a command.
 **`table` is a PROJECTION — NEVER a source to read a value back out of.** Its output is *formatted for a
 human*, and the formatting is lossy in four ways:
 
-- **It shows only SOME ROWS.** The default view **hides finished work** — a row that reached the run's
-  *successful* terminal state and needs nothing further from anyone. It is **not** "terminal rows": an
-  `aborted` PR is terminal too and it **stays visible**, because it is the run's *unfinished business* —
-  left open for its owner, with an `abort-<id>.md` a human is meant to read. Everything still in play,
-  parked included, always shows. **The omission is NEVER silent**: whenever the view drops a row, `table`
-  prints an out-of-band line stating **how many** rows it hid and the flag that reveals them, and **`--all`
-  shows every row** (it composes with `--fields` — one picks the rows, the other the columns). So **a
-  missing ROW is not a missing PR**, exactly as a missing column is not a missing value. Which statuses the
-  default hides is owned by `TABLE_HIDDEN_STATUSES` in `scripts/ledger.py` and named **live** in `ledger.py
-  table --help`; when this paragraph and that output disagree, **the script is right**.
+- **It shows only SOME ROWS.** The default view **hides the rows campaign is done with** — the ones it
+  will take no further action on, however they ended. Everything still in play, parked included, always
+  shows. **The omission is NEVER silent**: whenever the view drops a row, `table` prints an out-of-band
+  line stating **how many** rows it hid, **which statuses** they were dropped for — naming only the ones
+  actually dropped, so the line stays true when the ledger holds none of a kind — and the flag that
+  reveals them, and **`--all` shows every row** (it composes with `--fields` — one picks the rows, the
+  other the columns). So **a missing ROW is not a missing PR**, exactly as a missing column is not a
+  missing value. Which statuses the default hides is owned by `TABLE_HIDDEN_STATUSES` in
+  `scripts/ledger.py` and named **live** in `ledger.py table --help`; when this paragraph and that output
+  disagree, **the script is right**.
+
+  A hidden row includes the **`aborted`** one — the run's *unfinished business*, left open for its owner
+  with an `abort-<id>.md` a human is meant to read. That is not the status view dropping the thing a human
+  must act on: the **final report** enumerates every aborted PR, why, and where its log is
+  (`bailout-and-final-report.md`, "Final report"); the disclosure line **names `aborted` by status**
+  whenever such a row was dropped; and `--all` brings it straight back. A row hidden **with disclosure**,
+  reported in full elsewhere, is not a row buried.
 - **It shows only SOME fields.** The default view is a **SUBSET** of the row fields, and **NEITHER the
   shown nor the hidden set is enumerated here** — both are **DERIVED from the live schema**, never retyped
   on this page. The shown set is `TABLE_DEFAULT_FIELDS` in `scripts/ledger.py`, printed **live** by
@@ -705,7 +712,7 @@ human*, and the formatting is lossy in four ways:
   block, the empty-grid markers, the hidden-count line), so **no row can ever forge one**. That is what
   makes the omission notice trustworthy, and it is why an empty grid always **says which empty it is** —
   a ledger that holds nothing and a ledger whose every row is hidden print **different** markers, so an
-  end-of-run table where everything merged can never be misread as a campaign that adopted no PRs.
+  end-of-run table where every PR has finished can never be misread as a campaign that adopted no PRs.
 
 It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
 errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
@@ -73,6 +73,13 @@ def hidden_notice(n: int, hidden: tuple[str, ...]) -> str:
     A filtered view that does not say what it hid is a lie by omission. The count and the flag that reveals
     every row are always present. The wording is derived from the caller's hidden-state set, so a store
     cannot change that set while leaving a stale description beside it.
+
+    ``hidden`` is THE STATES ACTUALLY DROPPED FROM THIS RENDER, never the store's configured hidden set.
+    The two coincide only while a store hides ONE state — then any drop at all is a drop of that state, so
+    a single-state caller may pass its configured tuple and stay correct by construction. A store hiding
+    SEVERAL must narrow the tuple to what this table really dropped: naming a state whose rows are all
+    still on screen is the same lie by omission, told the other way round, and hiding four rows of one
+    state while naming only the other is the version of it that actually misleads.
     """
     what = "/".join(hidden)
     return f"# {n} {what} row{'' if n == 1 else 's'} hidden — pass --all to show every row"

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -421,7 +421,9 @@ def is_blank(value: str) -> bool:
 # that FINISHED is not here to be hidden: it is DELETED (the merged PR, or the issue, is the record). What
 # is left to hide is the entry that is closed and yet KEPT — the `rejected` one, kept precisely so the next
 # run does not re-raise what the user already ruled against. Everything else is somebody's open obligation.
-# This is the same line `ledger.py`'s TABLE_HIDDEN_STATUSES draws, applied to a different store.
+# `ledger.py`'s TABLE_HIDDEN_STATUSES answers the same QUESTION for the campaign ledger — what has this
+# store stopped owing anyone? — but it answers it for a different store, so its members are its own and
+# are not restated here.
 TABLE_HIDDEN_STATES = ("rejected",)
 
 # `pr` — not `published`: a published entry is DELETED (the issue is the record), so that column could only

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -642,8 +642,8 @@ def t_empty_marker_not_forgeable(L: ModuleType, tmp: Path) -> None:
                   f"[{name}/{field}] a line of a NON-EMPTY table is the empty marker:\n{out}")
 
 
-def t_table_hides_merged(L: ModuleType, tmp: Path) -> None:
-    """The DEFAULT view drops `merged` rows and shows everything else; `--all` shows the whole ledger.
+def t_table_hides_terminal(L: ModuleType, tmp: Path) -> None:
+    """The DEFAULT view drops TERMINAL rows — `merged` and `aborted` alike — and shows everything else.
 
     This is the projection's ROW rule, and it is the mirror of the FIELD rule: a missing row is not a
     missing PR. Both are pinned here — the default really does hide, and `--all` really does reveal.
@@ -652,7 +652,7 @@ def t_table_hides_merged(L: ModuleType, tmp: Path) -> None:
         tmp / "mix.jsonl", header_line(L),
         row_line(L, pr="1", status="merged"),
         row_line(L, pr="2", status="in_review"),
-        row_line(L, pr="3", status="merged"),
+        row_line(L, pr="3", status="aborted"),
         row_line(L, pr="4", status="awaiting-user"),
     )
     code, out, err = cli(L, ["--file", str(path), "table"])
@@ -660,7 +660,9 @@ def t_table_hides_merged(L: ModuleType, tmp: Path) -> None:
     _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
     col = L.TABLE_DEFAULT_FIELDS.index("pr")
     check([c[col] for c in cells] == ["2", "4"],
-          f"the default view did not hide exactly the merged rows: {[c[col] for c in cells]!r}\n{out}")
+          f"the default view did not hide exactly the terminal rows: {[c[col] for c in cells]!r}\n{out}")
+    check(notices(out) == [L.hidden_notice(2, ("merged", "aborted"))],
+          f"the table hid one merged and one aborted row and said {notices(out)!r}\n{out}")
 
     code, out, err = cli(L, ["--file", str(path), "table", "--all"])
     check(code == 0, f"table --all exited {code}: {err!r}")
@@ -676,71 +678,78 @@ def t_table_hidden_count(L: ModuleType, tmp: Path) -> None:
     A filtered view that does not say what it hid is a lie by omission: nothing is fabricated, the reader
     is simply never told they are looking at a SUBSET. This repo has already shipped that bug twice (a
     summary that quietly dropped its caveats, a `gh pr list` that silently capped at 30). So the notice is
-    pinned on all three counts: it APPEARS whenever a row is dropped, it is ABSENT when none is, and the
-    number in it is the number actually dropped — a notice with a wrong count is a new lie, not a fix.
+    pinned on all four counts: it APPEARS whenever a row is dropped, it is ABSENT when none is, the number
+    in it is the number actually dropped, and it names exactly the statuses those rows were dropped for —
+    a notice with a wrong count, or one naming a status nothing was hidden for, is a new lie, not a fix.
     """
-    for merged in range(0, 4):
-        for live in (0, 2):
-            path = write_lines(
-                tmp / f"n{merged}-{live}.jsonl", header_line(L),
-                *(row_line(L, pr=str(i), status="merged") for i in range(1, merged + 1)),
-                *(row_line(L, pr=str(100 + i), status="in_review") for i in range(live)),
-            )
-            code, out, err = cli(L, ["--file", str(path), "table"])
-            check(code == 0, f"table exited {code}: {err!r}")
-            _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
-            check(len(cells) == live, f"[{merged}/{live}] {len(cells)} rows shown, not {live}\n{out}")
+    for merged in range(0, 3):
+        for aborted in range(0, 3):
+            for live in (0, 2):
+                tag = f"{merged}m/{aborted}a/{live}"
+                path = write_lines(
+                    tmp / f"n{merged}-{aborted}-{live}.jsonl", header_line(L),
+                    *(row_line(L, pr=str(i), status="merged") for i in range(1, merged + 1)),
+                    *(row_line(L, pr=str(50 + i), status="aborted") for i in range(aborted)),
+                    *(row_line(L, pr=str(100 + i), status="in_review") for i in range(live)),
+                )
+                code, out, err = cli(L, ["--file", str(path), "table"])
+                check(code == 0, f"table exited {code}: {err!r}")
+                _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
+                check(len(cells) == live, f"[{tag}] {len(cells)} rows shown, not {live}\n{out}")
 
-            said = [n for n in notices(out)
-                    if n not in (L.TABLE_EMPTY_MARKER, L.TABLE_ALL_HIDDEN_MARKER)]  # the DISCLOSURE line only
-            if not merged:
-                check(said == [], f"[{merged}/{live}] nothing was hidden, yet the table says {said!r}\n{out}")
-                continue
-            check(said == [L.hidden_notice(merged)],
-                  f"[{merged}/{live}] the table hid {merged} row(s) and reported {said!r} — the omission "
-                  f"must be stated, and stated CORRECTLY\n{out}")
-            check(str(merged) in said[0] and "--all" in said[0],
-                  f"[{merged}/{live}] the notice names neither the count nor the flag: {said[0]!r}")
-            # …and the count is the number of rows `--all` reveals that the default did not. Derived from
-            # the OUTPUT, not from the fixture's own arithmetic — otherwise it only checks itself.
-            code, allout, _ = cli(L, ["--file", str(path), "table", "--all"])
-            _, _, allcells = grid(L, allout, L.TABLE_DEFAULT_FIELDS)
-            check(len(allcells) - len(cells) == merged,
-                  f"[{merged}/{live}] the notice claims {merged} hidden, but --all reveals "
-                  f"{len(allcells) - len(cells)} more rows")
+                hidden = merged + aborted
+                # the STATUSES the notice may name are the ones a row was actually dropped for
+                want = tuple(s for s, n in (("merged", merged), ("aborted", aborted)) if n)
+                said = [n for n in notices(out)
+                        if n not in (L.TABLE_EMPTY_MARKER, L.TABLE_ALL_HIDDEN_MARKER)]  # the DISCLOSURE line
+                if not hidden:
+                    check(said == [], f"[{tag}] nothing was hidden, yet the table says {said!r}\n{out}")
+                    continue
+                check(said == [L.hidden_notice(hidden, want)],
+                      f"[{tag}] the table hid {hidden} row(s) and reported {said!r} — the omission "
+                      f"must be stated, and stated CORRECTLY\n{out}")
+                check(str(hidden) in said[0] and "--all" in said[0],
+                      f"[{tag}] the notice names neither the count nor the flag: {said[0]!r}")
+                # …and the count is the number of rows `--all` reveals that the default did not. Derived
+                # from the OUTPUT, not from the fixture's own arithmetic — otherwise it only checks itself.
+                code, allout, _ = cli(L, ["--file", str(path), "table", "--all"])
+                _, _, allcells = grid(L, allout, L.TABLE_DEFAULT_FIELDS)
+                check(len(allcells) - len(cells) == hidden,
+                      f"[{tag}] the notice claims {hidden} hidden, but --all reveals "
+                      f"{len(allcells) - len(cells)} more rows")
 
 
-def t_table_all_merged(L: ModuleType, tmp: Path) -> None:
-    """EVERY row merged is a REAL end-of-run state — and it must NEVER read as an empty ledger.
+def t_table_all_terminal(L: ModuleType, tmp: Path) -> None:
+    """EVERY row terminal is a REAL end-of-run state — and it must NEVER read as an empty ledger.
 
     The default view shows no rows here, exactly as it does for a ledger that adopted nothing. Those are
-    OPPOSITE facts — "nothing was ever adopted" vs "everything finished" — and printing `# (no rows)` for
-    both would tell the reader at the end of a successful run that their campaign did nothing at all.
+    OPPOSITE facts — "nothing was ever adopted" vs "everything reached an end" — and printing `# (no rows)`
+    for both would tell the reader at the end of a run that their campaign did nothing at all.
     So the two cases print DIFFERENT markers, and the all-hidden one also carries the count.
     """
     done = write_lines(tmp / "done.jsonl", header_line(L, run_id="r1"),
-                       row_line(L, pr="1", status="merged"), row_line(L, pr="2", status="merged"))
+                       row_line(L, pr="1", status="merged"), row_line(L, pr="2", status="aborted"))
     empty = write_lines(tmp / "none.jsonl", header_line(L, run_id="r1"))
 
     code, out, err = cli(L, ["--file", str(done), "table"])
     check(code == 0, f"table exited {code}: {err!r}")
     _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
-    check(cells == [], f"an all-merged ledger showed rows by default: {cells!r}\n{out}")
-    check(notices(out) == [L.TABLE_ALL_HIDDEN_MARKER, L.hidden_notice(2)],
-          f"an all-merged ledger must say the ledger is NOT empty, and how many rows it hid: "
+    check(cells == [], f"an all-terminal ledger showed rows by default: {cells!r}\n{out}")
+    check(notices(out) == [L.TABLE_ALL_HIDDEN_MARKER, L.hidden_notice(2, ("merged", "aborted"))],
+          f"an all-terminal ledger must say the ledger is NOT empty, and how many rows it hid: "
           f"{notices(out)!r}\n{out}")
     check(L.TABLE_EMPTY_MARKER not in out.split("\n"),
-          f"an all-merged ledger printed the EMPTY-LEDGER marker — it reads as 'no PRs at all':\n{out}")
+          f"an all-terminal ledger printed the EMPTY-LEDGER marker — it reads as 'no PRs at all':\n{out}")
 
     code, blank, err = cli(L, ["--file", str(empty), "table"])
     check(code == 0, f"table exited {code}: {err!r}")
     check(notices(blank) == [L.TABLE_EMPTY_MARKER],
           f"a genuinely empty ledger must say exactly {L.TABLE_EMPTY_MARKER!r}: {notices(blank)!r}\n{blank}")
     check(out != blank,
-          f"an all-merged ledger renders EXACTLY what an EMPTY ledger renders — the two are "
+          f"an all-terminal ledger renders EXACTLY what an EMPTY ledger renders — the two are "
           f"indistinguishable:\n{out}")
 
-    # …and `--all` on the all-merged ledger brings every row back, with nothing left to disclose.
+    # …and `--all` on the all-terminal ledger brings every row back, with nothing left to disclose.
     code, out, err = cli(L, ["--file", str(done), "table", "--all"])
     check(code == 0, f"table --all exited {code}: {err!r}")
     _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
@@ -748,25 +757,60 @@ def t_table_all_merged(L: ModuleType, tmp: Path) -> None:
     check(notices(out) == [], f"--all hid nothing, yet the table claims it did: {notices(out)!r}")
 
 
-def t_table_aborted_is_visible(L: ModuleType, tmp: Path) -> None:
-    """`aborted` STAYS VISIBLE by default — the design call, pinned.
+def t_table_live_statuses_all_visible(L: ModuleType, tmp: Path) -> None:
+    """ONLY the terminal statuses hide. Everything still in play shows — parked rows included.
 
-    It is terminal like `merged`, so a rule that hid "terminal" rows would drop it. It must not: an
-    aborted PR is the run's UNFINISHED BUSINESS — left open for its owner, with an `abort-<id>.md` a human
-    is meant to read (`bailout-and-final-report.md`). Hiding the one row that still wants attention is the
-    exact failure a status view exists to prevent. Every non-`merged` status shows; only `merged` hides.
+    The hidden set is drawn at "campaign will take no further action on this row", NOT at "this row is
+    quiet". A parked PR is waiting on the user and a `repairing` one is waiting on a reassessment; both are
+    live work, and a status view that dropped them would hide the very rows the reader has to act on.
     """
-    statuses = ("in_review", "aborted", "awaiting-api", "awaiting-user", "pending", "merged")
+    statuses = ("in_review", "awaiting-api", "awaiting-user", L.REPAIR_STATUS, "merged", "aborted")
     path = write_lines(tmp / "st.jsonl", header_line(L),
                        *(row_line(L, pr=str(i + 1), status=s) for i, s in enumerate(statuses)))
     code, out, err = cli(L, ["--file", str(path), "table", "--fields", "pr,status"])
     check(code == 0, f"table exited {code}: {err!r}")
     _, _, cells = grid(L, out, ("pr", "status"))
     shown = [c[1] for c in cells]
-    check(shown == [s for s in statuses if s != "merged"],
-          f"the default view hid something other than `merged` — it shows {shown!r}\n{out}")
-    check("aborted" in shown, "an ABORTED row was hidden — the run's unfinished business is invisible")
-    check(notices(out) == [L.hidden_notice(1)], f"exactly one merged row should be hidden: {notices(out)!r}")
+    check(shown == [s for s in statuses if s not in L.TABLE_HIDDEN_STATUSES],
+          f"the default view hid something other than the terminal statuses — it shows {shown!r}\n{out}")
+    check(notices(out) == [L.hidden_notice(2, ("merged", "aborted"))],
+          f"one merged and one aborted row should be hidden, and named: {notices(out)!r}")
+
+
+def t_table_notice_names_what_was_dropped(L: ModuleType, tmp: Path) -> None:
+    """THE DISCLOSURE NAMES THE STATUSES ACTUALLY DROPPED — never the view's configured hidden set.
+
+    The two hidden statuses mean opposite things to a reader: `merged` is finished work, `aborted` is the
+    run's unfinished business, left open for its owner with an `abort-<id>.md` a human is meant to read
+    (`bailout-and-final-report.md`). A line reading `merged` while four aborted rows sit behind it tells
+    the reader the view is complete on exactly the rows they most need — worse than no line at all. The
+    mirror error is as false: naming `aborted` when every hidden row merged invents a PR the run gave up
+    on. So the wording is pinned LITERALLY here, in every combination, INCLUDING zero of one kind — and
+    the joint form is pinned against fixture ORDER too, since the names come from the hidden set's order,
+    never the rows'.
+    """
+    cases = (
+        (("merged",), "# 1 merged row hidden — pass --all to show every row"),
+        (("merged", "merged"), "# 2 merged rows hidden — pass --all to show every row"),
+        (("aborted",), "# 1 aborted row hidden — pass --all to show every row"),
+        (("aborted", "aborted"), "# 2 aborted rows hidden — pass --all to show every row"),
+        (("merged", "aborted"), "# 2 merged/aborted rows hidden — pass --all to show every row"),
+        (("aborted", "merged", "merged"), "# 3 merged/aborted rows hidden — pass --all to show every row"),
+    )
+    for i, (hidden, want) in enumerate(cases):
+        path = write_lines(
+            tmp / f"named{i}.jsonl", header_line(L),
+            row_line(L, pr="1", status="in_review"),
+            *(row_line(L, pr=str(10 + j), status=s) for j, s in enumerate(hidden)),
+        )
+        code, out, err = cli(L, ["--file", str(path), "table"])
+        check(code == 0, f"[{hidden!r}] table exited {code}: {err!r}")
+        said = [n for n in notices(out) if n not in (L.TABLE_EMPTY_MARKER, L.TABLE_ALL_HIDDEN_MARKER)]
+        check(said == [want], f"[{hidden!r}] the table said {said!r}, not {[want]!r}\n{out}")
+        # …and a status NOTHING was hidden for is never named: that claim is as false as omitting one.
+        for absent in (s for s in L.TABLE_HIDDEN_STATUSES if s not in hidden):
+            check(absent not in said[0],
+                  f"[{hidden!r}] the notice names `{absent}`, of which no row was hidden: {said[0]!r}")
 
 
 def t_table_all_composes_with_fields(L: ModuleType, tmp: Path) -> None:
@@ -779,7 +823,7 @@ def t_table_all_composes_with_fields(L: ModuleType, tmp: Path) -> None:
     check(code == 0, f"table exited {code}: {err!r}")
     _, _, cells = grid(L, out, fields)
     check(cells == [["live", "in_review"]], f"--fields did not hide the merged row: {cells!r}\n{out}")
-    check(notices(out) == [L.hidden_notice(1)],
+    check(notices(out) == [L.hidden_notice(1, ("merged",))],
           f"--fields dropped the hidden-count notice: {notices(out)!r}\n{out}")
 
     code, out, err = cli(L, ["--file", str(path), "table", "--all", "--fields", ",".join(fields)])
@@ -821,10 +865,10 @@ def t_hidden_row_cannot_reach_the_output(L: ModuleType, tmp: Path) -> None:
         check(code == 0, f"[{fields}] table exited {code}: {err!r}")
         code, got, err = cli(L, ["--file", str(poisoned), *argv])
         check(code == 0, f"[{fields}] table exited {code}: {err!r}")
-        check(notices(got) == [L.hidden_notice(n)],
+        check(notices(got) == [L.hidden_notice(n, ("merged",))],
               f"[{fields}] the hidden hostile rows were not disclosed: {notices(got)!r}")
         # strip ONLY the disclosure line; everything else must be byte-identical to the clean ledger
-        stripped = "".join(l + "\n" for l in got.split("\n")[:-1] if l != L.hidden_notice(n))
+        stripped = "".join(l + "\n" for l in got.split("\n")[:-1] if l != L.hidden_notice(n, ("merged",)))
         check(stripped == want,
               f"[{fields}] a HIDDEN row changed the VISIBLE output — it reached the widths or the grid.\n"
               f"--- with hidden rows ---\n{stripped}--- without them ---\n{want}")
@@ -853,9 +897,10 @@ def t_out_of_band_lines_not_forgeable(L: ModuleType, tmp: Path) -> None:
                              row_line(L, pr="9", status="merged"))
     for name, forgery in (
         ("all-hidden-marker", L.TABLE_ALL_HIDDEN_MARKER),
-        ("notice", L.hidden_notice(1)),
+        ("notice", L.hidden_notice(1, ("merged",))),
         ("notice-zero", "# 0 merged rows hidden — pass --all to show every row"),
-        ("notice-padded", L.hidden_notice(1) + "  "),
+        ("notice-padded", L.hidden_notice(1, ("merged",)) + "  "),
+        ("notice-joint", L.hidden_notice(2, ("merged", "aborted"))),
     ):
         for field in ("slug", "branch", "pr"):
             path = write_lines(tmp / f"{name}-{field}.jsonl", header_line(L, run_id="r1"),
@@ -871,7 +916,8 @@ def t_out_of_band_lines_not_forgeable(L: ModuleType, tmp: Path) -> None:
             # …and no LINE of it IS one of the out-of-band lines (the escaped cell may CONTAIN the text —
             # `\# 1 merged row hidden…` does — but the `\` in front is exactly what the namespace buys).
             body = out.split("\n\n", 1)[1].split("\n")
-            for line in (L.TABLE_ALL_HIDDEN_MARKER, L.hidden_notice(1), L.TABLE_EMPTY_MARKER):
+            for line in (L.TABLE_ALL_HIDDEN_MARKER, L.hidden_notice(1, ("merged",)),
+                         L.hidden_notice(2, ("merged", "aborted")), L.TABLE_EMPTY_MARKER):
                 check(line not in body,
                       f"[{name}/{field}] a line of a table with a VISIBLE row IS {line!r}:\n{out}")
 
@@ -2838,10 +2884,11 @@ CASES = [
     ("table-missing-file", "a missing ledger is a fresh start: defaults, `# (no rows)`", t_table_missing_file),
     ("table-no-rows", "a header-only ledger says `# (no rows)`", t_table_no_rows),
     ("empty-marker-safe", "no ROW can forge the empty-ledger marker — it lives where no cell can reach", t_empty_marker_not_forgeable),
-    ("table-hides-merged", "the default view hides merged rows; --all shows every row", t_table_hides_merged),
+    ("table-hides-terminal", "the default view hides terminal rows (merged AND aborted); --all shows every row", t_table_hides_terminal),
     ("table-hidden-count", "the omission is NEVER silent — the hidden count is stated, and it is correct", t_table_hidden_count),
-    ("table-all-merged", "an all-merged ledger never reads as an EMPTY one — different marker, plus the count", t_table_all_merged),
-    ("table-aborted-visible", "aborted is terminal but STAYS VISIBLE — only `merged` hides", t_table_aborted_is_visible),
+    ("table-all-terminal", "an all-terminal ledger never reads as an EMPTY one — different marker, plus the count", t_table_all_terminal),
+    ("table-live-visible", "every LIVE status shows, parked included — only the terminal ones hide", t_table_live_statuses_all_visible),
+    ("table-notice-names-dropped", "the notice names the statuses actually dropped, never the configured set", t_table_notice_names_what_was_dropped),
     ("table-all-and-fields", "--all picks the rows, --fields the columns — they compose", t_table_all_composes_with_fields),
     ("hidden-row-inert", "a hostile value in a HIDDEN row cannot change one byte of the visible table", t_hidden_row_cannot_reach_the_output),
     ("out-of-band-safe", "no ROW can forge the all-hidden marker or the hidden-count notice", t_out_of_band_lines_not_forgeable),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -26,6 +26,12 @@ from typing import NoReturn
 from _gauntlet.atomic import replace_text
 from _gauntlet.jsonl import JsonlError, object_lines
 from _gauntlet.table import config_lines, escape_cell as _shared_escape_cell, grid_lines
+# Re-exported WITHOUT a default, because no one-argument default can be right: the notice names the
+# statuses a render ACTUALLY dropped (`hidden_statuses()`), never the configured set, and
+# `TABLE_HIDDEN_STATUSES` holds two — a defaulted `hidden_notice(1)` would announce a hidden `aborted`
+# row on a ledger holding none. Every `hidden_notice` call in the tree passes its own status tuple, so
+# nothing reaches the missing default. The "Compatibility export" below scopes to `escape_cell` alone;
+# this name carries no such promise.
 from _gauntlet.table import hidden_notice
 
 # Compatibility export for existing test and script consumers. New consumers import `_gauntlet.table`.

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -26,7 +26,7 @@ from typing import NoReturn
 from _gauntlet.atomic import replace_text
 from _gauntlet.jsonl import JsonlError, object_lines
 from _gauntlet.table import config_lines, escape_cell as _shared_escape_cell, grid_lines
-from _gauntlet.table import hidden_notice as _shared_hidden_notice
+from _gauntlet.table import hidden_notice
 
 # Compatibility export for existing test and script consumers. New consumers import `_gauntlet.table`.
 escape_cell = _shared_escape_cell
@@ -426,7 +426,9 @@ HELD_STATUSES = ("awaiting-api", "awaiting-user", REPAIR_STATUS)
 
 # TERMINAL — the statuses in which a row is DONE and out of the live gate: `merged` finished successfully,
 # `aborted` gave up. Named ONCE so any check asking "is this row still ACTIVE?" reads the set instead of
-# retyping the pair (`cmd_park` and the `default_non_goals` broadening guard both resolve through it).
+# retyping the pair; every such check resolves through it (grep the name for today's readers rather than
+# trusting a list here, which goes stale the next time one is added). `TABLE_HIDDEN_STATUSES` IS this
+# tuple, so its ORDER is also the order the table's hidden-count notice names them in.
 TERMINAL_STATUSES = ("merged", "aborted")
 
 
@@ -1559,26 +1561,41 @@ TABLE_SHA_WIDTH = 8
 #
 # The two EMPTY-GRID markers are deliberately DIFFERENT LINES, because they are different facts and a
 # reader acts differently on each: an empty ledger has adopted nothing, while an all-hidden ledger has
-# finished everything. Printing `# (no rows)` for the second would be the exact lie this file exists to
-# prevent — a table saying something the ledger never did — and "every PR is merged" is a REAL end-of-run
-# state, not a corner case.
+# reached a terminal state on everything. Printing `# (no rows)` for the second would be the exact lie this
+# file exists to prevent — a table saying something the ledger never did — and "every PR is terminal" is a
+# REAL end-of-run state, not a corner case.
 TABLE_EMPTY_MARKER = "# (no rows)"
 TABLE_ALL_HIDDEN_MARKER = "# (no rows shown — the ledger is NOT empty; every row it holds is hidden)"
 
-# What the DEFAULT view hides. ONLY `merged` — and that is a deliberate call, not a synonym for
-# "terminal". A merged PR is DONE: nothing in the run and nobody reading the table has anything left to do
-# about it, and in a long run these rows are most of the ledger, crowding out the PRs still in play.
-# `aborted` is terminal too, but it is the OPPOSITE kind of terminal — the run GAVE UP on that PR and left
-# it open for its owner (`bailout-and-final-report.md`). It is precisely the row a HUMAN may still need to
-# act on, so hiding it would bury the run's unfinished business, which is the one thing a status view must
-# never do. The line is drawn at "finished successfully", NOT at "reached a terminal state". Everything
-# else (in-flight and parked alike) is live work and always shows.
-TABLE_HIDDEN_STATUSES = ("merged",)
+# What the DEFAULT view hides: a row that is DONE and out of the live gate — campaign will take no further
+# action on it, whichever way it ended — while everything still in play (in-flight and parked alike) always
+# shows. In a long run the finished rows become most of the ledger and crowd out the PRs a reader is
+# actually there to look at.
+#
+# That is `TERMINAL_STATUSES` exactly, so this IS that set rather than a second spelling of it: the two can
+# never disagree, and a status added there is hidden here with no edit. The tuple's ORDER is the notice's
+# render order, which is the only property this view adds.
+#
+# `aborted` is hidden DESPITE being the run's unfinished business, left open for its owner with an
+# `abort-<id>.md` a human is meant to read (`bailout-and-final-report.md`). That is not a claim the row
+# stopped mattering: it is that the STATUS VIEW is not what carries it. The final report enumerates every
+# aborted PR and why, the notice below names `aborted` whenever such a row was dropped, and `--all` brings
+# it straight back — so the human is told, by name, that unfinished business is off screen and how to see
+# it. A row hidden WITH DISCLOSURE is not a row buried.
+TABLE_HIDDEN_STATUSES = TERMINAL_STATUSES
 
 
-def hidden_notice(n: int, hidden: "tuple[str, ...]" = TABLE_HIDDEN_STATUSES) -> str:
-    """Keep the ledger's default hidden set while delegating shared rendering."""
-    return _shared_hidden_notice(n, hidden)
+def hidden_statuses(dropped: "list[dict]") -> "tuple[str, ...]":
+    """The hidden statuses ACTUALLY present in `dropped`, in `TABLE_HIDDEN_STATUSES` render order.
+
+    The notice must name what this table really dropped, not what the view is CONFIGURED to drop. Passing
+    the configured set would make a ledger holding only merged rows announce hidden `aborted` ones — a run
+    reading as if it had given up on a PR it never opened — and, the direction that actually costs the
+    reader something, would let a mixed ledger's line be believed as a complete account of what it hid.
+    Deriving the names from the dropped rows keeps every combination true, INCLUDING zero of one kind.
+    """
+    present = {row["status"] for row in dropped}
+    return tuple(s for s in TABLE_HIDDEN_STATUSES if s in present)
 
 
 def cmd_table(path: Path, args) -> int:
@@ -1590,11 +1607,16 @@ def cmd_table(path: Path, args) -> int:
             check_field(f, ROW_FIELDS + (TABLE_BASE_COLUMN,))
     else:
         fields = TABLE_DEFAULT_FIELDS
-    # The DEFAULT view drops finished work (see TABLE_HIDDEN_STATUSES); --all shows the whole ledger.
+    # The DEFAULT view drops the rows campaign is done with (see TABLE_HIDDEN_STATUSES); --all shows the
+    # whole ledger.
     # `--all` composes with `--fields`: one picks the ROWS, the other the COLUMNS, and neither reads the
-    # other.
-    shown = rows if args.show_all else [r for r in rows if r["status"] not in TABLE_HIDDEN_STATUSES]
-    hidden = len(rows) - len(shown)
+    # other. The dropped rows are kept, not just counted: the notice names the statuses actually among
+    # them, which a count alone cannot tell you.
+    if args.show_all:
+        shown, dropped = rows, []
+    else:
+        shown = [r for r in rows if r["status"] not in TABLE_HIDDEN_STATUSES]
+        dropped = [r for r in rows if r["status"] in TABLE_HIDDEN_STATUSES]
     for line in config_lines([(f, header[f]) for f in HEADER_FIELDS]):
         print(line)
     print()
@@ -1620,8 +1642,8 @@ def cmd_table(path: Path, args) -> int:
         # An empty grid is now AMBIGUOUS — nothing adopted, or everything finished — so say WHICH.
         # Both markers live in the '#' namespace: no cell can render a line that impersonates either.
         print(TABLE_EMPTY_MARKER if not rows else TABLE_ALL_HIDDEN_MARKER)
-    if hidden:
-        print(hidden_notice(hidden))
+    if dropped:
+        print(hidden_notice(len(dropped), hidden_statuses(dropped)))
     return 0
 
 
@@ -1757,10 +1779,11 @@ def build_parser() -> argparse.ArgumentParser:
     t = sub.add_parser("table", help="print the run header and the live rows as an aligned table")
     t.add_argument("--fields", help=f"comma-separated row fields to show (default: {','.join(TABLE_DEFAULT_FIELDS)})")
     # The default hides rows; --all is how a reader gets the whole ledger back. The help text is derived
-    # from TABLE_HIDDEN_STATUSES for the same reason hidden_notice() is: so it cannot drift from it.
+    # from TABLE_HIDDEN_STATUSES for the same reason the notice is: so it cannot drift from it. Here the
+    # WHOLE configured set is right — this line describes the view, not any one render of it.
     t.add_argument("--all", dest="show_all", action="store_true",
                    help=f"show every row (the default hides status={'/'.join(TABLE_HIDDEN_STATUSES)} "
-                        f"and reports how many it hid)")
+                        f"and reports how many it hid, naming the statuses it actually dropped)")
 
     sub.add_parser("self-test", help="run every fixture and assert the rules this file enforces still hold")
     return parser

--- a/plugins/gauntlet/skills/ledger/SKILL.md
+++ b/plugins/gauntlet/skills/ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ledger
-description: Show a Gauntlet campaign ledger through its existing read-only table command. Use when the user asks for campaign status, a campaign ledger, PR state for a named or current campaign run, or hidden and merged campaign entries.
+description: Show a Gauntlet campaign ledger through its existing read-only table command. Use when the user asks for campaign status, a campaign ledger, PR state for a named or current campaign run, or hidden, merged, and aborted campaign entries.
 ---
 
 # Ledger
@@ -23,7 +23,9 @@ Invocation: Claude Code `/gauntlet:ledger`; Codex `$gauntlet:ledger`.
    ["python3", "<absolute-ledger.py>", "--file", "<absolute-state.jsonl>", "table"]
    ```
 
-5. Append `"--all"` only when user asks for hidden, merged, closed, or all entries.
-6. Print script stdout as-is. On failure, relay stderr as-is and stop.
+5. Append `"--all"` only when user asks for hidden, merged, aborted, closed, or all entries.
+6. Print script stdout as-is — every line, including the `#` lines above and below the grid. The default
+   view is a filtered one and those lines are what disclose the filtering. On failure, relay stderr as-is
+   and stop.
 
 Read-only. NEVER create, edit, parse, summarize, or reformat ledger data or table output.


### PR DESCRIPTION
## Purpose
- `ledger.py table` hides `aborted` by default, as it already hides `merged`.
- `TABLE_HIDDEN_STATUSES` is `TERMINAL_STATUSES` itself, so the two cannot disagree.
- The hidden-count line names the statuses actually dropped, not the configured set.
- `--all` still shows every row and still prints no disclosure line.
## Non-goals
- No change to what `get`, `list`, `--fields`, or a gate decision sees — display only.
- No change to the followups or review-learnings hidden sets or their wording.
- No per-status counts in the notice, and no `plugin.json` version change.
## Threat model
- Written by: the campaign driver via `ledger.py`, and the single user by hand.
- Input is a git-ignored local `.gauntlet/tmp/<run-id>/state.jsonl`; `table` only reads it.
- Not written by: PR authors, reviewers, CI, or anything off this machine.
- Values stay untrusted anyway: cells are escaped, the notice sits in the `#` namespace.
