### PR TITLE
share one self-test fixture runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/run-id-test.py
             plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/marked_stub.pyi
             plugins/gauntlet/skills/campaign/scripts/script-table-test.py
+            plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py
             plugins/gauntlet/skills/campaign/scripts/base-preflight.py
             plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
             plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
@@ -447,3 +448,12 @@ jobs:
       # nothing at all (the section anchor or the directory moved) each fail the build.
       - name: Script-table contract (SKILL.md inventory matches scripts/)
         run: python3 plugins/gauntlet/skills/campaign/scripts/script-table-test.py
+
+      # Most `self-test` steps above now get their exit code from ONE shared runner
+      # (`_gauntlet/testing.py`). That concentration is the point of it — and the hazard: a runner that
+      # swallowed a failing fixture, miscounted, or returned 0 over an empty case table would turn every
+      # one of those steps green at once, and every one of them would still LOOK green, so their output
+      # cannot be the evidence. This step is the evidence. It drives the runner into every way of not
+      # passing that the runner guards, and fails if any of those came back zero or unreported.
+      - name: Shared fixture runner refuses every way of not passing
+        run: python3 plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -304,6 +304,7 @@ a line the tool writes.
 | `nudge.py` | Advisory reminder printer for heartbeat start; always exits 0 | its own module docstring |
 | `transport-contract-test.py` | Standalone suite the plugin validator runs directly to pin the typed review/adoption boundary; owns no run state | `references/runtime-adapter.md` |
 | `script-table-test.py` | Standalone suite CI runs directly to prove this table and `scripts/` agree; owns no run state | this section |
+| `self-test-runner-test.py` | Standalone suite CI runs directly to prove the shared fixture runner most `self-test` subcommands exit through refuses every way of not passing that it guards; owns no run state | `scripts/_gauntlet/testing.py` |
 
 Each schema-owning accessor that carries a sibling suite keeps its fixtures in a **sibling
 `*-test.py`** — the accessor's own filename with `-test` appended, in the same directory; its
@@ -311,9 +312,18 @@ Each schema-owning accessor that carries a sibling suite keeps its fixtures in a
 and it is deliberately **not** an enumeration: a list of the suites that exist today is a restatement,
 and it goes stale the next time one is added — by an author who never reads this line. Not every script
 follows it, so do not assume a sibling for one you have not checked: `ci-snapshot.py` has a `self-test`
-whose fixtures are in-file plus golden files under `scripts/fixtures/`, not a sibling module; and the
-standalone suites above (`transport-contract-test.py`, `script-table-test.py`) are run directly, with
-no accessor `self-test` subcommand.
+whose fixtures are in-file plus golden files under `scripts/fixtures/`, not a sibling module; and every
+row above whose Job opens with **Standalone suite** is run directly, with no accessor `self-test`
+subcommand — read them off the table, which `script-table-test.py` keeps complete, rather than from a
+second copy of the list here.
+
+Where an accessor's `self-test` follows the sibling rule it USUALLY routes through one shared
+implementation — `run_sibling_suite` in `scripts/_gauntlet/testing.py` — so the loud-on-missing load, the
+empty-case-table refusal, the loop and the verdict have ONE owner rather than N hand-copies that drift
+apart. The accessor still supplies what is its own: its fixture file, the failure type its fixtures
+raise, the name-column width, and the name of the contract they pin. This is **not universal** — a suite
+whose cases are shaped differently keeps its own loop — so read the accessor's `self_test` to see which
+it is; never assume either way.
 
 ## Worker Dispatch — logical model class
 

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -3,9 +3,17 @@
 
 from __future__ import annotations
 
-from contextlib import redirect_stderr, redirect_stdout
+import inspect
+import tempfile
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
-from typing import Callable
+from pathlib import Path
+from typing import Callable, Generator, Sequence
+
+from _gauntlet.modules import load_module_from_path
+
+# One fixture row: a short name, the rule it pins, and the callable that proves it.
+Case = tuple[str, str, Callable[..., object]]
 
 
 def capture_cli(main: "Callable[[list[str]], int]", argv: "list[str]") -> "tuple[int, str, str]":
@@ -21,3 +29,187 @@ def capture_cli(main: "Callable[[list[str]], int]", argv: "list[str]") -> "tuple
     except SystemExit as exc:
         code = exc.code if isinstance(exc.code, int) else 1
     return code, out.getvalue(), err.getvalue()
