### PR TITLE
require ledger row on triage derive

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -22,9 +22,12 @@ python3 <skill-dir>/scripts/triage.py derive \
 ```
 
 Here `<base>` is **this PR row's effective base** — its explicit `base_branch`, else the legacy header
-fallback (`ledger.py`'s `effective_base`), never the one header base. Passing `--file <state.jsonl> --pr
-<pr>` makes `--base` an **assertion**: `triage.py` refuses (exit 2, no JSON) if `origin/<base>` does not
-name that row's effective base, so the diff can never be measured against a branch the row does not track.
+fallback (`ledger.py`'s `effective_base`), never the one header base. `--file <state.jsonl> --pr <pr>` are
+**required**, which makes `--base` an **assertion**: `triage.py` refuses (exit 2, no JSON) if `origin/<base>`
+does not name that row's effective base, and refuses an invocation that omits either flag, so the diff can
+never be measured against a branch the row does not track. **NEVER hand-type this command without them** —
+without the ledger `--base` is an unchecked base *source*, and a wrong one drops the files the two branches
+share, so a code-touching PR reads as all-prose, the floor falls away, and `TRIVIAL` is admitted.
 
 The command resolves the merge-base, reads Git's NUL-delimited raw diff and modes at the expected
 40-character head, and re-reads `HEAD` after classification. A stale expected head, moving head, malformed

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -110,6 +110,20 @@ def _build_ledger(directory: Path, pr: str, base_branch: str) -> Path:
     return ledger
 
 
+@contextmanager
+def cli_base(repo: Path, base: str, pr: str = "31", branch: str = "triage-base"):
+    """Yield the `--base`/`--file`/`--pr` argv fragment a CLI `derive` needs to diff against `base`.
+
+    `derive` REQUIRES `--file`/`--pr`, and the diff is measured from the ROW's effective base — not the
+    `--base` spelling — so a fixture cannot just hand a bare commit SHA to `--base` any more. Point
+    `refs/remotes/origin/<branch>` at `base` and build a one-row ledger whose `base_branch` is `<branch>`,
+    so the assertion agrees and the operational ref resolves back to `base`."""
+    git(repo, "update-ref", f"refs/remotes/origin/{branch}", base)
+    with tempfile.TemporaryDirectory() as directory:
+        ledger = _build_ledger(Path(directory), pr, branch)
+        yield ["--base", f"origin/{branch}", "--file", str(ledger), "--pr", pr]
+
+
 def t_human_docs_have_no_floor() -> None:
     with repository() as (repo, base):
         write(repo, "docs/guide.md", "# Guide\n")
@@ -136,8 +150,9 @@ def t_benign_extensionless_docs_remain_human() -> None:
         write(repo, "LICENSE", "License terms\n")
         head = commit(repo, "benign extensionless docs")
         result = derive(repo, base)
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(result["floor"] is None, f"plain extensionless docs must keep the no-floor result: {result!r}")
     check({row["class"] for row in result["files"]} == {M.HUMAN_DOC},
           f"plain extensionless docs must remain HUMAN-DOC: {result!r}")
@@ -161,8 +176,9 @@ def t_prose_named_source_is_code() -> None:
               f"source suffixes on prose stems must floor STANDARD: {result!r}")
         check({row["class"] for row in result["files"]} == {M.CODE},
               f"CHANGELOG.py and license.go must classify CODE: {result!r}")
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(code == M.EXIT_REFUSED and out == "",
           f"--tier TRIVIAL must be refused for source named like prose: {code}/{out!r}")
     check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
@@ -243,8 +259,9 @@ def t_pulumi_manifests_are_sensitive() -> None:
             check(result["floor"] == M.HIGH and one_file(result)["class"] == M.SENSITIVE,
                   f"{path} must floor HIGH end to end: {result!r}")
             for below in (M.TRIVIAL, M.STANDARD):
-                code, out, err = capture_cli(M.main, [
-                    "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", below])
+                with cli_base(repo, base) as ledger_args:
+                    code, out, err = capture_cli(M.main, [
+                        "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", below])
                 check(code == M.EXIT_REFUSED and out == "",
                       f"--tier {below} must be vetoed for {path}: {code}/{out!r}")
                 check("below the mechanical floor" in err and "HIGH" in err,
@@ -335,8 +352,9 @@ def t_symlink_at_human_doc_path_is_code() -> None:
               f"the changed file must be the symlink: {row!r}")
         check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
               f"a symlink at a docs path must be CODE and floor STANDARD, not a prose no-floor: {result!r}")
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(code == M.EXIT_REFUSED and out == "",
           f"--tier TRIVIAL must be refused when a symlink clears the doc path: {code}/{out!r}")
     check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
@@ -407,8 +425,9 @@ def t_modification_classifies_base_and_head() -> None:
         check(row["status"] == "M", f"the change must be a modification: {row!r}")
         check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
               f"a modification that strips frontmatter must classify the base side CODE and floor STANDARD: {result!r}")
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(code == M.EXIT_REFUSED and out == "",
           f"--tier TRIVIAL must be refused for a frontmatter-strip modification: {code}/{out!r}")
     check("below the mechanical floor" in err, f"the refusal must name the floor, not a missing worktree: {err!r}")
@@ -459,8 +478,9 @@ def t_tier_below_floor_is_refused() -> None:
         write(repo, "scripts/tool.py", "print('x')\n")
         head = commit(repo, "sensitive")
         for below in (M.TRIVIAL, M.STANDARD):
-            code, out, err = capture_cli(M.main, [
-                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", below])
+            with cli_base(repo, base) as ledger_args:
+                code, out, err = capture_cli(M.main, [
+                    "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", below])
             check(code == M.EXIT_REFUSED and out == "",
                   f"--tier {below} below a HIGH floor must be refused with no JSON: {code}/{out!r}")
             check("below the mechanical floor" in err and "HIGH" in err,
@@ -491,9 +511,10 @@ def t_head_mismatch_is_refused_without_output() -> None:
         write(repo, "docs/guide.md", "# Guide\n")
         head = commit(repo, "docs")
         wrong = ("0" if head[0] != "0" else "1") + head[1:]
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", wrong,
-        ])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", wrong,
+            ])
     check(code == M.EXIT_REFUSED and out == "", f"stale expected head must emit no JSON, got {code}/{out!r}")
     check("HEAD mismatch" in err and wrong in err and head in err, f"mismatch refusal must name both SHAs: {err!r}")
 
@@ -562,17 +583,23 @@ def t_empty_diff_floors_standard() -> None:
 
 
 def t_bad_inputs_and_git_failures_emit_no_partial_json() -> None:
+    # The unresolvable-base case now comes from the ROW, not from `--base`: `--base` is only an assertion, so
+    # an unresolvable ref is one the row's effective base names and no remote-tracking ref backs.
     with repository() as (repo, base):
         head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
-        cases = (
-            ["derive", "--worktree", str(repo), "--base", base, "--head-sha", "short"],
-            ["derive", "--worktree", str(repo), "--base=--not-a-ref", "--head-sha", head],
-            ["derive", "--worktree", str(repo / "missing"), "--base", base, "--head-sha", head],
-        )
-        for argv in cases:
-            code, out, err = capture_cli(M.main, list(argv))
-            check(code == M.EXIT_REFUSED and out == "" and "REFUSED" in err,
-                  f"bad input must fail atomically with no JSON: {argv!r} -> {code}/{out!r}/{err!r}")
+        with tempfile.TemporaryDirectory() as directory:
+            unbacked = _build_ledger(Path(directory), "31", "no-such-branch")
+            with cli_base(repo, base) as ledger_args:
+                cases = (
+                    ["derive", "--worktree", str(repo), *ledger_args, "--head-sha", "short"],
+                    ["derive", "--worktree", str(repo), "--base", "origin/no-such-branch",
+                     "--file", str(unbacked), "--pr", "31", "--head-sha", head],
+                    ["derive", "--worktree", str(repo / "missing"), *ledger_args, "--head-sha", head],
+                )
+                for argv in cases:
+                    code, out, err = capture_cli(M.main, list(argv))
+                    check(code == M.EXIT_REFUSED and out == "" and "REFUSED" in err,
+                          f"bad input must fail atomically with no JSON: {argv!r} -> {code}/{out!r}/{err!r}")
 
 
 def t_raw_parser_refuses_partial_records() -> None:
@@ -658,8 +685,9 @@ def t_quoted_frontmatter_keys_are_code() -> None:
         row = one_file(result)
         check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
               f"quoted-key agent frontmatter must be CODE and floor STANDARD: {result!r}")
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(code == M.EXIT_REFUSED and out == "",
           f"--tier TRIVIAL must be refused for quoted-key agent frontmatter: {code}/{out!r}")
     check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
@@ -681,8 +709,9 @@ def t_escaped_double_quoted_frontmatter_fails_closed() -> None:
         write(repo, "docs/operator-guide.md", doc)
         head = commit(repo, "escaped frontmatter key")
         result = derive(repo, base)
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(result["floor"] == M.STANDARD and one_file(result)["class"] == M.CODE,
           f"escaped double-quoted frontmatter must floor STANDARD: {result!r}")
     check(code == M.EXIT_REFUSED and out == "",
@@ -706,8 +735,9 @@ def t_flow_style_frontmatter_is_code() -> None:
             row = one_file(result)
             check(row["class"] == M.CODE and result["floor"] == M.STANDARD,
                   f"flow-style agent frontmatter must be CODE and floor STANDARD: {result!r}")
-            code, out, err = capture_cli(M.main, [
-                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+            with cli_base(repo, base) as ledger_args:
+                code, out, err = capture_cli(M.main, [
+                    "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
         check(code == M.EXIT_REFUSED and out == "",
               f"--tier TRIVIAL must be refused for flow-style frontmatter: {code}/{out!r}")
         check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
@@ -729,8 +759,9 @@ def t_unparseable_frontmatter_fails_closed_to_code() -> None:
         result = derive(repo, base)
         check(result["floor"] == M.STANDARD and one_file(result)["class"] == M.CODE,
               f"unparseable frontmatter must floor STANDARD: {result!r}")
-        code, out, err = capture_cli(M.main, [
-            "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+        with cli_base(repo, base) as ledger_args:
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
     check(code == M.EXIT_REFUSED and out == "",
           f"--tier TRIVIAL must be refused for unparseable frontmatter: {code}/{out!r}")
     check("below the mechanical floor" in err, f"the refusal must name the floor: {err!r}")
@@ -762,8 +793,9 @@ def t_frontmatter_runs_for_extensionless_prose() -> None:
             write(repo, name, agent_doc)
             head = commit(repo, "extensionless agent frontmatter")
             result = derive(repo, base)
-            code, out, err = capture_cli(M.main, [
-                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", M.TRIVIAL])
+            with cli_base(repo, base) as ledger_args:
+                code, out, err = capture_cli(M.main, [
+                    "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", M.TRIVIAL])
         check(result["floor"] == M.STANDARD and one_file(result)["class"] == M.CODE,
               f"{name} carrying agent frontmatter must floor STANDARD: {result!r}")
         check(code == M.EXIT_REFUSED and out == "",
@@ -810,8 +842,9 @@ def t_pip_source_and_conda_manifests_are_sensitive() -> None:
         check(result["floor"] == M.HIGH and one_file(result)["class"] == M.SENSITIVE,
               f"requirements.in is a dependency manifest and must floor HIGH: {result!r}")
         for below in (M.TRIVIAL, M.STANDARD):
-            code, out, err = capture_cli(M.main, [
-                "derive", "--worktree", str(repo), "--base", base, "--head-sha", head, "--tier", below])
+            with cli_base(repo, base) as ledger_args:
+                code, out, err = capture_cli(M.main, [
+                    "derive", "--worktree", str(repo), *ledger_args, "--head-sha", head, "--tier", below])
             check(code == M.EXIT_REFUSED and out == "",
                   f"--tier {below} below requirements.in's HIGH floor must be refused: {code}/{out!r}")
             check("below the mechanical floor" in err and "HIGH" in err,
@@ -917,6 +950,8 @@ def t_ledger_variant_spelling_floors_canonically() -> None:
 
 def t_ledger_file_without_pr_refuses() -> None:
     # `--file` needs `--pr` to select the row; without it, refuse rather than silently skip the assertion.
+    # `--pr` is argparse-required now, so the refusal comes from the parser — the guarantee is unchanged and
+    # this pins that the missing row key is still named, never defaulted.
     with repository() as (repo, _base):
         head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
         with tempfile.TemporaryDirectory() as d:
@@ -938,6 +973,62 @@ def t_ledger_missing_row_refuses() -> None:
                 "--file", str(ledger), "--pr", "99"])
         check(code == M.EXIT_REFUSED and out == "", f"an unknown row must refuse (code={code}, out={out!r})")
         check("no ledger row for pr 99" in err, f"the refusal must name the missing row: {err!r}")
+
+
+def t_derive_without_ledger_is_refused() -> None:
+    """`--file`/`--pr` are REQUIRED, so the base assertion can never be SKIPPED.
+
+    While they were optional a wrong `--base` was an unchecked base SOURCE, and that silently LOWERED the
+    floor: this repository (`main` -> `feat` adding a CODE file -> head adding only prose) diffs from `main`
+    as CODE + prose -> floor STANDARD, but from the intermediate `feat` as prose only -> NO floor, so a
+    `--tier TRIVIAL` the true base vetoes was accepted with exit 0 and well-formed JSON. That halves
+    `required(tier)` (1 verdict for TRIVIAL, else 2) with no signal.
+
+    The three checks below pin the whole chain, and the FIRST discriminates: revert `required=True` on
+    `--file`/`--pr` and it fails, because the omitted-ledger invocation exits 0 instead of refusing."""
+    with tempfile.TemporaryDirectory() as directory:
+        repo = Path(directory)
+        git(repo, "init", "-q", "-b", "main")
+        git(repo, "config", "user.name", "Gauntlet Test")
+        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        write(repo, "seed.txt", "seed\n")
+        main_tip = commit(repo, "main: seed")
+        git(repo, "checkout", "-q", "-b", "feat", main_tip)
+        write(repo, "src/mod.py", "value = 1\n")
+        feat_tip = commit(repo, "feat: add code")
+        git(repo, "checkout", "-q", "-b", "pr-head", feat_tip)
+        write(repo, "docs/note.md", "# Note\n\nprose only\n")
+        head = commit(repo, "pr: add prose")
+        git(repo, "update-ref", "refs/remotes/origin/main", main_tip)
+        git(repo, "update-ref", "refs/remotes/origin/feat", feat_tip)
+
+        with tempfile.TemporaryDirectory() as d:
+            ledger = _build_ledger(Path(d), "31", "main")
+            # 1. No ledger at all: refused before any diff, naming both missing flags.
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/feat", "--head-sha", head,
+                "--tier", M.TRIVIAL])
+            check(code == M.EXIT_REFUSED and out == "",
+                  f"derive without --file/--pr must refuse with no JSON (code={code}, out={out!r})")
+            check("--file" in err and "--pr" in err,
+                  f"the refusal must name the required ledger flags: {err!r}")
+            # 2. The ledger present: the same wrong base is caught as a disagreeing assertion.
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/feat", "--head-sha", head,
+                "--tier", M.TRIVIAL, "--file", str(ledger), "--pr", "31"])
+            check(code == M.EXIT_REFUSED and out == "" and "disagrees" in err,
+                  f"a --base disagreeing with the row must refuse: {code}/{out!r}/{err!r}")
+            # 3. The row's true base is what the diff is measured from, and it vetoes TRIVIAL.
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/main", "--head-sha", head,
+                "--file", str(ledger), "--pr", "31"])
+            check(code == M.EXIT_OK and json.loads(out)["floor"] == M.STANDARD,
+                  f"the row's base must floor STANDARD — the CODE file is in the diff: {code}/{out!r}/{err!r}")
+            code, out, err = capture_cli(M.main, [
+                "derive", "--worktree", str(repo), "--base", "origin/main", "--head-sha", head,
+                "--tier", M.TRIVIAL, "--file", str(ledger), "--pr", "31"])
+            check(code == M.EXIT_REFUSED and out == "" and "below the mechanical floor" in err,
+                  f"TRIVIAL must be vetoed from the row's true base: {code}/{out!r}/{err!r}")
 
 
 CASES = [
@@ -993,6 +1084,8 @@ CASES = [
      t_ledger_variant_spelling_floors_canonically),
     ("ledger-file-needs-pr", "--file without --pr is refused", t_ledger_file_without_pr_refuses),
     ("ledger-missing-row", "--file --pr naming an unknown row is refused", t_ledger_missing_row_refuses),
+    ("ledger-required", "derive without --file/--pr is refused — a wrong --base cannot lower the floor",
+     t_derive_without_ledger_is_refused),
 ]
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -17,13 +17,18 @@ semantic "is this all human prose?" call.  The optional ``--tier`` lets a caller
 DECIDED; the command then acts as a LOWER-BOUND check and REFUSES a tier below the floor (veto-downward).
 It never grants a tier and never lowers one.
 
-    triage.py derive --worktree <path> --base <ref> --head-sha <40-hex> [--tier TRIVIAL|STANDARD|HIGH]
-        [--file <ledger> --pr <N>]
+    triage.py derive --worktree <path> --base <ref> --head-sha <40-hex> --file <ledger> --pr <N>
+        [--tier TRIVIAL|STANDARD|HIGH]
     triage.py self-test
 
-When ``--file <ledger> --pr <N>`` is given, ``--base`` is an ASSERTION checked against the selected row's
+``--file <ledger> --pr <N>`` are REQUIRED.  ``--base`` is an ASSERTION checked against the selected row's
 effective base (its explicit ``base_branch``, else the legacy header fallback), never an independent base
-source; a disagreement refuses.  Omit them and ``--base`` is used exactly as before.
+source; a disagreement refuses, and the diff is measured from the ROW's base, not the ``--base`` spelling.
+They are required because without them ``--base`` silently becomes an unchecked base SOURCE: a diff taken
+from the wrong branch drops every file the two branches share, so a code-touching PR can read as all-prose,
+LOWER the floor, and admit a ``TRIVIAL`` the true base vetoes — halving ``required(tier)`` with no signal.
+This command cannot locate the ledger on its own, so refusing is the only mechanical option; it is the same
+answer the ledger assertion already gives one branch later.
 
 Success prints one deterministic JSON object and exits 0.  Any Git failure, malformed evidence, stale
 expected head, moving head, or a ``--tier`` below the floor prints no JSON, explains the refusal on
@@ -595,8 +600,8 @@ def derive(*, worktree: str, base: str, head_sha: str, tier: str | None = None,
 
 
 def _assert_ledger_base(file: str, pr: str, base: str) -> "tuple[str | None, str | None]":
-    """When a ledger is supplied, `--base` is an ASSERTION, not a base source: the ROW owns the base. Resolve
-    the row's `effective_base` (its explicit `base_branch`, else the legacy header fallback, through
+    """`--base` is an ASSERTION, not a base source: the ROW owns the base. Resolve the row's
+    `effective_base` (its explicit `base_branch`, else the legacy header fallback, through
     `ledger.py`'s accessor — never a second copy of that rule) and return `(effective_base, None)` when
     `--base` agrees, else `(None, <error string>)`. Triage passes `--base` as `origin/<base>`; agreement is
     decided by `ledger.py`'s `base_agrees` (the one owner of that comparison — identical strings always
@@ -624,18 +629,16 @@ def _assert_ledger_base(file: str, pr: str, base: str) -> "tuple[str | None, str
 
 
 def cmd_derive(args: argparse.Namespace) -> int:
-    base = args.base
-    if args.file is not None:
-        if args.pr is None:
-            print("triage: REFUSED — --file requires --pr to select the ledger row", file=sys.stderr)
-            return EXIT_REFUSED
-        effective_base, problem = _assert_ledger_base(args.file, args.pr, args.base)
-        if problem is not None:
-            print(f"triage: REFUSED — {problem}", file=sys.stderr)
-            return EXIT_REFUSED
-        # Build the operational git ref from the ROW's resolved base, never the raw `--base` spelling:
-        # `origin/<effective_base>` is the remote-tracking ref triage diffs against.
-        base = f"origin/{effective_base}"
+    # `--file`/`--pr` are argparse-REQUIRED, so the ledger assertion is UNCONDITIONAL: there is no argv that
+    # reaches the diff with an unasserted `--base`. Making it conditional is what let a wrong `--base` become
+    # a silent base source and lower the floor.
+    effective_base, problem = _assert_ledger_base(args.file, args.pr, args.base)
+    if problem is not None:
+        print(f"triage: REFUSED — {problem}", file=sys.stderr)
+        return EXIT_REFUSED
+    # Build the operational git ref from the ROW's resolved base, never the raw `--base` spelling:
+    # `origin/<effective_base>` is the remote-tracking ref triage diffs against.
+    base = f"origin/{effective_base}"
     try:
         result = derive(
             worktree=args.worktree,
@@ -686,10 +689,12 @@ def parser() -> argparse.ArgumentParser:
         "--tier", choices=sorted(TIER_VALUES),
         help="the caller's DECIDED tier; refused if it is below the mechanical floor (veto-downward)")
     derive_parser.add_argument(
-        "--file", help="OPTIONAL ledger (state.jsonl); when given, --base is asserted against the selected "
-                       "row's effective base (requires --pr). Absent: --base is used as-is, as before")
+        "--file", required=True,
+        help="REQUIRED ledger (state.jsonl); --base is asserted against the selected row's effective base, "
+             "which is also what the diff is measured from")
     derive_parser.add_argument(
-        "--pr", help="PR number (row key) selecting the ledger row for the --file base assertion")
+        "--pr", required=True,
+        help="REQUIRED PR number (row key) selecting the ledger row for the --file base assertion")
     derive_parser.set_defaults(func=cmd_derive)
     test_parser = sub.add_parser("self-test", help="run the sibling fixture suite")
     test_parser.set_defaults(func=cmd_self_test)


### PR DESCRIPTION
- `derive` left `--file`/`--pr` optional, so the ledger base assertion was skippable
- a wrong `--base` then floored `null` not `STANDARD` and admitted `TRIVIAL` at exit 0
- both flags now required; new `ledger-required` fixture pins the refusal
