### PR TITLE
share one gh pr view fetch owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
@@ -1,0 +1,54 @@
+# ci: pyright
+"""The `gh pr view` fetch shared by Gauntlet campaign deciders."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str | None" = None,
+                 view_json: "str | None" = None) -> "tuple[object, str | None]":
+    """One PR's `--json` view, as `(view, error)` — exactly one of the pair is meaningful.
+
+    `view_json` names a RECORDED response file and takes the place of the call, so a decider can be driven
+    without `gh` and without a network. Otherwise the fetch is `gh pr view <pr> [--repo <repo>] --json
+    <fields>`, run in `cwd` when one is given.
+
+    THE ERROR COMES BACK AS A VALUE — it is never raised here and never swallowed. Every caller is a gate
+    that must fail CLOSED on a view it could not obtain, and each spells that refusal in its own vocabulary
+    (a `recheck`, a not-yet) with its own exception type. Returning the message leaves that wrapping to the
+    caller while making the failure branch impossible to skip: there is no path here that hands back a view
+    the fetch did not produce.
+
+    EVERY failure path yields an error. A SPAWN failure raises `OSError` from `subprocess.run` itself,
+    BEFORE any returncode exists — `gh` absent or not executable, or `cwd` not a usable directory. Uncaught,
+    that prints a traceback and never fails closed, so it is caught here and joins the non-zero-exit and
+    non-JSON branches, as does an unreadable or unparseable `view_json` file.
+
+    BRANCH ON `error is not None`, NEVER ON `view is None`. `null` is valid JSON, so a recorded `null` is a
+    SUCCESSFUL read of a view that is malformed — a different thing from a fetch that failed, and not this
+    function's call to make. Nothing here inspects the SHAPE of the response: the fields a view must carry
+    differ per caller, and validating them is the caller's boundary, not the fetch's.
+    """
+    if view_json is not None:
+        try:
+            return json.loads(Path(view_json).read_text(encoding="utf-8")), None
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, str(exc)
+    argv = ["gh", "pr", "view", str(pr)]
+    if repo:
+        argv += ["--repo", repo]
+    argv += ["--json", fields]
+    try:
+        proc = subprocess.run(  # noqa: S603
+            argv, capture_output=True, text=True, check=False, cwd=cwd)
+    except OSError as exc:
+        return None, f"could not run `gh pr view {pr}`: {exc}"
+    if proc.returncode != 0:
+        return None, f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}"
+    try:
+        return json.loads(proc.stdout), None
+    except json.JSONDecodeError as exc:
+        return None, f"gh response is not JSON ({exc})"

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
@@ -34,6 +34,12 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     `subprocess.run` ITSELF when `gh`'s stdout or stderr is not UTF-8, i.e. from the very call the `OSError`
     clause guards. Both are caught, so invalid bytes from either source come back as an error value.
 
+    DEEP NESTING IS A FAILURE PATH TOO, and it escapes BOTH clauses above. `json.loads` recurses per
+    nesting level, so a response of enough open brackets raises `RecursionError` — whose bases are
+    `RuntimeError` and `Exception`, so it is NOT a `ValueError`: neither `json.JSONDecodeError` nor
+    `UnicodeDecodeError` can see it, and it is not an `OSError` either. Uncaught it is a traceback with no
+    verdict, from the one call every caller relies on to fail closed. Both parses catch it.
+
     BRANCH ON `error is not None`, NEVER ON `view is None`. `null` is valid JSON, so a recorded `null` is a
     SUCCESSFUL read of a view that is malformed — a different thing from a fetch that failed, and not this
     function's call to make. Nothing here inspects the SHAPE of the response: the fields a view must carry
@@ -44,6 +50,8 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
             return json.loads(Path(view_json).read_text(encoding="utf-8")), None
         except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             return None, str(exc)
+        except RecursionError as exc:
+            return None, f"{view_json} is nested too deeply to parse ({exc})"
     argv = ["gh", "pr", "view", str(pr)]
     if repo:
         argv += ["--repo", repo]
@@ -61,3 +69,5 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
         return json.loads(proc.stdout), None
     except json.JSONDecodeError as exc:
         return None, f"gh response is not JSON ({exc})"
+    except RecursionError as exc:
+        return None, f"gh response is nested too deeply to parse ({exc})"

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
@@ -27,6 +27,13 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     that prints a traceback and never fails closed, so it is caught here and joins the non-zero-exit and
     non-JSON branches, as does an unreadable or unparseable `view_json` file.
 
+    UNDECODABLE BYTES ARE A FAILURE PATH, NOT A CRASH, and they raise from a place that looks like neither a
+    read nor a parse. `UnicodeDecodeError` subclasses `ValueError`, so an `except OSError` never sees it and
+    an `except json.JSONDecodeError` catches only the parse. It arrives from TWO spots: `read_text` on a
+    recorded file whose bytes are not UTF-8, and — because `text=True` decodes inside `communicate()` —
+    `subprocess.run` ITSELF when `gh`'s stdout or stderr is not UTF-8, i.e. from the very call the `OSError`
+    clause guards. Both are caught, so invalid bytes from either source come back as an error value.
+
     BRANCH ON `error is not None`, NEVER ON `view is None`. `null` is valid JSON, so a recorded `null` is a
     SUCCESSFUL read of a view that is malformed — a different thing from a fetch that failed, and not this
     function's call to make. Nothing here inspects the SHAPE of the response: the fields a view must carry
@@ -35,7 +42,7 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     if view_json is not None:
         try:
             return json.loads(Path(view_json).read_text(encoding="utf-8")), None
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             return None, str(exc)
     argv = ["gh", "pr", "view", str(pr)]
     if repo:
@@ -46,6 +53,8 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
             argv, capture_output=True, text=True, check=False, cwd=cwd)
     except OSError as exc:
         return None, f"could not run `gh pr view {pr}`: {exc}"
+    except UnicodeDecodeError as exc:
+        return None, f"`gh pr view {pr}` output is not valid UTF-8: {exc}"
     if proc.returncode != 0:
         return None, f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}"
     try:

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
@@ -11,10 +11,14 @@ from pathlib import Path
 def _detail(exc: Exception) -> str:
     """One failure, described so the message is never EMPTY and always names what went wrong.
 
-    The catches below are total, so they see exceptions raised with NO message at all — `MemoryError` is one
-    the parses can genuinely produce — and a reason line reading `could not read ...:` with nothing after the
-    colon tells a reader nothing. The type name is always there, so it always leads; the message, when there
-    is one, follows it.
+    ONLY THE TOTAL `except Exception` CLAUSES BELOW CALL THIS, and that is the whole reason it exists: being
+    total, they see exceptions raised with NO message at all — `MemoryError` is one the parses can genuinely
+    produce — and a reason line reading `could not read ...:` with nothing after the colon tells a reader
+    nothing. The type name is always there, so it always leads; the message, when there is one, follows it.
+
+    The narrower clauses that precede each total one do NOT call this, and must not start. They exist to
+    reproduce a message from before this module owned the fetch, byte for byte, and a type-name prefix would
+    change it. They also never need one: every type they name always carries a message of its own.
     """
     text = str(exc).strip()
     return f"{type(exc).__name__}: {text}" if text else type(exc).__name__
@@ -51,6 +55,26 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     `GeneratorExit` derive from `BaseException` alone, so an operator's Ctrl-C and a caller's exit still
     propagate. NEVER widen this to `BaseException`.
 
+    THE NARROW `except` LEADING EACH BLOCK IS NOT THE LIST THE TOTAL GUARANTEE FORBIDS, AND CONFUSING THE
+    TWO IS THE MISTAKE TO AVOID. The forbidden list is an attempt to enumerate the failures this function
+    HANDLES; it cannot terminate, which is why the trailing `except Exception` on every block stays and is
+    what keeps the handling total. The leading clauses enumerate a different thing: the failures that ALREADY
+    HAD A MESSAGE before this fetch was extracted into one owner. That set is CLOSED and can never grow,
+    because history fixes it rather than anything the code can raise — it is exactly what the two `load_view`
+    bodies this replaced caught, and both raised byte-identical strings, so one owner reproduces them with no
+    per-caller parameter. A failure absent from that set had no earlier message at all: it ended in a
+    traceback and no verdict, so there is nothing about it that could drift. NEVER ADD A CLAUSE THERE. A new
+    failure belongs to the total catch, whose wording this module owns outright.
+
+    `_detail` STAYS ON THE TOTAL CLAUSES ONLY. Its type-name prefix exists for an exception carrying NO
+    message, which is a property of a total catch; every type the leading clauses name always carries one
+    (`JSONDecodeError` always builds `msg: line L column C (char N)`, and an `OSError` from a real syscall
+    always carries errno and strerror), so those clauses need no prefix and cannot print a bare colon.
+
+    ORDERING IS WHAT MAKES BOTH TRUE AT ONCE, and it is safe by subclassing rather than by luck: the
+    integer-limit `ValueError` and `UnicodeDecodeError` are `ValueError`s but NOT `json.JSONDecodeError`s,
+    so they fall past the leading clause to the total one, which is where they belong — they are new here.
+
     BRANCH ON `error is not None`, NEVER ON `view is None`. `null` is valid JSON, so a recorded `null` is a
     SUCCESSFUL read of a view that is malformed — a different thing from a fetch that failed, and not this
     function's call to make. Nothing here inspects the SHAPE of the response: the fields a view must carry
@@ -59,6 +83,10 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     if view_json is not None:
         try:
             return json.loads(Path(view_json).read_text(encoding="utf-8")), None
+        # HISTORICAL MESSAGE, exactly as the recorded-file read spelled it before this owner existed. See the
+        # docstring's closed-set paragraph — this clause is not the enumeration the total guarantee forbids.
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, str(exc)
         except Exception as exc:  # noqa: BLE001 — the total guarantee above
             return None, f"could not read the recorded view {view_json}: {_detail(exc)}"
     argv = ["gh", "pr", "view", str(pr)]
@@ -68,11 +96,17 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     try:
         proc = subprocess.run(  # noqa: S603
             argv, capture_output=True, text=True, check=False, cwd=cwd)
+    # HISTORICAL MESSAGE, exactly as the spawn spelled it before this owner existed.
+    except OSError as exc:
+        return None, f"could not run `gh pr view {pr}`: {exc}"
     except Exception as exc:  # noqa: BLE001 — the total guarantee above
         return None, f"could not run `gh pr view {pr}`: {_detail(exc)}"
     if proc.returncode != 0:
         return None, f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}"
     try:
         return json.loads(proc.stdout), None
+    # HISTORICAL MESSAGE, exactly as the response parse spelled it before this owner existed.
+    except json.JSONDecodeError as exc:
+        return None, f"gh response is not JSON ({exc})"
     except Exception as exc:  # noqa: BLE001 — the total guarantee above
         return None, f"could not read the `gh pr view {pr}` response: {_detail(exc)}"

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
@@ -8,6 +8,18 @@ import subprocess
 from pathlib import Path
 
 
+def _detail(exc: Exception) -> str:
+    """One failure, described so the message is never EMPTY and always names what went wrong.
+
+    The catches below are total, so they see exceptions raised with NO message at all — `MemoryError` is one
+    the parses can genuinely produce — and a reason line reading `could not read ...:` with nothing after the
+    colon tells a reader nothing. The type name is always there, so it always leads; the message, when there
+    is one, follows it.
+    """
+    text = str(exc).strip()
+    return f"{type(exc).__name__}: {text}" if text else type(exc).__name__
+
+
 def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str | None" = None,
                  view_json: "str | None" = None) -> "tuple[object, str | None]":
     """One PR's `--json` view, as `(view, error)` — exactly one of the pair is meaningful.
