### PR TITLE
default nudge rundir to the ledger directory

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -25,12 +25,16 @@ the worker returns, and what never moves into it. The steps below are unchanged 
    This lease gate is what guarantees **no two agents drive one ledger**.
 
    Once you own the run and have loaded its ledger, run
-   `scripts/nudge.py --file <rundir>/state.jsonl --followups .gauntlet/followups.jsonl --rundir <rundir>`
+   `scripts/nudge.py --file <rundir>/state.jsonl --followups <project_root>/.gauntlet/followups.jsonl --rundir <rundir>`
    and **READ its output** before reconciling. It is the **advisory reminder list** — computed from durable
    state so an amnesiac fresh-context heartbeat is HANDED its obligations rather than told to remember
    them. It **decides nothing and always exits 0**; each reminder just points at the owner of the actual
    check (labels, caps, the health pass below — including its `watchdog due` reminder). Act on the
    reminders through those owners; ignore none silently.
+   Every path here is **absolute**, from the record resolved above: the follow-up store is `.gauntlet/`
+   under `repository.project_root`, and the tool uses `--followups` **as given** — a cwd-relative path
+   makes the answer depend on where the heartbeat was launched, and a driver working in a worktree would
+   find no store there at all.
 
    Once bound and confirmed owner, decide on **liveness of THIS run**, not on whether some `state.jsonl`
    exists — and scope **every** git/gh scan to this run's `gauntlet-run-<run-id>` label so another run's

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -11,7 +11,9 @@ that emits every line unconditionally — which is no printer at all.
 
 from __future__ import annotations
 
+import io
 import tempfile
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -324,6 +326,44 @@ def t_watchdog_due_silent_without_open_work():
                   f"a run with no open work must NOT fire the watchdog-due reminder (rows={rows}, wd={wd!r})")
 
 