+
+
+# --- the shared fixture runner ------------------------------------------------
+#
+# A `self-test` subcommand is an EXIT CODE that CI and the review gate both trust, so the one thing this
+# runner must never do is return 0 over a suite that proved nothing. It returns 1 for a missing fixture
+# file, a fixture file that will not load, an absent or empty `CASES`, a fixture that raises the suite's
+# own failure type, a fixture that raises anything else, a fixture that EXITS the interpreter instead of
+# raising, and a fixture whose body cannot run because of how it was declared. Every one of those already
+# failed in at least one of the hand-copied loops this replaces — the runner adds no guarantee that was
+# not already being made somewhere in this directory.
+#
+# `self-test-runner-test.py` is that claim EXECUTED. A runner is exactly the kind of code whose bugs are
+# invisible in a green run: one that swallowed a failing fixture, miscounted, or returned 0 over an empty
+# case table would turn every suite in this directory green at once, and every one of them would still
+# LOOK green, so their output cannot be the evidence.
+#
+# `KeyboardInterrupt` is deliberately not caught. It is not a fixture's verdict, it is the operator's:
+# Ctrl-C must ABORT the run, not be filed as one failed check while the remaining fixtures carry on. That
+# is why the catches below name `SystemExit` and `Exception`, never `BaseException`.
+#
+# What stays the CALLER's, because each tool names its own contract: the SUBJECT ("the lease's contract"),
+# the failure type its fixtures raise, the name-column width, and whether each fixture is handed a fresh
+# working directory. What is now shared: the load, the guards, the loop, the per-case reporting, and the
+# verdict.
+
+_MISSING = ("the fixture file {path} IS MISSING — this suite has no fixtures to run and CANNOT report "
+            "health. Every rule this file enforces is now unpinned.")
+_UNLOADABLE = "{path} exists but cannot be loaded as a module"
+_NO_CASES = ("{path} exports no CASES — every rule in this file is unpinned while the suite still "
+             "exits 0")
+_EMPTY = ("the suite holds NO fixtures — a self-test with no subject passes every time, so an empty case "
+          "table is a FAILURE, never an all-clear")
+_NEVER_RAN = ("the fixture is {kind}, so CALLING it only builds an object and runs no body at all — this "
+              "check proved NOTHING while reporting a pass. A fixture must do its work when it is "
+              "called: never `yield` from it, never declare it `async`.")
+_EXITED = ("raised SystemExit({code!r}) — a fixture must RAISE to fail, never exit the interpreter: "
+           "unhandled, this would have ended the suite here, skipping every fixture after it")
+
+_SIBLING_NAME = "sibling-fixtures"
+
+
+@contextmanager
+def _work_root(per_case_dir: bool) -> "Generator[Path | None, None, None]":
+    """A temporary root for per-fixture working directories, or ``None`` when fixtures take no argument."""
+    if not per_case_dir:
+        yield None
+        return
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+def _sole_failure(name: str, rule: str, detail: str, *, subject: str, width: int) -> int:
+    """Report ONE failed check that stands for the whole suite, and return 1."""
+    print(f"FAIL     {name:{width}} -> {rule}\n         {detail}")
+    print(f"\n1 check(s) FAILED — {subject} is broken.")
+    return 1
+
+
+def _never_ran(fn: "Callable[..., object]") -> "str | None":
+    """Why calling ``fn`` would run no body at all, or ``None`` when it is an ordinary function.
+
+    Three DECLARATIONS make a call build an object instead of executing the body: a generator function
+    (its body contains ``yield``), a coroutine function (it is ``async def``) and an async generator
+    (both at once). A fixture written any of those ways passes every time while proving nothing — an
+    un-awaited coroutine surfaces only as a ``RuntimeWarning`` that no exit code reflects.
+
+    This classifies the FUNCTION, never what a call returned, and that distinction is the whole point.
+    A fixture that runs to completion and then returns a generator — ``return (row for row in rows)`` —
+    is an ordinary fixture that PASSED; judging it by its return value fails it with a message asserting
+    its body never executed, which is a false failure stating a false reason. ``inspect`` reads the code
+    object's own flags, so it cannot make that mistake. Do not "simplify" this to a test on the result.
+    """
+    if inspect.isasyncgenfunction(fn):
+        return _NEVER_RAN.format(kind="an async generator function (`async def` with `yield`)")
+    if inspect.iscoroutinefunction(fn):
+        return _NEVER_RAN.format(kind="a coroutine function (`async def`)")
+    if inspect.isgeneratorfunction(fn):
+        return _NEVER_RAN.format(kind="a generator function (its body contains `yield`)")
+    return None
+
+
+def run_cases(
+    cases: "Sequence[Case]",
+    *,
+    failure: "type[BaseException]",
+    subject: str,
+    width: int = 30,
+    per_case_dir: bool = False,
+) -> int:
+    """Run every ``(name, rule, fn)`` row; return 0 iff all of them passed AND there was at least one.
+
+    ``failure`` is the suite's own assertion type: it is reported as the fixture's own message, while
+    anything else is reported with its type name, because a fixture that CRASHES has not passed either
+    way. ``SystemExit`` is caught with the rest and named specifically: a fixture that exits the
+    interpreter would otherwise end the suite mid-list, and ``SystemExit(0)`` would end it GREEN.
+
+    ``subject`` names the contract in the verdict line. ``per_case_dir`` hands each fixture a fresh empty
+    directory under one temporary root, numbered and named for the fixture so two rows sharing a name
+    still get their own.
+    """
+    rows = list(cases)
+    if not rows:
+        return _sole_failure("empty-case-table", "a suite must hold at least one fixture", _EMPTY,
+                             subject=subject, width=width)
+    failures = 0
+    with _work_root(per_case_dir) as root:
+        for index, (name, rule, fn) in enumerate(rows):
+            never_ran = _never_ran(fn)
+            if never_ran is not None:
+                print(f"FAIL     {name:{width}} -> {rule}\n         {never_ran}")
+                failures += 1
+                continue
+            try:
+                if root is None:
+                    fn()
+                else:
+                    work = root / f"{index:02d}-{name}"
+                    work.mkdir(parents=True)
+                    fn(work)
+            except failure as exc:
+                print(f"FAIL     {name:{width}} -> {rule}\n         {exc}")
+                failures += 1
+            except SystemExit as exc:  # a BaseException: it would otherwise take the whole suite with it
+                print(f"FAIL     {name:{width}} -> {rule}\n         {_EXITED.format(code=exc.code)}")
+                failures += 1
+            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
+                print(f"FAIL     {name:{width}} -> {rule}\n         raised {type(exc).__name__}: {exc}")
+                failures += 1
+            else:
+                print(f"ok       {name:{width}} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — {subject} is broken.")
+        return 1
+    print(f"all {len(rows)} fixtures hold — {subject} is intact.")
+    return 0
+
+
+def run_sibling_suite(
+    sibling: Path,
+    module_name: str,
+    *,
+    failure: "type[BaseException]",
+    subject: str,
+    width: int = 30,
+    per_case_dir: bool = False,
+) -> int:
+    """Load ``sibling``'s ``CASES`` and run them. Return 0 iff every rule the caller claims actually holds.
+
+    A missing file, one that will not load, and an absent or empty ``CASES`` are each reported as ONE
+    failed check and return 1 — a self-test that reports success because it found nothing to check
+    certifies a contract that nothing checked.
+
+    An exception raised while EXECUTING the fixture file propagates untouched, exactly as every
+    hand-rolled loader here did: a fixture module that cannot even import is a broken install, and its
+    own traceback says more than any message this could print.
+    """
+    rule = f"the fixtures in {sibling.name} must be RUNNABLE"
+    if not sibling.exists():
+        return _sole_failure(_SIBLING_NAME, rule, _MISSING.format(path=sibling),
+                             subject=subject, width=width)
+    module = load_module_from_path(module_name, sibling, register=True)
+    if module is None:
+        return _sole_failure(_SIBLING_NAME, rule, _UNLOADABLE.format(path=sibling),
+                             subject=subject, width=width)
+    cases = getattr(module, "CASES", None)
+    if not cases:
+        return _sole_failure(_SIBLING_NAME, rule, _NO_CASES.format(path=sibling),
+                             subject=subject, width=width)
+    return run_cases(cases, failure=failure, subject=subject, width=width, per_case_dir=per_case_dir)
+
+
+def checker(failure: "type[BaseException]") -> "Callable[[bool, str], None]":
+    """A ``check(cond, msg)`` that raises ``failure(msg)`` when ``cond`` is false.
+
+    Every sibling suite in this directory needs exactly this, bound to the failure type its own accessor
+    exports, and each one used to declare its own copy. The runner reports ``failure`` as the fixture's
+    own message, so binding the two together here is what keeps a fixture's stated reason intact.
+    """
+    def check(cond: bool, msg: str) -> None:
+        if not cond:
+            raise failure(msg)
+    return check

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -18,20 +18,13 @@ import sys
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "base-preflight.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("base_preflight_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the base-currency decider at {OWNER}")
-    return mod
-
-
-M = _load_owner()
+M = load_sibling("base_preflight_owner", OWNER.parent, OWNER.name)
 
 
 def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN", baseRefName="main") -> dict:
@@ -40,9 +33,7 @@ def view(*, mergeable="MERGEABLE", mergeStateStatus="CLEAN", baseRefName="main")
     return {"mergeable": mergeable, "mergeStateStatus": mergeStateStatus, "baseRefName": baseRefName}
 
 
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 def expect(v: dict, verdict: str, reason: "str | None" = None) -> None:

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "base-preflight-test.py"     # the fixture suite — this tool's executable contract
@@ -383,47 +384,10 @@ class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
-            f"health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("base_preflight_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the base-preflight decider's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the base-preflight decider's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the base-preflight decider's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "base_preflight_test", failure=SelfTestFailure,
+                             subject="the base-preflight decider's contract")
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/carryover.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover.py
@@ -33,6 +33,7 @@ from typing import Callable
 
 from _gauntlet.atomic import replace_text
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = "Distill a run's terminal ledger into .gauntlet/history/<run-id>.md — exactly once."
 