@@ -22,23 +34,22 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     caller while making the failure branch impossible to skip: there is no path here that hands back a view
     the fetch did not produce.
 
-    EVERY failure path yields an error. A SPAWN failure raises `OSError` from `subprocess.run` itself,
-    BEFORE any returncode exists — `gh` absent or not executable, or `cwd` not a usable directory. Uncaught,
-    that prints a traceback and never fails closed, so it is caught here and joins the non-zero-exit and
-    non-JSON branches, as does an unreadable or unparseable `view_json` file.
+    THE GUARANTEE IS TOTAL, AND IT IS DELIBERATELY NOT A LIST: NO `Exception` ESCAPES THIS FUNCTION. Reading
+    the recorded file, spawning `gh`, and parsing either response are each wrapped whole, so however the read,
+    the spawn or the parse fails, the failure leaves as an error string. DO NOT REPLACE THAT WITH THE TYPES
+    THAT HAPPEN TO REACH IT TODAY. Naming them is what this function did for three rounds, and each round
+    shipped exactly the one type the round had seen: the parse alone can raise a decode error, a recursion
+    error and a plain integer-limit `ValueError`, and the next input nobody has thought of raises something
+    else again. An enumeration cannot terminate; the wrapper can.
 
-    UNDECODABLE BYTES ARE A FAILURE PATH, NOT A CRASH, and they raise from a place that looks like neither a
-    read nor a parse. `UnicodeDecodeError` subclasses `ValueError`, so an `except OSError` never sees it and
-    an `except json.JSONDecodeError` catches only the parse. It arrives from TWO spots: `read_text` on a
-    recorded file whose bytes are not UTF-8, and — because `text=True` decodes inside `communicate()` —
-    `subprocess.run` ITSELF when `gh`'s stdout or stderr is not UTF-8, i.e. from the very call the `OSError`
-    clause guards. Both are caught, so invalid bytes from either source come back as an error value.
-
-    DEEP NESTING IS A FAILURE PATH TOO, and it escapes BOTH clauses above. `json.loads` recurses per
-    nesting level, so a response of enough open brackets raises `RecursionError` — whose bases are
-    `RuntimeError` and `Exception`, so it is NOT a `ValueError`: neither `json.JSONDecodeError` nor
-    `UnicodeDecodeError` can see it, and it is not an `OSError` either. Uncaught it is a traceback with no
-    verdict, from the one call every caller relies on to fail closed. Both parses catch it.
+    OVER-CATCHING IS THE CHEAP MISTAKE HERE AND UNDER-CATCHING IS THE EXPENSIVE ONE — that asymmetry, not
+    tidiness, is why the catch is wide. Each `try` body is tiny and fixed (a read plus a parse, a single
+    call, a single parse), so there is almost no room for a programming error to hide in one; if one did, it
+    becomes a value, the caller wraps it in its own error type, and the run still ends in a structured
+    verdict. Under-catching ends it in a traceback with NO verdict, from the one call every caller relies on
+    to fail closed. `Exception` is also the widest catch that is SAFE: `KeyboardInterrupt`, `SystemExit` and
+    `GeneratorExit` derive from `BaseException` alone, so an operator's Ctrl-C and a caller's exit still
+    propagate. NEVER widen this to `BaseException`.
 
     BRANCH ON `error is not None`, NEVER ON `view is None`. `null` is valid JSON, so a recorded `null` is a
     SUCCESSFUL read of a view that is malformed — a different thing from a fetch that failed, and not this
@@ -48,10 +59,8 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     if view_json is not None:
         try:
             return json.loads(Path(view_json).read_text(encoding="utf-8")), None
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
-            return None, str(exc)
-        except RecursionError as exc:
-            return None, f"{view_json} is nested too deeply to parse ({exc})"
+        except Exception as exc:  # noqa: BLE001 — the total guarantee above
+            return None, f"could not read the recorded view {view_json}: {_detail(exc)}"
     argv = ["gh", "pr", "view", str(pr)]
     if repo:
         argv += ["--repo", repo]
@@ -59,15 +68,11 @@ def pr_view_json(pr: str, *, fields: str, repo: "str | None" = None, cwd: "str |
     try:
         proc = subprocess.run(  # noqa: S603
             argv, capture_output=True, text=True, check=False, cwd=cwd)
-    except OSError as exc:
-        return None, f"could not run `gh pr view {pr}`: {exc}"
-    except UnicodeDecodeError as exc:
-        return None, f"`gh pr view {pr}` output is not valid UTF-8: {exc}"
+    except Exception as exc:  # noqa: BLE001 — the total guarantee above
+        return None, f"could not run `gh pr view {pr}`: {_detail(exc)}"
     if proc.returncode != 0:
         return None, f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}"
     try:
         return json.loads(proc.stdout), None
-    except json.JSONDecodeError as exc:
-        return None, f"gh response is not JSON ({exc})"
-    except RecursionError as exc:
-        return None, f"gh response is nested too deeply to parse ({exc})"
+    except Exception as exc:  # noqa: BLE001 — the total guarantee above
+        return None, f"could not read the `gh pr view {pr}` response: {_detail(exc)}"

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import inspect
+import os
+import sys
 import tempfile
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from io import StringIO
@@ -29,6 +31,36 @@ def capture_cli(main: "Callable[[list[str]], int]", argv: "list[str]") -> "tuple
     except SystemExit as exc:
         code = exc.code if isinstance(exc.code, int) else 1
     return code, out.getvalue(), err.getvalue()
+
+
+@contextmanager
+def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, None]":
+    """Put a fake ``gh`` FIRST on ``PATH`` that writes exactly ``stdout`` as RAW BYTES, then exits.
+
+    A str-typed stub over ``subprocess.run`` cannot reproduce what an operator's ``gh`` can actually do,
+    because bytes that are not valid UTF-8 never survive being written as a Python ``str``. Only a real
+    child process writing to its raw stdout buffer gets them onto the pipe — and that is the whole point
+    for a decider that spawns with ``text=True``, where the decode happens inside ``communicate()`` and
+    any failure therefore surfaces from the ``subprocess.run`` CALL rather than from the parse after it.
+
+    ``PATH`` is restored on the way out, so the real ``gh`` answers again for every later fixture.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fake = Path(tmpdir) / "gh"
+        fake.write_text(
+            f"#!{sys.executable}\n"
+            "import sys\n"
+            f"sys.stdout.buffer.write({stdout!r})\n"
+            "sys.stdout.buffer.flush()\n"
+            f"raise SystemExit({exit_code})\n",
+            encoding="utf-8")
+        fake.chmod(0o755)
+        before = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{tmpdir}{os.pathsep}{before}"
+        try:
+            yield
+        finally:
+            os.environ["PATH"] = before
 
 
 # --- the shared fixture runner ------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -33,6 +33,28 @@ def capture_cli(main: "Callable[[list[str]], int]", argv: "list[str]") -> "tuple
     return code, out.getvalue(), err.getvalue()
 
 
+# How deep the nesting below goes. `json.loads` recurses once per level, but the depth at which it gives
+# up is NOT `sys.getrecursionlimit()`: the C scanner is bounded by the interpreter's stack headroom, so the
+# real threshold moves with the Python build and the platform. A fixture that sat near it would pass on one
+# machine and not the next, so this is deliberately far past any of them rather than tuned to one.
+_NESTING_DEPTH = 100_000
+
+
+def deeply_nested_json() -> bytes:
+    """A well-formed JSON array nested far past any parse's recursion limit, as the RAW BYTES of a response.
+
+    This is the input that makes `json.loads` raise `RecursionError` — whose bases are `RuntimeError` and
+    `Exception`, so it is NOT a `ValueError`: an `except json.JSONDecodeError` cannot see it, and neither
+    can the `UnicodeDecodeError` clause that sits beside it in the same reader.
+
+    It is the shared input for the suites that drive `_gauntlet/gh.py`'s two parses, which want a WHOLE
+    response. It is deliberately NOT the tree's only deep-JSON fixture: the JSONL readers pin the same
+    escape with a deep LINE, in inputs their own suites own, and merging the two would be merging inputs
+    of different shapes for different parsers rather than removing a duplicate.
+    """
+    return b"[" * _NESTING_DEPTH + b"]" * _NESTING_DEPTH
+
+
 @contextmanager
 def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, None]":
     """Put a fake ``gh`` FIRST on ``PATH`` that writes exactly ``stdout`` as RAW BYTES, then exits.