+def _run_main(argv) -> str:
+    """main()'s printed output, so a fixture can pin the FLAG PLUMBING and not only `reminders()`."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        code = N.main(argv)
+    check(code == 0, f"main({argv!r}) must exit 0 — a nudge never blocks")
+    return buf.getvalue()
+
+
+def t_rundir_defaults_to_the_ledger_directory():
+    """`--file` alone must NOT report every intent file missing. The ledger IS `<rundir>/state.jsonl`, so
+    the run directory is its parent and nudge derives it. Before this, a `--file`-only call passed
+    rundir=None, `rundir_has` read that as "absent", and every review-due PR got a confident, wrong
+    "no intent-<N>.md" line with no error and no warning."""
+    with tempfile.TemporaryDirectory() as d:
+        rd = Path(d)
+        led = rd / "state.jsonl"
+        led.write_text('{"type": "header", "run_id": "g1", "required_set": "none"}\n'
+                       '{"type": "row", "id": "pr9", "pr": "9", "status": "in_review", "tier": "HIGH",'
+                       ' "reviews_ok": "0", "ci": "green"}\n', encoding="utf-8")
+        (rd / "intent-9.md").write_text("x", encoding="utf-8")
+        check("no intent-9.md" not in _run_main(["--file", str(led)]),
+              "an intent file NEXT TO the ledger must silence the nudge with NO --rundir passed — the run "
+              "directory is the ledger's parent, never unknown")
+        # Teeth: the derived rundir is really being READ, not just suppressing the rule. Remove the file and
+        # the same --file-only invocation must fire again.
+        (rd / "intent-9.md").unlink()
+        check("no intent-9.md" in _run_main(["--file", str(led)]),
+              "with the intent file gone the same --file-only invocation must fire the nudge — the derived "
+              "run directory is read, not ignored")
+        # An explicit --rundir still WINS over the derived default.
+        other = rd / "elsewhere"
+        other.mkdir()
+        (other / "intent-9.md").write_text("x", encoding="utf-8")
+        check("no intent-9.md" not in _run_main(["--file", str(led), "--rundir", str(other)]),
+              "an explicit --rundir must override the derived default")
+
+
 def t_a_nudge_never_blocks():
     # main() over a real ledger file exits 0 no matter what it prints.
     with tempfile.TemporaryDirectory() as d:
@@ -358,5 +398,7 @@ CASES = [
     ("quiet-names-the-park", "a parked-only quiet run says it waits on the user and surfaces the question", t_quiet_run_names_the_park),
     ("watchdog-due-fires", "watchdog-due reminder fires on unset/overdue/invalid with open work, silent when ok", t_watchdog_due_fires_on_unset_overdue_invalid_with_open_work),
     ("watchdog-due-needs-open-work", "watchdog-due reminder is silent with no open/terminal-only rows", t_watchdog_due_silent_without_open_work),
+    ("rundir-defaults-to-ledger-dir", "--file alone derives the run directory from the ledger's parent",
+     t_rundir_defaults_to_the_ledger_directory),
     ("never-blocks", "a nudge always exits 0", t_a_nudge_never_blocks),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -44,8 +44,9 @@ def row(pr, status, **kw) -> dict:
     return r
 
 
-def fire(rows, *, hdr=None, n_followups=0, rundir=None, now=None) -> list:
-    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, now)
+def fire(rows, *, hdr=None, n_followups: "int | None" = 0, rundir=None, now=None,
+         followups_path: "Path | None" = None) -> list:
+    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, now, followups_path)
 
 
 # A fixed "now" and two stamps around it, so the quiet-run rule is DETERMINISTIC: one older than
@@ -160,6 +161,45 @@ def t_followups_fire_only_when_open():
           "open follow-ups must nudge, with the count")
     check(not has(fire([], n_followups=0), "open follow-up"),
           "zero open follow-ups must NOT nudge")
+
+
+def t_unread_followup_store_is_disclosed():
+    """An UNREAD follow-up store must SAY SO, naming why — never fall silent. Silence is what a caller
+    reads as "this run has no open follow-ups", and the store goes unread on two ordinary invocations:
+    `--followups` omitted, and a path that is not there. The store path is not derivable from `--rundir`
+    (`.gauntlet/` is a project-root concern, not a run-directory one) and the printer always exits 0, so
+    DISCLOSURE — not a default and not a refusal — is the whole fix."""
+    # unit level: not-read (None) discloses; a successful read never does.
+    absent = fire([], n_followups=None)
+    check(has(absent, "follow-up store NOT READ (no --followups given)"),
+          "an omitted --followups must disclose that the store was not read, and why")
+    missing = fire([], n_followups=None, followups_path=Path("/nonexistent/typo.jsonl"))
+    check(has(missing, "follow-up store NOT READ (no file at /nonexistent/typo.jsonl)"),
+          "a --followups path that is not there must disclose it, NAMING the path it tried")
+    # Teeth: a store that WAS read never claims it was not — neither with open entries nor empty.
+    check(not has(fire([], n_followups=3), "NOT READ"),
+          "a store that was read must report its count, never the not-read disclosure")
+    check(not has(fire([], n_followups=0), "NOT READ"),
+          "an EMPTY store that was read is genuinely zero — it must stay silent, not disclose")
+    # main() plumbing: the same two invocations end to end, plus a real store proving the count wins.
+    with tempfile.TemporaryDirectory() as d:
+        rd = Path(d)
+        led = rd / "state.jsonl"
+        led.write_text('{"type": "header", "run_id": "g1", "required_set": "none"}\n', encoding="utf-8")
+        check("follow-up store NOT READ (no --followups given)" in _run_main(["--file", str(led)]),
+              "a --file-only invocation must DISCLOSE the unread store — the silent-misuse case")
+        typo = rd / "typo.jsonl"
+        check(f"follow-up store NOT READ (no file at {typo})"
+              in _run_main(["--file", str(led), "--followups", str(typo)]),
+              "a mistyped --followups path must DISCLOSE it end to end, naming the path")
+        # Teeth end to end: a REAL store with an open entry prints the count and no disclosure. Built
+        # through followups.py's own writer, so this fixture never restates that store's schema.
+        store = rd / "followups.jsonl"
+        N.F.dump(store, [{"id": "fu1", "title": "t", "evidence": "e", "deferred_why": "w"}], 0)
+        out = _run_main(["--file", str(led), "--followups", str(store)])
+        check("1 open follow-up(s) — start any you can." in out and "NOT READ" not in out,
+              "a store that exists must yield the COUNT and no disclosure — the disclosure must "
+              "discriminate on whether the store was actually read")
 
 
 # --- held PRs short-circuit ---------------------------------------------------
@@ -385,6 +425,8 @@ CASES = [
      t_settled_base_report),
     ("fanout-open-only", "fan-out nudges only with open work", t_fanout_fires_only_with_open_work),
     ("followups-open-only", "follow-ups nudge only when open, with the count", t_followups_fire_only_when_open),
+    ("followups-unread-disclosed", "an unread follow-up store SAYS so, naming why — never silence",
+     t_unread_followup_store_is_disclosed),
     ("parked-short-circuits", "a parked PR fires only its held reminder", t_parked_pr_fires_only_its_own_reminder),
     ("repairing-splits", "repairing splits on whether a decision is recorded", t_repairing_splits_on_decision),
     ("intent-missing", "intent nudge fires only without the file", t_intent_missing_fires_only_without_the_file),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -94,6 +94,20 @@ def rundir_has(rundir: "Path | None", name: str) -> bool:
     return rundir is not None and (rundir / name).exists()
 
 
+def resolve_rundir(file_arg: str, rundir_arg: "str | None") -> Path:
+    """The run directory to check `<rundir>` files against — the explicit `--rundir`, else DERIVED from the
+    ledger path. The ledger IS `<rundir>/state.jsonl`, so its parent IS the run directory; there is no
+    invocation where `--file` is usable and the run directory is unknowable, and `--file` is already
+    mandatory. Deriving it is what keeps a `--file`-only call from reporting every intent file MISSING —
+    `rundir_has` reads a `None` rundir as "the file is not there", which is indistinguishable in the output
+    from a genuinely missing intent file. An explicit `--rundir` still wins, for the caller who really does
+    keep the two apart.
+    """
+    if rundir_arg:
+        return Path(rundir_arg)
+    return Path(file_arg).resolve().parent
+
+
 def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
               now: "datetime | None" = None) -> list:
     """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings.