@@ -295,46 +296,10 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def sibling_cases() -> list:
-    if not TEST_PY.exists():
-        raise SelfTestFailure(f"the fixture file {TEST_PY} IS MISSING — this suite has no fixtures to run "
-                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("carryover_test", TEST_PY, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{TEST_PY} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{TEST_PY} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {TEST_PY.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the carryover distiller's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the carryover distiller's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the carryover distiller's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(TEST_PY, "carryover_test", failure=SelfTestFailure,
+                             subject="the carryover distiller's contract")
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -26,26 +26,17 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "clean-rebase.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("clean_rebase_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the clean-rebase tool at {OWNER}")
-    return mod
-
-
-M = _load_owner()
+M = load_sibling("clean_rebase_owner", OWNER.parent, OWNER.name)
 L = M.L  # the ledger module the tool loaded
 
 
-def check(cond, msg) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 # --- git / ledger helpers -----------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
 
@@ -383,47 +384,10 @@ class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
-            f"health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("clean_rebase_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the clean-rebase tool's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the clean-rebase tool's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the clean-rebase tool's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "clean_rebase_test", failure=SelfTestFailure,
+                             subject="the clean-rebase tool's contract")
 
 
 # --- CLI ----------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py
@@ -9,27 +9,18 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 
 HERE = Path(__file__).resolve().parent
 OWNER = HERE / "finding-audit.py"
 
 
-def _load_owner():
-    module = load_module_from_path("finding_audit_owner_for_test", OWNER)
-    if module is None:
-        raise RuntimeError(f"cannot load {OWNER}")
-    return module
+A = load_sibling("finding_audit_owner_for_test", OWNER.parent, OWNER.name)
 
 
-A = _load_owner()
-
-
-def check(condition: bool, message: str) -> None:
-    if not condition:
-        raise AssertionError(message)
+check = checker(AssertionError)
 
 
 PURPOSE = "Keep the campaign fix scope bound to audited gating findings."

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -21,13 +21,12 @@ import json
 import os
 import re
 import sys
-import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import ledger  # noqa: E402
 from _gauntlet.table import escape_cell, hidden_notice  # noqa: E402
-from _gauntlet.testing import capture_cli  # noqa: E402
+from _gauntlet.testing import capture_cli, run_cases  # noqa: E402
 
 # The ledger's test ORACLE — `grid`, `notices`, `check`, `SelfTestFailure`, and the hostile corpus — lives
 # in the ledger's SIBLING suite, `ledger-test.py`, loaded BY PATH (its name is not a legal module name).
@@ -1472,45 +1471,9 @@ CASES = [
 
 
 def self_test() -> int:
-    """Run every fixture. Return 0 iff every rule the store claims to enforce actually holds.
-
-    A SUITE THAT RAN NOTHING IS NOT A PASS: an empty `CASES` fails here rather than printing an all-clear.
-    CI runs `followups.py self-test` and trusts the exit code, so the one thing this must never do is report
-    success over a suite that checked nothing.
-    """
-    if not CASES:
-        print("CASES is EMPTY — this suite has not tested anything, and that is not a pass.")
-        return 1
-    failures = 0
-    with tempfile.TemporaryDirectory() as tmpdir:
-        for i, (name, rule, fn) in enumerate(CASES):
-            work = Path(tmpdir) / f"{i:02d}-{name}"
-            work.mkdir(parents=True)
-            try:
-                fn(work)
-            except SelfTestFailure as exc:
-                print(f"FAIL     {name:24} -> {rule}\n         {exc}")
-                failures += 1
-                continue
-            except SystemExit as exc:
-                # A fixture called an accessor DIRECTLY (`load()`, not through `run()`) and it REFUSED —
-                # `fail()` raises SystemExit, a BaseException that would otherwise take the whole run down,
-                # printing no verdict and naming no rule.
-                print(f"FAIL     {name:24} -> {rule}\n         the accessor REFUSED the store (exit "
-                      f"{exc.code}) inside the fixture — its message is on stderr, above")
-                failures += 1
-                continue
-            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
-                print(f"FAIL     {name:24} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-                failures += 1
-                continue
-            print(f"ok       {name:24} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the follow-up store's contract is broken.")
-        return 1
-    print(f"all {len(CASES)} fixtures hold — the follow-up store's contract is intact.")
-    return 0
+    """Run every fixture on the shared runner. `followups.py self-test` is the door CI uses."""
+    return run_cases(CASES, failure=SelfTestFailure, subject="the follow-up store's contract",
+                     width=24, per_case_dir=True)
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -74,7 +74,6 @@ from __future__ import annotations
 
 import argparse
 import fcntl
-import importlib.util
 import json
 import re
 import sys
@@ -90,6 +89,7 @@ from urllib.parse import unquote, urlsplit
 from _gauntlet.atomic import replace_text
 from _gauntlet.jsonl import JsonlError, object_lines
 from _gauntlet.table import config_lines, grid_lines, hidden_notice
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = "Schema-owning accessor for the follow-up ledger (.gauntlet/followups.jsonl)."
 
@@ -863,29 +863,23 @@ TESTS = Path(__file__).resolve().parent / "followups-test.py"
 
 
 def self_test() -> int:
-    """Run the fixtures in `followups-test.py`.
+    """Run every fixture in `followups-test.py` on the shared runner (`_gauntlet/testing.py`).
 
-    Loaded BY PATH, from THIS script's own directory — never by name and never relative to the cwd:
-    `followups-test` is not a legal module name, and the driver invokes this from arbitrary directories
-    while the script itself lives wherever the plugin is installed. `__file__` is the only thing that knows
-    where its sibling is.
+    The sibling is loaded BY PATH, from THIS script's own directory — never by name and never relative to
+    the cwd: `followups-test` is not a legal module name, and the driver invokes this from arbitrary
+    directories while the script itself lives wherever the plugin is installed. `__file__` is the only
+    thing that knows where its sibling is.
 
-    A MISSING SIBLING IS A LOUD FAILURE, NEVER A PASS. A self-test that reports success because it found no
-    tests is worse than one that fails: it certifies a contract that nothing checked.
+    `failure=AssertionError` is this suite's own failure type reached by its base class: the fixtures
+    raise `ledger-test.py`'s `SelfTestFailure`, which subclasses it, and this file never imports that
+    module. Each fixture is handed its own empty working directory — they build stores on disk.
     """
-    if not TESTS.exists():
-        fail(f"the fixtures are GONE — {TESTS} does not exist. `self-test` verifies NOTHING without them, "
-             f"and it must never report success when it has checked nothing.")
     # The fixtures `import followups`. Run as a script, THIS module is `__main__` and is not registered
     # under its own name — so that import would load and execute a SECOND copy of this file, and the
     # fixtures would then be testing that copy instead of the one running. Register this one first.
     sys.modules.setdefault("followups", sys.modules[__name__])
-    spec = importlib.util.spec_from_file_location("followups_test", TESTS)
-    if spec is None or spec.loader is None:  # a broken install — never an input error
-        fail(f"cannot load the fixtures at {TESTS}")
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.self_test()
+    return run_sibling_suite(TESTS, "followups_test", failure=AssertionError,
+                             subject="the follow-up store's contract", width=24, per_case_dir=True)
 
 
 # --- cli ----------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/format-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/format-preflight-test.py
@@ -15,24 +15,16 @@ import os
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import checker
 
 OWNER = Path(__file__).resolve().parent / "format-preflight.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("format_preflight_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the format-preflight guard at {OWNER}")
-    return mod
+R = load_sibling("format_preflight_owner", OWNER.parent, OWNER.name)
 
 
-R = _load_owner()
-
-
-def check(cond, msg):
-    if not cond:
-        raise R.SelfTestFailure(msg)
+check = checker(R.SelfTestFailure)
 
 
 def _result_for(worktree: str, file_arg: str) -> dict:

--- a/plugins/gauntlet/skills/campaign/scripts/format-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/format-preflight.py
@@ -46,7 +46,7 @@ import stat
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "format-preflight-test.py"     # the fixture suite — this tool's executable contract
@@ -186,47 +186,10 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
-            f"health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("format_preflight_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':32} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the format-preflight guard's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:32} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:32} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:32} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the format-preflight guard's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the format-preflight guard's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "format_preflight_test", failure=SelfTestFailure,
+                             subject="the format-preflight guard's contract", width=32)
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
@@ -16,25 +16,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "heartbeat.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("heartbeat_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the heartbeat wake-prompt emitter at {OWNER}")
-    return mod
+H = load_sibling("heartbeat_owner", OWNER.parent, OWNER.name)
 
 
-H = _load_owner()
-
-
-def check(cond, msg):
-    if not cond:
-        raise H.SelfTestFailure(msg)
+check = checker(H.SelfTestFailure)
 
 
 RUN, TOK = "g260704-0915-a3f29c1b", "aabbccdd"

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -44,7 +44,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = "Print a scheduled heartbeat or session-watchdog wake prompt."
 
@@ -158,46 +158,10 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
-                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("heartbeat_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the campaign wake-command tool's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the campaign wake-command tool's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the campaign wake-command tool's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "heartbeat_test", failure=SelfTestFailure,
+                             subject="the campaign wake-command tool's contract")
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
@@ -19,25 +19,17 @@ from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import checker
 
 OWNER = Path(__file__).resolve().parent / "label-mirror.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("label_mirror_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the label-mirror at {OWNER}")
-    return mod
-
-
-M = _load_owner()
+M = load_sibling("label_mirror_owner", OWNER.parent, OWNER.name)
 L = M.L
 
 
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 class FakeGh:

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
@@ -40,7 +40,8 @@ import sys
 from pathlib import Path
 from typing import Callable, NoReturn
 
-from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "label-mirror-test.py"     # the fixture suite — this tool's executable contract
@@ -213,48 +214,10 @@ class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
 
 
-def _sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture suite is NOT AT {SIBLING} — `self-test` has NO SUBJECT, and a check that cannot "
-            f"find the thing it tests must FAIL, never pass.")
-    mod = load_module_from_path("label_mirror_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    """Run the sibling suite over every fixture. Non-zero on any failure."""
-    failures = 0
-    try:
-        cases = _sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the label-mirror's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} fixture(s) failed — the label-mirror's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the label-mirror's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "label_mirror_test", failure=SelfTestFailure,
+                             subject="the label-mirror's contract")
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -21,19 +21,12 @@ import sys
 import time
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
 
 OWNER = Path(__file__).resolve().parent / "lease.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("lease_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the lease accessor at {OWNER}")
-    return mod
-
-
-L = _load_owner()
+L = load_sibling("lease_owner", OWNER.parent, OWNER.name)
 
 
 # --- helpers ------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -44,15 +44,13 @@ import os
 import secrets
 import stat
 import sys
-import tempfile
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import NoReturn
 
 from _gauntlet.atomic import replace_text
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.testing import capture_cli, run_sibling_suite
 
 DESCRIPTION = "Schema-owning accessor for the campaign run lease (lease.json)."
 
@@ -560,55 +558,14 @@ def run(argv: "list[str]") -> "tuple[int, str, str]":
     return capture_cli(main, argv)
 
 
-def sibling_cases() -> list:
-    """Load the sibling's fixtures — and FAIL LOUDLY if they are not there.
-
-    A self-test that passes because it found nothing to check reports health while checking nothing.
-    """
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
-            f"health. Every rule this file enforces is now unpinned."
-        )
-    mod = load_module_from_path("lease_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':26} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the lease's contract is broken.")
-        return 1
-    with tempfile.TemporaryDirectory() as tmpdir:
-        for name, rule, fn in cases:
-            work = Path(tmpdir) / name
-            work.mkdir()
-            try:
-                fn(work)
-            except SelfTestFailure as exc:
-                print(f"FAIL     {name:26} -> {rule}\n         {exc}")
-                failures += 1
-            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
-                print(f"FAIL     {name:26} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-                failures += 1
-            else:
-                print(f"ok       {name:26} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the lease's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the lease's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`).
+
+    Each fixture is handed its own empty working directory: a lease is a FILE, so a fixture that shared
+    a directory with the next one would be reading the previous fixture's state.
+    """
+    return run_sibling_suite(SIBLING, "lease_test", failure=SelfTestFailure,
+                             subject="the lease's contract", width=26, per_case_dir=True)
 
 
 # --- cli ----------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -18,20 +18,13 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "merge-check.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("merge_check_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the merge-readiness decider at {OWNER}")
-    return mod
-
-
-M = _load_owner()
+M = load_sibling("merge_check_owner", OWNER.parent, OWNER.name)
 L = M.L
 
 SHA_A = "a" * 40   # the reviewed head
@@ -62,9 +55,7 @@ def decide(r: dict, v: dict) -> dict:
     return M.decide(r, v, required=M.REQUIRED, effective_base=L.effective_base(_HEADER, r))
 
 
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -43,7 +43,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "merge-check-test.py"     # the fixture suite — this tool's executable contract
@@ -324,48 +325,10 @@ class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
 
 
-def _sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture suite is NOT AT {SIBLING} — `self-test` has NO SUBJECT, and a check that cannot "
-            f"find the thing it tests must FAIL, never pass.")
-    mod = load_module_from_path("merge_check_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    """Run the sibling suite over every fixture. Non-zero on any failure."""
-    failures = 0
-    try:
-        cases = _sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the merge-readiness decider's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} fixture(s) failed — the merge-readiness decider's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the decider's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "merge_check_test", failure=SelfTestFailure,
+                             subject="the merge-readiness decider's contract")
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -11,16 +11,10 @@ import sys
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.testing import checker
 
 OWNER = Path(__file__).resolve().parent / "merge.py"
-
-
-def _load_owner():
-    mod = load_module_from_path("merge_runner_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load {OWNER}")
-    return mod
 
 
 def _load_reconcile():
@@ -34,7 +28,7 @@ def _load_reconcile():
     return mod
 
 
-M = _load_owner()
+M = load_sibling("merge_runner_owner", OWNER.parent, OWNER.name)
 L = M.L
 # The reconcile detector. The routing-decision fixture drives BOTH tools: the fact reconcile emits, and the
 # `merge.py run` finalizer that fact routes to.
@@ -43,9 +37,7 @@ RECON = _load_reconcile()
 SHA = "a" * 40
 
 
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 class Fake:

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -36,7 +36,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import run_sibling_suite
 
 HERE = Path(__file__).resolve().parent
 SIBLING = HERE / "merge-test.py"
@@ -793,38 +794,10 @@ class SelfTestFailure(AssertionError):
     """A claimed merge-runner rule did not hold."""
 
 
-def _sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(f"fixture suite is missing at {SIBLING}")
-    mod = load_module_from_path("merge_runner_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"cannot load fixture suite at {SIBLING}")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING.name} exports no CASES")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = _sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL sibling-fixtures: {exc}")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except Exception as exc:  # noqa: BLE001
-            failures += 1
-            print(f"FAIL {name}: {rule}\n     {type(exc).__name__}: {exc}")
-        else:
-            print(f"ok   {name}: {rule}")
-    if failures:
-        print(f"{failures} merge-runner fixture(s) failed")
-        return 1
-    print(f"all {len(cases)} merge-runner fixtures hold")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "merge_runner_test", failure=SelfTestFailure,
+                             subject="the merge runner's contract", width=34)
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -17,19 +17,13 @@ from contextlib import redirect_stdout
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import checker
 
 OWNER = Path(__file__).resolve().parent / "nudge.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("nudge_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the nudge printer at {OWNER}")
-    return mod
-
-
-N = _load_owner()
+N = load_sibling("nudge_owner", OWNER.parent, OWNER.name)
 L = N.L
 
 
@@ -63,9 +57,7 @@ def has(lines, substr) -> bool:
     return any(substr in line for line in lines)
 
 
-def check(cond, msg):
-    if not cond:
-        raise N.SelfTestFailure(msg)
+check = checker(N.SelfTestFailure)
 
 
 # --- always-fire floor --------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -25,7 +25,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = "Print per-heartbeat reminders for the campaign orchestrator (sticky notes, not a supervisor)."
 
@@ -296,46 +297,10 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
-                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("nudge_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the nudge printer's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the nudge printer's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the nudge printer's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "nudge_test", failure=SelfTestFailure,
+                             subject="the nudge printer's contract")
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -21,34 +21,21 @@ from io import StringIO
 from pathlib import Path
 from subprocess import CompletedProcess
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "pr-adopt.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("pr_adopt_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the pr-adopt tool at {OWNER}")
-    return mod
-
-
-M = _load_owner()
+M = load_sibling("pr_adopt_owner", OWNER.parent, OWNER.name)
 
 
 def _sibling(name: str, filename: str):
-    """Load a sibling campaign tool as a module for the cross-script integration fixture below. Guards the
-    `None` return exactly as `_load_owner` does, so every attribute access is on a real module."""
-    mod = load_module_from_path(name, Path(__file__).resolve().parent / filename)
-    if mod is None:
-        raise RuntimeError(f"cannot load the sibling tool at {filename}")
-    return mod
+    """Load a sibling campaign tool as a module for the cross-script integration fixture below."""
+    return load_sibling(name, OWNER.parent, filename)
 
 
-def check(cond, msg) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 def lbl(name: str) -> dict:

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -45,7 +45,8 @@ import sys
 from pathlib import Path
 
 from _gauntlet.atomic import replace_text
-from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
 
@@ -594,46 +595,10 @@ class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
-                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("pr_adopt_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — pr-adopt's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — pr-adopt's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — pr-adopt's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "pr_adopt_test", failure=SelfTestFailure,
+                             subject="pr-adopt's contract")
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -24,20 +24,13 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "reconcile.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("reconcile_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the reconcile detector at {OWNER}")
-    return mod
-
-
-M = _load_owner()
+M = load_sibling("reconcile_owner", OWNER.parent, OWNER.name)
 LED = M.L                                   # the ledger schema owner reconcile reuses
 
 RUN_ID = "grec-0001"
@@ -50,9 +43,7 @@ SHA_B = "b" * 40
 _UNSET = object()
 
 
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise M.SelfTestFailure(msg)
+check = checker(M.SelfTestFailure)
 
 
 # --- fixture builders ---------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -50,7 +50,8 @@ import tempfile
 from pathlib import Path
 from typing import Callable
 
-from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "reconcile-test.py"       # the fixture suite — this tool's executable contract
@@ -436,48 +437,10 @@ class SelfTestFailure(AssertionError):
     """A rule this file claims to enforce does not hold."""
 
 
-def _sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture suite is NOT AT {SIBLING} — `self-test` has NO SUBJECT, and a check that cannot "
-            f"find the thing it tests must FAIL, never pass.")
-    mod = load_module_from_path("reconcile_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    """Run the sibling suite over every fixture. Non-zero on any failure."""
-    failures = 0
-    try:
-        cases = _sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':34} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the reconcile fetch/detect contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:34} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:34} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:34} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} fixture(s) failed — the reconcile fetch/detect contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the fetch/detect contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "reconcile_test", failure=SelfTestFailure,
+                             subject="the reconcile fetch/detect contract", width=34)
 
 
 def main(argv: "list[str] | None" = None) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -18,40 +18,23 @@ import sys
 from pathlib import Path
 
 from _gauntlet.modules import load_module_from_path, load_sibling
-from _gauntlet.testing import capture_cli
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "repair-pass.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("repair_pass_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the repair pass at {OWNER}")
-    return mod
-
-
-R = _load_owner()
+R = load_sibling("repair_pass_owner", OWNER.parent, OWNER.name)
 L = R.L  # the ledger — the ONE owner of the schema, the caps and the statuses
 # The audit's schema owner — fixtures now produce real `.jsonl` audits through it, the way the runtime does,
 # instead of hand-writing the old `.md` file the bundle no longer reads.
-def _load_finding_audit():
-    """Load finding-audit.py by path, guarding+raising so the value is non-Optional — the same shape as
-    `_load_owner`, so `FA.main` is well-typed inside every fixture. A module-level `assert FA is not None`
-    would NOT type-narrow the global inside function bodies; the guarded helper does."""
-    mod = load_module_from_path("repair_pass_test_finding_audit", OWNER.parent / "finding-audit.py")
-    if mod is None:
-        raise RuntimeError(f"cannot load the finding-audit accessor at {OWNER.parent / 'finding-audit.py'}")
-    return mod
-
-
-FA = _load_finding_audit()
+# `load_sibling` raises rather than returning `None`, so `FA.main` is well-typed inside every fixture.
+# A module-level `assert FA is not None` would NOT type-narrow the global inside function bodies.
+FA = load_sibling("repair_pass_test_finding_audit", OWNER.parent, "finding-audit.py")
 
 SHA = "c" * 40
 
 
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise R.SelfTestFailure(msg)
+check = checker(R.SelfTestFailure)
 
 
 def ledger_cli(argv: "list[str]") -> "tuple[int, str, str]":

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -57,7 +57,7 @@ from pathlib import Path
 from typing import NoReturn
 
 from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.testing import capture_cli, run_sibling_suite
 
 DESCRIPTION = "Build and bind the reassessment pass for a PR that has stopped converging."
 
@@ -1174,57 +1174,14 @@ def run(argv: "list[str]") -> "tuple[int, str, str]":
     return capture_cli(main, argv)
 
 
-def sibling_cases() -> list:
-    """Load the sibling's fixtures — and FAIL LOUDLY if they are not there.
-
-    A self-test that passes because it found nothing to check is worse than no self-test: it reports health
-    while checking nothing. A reviewer proved exactly that on this repo's own follow-up ledger, where
-    `self_test()` went green with an empty case list. Missing, unloadable, or exporting no cases: all hard
-    errors, never an empty list quietly appended to nothing.
-    """
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run and CANNOT report "
-            f"health. Every rule this file enforces is now unpinned."
-        )
-    mod = load_module_from_path("repair_pass_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':22} -> the fixtures in {SIBLING.name} must be RUNNABLE\n         {exc}")
-        print("\n1 check(s) FAILED — the repair pass's contract is broken.")
-        return 1
-    with tempfile.TemporaryDirectory() as tmpdir:
-        for name, rule, fn in cases:
-            work = Path(tmpdir) / name
-            work.mkdir()
-            try:
-                fn(work)
-            except SelfTestFailure as exc:
-                print(f"FAIL     {name:22} -> {rule}\n         {exc}")
-                failures += 1
-            except Exception as exc:  # noqa: BLE001 — a fixture that CRASHES has not passed
-                print(f"FAIL     {name:22} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-                failures += 1
-            else:
-                print(f"ok       {name:22} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the repair pass's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the repair pass's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`).
+
+    Each fixture is handed its own empty working directory: these fixtures build run directories and
+    ledgers on disk, so one sharing a directory with the next would be reading the previous one's state.
+    """
+    return run_sibling_suite(SIBLING, "repair_pass_test", failure=SelfTestFailure,
+                             subject="the repair pass's contract", width=22, per_case_dir=True)
 
 
 # --- cli ----------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -11,26 +11,17 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 
 OWNER = Path(__file__).resolve().parent / "review-dispatch.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("review_dispatch_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the review-dispatch tool at {OWNER}")
-    return mod
+D = load_sibling("review_dispatch_owner", OWNER.parent, OWNER.name)
 
 
-D = _load_owner()
-
-
-def check(condition: bool, message: str) -> None:
-    if not condition:
-        raise D.SelfTestFailure(message)
+check = checker(D.SelfTestFailure)
 
 
 SHA = "a3f29c1b7d4e6f8091a2b3c4d5e6f708192a3b4c"

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Callable, NoReturn
 
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 
 _HERE = Path(__file__).resolve().parent
@@ -542,44 +543,10 @@ def prepare(args) -> dict:
     return {"route": args.route, "transport": transport}
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} IS MISSING — the review-dispatch tool has no runnable contract"
-        )
-    mod = load_module_from_path("review_dispatch_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — the suite cannot report health")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     sibling-fixtures -> {exc}")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:34} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:34} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:34} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the review-dispatch contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the review-dispatch contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "review_dispatch_test", failure=SelfTestFailure,
+                             subject="the review-dispatch contract", width=34)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/plugins/gauntlet/skills/campaign/scripts/review-learnings-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-learnings-test.py
@@ -17,7 +17,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -25,7 +24,7 @@ sys.path.insert(0, str(HERE))
 import ledger  # noqa: E402
 from _gauntlet.modules import load_module_from_path  # noqa: E402
 from _gauntlet.table import escape_cell, hidden_notice  # noqa: E402
