### PR TITLE
make dispatch-check an allow-list

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -131,7 +131,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 9. `ci-status.py required-set --ledger <rundir>/state.jsonl`: refresh the required set before any CI
    derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that
-    mutates a PR — it exits non-zero for a HELD one.
+    mutates a PR. It is an ALLOW-LIST — only an `in_review` row exits zero; HELD, terminal and
+    unrecognised rows all refuse, and the refusal says which (`references/files-and-ledger.md`,
+    "`dispatch-check` is the guard").
 11. **Due-work dispatch.** Follow `references/stage-2-review-gate.md`, "2a-triage", for each non-held
     PR's complete heartbeat triage procedure, then launch ALL due work up to caps — reviews, CI fixes,
     precondition clearing, base refresh — with mutating actions skipping HELD PRs, and stop in-flight
@@ -273,7 +275,7 @@ a line the tool writes.
 | `pr-adopt.py` | `plan` / `adopt` — mechanically adopt an existing first-party PR into a run: refuse fork/foreign/non-open, register the ledger row + ownership/status labels, discover-or-create the PR-head worktree | `references/pr-adoption.md` |
 | `triage.py` | `derive` — classify one stable, SHA-pinned PR diff and emit the per-file inventory + reasons and a mechanical FLOOR tier (SENSITIVE→HIGH, any non-prose→STANDARD, all-prose→no floor; never TRIVIAL — the orchestrator decides the tier); optional `--tier` vetoes a below-floor tier | `references/stage-2-review-gate.md` |
 | `heartbeat.py` | Emit the lean same-session wake prompts (scheduled heartbeat and session watchdog) the driver arms for its next wake | `references/runtime-adapter.md` |
-| `ledger.py` | Schema-owning accessor for `state.jsonl` — plus `verdict`, the ONLY verdict recorder (tally, caps, `repairing` hold), and `dispatch-check`, the held-PR guard run before any mutating action | `references/files-and-ledger.md` |
+| `ledger.py` | Schema-owning accessor for `state.jsonl` — plus `verdict`, the ONLY verdict recorder (tally, caps, `repairing` hold), and `dispatch-check`, the allow-list dispatch guard run before any mutating action | `references/files-and-ledger.md` |
 | `review-pass.py` | Executable contract for a review pass's artifacts — plan (`plan-add`/`plan-waive`, with `plan-check` gating dispatch on the default dimensions), `pass_identity`, progress, findings, active-attempt report result, `intent-check`, and the `verify` that answers "does this pass COUNT?" | `references/stage-2-review-gate.md` |
 | `review-dispatch.py` | `prepare` — validate one fresh review attempt and its typed prompt profile, derive every artifact path, write `pass_identity` + exact bound prompt, and return the host-neutral typed transport record; never selects or launches a route | `references/review-dispatch.md` |
 | `finding-audit.py` | Schema-owning accessor for complete gating-finding audits, mechanically derived review-fix scope, and durable standoff rulings | `references/finding-audit.md` |

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -488,6 +488,12 @@ Header field notes (the header fields above; per-row fields follow):
   gate flow, `declined` with a terminal `aborted`. A one-off approval lands here only; it never flips
   the run-wide `api_changes` header.
 - `status` — `in_review` → `merged`, or `aborted`; plus the **HELD** (non-terminal) statuses below.
+  **The vocabulary is CLOSED**: `STATUSES` in `scripts/ledger.py` is the one enumeration, and
+  `set`/`add-row --status` **refuses** any value outside it. That refusal is what makes the dispatch
+  allow-list safe to be strict — a status the guard cannot clear is a status nothing can write, so one
+  mistyped `--status` can no longer strand a PR that every consumer then ignores. A row that has not yet
+  been through adoption carries `ledger.py`'s pre-admission default instead, which is **not** a member and
+  which nothing may write: adoption is what puts a new row at `in_review` (`pr-adoption.md`).
 
 ### `status` held and parked taxonomy
 
