### PR TITLE
add a status_verbosity header field

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -145,7 +145,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     and the loop continues per `references/loop-control.md`, "Primary continuity", whenever non-terminal
     work remains. NEVER sleep with due work un-launched or no path to the next reconcile. Then follow
     `references/loop-control.md`, "Reschedule or exit", exactly: a scheduled-heartbeat host renders the
-    status — the `ledger.py table` output that block defines — and then schedules-or-replaces the primary
+    status — the `ledger.py table` output that block defines, at the verbosity the header
+    `status_verbosity` field selects (default `full`; `brief` drops the set-once run configuration and
+    nothing else) — and then schedules-or-replaces the primary
     wake as the turn's LAST action ("Primary continuity"; scheduling ends the turn on that host:
     `references/runtime-adapter.md`, "Scheduled-heartbeat host"); a scheduler-less host renders the same
     status, performs one bounded wait, and returns to the reconcile step while non-terminal work remains.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -108,7 +108,7 @@ following line is one adopted PR's row record (`{"type": "row", …}`). Every re
 — fields are keyed by NAME, never by column position:
 
 ```
-{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4", "last_activity": "2026-07-04T09:40:00Z", "watchdog_due": "2026-07-04T10:25:00Z", "pending_adoption": "-", "default_non_goals": "[\"hardening a self-test against a developer who edits it\"]"}
+{"type": "header", "run_id": "g260704-0915-a3f29c1b", "base_branch": "main", "api_changes": "ask", "reviewer": "codex", "required_set": "declared:[{\"context\": \"build\", \"app\": \"-\"}, {\"context\": \"test (3.12, ubuntu)\", \"app\": \"15368\"}]", "skill_version": "0.1.4", "last_activity": "2026-07-04T09:40:00Z", "watchdog_due": "2026-07-04T10:25:00Z", "pending_adoption": "-", "default_non_goals": "[\"hardening a self-test against a developer who edits it\"]", "status_verbosity": "full"}
 {"type": "row", "id": "pr41", "slug": "fix-null-deref", "branch": "fix-null-deref", "worktree": "/srv/example-repo/.worktrees/fix-null-deref", "worktree_owned": "yes", "branch_owned": "yes", "pr": "41", "head_sha": "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c", "reviews_ok": "2", "ci": "green", "tier": "STANDARD", "attempts": "1", "started": "2026-07-04T09:15:00Z", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:9f2c\u2026", "settled_strikes": "0", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-", "review_rounds": "3", "ns_streak": "0", "intent": "stated@2026-07-04T09:15:00Z", "pr_origin": "gauntlet", "repair_count": "0", "repair_decision": "-"}
 {"type": "row", "id": "pr52", "slug": "add-retry-flag", "branch": "add-retry-flag", "worktree": "/home/example/checkouts/add-retry-flag", "worktree_owned": "no", "branch_owned": "no", "pr": "52", "head_sha": "b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7089a1b", "reviews_ok": "0", "ci": "pending", "tier": "HIGH", "attempts": "0", "started": "-", "api_approval": "-", "status": "in_review", "ci_fingerprint": "sha256:4a71\u2026", "settled_strikes": "1", "unusable_refetches": "0", "ci_stalled_since": "-", "ci_reason": "required check absent: integration-tests", "blocker_ruling": "-", "review_rounds": "5", "ns_streak": "2", "intent": "authored@2026-07-04T09:20:00Z", "pr_origin": "external", "repair_count": "0", "repair_decision": "-"}
 ```
@@ -139,7 +139,8 @@ this header field is only what a row carrying no explicit set inherits through `
 maintain; the quiet-run sensor `nudge.py` reads, defined below), `watchdog_due` (**the durable
 health-pass deadline** — a UTC ISO-8601 stamp `ledger.py watchdog` stamps and reads, defined below),
 `pending_adoption` (**the run-intent checkpoint** — the requested PR list recorded at setup, defined
-below), `default_non_goals` (**the run-wide default Non-goals**, defined below).
+below), `default_non_goals` (**the run-wide default Non-goals**, defined below), `status_verbosity`
+(**how much of the per-heartbeat status render to print**, defined below).
 
 `skill_version` is read at startup from the **running plugin's** `plugin.json` (`SKILL.md`) and stated in
 the final report. **It is not cosmetic.** The harness loads this skill from the **installed plugin cache**,
@@ -233,6 +234,32 @@ other malformed value rather than silently reading as `[]`. Its run-wide meaning
 intent-check --ledger` refuses a PR whose managed block has drifted from this field before dispatch, and
 `verify --ledger` compares the dispatch-time `pass_identity.default_non_goals` binding to this field at
 tally (`check_scope`).
+
+`status_verbosity` records **HOW MUCH OF THE PER-HEARTBEAT STATUS RENDER TO PRINT** — `full` | `brief`,
+the operator's own display setting. Unlike `watchdog_due` it is an **ORDINARY, hand-settable config field**
+(`header set status_verbosity brief`): it has a real door, and **writing it IS meaningful activity** (no
+exemption — it is not a sensor). `ledger.py`'s `parse_status_verbosity` is the **ONE validator** and
+`status_verbosity(header)` the **ONE read door**; a value outside the vocabulary is **REFUSED without
+mutating the ledger** (fail closed). It **defaults to `full`**, and that default is load-bearing rather
+than a taste: an existing run renders exactly as it did until the operator opts in.
+
+**It is PRESENTATION and nothing else.** No verdict, CI derivation, cap, park, label or merge
+precondition reads it, and no stored value changes with it — `header get` and `list` still return every
+field under either mode. **`loop-control.md`, "Reschedule or exit", owns what the surrounding render may
+omit and what it must always print.** Inside `table` it decides exactly one thing: whether the
+`# <field>: <value>` run-config block is printed above the grid. `brief` drops that block — set-once
+configuration a heartbeat would otherwise reprint every time — **and drops nothing else. It never removes
+a row, an empty-grid marker, or the hidden-count disclosure line**; a verbosity that could suppress those
+would turn a filtered table back into the lie by omission they exist to prevent, and the row it would bury
+is the `aborted` one. A brief render is a shorter preamble, never a smaller ledger.
+
+A stored value the validator refuses — reachable only by hand-editing the store, since the door refuses it
+— **degrades to `full` on READ** rather than raising. That direction is deliberate and is the opposite of
+`default_non_goals`': the only thing this setting can do is **suppress output**, so a setting nobody can
+read must hide nothing, and a status render that died on a typo in a display field would take the whole
+heartbeat's report with it. This is the stance `watchdog check` takes toward a malformed deadline — a read
+that gates nothing must never fail — while an unreadable `default_non_goals` would silently narrow a
+**review**, which is why that one raises instead.
 
 Header field notes (the header fields above; per-row fields follow):
 
@@ -618,7 +645,7 @@ ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfi
 ledger.py --file <state.jsonl> base-ok --pr N --head-sha <sha>    # record a base-preflight `proceed` for the head (base_ok_sha) — written only by base-preflight.py, never hand-set
 ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
-ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only)
+ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only; the header status_verbosity decides whether the run-config block prints)
 ledger.py --file <state.jsonl> dispatch-check --pr N [--action ordinary|repair]
 ledger.py --file <state.jsonl> park --pr N --reason <blocker>     # MACHINE-BLOCKER park: status=awaiting-user, ci_reason=<blocker>, blocker_ruling=- — one write
 ledger.py --file <state.jsonl> unpark --pr N                      # retry unpark: status=in_review, ruling spent, liveness counters reset — one write
