### PR TITLE
share one UTC timestamp format owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
@@ -1,0 +1,21 @@
+# ci: pyright
+"""The `Z`-suffixed UTC stamp shared by Gauntlet campaign stores."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# The ONE spelling of the `Z`-suffixed stamp: UTC, second precision, `Z` as a literal. Producers and
+# parsers of that form both take the format from here, so it can never be half-changed.
+#
+# This is NOT the campaign's only timestamp form, and must never be read as one. `ledger.py`'s
+# `now_activity()` and the `ci_stalled_since` value `ci-status.py` writes use
+# `datetime.isoformat(timespec="seconds")` instead, which spells the offset `+00:00` rather than `Z`.
+# Those two agree with each other deliberately (`ledger.now_activity` owns that reasoning); neither
+# reads nor writes anything through this module, and neither belongs here.
+TS_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def now_iso() -> str:
+    """The current UTC moment as a `TS_FORMAT` stamp."""
+    return datetime.now(timezone.utc).strftime(TS_FORMAT)

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -79,7 +79,6 @@ import re
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 from urllib.parse import unquote, urlsplit
@@ -87,6 +86,7 @@ from urllib.parse import unquote, urlsplit
 # The grid is NOT reimplemented here. The private campaign package owns escaping, layout, and omission
 # notices; this file owns only the follow-up schema, lifecycle, and store lifetime.
 from _gauntlet.atomic import replace_text
+from _gauntlet.clock import now_iso
 from _gauntlet.jsonl import JsonlError, object_lines
 from _gauntlet.table import config_lines, grid_lines, hidden_notice
 from _gauntlet.testing import run_sibling_suite
@@ -452,10 +452,6 @@ ID_RE = re.compile(r"^fu[1-9][0-9]*$")
 def fail(msg: str) -> NoReturn:
     print(f"followups: {msg}", file=sys.stderr)
     raise SystemExit(1)
-
-
-def now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 # --- parse / serialize --------------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -52,10 +52,10 @@ import re
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
+from _gauntlet.clock import now_iso
 from _gauntlet.modules import load_module_from_path
 from _gauntlet.testing import capture_cli, run_sibling_suite
 
@@ -187,10 +187,6 @@ def decision_projection(row: dict) -> "dict[str, str]":
 def fail(msg: str) -> NoReturn:
     print(f"repair-pass: {msg}", file=sys.stderr)
     raise SystemExit(1)
-
-
-def now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def permitted_for(row: dict) -> "tuple[str, ...]":
@@ -1111,7 +1107,7 @@ def cmd_decide(path: Path, args) -> int:
              f"would let the ledger say one thing while the record says another.")
 
     row["repair_count"] = str(L.counter(row, "repair_count") + 1)
-    row["repair_decision"] = f"{args.decision}@{now()}"
+    row["repair_decision"] = f"{args.decision}@{now_iso()}"
     if args.decision == "abort":
         # Terminal. The driver still runs the abort PROCEDURE (leave the PR OPEN, drop this run's labels,
         # write abort-<id>.md) — `bailout-and-final-report.md` owns it, and this does not replace it.

--- a/plugins/gauntlet/skills/campaign/scripts/review-learnings.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-learnings.py
@@ -41,12 +41,12 @@ import re
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _gauntlet.atomic import replace_text  # noqa: E402
+from _gauntlet.clock import now_iso  # noqa: E402
 from _gauntlet.jsonl import JsonlError, object_lines  # noqa: E402
 from _gauntlet.testing import run_sibling_suite  # noqa: E402
 from _gauntlet.table import config_lines, grid_lines, hidden_notice  # noqa: E402
@@ -239,10 +239,6 @@ TABLE_RULE = "DRIVER-CONSULTED, never injected into a review pass. Promotion bey
 def fail(msg: str) -> NoReturn:
     print(f"review-learnings: {msg}", file=sys.stderr)
     raise SystemExit(1)
-
-
-def now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def is_blank(value: str) -> bool:

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -2472,6 +2472,11 @@ def run_status_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> int:
             else:
                 path.write_text("".join(line + "\n" for line in content), encoding="utf-8")
         for fname, ts in case.get("mtimes", {}).items():
+            # Spelled out rather than taken from `_gauntlet.clock.TS_FORMAT` ON PURPOSE. The fixtures above
+            # write their `mtimes` keys as literal strings, so reading them back through the constant the
+            # tool itself uses would make a wrong edit to that constant agree with itself and pass. This
+            # copy is the independent pin; it is the one place the literal is allowed to live outside its
+            # owner.
             epoch = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc).timestamp()
             os.utime(d / fname, (epoch, epoch))
         argv = ["status", "--run", str(d), "--now", case["now"], *case.get("flags", [])]

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -121,6 +121,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple, NoReturn
 
+from _gauntlet.clock import TS_FORMAT
+
 # --- the contract (stage-2-review-gate.md) ------------------------------------------------------
 
 # Verdicts. `ok` is the ONLY one that lets a pass be counted — after this tool reads its report result.
@@ -509,11 +511,12 @@ def real_utc(value: str) -> bool:
     that matters — the deadline measured from an impossible time is a deadline whose arithmetic cannot be
     done, which is the very failure the shape check was written to stop. So after the shape holds, the
     value is PARSED, and what does not parse is refused: `strptime` is the arbiter of what a date is, not
-    ten digits in the right places. (`%Y-%m-%dT%H:%M:%SZ` — the `Z` is a literal, so this is UTC by
-    construction; a value carrying any other offset never reaches here, `TS_RE` having refused it.)
+    ten digits in the right places. (It parses against `TS_FORMAT`, whose trailing `Z` is a literal, so a
+    value that parses is UTC by construction; one carrying any other offset never reaches here, `TS_RE`
+    having refused it.)
     """
     try:
-        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
+        datetime.strptime(value, TS_FORMAT)
     except ValueError:
         return False
     return True
@@ -2287,7 +2290,7 @@ def cmd_amend(args) -> int:
     # name. `reason` reaches the same non-blank rule the read side already applies to it.
     rec: "dict[str, object]" = {
         "type": AMENDMENT,
-        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "ts": datetime.now(timezone.utc).strftime(TS_FORMAT),
         "reason": args.reason,
         "proposed_unit": {
             "type": UNIT, "id": args.id, "kind": args.kind, "target": args.target,
@@ -2667,7 +2670,7 @@ def status_now(args) -> datetime:
     fixture can fix elapsed/health without the wall clock; absent both, it is the real now."""
     raw = getattr(args, "now", None) or os.environ.get(NOW_ENV)
     if raw:
-        return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
+        return datetime.strptime(raw, TS_FORMAT)
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
@@ -2923,7 +2926,7 @@ def status_row(progress: Path, now: datetime, want_verify: bool,
     elapsed_s: "float | None" = None
     if isinstance(ident, dict) and isinstance(ident.get("dispatched_at"), str):
         try:
-            elapsed_s = (now - datetime.strptime(ident["dispatched_at"], "%Y-%m-%dT%H:%M:%SZ")).total_seconds()
+            elapsed_s = (now - datetime.strptime(ident["dispatched_at"], TS_FORMAT)).total_seconds()
         except ValueError:
             elapsed_s = None
     try:
@@ -3032,7 +3035,7 @@ def cmd_status(args) -> int:
     if reviewer:
         segs.append(f"reviewer={reviewer}")
     segs.append(scope)
-    segs.append(f"as-of {now.strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    segs.append(f"as-of {now.strftime(TS_FORMAT)}")
     header = "# " + "   ".join(segs)
 
     hidden_note = (f"# {hidden} terminal pass(es) hidden (done/gone) — --history to show them"


### PR DESCRIPTION
- New `_gauntlet/clock.py` owns `TS_FORMAT` and `now_iso()`; four scripts drop their copies of the literal.
- Its comment names the separate `isoformat(timespec="seconds")` family so the two are not conflated.
- `review-pass-test.py` keeps its literal on purpose, commented, as the independent pin.
