### PR TITLE
load the ledger through the shared sibling door

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -48,7 +48,7 @@ from pathlib import Path
 
 from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.git_refs import select_base_fetch_refs
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
@@ -57,14 +57,7 @@ LEDGER = _HERE / "ledger.py"                   # the sibling that owns base_ok_s
 PR_ADOPT = _HERE / "pr-adopt.py"               # owns BASE_CHANGE_PARK_REASON — reused, never re-spelt here
 
 
-def _load_ledger():
-    mod = load_module_from_path("base_preflight_ledger", LEDGER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER}")
-    return mod
-
-
-L = _load_ledger()
+L = load_sibling("base_preflight_ledger", _HERE, "ledger.py")
 
 # Loaded LAZILY (only when a live retarget is found) so the pure decider and self-test never pull the
 # adoption module chain: pr-adopt.py OWNS `BASE_CHANGE_PARK_REASON`, the EXACT machine-blocker wording a

--- a/plugins/gauntlet/skills/campaign/scripts/carryover.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover.py
@@ -32,13 +32,12 @@ from pathlib import Path
 from typing import Callable
 
 from _gauntlet.atomic import replace_text
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = "Distill a run's terminal ledger into .gauntlet/history/<run-id>.md — exactly once."
 
 HERE = Path(__file__).resolve().parent
-LEDGER_PY = HERE / "ledger.py"          # the schema owner — its loader's strictness is reused, never re-rolled
 TEST_PY = HERE / "carryover-test.py"    # the fixture suite — this tool's executable contract, a SIBLING
 
 FORMAT_VERSION = "2"
@@ -83,10 +82,8 @@ class Refusal(Exception):
 
 
 def _ledger():
-    mod = load_module_from_path("carryover_ledger", LEDGER_PY)
-    if mod is None:  # pragma: no cover - a broken checkout, not a verdict
-        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER_PY}")
-    return mod
+    """The schema owner, loaded lazily — its loader's strictness is reused, never re-rolled."""
+    return load_sibling("carryover_ledger", HERE, "ledger.py")
 
 
 # --- projection (pure) --------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -46,7 +46,7 @@ from pathlib import Path
 
 from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.git_refs import select_base_fetch_refs
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
@@ -56,14 +56,7 @@ SIBLING = _HERE / "clean-rebase-test.py"     # the fixture suite — this tool's
 LEDGER_PY = _HERE / "ledger.py"
 
 
-def _load_ledger():
-    mod = load_module_from_path("clean_rebase_ledger", LEDGER_PY)
-    if mod is None:
-        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER_PY}")
-    return mod
-
-
-L = _load_ledger()
+L = load_sibling("clean_rebase_ledger", _HERE, "ledger.py")
 
 # TERMINAL statuses — a done PR is never rebased. `files-and-ledger.md` (`status`: "in_review -> merged,
 # or aborted; plus the HELD (non-terminal) statuses") owns the enumeration; these are the two it names as

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -19,7 +19,7 @@ import tempfile
 from pathlib import Path
 from typing import Callable, NoReturn
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import run_sibling_suite
 
 
@@ -59,14 +59,7 @@ def _load_review_pass():
 RP = _load_review_pass()
 
 
-def _load_ledger():
-    mod = load_module_from_path("review_dispatch_ledger", LEDGER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER}")
-    return mod
-
-
-L = _load_ledger()
+L = load_sibling("review_dispatch_ledger", _HERE, "ledger.py")
 
 
 class Refusal(Exception):

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -47,22 +47,13 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Callable
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "triage-test.py"
-LEDGER_PY = _HERE / "ledger.py"
 
-
-def _load_ledger():
-    mod = load_module_from_path("triage_ledger", LEDGER_PY)
-    if mod is None:
-        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER_PY}")
-    return mod
-
-
-L = _load_ledger()
+L = load_sibling("triage_ledger", _HERE, "ledger.py")
 
 EXIT_OK = 0
 EXIT_REFUSED = 2

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
@@ -31,7 +31,7 @@ import tempfile
 from pathlib import Path
 from typing import Callable
 
-from _gauntlet.modules import load_module_from_path
+from _gauntlet.modules import load_module_from_path, load_sibling
 
 HERE = Path(__file__).resolve().parent
 TEMPLATE = HERE / "worker-prompt-template.txt"
@@ -40,14 +40,7 @@ FORMAT_PREFLIGHT = HERE / "format-preflight.py"
 LEDGER = HERE / "ledger.py"
 
 
-def _load_ledger():
-    mod = load_module_from_path("worker_prompt_ledger", LEDGER)
-    if mod is None:
-        raise RuntimeError(f"cannot load the ledger accessor at {LEDGER}")
-    return mod
-
-
-L = _load_ledger()
+L = load_sibling("worker_prompt_ledger", HERE, "ledger.py")
 
 EXIT_OK = 0
 EXIT_REFUSED = 2


### PR DESCRIPTION
- Six campaign tools now load the ledger via `_gauntlet.modules.load_sibling`.
- Their install error becomes `cannot load ledger.py`, as for existing callers.
- `review-pass.py` is excluded: it raises `Defect`, which eight handlers catch.