@@ -43,7 +65,13 @@ def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, N
     for a decider that spawns with ``text=True``, where the decode happens inside ``communicate()`` and
     any failure therefore surfaces from the ``subprocess.run`` CALL rather than from the parse after it.
 
-    ``PATH`` is restored on the way out, so the real ``gh`` answers again for every later fixture.
+    ``PATH`` is restored on the way out, so the real ``gh`` answers again for every later fixture. RESTORED
+    means RESTORED, INCLUDING ITS ABSENCE: an unset ``PATH`` and ``PATH=""`` are NOT the same thing to
+    ``exec``. With the variable gone, ``execvp`` falls back to ``confstr(_CS_PATH)`` and a bare ``git``
+    still resolves; with it set to the empty string there is nothing to search and the spawn raises
+    ``FileNotFoundError``. Writing back a defaulted ``""`` would therefore leave the process in a state it
+    was never in, and every later fixture that spawns a bare command name would fail — so an originally
+    ABSENT ``PATH`` is DELETED here, never re-created empty.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         fake = Path(tmpdir) / "gh"
@@ -55,12 +83,15 @@ def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, N
             f"raise SystemExit({exit_code})\n",
             encoding="utf-8")
         fake.chmod(0o755)
-        before = os.environ.get("PATH", "")
-        os.environ["PATH"] = f"{tmpdir}{os.pathsep}{before}"
+        before = os.environ.get("PATH")
+        os.environ["PATH"] = tmpdir if not before else f"{tmpdir}{os.pathsep}{before}"
         try:
             yield
         finally:
-            os.environ["PATH"] = before
+            if before is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = before
 
 
 # --- the shared fixture runner ------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -7,10 +7,10 @@ import inspect
 import os
 import sys
 import tempfile
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from contextlib import contextmanager, nullcontext, redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Callable, Generator, Sequence
+from typing import Callable, ContextManager, Generator, Sequence
 
 from _gauntlet.modules import load_module_from_path
 
@@ -96,8 +96,9 @@ def hostile_json_responses() -> "list[tuple[str, bytes]]":
 
 
 @contextmanager
-def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, None]":
-    """Put a fake ``gh`` FIRST on ``PATH`` that writes exactly ``stdout`` as RAW BYTES, then exits.
+def gh_writing(stdout: bytes, *, stderr: bytes = b"", exit_code: int = 0) -> "Generator[None, None, None]":
+    """Put a fake ``gh`` FIRST on ``PATH`` that writes exactly ``stdout`` (and ``stderr``) as RAW BYTES,
+    then exits.
 
     A str-typed stub over ``subprocess.run`` cannot reproduce what an operator's ``gh`` can actually do,
     because bytes that are not valid UTF-8 never survive being written as a Python ``str``. Only a real
@@ -120,6 +121,8 @@ def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, N
             "import sys\n"
             f"sys.stdout.buffer.write({stdout!r})\n"
             "sys.stdout.buffer.flush()\n"
+            f"sys.stderr.buffer.write({stderr!r})\n"
+            "sys.stderr.buffer.flush()\n"
             f"raise SystemExit({exit_code})\n",
             encoding="utf-8")
         fake.chmod(0o755)
@@ -132,6 +135,71 @@ def gh_writing(stdout: bytes, *, exit_code: int = 0) -> "Generator[None, None, N
                 os.environ.pop("PATH", None)
             else:
                 os.environ["PATH"] = before
+
+
+@contextmanager
+def gh_spawn_failing() -> "Generator[None, None, None]":
+    """Make the fetch's SPAWN raise the exact ``OSError`` an absent ``gh`` raises, then restore it.
+
+    ``subprocess.run`` is patched in ``_gauntlet/gh.py`` — the module that OWNS the spawn — because patching
+    anywhere else leaves the real ``gh`` to answer and the fixture passes on a fetch it never broke. The
+    exception is built exactly as ``execvp`` builds it, so the message a caller prints is the one an operator
+    without ``gh`` sees; emptying ``PATH`` instead would make the fixture depend on the machine's ``gh``.
+    """
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+    from _gauntlet import gh as _gh
+    real_run = _gh.subprocess.run
+    setattr(_gh.subprocess, "run", boom)
+    try:
+        yield
+    finally:
+        setattr(_gh.subprocess, "run", real_run)
+
+
+# One legacy view-fetch failure: a short name, the extra CLI args that provoke it, a factory for the context
+# it needs, and the EXACT message tail the caller must print after its own `could not fetch PR view: ` prefix.
+LegacyViewCase = tuple[str, "list[str]", "Callable[[], ContextManager[None]]", str]
+
+
+def legacy_view_error_cases(work: Path, *, pr: str = "9") -> "list[LegacyViewCase]":
+    """Every view-fetch failure that ALREADY HAD A MESSAGE before `_gauntlet/gh.py` owned the fetch, with the
+    exact wording each one must still produce. THE SET IS CLOSED: it is fixed by history, not by what the
+    fetch can raise, so nothing is ever added here. A failure absent from it had no prior message at all — it
+    ended in a traceback and no verdict — and its wording is owned by `gh.py` alone.
+
+    THE TAILS BELOW ARE LITERALS ON PURPOSE, and asserting the WHOLE reason is the entire point of this
+    table. Both callers already had fixtures asserting the shared `could not fetch PR view: ` PREFIX, and a
+    rewrite of every tail behind that prefix passed all of them, through six rounds of review, unnoticed. A
+    prefix assertion cannot fail for a reworded tail; only a full-string one can.
+
+    Both callers are checked against the SAME rows because both are meant to print the same thing: the two
+    `load_view` bodies this fetch replaced produced byte-identical messages, so a per-caller expectation here
+    would be a claim the code never made. Each suite supplies its own base argv and its own verdict name; the
+    reason tail is all that is shared, and it is shared completely.
+
+    `work` is a fixture's own empty directory; the recorded-view rows are materialized inside it.
+    """
+    empty = work / "empty-view.json"
+    empty.write_bytes(b"")
+    missing = work / "no-such-view.json"
+    a_dir = work / "view-is-a-directory"
+    a_dir.mkdir(exist_ok=True)
+    return [
+        ("recorded-view-not-json", ["--view-json", str(empty)], nullcontext,
+         "Expecting value: line 1 column 1 (char 0)"),
+        ("recorded-view-missing", ["--view-json", str(missing)], nullcontext,
+         f"[Errno 2] No such file or directory: '{missing}'"),
+        ("recorded-view-is-a-directory", ["--view-json", str(a_dir)], nullcontext,
+         f"[Errno 21] Is a directory: '{a_dir}'"),
+        ("gh-spawn-failed", ["--repo", "o/n"], gh_spawn_failing,
+         f"could not run `gh pr view {pr}`: [Errno 2] No such file or directory: 'gh'"),
+        ("gh-response-not-json", ["--repo", "o/n"], lambda: gh_writing(b"not json at all"),
+         "gh response is not JSON (Expecting value: line 1 column 1 (char 0))"),
+        ("gh-exited-non-zero", ["--repo", "o/n"],
+         lambda: gh_writing(b"", stderr=b"boom from gh", exit_code=3),
+         f"`gh pr view {pr}` exited 3: boom from gh"),
+    ]
 
 
 # --- the shared fixture runner ------------------------------------------------

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -43,9 +43,9 @@ _NESTING_DEPTH = 100_000
 def deeply_nested_json() -> bytes:
     """A well-formed JSON array nested far past any parse's recursion limit, as the RAW BYTES of a response.
 
-    This is the input that makes `json.loads` raise `RecursionError` — whose bases are `RuntimeError` and
-    `Exception`, so it is NOT a `ValueError`: an `except json.JSONDecodeError` cannot see it, and neither
-    can the `UnicodeDecodeError` clause that sits beside it in the same reader.
+    This is the input that makes `json.loads` raise `RecursionError`, which is a `RuntimeError` and NOT a
+    `ValueError` — so it lands in a DIFFERENT branch of the exception tree from a syntax error or a decode
+    error, and any reader that catches by naming types will miss it unless it named this one too.
 
     It is the shared input for the suites that drive `_gauntlet/gh.py`'s two parses, which want a WHOLE
     response. It is deliberately NOT the tree's only deep-JSON fixture: the JSONL readers pin the same
@@ -53,6 +53,46 @@ def deeply_nested_json() -> bytes:
     of different shapes for different parsers rather than removing a duplicate.
     """
     return b"[" * _NESTING_DEPTH + b"]" * _NESTING_DEPTH
