### PR TITLE
share one git repository fixture owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
@@ -1,0 +1,66 @@
+# ci: pyright
+"""One owner for the throwaway Git repositories the campaign self-test suites build.
+
+Several suites here prove their claims against a REAL git, not a mock: they build a repository in a
+temporary directory, commit into it, and read SHAs back with plumbing. Each of them used to carry its own
+copy of the same three steps — run git in a repository and raise when it fails, give the repository a
+commit identity so `git commit` works on a machine with no global config, and read a revision back as a
+string.
+
+The failure TYPE is why this is a class and not four plain functions. Every suite raises its own module's
+`SelfTestFailure`, and `_gauntlet.testing.run_cases` reports its `failure` argument as the fixture's own
+message while reporting anything else with a type-name prefix. A single helper hard-coding one exception
+would therefore change how a fixture's failure READS in every suite but one. Binding the type once, at
+construction, keeps each suite's reporting exactly as it was — the same reason `testing.checker` takes the
+type as an argument.
+
+Output is captured as TEXT with `errors="replace"`. Some fixtures deliberately create paths holding bytes
+that are not valid UTF-8, and git echoes those paths back in its stderr; a strict decode would turn a
+fixture's diagnostic into a `UnicodeDecodeError` that hides the real failure.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# The commit identity every fixture repository is given. It is a documentation-reserved domain, so it can
+# never resolve; no fixture asserts on either value, they only have to exist for `git commit` to run.
+FIXTURE_NAME = "Gauntlet Test"
+FIXTURE_EMAIL = "gauntlet@example.invalid"
+
+
+class GitFixture:
+    """Git operations on throwaway repositories, reporting failures as one suite's own failure type."""
+
+    def __init__(self, failure: "type[BaseException]") -> None:
+        self._failure = failure
+
+    def run(self, repo: Path, *args: str) -> "subprocess.CompletedProcess[str]":
+        """Run `git <args>` inside `repo`; raise the bound failure type when git exits non-zero.
+
+        There is no "tolerate a failure" switch on purpose. A fixture that ignores a setup command's exit
+        code builds a repository that is not the one it describes, and then proves something about the
+        wrong subject; the two suites that used to carry such a flag never once passed it.
+        """
+        result = subprocess.run(["git", "-C", str(repo), *args],  # noqa: S603 - fixture repos we built
+                                capture_output=True, text=True, errors="replace", check=False)
+        if result.returncode != 0:
+            raise self._failure(
+                f"git {' '.join(args)} failed in {repo} ({result.returncode}): {result.stderr.strip()}")
+        return result
+
+    def configure_identity(self, repo: Path) -> None:
+        """Give `repo` a commit identity, so committing does not depend on the machine's global config."""
+        self.run(repo, "config", "user.name", FIXTURE_NAME)
+        self.run(repo, "config", "user.email", FIXTURE_EMAIL)
+
+    def init_repo(self, repo: Path, *, branch: str = "main") -> None:
+        """Create `repo` if absent, initialise it on `branch`, and give it the fixture commit identity."""
+        repo.mkdir(parents=True, exist_ok=True)
+        self.run(repo, "init", "-q", "-b", branch)
+        self.configure_identity(repo)
+
+    def head(self, repo: Path, ref: str = "HEAD") -> str:
+        """`ref` resolved to a full SHA, stripped — what a fixture pins a ledger row's `head_sha` to."""
+        return self.run(repo, "rev-parse", ref).stdout.strip()

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import capture_cli, checker
 
@@ -201,16 +202,10 @@ def t_cli_bad_project_root_fails_closed():
           f"the reason must name the fetch failure, got {result['reason']!r}")
 
 
