### PR TITLE
mark worker reports as driver-internal

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -116,7 +116,8 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 
 8. At heartbeat entry, once you own the run and load its ledger, run `nudge.py` and READ its advisory
    reminders — computed from durable state, decides nothing, always exits 0 (`references/loop-control.md`
-   step 1). Then produce the run's validated PR snapshot through `reconcile.py fetch`, reconcile it
+   step 1). Those reminders, and every worker report this step folds, are driver-internal
+   (`references/loop-control.md`, "Driver-internal outputs"). Then produce the run's validated PR snapshot through `reconcile.py fetch`, reconcile it
    through `reconcile.py detect` (treat `state.jsonl` as cache), and fold completed
    review / CI / fix tasks against the SHA each ran on. On a host with a fresh-worker mechanism, the
    Step 1 reconcile runs in ONE fresh reconcile worker per heartbeat and the driver folds, dispatches,

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -94,7 +94,9 @@ no usable bundle. The script launches no worker and judges no repair.
 **THE ORCHESTRATOR RECORDS EVERY SITE THE FIXER LEFT ALONE — as a follow-up, in the same heartbeat it reads the
 report.** The template's report block makes the subagent report sites it deliberately did not touch (and any
 pre-existing defect it noticed and declined to fix); **that report dies with the subagent**, so a
-disposition nobody wrote down is a defect nobody will ever see again. Record each one through
+disposition nobody wrote down is a defect nobody will ever see again. It is also driver-internal — READ
+it in full and record from it, and do not reproduce it to the user (`loop-control.md`, "Driver-internal
+outputs"). Record each one through
 `scripts/followups.py` — the subagent's own report is the entry's evidence, and why the fixer left it
 alone is why it was deferred. They are **CANDIDATES, not issues**: local, and never published without the
 user's agreement on that specific item (`followups.md`).

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -94,9 +94,8 @@ no usable bundle. The script launches no worker and judges no repair.
 **THE ORCHESTRATOR RECORDS EVERY SITE THE FIXER LEFT ALONE — as a follow-up, in the same heartbeat it reads the
 report.** The template's report block makes the subagent report sites it deliberately did not touch (and any
 pre-existing defect it noticed and declined to fix); **that report dies with the subagent**, so a