+
+
+# Python 3.11 and later refuse to convert an integer STRING longer than this many digits, so a JSON document
+# holding a longer integer literal is well-formed and still unparseable. The limit is CPython's documented
+# `sys.get_int_max_str_digits()` default; the payload below clears it by a wide margin rather than sitting on
+# it, so this fixture does not become a test of one interpreter's threshold.
+_OVERSIZED_INT_DIGITS = 5000
+
+
+def oversized_int_json() -> bytes:
+    """A well-formed JSON object whose integer literal is too long for CPython to convert, as RAW BYTES.
+
+    This is the input that makes `json.loads` raise a PLAIN `ValueError` — not a `json.JSONDecodeError`, not
+    a `UnicodeDecodeError`, but their shared BASE. A reader that catches the two subclasses by name lets this
+    one straight through, which is exactly how it was found.
+    """
+    return b'{"n": ' + b"9" * _OVERSIZED_INT_DIGITS + b"}"
+
+
+def hostile_json_responses() -> "list[tuple[str, bytes]]":
+    """Every `(name, raw bytes)` row a `gh pr view` reader must survive, as a TABLE rather than a member list.
+
+    THIS IS THE CHECK THAT CAN FAIL FOR AN INPUT NOBODY NAMED. The per-exception fixtures beside it pin which
+    input produces which message, and that is worth having — but each one is written around an exception type
+    that was already known, so a family member discovered tomorrow cannot make any of them go red. A caller
+    drives this whole table through its real CLI and asserts the same property for every row: a structured
+    verdict on stdout, no traceback on stderr. ADD A ROW HERE when a new hostile input turns up; that is the
+    one edit that makes every suite using the table cover it at once.
+
+    The rows are deliberately spread across the exception tree — a syntax error, a decode failure before the
+    parse is even reached, a conversion limit inside a well-formed document, and a recursion limit — so that
+    a reader narrowed back to catching a single branch fails at least one row.
+    """
+    return [
+        ("bad-syntax", b"{not json at all"),
+        ("truncated", b'{"mergeable": "MERGEA'),
+        ("undecodable-bytes", b'{"mergeable": "MERGEABLE", "x": "\xff"}'),
+        ("oversized-int", oversized_int_json()),
+        ("deep-nesting", deeply_nested_json()),
+    ]
 
 
 @contextmanager

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -21,7 +21,8 @@ from pathlib import Path
 
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import capture_cli, checker, deeply_nested_json, gh_writing
+from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
+                               hostile_json_responses)
 
 OWNER = Path(__file__).resolve().parent / "base-preflight.py"
 
@@ -204,11 +205,11 @@ def t_cli_bad_project_root_fails_closed():
 
 
 def t_cli_undecodable_view_json_fails_closed():
-    # A recorded --view-json whose BYTES are not UTF-8. The decode raises UnicodeDecodeError, which
-    # subclasses ValueError and is therefore invisible to an `except OSError` and to an
-    # `except json.JSONDecodeError` — the read never reaches the parse. It must still fail CLOSED: a
-    # structured recheck on stdout, a NON-ZERO exit, and NO traceback. capture_cli only catches SystemExit,
-    # so an uncaught decode error would ESCAPE here and fail this fixture — that is the teeth.
+    # A recorded --view-json whose BYTES are not UTF-8, so the failure comes from the DECODE and the read
+    # never reaches the parse. It must fail CLOSED: a structured recheck on stdout, a NON-ZERO exit, and NO
+    # traceback. capture_cli only catches SystemExit, so an uncaught decode error would ESCAPE here and fail
+    # this fixture — that is the teeth. This row pins the MESSAGE for this input; that no input at all can
+    # escape is the hostile-table fixture's job, not this one's.
     with tempfile.TemporaryDirectory() as d:
         vjson = Path(d) / "view.json"
         vjson.write_bytes(b'{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "x": "\xff"}')
@@ -224,9 +225,9 @@ def t_cli_undecodable_view_json_fails_closed():
 
 def t_cli_undecodable_gh_stdout_fails_closed():
     # The same invalid bytes, but from a REAL `gh` resolved through PATH. With text=True the decode happens
-    # inside communicate(), so UnicodeDecodeError comes out of the subprocess.run CALL — exactly where the
-    # OSError clause sits, and a ValueError subclass that clause cannot see. No --view-json, so load_view
-    # takes the gh path. Fail CLOSED: a structured recheck on stdout, NON-ZERO exit, NO traceback.
+    # inside communicate(), so the failure surfaces from the subprocess.run CALL rather than from the parse
+    # after it — a SPAWN-site failure that looks like neither a read nor a parse. No --view-json, so
+    # load_view takes the gh path. Fail CLOSED: a structured recheck on stdout, NON-ZERO exit, NO traceback.
     with gh_writing(b'{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "x": "\xff"}'):
         code, out, err = capture_cli(M.main, ["check", "--pr", "9"])
     check(code != 0, f"undecodable gh output must exit non-zero (fail closed), got {code} (stderr: {err})")
@@ -240,10 +241,11 @@ def t_cli_undecodable_gh_stdout_fails_closed():
 
 def t_cli_deep_view_json_fails_closed():
     # A recorded --view-json nested far past the parse's recursion limit. `json.loads` recurses per nesting
-    # level, so it raises RecursionError — a RuntimeError, NOT a ValueError, so neither the JSONDecodeError
-    # clause nor the UnicodeDecodeError one beside it can see it, and it is not an OSError either. It must
-    # still fail CLOSED: a structured recheck on stdout, a NON-ZERO exit, and NO traceback. capture_cli only
-    # catches SystemExit, so an uncaught RecursionError would ESCAPE here and fail this fixture — the teeth.
+    # level, so it raises RecursionError — a RuntimeError, in a different branch of the exception tree from
+    # every other input here. It must fail CLOSED: a structured recheck on stdout, a NON-ZERO exit, and NO
+    # traceback. capture_cli only catches SystemExit, so an uncaught RecursionError would ESCAPE here and
+    # fail this fixture — the teeth. This row pins the MESSAGE for this input; the hostile-table fixture is
+    # what pins that no input escapes.
     with tempfile.TemporaryDirectory() as d:
         vjson = Path(d) / "view.json"
         vjson.write_bytes(deeply_nested_json())
@@ -260,8 +262,9 @@ def t_cli_deep_view_json_fails_closed():
 def t_cli_deep_gh_stdout_fails_closed():
     # The same too-deep response, but from a REAL `gh` resolved through PATH, so the RecursionError comes
     # out of the SECOND parse — the live-fetch one, a separate `try` from the recorded-file parse above and
-    # therefore a separate escape. No --view-json, so load_view takes the gh path. Fail CLOSED: a structured
-    # recheck on stdout, NON-ZERO exit, NO traceback.
+    # therefore a separate escape. Every guarantee `_gauntlet/gh.py` makes has to hold at BOTH parse sites,
+    # and only a fixture on each proves it. No --view-json, so load_view takes the gh path. Fail CLOSED: a
+    # structured recheck on stdout, NON-ZERO exit, NO traceback.
     with gh_writing(deeply_nested_json()):
         code, out, err = capture_cli(M.main, ["check", "--pr", "9"])
     check(code != 0, f"too-deep gh output must exit non-zero (fail closed), got {code} (stderr: {err})")
