### PR TITLE
clear ns_streak on a non-abort repair decision

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -341,8 +341,10 @@ Header field notes (the header fields above; per-row fields follow):
   `reviews_ok=0 attempts=0`. Note the asymmetry it closes: the **CI** path already carries three persisted
   counters with caps (`settled_strikes`, `unusable_refetches`, `ci_stalled_since`) and has never spiralled;
   the **review** path carried none.
-- `ns_streak` — consecutive NOT SATISFIED verdicts. Cleared **only** by a SATISFIED — never by a fix, a
-  rebase or a content change. Same owner, same absent flag, same reason.
+- `ns_streak` — consecutive NOT SATISFIED verdicts. Cleared by exactly **two** tool writes, and never by a
+  fix, a rebase or a content change: a **SATISFIED** verdict, and a **non-abort reassessment decision**
+  (`repair-pass.py decide`, which `repair-pass.md` owns). Same absent flag as `review_rounds`, same reason —
+  the second writer is a tool that must SPEND a repair to clear it, not a door a driver can type at.
 - `base_ok_sha` — the head a base-preflight **`proceed`** was last decided for: the **MECHANICAL** form of the
   rebase-before-review precondition. **`ledger.py verdict` refuses unless `base_ok_sha == head_sha`** — for a
   SATISFIED **or** a NOT SATISFIED, since a counted NOT SATISFIED spends `review_rounds`/`ns_streak` toward the

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -16,7 +16,8 @@ ledger.py --file <state.jsonl> verdict --pr <N> --head-sha <the live head> --ver
 - **`review_rounds`** — landed verdicts. **NEVER reset** — not by a fix, a rebase, or a content change.
   This is the loop's only memory. Reset it and every round looks like round 1 again, which is precisely how
   21 of them passed unnoticed.
-- **`ns_streak`** — consecutive `NOT SATISFIED`. Reset **only** by a `SATISFIED`.
+- **`ns_streak`** — consecutive `NOT SATISFIED`. Reset by a `SATISFIED`, and by a **non-abort decision
+  recorded here** ("A repair that changes the terms clears the streak", below). Nothing else.
 
 **Hand-setting `reviews_ok` for a verdict is FORBIDDEN** — it applies the tally and silently skips the
 counters, restoring the amnesia. **But a gate RESET is not a verdict**: a content change (a fix commit, a
@@ -234,6 +235,28 @@ row remain refused. A conflict or a diff-changing rebase remains outside this ex
 When the repair has landed, return the row to the gate (`ledger.py … set --pr <N> --status in_review`) and
 let the review gauntlet run again from the top. **`review_rounds` is not reset** — it never is. A PR that
 comes back to a cap has spent another repair.
+
+### A repair that changes the terms clears the streak
+
+**`repair-pass.py decide` sets `ns_streak = 0` on every NON-ABORT decision**, in the same write that spends
+the budget. Not the driver, not a flag — there is none — and not `abort`, which is terminal and has no next
+round to serve. A **legacy DEMOTE** never reaches it either: `decide` refuses a row that already carries a
+`repair_decision`, so a demote row returns to `in_review` with its streak untouched, through its own
+procedure above.
+
+**Why.** REPAIR-INTENT, RESCOPE and ROOT-CAUSE all change **what the reviewer measures against**. A streak
+earned under the old terms is evidence about terms that no longer exist — so counting it against the new
+ones is counting the wrong thing. Without this, **a repair that WORKS buys exactly one round**: PR #201 hit
+the cap over five rounds of one finding class, spent a REPAIR-INTENT that provably closed that class — the
+next round raised nothing from it and found four unrelated defects instead — and was then forced to abort,
+because the streak was still at the cap and one more `NOT SATISFIED` tripped it again. The mechanism that
+exists to rescue a stuck PR killed one it had just unstuck.
+
+**Why this cannot become the spiral it is meant to stop, which is the only reason it is safe.**
+`review_rounds` is **not** reset here and never is, so **`ROUND_CAP` still bounds the PR's entire life** no
+matter how many streaks are cleared. Total exposure is unchanged — `ROUND_CAP` rounds and `REPAIR_CAP`
+repairs — and clearing the streak only changes **which cap fires first** for a PR whose terms changed
+mid-loop. A repair that changes nothing still cannot buy more than `REPAIR_CAP` of them.
 
 ### Bound the repair itself — it must not become the new spiral
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -849,10 +849,12 @@ indistinguishable from an earned one, so the door is simply not there.
 (`set --reviews-ok 0` stays available and is still correct: **voiding** the tally on a PR-content change is
 not a verdict — no round happened — and the table below lists every site that owes it.)
 
-**`review_rounds` and `ns_streak` are the loop's only memory across fresh-context heartbeats, and neither is
-ever reset** — not by a fix, a rebase, a content change, or a re-triage. Both are written **and READ** by
-`verdict` itself; see `files-and-ledger.md` (the `review_rounds` / `ns_streak` field definitions) for what
-the counters mean and why the reader is fused into the door that cannot be skipped.
+**`review_rounds` and `ns_streak` are the loop's only memory across fresh-context heartbeats, and NOTHING a
+gate reset touches ever clears either** — not a fix, a rebase, a content change, or a re-triage.
+`review_rounds` is never reset by anything at all. `ns_streak` is cleared by a SATISFIED, and by a non-abort
+reassessment decision (`repair-pass.md` owns that second writer and why it is safe). Both are written **and
+READ** by `verdict` itself; see `files-and-ledger.md` (the `review_rounds` / `ns_streak` field definitions)
+for what the counters mean and why the reader is fused into the door that cannot be skipped.
 
 **At a review-loop cap, `verdict` sets `status = repairing` and EXITS NON-ZERO.** The PR has stopped
 converging: **do NOT dispatch a fix subagent and do NOT launch another review pass for it.** Run

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1307,7 +1307,7 @@ def t_verdict_counts_rounds(L: ModuleType, tmp: Path) -> None:
           f"the NS streak must ACCUMULATE: {row!r}")
     row = verdict("satisfied")
     check((row["review_rounds"], row["reviews_ok"], row["ns_streak"]) == ("3", "1", "0"),
-          f"a SATISFIED adds one to the tally and CLEARS the streak — and only a SATISFIED does: {row!r}")
+          f"a SATISFIED adds one to the tally and CLEARS the streak — the only verdict that does: {row!r}")
     row = verdict("not-satisfied")
     check((row["review_rounds"], row["reviews_ok"], row["ns_streak"]) == ("4", "0", "1"),
           f"a NOT SATISFIED VOIDS the tally — one pass saying the content is wrong is enough: {row!r}")