@@ -232,7 +246,8 @@ def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument("--file", help="the run ledger (<rundir>/state.jsonl)")
     parser.add_argument("--followups", help="the follow-up store (.gauntlet/followups.jsonl)")
-    parser.add_argument("--rundir", help="the run directory, for intent/CI/progress file checks")
+    parser.add_argument("--rundir", help="the run directory, for intent/CI/progress file checks "
+                                         "(default: the directory holding --file)")
     parser.add_argument("--self-test", action="store_true", help="run every fixture and assert the rules "
                                                                  "this file enforces still hold")
     args = parser.parse_args(argv)
@@ -244,7 +259,7 @@ def main(argv: "list[str] | None" = None) -> int:
         parser.error("the following arguments are required: --file")
     header, rows = L.load(Path(args.file))
     n_followups = open_followups(Path(args.followups) if args.followups else None)
-    rundir = Path(args.rundir) if args.rundir else None
+    rundir = resolve_rundir(args.file, args.rundir)
     print(render(header, rows, n_followups, rundir))
     return 0  # a nudge NEVER blocks — it only reminds
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -83,11 +83,31 @@ def required(tier: str) -> int:
     return 1 if tier == "TRIVIAL" else 2
 
 
-def open_followups(followups_path: "Path | None") -> int:
+def open_followups(followups_path: "Path | None") -> "int | None":
+    """How many follow-ups are OPEN — or `None` when the store was NOT READ (no `--followups` was given,
+    or the path given is not there). `None` is NOT `0`, and keeping them apart is the whole point: an
+    unread store counted as zero is INDISTINGUISHABLE in the output from a genuinely empty queue, so an
+    omitted or mistyped flag retired the durable follow-up queue with no error, no warning, and a
+    confident header above it. The caller DISCLOSES the `None` (`followups_line`); it never invents a
+    count from a store it did not open.
+    """
     if followups_path is None or not followups_path.exists():
-        return 0
+        return None
     entries = F.load(followups_path)
     return sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN)