@@ -500,10 +506,12 @@ Header field notes (the header fields above; per-row fields follow):
   owns it.
   Being held does not raise `reviews_ok`, so the guard reads **`status`** — never `reviews_ok`/`ci`/
   `mergeable` alone, which would re-review a held PR and merge it without its question ever being answered.
-  **It is a command, not a memory exercise**: `ledger.py … dispatch-check --pr <N>` exits non-zero on
-  every held status, and the members are `HELD_STATUSES` in `scripts/ledger.py` — **the one place they are
+  **It is a command, not a memory exercise**: `ledger.py … dispatch-check --pr <N>` refuses every held
+  status, and the members are `HELD_STATUSES` in `scripts/ledger.py` — **the one place they are
   enumerated. Never retype that list; ask the tool.** A status added to it is enforced everywhere with no
-  edit to any of the sites that consult it.
+  edit to any of the sites that consult it. The guard refuses **more** than these — it is an allow-list on
+  `in_review` (**`dispatch-check` is the guard**, below, owns what it clears and what it refuses) — so
+  never read a non-zero exit as proof the row is held; the refusal names which case it is.
 
   **Held-PR watch action.** Observing is not mutating. Run `liveness`, then ensure or
   relaunch a watch only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN
@@ -626,7 +634,16 @@ through `set`, exactly as it always has — `verdict` records what a *reviewer d
 a *commit did*.
 
 **`dispatch-check` is the guard, and it is a COMMAND, not a rule to remember.** Run it before **any**
-action that MUTATES a PR; it exits non-zero when the row is HELD (`status`, above). `--action repair` is
+action that MUTATES a PR.
+
+**It is an ALLOW-LIST, not a reject-list, and that is the whole point:** it exits **zero only for
+`in_review`**, and non-zero for every other status — the same polarity, for the same reason, as
+`merge-check.py decide`'s status allow-list. That **SUBSUMES** the held freeze (a held row is simply not
+`in_review`) and it also refuses a **TERMINAL** row (done and out of the gate), a row **adoption never
+admitted**, and any value that is **not a status at all**. A reject-list of held statuses green-lit all
+three. The refusal **says which of them this is**, so a driver can tell "wait for the user" from "this
+row is finished" from "this row is broken". The vocabulary is `STATUSES` in `scripts/ledger.py`
+(`status`, above) — **never retype it; ask the tool.** `--action repair` is
 the one kind of work a `repairing` row accepts, and it is refused until the reassessment's decision is on
 the row — otherwise a driver could call its next targeted fix "the repair" and go on whacking moles under
 a new name. The non-legacy recorded repair's required clean base-only rebase is part of that action;
@@ -714,7 +731,8 @@ human*, and the formatting is lossy in four ways:
   a ledger that holds nothing and a ledger whose every row is hidden print **different** markers, so an
   end-of-run table where every PR has finished can never be misread as a campaign that adopted no PRs.
 
-It rejects an unknown field name (listing the valid ones), refuses a duplicate `pr` on `add-row`,
+It rejects an unknown field name (listing the valid ones), refuses a `--status` outside the closed
+`STATUSES` vocabulary at both write doors (`status`, above), refuses a duplicate `pr` on `add-row`,
 errors on a missing row for `set`/`get`, and creates the file with the header if it is missing. It also
 validates the store on every read and refuses a corrupt ledger — a malformed JSON line, a record that
 is not a JSON object or has a missing/unknown `type`, a duplicate `pr` row, or a header that is missing,

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -275,6 +275,11 @@ the worker returns, and what never moves into it. The steps below are unchanged 
    ledger.py --file <state.jsonl> dispatch-check --pr <N>     # non-zero => do NOT act on this PR
    ```
 
+   **Non-zero does NOT mean "held".** The command is an allow-list on `in_review`, so it also refuses a
+   terminal row, a row adoption never admitted, and a value that is not a status at all; its refusal names
+   which case it is (`files-and-ledger.md`, "**`dispatch-check` is the guard**"). Either way the answer is
+   the same one this guard gives: do not act on the PR.
+
    `HELD_STATUSES` in `scripts/ledger.py` is the **one place** the members are enumerated, and
    `files-and-ledger.md`, `status`, is their definition. **Never retype that list here or anywhere else** —
    a status added to it must be enforced at every site with no edit to any of them. Today it holds two

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -100,9 +100,10 @@ diff properties, so filesystem inspection of only the new checkout is not a subs
 #### A HELD PR IS NOT REVIEWABLE — check `status` FIRST, and check it with the TOOL
 
 **A HELD PR IS NOT REVIEWABLE — check `status` FIRST, and check it with the TOOL.** Run `ledger.py …