@@ -271,6 +274,45 @@ def t_cli_deep_gh_stdout_fails_closed():
           f"too-deep gh output must decide recheck, never proceed, got {result!r}")
     check(result["reason"].startswith("could not fetch PR view:"),
           f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
+def t_cli_hostile_responses_never_escape():
+    """THE GUARANTEE, not a member list: for EVERY hostile response in the shared table, and at BOTH of the
+    fetch's parse sites, the CLI prints a structured verdict and prints no traceback.
+
+    The per-input fixtures above cannot make this claim. Each was written around an exception type that was
+    already known, so a family member discovered tomorrow leaves all of them green — which is how a plain
+    `ValueError` from an oversized integer literal reached a released decider past clauses that already named
+    a decode error and a recursion error. This fixture is driven by DATA: a row added to
+    `hostile_json_responses` fails here until the fetch survives it.
+
+    Both sites, every row. The recorded-file parse and the live-fetch parse are separate `try` blocks, so a
+    guarantee proved at one says nothing about the other.
+    """
+    for name, payload in hostile_json_responses():
+        with tempfile.TemporaryDirectory() as d:
+            vjson = Path(d) / "view.json"
+            vjson.write_bytes(payload)
+            recorded = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
+        with gh_writing(payload):
+            live = capture_cli(M.main, ["check", "--pr", "9"])
+        for site, (code, out, err) in (("--view-json", recorded), ("gh stdout", live)):
+            label = f"[{name} via {site}]"
+            # capture_cli only catches SystemExit, so anything else escaping the fetch lands HERE as a raised
+            # exception and the runner reports this fixture as a crash — the teeth.
+            check(err == "", f"{label} must NOT print a traceback, got stderr {err!r}")
+            check(code != 0, f"{label} must exit non-zero (fail closed), got {code}")
+            try:
+                result = json.loads(out)
+            except json.JSONDecodeError as exc:
+                raise M.SelfTestFailure(
+                    f"{label} must print a structured verdict on stdout, got {out!r} ({exc})") from exc
+            check(result.get("verdict") == "recheck",
+                  f"{label} must decide recheck, never proceed, got {result!r}")
+            check(str(result.get("reason", "")).startswith("could not fetch PR view:"),
+                  f"{label} must name the fetch failure, got {result!r}")
+            check(result["reason"].strip() != "could not fetch PR view:",
+                  f"{label} must say WHAT failed, not an empty detail, got {result['reason']!r}")
 
 
 def t_gh_writing_restores_an_absent_path():
@@ -952,6 +994,8 @@ CASES = [
      t_cli_deep_view_json_fails_closed),
     ("cli-deep-gh-stdout", "gh stdout too deeply nested to parse fails closed to recheck, no traceback",
      t_cli_deep_gh_stdout_fails_closed),
+    ("cli-hostile-responses", "every hostile response in the shared table fails closed at BOTH parse sites",
+     t_cli_hostile_responses_never_escape),
     ("gh-writing-restores-absent-path", "gh_writing restores an absent PATH by deleting it, never as ''",
      t_gh_writing_restores_an_absent_path),
     ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling rebases",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -13,6 +13,7 @@ the mapping is pinned TOTALLY over the enum, plus unrecognised-value fixtures th
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -20,7 +21,7 @@ from pathlib import Path
 
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import capture_cli, checker, gh_writing
+from _gauntlet.testing import capture_cli, checker, deeply_nested_json, gh_writing
 
 OWNER = Path(__file__).resolve().parent / "base-preflight.py"
 
@@ -235,6 +236,66 @@ def t_cli_undecodable_gh_stdout_fails_closed():
           f"undecodable gh output must decide recheck, never proceed, got {result!r}")
     check(result["reason"].startswith("could not fetch PR view:"),
           f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
+def t_cli_deep_view_json_fails_closed():
+    # A recorded --view-json nested far past the parse's recursion limit. `json.loads` recurses per nesting
+    # level, so it raises RecursionError — a RuntimeError, NOT a ValueError, so neither the JSONDecodeError
+    # clause nor the UnicodeDecodeError one beside it can see it, and it is not an OSError either. It must
+    # still fail CLOSED: a structured recheck on stdout, a NON-ZERO exit, and NO traceback. capture_cli only
+    # catches SystemExit, so an uncaught RecursionError would ESCAPE here and fail this fixture — the teeth.
+    with tempfile.TemporaryDirectory() as d:
+        vjson = Path(d) / "view.json"
+        vjson.write_bytes(deeply_nested_json())
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
+    check(code != 0, f"a too-deep --view-json must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"a too-deep --view-json must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck",
+          f"a too-deep --view-json must decide recheck, never proceed, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
+def t_cli_deep_gh_stdout_fails_closed():
+    # The same too-deep response, but from a REAL `gh` resolved through PATH, so the RecursionError comes
+    # out of the SECOND parse — the live-fetch one, a separate `try` from the recorded-file parse above and
+    # therefore a separate escape. No --view-json, so load_view takes the gh path. Fail CLOSED: a structured
+    # recheck on stdout, NON-ZERO exit, NO traceback.
+    with gh_writing(deeply_nested_json()):
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9"])
+    check(code != 0, f"too-deep gh output must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"too-deep gh output must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck",
+          f"too-deep gh output must decide recheck, never proceed, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
+def t_gh_writing_restores_an_absent_path():
+    # gh_writing's PATH restoration, pinned from the suite whose ORDER its failure mode breaks: the two
+    # fixtures above use gh_writing, and everything after them spawns git. An unset PATH and PATH="" are not
+    # the same thing to exec — with the variable gone execvp falls back to confstr(_CS_PATH) and a bare
+    # `git` still resolves, while PATH="" leaves nothing to search and the spawn raises FileNotFoundError.
+    # So a restoration that writes back a defaulted "" leaves the process in a state it was never in, and
+    # every later git-using fixture fails — but ONLY when the suite was launched with PATH already absent,
+    # which is exactly why running the suite the ordinary way never noticed. Reproduce that launch here.
+    outer = os.environ.pop("PATH", None)
+    try:
+        with gh_writing(b"{}"):
+            pass
+        check("PATH" not in os.environ,
+              f"gh_writing must restore an ABSENT PATH by DELETING it, got {os.environ.get('PATH')!r}")
+        # The consequence, not just the variable: a bare command name must still spawn afterwards.
+        proc = subprocess.run(["git", "--version"], capture_output=True, text=True, check=False)  # noqa: S603,S607
+        check(proc.returncode == 0,
+              f"a bare `git` must still spawn after restoration, got exit {proc.returncode}")
+    finally:
+        if outer is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = outer
 
 
 # The repository fixtures come from the shared owner, bound to THIS suite's failure type.
@@ -887,6 +948,12 @@ CASES = [
      t_cli_undecodable_view_json_fails_closed),
     ("cli-undecodable-gh-stdout", "gh stdout that is not UTF-8 fails closed to recheck, no traceback",
      t_cli_undecodable_gh_stdout_fails_closed),
+    ("cli-deep-view-json", "a --view-json too deeply nested to parse fails closed to recheck, no traceback",
+     t_cli_deep_view_json_fails_closed),
+    ("cli-deep-gh-stdout", "gh stdout too deeply nested to parse fails closed to recheck, no traceback",
+     t_cli_deep_gh_stdout_fails_closed),
+    ("gh-writing-restores-absent-path", "gh_writing restores an absent PATH by deleting it, never as ''",
+     t_gh_writing_restores_an_absent_path),
     ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling rebases",
      t_clean_view_with_stale_base_rebases),
     ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import capture_cli, checker
+from _gauntlet.testing import capture_cli, checker, gh_writing
 
 OWNER = Path(__file__).resolve().parent / "base-preflight.py"
 
@@ -198,6 +198,41 @@ def t_cli_bad_project_root_fails_closed():
     result = json.loads(out)
     check(result["verdict"] == "recheck",
           f"a bad --project-root must decide recheck, never proceed, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
+def t_cli_undecodable_view_json_fails_closed():
+    # A recorded --view-json whose BYTES are not UTF-8. The decode raises UnicodeDecodeError, which
+    # subclasses ValueError and is therefore invisible to an `except OSError` and to an
+    # `except json.JSONDecodeError` — the read never reaches the parse. It must still fail CLOSED: a
+    # structured recheck on stdout, a NON-ZERO exit, and NO traceback. capture_cli only catches SystemExit,
+    # so an uncaught decode error would ESCAPE here and fail this fixture — that is the teeth.
+    with tempfile.TemporaryDirectory() as d:
+        vjson = Path(d) / "view.json"
+        vjson.write_bytes(b'{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "x": "\xff"}')
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson)])
+    check(code != 0, f"an undecodable --view-json must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"an undecodable --view-json must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck",
+          f"an undecodable --view-json must decide recheck, never proceed, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the fetch failure, got {result['reason']!r}")
+
+
+def t_cli_undecodable_gh_stdout_fails_closed():
+    # The same invalid bytes, but from a REAL `gh` resolved through PATH. With text=True the decode happens
+    # inside communicate(), so UnicodeDecodeError comes out of the subprocess.run CALL — exactly where the
+    # OSError clause sits, and a ValueError subclass that clause cannot see. No --view-json, so load_view
+    # takes the gh path. Fail CLOSED: a structured recheck on stdout, NON-ZERO exit, NO traceback.
+    with gh_writing(b'{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN", "x": "\xff"}'):
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9"])
+    check(code != 0, f"undecodable gh output must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"undecodable gh output must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck",
+          f"undecodable gh output must decide recheck, never proceed, got {result!r}")
     check(result["reason"].startswith("could not fetch PR view:"),
           f"the reason must name the fetch failure, got {result['reason']!r}")
 
@@ -848,6 +883,10 @@ CASES = [
     ("cli-malformed", "a view missing a field fails closed to recheck, never KeyError", t_cli_malformed),
     ("cli-bad-project-root", "an invalid --project-root fails closed to recheck, no traceback",
      t_cli_bad_project_root_fails_closed),
+    ("cli-undecodable-view-json", "a --view-json that is not UTF-8 fails closed to recheck, no traceback",
+     t_cli_undecodable_view_json_fails_closed),
+    ("cli-undecodable-gh-stdout", "gh stdout that is not UTF-8 fails closed to recheck, no traceback",
+     t_cli_undecodable_gh_stdout_fails_closed),
     ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling rebases",
      t_clean_view_with_stale_base_rebases),
     ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
-                               hostile_json_responses)
+                               hostile_json_responses, legacy_view_error_cases)
 
 OWNER = Path(__file__).resolve().parent / "base-preflight.py"
 
@@ -313,6 +313,31 @@ def t_cli_hostile_responses_never_escape():
                   f"{label} must name the fetch failure, got {result!r}")
             check(result["reason"].strip() != "could not fetch PR view:",
                   f"{label} must say WHAT failed, not an empty detail, got {result['reason']!r}")