@@ -1322,7 +1322,13 @@ def t_review_rounds_never_reset(L: ModuleType, tmp: Path) -> None:
 
     Not a fix, not a rebase, not a content change, not a re-triage. The rule is enforced by the ABSENCE of
     a flag rather than by a promise: `set --review-rounds 0` and `add-row --review-rounds 0` are refused by
-    ARGPARSE, which does not know what the field means and cannot be talked round. `ns_streak` is the same.
+    ARGPARSE, which does not know what the field means and cannot be talked round.
+
+    `ns_streak` has the same absent door, and that is what this fixture pins for it — NOT "nothing clears
+    it". Two TOOL writes do: a SATISFIED verdict, and a non-abort `repair-pass.py decide`
+    (`repair-pass.md`, "A repair that changes the terms clears the streak", and the fixture there). Neither
+    is reachable by typing a flag, which is the property under test. `review_rounds` has no second writer
+    at all and must never grow one.
 
     A rule that says "never reset it" is an exhortation, and the loop it guards ran for eight hours under
     three of those. Removing the door is a mechanism.
@@ -1353,7 +1359,8 @@ def t_review_rounds_never_reset(L: ModuleType, tmp: Path) -> None:
     check(out == "2\n", f"a gate reset took `review_rounds` with it ({out!r}) — this is THE bug: the loop "
                         f"erases the evidence that it is looping, at the exact moment that evidence matters")
     code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "ns_streak"])
-    check(out == "2\n", f"a gate reset cleared `ns_streak` ({out!r}) — only a SATISFIED may")
+    check(out == "2\n", f"a gate reset cleared `ns_streak` ({out!r}) — a content change is not a verdict "
+                        f"and not a repair, and those two tool writes are the only things that may clear it")
 
 
 def t_set_cannot_raise_the_tally(L: ModuleType, tmp: Path) -> None:
@@ -3262,7 +3269,7 @@ CASES = [
     ("default-non-goals-broadening-guard", "a BROADENING default_non_goals change is refused while a non-terminal PR holds review credit; an add, or no active credit, is allowed", t_default_non_goals_broadening_guard),
     ("null-reads-as-default", "a present JSON null reads back as the field default, not the string \"None\"", t_null_reads_as_default),
     ("verdict-counts-rounds", "`verdict` bumps review_rounds on EVERY verdict and applies the tally atomically", t_verdict_counts_rounds),
-    ("rounds-never-reset", "NOTHING resets review_rounds/ns_streak — there is no flag, at any door", t_review_rounds_never_reset),
+    ("rounds-never-reset", "review_rounds/ns_streak have no flag at any door; a gate reset touches neither", t_review_rounds_never_reset),
     ("tally-floor-only", "`set` may VOID reviews_ok, NEVER raise it — only a verdict adds a verdict", t_set_cannot_raise_the_tally),
     ("escalation-reset-atomic", "the depth-raising reset writes deeper tier + voided tally in ONE atomic set", t_escalation_reset_is_one_atomic_write),
     ("deescalation-tier-only", "a de-escalation writes the tier ALONE and preserves the standing tally", t_deescalation_is_a_tier_only_write),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -222,7 +222,12 @@ ROW_FIELDS = (
     #
     # A heartbeat is a fresh agent instance. A counter that lives in the driver's head does not exist.
     "review_rounds",   # landed verdicts, ever, for this PR. MONOTONE — NEVER reset, by anything.
-    "ns_streak",       # consecutive NOT SATISFIED. Reset ONLY by a SATISFIED.
+    # Consecutive NOT SATISFIED. TWO writers clear it, and NEITHER is a `set` flag: a SATISFIED verdict
+    # (`cmd_verdict`), and a NON-ABORT reassessment decision (`repair-pass.py decide`). The second exists
+    # because a repair CHANGES WHAT THE REVIEWER MEASURES AGAINST, so a streak earned under the old terms
+    # says nothing about the new ones — without it a repair that works buys exactly one round before the
+    # cap fires again. `review_rounds` is reset by neither, so `ROUND_CAP` still bounds the whole life.
+    "ns_streak",
     # THE HEAD A BASE-PREFLIGHT `proceed` WAS LAST DECIDED FOR — the MECHANICAL form of the
     # rebase-before-review precondition (stage-2-review-gate.md, "Recording a verdict"). `base-preflight.py
     # check` writes it (through `base-ok`, the ONLY sanctioned writer) when — and only when — it decides
@@ -364,14 +369,20 @@ NO_SET_HEADER = {
         "never carry",
 }
 
-# The two fields `verdict` OWNS — and the ONLY reason they are not settable through `set`/`add-row` is
-# that a door which can write them is a door that can RESET them.
+# The two fields with NO `set`/`add-row` flag because a door which can write them is a door that can
+# RESET them. The name says `verdict` because that is the door the DRIVER goes through; it is the
+# exclusion from the hand-write doors, NOT a claim that `verdict` is the sole writer of both.
 #
 # `review_rounds` is the loop's only memory across fresh-context heartbeats, and its whole value is that it is
 # MONOTONE. A rule stating "never reset it" is an exhortation; REMOVING THE DOOR is a mechanism. So there
 # is no `--review-rounds` flag to type: `verdict` increments them, and nothing else writes them at all.
 # (`reviews_ok` is different — a content change legitimately voids the tally, so `set --reviews-ok 0`
 # must stay. What `set` may NOT do is RAISE it: see `check_tally`.)
+#
+# `ns_streak` is the one asymmetry, and it is deliberate: `repair-pass.py decide` ALSO clears it, on a
+# non-abort decision. That is a second TOOL door, not a hand-write door — the field's own comment above
+# owns why, and the exclusion here is exactly what stops a driver from clearing it without spending a
+# repair. `review_rounds` has no such second writer and must never grow one.
 VERDICT_OWNED = ("review_rounds", "ns_streak")
 
 # The repair's own fields, owned by `repair-pass.py` and settable through NO flag — the same mechanism as
@@ -1327,7 +1338,9 @@ def cmd_verdict(path: Path, args) -> int:
         tool to argue with;
       * applies the TALLY — `satisfied` adds one to `reviews_ok`; `not-satisfied` VOIDS it (the SHA's
         verdicts are worthless the moment one pass says the content is wrong);
-      * moves `ns_streak` — up on `not-satisfied`, back to 0 on a `satisfied` and on nothing else.
+      * moves `ns_streak` — up on `not-satisfied`, back to 0 on a `satisfied`. This door is not its only
+        writer: `repair-pass.py decide` also clears it on a non-abort reassessment decision, because a
+        repair changes the terms the streak was measuring. Nothing else writes it, and there is no flag.
 
     **The head SHA is checked against the row, and a mismatch is REFUSED.** A verdict describes the
     content the pass RAN on. If the tip has moved since, that verdict describes content that is no longer

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -1148,7 +1148,9 @@ def settable(name: str) -> bool:
 
     `pr` is the row key (passed via --pr) and `id` is derived from it. `VERDICT_OWNED` is the new
     exclusion, and it is the mechanism behind "`review_rounds` is NEVER reset": a door that can write a
-    counter is a door that can zero it, so those two fields simply have NO flag. `verdict` writes them.
+    counter is a door that can zero it, so those two fields simply have NO flag. `verdict` is the only
+    writer of `review_rounds`; `ns_streak` has a second TOOL writer and still no flag at either door (the
+    `VERDICT_OWNED` comment owns that asymmetry).
     `REPAIR_OWNED` is the same mechanism for the repair's bound: a driver that could zero `repair_count`
     could repair forever, so only `repair-pass.py decide` writes what a PR has spent. `PREFLIGHT_OWNED` is
     the same mechanism for the base-currency precondition: a door that can hand-write `base_ok_sha` could
@@ -1326,8 +1328,9 @@ def cmd_set(path: Path, args) -> int:
 
 
 def cmd_verdict(path: Path, args) -> int:
-    """Record ONE landed review verdict — the ONLY sanctioned way, and the only door that writes the
-    counters (stage-2-review-gate.md, "Recording a verdict").
+    """Record ONE landed review verdict — the ONLY sanctioned way, and the only door that writes
+    `review_rounds` (stage-2-review-gate.md, "Recording a verdict"). It is NOT the only writer of
+    `ns_streak`; the bullet for that field below names the other one.
 
     It does THREE things in one atomic write, and the whole point is that they cannot be done separately:
 
@@ -1938,7 +1941,9 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--pr", required=True, help="PR number (row key)")
     add_row_field_opts(s, creating=False)  # set may NOT write CREATE_ONLY fields — no --base-branch flag
 
-    # The ONE door that records a review verdict — and the only writer of `review_rounds`/`ns_streak`.
+    # The ONE door that records a review verdict — and the only writer of `review_rounds`. It also moves
+    # `ns_streak`, which has a second tool writer (`repair-pass.md`, "A repair that changes the terms
+    # clears the streak").
     v = sub.add_parser("verdict", help="record ONE landed review verdict: bumps review_rounds, applies "
                                        "the tally, moves ns_streak — atomically. NEVER set reviews_ok by hand")
     v.add_argument("--pr", required=True, help="PR number (row key)")

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -254,6 +254,42 @@ def t_unknown_origin_is_treated_as_external(tmp: Path) -> None:
     check("did not open this PR" in err, f"refused for the wrong reason: {err!r}")
 
 
+# --- a repair that changes the terms clears the streak ------------------------
+
+def t_a_non_abort_repair_clears_the_streak(tmp: Path) -> None:
+    """Every NON-ABORT decision zeroes `ns_streak`; ABORT does not; `review_rounds` survives all of them.
+
+    A repair changes WHAT THE REVIEWER MEASURES AGAINST, so the streak earned under the old terms is
+    evidence about terms that no longer exist. Without this a repair that WORKS buys exactly one round:
+    PR #201 hit the cap, spent a REPAIR-INTENT that provably closed the failing class, and was forced to
+    abort anyway because the streak was still sitting at the cap when the next round failed on something
+    else entirely.
+
+    `review_rounds` is checked in the SAME fixture, not a separate one, because it is the reason this is
+    safe rather than a second spiral: ROUND_CAP still bounds the PR's whole life however many streaks are
+    cleared. If a future change ever resets it here, this fixture is what says so.
+    """
+    for decision in R.DECISIONS:
+        path, record = setup(tmp, f"streak-{decision}.jsonl", pr_origin="gauntlet",
+                             ns_streak=str(L.NS_STREAK_CAP), decision=decision)
+        before = field(path, "review_rounds")
+        code, _, err = decide(path, record, decision)
+        check(code == 0, f"[{decision}] a permitted decision was refused: {err!r}")
+
+        want = str(L.NS_STREAK_CAP) if decision == "abort" else "0"
+        got = field(path, "ns_streak")
+        check(got == want,
+              f"[{decision}] ns_streak is {got!r}, want {want!r} — "
+              + ("ABORT is terminal, so there is no next round for a reset to serve"
+                 if decision == "abort" else
+                 "a repair that changes the terms must not leave the PR one NOT SATISFIED from a cap it "
+                 "already escaped"))
+
+        check(field(path, "review_rounds") == before,
+              f"[{decision}] review_rounds moved from {before!r} — it is NEVER reset, and it is the only "
+              f"reason clearing the streak cannot become an unbounded loop")
+
+
 # --- the repair's own bound ---------------------------------------------------
 
 def t_repair_budget_is_spent(tmp: Path) -> None:
@@ -1636,6 +1672,7 @@ CASES = [
     ("external-not-rewritten", "an external PR refuses RESCOPE and ROOT-CAUSE, and takes the other two", t_external_pr_is_never_rewritten),
     ("gauntlet-takes-all", "a campaign-authored PR may take every decision", t_gauntlet_pr_takes_every_repair),
     ("unknown-is-external", "an unset origin is EXTERNAL — the fail-safe direction", t_unknown_origin_is_treated_as_external),
+    ("repair-clears-streak", "a non-abort decision zeroes ns_streak; abort does not; review_rounds never moves", t_a_non_abort_repair_clears_the_streak),
     ("budget-spent", "at REPAIR_CAP the only decision left is abort", t_repair_budget_is_spent),
     ("abort-leaves-it-open", "abort is terminal, leaves the PR OPEN, and reuses the existing procedure", t_abort_is_terminal_and_leaves_the_pr_open),
     ("only-a-capped-pr", "a PR that never hit a cap cannot be reassessed", t_only_a_capped_pr_may_be_reassessed),

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -1116,6 +1116,28 @@ def cmd_decide(path: Path, args) -> int:
         # Terminal. The driver still runs the abort PROCEDURE (leave the PR OPEN, drop this run's labels,
         # write abort-<id>.md) — `bailout-and-final-report.md` owns it, and this does not replace it.
         row["status"] = "aborted"
+    else:
+        # A NON-ABORT REPAIR CHANGES WHAT THE REVIEWER MEASURES AGAINST, so the streak it accumulated
+        # under the OLD terms is no longer evidence about the NEW ones. Zero it here, at the same write
+        # that spends the budget.
+        #
+        # Without this, a repair that WORKS buys exactly ONE round. That is not hypothetical: PR #201 took
+        # `ns_streak` to the cap over five rounds of one finding class, spent repair 1 on a REPAIR-INTENT
+        # that provably closed that class — the next round raised nothing from it and found four unrelated
+        # defects instead — and was then forced to abort, because the streak was still sitting at the cap
+        # and one more NOT SATISFIED tripped it again. The mechanism meant to rescue a stuck PR killed a
+        # PR it had just unstuck.
+        #
+        # ABORT is excluded because it is terminal: the row leaves the gate, so there is no next round for
+        # a reset to serve. A legacy DEMOTE never reaches this branch — `decide` refuses a row that already
+        # carries a `repair_decision`, so a demote row returns to `in_review` through its own procedure with
+        # its streak untouched (`repair-pass.md`, "Complete a legacy DEMOTE").
+        #
+        # WHY THIS CANNOT BECOME A LOOP, which is the only reason it is safe: `review_rounds` is NOT reset
+        # here and never is, so `ROUND_CAP` still bounds the PR's whole life no matter how many streaks are
+        # cleared. Total exposure stays what it always was — `ROUND_CAP` rounds and `REPAIR_CAP` repairs —
+        # and this only changes WHICH cap fires first for a PR whose terms changed mid-loop.
+        row["ns_streak"] = "0"
     L.dump(path, header, rows)
     print(json.dumps({f: row[f] for f in L.ROW_FIELDS}))
 


### PR DESCRIPTION
- `repair-pass.py decide` zeroes `ns_streak` on every non-abort decision
- `review_rounds` untouched, so `ROUND_CAP` still bounds total exposure
- swept every "cleared only by a SATISFIED" restatement, docs and tests