+
+
+def followups_line(n_followups: "int | None", followups_path: "Path | None") -> "str | None":
+    """The one follow-up reminder: a COUNT when the store was read, a DISCLOSURE naming why when it was
+    not, and silence ONLY for a read that genuinely found nothing open. An unread store is never silent —
+    that silence is what a caller reads as "this run has no open follow-ups".
+    """
+    if n_followups is None:
+        where = f"no file at {followups_path}" if followups_path is not None else "no --followups given"
+        return f"follow-up store NOT READ ({where}) — open follow-ups are UNKNOWN, not zero."
+    if n_followups:
+        return f"{n_followups} open follow-up(s) — start any you can."
+    return None
 
 
 def rundir_has(rundir: "Path | None", name: str) -> bool:
@@ -108,12 +128,15 @@ def resolve_rundir(file_arg: str, rundir_arg: "str | None") -> Path:
     return Path(file_arg).resolve().parent
 
 
-def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
-              now: "datetime | None" = None) -> list:
+def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
+              now: "datetime | None" = None, followups_path: "Path | None" = None) -> list:
     """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings.
 
     `now` is the current UTC time, injectable so the quiet-run rule is testable; it defaults to
     `datetime.now(timezone.utc)` when a caller (main) does not pass one.
+
+    `followups_path` is only what the follow-up store was LOOKED FOR at — it is never read here, and it
+    exists so an unread store can name the path it tried (`followups_line`).
     """
     if now is None:
         now = datetime.now(timezone.utc)
@@ -153,8 +176,9 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
             out.append(f"base {base} (PR(s) {prs}): required set {rset}.")
     if active:
         out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
-    if n_followups:
-        out.append(f"{n_followups} open follow-up(s) — start any you can.")
+    fu_line = followups_line(n_followups, followups_path)
+    if fu_line:
+        out.append(fu_line)
 
     # --- watchdog-due reminder -------------------------------------------------
     # The durable long-cadence health-pass deadline (ledger.py's `watchdog_due`). When it is due, never armed,
@@ -233,9 +257,9 @@ def reminders(header: dict, rows: list, n_followups: int, rundir: "Path | None",
     return out
 
 
-def render(header: dict, rows: list, n_followups: int, rundir: "Path | None",
-           now: "datetime | None" = None) -> str:
-    lines = reminders(header, rows, n_followups, rundir, now)
+def render(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
+           now: "datetime | None" = None, followups_path: "Path | None" = None) -> str:
+    lines = reminders(header, rows, n_followups, rundir, now, followups_path)
     run_id = header.get("run_id", "-")
     head = f"NUDGE (run {run_id}) — {len(lines)} reminder(s):"
     body = "\n".join(f"  - {line}" for line in lines)
@@ -245,7 +269,10 @@ def render(header: dict, rows: list, n_followups: int, rundir: "Path | None",
 def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(description=DESCRIPTION)
     parser.add_argument("--file", help="the run ledger (<rundir>/state.jsonl)")
-    parser.add_argument("--followups", help="the follow-up store (.gauntlet/followups.jsonl)")
+    parser.add_argument("--followups", help="the follow-up store (<project_root>/.gauntlet/followups.jsonl). "
+                                            "Used AS GIVEN — a relative path resolves against the CWD, so "
+                                            "pass an absolute one. Omitted, or not found, the reminder SAYS "
+                                            "the store was not read; it never reports zero")
     parser.add_argument("--rundir", help="the run directory, for intent/CI/progress file checks "
                                          "(default: the directory holding --file)")
     parser.add_argument("--self-test", action="store_true", help="run every fixture and assert the rules "
@@ -258,9 +285,10 @@ def main(argv: "list[str] | None" = None) -> int:
     if args.file is None:
         parser.error("the following arguments are required: --file")
     header, rows = L.load(Path(args.file))
-    n_followups = open_followups(Path(args.followups) if args.followups else None)
+    followups_path = Path(args.followups) if args.followups else None
+    n_followups = open_followups(followups_path)
     rundir = resolve_rundir(args.file, args.rundir)
-    print(render(header, rows, n_followups, rundir))
+    print(render(header, rows, n_followups, rundir, followups_path=followups_path))
     return 0  # a nudge NEVER blocks — it only reminds
 
 


### PR DESCRIPTION
- `nudge.py --file` without `--rundir` printed a wrong `PR <N>: no intent-<N>.md` for every review-due PR
- `--rundir` now defaults to the ledger's parent directory; an explicit value still wins
- new fixture `rundir-defaults-to-ledger-dir` pins it; exit behavior unchanged