+
+
+def t_cli_legacy_view_errors_keep_their_exact_wording():
+    """THE WHOLE REASON STRING, for every failure that had one before `_gauntlet/gh.py` owned the fetch.
+
+    Extracting the fetch into a shared owner was meant to leave each caller's message BYTE FOR BYTE intact.
+    Every fixture above asserts only the `could not fetch PR view: ` PREFIX, so a rewrite of the tail behind
+    it — the part a reader actually reads — cannot fail any of them, and one went unnoticed for six rounds of
+    review. This row is the assertion that can catch it: the shared table owns the exact tail, and equality
+    is the check.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        for name, extra, context, tail in legacy_view_error_cases(Path(d)):
+            with context():
+                code, out, err = capture_cli(M.main, ["check", "--pr", "9"] + extra)
+            label = f"[{name}]"
+            check(err == "", f"{label} must NOT print a traceback, got stderr {err!r}")
+            check(code != 0, f"{label} must exit non-zero (fail closed), got {code}")
+            result = json.loads(out)
+            check(result["verdict"] == "recheck",
+                  f"{label} must decide recheck, never proceed, got {result!r}")
+            expected = f"could not fetch PR view: {tail}"
+            check(result["reason"] == expected,
+                  f"{label} must print the reason UNCHANGED from before the fetch was shared.\n"
+                  f"           expected {expected!r}\n           got      {result['reason']!r}")
 
 
 def t_gh_writing_restores_an_absent_path():
@@ -996,6 +1021,8 @@ CASES = [
      t_cli_deep_gh_stdout_fails_closed),
     ("cli-hostile-responses", "every hostile response in the shared table fails closed at BOTH parse sites",
      t_cli_hostile_responses_never_escape),
+    ("cli-legacy-view-messages", "every pre-existing view-fetch failure keeps its EXACT reason string",
+     t_cli_legacy_view_errors_keep_their_exact_wording),
     ("gh-writing-restores-absent-path", "gh_writing restores an absent PATH by deleting it, never as ''",
      t_gh_writing_restores_an_absent_path),
     ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling rebases",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -224,10 +224,13 @@ def validate_view(view: object) -> "str | None":
 def load_view(pr: str, repo: "str | None", view_json: "str | None",
               project_root: "str | None") -> dict:
     """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
-    `gh pr view` itself, both through `_gauntlet/gh.py`, the ONE owner of that fetch. It reports a failure
-    as a MESSAGE — including the spawn failure that raises before any returncode exists, which uncaught
-    would print a traceback instead of a verdict — and every one of them becomes a `ViewError` here, which
-    the caller turns into a fail-closed `recheck`.
+    `gh pr view` itself, both through `_gauntlet/gh.py` — the ONE owner of that fetch AND of the set of
+    failures it hands back as a MESSAGE rather than raising, each of which uncaught would print a traceback
+    instead of a verdict. Every one of those messages becomes a `ViewError` here, which the caller turns
+    into a fail-closed `recheck`.
+
+    Do NOT restate that set here. It has already grown once (undecodable bytes joined the spawn failure),
+    and an unpacked copy in this docstring is exactly the gloss that would have gone stale when it did.
     """
     view, error = pr_view_json(pr, fields=VIEW_FIELDS, repo=repo, cwd=project_root,
                                view_json=view_json)

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -229,8 +229,8 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None",
     instead of a verdict. Every one of those messages becomes a `ViewError` here, which the caller turns
     into a fail-closed `recheck`.
 
-    Do NOT restate that set here. It has already grown once (undecodable bytes joined the spawn failure),
-    and an unpacked copy in this docstring is exactly the gloss that would have gone stale when it did.
+    Do NOT restate that set here. It has grown MORE THAN ONCE since this docstring was written, and each
+    time, an unpacked copy here is the gloss that would have gone stale — which is why there is not one.
     """
     view, error = pr_view_json(pr, fields=VIEW_FIELDS, repo=repo, cwd=project_root,
                                view_json=view_json)

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -45,8 +45,10 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import cast
 
 from _gauntlet.argv import bind_separate_option_value
+from _gauntlet.gh import pr_view_json
 from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import run_sibling_suite
@@ -222,32 +224,19 @@ def validate_view(view: object) -> "str | None":
 def load_view(pr: str, repo: "str | None", view_json: "str | None",
               project_root: "str | None") -> dict:
     """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
-    `gh pr view` itself. Any failure raises `ViewError`, which the caller turns into a fail-closed `recheck`.
+    `gh pr view` itself, both through `_gauntlet/gh.py`, the ONE owner of that fetch. It reports a failure
+    as a MESSAGE — including the spawn failure that raises before any returncode exists, which uncaught
+    would print a traceback instead of a verdict — and every one of them becomes a `ViewError` here, which
+    the caller turns into a fail-closed `recheck`.
     """
-    if view_json is not None:
-        try:
-            return json.loads(Path(view_json).read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise ViewError(str(exc)) from exc
-    argv = ["gh", "pr", "view", str(pr)]
-    if repo:
-        argv += ["--repo", repo]
-    argv += ["--json", VIEW_FIELDS]
-    try:
-        proc = subprocess.run(  # noqa: S603
-            argv, capture_output=True, text=True, check=False, cwd=project_root)
-    except OSError as exc:
-        # subprocess.run RAISES before it ever produces a returncode when the executable is missing
-        # (FileNotFoundError) or `--project-root` is not a usable directory (NotADirectoryError) — both are
-        # OSError. Uncaught, that prints a traceback and never fails closed; turn it into a ViewError so the
-        # caller emits a structured `recheck` and exits non-zero, exactly like a non-zero `gh` exit.
-        raise ViewError(f"could not run `gh pr view {pr}`: {exc}") from exc
-    if proc.returncode != 0:
-        raise ViewError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise ViewError(f"gh response is not JSON ({exc})") from exc
+    view, error = pr_view_json(pr, fields=VIEW_FIELDS, repo=repo, cwd=project_root,
+                               view_json=view_json)
+    if error is not None:
+        raise ViewError(error)
+    # The fetch hands back whatever JSON the response held, `null` and arrays included. `validate_view` is
+    # the boundary that refuses a non-object, exactly as before; the cast records that this annotation was
+    # always that boundary's promise rather than this function's.
+    return cast(dict, view)
 
 
 def record_base_ok(ledger_file: str, pr: str, worktree: "str | None") -> "str | None":

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from _gauntlet import gh as GH
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import capture_cli, checker, gh_writing
+from _gauntlet.testing import capture_cli, checker, deeply_nested_json, gh_writing
 
 OWNER = Path(__file__).resolve().parent / "merge-check.py"
 
@@ -458,6 +458,47 @@ def t_cli_undecodable_gh_stdout():
           f"the reason must name the failed view fetch, got {result['reason']!r}")
 
 
