### PR TITLE
align merge.py's malformed-view refusals

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -533,8 +533,12 @@ def t_malformed_view_messages_match_the_other_deciders():
         # direction that needs the fixture: the reverse (True passing an isinstance str check) cannot happen.
         ("bool-field-wrong-type", lambda v: {**v, "isDraft": "false"},
          "malformed live PR view: field 'isDraft' must be a bool, got str"),
+        ("labels-missing", lambda v: {k: x for k, x in v.items() if k != "labels"},
+         "malformed live PR view: missing field 'labels'"),
         ("labels-not-a-list", lambda v: {**v, "labels": {"name": "x"}},
          "malformed live PR view: field 'labels' must be a list, got dict"),
+        ("label-object-name-missing", lambda v: {**v, "labels": [{}]},
+         "malformed live PR view: field 'labels' contains an object without a 'name'"),
         ("label-name-not-a-string", lambda v: {**v, "labels": [{"name": 7}]},
          "malformed live PR view: field 'labels' must hold string names, got int"),
     )

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import checker
@@ -508,6 +509,50 @@ def t_owner_label_and_uncertain_view_refused():
         check(code != 0 and "mergeStateStatus" in err, f"malformed GitHub state was not refused: {err}")
     finally:
         finish(td, real)
+
+
+def t_malformed_view_messages_match_the_other_deciders():
+    """Every malformation of the live view refuses with the SAME message body `base-preflight.py` and
+    `merge-check.py` produce, behind one `malformed live PR view: ` wrapper.
+
+    The point of the fixture is the EXACT string, not merely that it refused. Three tools validate a
+    `gh pr view` payload against the same three failures, and the drift that a prefix-only assertion misses
+    is precisely what this pins. Each case names the observed type, which is what tells a reader whether a
+    field was ABSENT or merely the wrong JSON type — a distinction the pre-change merge runner could not
+    make, because it read every field through `.get()`."""
+    cases = (
+        ("not-an-object", lambda v: ["a list"],
+         "malformed live PR view: view is not a JSON object (got list)"),
+        ("string-field-missing", lambda v: {k: x for k, x in v.items() if k != "state"},
+         "malformed live PR view: missing field 'state'"),
+        ("string-field-wrong-type", lambda v: {**v, "headRefOid": 40},
+         "malformed live PR view: field 'headRefOid' must be a string, got int"),
+        ("bool-field-missing", lambda v: {k: x for k, x in v.items() if k != "isDraft"},
+         "malformed live PR view: missing field 'isDraft'"),
+        # A JSON string is not a bool even when it reads like one. bool is a subclass of int, so this is the
+        # direction that needs the fixture: the reverse (True passing an isinstance str check) cannot happen.
+        ("bool-field-wrong-type", lambda v: {**v, "isDraft": "false"},
+         "malformed live PR view: field 'isDraft' must be a bool, got str"),
+        ("labels-not-a-list", lambda v: {**v, "labels": {"name": "x"}},
+         "malformed live PR view: field 'labels' must be a list, got dict"),
+        ("label-name-not-a-string", lambda v: {**v, "labels": [{"name": 7}]},
+         "malformed live PR view: field 'labels' must hold string names, got int"),
+    )
+    for name, mutate, expected in cases:
+        td, root, f, led, real = scenario()
+        original_view = f.view
+        try:
+            # `Fake.view` is typed as returning a dict because every OTHER fixture hands back a
+            # well-formed payload. A malformed one is the subject here, and the not-an-object case
+            # is a list on purpose, so the cast records that this fixture is deliberately outside
+            # that annotation rather than drifting from it.
+            f.view = cast(Any, lambda mutate=mutate: mutate(original_view()))
+            code, _, err = invoke(f, led, root)
+            check(code != 0, f"{name}: a malformed view was accepted")
+            check(err == expected, f"{name}: expected {expected!r}, got {err!r}")
+            check(f.merged_calls == 0, f"{name}: a malformed view reached the merge")
+        finally:
+            finish(td, real)
 
 
 def t_base_checked_out_and_absent():