@@ -670,6 +697,12 @@ answered through `finding-audit.py rule-standoff`, not `blocker_ruling`, so its 
 to waiting (`loop-control.md`, "Reschedule or exit"). It renders state and makes NO gate decisions; its
 one computed value is the display-only `base` column (the `base` bullet under "It shows only SOME fields",
 below).
+
+**How much of it prints is the operator's call, and it reaches only the PREAMBLE.** The header
+`status_verbosity` field (above) decides whether the `# <field>: <value>` run-config block appears above
+the grid; `brief` omits it. Everything from the column-header line down is byte-identical under either
+mode — including every out-of-band `#` line below the grid, which the next four bullets are about. The
+verbosity is not a fifth way this projection is lossy: it drops no value, no row, and no disclosure.
 
 **Read the ledger by FIELD NAME through `ledger.py get`** (or `list`) — **never by parsing the table**.
 A SHA (or any value) recovered from `table`'s grid is a truncated, escaped rendering, and feeding one back

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -247,7 +247,14 @@ than a taste: an existing run renders exactly as it did until the operator opts 
 precondition reads it, and no stored value changes with it — `header get` and `list` still return every
 field under either mode. **`loop-control.md`, "Reschedule or exit", owns what the surrounding render may
 omit and what it must always print.** Inside `table` it decides exactly one thing: whether the
-`# <field>: <value>` run-config block is printed above the grid. `brief` drops that block — set-once
+`# <field>: <value>` run-config block is printed above the grid. **It is not itself one of that block's
+lines.** The printed block is `ledger.py`'s `TABLE_CONFIG_FIELDS` — the header fields minus the
+presentation ones (`HEADER_PRESENTATION_FIELDS`), declared in the schema rather than at the render site —
+so a **PRESENTATION** field is stored, gettable and settable like any other and simply never printed
+there. That exclusion is what makes the `full` default a true no-op: a ledger written before this field
+existed back-fills the default and still prints the block it always printed, byte for byte. Under `brief`
+the block is gone entirely, so printing the setting inside it could never have explained a missing
+preamble either. `brief` drops that block — set-once
 configuration a heartbeat would otherwise reprint every time — **and drops nothing else. It never removes
 a row, an empty-grid marker, or the hidden-count disclosure line**; a verbosity that could suppress those
 would turn a filtered table back into the lie by omission they exist to prevent, and the row it would bury
@@ -700,7 +707,9 @@ below).
 
 **How much of it prints is the operator's call, and it reaches only the PREAMBLE.** The header
 `status_verbosity` field (above) decides whether the `# <field>: <value>` run-config block appears above
-the grid; `brief` omits it. Everything from the column-header line down is byte-identical under either
+the grid; `brief` omits it. The field does **not** appear among that block's own lines — the block is
+`TABLE_CONFIG_FIELDS`, the header fields minus the presentation ones (see the field, above) — so a ledger
+predating the setting renders exactly as it did. Everything from the column-header line down is byte-identical under either
 mode — including every out-of-band `#` line below the grid, which the next four bullets are about. The
 verbosity is not a fifth way this projection is lossy: it drops no value, no row, and no disclosure.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -670,10 +670,13 @@ resume. This block OWNS when the loop continues; every other site points here, n
      itself** (a health-pass diagnosis, when one fired above, leads *in front of* the table — it never
      replaces or reorders it). Run
      `ledger.py --file <state.jsonl> table` and include its output verbatim, fenced, in the status
-     message. **Verbatim means WHOLE** — including every `#` line it prints below the grid. The default
+     message. **Verbatim means WHOLE — every line THE COMMAND PRINTED**, including every `#` line below
+     the grid. The default
      view is a **filtered** one and those lines are what disclose the filtering
      (`files-and-ledger.md`, "`table` is a PROJECTION"); drop them and the user is shown a subset
