### PR TITLE
release gauntlet 0.6.0

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- Bump both Gauntlet manifests to 0.6.0; 0.5.1 was bumped but never released.
- Minor, not patch: `triage derive` now requires `--file`/`--pr` and `dispatch-check` is an allow-list.
- Ships the `status_verbosity` field, the finding `base` question, and the shared script helpers.