@@ -1799,5 +1844,6 @@ CASES = [
     ("realgit-staged-equal-incoming", "REAL git: a path staged to exactly its incoming content does not block ff-only and is not named; only the true blocker is (finding 1)", t_realgit_staged_equal_incoming_not_named),
     ("realgit-ff-capture-non-utf8", "REAL git: _sync_base's checked-out-base ff capture survives a non-UTF-8 (0xff) blocking filename under core.quotePath=false — no crash, names the path, preserves git's original diagnostic (finding 2)", t_realgit_ff_capture_survives_non_utf8_filename),
     ("realgit-stale-index-lock-raw", "REAL git: a stale .git/index.lock makes the checked-out-base ff fail for an UNRELATED reason (no `overwritten by merge`); _sync_base does NOT fire the tailored path-list/stash refusal even though the probe still names an overlapping path — it falls back to git's raw lock error", t_realgit_stale_index_lock_falls_back_to_raw_error),
+    ("malformed-view-messages", "every live-view malformation refuses with the EXACT message body base-preflight.py and merge-check.py produce, and names the observed type so absent and wrong-type stay distinguishable", t_malformed_view_messages_match_the_other_deciders),
     ("realgit-main-stderr-raw-byte", "REAL git via a subprocess: main() writes the base-sync refusal to stderr BYTE-EXACT — git's raw 0xff diagnostic byte survives verbatim to the CLI boundary (not backslashreplaced to `\\udcff`), while the JSON-quoted tailored path stays ASCII/line-safe (finding 1)", t_realgit_main_stderr_preserves_raw_git_byte),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -150,12 +150,19 @@ def _labels(view: dict) -> "tuple[list[str], str | None]":
     `None` when nothing is. ONE walk serves both callers: `_view_problem` reads the problem and refuses,
     and the label gate reads the names on a view that already passed. Returning the problem instead of
     raising it is what lets every view malformation reach the CLI through one wrapper."""
-    raw = view.get("labels")
+    if "labels" not in view:
+        return [], "missing field 'labels'"
+    raw = view["labels"]
     if not isinstance(raw, list):
         return [], f"field 'labels' must be a list, got {type(raw).__name__}"
     names: list[str] = []
     for item in raw:
-        name = item.get("name") if isinstance(item, dict) else item
+        if isinstance(item, dict):
+            if "name" not in item:
+                return names, "field 'labels' contains an object without a 'name'"
+            name = item["name"]
+        else:
+            name = item
         if not isinstance(name, str):
             return names, f"field 'labels' must hold string names, got {type(name).__name__}"
         names.append(name)

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -35,6 +35,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import cast
 
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
@@ -138,30 +139,57 @@ def resolve_project_root(checkout: Path) -> Path:
     return resolved
 
 
-def _labels(view: dict) -> list[str]:
+# The string fields `execute` consumes off the live view. `isDraft` is a bool and `labels` a list, so each
+# is checked on its own below.
+_VIEW_STR_FIELDS = ("state", "headRefOid", "headRefName", "baseRefName", "mergeable",
+                    "mergeStateStatus")
+
+
+def _labels(view: dict) -> "tuple[list[str], str | None]":
+    """The live view's label names, paired with a short description of the FIRST thing wrong with them —
+    `None` when nothing is. ONE walk serves both callers: `_view_problem` reads the problem and refuses,
+    and the label gate reads the names on a view that already passed. Returning the problem instead of
+    raising it is what lets every view malformation reach the CLI through one wrapper."""
     raw = view.get("labels")
     if not isinstance(raw, list):
-        raise Refusal("live PR field 'labels' must be a list")
+        return [], f"field 'labels' must be a list, got {type(raw).__name__}"
     names: list[str] = []
     for item in raw:
         name = item.get("name") if isinstance(item, dict) else item
         if not isinstance(name, str):
-            raise Refusal("live PR labels must contain string names")
+            return names, f"field 'labels' must hold string names, got {type(name).__name__}"
         names.append(name)
-    return names
+    return names, None
+
+
+def _view_problem(view: object) -> "str | None":
+    """`None` if `view` is a JSON object carrying every field `execute` consumes at the right JSON type;
+    otherwise a short description of the FIRST thing wrong. PURE — no I/O.
+
+    The message bodies match `base-preflight.py` and `merge-check.py` verbatim: all three validate a
+    `gh pr view` payload against the same three failures (not an object, a missing field, a field of the
+    wrong type), and a reader who has seen one tool's refusal must not have to learn a second dialect to
+    read another's. `_validate_view` wraps whatever this returns."""
+    if not isinstance(view, dict):
+        return f"view is not a JSON object (got {type(view).__name__})"
+    for field in _VIEW_STR_FIELDS:
+        if field not in view:
+            return f"missing field {field!r}"
+        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
+        if not isinstance(view[field], str):
+            return f"field {field!r} must be a string, got {type(view[field]).__name__}"
+    if "isDraft" not in view:
+        return "missing field 'isDraft'"
+    if not isinstance(view["isDraft"], bool):
+        return f"field 'isDraft' must be a bool, got {type(view['isDraft']).__name__}"
+    return _labels(view)[1]
 
 
 def _validate_view(view: object) -> dict:
-    if not isinstance(view, dict):
-        raise Refusal("live PR view is not a JSON object")
-    for field in ("state", "headRefOid", "headRefName", "baseRefName", "mergeable",
-                  "mergeStateStatus"):
-        if not isinstance(view.get(field), str):
-            raise Refusal(f"live PR field {field!r} must be a string")
-    if not isinstance(view.get("isDraft"), bool):
-        raise Refusal("live PR field 'isDraft' must be a bool")
-    _labels(view)
-    return view
+    problem = _view_problem(view)
+    if problem is not None:
+        raise Refusal(f"malformed live PR view: {problem}")
+    return cast(dict, view)
 
 
 def _view(pr: str, repo: str, root: Path) -> dict:
@@ -253,7 +281,7 @@ def _validate_state(header: dict, row: dict, pr: str, root: Path, view: dict,
             # the SAME machine-blocker wording every other base door records (pr-adopt.py owns it, via
             # merge-check). A base that merely ADVANCED (same name) is handled by _base_is_current, not here.
             raise Refusal(MC.PA.BASE_CHANGE_PARK_REASON.format(recorded=base, live=view["baseRefName"]))
-    labels = _labels(view)
+    labels, _ = _labels(view)
     ours = f"{RUN_LABEL_PREFIX}{run_id}"
     run_labels = [name for name in labels if name.startswith(RUN_LABEL_PREFIX)]
     # The FOREIGN-label refusal comes FIRST and is never relaxed — it is the run-isolation guard, and must


### PR DESCRIPTION
- Reports a malformed live view in the wording base-preflight.py and merge-check.py already use.
- Distinguishes an absent field from a wrong-typed one, which `.get()` could not.
- Refuses and accepts exactly the payloads it did before; a fixture pins each exact string.