-def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
-    result = subprocess.run(["git", "-C", str(cwd), *args], capture_output=True, text=True, check=False)
-    check(result.returncode == 0,
-          f"git {' '.join(args)} failed in {cwd}: {result.stderr.strip()}")
-    return result
-
-
-def _configure_repo(path: Path) -> None:
-    _git(path, "config", "user.email", "fixture@example.invalid")
-    _git(path, "config", "user.name", "Fixture")
+# The repository fixtures come from the shared owner, bound to THIS suite's failure type.
+_GIT = GitFixture(M.SelfTestFailure)
+_git = _GIT.run
+_configure_repo = _GIT.configure_identity
 
 
 def t_clean_view_with_stale_base_rebases():

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -26,6 +26,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import capture_cli, checker
 
@@ -41,24 +42,17 @@ check = checker(M.SelfTestFailure)
 
 # --- git / ledger helpers -----------------------------------------------------
 
+# The repository fixtures come from the shared owner, bound to THIS suite's failure type so a broken setup
+# step still reports as this suite's own message.
+_GIT = GitFixture(M.SelfTestFailure)
+git = _GIT.run
+head = _GIT.head
+_cfg = _GIT.configure_identity
+
+
 def _run(argv, cwd=None):
+    # Only for the two commands that run OUTSIDE any repository: creating the bare remote and cloning it.
     return subprocess.run(argv, capture_output=True, text=True, cwd=cwd)  # noqa: S603
-
-
-def git(cwd, *args, allow_fail=False):
-    r = _run(["git", "-C", str(cwd), *args])
-    if not allow_fail and r.returncode != 0:
-        raise M.SelfTestFailure(f"git {' '.join(args)} failed in {cwd}: {r.stderr.strip()}")
-    return r
-
-
-def _cfg(repo):
-    git(repo, "config", "user.email", "t@example.com")
-    git(repo, "config", "user.name", "Tester")
-
-
-def head(cwd, ref="HEAD") -> str:
-    return git(cwd, "rev-parse", ref).stdout.strip()
 
 
 def _ledger(*args) -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -14,10 +14,10 @@ check outranks the enums.
 from __future__ import annotations
 
 import json
-import subprocess
 import tempfile
 from pathlib import Path
 
+from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import capture_cli, checker
 
@@ -58,12 +58,9 @@ def decide(r: dict, v: dict) -> dict:
 check = checker(M.SelfTestFailure)
 
 
-def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
-    proc = subprocess.run(
-        ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=False)
-    check(proc.returncode == 0,
-          f"git {' '.join(args)} failed in {cwd}: {proc.stderr.strip()}")
-    return proc
+# The repository fixtures come from the shared owner, bound to THIS suite's failure type.
+_GIT = GitFixture(M.SelfTestFailure)
+_git = _GIT.run
 
 
 def expect(r: dict, v: dict, verdict: str, reason: "str | None" = None) -> dict:
@@ -252,10 +249,7 @@ def t_cli_ancestry_uses_reviewed_sha_not_moved_worktree_head():
     try:
         with tempfile.TemporaryDirectory() as d:
             candidate = Path(d) / "candidate"
-            candidate.mkdir()
-            _git(candidate, "init", "-b", "main")
-            _git(candidate, "config", "user.email", "fixture@example.invalid")
-            _git(candidate, "config", "user.name", "Fixture")
+            _GIT.init_repo(candidate)
             (candidate / "f").write_text("reviewed\n", encoding="utf-8")
             _git(candidate, "add", "f")
             _git(candidate, "commit", "-m", "reviewed")

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import capture_cli, checker
 
@@ -36,6 +37,11 @@ SHA = "c" * 40
 
 check = checker(R.SelfTestFailure)
 
+# The repository fixtures come from the shared owner, bound to THIS suite's failure type. `_GIT.head` is
+# reached through the object, never aliased: several fixtures below bind a LOCAL `head`.
+_GIT = GitFixture(R.SelfTestFailure)
+git = _GIT.run
+
 
 def ledger_cli(argv: "list[str]") -> "tuple[int, str, str]":
     """Drive the LEDGER's real CLI in-process — the guard and the row reads live there, not here."""
@@ -46,30 +52,14 @@ def decision_repo(tmp: Path) -> "tuple[Path, str]":
     """One clean Git worktree shared by a fixture's decision-door ledgers."""
     repo = tmp / "decision-worktree"
     if not repo.exists():