-dispatch-check --pr <N>`: it exits non-zero on every **HELD** status (`files-and-ledger.md`, `status` —
-the owner; `HELD_STATUSES` in `scripts/ledger.py` is the one place they are enumerated, so **never retype
-that list**). A held PR is **FROZEN**: take no action that **MUTATES** it — no review pass, no
+dispatch-check --pr <N>`: it exits zero **only** for `in_review`, so every **HELD** status refuses — and
+so does a terminal or unrecognised row (`files-and-ledger.md`, `status` and "**`dispatch-check` is the
+guard**" — the owners; `HELD_STATUSES` in `scripts/ledger.py` is the one place the held members are
+enumerated, so **never retype that list**). A held PR is **FROZEN**: take no action that **MUTATES** it — no review pass, no
 precondition fix (including the judgment-path rebase below — conflict-resolving or diff-changed), no CI fix, no review fix, no merge, and nothing
 else that changes it (`loop-control.md` step 3, "held-status guard" — the governing property; these
 are only examples). Held leaves

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1885,11 +1885,16 @@ def t_no_verdict_for_a_held_row(L: ModuleType, tmp: Path) -> None:
 
 
 def t_dispatch_check_is_the_guard(L: ModuleType, tmp: Path) -> None:
-    """`dispatch-check` refuses a mutating dispatch on EVERY held status, and allows one on a live row.
+    """`dispatch-check` is an ALLOW-LIST: ONLY a `LIVE_STATUS` row may be acted on. Everything else STOPS.
 
     The park was already a prose rule obeyed by attention; `repairing` is a new one. Both are now a command
     that FAILS. The message must say what CLEARS the hold — a guard that only says "refused" teaches the
     driver nothing and invites it to route around the guard.