+def t_cli_deep_view_json():
+    # A recorded --view-json nested far past the parse's recursion limit. `json.loads` recurses per nesting
+    # level, so it raises RecursionError — a RuntimeError, NOT a ValueError, so neither the JSONDecodeError
+    # clause nor the UnicodeDecodeError one beside it can see it, and it is not an OSError either. It must
+    # still fail CLOSED through the one `except ViewError`: a structured not-yet on stdout, a NON-ZERO exit,
+    # and NO traceback. capture_cli only catches SystemExit, so an uncaught RecursionError would ESCAPE
+    # here — that is the teeth.
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        vjson = Path(d) / "view.json"
+        vjson.write_bytes(deeply_nested_json())
+        code, out, err = capture_cli(
+            M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    check(code != 0, f"a too-deep --view-json must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"a too-deep --view-json must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet",
+          f"a too-deep --view-json must decide not-yet, never merge, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the failed view fetch, got {result['reason']!r}")
+
+
+def t_cli_deep_gh_stdout():
+    # The same too-deep response, but from a REAL `gh` resolved through PATH, so the RecursionError comes
+    # out of the SECOND parse — the live-fetch one, a separate `try` from the recorded-file parse above and
+    # therefore a separate escape. No --view-json, so load_view takes the gh path.
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        with gh_writing(deeply_nested_json()):
+            code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--file", str(led), "--repo", "o/n"])
+    check(code != 0, f"too-deep gh output must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"too-deep gh output must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet",
+          f"too-deep gh output must decide not-yet, never merge, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the failed view fetch, got {result['reason']!r}")
+
+
 def t_cli_unresolved_base_never_merges():
     """THE FINDING #2 REGRESSION TEST: a both-`-` ledger (header AND row base_branch='-', so effective_base
     resolves to '-') with a CLEAN/MERGEABLE/OPEN view whose baseRefName='-' must NEVER merge — even when the
@@ -548,4 +589,8 @@ CASES = [
      t_cli_undecodable_view_json),
     ("cli-undecodable-gh-stdout", "gh stdout that is not UTF-8 fails closed to not-yet",
      t_cli_undecodable_gh_stdout),
+    ("cli-deep-view-json", "a --view-json too deeply nested to parse fails closed to not-yet",
+     t_cli_deep_view_json),
+    ("cli-deep-gh-stdout", "gh stdout too deeply nested to parse fails closed to not-yet",
+     t_cli_deep_gh_stdout),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -20,7 +20,8 @@ from pathlib import Path
 from _gauntlet import gh as GH
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import capture_cli, checker, deeply_nested_json, gh_writing
+from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
+                               hostile_json_responses)
 
 OWNER = Path(__file__).resolve().parent / "merge-check.py"
 
@@ -420,11 +421,11 @@ def t_cli_gh_spawn_failure():
 
 
 def t_cli_undecodable_view_json():
-    # A recorded --view-json whose BYTES are not UTF-8. The decode raises UnicodeDecodeError, which
-    # subclasses ValueError and is therefore invisible to an `except OSError` and to an
-    # `except json.JSONDecodeError` — the read never reaches the parse. It must still fail CLOSED through
-    # the one `except ViewError`: a structured not-yet on stdout, a NON-ZERO exit, and NO traceback.
-    # capture_cli only catches SystemExit, so an uncaught decode error would ESCAPE here — that is the teeth.
+    # A recorded --view-json whose BYTES are not UTF-8, so the failure comes from the DECODE and the read
+    # never reaches the parse. It must fail CLOSED through the one `except ViewError`: a structured not-yet
+    # on stdout, a NON-ZERO exit, and NO traceback. capture_cli only catches SystemExit, so an uncaught
+    # decode error would ESCAPE here — that is the teeth. This row pins the MESSAGE for this input; that no
+    # input at all can escape is the hostile-table fixture's job, not this one's.
     with tempfile.TemporaryDirectory() as d:
         led = Path(d) / "state.jsonl"
         L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
@@ -442,8 +443,8 @@ def t_cli_undecodable_view_json():
 
 def t_cli_undecodable_gh_stdout():
     # The same invalid bytes, but from a REAL `gh` resolved through PATH. With text=True the decode happens
-    # inside communicate(), so UnicodeDecodeError comes out of the subprocess.run CALL — exactly where the
-    # OSError clause sits, and a ValueError subclass that clause cannot see. Drive the real CLI with NO
+    # inside communicate(), so the failure surfaces from the subprocess.run CALL rather than from the parse
+    # after it — a SPAWN-site failure that looks like neither a read nor a parse. Drive the real CLI with NO
     # --view-json so load_view takes the gh path.
     with tempfile.TemporaryDirectory() as d:
         led = Path(d) / "state.jsonl"
@@ -460,11 +461,11 @@ def t_cli_undecodable_gh_stdout():
 
 def t_cli_deep_view_json():
     # A recorded --view-json nested far past the parse's recursion limit. `json.loads` recurses per nesting
-    # level, so it raises RecursionError — a RuntimeError, NOT a ValueError, so neither the JSONDecodeError
-    # clause nor the UnicodeDecodeError one beside it can see it, and it is not an OSError either. It must
-    # still fail CLOSED through the one `except ViewError`: a structured not-yet on stdout, a NON-ZERO exit,
-    # and NO traceback. capture_cli only catches SystemExit, so an uncaught RecursionError would ESCAPE
-    # here — that is the teeth.
+    # level, so it raises RecursionError — a RuntimeError, in a different branch of the exception tree from
+    # every other input here. It must fail CLOSED through the one `except ViewError`: a structured not-yet on
+    # stdout, a NON-ZERO exit, and NO traceback. capture_cli only catches SystemExit, so an uncaught
+    # RecursionError would ESCAPE here — that is the teeth. This row pins the MESSAGE for this input; the
+    # hostile-table fixture is what pins that no input escapes.
     with tempfile.TemporaryDirectory() as d:
         led = Path(d) / "state.jsonl"
         L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
@@ -484,7 +485,8 @@ def t_cli_deep_view_json():
 def t_cli_deep_gh_stdout():
     # The same too-deep response, but from a REAL `gh` resolved through PATH, so the RecursionError comes
     # out of the SECOND parse — the live-fetch one, a separate `try` from the recorded-file parse above and
-    # therefore a separate escape. No --view-json, so load_view takes the gh path.
+    # therefore a separate escape. Every guarantee `_gauntlet/gh.py` makes has to hold at BOTH parse sites,
+    # and only a fixture on each proves it. No --view-json, so load_view takes the gh path.
     with tempfile.TemporaryDirectory() as d:
         led = Path(d) / "state.jsonl"
         L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
@@ -497,6 +499,48 @@ def t_cli_deep_gh_stdout():
           f"too-deep gh output must decide not-yet, never merge, got {result!r}")
     check(result["reason"].startswith("could not fetch PR view:"),
           f"the reason must name the failed view fetch, got {result['reason']!r}")
+
+
+def t_cli_hostile_responses_never_escape():
+    """THE GUARANTEE, not a member list: for EVERY hostile response in the shared table, and at BOTH of the
+    fetch's parse sites, the CLI prints a structured verdict and prints no traceback.
+
+    The per-input fixtures above cannot make this claim. Each was written around an exception type that was
+    already known, so a family member discovered tomorrow leaves all of them green — which is how a plain
+    `ValueError` from an oversized integer literal reached a released decider past clauses that already named
+    a decode error and a recursion error. This fixture is driven by DATA: a row added to
+    `hostile_json_responses` fails here until the fetch survives it.
+
+    Both sites, every row. The recorded-file parse and the live-fetch parse are separate `try` blocks, so a
+    guarantee proved at one says nothing about the other.
+    """
+    for name, payload in hostile_json_responses():
+        with tempfile.TemporaryDirectory() as d:
+            led = Path(d) / "state.jsonl"
+            L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+            vjson = Path(d) / "view.json"
+            vjson.write_bytes(payload)
+            recorded = capture_cli(
+                M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+            with gh_writing(payload):
+                live = capture_cli(M.main, ["check", "--pr", "9", "--file", str(led), "--repo", "o/n"])
+        for site, (code, out, err) in (("--view-json", recorded), ("gh stdout", live)):
+            label = f"[{name} via {site}]"
+            # capture_cli only catches SystemExit, so anything else escaping the fetch lands HERE as a raised
+            # exception and the runner reports this fixture as a crash — the teeth.
+            check(err == "", f"{label} must NOT print a traceback, got stderr {err!r}")
+            check(code != 0, f"{label} must exit non-zero (fail closed), got {code}")
+            try:
+                result = json.loads(out)
+            except json.JSONDecodeError as exc:
+                raise M.SelfTestFailure(
+                    f"{label} must print a structured verdict on stdout, got {out!r} ({exc})") from exc
+            check(result.get("verdict") == "not-yet",
+                  f"{label} must decide not-yet, never merge, got {result!r}")
+            check(str(result.get("reason", "")).startswith("could not fetch PR view:"),
+                  f"{label} must name the failed view fetch, got {result!r}")
+            check(result["reason"].strip() != "could not fetch PR view:",
+                  f"{label} must say WHAT failed, not an empty detail, got {result['reason']!r}")
 
 
 def t_cli_unresolved_base_never_merges():
@@ -593,4 +637,6 @@ CASES = [
      t_cli_deep_view_json),
     ("cli-deep-gh-stdout", "gh stdout too deeply nested to parse fails closed to not-yet",
      t_cli_deep_gh_stdout),
+    ("cli-hostile-responses", "every hostile response in the shared table fails closed at BOTH parse sites",
+     t_cli_hostile_responses_never_escape),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from _gauntlet import gh as GH
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import capture_cli, checker
+from _gauntlet.testing import capture_cli, checker, gh_writing
 
 OWNER = Path(__file__).resolve().parent / "merge-check.py"
 
@@ -419,6 +419,45 @@ def t_cli_gh_spawn_failure():
           f"the reason must name the failed view fetch, got {result['reason']!r}")
 
 
+def t_cli_undecodable_view_json():
+    # A recorded --view-json whose BYTES are not UTF-8. The decode raises UnicodeDecodeError, which
+    # subclasses ValueError and is therefore invisible to an `except OSError` and to an
+    # `except json.JSONDecodeError` — the read never reaches the parse. It must still fail CLOSED through
+    # the one `except ViewError`: a structured not-yet on stdout, a NON-ZERO exit, and NO traceback.
+    # capture_cli only catches SystemExit, so an uncaught decode error would ESCAPE here — that is the teeth.
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        vjson = Path(d) / "view.json"
+        vjson.write_bytes(b'{"state": "OPEN", "x": "\xff"}')
+        code, out, err = capture_cli(
+            M.main, ["check", "--pr", "9", "--file", str(led), "--view-json", str(vjson)])
+    check(code != 0, f"an undecodable --view-json must exit non-zero (fail closed), got {code} (stderr: {err})")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet",
+          f"an undecodable --view-json must decide not-yet, never merge, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the failed view fetch, got {result['reason']!r}")
+
+
+def t_cli_undecodable_gh_stdout():
+    # The same invalid bytes, but from a REAL `gh` resolved through PATH. With text=True the decode happens
+    # inside communicate(), so UnicodeDecodeError comes out of the subprocess.run CALL — exactly where the
+    # OSError clause sits, and a ValueError subclass that clause cannot see. Drive the real CLI with NO
+    # --view-json so load_view takes the gh path.
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        with gh_writing(b'{"state": "OPEN", "x": "\xff"}'):
+            code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--file", str(led), "--repo", "o/n"])
+    check(code != 0, f"undecodable gh output must exit non-zero (fail closed), got {code} (stderr: {err})")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet",
+          f"undecodable gh output must decide not-yet, never merge, got {result!r}")
+    check(result["reason"].startswith("could not fetch PR view:"),
+          f"the reason must name the failed view fetch, got {result['reason']!r}")
+
+
 def t_cli_unresolved_base_never_merges():
     """THE FINDING #2 REGRESSION TEST: a both-`-` ledger (header AND row base_branch='-', so effective_base
     resolves to '-') with a CLEAN/MERGEABLE/OPEN view whose baseRefName='-' must NEVER merge — even when the