-from _gauntlet.testing import capture_cli  # noqa: E402
+from _gauntlet.testing import capture_cli, run_cases  # noqa: E402
 
 
 def _load(name: str, filename: str):
@@ -792,37 +791,9 @@ CASES = [
 
 
 def self_test() -> int:
-    """Run every fixture. Return 0 iff every rule the store claims to enforce actually holds."""
-    if not CASES:
-        print("CASES is EMPTY — this suite has not tested anything, and that is not a pass.")
-        return 1
-    failures = 0
-    with tempfile.TemporaryDirectory() as tmpdir:
-        for i, (name, rule, fn) in enumerate(CASES):
-            work = Path(tmpdir) / f"{i:02d}-{name}"
-            work.mkdir(parents=True)
-            try:
-                fn(work)
-            except SelfTestFailure as exc:
-                print(f"FAIL     {name:24} -> {rule}\n         {exc}")
-                failures += 1
-                continue
-            except SystemExit as exc:
-                print(f"FAIL     {name:24} -> {rule}\n         the accessor REFUSED the store (exit "
-                      f"{exc.code}) inside the fixture — its message is on stderr, above")
-                failures += 1
-                continue
-            except Exception as exc:  # noqa: BLE001
-                print(f"FAIL     {name:24} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-                failures += 1
-                continue
-            print(f"ok       {name:24} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the review-learnings store's contract is broken.")
-        return 1
-    print(f"all {len(CASES)} fixtures hold — the review-learnings store's contract is intact.")
-    return 0
+    """Run every fixture on the shared runner. `review-learnings.py self-test` is the door CI uses."""
+    return run_cases(CASES, failure=SelfTestFailure, subject="the review-learnings store's contract",
+                     width=24, per_case_dir=True)
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/review-learnings.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-learnings.py
@@ -48,7 +48,7 @@ from typing import NoReturn
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _gauntlet.atomic import replace_text  # noqa: E402
 from _gauntlet.jsonl import JsonlError, object_lines  # noqa: E402
-from _gauntlet.modules import load_module_from_path  # noqa: E402
+from _gauntlet.testing import run_sibling_suite  # noqa: E402
 from _gauntlet.table import config_lines, grid_lines, hidden_notice  # noqa: E402
 
 DESCRIPTION = (
@@ -600,17 +600,15 @@ TESTS = Path(__file__).resolve().parent / "review-learnings-test.py"
 
 
 def self_test() -> int:
-    """Run the fixtures in `review-learnings-test.py`, loaded BY PATH from this script's own directory.
+    """Run every fixture in `review-learnings-test.py` on the shared runner (`_gauntlet/testing.py`).
 
-    A MISSING SIBLING IS A LOUD FAILURE, NEVER A PASS: a self-test that reports success because it found no
-    tests certifies a contract that nothing checked.
+    `failure=AssertionError` is this suite's own failure type reached by its base class: the fixtures
+    raise `ledger-test.py`'s `SelfTestFailure`, which subclasses it, and this file never imports that
+    module. Each fixture is handed its own empty working directory — they build stores on disk.
     """
-    if not TESTS.exists():
-        fail(f"the fixtures are GONE — {TESTS} does not exist. `self-test` verifies NOTHING without them.")
-    module = load_module_from_path("review_learnings_test", TESTS, register=True)
-    if module is None:
-        fail(f"cannot load the fixtures at {TESTS}")
-    return module.self_test()
+    return run_sibling_suite(TESTS, "review_learnings_test", failure=AssertionError,
+                             subject="the review-learnings store's contract", width=24,
+                             per_case_dir=True)
 
 
 # --- cli ----------------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
@@ -16,25 +16,17 @@ import os
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import checker
 
 OWNER = Path(__file__).resolve().parent / "reviewer-liveness.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("reviewer_liveness_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the reviewer-liveness probe at {OWNER}")
-    return mod
-
-
-R = _load_owner()
+R = load_sibling("reviewer_liveness_owner", OWNER.parent, OWNER.name)
 WINDOW = R.DEFAULT_QUIET_WINDOW_SECONDS
 
 
-def check(cond, msg):
-    if not cond:
-        raise R.SelfTestFailure(msg)
+check = checker(R.SelfTestFailure)
 
 
 def classify(*, exists, size, mtime_epoch, now_epoch, quiet_window=WINDOW):

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
@@ -47,7 +47,7 @@ import os
 import sys
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = "Report a background reviewer's stdout-stream liveness (stat only; decides nothing)."
 
@@ -134,46 +134,10 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
-                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("reviewer_liveness_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':32} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the reviewer-liveness probe's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:32} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:32} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:32} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the reviewer-liveness probe's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the reviewer-liveness probe's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "reviewer_liveness_test", failure=SelfTestFailure,
+                             subject="the reviewer-liveness probe's contract", width=32)
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/run-id-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/run-id-test.py
@@ -19,8 +19,8 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "run-id.py"
 
@@ -28,19 +28,10 @@ FIXED = datetime(2026, 7, 4, 9, 15)  # → stamp 260704-0915, matching the doc's
 RUN_ID_RE = r"g\d{6}-\d{4}-[0-9a-f]{8}"
 
 
-def _load_owner():
-    mod = load_module_from_path("run_id_owner", OWNER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the run-id tool at {OWNER}")
-    return mod
+R = load_sibling("run_id_owner", OWNER.parent, OWNER.name)
 
 
-R = _load_owner()
-
-
-def check(cond: bool, msg: str) -> None:
-    if not cond:
-        raise R.SelfTestFailure(msg)
+check = checker(R.SelfTestFailure)
 
 
 # --- the id shape -------------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/run-id.py
+++ b/plugins/gauntlet/skills/campaign/scripts/run-id.py
@@ -28,7 +28,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Callable
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "run-id-test.py"
@@ -133,46 +133,10 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def sibling_cases() -> list:
-    if not SIBLING.exists():
-        raise SelfTestFailure(f"the fixture file {SIBLING} IS MISSING — this suite has no fixtures to run "
-                              f"and CANNOT report health. Every rule this file enforces is now unpinned.")
-    mod = load_module_from_path("run_id_test", SIBLING, register=True)
-    if mod is None:
-        raise SelfTestFailure(f"{SIBLING} exists but cannot be loaded as a module")
-    cases = getattr(mod, "CASES", None)
-    if not cases:
-        raise SelfTestFailure(f"{SIBLING} exports no CASES — every rule in this file is unpinned while the "
-                              f"suite still exits 0")
-    return list(cases)
-
-
 def self_test() -> int:
-    failures = 0
-    try:
-        cases = sibling_cases()
-    except SelfTestFailure as exc:
-        print(f"FAIL     {'sibling-fixtures':30} -> the fixtures in {SIBLING.name} must be RUNNABLE\n"
-              f"         {exc}")
-        print("\n1 check(s) FAILED — the run-id tool's contract is broken.")
-        return 1
-    for name, rule, fn in cases:
-        try:
-            fn()
-        except SelfTestFailure as exc:
-            print(f"FAIL     {name:30} -> {rule}\n         {exc}")
-            failures += 1
-        except Exception as exc:  # noqa: BLE001
-            print(f"FAIL     {name:30} -> {rule}\n         raised {type(exc).__name__}: {exc}")
-            failures += 1
-        else:
-            print(f"ok       {name:30} -> {rule}")
-    print()
-    if failures:
-        print(f"{failures} check(s) FAILED — the run-id tool's contract is broken.")
-        return 1
-    print(f"all {len(cases)} fixtures hold — the run-id tool's contract is intact.")
-    return 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "run_id_test", failure=SelfTestFailure,
+                             subject="the run-id tool's contract")
 
 
 if __name__ == "__main__":

--- a/plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# ci: pyright
+"""Fixtures for the shared fixture runner in `_gauntlet/testing.py`.
+
+MOST `self-test` SUBCOMMANDS IN THIS DIRECTORY NOW GET THEIR EXIT CODE FROM THAT ONE RUNNER. That
+concentration is the point of it, and it is also the hazard: a runner that swallowed a failing fixture,
+miscounted, or returned 0 over an empty case table would turn every one of those suites green at once,
+and every one of them would still LOOK green — so their output cannot be the evidence. THIS FILE IS THE
+EVIDENCE. It drives the runner into every way of not passing that the runner guards, and fails if any of
+those came back zero or unreported.
+
+Run it directly (`python3 self-test-runner-test.py`); CI does. It has no accessor and no `self-test`
+subcommand of its own, because the thing it tests IS the self-test machinery.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from _gauntlet.testing import capture_cli, run_cases, run_sibling_suite
+
+SUBJECT = "the runner's own contract"
+
+
+class Failure(AssertionError):
+    """Stands in for a suite's own failure type — the `failure=` argument the runner is handed."""
+
+
+class OtherFailure(RuntimeError):
+    """Anything a fixture raises that is NOT the suite's failure type."""
+
+
+def check(cond: bool, msg: str) -> None:
+    if not cond:
+        raise Failure(msg)
+
+
+def drive(**kwargs) -> "tuple[int, str]":
+    """Run `run_cases` with stdout captured, and return its exit code and what it printed."""
+    code, out, _err = capture_cli(lambda _argv: run_cases(subject=SUBJECT, **kwargs), [])
+    return code, out
+
+
+def drive_sibling(sibling: Path, module_name: str = "runner_probe_suite") -> "tuple[int, str]":
+    """Same, for the sibling-loading door."""
+    code, out, _err = capture_cli(
+        lambda _argv: run_sibling_suite(sibling, module_name, failure=Failure, subject=SUBJECT), [])
+    return code, out
+
+
+def passing() -> None:
+    """An ordinary fixture: it does its work and raises nothing."""
+
+
+# --- the happy path, so the negatives below mean something --------------------
+
+def t_all_passing_returns_zero() -> None:
+    code, out = drive(cases=[("a", "a rule", passing), ("b", "another", passing)], failure=Failure)
+    check(code == 0, f"a suite whose fixtures all pass must exit 0, got {code}")
+    check(out.count("ok       ") == 2, f"every passing fixture gets an `ok` line: {out!r}")
+    check(f"all 2 fixtures hold — {SUBJECT} is intact." in out, f"the verdict names the subject: {out!r}")
+
+
+def t_a_returned_value_is_not_a_verdict() -> None:
+    """The contract is RAISE-to-fail, so what a fixture returns is nobody's business."""
+    code, _out = drive(cases=[("falsy", "returning False is not failing", lambda: False),
+                              ("none", "returning None is not failing", lambda: None)],
+                       failure=Failure)
+    check(code == 0, f"a fixture that returns a falsy value has PASSED, got exit {code}")
+
+
+# --- a fixture that fails, in each of the ways it can --------------------------
+
+def t_the_suites_own_failure_is_reported_with_its_message() -> None:
+    def fails() -> None:
+        raise Failure("the rule this fixture pins does not hold")
+
+    code, out = drive(cases=[("ok-one", "holds", passing), ("bad", "the broken rule", fails)],
+                      failure=Failure)
+    check(code == 1, f"one failing fixture must make the whole suite exit 1, got {code}")
+    check("the rule this fixture pins does not hold" in out,
+          f"the fixture's OWN message is what identifies the broken rule: {out!r}")
+    check(f"1 check(s) FAILED — {SUBJECT} is broken." in out, f"the tally names the subject: {out!r}")
+    check("ok       ok-one" in out, f"the fixtures that passed still report: {out!r}")
+
+
+def t_any_other_exception_is_a_failure_named_by_its_type() -> None:
+    def crashes() -> None:
+        raise OtherFailure("boom")
+
+    code, out = drive(cases=[("crash", "a rule", crashes)], failure=Failure)
+    check(code == 1, f"a fixture that CRASHES has not passed, got exit {code}")
+    check("raised OtherFailure: boom" in out,
+          f"a crash is reported with its type — it is not a verdict the fixture rendered: {out!r}")
+
+
+def t_a_fixture_that_exits_is_reported_and_the_rest_still_run() -> None:
+    """`SystemExit(0)` is the dangerous one: unhandled it would end the suite silently and GREEN."""
+    def exits() -> None:
+        raise SystemExit(0)
+
+    code, out = drive(cases=[("exits", "a rule", exits), ("after", "runs anyway", passing)],
+                      failure=Failure)
+    check(code == 1, f"a fixture that EXITS the interpreter has not passed, got exit {code}")
+    check("raised SystemExit(0)" in out, f"the report names what it exited with: {out!r}")
+    check("ok       after" in out,
+          f"the fixtures AFTER an exiting one must still run — the exit was contained: {out!r}")
+
+
+def t_every_failure_is_counted_not_just_the_first() -> None:
+    def fails() -> None:
+        raise Failure("no")
+
+    code, out = drive(cases=[("a", "r", fails), ("b", "r", fails), ("c", "r", passing)], failure=Failure)
+    check(code == 1, f"expected exit 1, got {code}")
+    check("2 check(s) FAILED" in out, f"the tally counts EVERY failure, not just the first: {out!r}")
+
+
+# --- a suite that proved nothing ----------------------------------------------
+
+def t_an_empty_case_table_is_a_failure() -> None:
+    """A self-test with no subject passes every time. That is the loudest false green there is."""
+    code, out = drive(cases=[], failure=Failure)
+    check(code == 1, f"an EMPTY case table must FAIL, never report an all-clear; got exit {code}")
+    check("empty-case-table" in out, f"the refusal names itself: {out!r}")
+
+
+def t_a_missing_sibling_is_a_failure() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        code, out = drive_sibling(Path(d) / "not-there-test.py")
+    check(code == 1, f"a MISSING fixture file must FAIL — it has nothing to check; got exit {code}")
+    check("sibling-fixtures" in out and "IS MISSING" in out, f"the refusal says what is wrong: {out!r}")
+
+
+def t_an_unloadable_sibling_is_a_failure() -> None:
+    """A path Python has no loader for: the module comes back as `None`, never as an empty suite."""
+    with tempfile.TemporaryDirectory() as d:
+        sibling = Path(d) / "fixtures-test.txt"  # a real file, but not one importlib can load
+        sibling.write_text("CASES = []\n", encoding="utf-8")
+        code, out = drive_sibling(sibling)
+    check(code == 1, f"a fixture file that cannot be LOADED must FAIL, got exit {code}")
+    check("cannot be loaded as a module" in out, f"the refusal says what is wrong: {out!r}")
+
+
+def t_a_sibling_exporting_no_cases_is_a_failure() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        sibling = Path(d) / "no-cases-test.py"
+        sibling.write_text("X = 1\n", encoding="utf-8")
+        code, out = drive_sibling(sibling, "runner_probe_no_cases")
+    check(code == 1, f"a sibling with NO `CASES` must FAIL, got exit {code}")
+    check("exports no CASES" in out, f"the refusal says what is wrong: {out!r}")
+
+
+def t_a_sibling_exporting_empty_cases_is_a_failure() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        sibling = Path(d) / "empty-cases-test.py"
+        sibling.write_text("CASES = []\n", encoding="utf-8")
+        code, _out = drive_sibling(sibling, "runner_probe_empty_cases")
+    check(code == 1, f"a sibling whose `CASES` is EMPTY must FAIL, got exit {code}")
+
+
+# --- a fixture whose body never ran -------------------------------------------
+#
+# These three classify the FUNCTION, before it is called. The regression fixture below is why: the
+# earlier attempt at this classified the RETURN VALUE, and failed ordinary fixtures for what they
+# returned. See `_never_ran` in `_gauntlet/testing.py`.
+
+def t_a_generator_fixture_never_ran() -> None:
+    def generator_fixture():
+        yield 1  # calling this BUILDS an iterator; the body never executes
+
+    code, out = drive(cases=[("gen", "a rule", generator_fixture)], failure=Failure)
+    check(code == 1, f"a fixture whose body never ran has proved NOTHING, got exit {code}")
+    check("generator function" in out, f"the report says why it never ran: {out!r}")
+
+
+def t_a_coroutine_fixture_never_ran() -> None:
+    async def coroutine_fixture() -> None:
+        raise Failure("this never runs — nothing awaits it")
+
+    code, out = drive(cases=[("coro", "a rule", coroutine_fixture)], failure=Failure)
+    check(code == 1, f"an `async def` fixture is never awaited and proves NOTHING, got exit {code}")
+    check("coroutine function" in out, f"the report says why it never ran: {out!r}")
+
+
+def t_an_async_generator_fixture_never_ran() -> None:
+    async def async_generator_fixture():
+        yield 1
+
+    code, out = drive(cases=[("agen", "a rule", async_generator_fixture)], failure=Failure)
+    check(code == 1, f"an async generator fixture proves NOTHING, got exit {code}")
+    check("async generator function" in out, f"the report says why it never ran: {out!r}")
+
+
+def t_a_fixture_that_ran_and_returned_a_generator_passes() -> None:
+    """REGRESSION. This is the exact fixture the earlier return-value classification failed.
+
+    It runs to completion — the marker proves it — and then returns a generator, which is an ordinary
+    thing for a fixture to do. Judging the RETURN VALUE reported "its body never executed" about a body
+    that plainly had. Judging the FUNCTION cannot make that mistake.
+    """
+    marker: "list[str]" = []
+
+    def ran_then_returns_a_generator():
+        marker.append("the body ran")
+        return (n for n in (1, 2, 3))
+
+    code, out = drive(cases=[("genexp", "a rule", ran_then_returns_a_generator)], failure=Failure)
+    check(marker == ["the body ran"], "the fixture's body must actually have run for this to test anything")
+    check(code == 0, f"a fixture that RAN and returned a generator has PASSED; got exit {code}\n{out}")
+    check("never" not in out, f"nothing may claim this body did not run: {out!r}")
+
+
+# --- the working directory ----------------------------------------------------
+
+def t_per_case_dir_hands_each_fixture_a_fresh_empty_directory() -> None:
+    seen: "list[Path]" = []
+
+    def uses_work(work: Path) -> None:
+        check(work.is_dir(), f"the fixture's working directory must EXIST, got {work}")
+        check(not list(work.iterdir()), f"it must be EMPTY, found {list(work.iterdir())}")
+        (work / "left-behind").write_text("x", encoding="utf-8")
+        seen.append(work)
+
+    code, _out = drive(cases=[("first", "r", uses_work), ("second", "r", uses_work)],
+                       failure=Failure, per_case_dir=True)
+    check(code == 0, f"expected exit 0, got {code}")
+    check(len(set(seen)) == 2, f"each fixture gets its OWN directory, got {seen}")
+
+
+def t_two_rows_sharing_a_name_still_get_separate_directories() -> None:
+    seen: "list[Path]" = []
+    code, _out = drive(cases=[("same", "r", seen.append), ("same", "r", seen.append)],
+                       failure=Failure, per_case_dir=True)
+    check(code == 0, f"a duplicate row NAME must not collide into one directory; got exit {code}")
+    check(len(set(seen)) == 2, f"the rows got the same directory: {seen}")
+
+
+# --- what the runner deliberately does NOT catch ------------------------------
+
+def t_keyboard_interrupt_aborts_rather_than_counting_as_one_failure() -> None:
+    """Ctrl-C is the OPERATOR's verdict, not a fixture's. It must end the run, not be filed as a check."""
+    def interrupted() -> None:
+        raise KeyboardInterrupt
+
+    aborted = False
+    try:
+        drive(cases=[("interrupt", "a rule", interrupted), ("after", "r", passing)], failure=Failure)
+    except KeyboardInterrupt:
+        aborted = True
+    check(aborted, "KeyboardInterrupt must PROPAGATE — never be caught and counted as one failed check")
+
+
+CASES = [
+    ("all-pass", "a suite whose fixtures all pass exits 0", t_all_passing_returns_zero),
+    ("return-is-not-verdict", "the contract is raise-to-fail; a return value is ignored",
+     t_a_returned_value_is_not_a_verdict),
+    ("own-failure", "the suite's failure type is reported with the fixture's own message",
+     t_the_suites_own_failure_is_reported_with_its_message),
+    ("other-exception", "any other exception fails, named by its type",
+     t_any_other_exception_is_a_failure_named_by_its_type),
+    ("fixture-exits", "a fixture that exits the interpreter fails, and the rest still run",
+     t_a_fixture_that_exits_is_reported_and_the_rest_still_run),
+    ("counts-all", "every failure is counted, not just the first",
+     t_every_failure_is_counted_not_just_the_first),
+    ("empty-table", "an empty case table is a FAILURE, never an all-clear",
+     t_an_empty_case_table_is_a_failure),
+    ("missing-sibling", "a missing fixture file is a FAILURE", t_a_missing_sibling_is_a_failure),
+    ("unloadable-sibling", "a fixture file that cannot be loaded is a FAILURE",
+     t_an_unloadable_sibling_is_a_failure),
+    ("no-cases", "a sibling exporting no CASES is a FAILURE", t_a_sibling_exporting_no_cases_is_a_failure),
+    ("empty-cases", "a sibling exporting an empty CASES is a FAILURE",
+     t_a_sibling_exporting_empty_cases_is_a_failure),
+    ("generator-fixture", "a `yield`ing fixture never ran and fails", t_a_generator_fixture_never_ran),
+    ("coroutine-fixture", "an `async def` fixture never ran and fails", t_a_coroutine_fixture_never_ran),
+    ("async-generator-fixture", "an async generator fixture never ran and fails",
+     t_an_async_generator_fixture_never_ran),
+    ("ran-then-returned-a-generator", "REGRESSION: a fixture that RAN and returned a generator PASSES",
+     t_a_fixture_that_ran_and_returned_a_generator_passes),
+    ("per-case-dir", "each fixture gets a fresh empty working directory",
+     t_per_case_dir_hands_each_fixture_a_fresh_empty_directory),
+    ("per-case-dir-name-clash", "rows sharing a name still get separate directories",
+     t_two_rows_sharing_a_name_still_get_separate_directories),
+    ("keyboard-interrupt", "Ctrl-C aborts the run rather than counting as one failed check",
+     t_keyboard_interrupt_aborts_rather_than_counting_as_one_failure),
+]
+
+
+def main() -> int:
+    """The one hand-rolled loop left in this directory, and DELIBERATELY so.
+
+    Every other suite runs on `run_cases`. This suite cannot: it is the code under test, and a runner
+    that swallowed failures would swallow the failures of the very fixtures meant to catch it. So the
+    loop here is short enough to read in full and check by eye.
+    """
+    failures = 0
+    for name, rule, fn in CASES:
+        try:
+            fn()
+        except Exception as exc:  # noqa: BLE001 — a fixture that crashes has not passed
+            print(f"FAIL     {name:32} -> {rule}\n         {type(exc).__name__}: {exc}")
+            failures += 1
+        else:
+            print(f"ok       {name:32} -> {rule}")
+    print()
+    if failures:
+        print(f"{failures} check(s) FAILED — the shared fixture runner is broken, and every suite that "
+              f"exits through it is reporting a health it has not proved.")
+        return 1
+    print(f"all {len(CASES)} fixtures hold — the shared fixture runner refuses every way of not passing "
+          f"that it guards.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -22,26 +22,17 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker, run_cases
 
 OWNER = Path(__file__).resolve().parent / "triage.py"
 LEDGER = Path(__file__).resolve().parent / "ledger.py"
 
 
-def _load_owner():
-    mod = load_module_from_path("campaign_triage_owner", OWNER, register=True)
-    if mod is None:
-        raise RuntimeError(f"cannot load deterministic tier derivation at {OWNER}")
-    return mod
+M = load_sibling("campaign_triage_owner", OWNER.parent, OWNER.name, register=True)
 
 
-M = _load_owner()
-
-
-def check(condition: bool, message: str) -> None:
-    if not condition:
-        raise M.SelfTestFailure(message)
+check = checker(M.SelfTestFailure)
 
 
 def git(repo: Path, *args: str, check_result: bool = True) -> subprocess.CompletedProcess[bytes]:
@@ -1089,18 +1080,8 @@ CASES = [
 ]
 
 
-def run_cases() -> int:
-    failures = 0
-    for name, description, fn in CASES:
-        try:
-            fn()
-            print(f"PASS {name}: {description}")
-        except Exception as exc:  # noqa: BLE001 - fixture runner must report every case
-            failures += 1
-            print(f"FAIL {name}: {description}: {exc}")
-    print(f"triage fixtures: {len(CASES) - failures} passed, {failures} failed")
-    return 1 if failures else 0
-
-
 if __name__ == "__main__":
-    raise SystemExit(run_cases())
+    # Running this file directly and running `triage.py self-test` must report the same thing, so both
+    # go through the shared runner rather than each keeping a loop.
+    raise SystemExit(run_cases(CASES, failure=M.SelfTestFailure,
+                               subject="the triage classifier's contract", width=34))

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -48,6 +48,7 @@ from pathlib import Path, PurePosixPath
 from typing import Callable
 
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "triage-test.py"
@@ -653,28 +654,10 @@ def cmd_derive(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def sibling_cases() -> list:
-    if not SIBLING.is_file():
-        raise SelfTestFailure(
-            f"the fixture file {SIBLING} is missing — deterministic tier derivation is untested")
-    module = load_module_from_path("campaign_triage_test", SIBLING, register=True)
-    if module is None or not hasattr(module, "CASES") or not module.CASES:
-        raise SelfTestFailure("triage sibling suite has no CASES — an empty gate checks nothing")
-    return module.CASES
-
-
 def cmd_self_test(_args: argparse.Namespace) -> int:
-    failures = 0
-    cases = sibling_cases()
-    for name, description, fn in cases:
-        try:
-            fn()
-            print(f"PASS {name}: {description}")
-        except Exception as exc:  # noqa: BLE001 - report all independent fixtures
-            failures += 1
-            print(f"FAIL {name}: {description}: {exc}")
-    print(f"triage fixtures: {len(cases) - failures} passed, {failures} failed")
-    return 1 if failures else 0
+    """Run every fixture in the sibling suite on the shared runner (`_gauntlet/testing.py`)."""
+    return run_sibling_suite(SIBLING, "campaign_triage_test", failure=SelfTestFailure,
+                             subject="the triage classifier's contract", width=34)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
@@ -13,20 +13,13 @@ import sys
 import tempfile
 from pathlib import Path
 
-from _gauntlet.modules import load_module_from_path
-from _gauntlet.testing import capture_cli
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "worker-prompt.py"
 
 
-def _load_owner():
-    module = load_module_from_path("worker_prompt_owner", OWNER)
-    if module is None:
-        raise RuntimeError(f"cannot load worker-prompt tool at {OWNER}")
-    return module
-
-
-M = _load_owner()
+M = load_sibling("worker_prompt_owner", OWNER.parent, OWNER.name)
 ISSUES = b"- src/widget.py:19: preserve literal {{ROLE}} and $(touch NEVER)\n"
 LOGS = b"lint: src/widget.py needs layout; literal @@END COMMON@@ and unicode \xe9\x9b\xaa\n"
 # A deterministic, host-neutral stand-in for the driver-resolved format-preflight.py path so the goldens
@@ -44,9 +37,7 @@ GOLDEN_METADATA_SHA256 = {
 }
 
 
-def check(condition: bool, message: str) -> None:
-    if not condition:
-        raise M.SelfTestFailure(message)
+check = checker(M.SelfTestFailure)
 
 
 def expect_refusal(call, message: str) -> None:


### PR DESCRIPTION
- 19 accessors' `self-test` and 18 suites' `_load_owner`/`check` route through `_gauntlet/testing.py`.
- The never-ran guard classifies the FUNCTION, so a fixture that ran and returned a generator passes.
- New CI-run `self-test-runner-test.py` pins the runner's refusals; 4 bespoke suites keep their loops.