-     presented as the whole ledger. Never re-type, trim, or re-align it. Then one line per remaining
+     presented as the whole ledger. Never re-type, trim, or re-align it — **the only thing that may
+     shorten this output is the tool's own `status_verbosity` setting (below), which shortens it before
+     you ever see it. You never shorten it yourself.** Then one line per remaining
      wait naming what it waits on (review in flight, CI watch, parked on the user's answer). Render it
      after every ledger write during this heartbeat — the ledger was reconciled this heartbeat, so the table is the
      state the next reconcile resumes from. State whether the session watchdog is armed or unavailable. For
@@ -681,7 +684,33 @@ resume. This block OWNS when the loop continues; every other site points here, n
      watchdog nudge", owns that result set and each host's value — never a claim that the primary wake is
      already armed: nothing arms it before the turn's final action, and the status names that final action
      as whichever runtime branch below the active host takes ("Primary continuity" above). Never imply
-     dead-session recovery. Then take
+     dead-session recovery.
+
+     **HOW MUCH OF THAT RENDER PRINTS IS THE OPERATOR'S SETTING — the ledger header field
+     `status_verbosity`** (`files-and-ledger.md` owns the field, its vocabulary and its validation;
+     `full` is the default, `brief` the opt-in). Re-read it from the header every heartbeat like any other
+     header field, never from memory. Under `full`, render exactly as above. Under `brief`, drop the
+     **SET-ONCE RUN CONFIGURATION**: `table` omits its `# <field>: <value>` block for you, and you
+     likewise stop restating those same header fields in prose. Keep the prose you write to **what moved
+     this heartbeat** — a row whose state did not change this heartbeat needs no line of its own, because
+     the table already carries it.
+
+     **`brief` NEVER drops any of the following. A render missing one is wrong, not lean:**
+     - **every park question, WITH how long it has waited.** A forgotten question is the most likely
+       reason a run went quiet; brevity is never a reason to stop putting it in front of the user.
+     - **every remaining-wait line** — one per wait, naming what it waits on, exactly as above.
+     - **every `#` line `table` printed below the grid** — the hidden-row counts. Drop them and a filtered
+       subset is presented as the whole ledger, and an **`aborted`** PR left open for its owner appears
+       ONLY there and in the final report.
+     - **the session watchdog's armed/unavailable state, and the reported `primary inspect` result.**
+     - **the health-pass diagnosis whenever a pass ran** — still LEADING the render, in front of the
+       table, exactly as above.
+
+     The setting is **PRESENTATION**. It decides nothing: no verdict, no CI derivation, no cap, no park,
+     no status label, no merge precondition — and the ledger it renders is the same either way. It also
+     never licenses skipping a step: `brief` shortens the REPORT, never the heartbeat's work.
+
+     Then take
      exactly one runtime branch:
      - **Scheduled-heartbeat host:** with the status above already rendered, schedule-or-replace the
        primary wake as the turn's LAST action ("Primary continuity" above) — scheduling ends the turn on

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -388,7 +388,9 @@ For a long campaign, the fresh context the design assumes comes from the **hand-
 and resume in a fresh one with `<campaign-invocation> --run <run-id>` — the durable state exists
 precisely so a fresh instance rebuilds everything (`loop-control.md`, "Resume after a killed session").
 When the driver's context is visibly heavy, say so in the status render and recommend that hand-off
-rather than walking silently toward a context limit.
+rather than walking silently toward a context limit. **This warning is not set-once run configuration, so
+it prints at either `status_verbosity`** (`loop-control.md`, "Reschedule or exit"): a brief render that
+swallowed it would be walking toward that limit silently, which is the one thing it exists to stop.
 
 ### Reconcile worker — heartbeat Step 1 in a fresh context
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -162,6 +162,17 @@ def row_line(L: ModuleType, **over: str) -> str:
     return json.dumps({"type": "row", **L.ROW_DEFAULTS, **over})
 
 
+def below_config(out: str) -> "list[str]":
+    """The printed lines from the column-header line onward — the grid and the out-of-band block below it.
+
+    A `full` render opens with the run-config block and separates it from the grid with a blank line; a
+    `brief` render (header `status_verbosity`) opens straight at the grid. That blank separator is the ONLY
+    empty line either render ever prints — every grid line, marker and notice is non-empty — so its
+    presence, not a line count, is what tells the two apart, and one helper serves both.
+    """
+    return out.split("\n\n", 1)[1].split("\n") if "\n\n" in out else out.split("\n")
+
+
 def body_lines(out: str) -> "list[str]":
     """The table's printed ROW lines, EXACTLY as they came out — the bytes a reader actually sees.
 
@@ -169,14 +180,14 @@ def body_lines(out: str) -> "list[str]":
     proves no cell can enter, so dropping them here cannot drop a row (and a forged one — which prints as
     `\\#…` — is still counted, which is the point).
     """
-    body = out.split("\n\n", 1)[1].split("\n")
+    body = below_config(out)
     check(body[-1] == "", "the table output must end in a newline")
     return [line for line in body[2:-1] if not line.startswith("#")]
 
 
 def notices(out: str) -> "list[str]":
     """The table's OUT-OF-BAND lines below the grid — the markers and the hidden-count notice."""
-    body = out.split("\n\n", 1)[1].split("\n")[:-1]
+    body = below_config(out)[:-1]
     return [line for line in body[2:] if line.startswith("#")]
 
 
@@ -190,6 +201,11 @@ def grid(L: ModuleType, out: str, fields: "tuple[str, ...]",
     (`followups.py`) renders through the same `config_lines()`/`grid_lines()` and asserts its output with
     THIS same oracle, passing ITS two — so the layout is verified by ONE parser and a second store cannot
     be checked by a weaker copy of it.
+
+    An EMPTY `config_fields` is the `brief` render (the ledger's `status_verbosity` header field): no
+    run-config block, and — asserted here, not assumed — no leading blank line either, so the output opens
+    on the column-header line. Everything BELOW that point is parsed by the same code in both modes, which
+    is what lets a fixture prove `brief` dropped the block and nothing else.
 
     Three properties, all checked here because all three are what a hostile value attacks:
 
@@ -223,8 +239,12 @@ def grid(L: ModuleType, out: str, fields: "tuple[str, ...]",
     config, lines = lines[:n], lines[n:]
     for f, line in zip(cfg_fields, config):
         check(line.startswith(f"# {f}: "), f"run-config line for {f!r} is {line!r}")
-    check(lines[0] == "", f"a blank line must separate the run config from the grid; got {lines[0]!r}")
-    body = lines[1:]
+    if cfg_fields:
+        check(lines[0] == "", f"a blank line must separate the run config from the grid; got {lines[0]!r}")
+        body = lines[1:]
+    else:
+        check(lines[0] != "", f"a render with no run-config block must open on the grid; got {lines[0]!r}")
+        body = lines
     check(len(body) >= 3, f"the grid needs a column-header line, a rule line and a body: {body!r}")
     colhead, rule, rest = body[0], body[1], body[2:]
     # Split the row region from the out-of-band lines below it. A '#' line is out-of-band BY CONSTRUCTION
@@ -1777,7 +1797,9 @@ def t_skill_version_is_recorded(L: ModuleType, tmp: Path) -> None:
     code, out, _ = cli(L, ["--file", str(path), "header", "get", "skill_version"])
     check(out == "0.1.4\n", f"skill_version did not survive the round trip: {out!r}")
 
-    # …and it is in the run-config block the table prints, so a report rendered from `table` carries it.
+    # …and it is in the run-config block the table prints under the DEFAULT verbosity, so a report
+    # rendered from `table` carries it. (An operator who selects `brief` drops that block by choice;
+    # `header get skill_version` above, and the final report, are where the value is always available.)
     code, out, _ = cli(L, ["--file", str(path), "table"])
     config, _, _ = grid(L, out, L.TABLE_DEFAULT_FIELDS)
     check("# skill_version: 0.1.4" in config,
@@ -2742,6 +2764,204 @@ def t_pending_adoption_is_an_ordinary_field(L: ModuleType, tmp: Path) -> None:
     check(header_field(L, path, "last_activity") == FROZEN_B, "clearing pending_adoption is also activity")
 
 
+# --- status_verbosity: the operator's display setting, and the lines it may NEVER drop -------------------
+#
+# The field is PRESENTATION. These fixtures pin the two halves that matter: the write door refuses anything
+# outside the vocabulary (so a typo cannot silently configure a render nobody specified), and `brief` drops
+# the run-config block and NOTHING else — least of all the disclosure lines that say the view is a subset.
+
+def t_status_verbosity_defaults_to_full(L: ModuleType, tmp: Path) -> None:
+    """The default is `full`, so an existing run renders exactly as it did until the operator opts in.
+
+    Pinned on both sides: the stored default reads back `full`, and the table really does print the WHOLE
+    run-config block — one line per `HEADER_FIELDS` member, read from the accessor, never a retyped list.
+    """
+    path = write_lines(tmp / "verb-default.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1"))
+    check(header_field(L, path, "status_verbosity") == L.STATUS_VERBOSITY_FULL,
+          f"status_verbosity must default to {L.STATUS_VERBOSITY_FULL!r}: "
+          f"{header_field(L, path, 'status_verbosity')!r}")
+    # An OLD ledger — written before this field existed — back-fills to the same default and renders full.
+    old = write_lines(tmp / "verb-old.jsonl", json.dumps({"type": "header", "run_id": "r1"}),
+                      row_line(L, pr="1"))
+    check(header_field(L, old, "status_verbosity") == L.STATUS_VERBOSITY_FULL,
+          "a ledger predating status_verbosity must read back the default, not fail")
+    for name, led in (("fresh", path), ("old", old)):
+        code, out, err = cli(L, ["--file", str(led), "table"])
+        check(code == 0, f"[{name}] table exited {code}: {err!r}")
+        config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
+        check(len(config) == len(L.HEADER_FIELDS),
+              f"[{name}] the default view printed {len(config)} run-config lines, not one per header field")
+        check(len(cells) == 1, f"[{name}] the row vanished from the default view: {out}")
+
+
+def t_status_verbosity_refuses_an_unknown_value(L: ModuleType, tmp: Path) -> None:
+    """`header set status_verbosity <not-a-mode>` is REFUSED at the write door, and the store is UNCHANGED.
+
+    A display setting that accepted anything would leave the operator with a render they never asked for and
+    no way to tell why — so the door validates against `STATUS_VERBOSITIES` and refuses BEFORE `save`. The
+    accepted values round-trip, and setting one IS meaningful activity (this is an ordinary config field,
+    like `pending_adoption` — not a sensor).
+    """
+    path = write_lines(tmp / "verb-refuse.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1"))
+    with frozen_clock(L, FROZEN_A):  # a real change first, so a later stamp is distinguishable
+        code, _, err = cli(L, ["--file", str(path), "header", "set", "status_verbosity",
+                               L.STATUS_VERBOSITY_BRIEF])
+        check(code == 0, f"header set status_verbosity brief exited {code}: {err!r}")
+    check(header_field(L, path, "status_verbosity") == L.STATUS_VERBOSITY_BRIEF,
+          f"brief did not round-trip: {header_field(L, path, 'status_verbosity')!r}")
+    check(header_field(L, path, "last_activity") == FROZEN_A,
+          "setting status_verbosity IS meaningful activity — it must stamp last_activity (no exemption)")
+
+    for bad in ("loud", "FULL", "", " brief", "brief ", "verbose", "-", "0"):
+        with frozen_clock(L, FROZEN_B):
+            code, out, err = cli(L, ["--file", str(path), "header", "set", "status_verbosity", bad])
+        check(code == 1, f"header set status_verbosity {bad!r} must be REFUSED (exit 1); got {code}: {out!r}")
+        check("status_verbosity" in err, f"the refusal must name the field: {err!r}")
+        for mode in L.STATUS_VERBOSITIES:
+            check(mode in err, f"the refusal must name the vocabulary ({mode!r} missing): {err!r}")
+        check(header_field(L, path, "status_verbosity") == L.STATUS_VERBOSITY_BRIEF,
+              f"a REFUSED header set overwrote status_verbosity with {bad!r} — it reached disk")
+        check(header_field(L, path, "last_activity") == FROZEN_A,
+              "a REFUSED header set stamped last_activity — it must write NOTHING")
+
+    with frozen_clock(L, FROZEN_B):
+        code, _, err = cli(L, ["--file", str(path), "header", "set", "status_verbosity",
+                               L.STATUS_VERBOSITY_FULL])
+        check(code == 0, f"header set status_verbosity full exited {code}: {err!r}")
+    check(header_field(L, path, "status_verbosity") == L.STATUS_VERBOSITY_FULL,
+          "the operator must be able to switch back to the full render")
+
+
+def t_brief_drops_the_run_config_block_and_nothing_else(L: ModuleType, tmp: Path) -> None:
+    """`brief` removes the run-config block — and the two renders are otherwise BYTE-IDENTICAL.
+
+    That equality is the whole assertion, and it is stronger than any list of things brief "still prints":
+    a change that dropped a row, a column, a marker or the hidden-count line under brief cannot satisfy it.
+    The full render's own output supplies the expectation, so nothing here is retyped.
+    """
+    rows = (row_line(L, pr="1", slug="live", status="in_review"),
+            row_line(L, pr="2", slug="parked", status="awaiting-user"),
+            row_line(L, pr="3", slug="done", status="merged"))
+    path = write_lines(tmp / "verb-brief.jsonl", header_line(L, run_id="r1", base_branch="main"), *rows)
+    n = len(L.HEADER_FIELDS)
+
+    for label, argv in (("default projection", []), ("--fields", ["--fields", "pr,base,status"])):
+        code, _, err = cli(L, ["--file", str(path), "header", "set", "status_verbosity",
+                               L.STATUS_VERBOSITY_FULL])
+        check(code == 0, f"[{label}] header set status_verbosity full exited {code}: {err!r}")
+        code, full_out, err = cli(L, ["--file", str(path), "table", *argv])
+        check(code == 0, f"[{label}] the full table exited {code}: {err!r}")
+
+        code, _, err = cli(L, ["--file", str(path), "header", "set", "status_verbosity",
+                               L.STATUS_VERBOSITY_BRIEF])
+        check(code == 0, f"[{label}] header set status_verbosity brief exited {code}: {err!r}")
+        code, brief_out, err = cli(L, ["--file", str(path), "table", *argv])
+        check(code == 0, f"[{label}] the brief table exited {code}: {err!r}")
+
+        # The run-config block is GONE — no line of the brief render opens one, and it does not open blank.
+        opened = [line for line in brief_out.split("\n")
+                  if any(line.startswith(f"# {f}: ") for f in L.HEADER_FIELDS)]
+        check(opened == [], f"[{label}] brief still printed run-config lines: {opened!r}\n{brief_out}")
+        check(brief_out.split("\n")[0] != "", f"[{label}] brief opened on a blank line: {brief_out!r}")
+
+        # …and EVERYTHING BELOW it is unchanged, BYTE FOR BYTE. This equality is the assertion: it is what
+        # no list of "brief still prints X" could give, because a change that dropped a row, a column, a
+        # marker or the hidden-count line under brief cannot satisfy it. The expectation is the full
+        # render's own bytes — nothing is retyped, so it cannot go stale.
+        full_lines = full_out.split("\n")
+        check(all(line.startswith("# ") for line in full_lines[:n]),
+              f"[{label}] the full render's first {n} lines are not the run-config block: {full_lines[:n]!r}")
+        check(full_lines[n] == "", f"[{label}] no blank line follows the full run-config block")
+        check("\n".join(full_lines[n + 1:]) == brief_out,
+              f"[{label}] brief is not the full render minus its run-config block:\n"
+              f"{full_out}\n--- vs ---\n{brief_out}")
+
+    # The grid still parses as a grid under brief, and holds the same cells the full view showed.
+    code, brief_out, _ = cli(L, ["--file", str(path), "table"])
+    _, _, brief_cells = grid(L, brief_out, L.TABLE_DEFAULT_FIELDS, config_fields=())
+    col = L.TABLE_DEFAULT_FIELDS.index("pr")
+    check([c[col] for c in brief_cells] == ["1", "2"],
+          f"brief did not show the live and parked rows: {[c[col] for c in brief_cells]!r}\n{brief_out}")
+
+    # Every header value is STILL IN THE STORE and still readable by name — brief hides the display of the
+    # run config, never the config itself.
+    for f in L.HEADER_FIELDS:
+        code, out, err = cli(L, ["--file", str(path), "header", "get", f])
+        check(code == 0, f"header get {f} exited {code} under brief: {err!r}")
+        check(out.endswith("\n"), f"header get {f} printed nothing under brief")
+
+
+def t_brief_never_hides_a_row_or_its_disclosure(L: ModuleType, tmp: Path) -> None:
+    """Under `brief` the grid, the parked rows, the empty-grid markers and the hidden-count line ALL stand.
+
+    This is the line the setting must never cross. A brief render that dropped the disclosure would present
+    a filtered subset as the whole ledger, and the row it would bury is the `aborted` one — the run's
+    unfinished business, left open for its owner. So each is asserted against the FULL render's own output.
+    """
+    mixed = write_lines(
+        tmp / "verb-mixed.jsonl", header_line(L, run_id="r1", status_verbosity=L.STATUS_VERBOSITY_BRIEF),
+        row_line(L, pr="1", status="merged"),
+        row_line(L, pr="2", status="in_review"),
+        row_line(L, pr="3", status="aborted"),
+        row_line(L, pr="4", status="awaiting-user"),
+    )
+    code, out, err = cli(L, ["--file", str(mixed), "table"])
+    check(code == 0, f"the brief table exited {code}: {err!r}")
+    _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS, config_fields=())
+    col = L.TABLE_DEFAULT_FIELDS.index("pr")
+    check([c[col] for c in cells] == ["2", "4"],
+          f"brief changed WHICH rows show — the parked row must stand: {[c[col] for c in cells]!r}\n{out}")
+    check(notices(out) == [L.hidden_notice(2, ("merged", "aborted"))],
+          f"brief dropped or altered the hidden-count disclosure: {notices(out)!r}\n{out}")
+
+    code, out, err = cli(L, ["--file", str(mixed), "table", "--all"])
+    check(code == 0, f"brief table --all exited {code}: {err!r}")
+    _, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS, config_fields=())
+    check([c[col] for c in cells] == ["1", "2", "3", "4"], f"--all must still show every row:\n{out}")
+    check(notices(out) == [], f"--all hid nothing, yet the brief render claims it did: {notices(out)!r}")
+
+    # Both empty-grid markers survive brief, and they stay DIFFERENT lines — an end-of-run ledger must
+    # never read as a campaign that adopted nothing.
+    empty = write_lines(tmp / "verb-empty.jsonl",
+                        header_line(L, run_id="r1", status_verbosity=L.STATUS_VERBOSITY_BRIEF))
+    code, out, _ = cli(L, ["--file", str(empty), "table"])
+    check((code, notices(out)) == (0, [L.TABLE_EMPTY_MARKER]),
+          f"a brief render of an empty ledger must still say {L.TABLE_EMPTY_MARKER!r}: {notices(out)!r}")
+    allgone = write_lines(tmp / "verb-allgone.jsonl",
+                          header_line(L, run_id="r1", status_verbosity=L.STATUS_VERBOSITY_BRIEF),
+                          row_line(L, pr="1", status="merged"), row_line(L, pr="2", status="aborted"))
+    code, out, _ = cli(L, ["--file", str(allgone), "table"])
+    check((code, notices(out)) == (0, [L.TABLE_ALL_HIDDEN_MARKER, L.hidden_notice(2, ("merged", "aborted"))]),
+          f"a brief render whose rows are all terminal must still say WHICH empty it is: {notices(out)!r}")
+
+
+def t_unreadable_status_verbosity_renders_full(L: ModuleType, tmp: Path) -> None:
+    """A hand-edited `status_verbosity` the validator refuses renders the FULL view — and never crashes.
+
+    The write door refuses every such value, so this can only come from a hand-edited store. Degrading to
+    `full` is the fail-safe DIRECTION for a setting whose only power is to suppress output: a setting nobody
+    can read must hide nothing, and the status render must not die on a typo in a display field.
+    """
+    for bad in ("loud", "", "-", "null"):
+        path = write_lines(tmp / f"verb-bad-{bad or 'blank'}.jsonl",
+                           json.dumps({"type": "header", "run_id": "r1", "status_verbosity": bad}),
+                           row_line(L, pr="1"))
+        header, _ = L.load(path)
+        check(L.status_verbosity(header) == L.STATUS_VERBOSITY_FULL,
+              f"an unreadable {bad!r} must read as {L.STATUS_VERBOSITY_FULL!r}, not {bad!r}")
+        code, out, err = cli(L, ["--file", str(path), "table"])
+        check(code == 0, f"table on an unreadable status_verbosity exited {code}: {err!r}")
+        config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
+        check(len(config) == len(L.HEADER_FIELDS),
+              f"an unreadable {bad!r} suppressed the run-config block — it hid MORE, not less:\n{out}")
+        check(len(cells) == 1, f"an unreadable {bad!r} dropped the row:\n{out}")
+    # A `null` on disk is a MISSING value, not a mode: it back-fills to the default through `_coerce_field`.
+    nul = write_lines(tmp / "verb-null.jsonl",
+                      json.dumps({"type": "header", "run_id": "r1", "status_verbosity": None}))
+    check(header_field(L, nul, "status_verbosity") == L.STATUS_VERBOSITY_FULL,
+          "a null status_verbosity must back-fill to the default, never to the string 'None'")
+
+
 # --- row-owned base / required set, with the header as the LEGACY FALLBACK -------------------------------
 #
 # `base_branch` and `required_set` are per-ROW state now; the header fields are only what a row with no
@@ -3027,6 +3247,11 @@ CASES = [
     ("watchdog-due-no-door", "`header set watchdog_due` is refused and writes nothing", t_watchdog_due_has_no_door),
     ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
     ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
+    ("verbosity-defaults-full", "status_verbosity defaults to `full` — an existing run renders as it did", t_status_verbosity_defaults_to_full),
+    ("verbosity-refuses-unknown", "a value outside STATUS_VERBOSITIES is refused at the write door, store unchanged", t_status_verbosity_refuses_an_unknown_value),
+    ("verbosity-brief-drops-config", "`brief` is the full render MINUS the run-config block, byte for byte", t_brief_drops_the_run_config_block_and_nothing_else),
+    ("verbosity-brief-discloses", "`brief` never drops a row, a marker, or the hidden-count disclosure", t_brief_never_hides_a_row_or_its_disclosure),
+    ("verbosity-unreadable-full", "an unreadable status_verbosity renders FULL — a setting nobody can read hides nothing", t_unreadable_status_verbosity_renders_full),
     ("old-ledger-header-fallback", "an old row with no base fields loads and resolves through the header", t_old_ledger_resolves_through_the_header),
     ("new-row-owns-its-base", "a new row's explicit base wins over the header, per row", t_new_row_owns_its_base),
     ("row-base-creation-only", "the row base is written once at add-row and immutable — no `set --base-branch`", t_row_base_is_creation_only),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -197,7 +197,9 @@ def grid(L: ModuleType, out: str, fields: "tuple[str, ...]",
     """Parse the printed table BACK and assert its INTEGRITY. Returns (config lines, widths, cells).
 
     `config_fields` and `markers` name the out-of-band text the store under test prints; they default to
-    the LEDGER's own (`L.HEADER_FIELDS`, and its empty/all-hidden markers). The sibling store
+    the LEDGER's own (`L.TABLE_CONFIG_FIELDS` — the block `cmd_table` actually prints, which is NOT every
+    header field: a presentation field is stored and gettable but never printed — and its
+    empty/all-hidden markers). The sibling store
     (`followups.py`) renders through the same `config_lines()`/`grid_lines()` and asserts its output with
     THIS same oracle, passing ITS two — so the layout is verified by ONE parser and a second store cannot
     be checked by a weaker copy of it.
@@ -209,7 +211,7 @@ def grid(L: ModuleType, out: str, fields: "tuple[str, ...]",
 
     Three properties, all checked here because all three are what a hostile value attacks:
 
-      * the run config is EXACTLY len(HEADER_FIELDS) lines, each opening `# <field>: `, and NO grid line
+      * the run config is EXACTLY len(cfg_fields) lines, each opening `# <field>: `, and NO grid line
         opens with `#` — except the out-of-band lines that are ALLOWED to (the empty/all-hidden markers and
         the hidden-count notice), which must form a CONTIGUOUS TRAILING BLOCK below the rows — so no value
         can forge a config line, a marker, or the notice, and none of them can hide BETWEEN rows;
@@ -229,7 +231,7 @@ def grid(L: ModuleType, out: str, fields: "tuple[str, ...]",
     same `a`, and this suite stayed green through it. An oracle that normalizes away the thing under test
     is not an oracle. What it hands back is what was PRINTED; nothing else.
     """
-    cfg_fields: "tuple[str, ...]" = L.HEADER_FIELDS if config_fields is None else config_fields
+    cfg_fields: "tuple[str, ...]" = L.TABLE_CONFIG_FIELDS if config_fields is None else config_fields
     mk: "tuple[str, ...]" = (L.TABLE_EMPTY_MARKER, L.TABLE_ALL_HIDDEN_MARKER) if markers is None else markers
     lines = out.split("\n")
     check(lines[-1] == "", "the table output must end in a newline")
@@ -2774,7 +2776,12 @@ def t_status_verbosity_defaults_to_full(L: ModuleType, tmp: Path) -> None:
     """The default is `full`, so an existing run renders exactly as it did until the operator opts in.
 
     Pinned on both sides: the stored default reads back `full`, and the table really does print the WHOLE
-    run-config block — one line per `HEADER_FIELDS` member, read from the accessor, never a retyped list.
+    run-config block — one line per `TABLE_CONFIG_FIELDS` member, read from the accessor.
+
+    That oracle is DERIVED from the schema, so it proves the block is complete but can say NOTHING about
+    which names belong in it: it would follow the tuple anywhere it moved. What the printed names must
+    actually BE is pinned against a frozen list by `t_legacy_config_block_is_unchanged`, and that fixture
+    is the one that catches a field being added to the printed block.
     """
     path = write_lines(tmp / "verb-default.jsonl", header_line(L, run_id="r1"), row_line(L, pr="1"))
     check(header_field(L, path, "status_verbosity") == L.STATUS_VERBOSITY_FULL,
@@ -2789,9 +2796,57 @@ def t_status_verbosity_defaults_to_full(L: ModuleType, tmp: Path) -> None:
         code, out, err = cli(L, ["--file", str(led), "table"])
         check(code == 0, f"[{name}] table exited {code}: {err!r}")
         config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
-        check(len(config) == len(L.HEADER_FIELDS),
-              f"[{name}] the default view printed {len(config)} run-config lines, not one per header field")
+        check(len(config) == len(L.TABLE_CONFIG_FIELDS),
+              f"[{name}] the default view printed {len(config)} run-config lines, not one per printed field")
         check(len(cells) == 1, f"[{name}] the row vanished from the default view: {out}")
+
+
+def t_legacy_config_block_is_unchanged(L: ModuleType, tmp: Path) -> None:
+    """A ledger written before `status_verbosity` existed prints the SAME run-config block it always did.
+
+    THE ORACLE IS FROZEN AND RETYPED ON PURPOSE, and that is the entire point of this fixture. Every other
+    assertion about the block derives its expectation from the schema tuple — `len(TABLE_CONFIG_FIELDS)`,
+    `L.HEADER_FIELDS` — so it follows the tuple wherever the tuple goes. An oracle computed from the thing
+    under test cannot catch a change to that thing: a field added to the printed block moves BOTH sides of
+    such a check at once and the suite stays green over a render that visibly changed. It did: the whole
+    fixture suite passed while a legacy ledger's block silently grew a line.
+
+    So the names below are a hand-copied snapshot of what the block held before this field was introduced,
+    and they are NOT to be regenerated from the accessor. If a change makes this fixture fail, that change
+    altered what an existing run prints — decide whether that is intended and edit this list deliberately.
+
+    It names NO symbol this branch added, deliberately: it therefore runs unchanged against the accessor as
+    it was before, which is what lets "the old code passes this too" be a claim rather than a hope. The
+    other half — that the excluded field is still stored, defaulted and readable by name — is pinned by
+    `t_status_verbosity_defaults_to_full` and `t_brief_drops_the_run_config_block_and_nothing_else`.
+    """
+    # Retyped by hand. Do NOT replace with anything derived from `L.HEADER_FIELDS`/`L.TABLE_CONFIG_FIELDS`.
+    frozen = ("run_id", "base_branch", "api_changes", "reviewer", "required_set", "skill_version",
+              "last_activity", "watchdog_due", "pending_adoption", "default_non_goals")
+
+    legacy = write_lines(tmp / "legacy-block.jsonl", json.dumps({"type": "header", "run_id": "r1"}),
+                         row_line(L, pr="1", slug="live"))
+    code, out, err = cli(L, ["--file", str(legacy), "table"])
+    check(code == 0, f"table on a pre-status_verbosity ledger exited {code}: {err!r}")
+
+    # Parsed straight off the printed bytes, then compared as NAMES — a count alone would accept a
+    # substitution, and `startswith` alone would accept an extra line beyond the ones checked. Only the
+    # PREAMBLE is read (everything above the first blank line), so the out-of-band lines the table may
+    # print below the rows — which also open `# ` — cannot pad or mask this list.
+    lines = out.split("\n")
+    preamble = lines[:lines.index("")]
+    check(all(line.startswith("# ") for line in preamble),
+          f"a legacy render's preamble holds a line that is not a run-config line: {preamble!r}")
+    printed = [line.split(":", 1)[0][2:] for line in preamble]
+    check(printed == list(frozen),
+          f"the run-config block a legacy ledger prints changed:\nexpected {list(frozen)}\ngot      {printed}\n{out}")
+
+    # …and the same output parses as a whole table against that frozen block, so nothing below it moved
+    # either. `grid` is given the frozen tuple explicitly: its default would derive the block from the
+    # schema, which is exactly the oracle this fixture exists to avoid.
+    config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS, config_fields=frozen)
+    check(len(config) == len(frozen), f"the legacy render's block is not {len(frozen)} lines: {config!r}")
+    check(len(cells) == 1, f"the legacy render lost its row:\n{out}")
 
 
 def t_status_verbosity_refuses_an_unknown_value(L: ModuleType, tmp: Path) -> None:
@@ -2843,7 +2898,10 @@ def t_brief_drops_the_run_config_block_and_nothing_else(L: ModuleType, tmp: Path
             row_line(L, pr="2", slug="parked", status="awaiting-user"),
             row_line(L, pr="3", slug="done", status="merged"))
     path = write_lines(tmp / "verb-brief.jsonl", header_line(L, run_id="r1", base_branch="main"), *rows)
-    n = len(L.HEADER_FIELDS)
+    # The size of the block `cmd_table` PRINTS — not of the header, which holds presentation fields the
+    # block never shows. This is a cut point into the full render's own bytes, so it must track what was
+    # printed.
+    n = len(L.TABLE_CONFIG_FIELDS)
 
     for label, argv in (("default projection", []), ("--fields", ["--fields", "pr,base,status"])):
         code, _, err = cli(L, ["--file", str(path), "header", "set", "status_verbosity",
@@ -2859,6 +2917,8 @@ def t_brief_drops_the_run_config_block_and_nothing_else(L: ModuleType, tmp: Path
         check(code == 0, f"[{label}] the brief table exited {code}: {err!r}")
 
         # The run-config block is GONE — no line of the brief render opens one, and it does not open blank.
+        # Scanned over EVERY header field, deliberately wider than the printed block: a brief render that
+        # leaked a field the full render does not even show would still be caught here.
         opened = [line for line in brief_out.split("\n")
                   if any(line.startswith(f"# {f}: ") for f in L.HEADER_FIELDS)]
         check(opened == [], f"[{label}] brief still printed run-config lines: {opened!r}\n{brief_out}")
@@ -2952,7 +3012,7 @@ def t_unreadable_status_verbosity_renders_full(L: ModuleType, tmp: Path) -> None
         code, out, err = cli(L, ["--file", str(path), "table"])
         check(code == 0, f"table on an unreadable status_verbosity exited {code}: {err!r}")
         config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
-        check(len(config) == len(L.HEADER_FIELDS),
+        check(len(config) == len(L.TABLE_CONFIG_FIELDS),
               f"an unreadable {bad!r} suppressed the run-config block — it hid MORE, not less:\n{out}")
         check(len(cells) == 1, f"an unreadable {bad!r} dropped the row:\n{out}")
     # A `null` on disk is a MISSING value, not a mode: it back-fills to the default through `_coerce_field`.
@@ -3248,6 +3308,7 @@ CASES = [
     ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
     ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
     ("verbosity-defaults-full", "status_verbosity defaults to `full` — an existing run renders as it did", t_status_verbosity_defaults_to_full),
+    ("verbosity-legacy-block-frozen", "a pre-status_verbosity ledger prints the SAME block — pinned against a frozen, retyped list", t_legacy_config_block_is_unchanged),
     ("verbosity-refuses-unknown", "a value outside STATUS_VERBOSITIES is refused at the write door, store unchanged", t_status_verbosity_refuses_an_unknown_value),
     ("verbosity-brief-drops-config", "`brief` is the full render MINUS the run-config block, byte for byte", t_brief_drops_the_run_config_block_and_nothing_else),
     ("verbosity-brief-discloses", "`brief` never drops a row, a marker, or the hidden-count disclosure", t_brief_never_hides_a_row_or_its_disclosure),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -56,6 +56,26 @@ STATUS_VERBOSITIES = (STATUS_VERBOSITY_FULL, STATUS_VERBOSITY_BRIEF)
 HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_set", "skill_version",
                  "last_activity", "watchdog_due", "pending_adoption", "default_non_goals",
                  "status_verbosity")
+
+# HEADER FIELDS THAT CONFIGURE THE RENDER RATHER THAN THE RUN — stored, gettable and settable like any
+# other header field, but NOT part of the run-config block the table prints. The exclusion is declared
+# HERE, in the schema, because it is a property of the FIELD, not a special case at one render site: a
+# second presentation field is added by naming it here and no printing code changes.
+#
+# It is also what keeps a promise the field could otherwise not keep. `load()` back-fills every missing
+# header key from `HEADER_DEFAULTS`, so an OLD ledger — written before `status_verbosity` existed — reads
+# back the default and, were the field printed, would gain a config line it never had. Printing the knob
+# that controls the block INSIDE that block is what made an existing run's output change with no operator
+# action; leaving it out is what makes the default a true no-op, and `ledger-test.py`'s
+# `t_legacy_config_block_is_unchanged` pins that against a frozen list rather than against this tuple.
+# Nothing is hidden by it: `header get`/`header set` and the stored record are untouched, and under
+# `brief` the whole block is gone anyway, so the line could never have explained a missing preamble.
+HEADER_PRESENTATION_FIELDS = ("status_verbosity",)
+
+# The run-config block `cmd_table` prints: `HEADER_FIELDS` minus the presentation ones, DERIVED so the two
+# can never drift and the field order stays the schema's.
+TABLE_CONFIG_FIELDS = tuple(f for f in HEADER_FIELDS if f not in HEADER_PRESENTATION_FIELDS)
+
 HEADER_DEFAULTS = {
     "run_id": "-",
     # LEGACY FALLBACK for the base branch. The base a PR merges into is now ROW state (`base_branch` in
@@ -1772,8 +1792,13 @@ def cmd_table(path: Path, args) -> int:
     # them would turn a filtered table back into the lie by omission `hidden_notice` exists to prevent —
     # and the row it would bury is the `aborted` one, this run's unfinished business. A brief render is a
     # SHORTER preamble, never a smaller ledger.
+    #
+    # The block itself is `TABLE_CONFIG_FIELDS` — the schema's own list of what belongs in it, which is
+    # every header field except the presentation ones. This site chooses WHETHER to print; it never
+    # chooses WHAT, so a legacy ledger's full render is byte-identical to the one it produced before this
+    # setting existed.
     if status_verbosity(header) == STATUS_VERBOSITY_FULL:
-        for line in config_lines([(f, header[f]) for f in HEADER_FIELDS]):
+        for line in config_lines([(f, header[f]) for f in TABLE_CONFIG_FIELDS]):
             print(line)
         print()
     # ONLY the rows that are actually printed become cells. That is not merely an optimization: it is what

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -44,8 +44,18 @@ TEST_PY = HERE / "ledger-test.py"     # the fixture suite — this accessor's ex
 
 # --- schema (owned here, once) ------------------------------------------------
 
+# HOW MUCH OF THE PER-HEARTBEAT STATUS RENDER TO PRINT — the ONE enumeration of what the
+# `status_verbosity` header field may hold. It is PRESENTATION and nothing else: no verdict, no CI
+# derivation, no cap, no park and no merge precondition reads it, and no value in the store changes with
+# it. `loop-control.md`, "Reschedule or exit", owns what the surrounding status render may omit under each
+# mode; in THIS file the setting decides exactly one thing (see `cmd_table`).
+STATUS_VERBOSITY_FULL = "full"
+STATUS_VERBOSITY_BRIEF = "brief"
+STATUS_VERBOSITIES = (STATUS_VERBOSITY_FULL, STATUS_VERBOSITY_BRIEF)
+
 HEADER_FIELDS = ("run_id", "base_branch", "api_changes", "reviewer", "required_set", "skill_version",
-                 "last_activity", "watchdog_due", "pending_adoption", "default_non_goals")
+                 "last_activity", "watchdog_due", "pending_adoption", "default_non_goals",
+                 "status_verbosity")
 HEADER_DEFAULTS = {
     "run_id": "-",
     # LEGACY FALLBACK for the base branch. The base a PR merges into is now ROW state (`base_branch` in
@@ -138,6 +148,23 @@ HEADER_DEFAULTS = {
     # stands (`guard_default_non_goals_change`). files-and-ledger.md, "default_non_goals", owns the field and
     # that lifecycle rule.
     "default_non_goals": "[]",
+    # HOW MUCH OF THE PER-HEARTBEAT STATUS RENDER TO PRINT — `full` | `brief` (`STATUS_VERBOSITIES`), the
+    # operator's own display setting. An ORDINARY, hand-settable config field (`header set
+    # status_verbosity brief`), exactly like `pending_adoption` and unlike `watchdog_due`: it has a real
+    # door, and writing it IS meaningful activity (no exemption — it is not a sensor). `parse_status_verbosity`
+    # is the ONE validator and `status_verbosity(header)` the ONE read door; a value outside the vocabulary
+    # is REFUSED at `header set` without mutating the ledger (fail closed).
+    #
+    # In THIS file it decides exactly one thing: whether `table` prints the `# <field>: <value>` run-config
+    # block above the grid. `brief` drops that block — set-once run configuration the heartbeat would
+    # otherwise reprint on every wake. It drops NOTHING else: not a row, not an empty-grid marker, and
+    # never the hidden-count disclosure line, which is what tells a reader the view is a SUBSET.
+    #
+    # The default is `full`, and that is load-bearing rather than a taste: an existing run renders exactly
+    # as it did until the operator opts in. A stored value the validator refuses degrades to `full` on READ
+    # (`status_verbosity`) — the only thing this setting can do is HIDE output, so a setting nobody can read
+    # must hide nothing.
+    "status_verbosity": STATUS_VERBOSITY_FULL,
 }
 
 ROW_FIELDS = (
@@ -927,6 +954,35 @@ def default_non_goals(header: dict) -> "list[str]":
     return parse_default_non_goals(header.get("default_non_goals", HEADER_DEFAULTS["default_non_goals"]))
 
 
+def parse_status_verbosity(value: object) -> str:
+    """VALIDATE a `status_verbosity` value — the ONE validator, shared by the write door and the read door.
+
+    Raises `ValueError` naming the vocabulary. The vocabulary is `STATUS_VERBOSITIES`, read rather than
+    retyped, so a third mode is added in one place and both doors see it with no edit here.
+    """
+    if not isinstance(value, str) or value not in STATUS_VERBOSITIES:
+        raise ValueError(f"must be one of {', '.join(STATUS_VERBOSITIES)}; got {value!r}")
+    return value
+
+
+def status_verbosity(header: dict) -> str:
+    """The run's status-render verbosity — the ONE door every consumer reads it through (never the raw
+    header value).
+
+    It DEGRADES to `full` on a stored value the validator refuses, and that direction is the whole point.
+    The write door validates and refuses, so an unreadable value can only reach the store by hand — and
+    the only thing this setting can ever do is SUPPRESS output. Degrading here prints MORE, never less: a
+    setting nobody can read must hide nothing, and a status render that dies on a typo takes the whole
+    heartbeat's report with it. That is the stance `watchdog check` takes toward a malformed deadline (a
+    read that gates nothing must never fail), not `default_non_goals`' raise — an unreadable value THERE
+    would silently narrow a review, while an unreadable value here narrows only the display.
+    """
+    try:
+        return parse_status_verbosity(header.get("status_verbosity", HEADER_DEFAULTS["status_verbosity"]))
+    except ValueError:
+        return STATUS_VERBOSITY_FULL
+
+
 def prs_with_review_credit(rows: "list[dict]") -> "list[str]":
     """The PRs of every NON-TERMINAL row that still holds BANKED review credit (`reviews_ok > 0`).
 
@@ -1008,6 +1064,14 @@ def cmd_header(path: Path, args) -> int:
         # A BROADENING change (a default removed) while banked review credit stands is a false-permissive
         # merge in waiting — refuse it, fail closed, BEFORE `save`. `guard_default_non_goals_change` owns why.
         guard_default_non_goals_change(header, rows, new_defaults)
+    if args.field == "status_verbosity":
+        # VALIDATE through the schema's own parser — the ONE place this field's vocabulary lives. The
+        # refusal raises BEFORE `save`, so a value outside it never reaches the ledger (fail closed), and
+        # the operator learns the vocabulary from the tool rather than from a doc that can go stale.
+        try:
+            value = parse_status_verbosity(args.value)
+        except ValueError as exc:
+            fail(f"status_verbosity {exc} — refused; the ledger is unchanged")
     activity = header.get(args.field) != value
     header[args.field] = value
     save(path, header, rows, activity=activity)
@@ -1697,9 +1761,21 @@ def cmd_table(path: Path, args) -> int:
     else:
         shown = [r for r in rows if r["status"] not in TABLE_HIDDEN_STATUSES]
         dropped = [r for r in rows if r["status"] in TABLE_HIDDEN_STATUSES]
-    for line in config_lines([(f, header[f]) for f in HEADER_FIELDS]):
-        print(line)
-    print()
+    # THE ONE THING `status_verbosity` DECIDES HERE: whether the run-config block is printed. It is
+    # set-once configuration, and the heartbeat that renders this table renders it again on every wake,
+    # so `brief` drops the block (and the blank line that separated it from the grid — a lone blank leader
+    # is not a lighter render, it is a ragged one).
+    #
+    # It drops NOTHING BELOW THIS POINT, and that boundary is the point of the setting rather than an
+    # oversight: the grid, the two empty-grid markers and the hidden-count notice all print identically in
+    # both modes. Those lines are what disclose that the view is a SUBSET, so a verbosity able to suppress
+    # them would turn a filtered table back into the lie by omission `hidden_notice` exists to prevent —
+    # and the row it would bury is the `aborted` one, this run's unfinished business. A brief render is a
+    # SHORTER preamble, never a smaller ledger.
+    if status_verbosity(header) == STATUS_VERBOSITY_FULL:
+        for line in config_lines([(f, header[f]) for f in HEADER_FIELDS]):
+            print(line)
+        print()
     # ONLY the rows that are actually printed become cells. That is not merely an optimization: it is what
     # keeps a hidden row from reaching the VISIBLE output at all. Build cells from every row and the widths
     # would still be measured over the hidden ones, so a merged PR with a 200-char slug would silently
@@ -1865,7 +1941,14 @@ def build_parser() -> argparse.ArgumentParser:
     ls = sub.add_parser("list", help="print matching rows' pr numbers")
     ls.add_argument("--where", help="filter as <field>=<value>")
 
-    t = sub.add_parser("table", help="print the run header and the live rows as an aligned table")
+    t = sub.add_parser(
+        "table",
+        help="print the run header and the live rows as an aligned table",
+        epilog=f"the header `status_verbosity` field ({'/'.join(STATUS_VERBOSITIES)}, default "
+               f"{STATUS_VERBOSITY_FULL}) decides whether the `# <field>: <value>` run-config block is "
+               f"printed above the grid; {STATUS_VERBOSITY_BRIEF} omits that block and nothing else — "
+               f"never a row, a marker, or the hidden-count line",
+    )
     t.add_argument("--fields", help=f"comma-separated row fields to show (default: {','.join(TABLE_DEFAULT_FIELDS)})")
     # The default hides rows; --all is how a reader gets the whole ledger back. The help text is derived
     # from TABLE_HIDDEN_STATUSES for the same reason the notice is: so it cannot drift from it. Here the

--- a/plugins/gauntlet/skills/ledger/SKILL.md
+++ b/plugins/gauntlet/skills/ledger/SKILL.md
@@ -24,8 +24,10 @@ Invocation: Claude Code `/gauntlet:ledger`; Codex `$gauntlet:ledger`.
    ```
 
 5. Append `"--all"` only when user asks for hidden, merged, aborted, closed, or all entries.
-6. Print script stdout as-is — every line, including the `#` lines above and below the grid. The default
-   view is a filtered one and those lines are what disclose the filtering. On failure, relay stderr as-is
-   and stop.
+6. Print script stdout as-is — every line the script printed, adding none and removing none. That
+   includes every `#` line. The `#` lines below the grid disclose that the view is filtered and are always
+   printed; the `# <field>: <value>` run-config block above it is printed only when the run's
+   `status_verbosity` setting selects it, so its absence is the tool's output, never something to restore.
+   On failure, relay stderr as-is and stop.
 
 Read-only. NEVER create, edit, parse, summarize, or reformat ledger data or table output.


### PR DESCRIPTION
- Header field `status_verbosity`: `full` (default) | `brief`; else refused, store unchanged
- `brief` drops only `table`'s run-config block; the grid below is byte-identical
- It never hides a row, the hidden-row disclosure, a park question, or a wait line
