### PR TITLE
share one sibling-module loader helper

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
@@ -26,3 +26,23 @@ def load_module_from_path(module_name: str, path: Path, *, register: bool = Fals
         sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def load_sibling(module_name: str, directory: Path, filename: str, *, register: bool = False) -> ModuleType:
+    """Load ``directory / filename`` as ``module_name``, raising instead of returning ``None``.
+
+    This is the non-optional door onto ``load_module_from_path`` for the campaign tools that load a sibling
+    script by its own directory. It changes exactly one thing: an absent spec or loader — a BROKEN INSTALL,
+    never an input error — becomes ``RuntimeError(f"cannot load {filename}")`` so the caller's binding is a
+    real module at every use. Everything else is the underlying loader's, unchanged and NEVER restated here:
+    ``register`` still decides ``sys.modules`` placement (default off, so repeated loads of one file under
+    different names leave no entries behind), and exceptions raised while executing the module still pass
+    through untouched — a failed module is the module's own error, not a load failure.
+
+    Callers whose install error is not that exact ``RuntimeError`` — a different message, a ``SystemExit``,
+    a printed diagnostic — keep calling ``load_module_from_path`` and own their own ``None`` handling.
+    """
+    module = load_module_from_path(module_name, directory / filename, register=register)
+    if module is None:
+        raise RuntimeError(f"cannot load {filename}")
+    return module

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
@@ -40,26 +40,19 @@ import sys
 from pathlib import Path
 from typing import Callable, NoReturn
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "label-mirror-test.py"     # the fixture suite — this tool's executable contract
 
 
-def _load(name: str, filename: str):
-    mod = load_module_from_path(name, _HERE / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load {filename}")
-    return mod
-
-
 # The schema owner. `load` and `COUNT_RE` are imported, never restated — the ledger format has one parser,
 # and the count format ("a decimal from 0 up") has one definition.
-L = _load("label_mirror_ledger", "ledger.py")
+L = load_sibling("label_mirror_ledger", _HERE, "ledger.py")
 
 # `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped, exactly as `merge-check.py` does. The
 # rule already lives in `nudge.py`; a copy here would be the drift this repo keeps killing.
-_N = _load("label_mirror_nudge", "nudge.py")
+_N = load_sibling("label_mirror_nudge", _HERE, "nudge.py")
 REQUIRED = _N.required
 
 # --- the two labels, and NOTHING ELSE is ever added or removed ------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -43,35 +43,28 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "merge-check-test.py"     # the fixture suite — this tool's executable contract
-
-
-def _load(name: str, filename: str):
-    mod = load_module_from_path(name, _HERE / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load {filename}")
-    return mod
 
 
 # The schema owner. `HELD_STATUSES` and `load` are imported, never restated — the file format has exactly
 # one parser, and the held set is imported only to make the parked-vs-terminal reason accurate. The merge
 # gate itself does NOT enumerate held statuses: `decide` ALLOW-LISTS `in_review` (below), so a new held
 # status — or any other non-`in_review` status — is frozen by that allow-list with no edit here.
-L = _load("merge_check_ledger", "ledger.py")
+L = load_sibling("merge_check_ledger", _HERE, "ledger.py")
 HELD_STATUSES = L.HELD_STATUSES
-B = _load("merge_check_base_preflight", "base-preflight.py")
+B = load_sibling("merge_check_base_preflight", _HERE, "base-preflight.py")
 # pr-adopt.py OWNS `BASE_CHANGE_PARK_REASON` — the EXACT machine-blocker wording a re-adoption / reconcile /
 # preflight park records. Both merge doors reuse that one owner so a live-base retarget reads identically
 # everywhere; never a second copy of the string here.
-PA = _load("merge_check_pr_adopt", "pr-adopt.py")
+PA = load_sibling("merge_check_pr_adopt", _HERE, "pr-adopt.py")
 
 # `required(tier)` — 1 if TRIVIAL else 2 — is REUSED, never retyped. The rule already lives in `nudge.py`
 # (and `review-pass.py`); a third copy here would be the drift this repo keeps killing. So merge-check
 # borrows the existing helper rather than spelling `1 if TRIVIAL else 2` a third time.
-_N = _load("merge_check_nudge", "nudge.py")
+_N = load_sibling("merge_check_nudge", _HERE, "nudge.py")
 REQUIRED = _N.required
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -36,21 +36,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 HERE = Path(__file__).resolve().parent
 SIBLING = HERE / "merge-test.py"
 
 
-def _load(name: str, filename: str):
-    mod = load_module_from_path(name, HERE / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load {filename}")
-    return mod
-
-
-L = _load("merge_runner_ledger", "ledger.py")
-MC = _load("merge_runner_check", "merge-check.py")
+L = load_sibling("merge_runner_ledger", HERE, "ledger.py")
+MC = load_sibling("merge_runner_check", HERE, "merge-check.py")
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}\Z")
 COUNT_RE = re.compile(r"^(?:0|[1-9][0-9]*)\Z")

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -25,7 +25,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 DESCRIPTION = "Print per-heartbeat reminders for the campaign orchestrator (sticky notes, not a supervisor)."
 
@@ -33,15 +33,8 @@ _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "nudge-test.py"
 
 
-def _load(name: str, filename: str):
-    mod = load_module_from_path(name, _HERE / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load {filename}")
-    return mod
-
-
-L = _load("nudge_ledger", "ledger.py")
-F = _load("nudge_followups", "followups.py")
+L = load_sibling("nudge_ledger", _HERE, "ledger.py")
+F = load_sibling("nudge_followups", _HERE, "followups.py")
 
 # A held PR is FROZEN — it fires ONLY its held reminder, never review/CI/merge nudges. The enumeration
 # lives in ledger.py; never retype it (a new held status inherits the freeze with no edit here).

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -45,7 +45,7 @@ import sys
 from pathlib import Path
 
 from _gauntlet.atomic import replace_text
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
 
@@ -75,17 +75,10 @@ GAUNTLET_AUTHORED_LABEL = "gauntlet-authored"
 BASE_CHANGE_PARK_REASON = "base changed from {recorded} to {live}; not supported mid-run"
 
 
-def _load(name: str, filename: str):
-    mod = load_module_from_path(name, _HERE / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load {filename}")
-    return mod
-
-
-L = _load("pr_adopt_ledger", "ledger.py")
+L = load_sibling("pr_adopt_ledger", _HERE, "ledger.py")
 # `required(tier)` — the review gate's SATISFIED-verdict floor — is OWNED by review-pass.py
 # (`required_reviews`); the status label mirrors that gate, so reuse the owner rather than retype the rule.
-RP = _load("pr_adopt_review_pass", "review-pass.py")
+RP = load_sibling("pr_adopt_review_pass", _HERE, "review-pass.py")
 
 # THE LIVENESS COUNTERS — RE-EXPORTED from ledger.py, never a second copy of the list. A re-adoption at a
 # moved head no longer hand-resets them: the ledger `set --head-sha` door does it (ledger.py's

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -50,22 +50,15 @@ import tempfile
 from pathlib import Path
 from typing import Callable
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "reconcile-test.py"       # the fixture suite — this tool's executable contract
 
 
-def _load(name: str, filename: str):
-    mod = load_module_from_path(name, _HERE / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load {filename}")
-    return mod
-
-
 # The schema owner. `load` (its parser, corruption checks and field normalization) is REUSED, never
 # restated — the ledger has exactly one reader, and reconcile is one of its consumers.
-L = _load("reconcile_ledger", "ledger.py")
+L = load_sibling("reconcile_ledger", _HERE, "ledger.py")
 
 # This module is the executable owner of the snapshot query and validation contract. Prose points to the
 # `fetch` command instead of restating its argv.

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import capture_cli
 
 OWNER = Path(__file__).resolve().parent / "repair-pass.py"
@@ -1668,6 +1668,51 @@ def t_shared_module_loader_preserves_importlib_semantics(tmp: Path) -> None:
           "a path with no executable module spec was accepted")
 
 
+def t_load_sibling_raises_and_keeps_the_loader_semantics(tmp: Path) -> None:
+    """`load_sibling` resolves against the given directory, raises the campaign tools' exact install error,
+    and forwards registration and execution exceptions to `load_module_from_path` untouched.
+
+    Every campaign tool that loads a sibling by its own directory calls this instead of keeping a private
+    copy of the guard, so these properties ARE its loading contract. The set of such callers is whatever
+    `load_sibling` is imported by — never restated here, so it cannot go stale."""
+    plain_name = "gauntlet_sibling_plain"
+    (tmp / "plain-sibling.py").write_text("VALUE = 7\n")
+    sys.modules.pop(plain_name, None)
+    plain = load_sibling(plain_name, tmp, "plain-sibling.py")
+    check(plain.VALUE == 7, "the filename was not resolved against the given directory")
+    check(plain_name not in sys.modules, "the default registration is no longer off")
+
+    registered_name = "gauntlet_sibling_registered"
+    (tmp / "registered-sibling.py").write_text(
+        "import sys\nSEES_SELF = sys.modules.get(__name__) is not None\n")
+    sys.modules.pop(registered_name, None)
+    try:
+        registered = load_sibling(registered_name, tmp, "registered-sibling.py", register=True)
+        check(registered.SEES_SELF, "register=True did not reach the loader before execution")
+        check(sys.modules.get(registered_name) is registered, "register=True stored a different module")
+    finally:
+        sys.modules.pop(registered_name, None)
+
+    broken_name = "gauntlet_sibling_broken"
+    (tmp / "broken-sibling.py").write_text("raise RuntimeError('sibling execution failed')\n")
+    sys.modules.pop(broken_name, None)
+    try:
+        load_sibling(broken_name, tmp, "broken-sibling.py")
+    except RuntimeError as exc:
+        check(str(exc) == "sibling execution failed", f"the execution exception changed: {exc!r}")
+    else:
+        check(False, "an exception from module execution was swallowed")
+
+    # The public install error, verbatim: the BARE filename, never the joined path. A caller that wants a
+    # different message, a SystemExit or a printed diagnostic keeps its own `load_module_from_path` guard.
+    try:
+        load_sibling("gauntlet_sibling_no_spec", tmp, "no-extension")
+    except RuntimeError as exc:
+        check(str(exc) == "cannot load no-extension", f"the install error changed: {exc!r}")
+    else:
+        check(False, "a path with no executable module spec was accepted")
+
+
 CASES = [
     ("external-not-rewritten", "an external PR refuses RESCOPE and ROOT-CAUSE, and takes the other two", t_external_pr_is_never_rewritten),
     ("gauntlet-takes-all", "a campaign-authored PR may take every decision", t_gauntlet_pr_takes_every_repair),
@@ -1704,4 +1749,5 @@ CASES = [
     ("bundle-atomic", "Git and atomic-write failures leave no partial bundle", t_bundle_git_and_atomic_failures_leave_no_output),
     ("decision-bundle-bound", "decide accepts only a record bound to the matching prepared bundle", t_decide_is_bound_to_prepared_bundle),
     ("shared-module-loader", "path loading preserves registration and exception behavior", t_shared_module_loader_preserves_importlib_semantics),
+    ("sibling-loader-door", "load_sibling resolves by directory, raises the bare-filename install error, and forwards loader semantics", t_load_sibling_raises_and_keeps_the_loader_semantics),
 ]


### PR DESCRIPTION
- Six tools each had a byte-identical `_load` guard; all now call `load_sibling`.
- Same error, same default-off registration, same exception pass-through.
- New `sibling-loader-door` fixture; five helper mutations each turn it red.
