### PR TITLE
sync GitHub-owned fields on terminal merge

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -160,12 +160,19 @@ When the loop exits, summarize:
   passes actually wrote and never invent a line for a pass that omitted one. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
 - **What each base REQUIRED** — the required-check set, now **per base** (`effective_required_set`;
-  `stage-2-ci.md` owns its states). A run may span several bases (`v3`, `main`), so report **each distinct
+  `stage-2-ci.md` owns its states), over the bases **this run GATED on and READ** — not every base the
+  terminal ledger names. A run may span several bases (`v3`, `main`), so report **each distinct gated
   base and which state it was in**, because it is what every `green` on that base rests on: `declared:…` —
   name the checks that had to pass; `none` — that base required nothing, **read and confirmed**, not merely
   unobserved. **NEVER report `unknown` as "no required checks"**: it means campaign **could not read** them
   **for that base**, nothing merged on it, and any PR that reached it **escalated** — say which base's read
   failed, so the user can fix the access rather than wonder why those PRs stalled.
+  **A row whose `base_branch` came from the terminal GitHub-owned refresh is NOT a gated base here**: it
+  contributes its base to **Merged** above and nothing to this bullet (`files-and-ledger.md`, "GitHub-owned
+  vs campaign-owned row fields", owns that write). Its `required_set` is campaign-owned, so it still holds
+  the set read for the base this run gated on, and grouping it under the refreshed base would report one
+  base's required checks under another base's name. Neither re-label that set nor substitute `unknown` for
+  it: no read failed, and `unknown` states above the opposite of what happened on that base.
 - **Repaired** — every PR that reached a review-loop cap and recorded a reassessment decision: its
   `review_rounds`, the decision, and a pointer to `repair-<pr>-<k>.md` (`repair-pass.md`). For a legacy
   `demote@…` row, **report each demoted finding explicitly** — they are true findings that were deliberately

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -503,7 +503,7 @@
   agree. Resolve a PR's base through `effective_base` (its row value, else the legacy header fallback).
   Reviews diff `origin/<base>...HEAD` and each PR merges into its `<base>`; a fix worktree branches off the
   PR's OWN head branch/SHA, never off `<base>` (see `pr-adoption.md`). That recorded row base is
-  **immutable** — the campaign never migrates a row to a new base; a live `baseRefName` retarget **PARKS the
+  **never retargeted** — the campaign never migrates a row to a new base; a live `baseRefName` retarget **PARKS the
   row** (never rewrites `base_branch`), through the park procedure owned by `pr-adoption.md` (re-adoption
   base gate) and `loop-control.md` (`base_changed` route). Re-resolve it each heartbeat (see "Base branch").
 - After every merge, let `merge.py run` fast-forward local `<base>` to `origin/<base>` (Stage 3,

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -627,6 +627,9 @@ like every other head write, so a genuine head move fires the head-move reset at
 field, "What a genuine head move resets"). That voids SHA-pinned evidence about the OLD head; it does not
 revise anything this run decided.
 
+**The base refresh raises the same question about its neighbours, and the answer is not here:**
+`bailout-and-final-report.md`'s **What each base REQUIRED** bullet owns it.
+
 **Where this actually fires: `merge.py`'s terminal write, on an `aborted` row GitHub now reports MERGED.**
 The abort leaves the PR open for its owner (`bailout-and-final-report.md`), so the user may merge it
 themselves; the finalizer records that (`stage-3-merge.md`). Recording `status = merged` **alone** is the

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -375,9 +375,11 @@ Header field notes (the header fields above; per-row fields follow):
   **admission** is LIVE too: adoption surfaces PRs on DIFFERENT bases into one run, each row owning the
   base it was created with, and PRs adopted together need **NOT** agree on `baseRefName` (`pr-adoption.md`,
   "PR adoption"). A new run leaves the header `base_branch` at `-` and records only per-row bases. It is **TOOL-OWNED and
-  IMMUTABLE after creation** (`CREATE_ONLY` in `scripts/ledger.py`): `add-row` writes it and **`set` has no
-  `--base-branch` flag**, so the recorded base can never be rewritten — the campaign does not migrate a row
-  to a new base. The default is **`-`**, which is both the schema's "not set" spelling **and** its "inherit
+  FIXED FOR THE ROW'S WORKING LIFE** (`CREATE_ONLY` in `scripts/ledger.py`): `add-row` writes it and **`set` has no
+  `--base-branch` flag**, so no driver can retarget a row it is still driving — the campaign does not migrate
+  a live row to a new base. The one write outside those doors is the **terminal** GitHub-owned refresh
+  ("GitHub-owned vs campaign-owned row fields"), which is not a retarget: it fires only on a row that is
+  already done, and it records the base the PR actually merged into. The default is **`-`**, which is both the schema's "not set" spelling **and** its "inherit
   the legacy header" signal, and is **DISTINCT from any explicit base name**: a `-` row inherits, an
   explicit-base row does not — which is what lets one run mix legacy inheriting rows with new explicit-base
   rows. An old ledger's rows read back `-` and resolve exactly as they always did, with no migration.
@@ -519,9 +521,13 @@ Header field notes (the header fields above; per-row fields follow):
   the user answers, so a later heartbeat — or a fresh agent that adopted the run — reads it and never
   re-asks about a PR already decided. It records the decision (an input); `status` stays the
   live position, so the two never contradict: `approved` pairs with the PR back in normal
-  gate flow, `declined` with a terminal `aborted`. A one-off approval lands here only; it never flips
+  gate flow, `declined` with a terminal `aborted` — **campaign's own** transitions. `status` may still move
+  on afterward without touching this field, because it is GitHub-owned and this one is not ("GitHub-owned vs
+  campaign-owned row fields"). A one-off approval lands here only; it never flips
   the run-wide `api_changes` header.
-- `status` — `in_review` → `merged`, or `aborted`; plus the **HELD** (non-terminal) statuses below.
+- `status` — `in_review` → `merged`, or `aborted`; plus the **HELD** (non-terminal) statuses below. The
+  merged/closed aspect of it is **GitHub-owned**, so `aborted` → `merged` is also reachable: the abort
+  leaves the PR open and the user may merge it themselves ("GitHub-owned vs campaign-owned row fields").
   **The vocabulary is CLOSED**: `STATUSES` in `scripts/ledger.py` is the one enumeration, and
   `set`/`add-row --status` **refuses** any value outside it. That refusal is what makes the dispatch
   allow-list safe to be strict — a status the guard cannot clear is a status nothing can write, so one
@@ -598,6 +604,37 @@ Header field notes (the header fields above; per-row fields follow):
     keep being driven, and the answer folds in as its own heartbeat (`loop-control.md` step 3, "Only the
     user's answer unparks a PR" — the owning definition of the record + unpark for **every** park class).
     NEVER park without surfacing the question, and NEVER park into a state whose exit is undefined.
+
+### GitHub-owned vs campaign-owned row fields
+
+A row holds **two kinds** of field, and the difference decides what a **live GitHub read** may write.
+
+| Kind | Authority | Members |
+|------|-----------|---------|
+| **GitHub-owned** | GitHub. The row only CACHES a copy | `head_sha`, `base_branch`, and the merged/closed aspect of `status`. `GITHUB_OWNED_FIELDS` in `scripts/merge.py` pairs each cached field with the live `gh pr view` field it copies |
+| **Campaign-owned** | This run. GitHub knows nothing about them | every other row field — what this run decided, spent, was told, or created |
+
+**A live read that updates one GitHub-owned field MUST update them ALL, from that SAME snapshot, in ONE
+write.** They describe one PR at one instant; refreshed apart, the row states a combination that never
+existed. `ci` is derived from GitHub too but is **NOT** in this set — `ci-status.py`'s own derivation path
+owns it, SHA-pinned and fail-closed, and no other site may write it.
+
+**Campaign-owned fields stay FROZEN at whatever this run last recorded, on purpose.** They are this run's
+account of its own work, and no later external event revises it: a PR the user merges after the campaign
+gave up does not retroactively give it more review rounds, a lower tier, or the user's approval. The one
+apparent exception is not one — refreshing `head_sha` goes through `ledger.py`'s `apply_head_sha` accessor
+like every other head write, so a genuine head move fires the head-move reset at the door (the `head_sha`
+field, "What a genuine head move resets"). That voids SHA-pinned evidence about the OLD head; it does not
+revise anything this run decided.
+
+**Where this actually fires: `merge.py`'s terminal write, on an `aborted` row GitHub now reports MERGED.**
+The abort leaves the PR open for its owner (`bailout-and-final-report.md`), so the user may merge it
+themselves; the finalizer records that (`stage-3-merge.md`). Recording `status = merged` **alone** is the
+failure this rule exists to stop: the row then reads `merged` beside an abort-time `head_sha` and
+`base_branch`, so the final report and the carryover projection name **the wrong commit and the wrong base
+branch** — and a user who retargeted the PR before merging it gets a history file asserting a merge into a
+branch the PR never touched. Refreshing the set together removes that whole class instead of qualifying
+each description of it.
 
 ### Review-pass artifacts — use `scripts/review-pass.py`
 

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -203,7 +203,7 @@ about and one whose partial rejection strands the rest.
    from one PR** takes **that PR's recorded base** (`effective_base` of its ledger row) as the proposed
    target; a **run-level** follow-up has **no implicit target**, so the **user chooses** it. The user may
    override the proposed target before the PR is opened. The resulting PR then enters through **normal
-   adoption**, which records its live `baseRefName` once as its immutable row base (`pr-adoption.md`).
+   adoption**, which records its live `baseRefName` once as its own recorded row base (`pr-adoption.md`).
    **Adoption admits PRs on DIFFERENT bases into one run** (`pr-adoption.md`, "PR adoption"), so the
    follow-up folds into THIS run (step 4) **regardless of whether its target matches the existing rows** —
    a different-base target is adopted here, never diverted for base disagreement. That PR is opened

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -132,7 +132,7 @@ For each `#PR` to adopt:
    field is added.
 
    **Re-adoption base gate — AFTER the terminal-row refusal and BEFORE any refresh write.** The recorded
-   row `base_branch` is immutable, and
+   row `base_branch` is never retargeted, and
    the campaign never migrates a row to a new base. On a re-adoption, `pr-adopt.py` first compares the PR's
    live `baseRefName` with the row's `effective_base`; **if they differ it PARKS the row** (machine-blocker,
    `status = awaiting-user`, `ci_reason` = `base changed from <recorded> to <live>; not supported mid-run`,
@@ -150,7 +150,7 @@ For each `#PR` to adopt:
      it reused a pre-existing local branch or checkout;
      `pr` = `<N>`; `head_sha` = `headRefOid`.
    - **On a NEW row only, initialize:** `base_branch` = the PR's live `baseRefName` (recorded ONCE through
-     `add-row --base-branch`, immutable after — this is the per-row base every later action resolves through
+     `add-row --base-branch`, never retargeted after — this is the per-row base every later action resolves through
      `effective_base`); `reviews_ok` = `0` (no verdicts yet); `ci` = `pending`;
      `tier` = bootstrap `STANDARD`; after step 5 follow `stage-2-review-gate.md`, "2a-triage", for the
      complete procedure;

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -19,7 +19,7 @@ Two entry paths feed it (see "Run identity and concurrency" for the full grammar
   reported blocker before adoption.
 
 Each adopted PR **records its own live `baseRefName`** on its ledger row — the row's `base_branch`, written
-**once at creation** by `pr-adopt.py` (`add-row --base-branch`) and **immutable** afterward (`files-and-ledger.md`,
+**once at creation** by `pr-adopt.py` (`add-row --base-branch`) and **never retargeted** afterward (`files-and-ledger.md`,
 the row `base_branch` field). Resolve a row's base through `ledger.py`'s `effective_base` (an explicit row
 value, else the legacy header fallback), never the raw header field. **Adopting several PRs at once does
 NOT require their bases to agree** — one run may hold PRs targeting different bases (some on `v3`, others on

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -6,7 +6,7 @@ view`), which may be a release or integration branch. A run is **not** confined 
 target `v3`, others `main`, in the same run, and PRs adopted together need **NOT** agree on `baseRefName`.
 
 The base is **per-row** state, recorded on each row **once** at adoption (`pr-adopt.py` → `add-row
---base-branch`) from its live `baseRefName`; that recorded value is **immutable** — the campaign never
+--base-branch`) from its live `baseRefName`; that recorded value is **never retargeted** — the campaign never
 migrates a row to a new base (a live retarget PARKS the row, see `pr-adoption.md`, `loop-control.md`). The
 ledger **header** `base_branch` is only the **legacy fallback** a row carrying none inherits. Every
 consumer resolves a row's base through `ledger.py`'s `effective_base(header, row)` (and

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -132,7 +132,11 @@ branch — the repo's "Automatically delete head branches" setting alone governs
 
 Each phase leaves a durable or safely repeatable checkpoint. Re-run the same command after any failure:
 GitHub `MERGED` skips the merge call; base updates are fast-forward-only; absent owned worktrees/branches
-count as completed cleanup; a terminal ledger row is a no-op.
+count as completed cleanup; a terminal ledger row is a no-op — except an `aborted` row whose live view
+reports MERGED, which is the user merging the PR this run gave up on. That is RECORDED: one terminal write
+flips `status` to `merged` and refreshes the GitHub-owned fields from the same view, and nothing else runs —
+no merge, no base-sync, and no cleanup of the worktree and branch the abort handed back. `files-and-ledger.md`,
+"GitHub-owned vs campaign-owned row fields", owns which fields move and which deliberately do not.
 
 When the checked-out local base is what git fast-forwards and an unrelated actor's **uncommitted** edits in
 that checkout block it, the command **refuses and lists the blocking paths it detected** (each staged, unstaged,

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -17,9 +17,9 @@ the counters would merge a PR whose disputed finding or API change the user has 
 whose diff the reassessment pass is in the middle of rescoping. For a park, only the user's answer unparks
 it, and **to the `status` that
 answer dictates** — `in_review` for a **resume** answer; terminal `aborted` for a **terminal** one (a
-`declined` API change, a `blocker_ruling` of `abort`), which never returns to `in_review` and is never
-merged (`loop-control.md` step 3, "Only the user's answer unparks a PR", owns the mapping). Until the
-answer lands the PR is skipped, never merged.
+`declined` API change, a `blocker_ruling` of `abort`), which never returns to `in_review` and which
+the campaign never merges (`loop-control.md` step 3, "Only the user's answer unparks a PR", owns the
+mapping). Until the answer lands the PR is skipped, never merged.
 
 ### The merge precondition — TWO enums, and NEITHER of them is a CI signal
 

--- a/plugins/gauntlet/skills/campaign/scripts/carryover.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover.py
@@ -92,8 +92,10 @@ def _ledger():
 
 def sections(rows: list[dict]) -> "list[tuple[str, tuple[str, ...], list[dict]]]":
     """The three terminal-class projections, in a FIXED order. Row order is the ledger's, so the output is
-    deterministic. A declined-API PR is terminal-`aborted`, so it appears in BOTH `aborted` and
-    `api-declined`; that overlap is documented in the file's header and is not double-counting.
+    deterministic. A declined-API PR appears in BOTH `api-declined` and its terminal section — `aborted`,
+    or `merged` when the user merged it after the campaign gave up (`files-and-ledger.md`, "GitHub-owned vs
+    campaign-owned row fields": `api_approval` records the decision, `status` the live position). That
+    overlap is documented in the file's header and is not double-counting.
     """
     merged = [r for r in rows if r["status"] == "merged"]
     aborted = [r for r in rows if r["status"] == "aborted"]
@@ -124,8 +126,9 @@ def render(run_id: str, base_branches: "list[str]", now: str,
     out.append("Each `## <section>` heading is followed by zero or more rows, one JSON object per PR:")
     out.append("  merged        pr, slug, head_sha (at merge), tier, review_rounds, base_branch")
     out.append("  aborted       pr, slug, ci_reason, blocker_ruling, base_branch  (the durable why it stopped)")
-    out.append("  api-declined  pr, slug, api_approval, base_branch. A declined PR is ALSO aborted, so it")
-    out.append("                appears in BOTH sections — this is a reminder projection, not double-counting.")
+    out.append("  api-declined  pr, slug, api_approval, base_branch. A declined PR is ALSO in its terminal")
+    out.append("                section (aborted, or merged if the user merged it after the campaign gave")
+    out.append("                up), so it appears in BOTH — a reminder projection, not double-counting.")
     out.append("Each object's `base_branch` is the row's EFFECTIVE base at distillation (its own recorded")
     out.append("base, else the run's legacy header base). `base_branches` below is the sorted, deduplicated")
     out.append("set of those bases; prune each entry against ITS OWN base, never the run's (carryover.md).")

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -246,10 +246,11 @@ ROW_FIELDS = (
     # a LEGACY FALLBACK for a row that carries none. `effective_base(header, row)` is the schema-owned
     # resolver — an explicit row value, else the header. files-and-ledger.md, "Base branch", owns the field.
     #
-    # It is TOOL-OWNED and CREATION-ONLY (`CREATE_ONLY`): `add-row` writes it when the row appears and
-    # NOTHING changes it after — there is no `--base-branch` flag at `set`. The campaign never migrates a row
-    # to a new base; a live base that no longer matches the recorded one is an unsupported change a consumer
-    # parks for the user, never a value `set` rewrites.
+    # It is TOOL-OWNED and CREATION-ONLY (`CREATE_ONLY`): `add-row` writes it when the row appears and no
+    # driver door changes it after — there is no `--base-branch` flag at `set`. The campaign never migrates
+    # a row to a new base; a live base that no longer matches the recorded one is an unsupported change a
+    # consumer parks for the user, never a value `set` rewrites. (`CREATE_ONLY` below names the one write
+    # outside those doors — the terminal GitHub-owned refresh, which is not a retarget.)
     #
     # The default is `-`, the schema's own "not set" spelling AND its "inherit the legacy header" signal:
     # an old ledger's rows read back `-` and resolve through the header, exactly as they always did. A `-`
@@ -389,12 +390,19 @@ PREFLIGHT_OWNED = ("base_ok_sha",)
 
 # The row fields that `add-row` may write ONCE, at row creation, and that `set` may NEVER change afterward.
 # `base_branch` is the target `baseRefName` recorded from live GitHub at adoption; the campaign never
-# migrates a row to a new base, so the field is TOOL-OWNED and IMMUTABLE after creation. The mechanism is
-# the same absent-door one `PREFLIGHT_OWNED` uses, but ASYMMETRIC across the two write doors: the flag is
-# present at `add-row` (creation must be able to record the base) and ABSENT at `set` (argparse then refuses
-# `set --base-branch`, so nothing can rewrite it). A field here is still `settable()`; CREATE_ONLY narrows
-# only WHICH door may write it. (`required_set` is NOT here — the grouped required-set refresh
-# rewrites it through `set`, so that door stays open; only the base itself is fixed for a row's life.)
+# migrates a LIVE row to a new base, so the field is TOOL-OWNED and fixed for the row's working life. The
+# mechanism is the same absent-door one `PREFLIGHT_OWNED` uses, but ASYMMETRIC across the two write doors:
+# the flag is present at `add-row` (creation must be able to record the base) and ABSENT at `set` (argparse
+# then refuses `set --base-branch`, so no driver can retarget a row it is still driving). A field here is
+# still `settable()`; CREATE_ONLY narrows only WHICH door may write it. (`required_set` is NOT here — the
+# grouped required-set refresh rewrites it through `set`, so that door stays open.)
+#
+# ONE writer sits outside those doors, and it is not a retarget: `merge.py`'s TERMINAL write refreshes the
+# GitHub-owned fields — `base_branch` among them — when it records a merge the campaign did not perform
+# (`references/files-and-ledger.md`, "GitHub-owned vs campaign-owned row fields"). It fires only on a row
+# that is already terminal, so no rebase, review, or merge can ever read the refreshed value; what reads it
+# is the final report and the carryover projection, which are exactly what must name the base the PR
+# actually merged into. CREATE_ONLY still binds every door a LIVE row is written through.
 CREATE_ONLY = ("base_branch",)
 
 # The park/unpark TRANSITIONS `park`/`unpark` own — the same mechanism as VERDICT_OWNED, one level up at the

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -83,7 +83,7 @@ HEADER_DEFAULTS = {
     # inherits, through `effective_base` — the schema-owned resolver, the sanctioned door for base
     # consumers. Per-row base resolution is LIVE: adoption records each row's base and every consumer
     # resolves through the accessor, never this header directly. Mixed-base ADMISSION is ENABLED: adoption
-    # admits PRs on DIFFERENT bases into one run and each admitted row owns its immutable base. A new run
+    # admits PRs on DIFFERENT bases into one run and each admitted row owns its own recorded base. A new run
     # leaves this header at `-`; an old single-base ledger keeps its header value and every one of its rows reads it.
     # files-and-ledger.md, "Base branch", owns the field.
     "base_branch": "-",
@@ -270,7 +270,7 @@ ROW_FIELDS = (
     # and do not go green" (stage-2-ci.md). An old single-base row reads back `-` and inherits (its base IS the
     # header base); a new run writes `unknown` on each row until a grouped read succeeds.
     # An ordinary settable field: the grouped required-set refresh writes the
-    # canonical value through `set` (unlike `base_branch`, which is immutable after creation).
+    # canonical value through `set` — a door `base_branch` has no flag at (`CREATE_ONLY`, which owns why).
     "required_set",
     # WHERE THIS PR'S INTENT CAME FROM — the PROVENANCE of `<rundir>/intent-<pr>.md`:
     #   `-`                not adopted yet
@@ -826,7 +826,7 @@ def find_row(rows: list[dict], pr: str) -> "dict | None":
 # header value. They are the sanctioned door every base/required-set consumer resolves through, and that
 # resolution is LIVE: adoption records each row's base, and every consumer routes through these accessors
 # rather than reading the header field directly. Mixed-base ADMISSION is ENABLED: adoption admits PRs on
-# DIFFERENT bases into one run and each admitted row owns its immutable base.
+# DIFFERENT bases into one run and each admitted row owns its own recorded base.
 # `-` is the row default and means exactly "inherit the header": an old
 # ledger's rows carry `-` and resolve to the header value they always used, while a row with an explicit
 # base (or an explicit required set) has that value returned unchanged. This is what lets legacy inheriting

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -757,18 +757,103 @@ def t_repeat_after_closed_terminal_is_noop():
         finally:
             finish(td, real)
 
-    # Guardrail: an `aborted` row whose live PR is OPEN or MERGED is a CONTRADICTION, not a no-op — the PR is
-    # no longer closed-without-merge. It must REFUSE naming the mismatch (not the generic "not in_review"),
-    # mirroring the merged+non-MERGED guard.
-    for live_state in ("OPEN", "MERGED"):
-        td, root, f, led, real = scenario(state=live_state, status="aborted")
-        try:
-            code, _result, err = invoke(f, led, root)
-            check(code != 0 and "aborted but GitHub state is" in err,
-                  f"aborted+{live_state} must refuse as a contradiction, got code={code} err={err!r}")
-            check(f.merged_calls == 0, f"aborted+{live_state} contradiction must not merge")
-        finally:
-            finish(td, real)
+    # Guardrail: an `aborted` row whose live PR is OPEN is a CONTRADICTION, not a no-op — the PR is neither
+    # closed-without-merge nor merged. It must REFUSE naming the mismatch (not the generic "not in_review"),
+    # mirroring the merged+non-MERGED guard. (aborted+MERGED is NOT a contradiction — it is the user merging
+    # the PR this run gave up on, recorded by t_aborted_row_records_external_merge_whole.)
+    td, root, f, led, real = scenario(state="OPEN", status="aborted")
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "aborted but GitHub state is" in err,
+              f"aborted+OPEN must refuse as a contradiction, got code={code} err={err!r}")
+        check(f.merged_calls == 0, "aborted+OPEN contradiction must not merge")
+    finally:
+        finish(td, real)
+
+
+def t_aborted_row_records_external_merge_whole():
+    """An `aborted` row GitHub reports MERGED records `merged` AND the whole GitHub-owned set, together.
+
+    THIS IS THE MUTATION PIN for the two-kinds-of-field rule (`files-and-ledger.md`, "GitHub-owned vs
+    campaign-owned row fields"). Drop `github_owned=` from the terminal write in `merge.py` and the row
+    still reaches `merged` — every "did it record the merge?" check keeps passing — while `head_sha` and
+    `base_branch` stay at their ABORT-time values, so the row claims a merge of the wrong commit into the
+    wrong branch. The three field checks below are what go red.
+
+    The drift knobs are the ORDINARY post-abort situation, not a corner case: bailout leaves the PR OPEN and
+    strips this run's labels (`bailout-and-final-report.md`), so by the time the user merges it themselves
+    the head may have moved and the base may have been retargeted. That is precisely why this path relaxes
+    the live-ref pins — and precisely why it must refresh what those pins used to guarantee.
+    """
+    live_head = "b" * 40
+    td, root, f, led, real = scenario(state="MERGED", status="aborted", labels=[],
+                                      view_head=live_head, view_base="release", view_branch="renamed")
+    try:
+        # Seed the campaign-owned fields AWAY from their defaults, so "frozen" and "reset at the accessor
+        # door" are both discriminating checks rather than assertions about untouched defaults.
+        seed_header, seed_rows = L.load(led)
+        seed_rows[0].update(ci_reason="required check absent: integration-tests",
+                            blocker_ruling="abort@2026-07-04T17:00:00Z", review_rounds="4",
+                            base_ok_sha=SHA, settled_strikes="3", unusable_refetches="1",
+                            ci_stalled_since="2026-07-04T10:00:00Z", ci_fingerprint="sha256:seed")
+        L.dump(led, seed_header, seed_rows)
+
+        code, result, err = invoke(f, led, root)
+        check(code == 0 and result is not None and result["status"] == "merged",
+              f"a verified external merge of an aborted row was not recorded: code={code} err={err!r}")
+        check(result is not None and result["cleanup"] == {},
+              f"the record is ledger-only, so it owns no cleanup result: {result}")
+
+        row = L.find_row(L.load(led)[1], "9")
+        check(row is not None, "fixture ledger lost PR 9")
+        assert row is not None
+        # GITHUB-OWNED: all three move, from the one view, in the one write.
+        check(row["status"] == "merged", f"status was not recorded: {row['status']!r}")
+        check(row["head_sha"] == live_head,
+              f"head_sha kept its abort-time value {row['head_sha']!r}, not the merged head {live_head!r}")
+        check(row["base_branch"] == "release",
+              f"base_branch kept its abort-time value {row['base_branch']!r}, not the live base 'release'")
+        # CAMPAIGN-OWNED: this run's own account of its work is not revised by a later external event.
+        check(row["reviews_ok"] == "2" and row["tier"] == "HIGH" and row["review_rounds"] == "4"
+              and row["ci_reason"] == "required check absent: integration-tests"
+              and row["blocker_ruling"] == "abort@2026-07-04T17:00:00Z",
+              f"a campaign-owned field was rewritten by the external merge: {row}")
+        # The head moved, so the head-move reset fired AT THE DOOR (`ledger.py`'s `apply_head_sha`) — this
+        # site hand-resets nothing, and `stage-2-ci.md`'s "any head write through the accessor" rule holds.
+        check(all(row[field] == L.ROW_DEFAULTS[field] for field in L.LIVENESS_COUNTERS)
+              and row["base_ok_sha"] == L.ROW_DEFAULTS["base_ok_sha"],
+              f"the head-move reset did not fire at the accessor door: {row}")
+        # Nothing but the ledger write ran: no second merge, no cleanup, no base fast-forward.
+        argvs = [argv for argv, _ in f.calls]
+        check(f.merged_calls == 0 and not any(a[:3] == ["gh", "pr", "merge"] for a in argvs),
+              "recording the disposition issued a merge")
+        check(not any("worktree" in a and "remove" in a for a in argvs), "the record ran owned cleanup")
+        check(not any(a[3:5] == ["merge", "--ff-only"] for a in argvs),
+              "the record fast-forwarded a base this run never merged into")
+        check(f.worktree_present and f.branch_present,
+              "the record destroyed resources the abort returned to the user")
+
+        # Idempotent: a re-run over the now-`merged` row is the ordinary merged-repeat no-op — and it is
+        # reached BECAUSE the refresh landed, since that path pins the live head and base against the row
+        # (unchanged main behavior) and an unrefreshed row would refuse there. The row's `branch` is
+        # campaign-owned (it names the LOCAL branch, which a GitHub-side rename does not touch), so the
+        # merged-repeat's headRefName pin still sees the rename; drop that one knob for the re-run.
+        f.view_branch = f.branch
+        code, result, err = invoke(f, led, root)
+        check(code == 0 and result is not None and result["status"] == "already-complete",
+              f"re-running over the recorded disposition was not a no-op: code={code} err={err!r}")
+    finally:
+        finish(td, real)
+
+    # FAIL CLOSED on a live value that cannot be what it claims to be: a headRefOid that is not a full
+    # 40-char object id is refused BEFORE any mutation, so the store never caches an unusable copy.
+    td, root, f, led, real = scenario(state="MERGED", status="aborted", labels=[], view_head="b" * 7)
+    try:
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "headRefOid" in err, f"a malformed live head was not refused: {err!r}")
+        check(status(led) == "aborted", "a refused refresh still mutated the ledger")
+    finally:
+        finish(td, real)
 
 
 def t_head_race_between_view_and_merge_refuses_before_landing():
@@ -1668,7 +1753,9 @@ CASES = [
     ("merge-accepted", "MERGED confirmation outranks a lost merge response", t_merge_transport_failure_after_acceptance_continues),
     ("terminal-write-resume", "a failed terminal write resumes after already-completed cleanup", t_terminal_write_failure_resumes_after_cleanup),
     ("terminal-repeat", "repeated invocation after terminal state is a no-op", t_repeat_after_terminal_is_noop),
-    ("aborted-terminal-repeat", "repeating after a CLOSED close-out is an already-complete no-op (moved refs tolerated); aborted+OPEN/MERGED refuses as a contradiction", t_repeat_after_closed_terminal_is_noop),
+    ("aborted-terminal-repeat", "repeating after a CLOSED close-out is an already-complete no-op (moved refs tolerated); aborted+OPEN refuses as a contradiction", t_repeat_after_closed_terminal_is_noop),
+    ("aborted-external-merge", "an aborted row GitHub reports MERGED records `merged` AND refreshes every GitHub-owned field from that view, freezes the campaign-owned ones, merges/cleans nothing, and fails closed on a malformed live head",
+     t_aborted_row_records_external_merge_whole),
     ("head-race", "--match-head-commit refuses a tip that advanced before the merge landed", t_head_race_between_view_and_merge_refuses_before_landing),
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),
     ("absent-resume", "an absent-but-unfinalized MERGED row resumes its remaining phases through run", t_absent_snapshot_merged_row_resumes_via_run),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -855,6 +855,31 @@ def t_aborted_row_records_external_merge_whole():
     finally:
         finish(td, real)
 
+    # …and FAIL CLOSED the other way: a live base the ROW CANNOT REPRESENT. `-` is the `base_branch`
+    # schema's own "not set / inherit the header" spelling, so caching it would make a PR that HAS a base
+    # read as carrying none. The DIAGNOSTIC is the thing pinned here, not merely the refusal: GitHub
+    # resolved this base and reported it, so "unresolved" — which is what `_validate_ref` correctly means
+    # about the LEDGER-side `-` — would be a false report about a live value. The check is a substring the
+    # generic wording cannot satisfy.
+    #
+    # HARNESS LIMIT this fixture is scoped to, deliberately: the Fake stubs `check-ref-format` to succeed
+    # unconditionally, so only the pure-Python guard is exercisable here; a fixture asserting on a name
+    # GIT rejects would pass for the wrong reason. `-` is that pure-Python case.
+    td, root, f, led, real = scenario(state="MERGED", status="aborted", labels=[],
+                                      view_head="b" * 40, view_base=L.ROW_DEFAULTS["base_branch"])
+    try:
+        before = led.read_bytes()
+        code, _result, err = invoke(f, led, root)
+        check(code != 0 and "cannot represent" in err,
+              f"an unrepresentable live base was not refused for the right reason: {err!r}")
+        check("unresolved" not in err,
+              f"the refusal claims GitHub failed to resolve a base it did resolve: {err!r}")
+        # Byte-identical, not merely `aborted`: a partial write of `head_sha` alone must not pass either.
+        check(led.read_bytes() == before, "a refused refresh still wrote the ledger")
+        check(status(led) == "aborted", "a refused refresh moved the row off its recorded abort")
+        check(f.merged_calls == 0, "a refused refresh issued a merge")
+    finally:
+        finish(td, real)
 
 def t_head_race_between_view_and_merge_refuses_before_landing():
     # A push advances the live tip to a DIFFERENT SHA in the window between the pre-merge view (which
@@ -1754,7 +1779,7 @@ CASES = [
     ("terminal-write-resume", "a failed terminal write resumes after already-completed cleanup", t_terminal_write_failure_resumes_after_cleanup),
     ("terminal-repeat", "repeated invocation after terminal state is a no-op", t_repeat_after_terminal_is_noop),
     ("aborted-terminal-repeat", "repeating after a CLOSED close-out is an already-complete no-op (moved refs tolerated); aborted+OPEN refuses as a contradiction", t_repeat_after_closed_terminal_is_noop),
-    ("aborted-external-merge", "an aborted row GitHub reports MERGED records `merged` AND refreshes every GitHub-owned field from that view, freezes the campaign-owned ones, merges/cleans nothing, and fails closed on a malformed live head",
+    ("aborted-external-merge", "an aborted row GitHub reports MERGED records `merged` AND refreshes every GitHub-owned field from that view, freezes the campaign-owned ones, merges/cleans nothing, and fails closed on a malformed live head or an unrepresentable live base",
      t_aborted_row_records_external_merge_whole),
     ("head-race", "--match-head-commit refuses a tip that advanced before the merge landed", t_head_race_between_view_and_merge_refuses_before_landing),
     ("merge-method", "merge method is a validated input; squash-disabled repo has a prevailing-method recourse", t_merge_method_input_validated_and_applied),

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -589,6 +589,14 @@ def _github_owned(root: Path, view: dict) -> dict:
     full 40-char lowercase object id, and `base_branch` is a name `git check-ref-format` accepts. A view
     that cannot satisfy both is refused here, before any mutation — the store never caches an unusable copy
     of a GitHub-owned field.
+
+    THE BOUNDARY, recorded rather than engineered around: a branch named exactly `-` is a name GitHub
+    accepts and the ROW CANNOT REPRESENT, because that one character is already the `base_branch` schema's
+    own "not set / inherit the legacy header" spelling (`ledger.py`, `ROW_DEFAULTS`). Caching it would make
+    a row that HAS a base read as carrying none. So this refuses instead, saying the value arrived and is
+    unrepresentable — NOT that it is unresolved, which is what `_validate_ref` means for the LEDGER-side
+    `-` and would be a false report about a base GitHub did resolve. Only that exact one-character name is
+    affected: hyphenated, dash-LEADING and dash-TRAILING names all record verbatim.
     """
     values: dict = {}
     for field, live in GITHUB_OWNED_FIELDS:
@@ -596,6 +604,12 @@ def _github_owned(root: Path, view: dict) -> dict:
     if not SHA_RE.match(values["head_sha"]):
         raise Refusal(
             f"live headRefOid {values['head_sha']!r} is not a full lowercase 40-character object id")
+    if values["base_branch"] == L.ROW_DEFAULTS["base_branch"]:
+        raise Refusal(
+            f"live baseRefName is {values['base_branch']!r}, which the ledger row cannot represent: that "
+            f"exact name is the `base_branch` schema's own \"not set / inherit the legacy header\" spelling "
+            f"(`ledger.py`). GitHub reported this base, so recording it as the row's would make a PR that "
+            f"HAS a base read as carrying none")
     _validate_ref(root, values["base_branch"], "live baseRefName")
     return values
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -12,6 +12,12 @@ that landed but never finished: the single live view distinguishes MERGED (resum
 cleanup / terminal-write phases) from CLOSED-without-merge (the terminal close-out — record `aborted`, no
 merge, no cleanup, because unmerged branch content must never be destroyed).
 
+An already-`aborted` row whose live view reports MERGED is the third outcome: the user merged the PR this
+run gave up on. That is RECORDED, never resumed — the terminal write flips `status` to `merged` and
+refreshes the whole GITHUB-OWNED field set from that same view in one atomic write, and nothing else runs
+(no merge, no base-sync, no cleanup of the resources the abort handed back). `references/files-and-ledger.md`,
+"GitHub-owned vs campaign-owned row fields", owns which fields those are and why the rest stay frozen.
+
     merge.py run --ledger <state.jsonl> --pr <N> --project-root <dir> --repo <owner/name> \
         [--merge-method squash|merge|rebase]
     merge.py self-test
@@ -54,6 +60,12 @@ VIEW_FIELDS = (
     "state,headRefOid,headRefName,baseRefName,labels,"
     "mergeable,mergeStateStatus,isDraft"
 )
+# The GITHUB-OWNED ledger row fields, each paired with the live `gh pr view` field it CACHES. GitHub is the
+# authority for every pair and the row only holds a copy, so a terminal write that records a merge this
+# campaign did not perform refreshes all of them from the ONE view it decided on — never `status` alone.
+# `references/files-and-ledger.md`, "GitHub-owned vs campaign-owned row fields", is the owner of that rule,
+# of this set's membership, and of why every other row field stays frozen. Never retype either list.
+GITHUB_OWNED_FIELDS = (("head_sha", "headRefOid"), ("base_branch", "baseRefName"))
 
 
 class Refusal(RuntimeError):
@@ -189,9 +201,12 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
     # between a bug and a destroyed worktree is never relaxed.
     #   * `check_live_refs=False` drops the live head/base/branch equality pins — the checks a MERGE needs to
     #     land on the exact reviewed tip, and the head pin a MERGED-resume keeps to confirm OUR reviewed head
-    #     is what landed. Only the CLOSED terminal paths drop it: a push or a base/branch rename before a
-    #     CLOSE is irrelevant to a row that only records terminal `aborted`, and a CLOSED PR never re-enters
-    #     the open snapshot to have its head_sha refreshed, so pinning it there would wedge the row forever.
+    #     is what landed. Only the LEDGER-ONLY paths drop it — the classification block in `execute` names
+    #     that set and owns why. A push or a base/branch rename before a CLOSE is irrelevant to a row that
+    #     only records terminal `aborted`, and neither a CLOSED nor an externally MERGED PR re-enters the
+    #     open snapshot to have its cache refreshed, so pinning it there would wedge the row forever. Where
+    #     the drift DOES matter — the externally merged `aborted` row, which records `merged` — the terminal
+    #     write refreshes the GitHub-owned fields from the same view instead of pinning them (`_mark_terminal`).
     #   * `require_resolved_ownership=False` drops the fail-closed that BOTH ownership fields are RESOLVED
     #     (∈{yes,no}). That fail-closed is a MERGE-INITIATING sanity gate: a HALF-ADOPTION (pr-adopt.py
     #     registers the ledger row BEFORE it resolves the worktree, so its documented git-failure path leaves
@@ -566,19 +581,56 @@ def _cleanup(root: Path, row: dict) -> dict:
     }
 
 
-def _mark_terminal(ledger: Path, pr: str, status: str) -> None:
+def _github_owned(root: Path, view: dict) -> dict:
+    """The GITHUB-OWNED row values read from ONE live view, VALIDATED before either can reach the store.
+
+    Both values are network-supplied, and both are pasted into commands and compared for equality by every
+    later reader, so each is checked against the same shape its own field already promises: `head_sha` is a
+    full 40-char lowercase object id, and `base_branch` is a name `git check-ref-format` accepts. A view
+    that cannot satisfy both is refused here, before any mutation — the store never caches an unusable copy
+    of a GitHub-owned field.
+    """
+    values: dict = {}
+    for field, live in GITHUB_OWNED_FIELDS:
+        values[field] = view[live]
+    if not SHA_RE.match(values["head_sha"]):
+        raise Refusal(
+            f"live headRefOid {values['head_sha']!r} is not a full lowercase 40-character object id")
+    _validate_ref(root, values["base_branch"], "live baseRefName")
+    return values
+
+
+def _mark_terminal(ledger: Path, pr: str, status: str, *,
+                   github_owned: "dict[str, str] | None" = None) -> None:
     """Write a TERMINAL ledger status (`merged` after a landed merge, `aborted` after a closed-without-merge
-    close-out) as the last, resumable phase. A same-value write is a no-op, so a re-run finalizes idempotently."""
+    close-out) as the last, resumable phase. A same-value write is a no-op, so a re-run finalizes idempotently.
+
+    `github_owned` (from `_github_owned`) refreshes the GitHub-owned cache in the SAME atomic write. It is
+    passed by the ONE path whose validation had to relax the live head/base pins — the already-`aborted` row
+    GitHub now reports MERGED — because that is exactly the path on which the cached copies may no longer
+    describe the PR. Writing `status = merged` there while `head_sha`/`base_branch` still held their
+    abort-time values would leave the row claiming a merge of the wrong commit into the wrong branch. Every
+    other terminal write pinned those fields to the live view already (`_validate_state`, `check_live_refs`),
+    so it has nothing to refresh and passes nothing.
+
+    `head_sha` is written through the schema owner's `apply_head_sha` accessor, so a genuine head move fires
+    the head-move reset AT THE DOOR exactly as every other head write does (`stage-2-ci.md`, "THE LIVENESS
+    COUNTERS", reset-site class 1). This site therefore hand-resets nothing.
+    """
     header, rows = L.load(ledger)
     row = L.find_row(rows, pr)
     if row is None:
         raise Refusal(f"ledger row for PR {pr} disappeared before terminal write")
-    if row["status"] != status:
-        row["status"] = status
-        try:
-            L.save(ledger, header, rows, activity=True)
-        except OSError as exc:
-            raise Refusal(f"terminal ledger write failed: {exc}") from exc
+    updates = {"status": status, **(github_owned or {})}
+    if all(row.get(field) == value for field, value in updates.items()):
+        return
+    if "head_sha" in updates:
+        L.apply_head_sha(row, updates.pop("head_sha"))
+    row.update(updates)
+    try:
+        L.save(ledger, header, rows, activity=True)
+    except OSError as exc:
+        raise Refusal(f"terminal ledger write failed: {exc}") from exc
 
 
 def execute(ledger: Path, pr: str, project_root: Path, repo: str,
@@ -619,12 +671,21 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
     #     merged PR reports MERGED, not CLOSED), left to the terminal status gate below.
     #   * aborted_repeat: an already-`aborted` row whose PR is still CLOSED — the terminal-repeat no-op,
     #     symmetric with the `merged`-repeat below.
-    #   Both are LEDGER-ONLY (record `aborted`/no-op, merge and clean nothing), so both drop the live
-    #   head/base/branch pins (`check_live_refs=False`): a push or base/branch rename before the CLOSE must
-    #   not wedge a settled row, and a CLOSED PR never re-enters the open snapshot to be re-gated.
+    #   * aborted_external_merge: an already-`aborted` row whose PR GitHub now reports MERGED — the user
+    #     merged the PR this run gave up on. RECORDING that disposition, never resuming a merge: the abort
+    #     already handed the owned worktree and branch back to the user, and whatever landed is the user's
+    #     own later work, not this run's reviewed tip. So no `_sync_base` and no `_cleanup` — only the
+    #     terminal write, which refreshes the GITHUB-OWNED fields from this same view.
+    #   All three are LEDGER-ONLY (record `aborted`/`merged`/no-op, merge and clean nothing), so all three
+    #   drop the live head/base/branch pins (`check_live_refs=False`): a push or base/branch rename before
+    #   the terminal outcome must not wedge a settled row, and no terminal row re-enters this run's gate.
+    #   Dropping the pins is what MAKES the GitHub-owned refresh necessary — the cached copies are exactly
+    #   what those pins used to guarantee — and it removes no protection from any resource: `_cleanup`'s own
+    #   identity guards are what refuse a foreign worktree or branch, and no ledger-only path calls it.
     close_out = view["state"] == "CLOSED" and row["status"] not in ("merged", "aborted")
     aborted_repeat = row["status"] == "aborted" and view["state"] == "CLOSED"
-    ledger_only = close_out or aborted_repeat
+    aborted_external_merge = row["status"] == "aborted" and view["state"] == "MERGED"
+    ledger_only = close_out or aborted_repeat or aborted_external_merge
     # merge_initiating is the ONE path that STARTS a merge — a live OPEN state on an in_review row. It is the
     # only path that requires the full merge-tip pins, RESOLVED ownership, and this run's OWN-label presence:
     # a half-adoption (unresolved ownership, no own label yet) must never be merged. Every other path only
@@ -640,13 +701,20 @@ def execute(ledger: Path, pr: str, project_root: Path, repo: str,
         return {"status": "closed-unmerged", "pr": pr, "cleanup": {}}
 
     if row["status"] == "aborted":
+        if view["state"] == "MERGED":
+            # The user merged the PR this campaign abandoned. Record the disposition, and record it WHOLE:
+            # `status` and every GitHub-owned field move together, from this one view, in one write. Nothing
+            # else runs — the `aborted_external_merge` classification above owns why.
+            _mark_terminal(ledger, pr, "merged", github_owned=_github_owned(root, view))
+            return {"status": "merged", "pr": pr, "cleanup": {}}
         # Terminal-repeat, symmetric with the `merged` no-op below (both terminal statuses are safe to
         # repeat). A CLOSED live state confirms the recorded abort still holds -> the same already-complete
-        # no-op, no ledger write. A live OPEN or MERGED state CONTRADICTS the terminal `aborted` row (the PR
-        # is no longer closed-without-merge); refuse naming the mismatch, never a silent no-op.
+        # no-op, no ledger write. A live OPEN state CONTRADICTS the terminal `aborted` row (the PR is
+        # neither closed-without-merge nor merged); refuse naming the mismatch, never a silent no-op.
         if view["state"] != "CLOSED":
             raise Refusal(
-                f"terminal ledger row says aborted but GitHub state is {view['state']!r}, not CLOSED")
+                f"terminal ledger row says aborted but GitHub state is {view['state']!r}, "
+                "not CLOSED or MERGED")
         return {"status": "already-complete", "pr": pr, "cleanup": {}}
 
     if row["status"] == "merged":


### PR DESCRIPTION
## Purpose

- `merge.py run` on an `aborted` row GitHub reports MERGED now records `merged` instead of refusing.
- That terminal write refreshes every GitHub-owned field (`head_sha`, `base_branch`) from the same view.
- `files-and-ledger.md` states the split once: GitHub-owned refreshed together, campaign-owned frozen.

## Non-goals

- No new discovery route — reconcile facts and Step 4 routing are untouched.
- No change to review acceptance, merge eligibility, or either plugin version.

## Threat model

- Live `headRefOid` / `baseRefName` are refused unless well-formed, before any mutation.
- `head_sha` goes through `apply_head_sha`, so the head-move reset fires at the door.
- The path merges nothing, syncs no base, and cleans no worktree or branch.