+
+    THE POLARITY IS THE CONTRACT, and it is pinned in both directions below, because the guard used to be
+    a REJECT-LIST (`status not in HELD_STATUSES`) and that is FAIL-OPEN: it green-lit a TERMINAL row and it
+    green-lit any value that was not spelled like a held status. `merge-check.py decide` already reasons
+    this way for the merge decision; this is the same polarity at the dispatch door.
     """
     for status in L.HELD_STATUSES:
         path = capped_row(L, tmp, f"dc-{status}.jsonl", status=status)
@@ -1901,10 +1906,40 @@ def t_dispatch_check_is_the_guard(L: ModuleType, tmp: Path) -> None:
 
     check(L.REPAIR_STATUS in L.HELD_STATUSES, "the repairing status must be HELD, or NO guard covers it")
 
-    for status in ("in_review", "pending"):
-        path = capped_row(L, tmp, f"live-{status}.jsonl", status=status)
-        code, _, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
-        check(code == 0, f"[{status}] a LIVE row was HELD (exit {code}) — the run would stall: {err!r}")
+    # A TERMINAL row is REFUSED. Under the old reject-list it exited 0 and the tool said campaign "may act
+    # on it" — a row that is DONE cleared for a review pass, a rebase, a relabel, a second merge.
+    for status in L.TERMINAL_STATUSES:
+        path = capped_row(L, tmp, f"dc-term-{status}.jsonl", status=status)
+        code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+        check(code == L.EXIT_STOP,
+              f"[{status}] a TERMINAL row was dispatchable (exit {code}) — the guard is fail-open: {out!r}")
+        check(status in err and "terminal" in err.lower(),
+              f"[{status}] the refusal must name the row TERMINAL, not merely refuse it: {err!r}")
+
+    # A status the enum does not contain is REFUSED — and so is the pre-admission default, which is the
+    # one non-enum value the tool itself writes. Each gets its OWN diagnosis: a driver must be able to tell
+    # "this row was never admitted" from "this row holds something no status is spelled like".
+    path = capped_row(L, tmp, "dc-unknown.jsonl", status="not-a-status")
+    code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == L.EXIT_STOP,
+          f"an UNRECOGNISED status was dispatchable (exit {code}) — the guard is fail-open: {out!r}")
+    check("not a ledger status" in err, f"the refusal does not name the defect: {err!r}")
+
+    pre = L.ROW_DEFAULTS["status"]
+    check(pre not in L.STATUSES, "the pre-admission default must not be a member, or this fixture is moot")
+    path = capped_row(L, tmp, "dc-preadmission.jsonl", status=pre)
+    code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == L.EXIT_STOP,
+          f"a row adoption never admitted was dispatchable (exit {code}): {out!r}")
+    check("adoption" in err, f"the refusal must point at the UNFINISHED ADOPTION, not merely refuse: {err!r}")
+
+    # …and the allow-list's other half: the ONE live status still passes. This is the concern the old
+    # reject-list fixture protected — a LIVE row frozen by the guard stalls the run — pinned here on
+    # `LIVE_STATUS`, which is the status a live row actually holds.
+    path = capped_row(L, tmp, "dc-live.jsonl", status=L.LIVE_STATUS)
+    code, out, err = cli(L, ["--file", str(path), "dispatch-check", "--pr", "1"])
+    check(code == 0, f"a LIVE row was REFUSED (exit {code}) — the run would stall: {err!r}")
+    check(L.LIVE_STATUS in out, f"the ok line must name the status it cleared: {out!r}")
 
     # `--action repair`: refused with no decision recorded, and refused on a row that is not repairing.
     path = capped_row(L, tmp, "rep.jsonl", status=L.REPAIR_STATUS)
@@ -1925,6 +1960,47 @@ def t_dispatch_check_is_the_guard(L: ModuleType, tmp: Path) -> None:
                              "--action", "repair"])
     check(code == 0, f"a legacy DEMOTE repair was stranded (exit {code}): {err!r}")
     check(legacy in out, f"dispatch-check did not preserve the legacy decision: {out!r}")
+
+
+def t_the_status_enum_is_closed(L: ModuleType, tmp: Path) -> None:
+    """`set`/`add-row --status` writes a `STATUSES` member or NOTHING — and the enum is COMPOSED, not typed.
+
+    The other half of the allow-list. A guard that only an `in_review` row clears is a guard that STRANDS
+    every row holding anything else, so the value must be unwritable in the first place: otherwise one
+    mistyped `--status` produces a ZOMBIE row that `dispatch-check` refuses, `nudge.py`'s in-flight rules
+    (all keyed on `LIVE_STATUS`) never mention, and `merge-check.py` refuses forever — a PR sitting in the
+    run with nothing driving it and nothing reporting it.
+
+    The composition is pinned too: a status added to `HELD_STATUSES` or `TERMINAL_STATUSES` must join the
+    write door's enum with NO edit to it, or the writer and the guard drift apart again.
+    """
+    check(L.STATUSES == (L.LIVE_STATUS,) + L.HELD_STATUSES + L.TERMINAL_STATUSES,
+          f"STATUSES is not COMPOSED from the live/held/terminal sets: {L.STATUSES!r} — a retyped copy "
+          f"drifts the day a status is added, and the guard and the write door stop agreeing")
+    check(L.ROW_DEFAULTS["status"] not in L.STATUSES,
+          "the pre-admission default is a TRANSITION TARGET now — nothing may move a row back to it")
+
+    # EVERY member is writable at BOTH doors: the enum must not be so tight it strands a real transition.
+    for status in L.STATUSES:
+        path = capped_row(L, tmp, f"enum-ok-{status}.jsonl")
+        code, _, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--status", status])
+        check(code == 0, f"[{status}] a REAL status was refused by `set` (exit {code}): {err!r}")
+        code, _, err = cli(L, ["--file", str(path), "add-row", "--pr", "77", "--status", status])
+        check(code == 0, f"[{status}] a REAL status was refused by `add-row` (exit {code}): {err!r}")
+
+    # …and nothing else is, at either door. `in-review` is the hyphen-for-underscore slip; the rest are the
+    # near-misses a hand-written command produces.
+    path = capped_row(L, tmp, "enum-bad.jsonl")
+    before = path.read_bytes()
+    for bogus in ("in-review", "In_Review", "in_review ", "pending", "held", "open", "-", ""):
+        for door in (["set", "--pr", "1"], ["add-row", "--pr", "77"]):
+            code, _, err = cli(L, ["--file", str(path), *door, "--status", bogus])
+            check(code == 1, f"[{door[0]} {bogus!r}] a NON-status was written (exit {code}) — the row is a "
+                             f"zombie: no guard clears it, no rule reports it, no merge finishes it")
+            check("not a ledger status" in err and L.LIVE_STATUS in err,
+                  f"[{door[0]} {bogus!r}] the refusal must name the vocabulary: {err!r}")
+            check(path.read_bytes() == before,
+                  f"[{door[0]} {bogus!r}] a REFUSED status still wrote the store")
 
 
 def t_the_repair_bound_has_no_door(L: ModuleType, tmp: Path) -> None:
@@ -2927,7 +3003,8 @@ CASES = [
     ("ns-streak-cap", "NS_STREAK_CAP is an independent sensor; one SATISFIED clears the streak", t_ns_streak_cap_fires),
     ("satisfied-never-fires", "a cap is NEVER evaluated on a SATISFIED — a passing PR is never torn up", t_a_satisfied_never_fires_a_cap),
     ("held-row-no-verdict", "no verdict may land on a held row", t_no_verdict_for_a_held_row),
-    ("dispatch-check", "every HELD status refuses a mutating dispatch; a repair needs its decision first", t_dispatch_check_is_the_guard),
+    ("dispatch-check", "an ALLOW-LIST: only a live row dispatches — held, terminal and unrecognised all STOP; a repair needs its decision first", t_dispatch_check_is_the_guard),
+    ("status-enum-closed", "`set`/`add-row --status` writes a STATUSES member or nothing — no zombie rows", t_the_status_enum_is_closed),
     ("repair-bound-no-door", "repair_count has NO flag — a budget you can zero is not a bound", t_the_repair_bound_has_no_door),
     ("repair-decision-cleared", "re-entering a cap CLEARS the stale reassessment decision — the repair budget binds", t_stale_repair_decision_cleared_at_cap),
     ("pr-origin-default", "an unknown origin is `external` — the fail-safe direction", t_pr_origin_defaults_to_external),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -415,10 +415,12 @@ REPAIR_CAP = 2
 REPAIR_STATUS = "repairing"
 
 # HELD — the statuses in which campaign MUST NOT dispatch ordinary gate work on a PR (a review pass, a
-# review fix, a CI fix, a merge, a rebase, a relabel — anything that MUTATES it). THE ONE ENUMERATION;
-# `dispatch-check` is what makes it a command that can FAIL rather than a rule an attentive agent must
-# remember. The members are held for DIFFERENT reasons and cleared by DIFFERENT events — never collapse
-# them:
+# review fix, a CI fix, a merge, a rebase, a relabel — anything that MUTATES it). THE ONE ENUMERATION of
+# the HELD reasons, and the set every consumer that must tell "parked" from "done" reads. It is NOT
+# `dispatch-check`'s test: that guard is an ALLOW-LIST on `LIVE_STATUS`, so it refuses these AND every
+# other non-live status, and consults this set only to explain WHICH refusal this is. `dispatch-check` is
+# what makes the freeze a command that can FAIL rather than a rule an attentive agent must remember. The
+# members are held for DIFFERENT reasons and cleared by DIFFERENT events — never collapse them:
 #
 #   awaiting-api / awaiting-user   parked on a HUMAN. Only the user's answer unparks.
 #   repairing                      at a review-loop cap. The reassessment pass and the repair it decides
@@ -436,6 +438,23 @@ HELD_STATUSES = ("awaiting-api", "awaiting-user", REPAIR_STATUS)
 # trusting a list here, which goes stale the next time one is added). `TABLE_HIDDEN_STATUSES` IS this
 # tuple, so its ORDER is also the order the table's hidden-count notice names them in.
 TERMINAL_STATUSES = ("merged", "aborted")
+
+# LIVE — the ONE status in which a row takes ordinary gate work. Named once so the WRITE DOOR and the
+# DISPATCH GUARD spell it the same way.
+LIVE_STATUS = "in_review"
+
+# THE STATUS VOCABULARY — every value a row's `status` may be MOVED to, and the ONE enumeration of it.
+# COMPOSED from the sets above, never retyped: a status added to `HELD_STATUSES` or `TERMINAL_STATUSES`
+# joins this enum with NO edit here, so the write door (`set`/`add-row --status`, through `check_status`)
+# and the dispatch guard (`dispatch-check`, whose ALLOW-LIST is `LIVE_STATUS`) cannot drift apart. That
+# pairing is the point: a status the guard cannot clear must also be a status nothing can write, or the
+# ledger grows ZOMBIE rows — dispatchable by nothing, reported by nothing, mergeable by nothing.
+#
+# `ROW_DEFAULTS["status"]` is deliberately NOT a member. It is what a row holds BEFORE adoption names a
+# status, not a state anything may move a row back to; adoption writes `in_review` on the row it creates
+# (`pr-adoption.md`). `dispatch-check` refuses it like any other non-live status — a row that was never
+# admitted to the gate takes no gate work.
+STATUSES = (LIVE_STATUS,) + HELD_STATUSES + TERMINAL_STATUSES
 
 
 def has_decided_repair(row: dict[str, str]) -> bool:
@@ -1083,6 +1102,28 @@ def check_tally(updates: dict, row: dict) -> None:
              f"manufacture one, because a hand-raised tally is indistinguishable from an earned one")
 
 
+def check_status(updates: dict) -> None:
+    """`set`/`add-row --status` may write only a REAL status — a `STATUSES` member, and nothing else.
+
+    **The write door and `dispatch-check`'s allow-list read the SAME enum**, so a status the guard cannot
+    clear is also a status nothing can write. Split them and the ledger grows a ZOMBIE row: a value one
+    character off a real status is accepted by a reject-list guard, matched by no consumer's
+    `status == in_review` test, and refused by the merge gate forever — so the PR sits in the run with
+    nothing driving it, nothing reminding anyone about it, and nothing able to finish it. A hyphen where
+    the enum has an underscore is the shape this catches, and it costs a whole run.
+
+    `ROW_DEFAULTS["status"]` is not a member: it is the pre-admission value, never a transition target.
+    """
+    if "status" not in updates:
+        return
+    want = updates["status"]
+    if want not in STATUSES:
+        fail(f"--status {want!r} is not a ledger status. The vocabulary is exactly {', '.join(STATUSES)} "
+             f"(`STATUSES`) — one of those, spelled that way. A value outside it produces a row no part of "
+             f"the gate can drive: `dispatch-check` refuses it, the in-flight rules that key on "
+             f"`{LIVE_STATUS}` never fire for it, and the merge gate refuses it forever")
+
+
 def cmd_add_row(path: Path, args) -> int:
     header, rows = load(path)
     pr = str(args.pr)
@@ -1091,6 +1132,9 @@ def cmd_add_row(path: Path, args) -> int:
     row = dict(ROW_DEFAULTS)
     # creating=True: `add-row` is the ONE door that may write a CREATE_ONLY field (row `base_branch`).
     updates = _named_field_values(args, creating=True)  # pr/id/VERDICT_OWNED excluded — derived or verdict-owned
+    # A row may be CREATED at any real status (an adoption starts one live; a fixture may seed a held or
+    # terminal one), but never at a value outside the vocabulary — the same door `set` gets.
+    check_status(updates)
     # A NEW row has run no reviews, so its tally is 0 and the floor rule applies from the defaults: a
     # `--reviews-ok 2` at CREATION is the same forged verdict as one at `set`, and it used to be the one
     # door where it went through.
@@ -1152,6 +1196,8 @@ def cmd_set(path: Path, args) -> int:
     updates = _named_field_values(args, creating=False)
     if not updates:
         fail("set requires at least one --<field> <value>")
+    # The vocabulary check comes FIRST: a `--status` outside the enum is not a transition to reason about.
+    check_status(updates)
     # The review-standoff park still uses `set --status awaiting-user`, but a recorded repair decision owns
     # a repairing row's next action. `park` already refuses this transition; keep the same guard at the
     # generic write door so a hand-assembled `set` cannot strand a repair that dispatch-check permits.
@@ -1369,6 +1415,17 @@ def cmd_dispatch_check(path: Path, args) -> int:
     guard would have a hole exactly where it matters: a driver could call its next fix "the repair",
     dispatch it, and go right on whacking moles under a new name. The decision must exist first, and the
     tool prints WHICH one, so the work that follows is the work that was decided.
+
+    **THE ORDINARY BRANCH IS AN ALLOW-LIST, NOT A REJECT-LIST, and that is the whole point** — the same
+    polarity, for the same reason, as `merge-check.py decide`'s status allow-list. Only `LIVE_STATUS`
+    passes. It SUBSUMES the old held freeze (a held row is simply not live) and closes the two holes a
+    reject-list of held statuses had, both of which are FAIL-OPEN:
+      * a TERMINAL row (`merged`/`aborted`) was green-lit. A row that is DONE and out of the gate was
+        cleared for a review pass, a rebase, a relabel, a second merge;
+      * ANY OTHER value was green-lit, including one no ledger status is spelled like. `check_status`
+        now refuses to WRITE such a value, so the two halves close the same hole from both ends.
+    The refusal DISCRIMINATES — held vs terminal vs not a status at all — because "refused" alone teaches
+    the driver nothing and invites it to route around the guard.
     """
     _, rows = load(path)
     pr = str(args.pr)