-disposition nobody wrote down is a defect nobody will ever see again. It is also driver-internal — READ
-it in full and record from it, and do not reproduce it to the user (`loop-control.md`, "Driver-internal
-outputs"). Record each one through
+disposition nobody wrote down is a defect nobody will ever see again. It is also driver-internal
+(`loop-control.md`, "Driver-internal outputs"). Record each one through
 `scripts/followups.py` — the subagent's own report is the entry's evidence, and why the fixer left it
 alone is why it was deferred. They are **CANDIDATES, not issues**: local, and never published without the
 user's agreement on that specific item (`followups.md`).

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -12,6 +12,32 @@ from its compact report; inline Step 1 is the fallback (no worker mechanism, or 
 worker). `runtime-adapter.md`, "Reconcile worker", owns the contract — what the driver passes in, what
 the worker returns, and what never moves into it. The steps below are unchanged whoever executes them.
 
+### Driver-internal outputs
+
+**`nudge.py`'s reminders, the reconcile worker's report, a review pass's report, and a fix worker's
+report are DRIVER-INTERNAL.** The driver READS each one and ACTS on it; it does **NOT** reproduce it —
+verbatim, quoted at length, or walked step by step — in what it shows the user. They are the loop's only
+unbounded output, and relaying them buries the decisions only the user can make.
+
+**This bounds REPRODUCING. It never weakens READING or ACTING.** Every obligation an internal output
+carries still runs in full: a fix worker's sweep-site dispositions still reach the driver's own recording
+step in the SAME heartbeat (`fix-subagent-contract.md`) — one that stops arriving there is work lost
+permanently — and a review pass's report still reaches its tally check (`stage-2-review-gate.md`, "Does
+this pass COUNT?").
+
+**What this NEVER silences: anything only the USER can act on.** Where another rule already requires
+something to reach the user, this one removes nothing from it and grants no discretion to trim it — a
+verbosity rule that hides a decision the user alone can make is worse than the noise it saves. Those
+rules keep their own wording; these are illustrations of them, not a second copy:
+
+- **Every park question, WITH how long it has waited**, in each of the three park classes — API approval,
+  review-standoff ruling, machine-blocker ruling ("Only the user's answer unparks a PR" in Step 3, and
+  the health pass in Step 5). Only the user's answer unparks a PR, so silence here wedges the run for good.
+- **The `ledger.py table` output, WHOLE** — every `#` disclosure line included (Step 5).
+- **Every disclosure the final report owes** (`bailout-and-final-report.md`, "Final report") — among them
+  `skill_version`, the required-set `unknown`-versus-`none` distinction, `authored@` intents, and open
+  follow-up candidates the user has not agreed to.
+
 **Every heartbeat — reconcile, dispatch, reschedule:**
 
 ### Step 1 — Resolve repository context, then the run + lease, then init / resume / start fresh
@@ -30,7 +56,8 @@ the worker returns, and what never moves into it. The steps below are unchanged 
    state so an amnesiac fresh-context heartbeat is HANDED its obligations rather than told to remember
    them. It **decides nothing and always exits 0**; each reminder just points at the owner of the actual
    check (labels, caps, the health pass below — including its `watchdog due` reminder). Act on the
-   reminders through those owners; ignore none silently.
+   reminders through those owners; ignore none silently. Its output is driver-internal
+   ("Driver-internal outputs" above).
    Every path here is **absolute**, from the record resolved above: the follow-up store is `.gauntlet/`
    under `repository.project_root`, and the tool uses `--followups` **as given** — a cwd-relative path
    makes the answer depend on where the heartbeat was launched, and a driver working in a worktree would
@@ -257,7 +284,8 @@ the worker returns, and what never moves into it. The steps below are unchanged 
    never set `reviews_ok` by hand. It refuses unless the base-preflight `proceed` above stamped `base_ok_sha`
    for this head (the `--file` on the precondition run is what records it).
    For any completed task (review, CI watch,
-   CI/review fix), record the result against the SHA it ran on and act per Stage 2.
+   CI/review fix), record the result against the SHA it ran on and act per Stage 2. Every report folded
+   here is driver-internal ("Driver-internal outputs" above).
 ### Step 3 — Dispatch due work
 
 3. **Dispatch due work — non-blocking, idempotent, bounded, work-conserving.** Scan the whole run,

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -821,8 +821,7 @@ pass is a trapdoor, not a disclosure:
 **`ok` is not SATISFIED.** The tool parses the reviewer's exact terminal result but does not judge the
 report's prose, raise `reviews_ok`, or merge. `ledger.py verdict` remains the only tally writer.
 
-**The report itself is driver-internal** (`loop-control.md`, "Driver-internal outputs"): the driver reads
-it and acts on it, and does not reproduce it to the user.
+**The report itself is driver-internal** (`loop-control.md`, "Driver-internal outputs").
 
 ### Recording a verdict — `ledger.py verdict` is the ONLY sanctioned path
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -821,6 +821,9 @@ pass is a trapdoor, not a disclosure:
 **`ok` is not SATISFIED.** The tool parses the reviewer's exact terminal result but does not judge the
 report's prose, raise `reviews_ok`, or merge. `ledger.py verdict` remains the only tally writer.
 
+**The report itself is driver-internal** (`loop-control.md`, "Driver-internal outputs"): the driver reads
+it and acts on it, and does not reproduce it to the user.
+
 ### Recording a verdict — `ledger.py verdict` is the ONLY sanctioned path
 
 As each verdict lands, record it with:


### PR DESCRIPTION
- nothing forbade relaying `nudge.py` reminders and worker reports to the user
- new `loop-control.md` "Driver-internal outputs" owns the rule; 5 sites point at it
- the rule names what it never silences (park questions, `table`, final report)