@@ -505,4 +544,8 @@ CASES = [
     ("cli-view-missing-field", "a view missing a field fails closed, never KeyError", t_cli_view_missing_field),
     ("cli-view-wrong-type", "a view field of the wrong JSON type fails closed", t_cli_view_wrong_type_field),
     ("cli-gh-spawn-failure", "a gh-spawn failure fails closed, no traceback", t_cli_gh_spawn_failure),
+    ("cli-undecodable-view-json", "a --view-json that is not UTF-8 fails closed to not-yet",
+     t_cli_undecodable_view_json),
+    ("cli-undecodable-gh-stdout", "gh stdout that is not UTF-8 fails closed to not-yet",
+     t_cli_undecodable_gh_stdout),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -21,7 +21,7 @@ from _gauntlet import gh as GH
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
-                               hostile_json_responses)
+                               hostile_json_responses, legacy_view_error_cases)
 
 OWNER = Path(__file__).resolve().parent / "merge-check.py"
 
@@ -543,6 +543,35 @@ def t_cli_hostile_responses_never_escape():
                   f"{label} must say WHAT failed, not an empty detail, got {result['reason']!r}")
 
 
+def t_cli_legacy_view_errors_keep_their_exact_wording():
+    """THE WHOLE REASON STRING, for every failure that had one before `_gauntlet/gh.py` owned the fetch.
+
+    Extracting the fetch into a shared owner was meant to leave each caller's message BYTE FOR BYTE intact.
+    Every fixture above asserts only the `could not fetch PR view: ` PREFIX, so a rewrite of the tail behind
+    it — the part a reader actually reads — cannot fail any of them, and one went unnoticed for six rounds of
+    review. This row is the assertion that can catch it: the shared table owns the exact tail, and equality
+    is the check. It runs the SAME table `base-preflight-test.py` runs, because the two callers are meant to
+    print the same thing.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        led = Path(d) / "state.jsonl"
+        L.dump(led, dict(L.HEADER_DEFAULTS, run_id="g1"), [row()])
+        for name, extra, context, tail in legacy_view_error_cases(Path(d)):
+            with context():
+                code, out, err = capture_cli(
+                    M.main, ["check", "--pr", "9", "--file", str(led)] + extra)
+            label = f"[{name}]"
+            check(err == "", f"{label} must NOT print a traceback, got stderr {err!r}")
+            check(code != 0, f"{label} must exit non-zero (fail closed), got {code}")
+            result = json.loads(out)
+            check(result["verdict"] == "not-yet",
+                  f"{label} must decide not-yet, never merge, got {result!r}")
+            expected = f"could not fetch PR view: {tail}"
+            check(result["reason"] == expected,
+                  f"{label} must print the reason UNCHANGED from before the fetch was shared.\n"
+                  f"           expected {expected!r}\n           got      {result['reason']!r}")
+
+
 def t_cli_unresolved_base_never_merges():
     """THE FINDING #2 REGRESSION TEST: a both-`-` ledger (header AND row base_branch='-', so effective_base
     resolves to '-') with a CLEAN/MERGEABLE/OPEN view whose baseRefName='-' must NEVER merge — even when the
@@ -639,4 +668,6 @@ CASES = [
      t_cli_deep_gh_stdout),
     ("cli-hostile-responses", "every hostile response in the shared table fails closed at BOTH parse sites",
      t_cli_hostile_responses_never_escape),
+    ("cli-legacy-view-messages", "every pre-existing view-fetch failure keeps its EXACT reason string",
+     t_cli_legacy_view_errors_keep_their_exact_wording),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -17,6 +17,7 @@ import json
 import tempfile
 from pathlib import Path
 
+from _gauntlet import gh as GH
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import capture_cli, checker
@@ -394,11 +395,13 @@ def t_cli_gh_spawn_failure():
     # gh ABSENT (or not executable): subprocess.run raises OSError BEFORE any returncode. It must fail
     # CLOSED through the one `except ViewError` — a structured not-yet, a NON-ZERO exit, and NO traceback —
     # never an uncaught FileNotFoundError with no verdict on stdout. Simulate the spawn failure by patching
-    # the module's subprocess.run; drive the real CLI with NO --view-json so it takes load_view's gh path.
+    # subprocess.run in `_gauntlet/gh.py` — the module that now OWNS the spawn, so patching anywhere else
+    # would leave the real `gh` to answer and this fixture would pass on a fetch it never broke. Drive the
+    # real CLI with NO --view-json so it takes load_view's gh path.
     def boom(*_args, **_kwargs):
         raise FileNotFoundError(2, "No such file or directory", "gh")
-    real_run = M.subprocess.run
-    M.subprocess.run = boom
+    real_run = GH.subprocess.run
+    setattr(GH.subprocess, "run", boom)
     try:
         with tempfile.TemporaryDirectory() as d:
             led = Path(d) / "state.jsonl"
@@ -407,7 +410,7 @@ def t_cli_gh_spawn_failure():
             # this fixture — that is the teeth.
             code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--file", str(led), "--repo", "o/n"])
     finally:
-        M.subprocess.run = real_run
+        setattr(GH.subprocess, "run", real_run)
     check(code != 0, f"a gh-spawn failure must exit non-zero (fail closed), got {code} (stderr: {err})")
     result = json.loads(out)
     check(result["verdict"] == "not-yet",

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -39,10 +39,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
+from typing import cast
 
+from _gauntlet.gh import pr_view_json
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
 
@@ -236,31 +237,18 @@ def validate_view(view: object) -> "str | None":
 
 def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
     """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
-    `gh pr view` itself. Any failure raises `ViewError`, which the caller turns into a fail-closed not-yet.
+    `gh pr view` itself, both through `_gauntlet/gh.py`, the ONE owner of that fetch. It reports a failure
+    as a MESSAGE — the spawn failure that raises before any returncode exists (gh absent or not executable)
+    included — and every one of them becomes a `ViewError` here, so every gh-path failure fails CLOSED via
+    the one `except ViewError` and never an uncaught traceback with no verdict on stdout.
     """
-    if view_json is not None:
-        try:
-            return json.loads(Path(view_json).read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise ViewError(str(exc)) from exc
-    argv = ["gh", "pr", "view", str(pr)]
-    if repo:
-        argv += ["--repo", repo]
-    argv += ["--json", VIEW_FIELDS]
-    # SPAWN failure (gh absent or not executable) raises OSError from subprocess.run itself, BEFORE any
-    # returncode exists. Route it through the same `ViewError` as the non-zero and non-JSON branches, so
-    # every gh-path failure fails CLOSED via the one `except ViewError` — never an uncaught traceback with
-    # no verdict on stdout.
-    try:
-        proc = subprocess.run(argv, capture_output=True, text=True, check=False)  # noqa: S603
-    except OSError as exc:
-        raise ViewError(f"could not run `gh pr view {pr}`: {exc}") from exc
-    if proc.returncode != 0:
-        raise ViewError(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise ViewError(f"gh response is not JSON ({exc})") from exc
+    view, error = pr_view_json(pr, fields=VIEW_FIELDS, repo=repo, view_json=view_json)
+    if error is not None:
+        raise ViewError(error)
+    # The fetch hands back whatever JSON the response held, `null` and arrays included. `validate_view` is
+    # the boundary that refuses a non-object, exactly as before; the cast records that this annotation was
+    # always that boundary's promise rather than this function's.
+    return cast(dict, view)
 
 
 def check(pr: str, ledger_path: Path, repo: "str | None", view_json: "str | None") -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -242,8 +242,8 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
     `ViewError` here, so every gh-path failure fails CLOSED via the one `except ViewError` and never an
     uncaught traceback with no verdict on stdout.
 
-    Do NOT restate that set here. It has already grown once (undecodable bytes joined the spawn failure),
-    and an unpacked copy in this docstring is exactly the gloss that would have gone stale when it did.
+    Do NOT restate that set here. It has grown MORE THAN ONCE since this docstring was written, and each
+    time, an unpacked copy here is the gloss that would have gone stale — which is why there is not one.
     """
     view, error = pr_view_json(pr, fields=VIEW_FIELDS, repo=repo, view_json=view_json)
     if error is not None:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -237,10 +237,13 @@ def validate_view(view: object) -> "str | None":
 
 def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:
     """The PR's live view — from a recorded `gh pr view` JSON (`--view-json`, testable without gh) or from
-    `gh pr view` itself, both through `_gauntlet/gh.py`, the ONE owner of that fetch. It reports a failure
-    as a MESSAGE — the spawn failure that raises before any returncode exists (gh absent or not executable)
-    included — and every one of them becomes a `ViewError` here, so every gh-path failure fails CLOSED via
-    the one `except ViewError` and never an uncaught traceback with no verdict on stdout.
+    `gh pr view` itself, both through `_gauntlet/gh.py` — the ONE owner of that fetch AND of the set of
+    failures it hands back as a MESSAGE rather than raising. Every one of those messages becomes a
+    `ViewError` here, so every gh-path failure fails CLOSED via the one `except ViewError` and never an
+    uncaught traceback with no verdict on stdout.
+
+    Do NOT restate that set here. It has already grown once (undecodable bytes joined the spawn failure),
+    and an unpacked copy in this docstring is exactly the gloss that would have gone stale when it did.
     """
     view, error = pr_view_json(pr, fields=VIEW_FIELDS, repo=repo, view_json=view_json)
     if error is not None:


### PR DESCRIPTION
- add `_gauntlet/gh.py` owning the `gh pr view` fetch, returning `(view, error)`
- route `base-preflight.py` and `merge-check.py` `load_view` through it, unchanged
- leave `merge.py` and `label-mirror.py` out — different messages and seams