@@ -1394,13 +1451,30 @@ def cmd_dispatch_check(path: Path, args) -> int:
               f"other work")
         return 0
 
-    if status not in HELD_STATUSES:
+    if status == LIVE_STATUS:
         print(f"ok: pr {pr} is {status} — campaign may act on it")
         return 0
-    print(f"held: pr {pr} is {status} — {held_reason(status)}", file=sys.stderr)
-    print(f"held: take NO action that MUTATES this PR (no review pass, review fix, CI fix, merge, rebase, "
-          f"push or relabel). Observing it is fine: the CI watch and reconcile are unaffected. Keep "
-          f"driving the run's OTHER PRs — a held PR never blocks the loop.", file=sys.stderr)
+
+    if status in HELD_STATUSES:
+        print(f"held: pr {pr} is {status}, not {LIVE_STATUS} — {held_reason(status)}", file=sys.stderr)
+    elif status in TERMINAL_STATUSES:
+        print(f"terminal: pr {pr} is {status}, not {LIVE_STATUS} — this row is DONE and out of the gate, "
+              f"and a terminal status is FINAL. Nothing clears it and nothing re-opens it: re-adoption of "
+              f"a terminal row is refused too (`pr-adoption.md`). If this PR needs work again it needs a "
+              f"NEW run, not an action on this row.", file=sys.stderr)
+    elif status == ROW_DEFAULTS["status"]:
+        print(f"refused: pr {pr} is {status}, not {LIVE_STATUS} — that is the value a row holds BEFORE "
+              f"adoption gives it one, so this row was created but never admitted to the gate. Finish the "
+              f"adoption (`pr-adoption.md`), which writes `status = {LIVE_STATUS}` on a new row.",
+              file=sys.stderr)
+    else:
+        print(f"refused: pr {pr} is {status!r}, which is not a ledger status at all — the vocabulary is "
+              f"exactly {', '.join(STATUSES)} (`STATUSES`). `set --status` refuses a value outside it, so "
+              f"this row was hand-edited or predates that guard. Correct the row before dispatching any "
+              f"work on it: nothing in the gate can drive a status it does not recognise.", file=sys.stderr)
+    print(f"refused: take NO action that MUTATES this PR (no review pass, review fix, CI fix, merge, "
+          f"rebase, push or relabel). Observing it is fine: the CI watch and reconcile are unaffected. "
+          f"Keep driving the run's OTHER PRs — one refused PR never blocks the loop.", file=sys.stderr)
     return EXIT_STOP
 
 