-        repo.mkdir()
-        commands = [
-            ["git", "-C", str(repo), "init", "-q", "-b", "main"],
-            ["git", "-C", str(repo), "config", "user.name", "Gauntlet Test"],
-            ["git", "-C", str(repo), "config", "user.email", "gauntlet@example.invalid"],
-        ]
-        for argv in commands:
-            result = subprocess.run(argv, capture_output=True, check=False)
-            if result.returncode != 0:
-                raise RuntimeError(result.stderr.decode(errors="replace"))
+        _GIT.init_repo(repo)
         (repo / "base.txt").write_text("base\n")
-        for argv in (["git", "-C", str(repo), "add", "base.txt"],
-                     ["git", "-C", str(repo), "commit", "-q", "-m", "base"],
-                     # decide re-resolves `origin/<base>` to verify the bundle's pinned base SHA (F2), so the
-                     # decision-door worktree must carry the remote-tracking ref, at the one commit it holds.
-                     ["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", "HEAD"]):
-            result = subprocess.run(argv, capture_output=True, check=False)
-            if result.returncode != 0:
-                raise RuntimeError(result.stderr.decode(errors="replace"))
-    result = subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
-                            capture_output=True, check=False)
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr.decode(errors="replace"))
-    return repo, result.stdout.decode().strip()
+        git(repo, "add", "base.txt")
+        git(repo, "commit", "-q", "-m", "base")
+        # decide re-resolves `origin/<base>` to verify the bundle's pinned base SHA (F2), so the
+        # decision-door worktree must carry the remote-tracking ref, at the one commit it holds.
+        git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo, _GIT.head(repo)
 
 
 def setup(tmp: Path, name: str = "state.jsonl", *, decision: str = "repair-intent",
@@ -448,19 +438,9 @@ INTENT = """## Purpose
 """
 
 
-def git(repo: Path, *argv: str) -> subprocess.CompletedProcess:
-    result = subprocess.run(["git", "-C", str(repo), *argv], capture_output=True, check=False)
-    check(result.returncode == 0,
-          f"git {' '.join(argv)} failed: {result.stderr.decode(errors='replace')!r}")
-    return result
-
-
 def init_repo(parent: Path, name: str = "worktree") -> "tuple[Path, str]":
     repo = parent / name
-    repo.mkdir()
-    git(repo, "init", "-q", "-b", "main")
-    git(repo, "config", "user.name", "Gauntlet Test")
-    git(repo, "config", "user.email", "gauntlet@example.invalid")
+    _GIT.init_repo(repo)
     (repo / "feature.txt").write_text("base\n")
     git(repo, "add", "feature.txt")
     git(repo, "commit", "-q", "-m", "base")
@@ -469,7 +449,7 @@ def init_repo(parent: Path, name: str = "worktree") -> "tuple[Path, str]":
     (repo / "feature.txt").write_text("base\nfeature\n")
     git(repo, "add", "feature.txt")
     git(repo, "commit", "-q", "-m", "feature change")
-    return repo, git(repo, "rev-parse", "HEAD").stdout.decode().strip()
+    return repo, _GIT.head(repo)
 
 
 def write_review_attempt(rundir: Path, round_no: int, attempt: int, head_sha: str,
@@ -1174,7 +1154,7 @@ def t_bundle_pins_base_sha_against_a_racing_fetch(tmp: Path) -> None:
     """
     case = bundle_setup(tmp, rounds=1, origin="external")
     repo, head = case["repo"], case["head_sha"]
-    base_before = git(repo, "rev-parse", "origin/main").stdout.decode().strip()
+    base_before = _GIT.head(repo, "origin/main")
     real_git = R._run_git
     advanced = False
 
@@ -1195,7 +1175,7 @@ def t_bundle_pins_base_sha_against_a_racing_fetch(tmp: Path) -> None:
         setattr(R, "_run_git", real_git)
 
     check(advanced, "the fixture never advanced origin/main mid-build — the race was not exercised")
-    base_after = git(repo, "rev-parse", "origin/main").stdout.decode().strip()
+    base_after = _GIT.head(repo, "origin/main")
     check(base_after == head and base_after != base_before,
           "the fixture did not actually move origin/main between reads")
     check(code == 0, f"bundle refused a build whose base was pinned before any read: {err!r}")

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -22,6 +22,7 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 
+from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import capture_cli, checker, run_cases
 
@@ -35,12 +36,10 @@ M = load_sibling("campaign_triage_owner", OWNER.parent, OWNER.name, register=Tru
 check = checker(M.SelfTestFailure)
 
 
-def git(repo: Path, *args: str, check_result: bool = True) -> subprocess.CompletedProcess[bytes]:
-    proc = subprocess.run(["git", *args], cwd=repo, capture_output=True, check=False)  # noqa: S603
-    if check_result and proc.returncode != 0:
-        raise M.SelfTestFailure(
-            f"git {' '.join(args)} failed ({proc.returncode}): {os.fsdecode(proc.stderr)}")
-    return proc
+# The repository fixtures come from the shared owner, bound to THIS suite's failure type. `GIT.head` is
+# reached through the object, never aliased: several fixtures below bind a LOCAL `head`.
+GIT = GitFixture(M.SelfTestFailure)
+git = GIT.run
 
 
 def write(repo: Path, name: str, content: str = "content\n", mode: int = 0o644) -> Path:
@@ -63,16 +62,14 @@ def write_bytes_name(repo: Path, name: bytes, content: bytes = b"content\n") -> 
 def commit(repo: Path, message: str) -> str:
     git(repo, "add", "--all")
     git(repo, "commit", "-q", "-m", message)
-    return os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+    return GIT.head(repo)
 
 
 @contextmanager
 def repository(base_files: dict[str, tuple[str, int]] | None = None):
     with tempfile.TemporaryDirectory() as directory:
         repo = Path(directory)
-        git(repo, "init", "-q", "-b", "main")
-        git(repo, "config", "user.name", "Gauntlet Test")
-        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        GIT.init_repo(repo)
         files = base_files or {"baseline.txt": ("base\n", 0o644)}
         for name, (content, mode) in files.items():
             write(repo, name, content, mode)
@@ -81,7 +78,7 @@ def repository(base_files: dict[str, tuple[str, int]] | None = None):
 
 
 def derive(repo: Path, base: str, *, tier: str | None = None) -> dict:
-    head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+    head = GIT.head(repo)
     return M.derive(worktree=str(repo), base=base, head_sha=head, tier=tier)
 
 
@@ -375,9 +372,7 @@ def t_gitlink_change_survives_gitmodules_ignore_all() -> None:
     Uses ``git update-index --cacheinfo`` (not ``git add --all``, which would drop an on-disk-absent gitlink)."""
     with tempfile.TemporaryDirectory() as directory:
         repo = Path(directory)
-        git(repo, "init", "-q", "-b", "main")
-        git(repo, "config", "user.name", "Gauntlet Test")
-        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        GIT.init_repo(repo)
         write(repo, "docs/guide.md", "# Guide\n")
         git(repo, "update-index", "--add", "--cacheinfo",
             "160000,1111111111111111111111111111111111111111,vendor/sub")
@@ -385,13 +380,13 @@ def t_gitlink_change_survives_gitmodules_ignore_all() -> None:
               '[submodule "vendor/sub"]\n\tpath = vendor/sub\n\turl = ./sub.git\n\tignore = all\n')
         git(repo, "add", "docs/guide.md", ".gitmodules")
         git(repo, "commit", "-q", "-m", "base with ignore=all submodule")
-        base = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        base = GIT.head(repo)
         git(repo, "update-index", "--cacheinfo",
             "160000,2222222222222222222222222222222222222222,vendor/sub")
         write(repo, "docs/guide.md", "# Guide v2\n")
         git(repo, "add", "docs/guide.md")
         git(repo, "commit", "-q", "-m", "advance gitlink and edit prose")
-        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        head = GIT.head(repo)
         result = M.derive(worktree=str(repo), base=base, head_sha=head)
     by_path = {row["path"]: row for row in result["files"]}
     check("vendor/sub" in by_path,
@@ -577,7 +572,7 @@ def t_bad_inputs_and_git_failures_emit_no_partial_json() -> None:
     # The unresolvable-base case now comes from the ROW, not from `--base`: `--base` is only an assertion, so
     # an unresolvable ref is one the row's effective base names and no remote-tracking ref backs.
     with repository() as (repo, base):
-        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        head = GIT.head(repo)
         with tempfile.TemporaryDirectory() as directory:
             unbacked = _build_ledger(Path(directory), "31", "no-such-branch")
             with cli_base(repo, base) as ledger_args:
@@ -870,7 +865,7 @@ def t_ledger_base_assertion_passes() -> None:
 def t_ledger_base_assertion_refuses() -> None:
     # `--base` disagreeing with the row's effective base is refused BEFORE any analysis, and emits no JSON.
     with repository() as (repo, _base):
-        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        head = GIT.head(repo)
         with tempfile.TemporaryDirectory() as d:
             ledger = _build_ledger(Path(d), "31", "main")
             code, out, err = capture_cli(M.main, [
@@ -906,9 +901,7 @@ def t_ledger_variant_spelling_floors_canonically() -> None:
     # operational ref is taken from the raw `--base` instead of the row's effective base.
     with tempfile.TemporaryDirectory() as directory:
         repo = Path(directory)
-        git(repo, "init", "-q", "-b", "main")
-        git(repo, "config", "user.name", "Gauntlet Test")
-        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        GIT.init_repo(repo)
         write(repo, "README.md", "readme\n")
         base0 = commit(repo, "base0")
         # ordinary sibling `rel`: adds the SENSITIVE script; its tracking ref becomes `origin/rel`.
@@ -944,7 +937,7 @@ def t_ledger_file_without_pr_refuses() -> None:
     # `--pr` is argparse-required now, so the refusal comes from the parser — the guarantee is unchanged and
     # this pins that the missing row key is still named, never defaulted.
     with repository() as (repo, _base):
-        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        head = GIT.head(repo)
         with tempfile.TemporaryDirectory() as d:
             ledger = _build_ledger(Path(d), "31", "main")
             code, out, err = capture_cli(M.main, [
@@ -956,7 +949,7 @@ def t_ledger_file_without_pr_refuses() -> None:
 
 def t_ledger_missing_row_refuses() -> None:
     with repository() as (repo, _base):
-        head = os.fsdecode(git(repo, "rev-parse", "HEAD").stdout).strip()
+        head = GIT.head(repo)
         with tempfile.TemporaryDirectory() as d:
             ledger = _build_ledger(Path(d), "31", "main")
             code, out, err = capture_cli(M.main, [
@@ -979,9 +972,7 @@ def t_derive_without_ledger_is_refused() -> None:
     `--file`/`--pr` and it fails, because the omitted-ledger invocation exits 0 instead of refusing."""
     with tempfile.TemporaryDirectory() as directory:
         repo = Path(directory)
-        git(repo, "init", "-q", "-b", "main")
-        git(repo, "config", "user.name", "Gauntlet Test")
-        git(repo, "config", "user.email", "gauntlet@example.invalid")
+        GIT.init_repo(repo)
         write(repo, "seed.txt", "seed\n")
         main_tip = commit(repo, "main: seed")
         git(repo, "checkout", "-q", "-b", "feat", main_tip)


### PR DESCRIPTION
- `_gauntlet/gitfixture.py` owns the throwaway-repo helpers five self-test suites each copied.
- It binds each suite's own failure type, so failures still report as that suite's message.
- Excluded: `merge-test.py` (env-isolated, other failure type) and two suites with no git fixture.
