### PR TITLE
make review residual-risk line optional

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -155,8 +155,9 @@ When the loop exits, summarize:
 - **Merged** — PR number + slug, one-line description, tier, and the **base it merged into** (its
   `effective_base`), so a mixed-base run shows which release line each PR shipped to.
 - **Residual risk** — for each merged PR, each accepting SATISFIED pass's `RESIDUAL-RISK` line (the
-  least-certain area it named — `required(tier)` lines, so two for a STANDARD/HIGH PR and one for a
-  TRIVIAL PR), and a flag when two accepting passes name the same area. This is non-actionable,
+  least-certain area it named), and a flag when two accepting passes name the same area. The line is
+  OPTIONAL, so a PR contributes at most `required(tier)` lines and may contribute none; report what the
+  passes actually wrote and never invent a line for a pass that omitted one. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
 - **What each base REQUIRED** — the required-check set, now **per base** (`effective_required_set`;
   `stage-2-ci.md` owns its states). A run may span several bases (`v3`, `main`), so report **each distinct

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -285,8 +285,8 @@
   **five** kinds of defect that make a pass `unusable` (Stage 2a, "Does this pass
   COUNT?", owns the enumeration):
   - **the active REPORT result is unusable** — missing, empty, truncated, duplicate, nonterminal,
-    malformed, from the wrong launch attempt, or missing SATISFIED's exact immediately preceding
-    `RESIDUAL-RISK:` line;
+    malformed, from the wrong launch attempt, or carrying a misplaced/malformed `RESIDUAL-RISK:` line —
+    OMITTING that line never makes a SATISFIED report unusable;
   - **the ARTIFACTS are malformed** — a short SHA or any other malformed identifier, a `done` for a unit
     that was never planned, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done`
     for one unit, a hand-written line of the wrong shape, an identity naming another commit or attempt;
@@ -345,9 +345,10 @@
   `file:line` defects at the normal finding bar (a real **GATING** one → NOT SATISFIED; the sweep is
   BOUNDED by the threat model, not narrowed, and its findings anchor like any other), and treats "nothing
   found" as a fine result; no speculative "might be fragile" notes (Stage 2a).
-- A SATISFIED verdict carries one `RESIDUAL-RISK: <area> — <why>` line (the least-certain part of the
-  diff). It is calibration metadata, never a finding: it never withholds the gate, never enters the fix
-  loop, and is never fed into the corroborating review. Do not manufacture a concern to fill it; a real
+- A SATISFIED verdict SHOULD carry one `RESIDUAL-RISK: <area> — <why>` line (the least-certain part of
+  the diff), and is accepted without one. It is calibration metadata, never a finding: it never withholds
+  the gate, never enters the fix loop, and is never fed into the corroborating review. Its absence never
+  makes the pass unusable. Do not manufacture a concern to fill it; a real
   **GATING** defect found while identifying it is a normal finding → NOT SATISFIED (Stage 2a).
 - One decision at N sites is the most common root cause. Trigger the §2a-deep root-cause pass on the
   **first** "missing/wrong at site X" finding (its shape, not a round count), map the whole space with

--- a/plugins/gauntlet/skills/campaign/references/review-dispatch.md
+++ b/plugins/gauntlet/skills/campaign/references/review-dispatch.md
@@ -89,7 +89,8 @@ shortens, or duplicates the template, and it never asks the reviewer to contact 
 
 The shared prompt tells every route to review the whole `origin/<base>...HEAD` diff against the intent and plan,
 record progress/findings/amendments only through the bundled tools, perform the adversarial sweep, obey
-the finding-anchor rule, and return the exact residual-risk/verdict ending. These are prompt contents,
+the finding-anchor rule, and return the exact verdict ending with its optional residual-risk line above
+it. These are prompt contents,
 not a second dispatch procedure; edit and test the bundled template when that contract changes.
 
 ### Launch the prepared attempt

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -91,8 +91,8 @@ command writes the one prompt every route receives and returns the active attemp
 not derive its paths, bind its intent, or reconstruct its record here. **The prompt IS the contract**:
 whatever it
 requires of a `codex exec` reviewer it requires of a native worker — the same question ("does this PR achieve its
-stated Purpose…"), the same emit-only rule, the same anchored findings, the same `RESIDUAL-RISK` +
-single-`VERDICT:` ending. Its terminal result and artifacts are read and verified by the same `review-pass.py verify`
+stated Purpose…"), the same emit-only rule, the same anchored findings, the same single-`VERDICT:` ending
+with its optional `RESIDUAL-RISK` line above it. Its terminal result and artifacts are read and verified by the same `review-pass.py verify`
 (Stage 2a, "Does this pass COUNT?"), so a pass dispatched without those inputs is not a lighter pass — it is
 an `unusable` one.
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -784,8 +784,11 @@ nonterminal, malformed, and wrong-attempt reports are `unusable`. The parsed bin
 the existing if-and-only-if rule: **`not-satisfied` exactly when at least one GATING finding stands.** A
 verdict that blocks a PR must name what blocks it, and a finding that blocks a PR cannot be waved through.
 
-**A SATISFIED report has exactly one `RESIDUAL-RISK:` line immediately above its verdict.** It uses the
-prompt's exact form. The line is forbidden on NOT SATISFIED and DEFERRED results.
+**A SATISFIED report MAY carry a `RESIDUAL-RISK:` line, and its absence NEVER blocks the verdict.** The
+line is calibration metadata, never a gate input, so a SATISFIED report without one counts exactly as a
+SATISFIED report with one. When it IS present the prompt still owns its exact form, there is at most one
+of it, and it is the last nonblank line before the verdict — blank lines between the two are tolerated,
+any other line is not. The line is forbidden on NOT SATISFIED and DEFERRED results.
 
 **A parsed DEFERRED result routes through progress state without becoming a judgment.** An unruled
 `plan_amendment_request` returns `amended`; an unfinished pass returns `incomplete`; a complete pass with
@@ -809,7 +812,7 @@ pass is a trapdoor, not a disclosure:
 | `ok` | 0 | the artifacts are sound: one strict result from the active attempt's report; a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt, **the live head SHA**, and a bound **`default_non_goals` still equal to the run's live defaults**; a **usable intent block** for this PR; every planned unit `done` **once**, with concrete evidence, after a `started` for it; every `done` for a unit that is **actually in the plan**; no unruled amendment; and the parsed result **coheres** with the findings | tally the parsed binary result through `ledger.py verdict` |
 | `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
 | `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
-| `unusable` | 1 | the artifacts are **defective** — the active report is missing, empty, truncated, duplicate, nonterminal, malformed, or lacks SATISFIED's exact residual-risk line; a short SHA or other malformed identifier; invalid progress/identity/findings; **no usable intent block**; a bound `default_non_goals` that no longer matches the run's live defaults (scope drift); a parsed result that does not cohere with findings; or a spurious DEFERRED result | the pass **CANNOT count**. Fix skipped adoption inputs when named; otherwise retry — the same pass, next launch attempt (`runtime-adapter.md`, "Review preparation mapping") — or take the fresh-worker fallback |
+| `unusable` | 1 | the artifacts are **defective** — the active report is missing, empty, truncated, duplicate, nonterminal, malformed, or carries a misplaced or malformed residual-risk line (its ABSENCE is fine); a short SHA or other malformed identifier; invalid progress/identity/findings; **no usable intent block**; a bound `default_non_goals` that no longer matches the run's live defaults (scope drift); a parsed result that does not cohere with findings; or a spurious DEFERRED result | the pass **CANNOT count**. Fix skipped adoption inputs when named; otherwise retry — the same pass, next launch attempt (`runtime-adapter.md`, "Review preparation mapping") — or take the fresh-worker fallback |
 
 **`ok` is not SATISFIED.** The tool parses the reviewer's exact terminal result but does not judge the
 report's prose, raise `reviews_ok`, or merge. `ledger.py verdict` remains the only tally writer.
@@ -930,16 +933,18 @@ found" is the expected, honest common outcome, and speculative "might be fragile
 and do not block SATISFIED. (This is distinct from a `plan_amendment_request`, which fixes the plan
 structurally; the sweep finds a defect now, regardless of the plan.)
 
-**Residual-risk signal (SATISFIED only).** A SATISFIED verdict carries one
+**Residual-risk signal (SATISFIED only, and OPTIONAL).** The prompt asks a SATISFIED verdict for one
 `RESIDUAL-RISK: <area> — <why>` line naming the part of the diff the pass verified with the least
 certainty, relative to the rest. It is calibration metadata, never a finding and never a verdict
 input: a SATISFIED with a residual-risk line is a **full** SATISFIED, and the line NEVER withholds the
 gate, NEVER enters the fix loop, and is NEVER fed into the corroborating review (which stays
-context-isolated). It reflects the gauntlet's purpose — lower the odds a defect survives stochastic
-variation, not claim certainty — by making residual uncertainty explicit instead of hidden behind a
-binary verdict. Record it with the verdict and carry **each accepting pass's** line into the final
-report, grouped by PR (one line per accepting pass — so `required(tier)` lines: two for a
-STANDARD/HIGH PR, one for a TRIVIAL PR). Its only aggregate use (when a PR has ≥2 accepting passes):
+context-isolated). Because it is not a gate input, **a SATISFIED report that omits it is accepted
+unchanged** — the pass counts, and nothing about the gate moves. It reflects the gauntlet's purpose —
+lower the odds a defect survives stochastic variation, not claim certainty — by making residual
+uncertainty explicit instead of hidden behind a binary verdict. Record it with the verdict and carry
+**each accepting pass's** line into the final report, grouped by PR (at most one line per accepting
+pass, and a pass that wrote none contributes none). Its only aggregate use (when a PR has ≥2 accepting
+passes that each named an area):
 when **both** accepting passes on the same content name the same area, note that convergence in the
 report, and the orchestrator MAY add a plan unit covering it the next time the PR content changes and a
 fresh review round starts — but it never blocks the current gate.

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -976,7 +976,7 @@ def t_bundle_exempts_every_prior_cap_round(tmp: Path) -> None:
     # The repair landed, the row returned to review, two more rounds ran, and round 3 is the SECOND cap.
     head = case["head_sha"]
     # A clean intermediate round: SATISFIED coheres with 0 gating findings, and #126's `parse_report`
-    # requires its one RESIDUAL-RISK line immediately above the verdict. No audit is owed (0 gating).
+    # accepts an optional RESIDUAL-RISK line last before the verdict. No audit is owed (0 gating).
     write_review_attempt(case["rundir"], 2, 1, head,
                          "round 2\n\nRESIDUAL-RISK: feature.txt — the clean re-review after the repair "
                          "landed\nVERDICT: SATISFIED\n")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -789,11 +789,15 @@ class Tables:
                 "want": UNUSABLE, "needle": "residual risk must be exactly",
                 "why": "the residual-risk fields and em dash have one exact shape",
             },
-            # The line being OPTIONAL is exactly what makes these two load-bearing: a detector that only
+            # The line being OPTIONAL is exactly what makes these three load-bearing: a detector that only
             # sees column 0 reads an INVISIBLY PREFIXED line as ABSENT, so a malformed line is silently
             # accepted instead of refused. Present-but-malformed and never-written must stay
             # distinguishable. `visible_start` in review-pass.py owns which prefixes count as invisible;
-            # these two sample it — one prefix a reader would notice as blank space, one they would not.
+            # these three sample one prefix per branch of its rule: whitespace a reader sees as blank space
+            # (`isspace`), a format character that renders nothing (`not isprintable`), and a
+            # Default_Ignorable code point that is printable and non-space, which only the named Unicode
+            # property reaches. A VISIBLE prefix (`- `, `> `, a spacing combining mark) is NOT in this set:
+            # such a line does not present as the exact token, so it is read as absent by contract.
             "indented-residual-risk": {
                 "report": "Report body.\n  RESIDUAL-RISK: parser — hard\nVERDICT: SATISFIED\n",
                 "want": UNUSABLE, "needle": "residual risk must be exactly",
@@ -807,6 +811,15 @@ class Tables:
                           "VERDICT: SATISFIED\n",
                 "want": UNUSABLE, "needle": "residual risk must be exactly",
                 "why": "an invisible prefix hides a malformed line from the detector, not from the report",
+            },
+            # U+034F COMBINING GRAPHEME JOINER is Mn, so it is BOTH printable and non-space: neither
+            # `isspace()` nor `not isprintable()` reaches it, only Default_Ignorable_Code_Point does. Its
+            # category is not the discriminator — U+0301 is Mn too and renders a visible acute.
+            "default-ignorable-prefixed-residual-risk": {
+                "report": "Report body.\n\u034fRESIDUAL-RISK: parser contract - wrong separator\n"
+                          "VERDICT: SATISFIED\n",
+                "want": UNUSABLE, "needle": "residual risk must be exactly",
+                "why": "a code point that renders as nothing is a prefix the reader cannot see",
             },
             "misplaced-residual-risk": {
                 "report": "RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -718,7 +718,7 @@ class Tables:
         self.REPORT_CASES: "dict[str, dict]" = {
             "valid-satisfied": {
                 "report": SAT_REPORT, "want": OK, "needle": "report verdict satisfied",
-                "why": "the parser derives SATISFIED and its immediately preceding residual risk",
+                "why": "the parser derives SATISFIED and the residual risk last before the verdict",
             },
             "valid-not-satisfied": {
                 "report": NOT_SAT_REPORT, "findings": [finding()], "want": OK,
@@ -776,10 +776,13 @@ class Tables:
                 "want": OK, "needle": "report verdict satisfied",
                 "why": "the active attempt's result wins while the dead attempt stays inert",
             },
-            "missing-residual-risk": {
-                "report": "VERDICT: SATISFIED\n", "want": UNUSABLE,
-                "needle": "exactly one `RESIDUAL-RISK:`",
-                "why": "SATISFIED carries the required calibration line",
+            # The calibration line is OPTIONAL. It never was a gate input, so its absence never made a
+            # verdict less usable — but requiring it discarded four complete review passes across two
+            # engines. A SATISFIED report without one counts.
+            "satisfied-without-residual-risk": {
+                "report": "Report body.\nVERDICT: SATISFIED\n", "want": OK,
+                "needle": "report verdict satisfied",
+                "why": "a missing calibration line does not block a SATISFIED verdict",
             },
             "malformed-residual-risk": {
                 "report": "RESIDUAL-RISK: parser contract - wrong separator\nVERDICT: SATISFIED\n",
@@ -787,15 +790,22 @@ class Tables:
                 "why": "the residual-risk fields and em dash have one exact shape",
             },
             "misplaced-residual-risk": {
-                "report": "RESIDUAL-RISK: parser — hard\n\nVERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "immediately above",
-                "why": "the residual-risk line has one exact position",
+                "report": "RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",
+                "want": UNUSABLE, "needle": "last nonblank line",
+                "why": "prose between the line and the verdict detaches the signal from the verdict",
+            },
+            # Real reviewers on two engines separated the two with a blank line. Nothing of substance
+            # intervenes, so the line still belongs to this verdict and the pass counts.
+            "blank-line-above-verdict-residual-risk": {
+                "report": "Report body.\nRESIDUAL-RISK: parser — hard\n\nVERDICT: SATISFIED\n",
+                "want": OK, "needle": "report verdict satisfied",
+                "why": "blank lines between the residual risk and the verdict do not detach it",
             },
             "duplicate-residual-risk": {
                 "report": "RESIDUAL-RISK: first — hard\nRESIDUAL-RISK: second — hard\n"
                           "VERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "exactly one `RESIDUAL-RISK:`",
-                "why": "one accepting pass contributes one residual-risk record",
+                "want": UNUSABLE, "needle": "at most one `RESIDUAL-RISK:`",
+                "why": "one accepting pass contributes at most one residual-risk record",
             },
             "residual-on-not-satisfied": {
                 "report": "RESIDUAL-RISK: parser — hard\nVERDICT: NOT SATISFIED\n",

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -789,13 +789,24 @@ class Tables:
                 "want": UNUSABLE, "needle": "residual risk must be exactly",
                 "why": "the residual-risk fields and em dash have one exact shape",
             },
-            # The line being OPTIONAL is exactly what makes this case load-bearing: a detector that only
-            # sees column 0 reads an indented line as ABSENT, so a malformed line is silently accepted
-            # instead of refused. Present-but-malformed and never-written must stay distinguishable.
+            # The line being OPTIONAL is exactly what makes these two load-bearing: a detector that only
+            # sees column 0 reads an INVISIBLY PREFIXED line as ABSENT, so a malformed line is silently
+            # accepted instead of refused. Present-but-malformed and never-written must stay
+            # distinguishable. `visible_start` in review-pass.py owns which prefixes count as invisible;
+            # these two sample it — one prefix a reader would notice as blank space, one they would not.
             "indented-residual-risk": {
                 "report": "Report body.\n  RESIDUAL-RISK: parser — hard\nVERDICT: SATISFIED\n",
                 "want": UNUSABLE, "needle": "residual risk must be exactly",
                 "why": "an indented line is present and malformed, not absent",
+            },
+            # U+FEFF is Cf, so `str.lstrip()` never removes it. Placed MID-FILE deliberately: reading the
+            # report as `utf-8-sig` would not reach this line, so the case pins the DETECTOR, not a
+            # decoding choice — `read_text` stays `utf-8` so the tool reads what the file says.
+            "bom-prefixed-residual-risk": {
+                "report": "Report body.\n\ufeffRESIDUAL-RISK: parser contract - wrong separator\n"
+                          "VERDICT: SATISFIED\n",
+                "want": UNUSABLE, "needle": "residual risk must be exactly",
+                "why": "an invisible prefix hides a malformed line from the detector, not from the report",
             },
             "misplaced-residual-risk": {
                 "report": "RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -789,6 +789,14 @@ class Tables:
                 "want": UNUSABLE, "needle": "residual risk must be exactly",
                 "why": "the residual-risk fields and em dash have one exact shape",
             },
+            # The line being OPTIONAL is exactly what makes this case load-bearing: a detector that only
+            # sees column 0 reads an indented line as ABSENT, so a malformed line is silently accepted
+            # instead of refused. Present-but-malformed and never-written must stay distinguishable.
+            "indented-residual-risk": {
+                "report": "Report body.\n  RESIDUAL-RISK: parser — hard\nVERDICT: SATISFIED\n",
+                "want": UNUSABLE, "needle": "residual risk must be exactly",
+                "why": "an indented line is present and malformed, not absent",
+            },
             "misplaced-residual-risk": {
                 "report": "RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",
                 "want": UNUSABLE, "needle": "last nonblank line",

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1306,7 +1306,12 @@ def parse_report(progress: Path) -> "dict[str, str | None]":
             "'VERDICT: DEFERRED — <one-line reason>'"
         )
 
-    residual_lines = [n for n, line in enumerate(lines) if line.startswith("RESIDUAL-RISK:")]
+    # DETECT on the stripped line, JUDGE the original. Detection has to see an indented line, because the
+    # line is optional now: a line the detector misses is indistinguishable from one that was never written,
+    # so a malformed `RESIDUAL-RISK:` would be silently read as absent instead of refused. Everything below
+    # — the count, the placement, and `RESIDUAL_RISK_RE` — still reads the ORIGINAL unstripped line, so an
+    # indented line is detected and then refused for its shape. This is not whitespace tolerance.
+    residual_lines = [n for n, line in enumerate(lines) if line.lstrip().startswith("RESIDUAL-RISK:")]
     residual: "str | None" = None
     if verdict == SATISFIED:
         if len(residual_lines) > 1:

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1251,6 +1251,23 @@ def report_path(progress: Path) -> Path:
     return progress.parent / (progress.name[: -len(PROGRESS_SUFFIX)] + REPORT_SUFFIX)
 
 
+def visible_start(line: str) -> int:
+    """Index of the first character of `line` a READER CAN SEE — where a token may legitimately begin.
+
+    Tests by CATEGORY, never by a list of code points, so a character nobody has thought of yet is not a
+    new hole: `str.isspace()` covers Zs/Zl/Zp and the ASCII whitespace controls, and `not
+    str.isprintable()` covers the rest of Cc plus all of Cf (U+FEFF, U+200B–U+200F, U+2060, U+00AD,
+    U+061C, U+180E), Cs, Co and Cn. `str.lstrip()` alone is not enough: U+FEFF is Cf with
+    `isspace() == False`, so a report whose first line still carries a decoded byte-order mark keeps it
+    attached to the token — and `read_text` decodes as `utf-8`, never `utf-8-sig`, on purpose, so that
+    what the tool reads is what the file says.
+    """
+    i = 0
+    while i < len(line) and (line[i].isspace() or not line[i].isprintable()):
+        i += 1
+    return i
+
+
 def parse_report(progress: Path) -> "dict[str, str | None]":
     """Read one exact terminal result from the active attempt's report.
 
@@ -1306,12 +1323,15 @@ def parse_report(progress: Path) -> "dict[str, str | None]":
             "'VERDICT: DEFERRED — <one-line reason>'"
         )
 
-    # DETECT on the stripped line, JUDGE the original. Detection has to see an indented line, because the
-    # line is optional now: a line the detector misses is indistinguishable from one that was never written,
-    # so a malformed `RESIDUAL-RISK:` would be silently read as absent instead of refused. Everything below
-    # — the count, the placement, and `RESIDUAL_RISK_RE` — still reads the ORIGINAL unstripped line, so an
-    # indented line is detected and then refused for its shape. This is not whitespace tolerance.
-    residual_lines = [n for n, line in enumerate(lines) if line.lstrip().startswith("RESIDUAL-RISK:")]
+    # DETECT past every INVISIBLE prefix (`visible_start` owns which those are), JUDGE the original.
+    # Detection has to see a line the token does not start at column 0 of — indented, or led by a decoded
+    # byte-order mark or any other character that leaves no mark on screen — because the line is optional
+    # now: a line the detector misses is indistinguishable from one that was never written, so a malformed
+    # `RESIDUAL-RISK:` would be silently read as absent instead of refused. Everything below — the count,
+    # the placement, and `RESIDUAL_RISK_RE` — still reads the ORIGINAL unstripped line, so such a line is
+    # detected and then refused for its shape. This WIDENS refusal; it is not whitespace tolerance.
+    residual_lines = [n for n, line in enumerate(lines)
+                      if line.startswith("RESIDUAL-RISK:", visible_start(line))]
     residual: "str | None" = None
     if verdict == SATISFIED:
         if len(residual_lines) > 1:

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1251,19 +1251,70 @@ def report_path(progress: Path) -> Path:
     return progress.parent / (progress.name[: -len(PROGRESS_SUFFIX)] + REPORT_SUFFIX)
 
 
+# The Default_Ignorable_Code_Point members that are BOTH printable and non-space — the part of "renders as
+# nothing" that `str.isspace()` and `not str.isprintable()` cannot reach (267 code points as of Unicode
+# 15.0, the version this was transcribed against; the ranges are the fact, the count is illustration).
+# Python classes them Mn or Lo: a Hangul filler is a LETTER and a variation selector is a MARK, and both
+# print as nothing. Every other member of the property (U+00AD, U+061C, U+200B–U+200F, U+202A–U+202E,
+# U+2060–U+206F, U+FEFF, U+FFF0–U+FFF8, U+1BCA0–U+1BCA3, U+1D173–U+1D17A, and the Cf and unassigned parts
+# of U+E0000–U+E0FFF) is already Cf or Cn, so the category tests below already catch it.
+#
+# UNICODE OWNS THIS LIST; this file only transcribes it. It is a NAMED property with fixed membership, not
+# a catalogue of characters somebody happened to run into, which is why enumerating code points here does
+# not reopen the hole the category tests avoid. Regenerate it from `DerivedCoreProperties.txt` for the
+# running Python's Unicode version — `unicodedata.unidata_version` — if that version ever adds a member;
+# never extend it by hand with a character that merely looks suspicious.
+#
+#   U+034F         combining grapheme joiner          U+3164          Hangul filler
+#   U+115F–U+1160  Hangul choseong/jungseong fillers  U+FE00–U+FE0F   variation selectors 1–16
+#   U+17B4–U+17B5  Khmer inherent vowels AQ/AA        U+FFA0          halfwidth Hangul filler
+#   U+180B–U+180D, U+180F  Mongolian free variation selectors 1–4
+#   U+E0100–U+E01EF        variation selectors supplement 17–256
+_DEFAULT_IGNORABLE = (
+    (0x034F, 0x034F), (0x115F, 0x1160), (0x17B4, 0x17B5), (0x180B, 0x180D), (0x180F, 0x180F),
+    (0x3164, 0x3164), (0xFE00, 0xFE0F), (0xFFA0, 0xFFA0), (0xE0100, 0xE01EF),
+)
+
+
+def _default_ignorable(ch: str) -> bool:
+    """Is `ch` a Default_Ignorable code point the category tests in `visible_start` do not already reach?"""
+    point = ord(ch)
+    return any(low <= point <= high for low, high in _DEFAULT_IGNORABLE)
+
+
 def visible_start(line: str) -> int:
     """Index of the first character of `line` a READER CAN SEE — where a token may legitimately begin.
 
-    Tests by CATEGORY, never by a list of code points, so a character nobody has thought of yet is not a
-    new hole: `str.isspace()` covers Zs/Zl/Zp and the ASCII whitespace controls, and `not
-    str.isprintable()` covers the rest of Cc plus all of Cf (U+FEFF, U+200B–U+200F, U+2060, U+00AD,
-    U+061C, U+180E), Cs, Co and Cn. `str.lstrip()` alone is not enough: U+FEFF is Cf with
-    `isspace() == False`, so a report whose first line still carries a decoded byte-order mark keeps it
-    attached to the token — and `read_text` decodes as `utf-8`, never `utf-8-sig`, on purpose, so that
-    what the tool reads is what the file says.
+    Two KINDS of test, and together they are COMPLETE for that meaning. The CATEGORY tests carry the
+    open-ended part, so a character nobody has thought of yet is not a new hole: `str.isspace()` covers
+    Zs/Zl/Zp and the ASCII whitespace controls, and `not str.isprintable()` covers the rest of Cc plus all
+    of Cf (U+FEFF, U+200B–U+200F, U+2060, U+00AD, U+061C, U+180E), Cs, Co, Cn. `_DEFAULT_IGNORABLE` carries
+    what no category test can: the code points that ARE printable and non-space and still render as
+    nothing. Its listing of code points is not the ad-hoc enumeration the category tests exist to avoid —
+    it transcribes one NAMED CLOSED Unicode property, and that property is what makes this complete: after
+    it there is no further category of invisible character to add.
+
+    `str.lstrip()` alone is not enough: U+FEFF is Cf with `isspace() == False`, so a report whose first
+    line still carries a decoded byte-order mark keeps it attached to the token — and `read_text` decodes
+    as `utf-8`, never `utf-8-sig`, on purpose, so that what the tool reads is what the file says.
+
+    THE BOUNDARY IS "INVISIBLE", AND IT MUST NOT MOVE OUTWARD — a claim about this code, checkable here.
+    A VISIBLE prefix (a markdown bullet or quote marker, bold markers, a spacing combining mark such as
+    U+0301, a lowercase spelling) is read as ABSENT on purpose: such a line does not present as the exact
+    token, and the exact form is `RESIDUAL_RISK_RE`'s to own. The wider rule that would close that whole
+    prefix class — skip every leading non-alphanumeric — was trialled, and it REFUSES VALID REPORTS. A
+    reviewer's SATISFIED report that quotes the intent bullet forbidding a residual-risk line on a
+    NOT SATISFIED or DEFERRED result (a bullet handed verbatim to every reviewer in the review prompt, so
+    quoting it is ordinary) is refused EVEN WHEN that report also carries a well-formed residual-risk line
+    of its own: the wider rule skips the quoted bullet's leading punctuation, counts the quotation as a
+    second occurrence, and the at-most-one check in `parse_report` fires. To falsify this, swap the loop
+    condition below for `not line[i].isalnum()` and count the detections in such a report — two, not one.
+    Destroying complete passes is the exact harm this parser exists to prevent.
     """
     i = 0
-    while i < len(line) and (line[i].isspace() or not line[i].isprintable()):
+    while i < len(line) and (
+        line[i].isspace() or not line[i].isprintable() or _default_ignorable(line[i])
+    ):
         i += 1
     return i
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -476,8 +476,11 @@ FINDINGS_NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-{COUNT}(?:\.a{ATTEMPT})
 
 # The strict terminal report contract. The prompt owns these exact lines; `parse_report` is their executable
 # reader. A deferred result includes a reason because it is a request the orchestrator must route. A
-# SATISFIED result includes the immediately preceding residual-risk line because that metadata is carried
-# into the campaign's final report.
+# SATISFIED result MAY carry a residual-risk line, which is carried into the campaign's final report. That
+# line is calibration metadata, never a gate input, so its ABSENCE has never made a verdict less usable —
+# yet requiring it discarded four complete, substantive review passes across two engines. It is optional
+# now; when present it must still be well-formed and stand last before the verdict, and it stays forbidden
+# on every non-SATISFIED result.
 REPORT_SATISFIED = "VERDICT: SATISFIED"
 REPORT_NOT_SATISFIED = "VERDICT: NOT SATISFIED"
 REPORT_DEFERRED_RE = re.compile(r"^VERDICT: DEFERRED — (?P<reason>\S(?:.*\S)?)\Z")
@@ -1252,8 +1255,9 @@ def parse_report(progress: Path) -> "dict[str, str | None]":
     """Read one exact terminal result from the active attempt's report.
 
     Report prose remains the reviewer's judgment. This parser owns only the framing that makes that
-    judgment usable: one terminal result on the last nonblank line, a reason for DEFERRED, and the
-    immediately preceding residual-risk line for SATISFIED.
+    judgment usable: one terminal result on the last nonblank line, a reason for DEFERRED, and — for
+    SATISFIED only, and only when the reviewer wrote one — the optional residual-risk line that stands
+    last before the verdict, blank lines between the two tolerated.
     """
     path = report_path(progress)
     text = read_text(path, "active review report")
@@ -1305,24 +1309,30 @@ def parse_report(progress: Path) -> "dict[str, str | None]":
     residual_lines = [n for n, line in enumerate(lines) if line.startswith("RESIDUAL-RISK:")]
     residual: "str | None" = None
     if verdict == SATISFIED:
-        if len(residual_lines) != 1:
+        if len(residual_lines) > 1:
             # MUTATE:report-residual-count:pass
             raise Defect(
-                f"{path.name}: SATISFIED requires exactly one `RESIDUAL-RISK:` line; found "
+                f"{path.name}: SATISFIED carries at most one `RESIDUAL-RISK:` line; found "
                 f"{len(residual_lines)}"
             )
-        if residual_lines[0] != last - 1:
-            # MUTATE:report-residual-position:pass
-            raise Defect(
-                f"{path.name}: SATISFIED requires its `RESIDUAL-RISK:` line immediately above the verdict"
-            )
-        residual = lines[last - 1]
-        if RESIDUAL_RISK_RE.match(residual) is None:
-            # MUTATE:report-residual-shape:pass
-            raise Defect(
-                f"{path.name}: residual risk must be exactly "
-                "'RESIDUAL-RISK: <area or file> — <why this was hardest to verify fully>'"
-            )
+        if residual_lines:
+            # ATTACHED, not adjacent. When the line IS there it must belong to THIS verdict — nothing of
+            # substance may stand between them. A blank line does not defeat that, and insisting on
+            # adjacency discarded four complete, substantive review passes across two engines.
+            # `nonblank[-2]` is always in range here: the residual line is nonblank and is not the verdict.
+            if residual_lines[0] != nonblank[-2]:
+                # MUTATE:report-residual-position:pass
+                raise Defect(
+                    f"{path.name}: a SATISFIED report's `RESIDUAL-RISK:` line must be the last nonblank "
+                    f"line before the verdict; only blank lines may separate the two"
+                )
+            residual = lines[residual_lines[0]]
+            if RESIDUAL_RISK_RE.match(residual) is None:
+                # MUTATE:report-residual-shape:pass
+                raise Defect(
+                    f"{path.name}: residual risk must be exactly "
+                    "'RESIDUAL-RISK: <area or file> — <why this was hardest to verify fully>'"
+                )
     elif residual_lines:
         # MUTATE:report-residual-binary-only:pass
         raise Defect(

--- a/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
+++ b/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
@@ -96,15 +96,19 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    between that line and the verdict.
    It is a calibration signal, NOT a finding, and does not weaken your
    SATISFIED — do not manufacture a concern to fill it; if identifying it surfaces a real GATING defect,
-   record it with the tool and return NOT SATISFIED instead. End with exactly one line:
+   record it with the tool and return NOT SATISFIED instead. The line is REQUESTED, not required: a
+   SATISFIED report WITHOUT it is accepted and counts in full, so when you cannot honestly name a
+   least-certain area, OMIT the line — that is the correct output, not a deficient one. Every rule above
+   governs the line when you DO write it; none of them is relaxed by its being optional.
+   End with exactly one line:
    'VERDICT: SATISFIED' or 'VERDICT: NOT SATISFIED'.
    The ONE exception is when you did NOT render a verdict because you raised a separate request the
    orchestrator must handle FIRST — you raised a plan_amendment_request naming a plan gap, or the
    dispatch was broken and you are stopping: then end with 'VERDICT: DEFERRED — <one-line reason>' and do
    NOT fabricate SATISFIED or NOT SATISFIED. A deferral is a REQUEST, not a verdict; the orchestrator
    routes it to the tool, which reads the progress file and decides what to do next. Build the complete
-   report, including RESIDUAL-RISK only when your verdict is SATISFIED, and the terminal VERDICT line,
-   before delivery. If
+   report, including RESIDUAL-RISK — optional, and only when your verdict is SATISFIED — and the
+   terminal VERDICT line, before delivery. If
    TRANSPORT.report.producer is "native-worker-write", write those exact report bytes to
    TRANSPORT.report.path through the host file API before returning the same text. If it is
    "external-process-capture", return the report only as the process's final output and do not write

--- a/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
+++ b/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
@@ -90,9 +90,11 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    checkable evidence) as a finding in itself.
    Summarise your findings in this report with file:line and the concrete fix (the tool holds the
    authoritative record). If — and only if — your verdict is SATISFIED,
-   output one line immediately above the verdict, in the form RESIDUAL-RISK: <area or file> — <why
-   this was the hardest part to verify fully>, naming the part of the diff you checked with the LEAST
-   certainty relative to the rest. It is a calibration signal, NOT a finding, and does not weaken your
+   output one line above the verdict with nothing but blank lines between the two, in the form
+   RESIDUAL-RISK: <area or file> — <why this was the hardest part to verify fully>, naming the part
+   of the diff you checked with the LEAST certainty relative to the rest. Nothing else may come
+   between that line and the verdict.
+   It is a calibration signal, NOT a finding, and does not weaken your
    SATISFIED — do not manufacture a concern to fill it; if identifying it surfaces a real GATING defect,
    record it with the tool and return NOT SATISFIED instead. End with exactly one line:
    'VERDICT: SATISFIED' or 'VERDICT: NOT SATISFIED'.

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -780,6 +780,17 @@ def check_document_contract() -> None:
     ):
         require(needle in prompt, f"review-prompt.txt lost reviewer operation: {needle}")
 
+    # The prompt IS the reviewer's contract, so the parser accepting a SATISFIED report without a
+    # RESIDUAL-RISK line has to be SAID here, not only in the references that summarise this file. Without
+    # it the prompt gives an unqualified order and a reviewer with no honest least-certain area is left
+    # between "output one line" and "do not manufacture a concern to fill it".
+    for needle in (
+        "The line is REQUESTED, not required",
+        "SATISFIED report WITHOUT it is accepted and counts in full",
+    ):
+        require(needle in prompt,
+                f"review-prompt.txt no longer states the residual-risk line is optional: {needle}")
+
     require("producer rule applies to initial launch, relaunch, and native fallback" in reviewer,
             "native report producer no longer covers every attempt state")
     reviewer_flat = " ".join(reviewer.split())


### PR DESCRIPTION
## Purpose
- `verify` accepts a SATISFIED report carrying no `RESIDUAL-RISK:` line
- `verify` accepts one whose `RESIDUAL-RISK:` line is separated from the verdict by blank lines only
- a present `RESIDUAL-RISK:` line is still refused when malformed, duplicated, or detached by prose
- `RESIDUAL-RISK:` on a NOT SATISFIED or DEFERRED report is still refused
- every reference and prompt restating the report contract now states the optional rule

## Non-goals
- no general whitespace tolerance elsewhere in report parsing
- no change to unit coverage, finding/verdict coherence, or head pinning
- no change to `default_non_goals` scope binding or amendment ruling
- no change to the line's exact `<area> — <why>` form when present
- no `plugin.json` version bump

## Threat model
- Who can write the inputs this code reads: the dispatched reviewer, writing its report file
- Who else: the single user driving the run, by hand-editing their own run directory
- Who cannot: nobody else — that directory is local, git-ignored, driver-owned, on no network