@@ -1499,7 +1573,7 @@ def cmd_unpark(path: Path, args) -> int:
              f"through the abort procedure (bailout-and-final-report.md), which owns it; `unpark` serves the "
              f"`retry` answer only")
 
-    updates = {"status": "in_review", "blocker_ruling": "-"}
+    updates = {"status": LIVE_STATUS, "blocker_ruling": "-"}
     for f in LIVENESS_COUNTERS:
         updates[f] = ROW_DEFAULTS[f]   # from the defaults — NEVER a retyped literal
     row.update(updates)
@@ -1725,7 +1799,14 @@ def build_parser() -> argparse.ArgumentParser:
             opts = [f"--{name.replace('_', '-')}"]
             if "_" in name:
                 opts.append(f"--{name}")
-            p.add_argument(*opts, dest=name, help=f"row field '{name}'")
+            field_help = f"row field '{name}'"
+            # `status` is the one field with a CLOSED vocabulary, so its help names it — DERIVED from the
+            # enum, so it cannot drift from what `check_status` enforces. Not `choices=`: an argparse
+            # rejection exits 2 (a usage error) and prints nothing about the zombie row a bad status makes,
+            # while `check_status` fails with 1 — "your input was rejected" — and says why it matters.
+            if name == "status":
+                field_help += f" — one of: {', '.join(STATUSES)}"
+            p.add_argument(*opts, dest=name, help=field_help)
 
     a = sub.add_parser("add-row", help="append a new row for --pr")
     a.add_argument("--pr", required=True, help="PR number (row key)")
@@ -1756,7 +1837,9 @@ def build_parser() -> argparse.ArgumentParser:
                         "stamp describes a base check for content that is not the live tip and is refused")
 
     d = sub.add_parser("dispatch-check", help="may campaign ACT on this PR? run before every action that "
-                                              f"MUTATES a PR; exits {EXIT_STOP} when the row is HELD")
+                                              f"MUTATES a PR; an ALLOW-LIST — exits {EXIT_STOP} unless the "
+                                              f"row is {LIVE_STATUS} (held, terminal and unrecognised all "
+                                              f"refuse)")
     d.add_argument("--pr", required=True, help="PR number (row key)")
     d.add_argument("--action", choices=("ordinary", "repair"), default="ordinary",
                    help="'ordinary' (default) = any action that mutates the PR — review, fix, merge, "


### PR DESCRIPTION
- `dispatch-check` used a reject-list and green-lit terminal and unrecognised rows — fail-open
- ordinary branch is now an allow-list on `in_review`, matching `merge-check.py decide`
- new `STATUSES` enum gates `set`/`add-row --status`, so no row can hold an undriveable status
