### PR TITLE
share one gh pr view field validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/review_door.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
             plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+            plugins/gauntlet/skills/campaign/scripts/_gauntlet/view.py
             plugins/gauntlet/skills/campaign/scripts/ledger.py
             plugins/gauntlet/skills/campaign/scripts/ledger-test.py
             plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/view.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/view.py
@@ -1,0 +1,43 @@
+# ci: pyright
+"""The field-shape check every Gauntlet campaign decider applies to a `gh pr view` payload."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def field_problem(view: object, *, strings: "Iterable[str]" = (),
+                  bools: "Iterable[str]" = ()) -> "str | None":
+    """`None` if `view` is a JSON object carrying every named field at the named JSON type; otherwise a
+    short description of the FIRST thing wrong. PURE — no I/O, no raising.
+
+    Three deciders read a `gh pr view` payload and refuse a malformed one: `base-preflight.py` and
+    `merge-check.py` turn the result into a fail-closed verdict, `merge.py` into a `Refusal`. Each one
+    checked its own field list against the same three failures, so this owns the CHECK and its WORDING
+    while each caller keeps its own field list and its own way of refusing.
+
+    `strings` and `bools` are ORDERED and checked in that order, strings first. The order is part of the
+    contract, not an accident of iteration: the caller decides which malformation a user hears about when
+    a payload has several, and a caller that reorders its own list changes only which of its own messages
+    comes first.
+
+    Missing is reported SEPARATELY from wrong-typed. They are different repairs — one payload lacks a
+    field the tool asked `gh` for, the other carries it at a type no `gh pr view` produces — and a single
+    message for both leaves the reader unable to tell which happened.
+    """
+    if not isinstance(view, dict):
+        return f"view is not a JSON object (got {type(view).__name__})"
+    for name in strings:
+        if name not in view:
+            return f"missing field {name!r}"
+        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
+        if not isinstance(view[name], str):
+            return f"field {name!r} must be a string, got {type(view[name]).__name__}"
+    for name in bools:
+        if name not in view:
+            return f"missing field {name!r}"
+        # The reverse of the note above: `isinstance(True, int)` holds, so a bool check must come from
+        # `bool` itself. A JSON string that reads like a bool ("false") is the case that reaches here.
+        if not isinstance(view[name], bool):
+            return f"field {name!r} must be a bool, got {type(view[name]).__name__}"
+    return None

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -52,6 +52,7 @@ from _gauntlet.gh import pr_view_json
 from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path, load_sibling
 from _gauntlet.testing import run_sibling_suite
+from _gauntlet.view import field_problem
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "base-preflight-test.py"     # the fixture suite — this tool's executable contract
@@ -209,16 +210,11 @@ def validate_view(view: object) -> "str | None":
     """`None` if `view` is a JSON object carrying `mergeable` and `mergeStateStatus` as strings; otherwise a
     short description of the FIRST thing wrong. PURE — no I/O. The CLI turns a non-`None` result into a
     fail-closed `recheck`, so `decide` is never reached with a malformed view (learned from a prior tool that
-    could KeyError past its boundary)."""
-    if not isinstance(view, dict):
-        return f"view is not a JSON object (got {type(view).__name__})"
-    for name in _VIEW_STR_FIELDS:
-        if name not in view:
-            return f"missing field {name!r}"
-        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
-        if not isinstance(view[name], str):
-            return f"field {name!r} must be a string, got {type(view[name]).__name__}"
-    return None
+    could KeyError past its boundary).
+
+    `_gauntlet/view.py` owns the check and its wording; the field list stays here, because which fields this
+    tool needs is this tool's business and no other decider's."""
+    return field_problem(view, strings=_VIEW_STR_FIELDS)
 
 
 def load_view(pr: str, repo: "str | None", view_json: "str | None",

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -18,6 +18,7 @@ import tempfile
 from pathlib import Path
 
 from _gauntlet import gh as GH
+from _gauntlet import view as VIEW
 from _gauntlet.gitfixture import GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
@@ -617,7 +618,53 @@ def t_base_advance_is_not_a_retarget():
     expect(row(base_branch="v3"), view(baseRefName="v3"), "merge", "")
 
 
+def t_shared_field_problem_semantics():
+    """`_gauntlet/view.py`'s OWN contract, exercised directly rather than through a caller.
+
+    Three deciders now read their refusal wording from this one helper, so its semantics need a fixture
+    that does not depend on any caller's field list. Two of them are properties the callers cannot show:
+    the ORDER guarantee (strings before bools, and each list in the order given), and that an empty
+    request still refuses a non-object.
+    """
+    fp = VIEW.field_problem
+    ok = {"a": "x", "b": "y", "flag": True}
+
+    check(fp(ok, strings=("a", "b"), bools=("flag",)) is None,
+          "a well-formed payload must produce no problem")
+    check(fp({}, strings=(), bools=()) is None, "an empty request over an object must pass")
+    # An empty request still refuses a NON-object: the caller asked for nothing, but "is this even a JSON
+    # object?" is the helper's own precondition, not one of the requested fields.
+    check(fp([], strings=(), bools=()) == "view is not a JSON object (got list)",
+          "an empty request must still refuse a non-object")
+    check(fp(None, strings=("a",)) == "view is not a JSON object (got NoneType)",
+          "a JSON null must be named by its own type")
+
+    check(fp({"b": "y"}, strings=("a", "b")) == "missing field 'a'",
+          "a missing string field must be named")
+    check(fp({"a": 1, "b": "y"}, strings=("a", "b")) == "field 'a' must be a string, got int",
+          "a wrong-typed string field must name the observed type")
+    check(fp({"a": "x"}, bools=("flag",)) == "missing field 'flag'",
+          "a missing bool field must be named")
+    check(fp({"flag": "false"}, bools=("flag",)) == "field 'flag' must be a bool, got str",
+          "a JSON string that reads like a bool is not a bool")
+    # bool IS a subclass of int, so this is the direction that could silently pass a bool as a string's
+    # sibling. It must not: a bool requested as a string is a wrong type like any other.
+    check(fp({"a": True}, strings=("a",)) == "field 'a' must be a string, got bool",
+          "a bool requested as a string must be refused")
+
+    # ORDER: strings are checked before bools, and each list in the order given. A caller relies on this to
+    # decide which malformation its user hears about first when a payload has several.
+    both_wrong = {"a": 1, "flag": "false"}
+    check(fp(both_wrong, strings=("a",), bools=("flag",)) == "field 'a' must be a string, got int",
+          "the string list must be checked before the bool list")
+    check(fp({}, strings=("a", "b")) == "missing field 'a'",
+          "the first requested field must be the one reported")
+    check(fp({}, strings=("b", "a")) == "missing field 'b'",
+          "reordering the request must reorder the report")
+
+
 CASES = [
+    ("shared-field-problem", "the shared view validator's own semantics: order, empty request, and every missing/wrong-type message", t_shared_field_problem_semantics),
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),
     ("base-retarget-parks", "a live base retarget parks with the shared reason", t_base_retarget_parks),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -46,6 +46,7 @@ from typing import cast
 from _gauntlet.gh import pr_view_json
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
+from _gauntlet.view import field_problem
 
 _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "merge-check-test.py"     # the fixture suite — this tool's executable contract
@@ -219,20 +220,11 @@ _VIEW_STR_FIELDS = ("mergeable", "mergeStateStatus", "state", "headRefOid", "bas
 def validate_view(view: object) -> "str | None":
     """`None` if `view` is a JSON object carrying every field `decide` consumes at the right JSON type;
     otherwise a short description of the FIRST thing wrong. PURE — no I/O. The CLI turns a non-`None` result
-    into a fail-closed not-yet, so `decide` is never reached with a malformed view."""
-    if not isinstance(view, dict):
-        return f"view is not a JSON object (got {type(view).__name__})"
-    for field in _VIEW_STR_FIELDS:
-        if field not in view:
-            return f"missing field {field!r}"
-        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
-        if not isinstance(view[field], str):
-            return f"field {field!r} must be a string, got {type(view[field]).__name__}"
-    if "isDraft" not in view:
-        return "missing field 'isDraft'"
-    if not isinstance(view["isDraft"], bool):
-        return f"field 'isDraft' must be a bool, got {type(view['isDraft']).__name__}"
-    return None
+    into a fail-closed not-yet, so `decide` is never reached with a malformed view.
+
+    `_gauntlet/view.py` owns the check and its wording; the field lists stay here, because which fields this
+    tool needs is this tool's business and no other decider's."""
+    return field_problem(view, strings=_VIEW_STR_FIELDS, bools=("isDraft",))
 
 
 def load_view(pr: str, repo: "str | None", view_json: "str | None") -> dict:

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -39,6 +39,7 @@ from typing import cast
 
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
+from _gauntlet.view import field_problem
 
 HERE = Path(__file__).resolve().parent
 SIBLING = HERE / "merge-test.py"
@@ -173,23 +174,14 @@ def _view_problem(view: object) -> "str | None":
     """`None` if `view` is a JSON object carrying every field `execute` consumes at the right JSON type;
     otherwise a short description of the FIRST thing wrong. PURE — no I/O.
 
-    The message bodies match `base-preflight.py` and `merge-check.py` verbatim: all three validate a
-    `gh pr view` payload against the same three failures (not an object, a missing field, a field of the
-    wrong type), and a reader who has seen one tool's refusal must not have to learn a second dialect to
-    read another's. `_validate_view` wraps whatever this returns."""
-    if not isinstance(view, dict):
-        return f"view is not a JSON object (got {type(view).__name__})"
-    for field in _VIEW_STR_FIELDS:
-        if field not in view:
-            return f"missing field {field!r}"
-        # bool is a subclass of int, not str, so a JSON string is the only thing that passes here.
-        if not isinstance(view[field], str):
-            return f"field {field!r} must be a string, got {type(view[field]).__name__}"
-    if "isDraft" not in view:
-        return "missing field 'isDraft'"
-    if not isinstance(view["isDraft"], bool):
-        return f"field 'isDraft' must be a bool, got {type(view['isDraft']).__name__}"
-    return _labels(view)[1]
+    `_gauntlet/view.py` owns the field-shape check and its wording, shared with `base-preflight.py` and
+    `merge-check.py`. `labels` is checked here and not there: it is a list of objects rather than a scalar
+    field, and no other decider reads it. `_validate_view` wraps whatever this returns."""
+    problem = field_problem(view, strings=_VIEW_STR_FIELDS, bools=("isDraft",))
+    if problem is not None:
+        return problem
+    # `field_problem` returning None has already established that `view` is a dict.
+    return _labels(cast(dict, view))[1]
 
 
 def _validate_view(view: object) -> dict:


### PR DESCRIPTION
- Adds `_gauntlet/view.py`, which owns the field-shape check and its wording for all three deciders.
- Each caller keeps its own field list, because which fields it needs is its own business.
- No message changes; a fixture covers the helper's own order and empty-request semantics.
