### PR TITLE
share the bare-remote and clone fixture steps

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
@@ -2,12 +2,13 @@
 """One owner for the throwaway Git repositories the campaign self-test suites build.
 
 Several suites here prove their claims against a REAL git, not a mock: they build a repository in a
-temporary directory, commit into it, and read SHAs back with plumbing. Each of them used to carry its own
-copy of the same three steps — run git in a repository and raise when it fails, give the repository a
-commit identity so `git commit` works on a machine with no global config, and read a revision back as a
-string.
+temporary directory, commit into it, push between clones, and read SHAs back with plumbing. Each of them
+used to carry its own copy of every step, and the copies drifted — one suite checked a setup command's
+exit code and another did not, so a broken setup could leave a fixture proving something about a
+repository it never built. The methods below are the whole set; each says what it is for, and no count
+of them is restated here, because a count is one more thing to keep true.
 
-The failure TYPE is why this is a class and not four plain functions. Every suite raises its own module's
+The failure TYPE is why this is a class and not a module of plain functions. Every suite raises its own module's
 `SelfTestFailure`, and `_gauntlet.testing.run_cases` reports its `failure` argument as the fixture's own
 message while reporting anything else with a type-name prefix. A single helper hard-coding one exception
 would therefore change how a fixture's failure READS in every suite but one. Binding the type once, at
@@ -64,3 +65,38 @@ class GitFixture:
     def head(self, repo: Path, ref: str = "HEAD") -> str:
         """`ref` resolved to a full SHA, stripped — what a fixture pins a ledger row's `head_sha` to."""
         return self.run(repo, "rev-parse", ref).stdout.strip()
+
+    def init_bare(self, remote: Path, *, branch: str = "main") -> None:
+        """Create `remote` as a bare repository whose default branch is `branch`.
+
+        A bare repository is the only thing a fixture can push to and clone from, so the suites that
+        model a real campaign — a PR branch on a remote, a base that advanced under it — start here
+        rather than with `init_repo`. It is given no commit identity: nothing is ever committed IN a
+        bare repository, only pushed into it from a clone that has one.
+        """
+        self._plain(["git", "init", "--bare", "-b", branch, str(remote)],
+                    f"could not create the fixture remote at {remote}")
+
+    def clone(self, remote: Path, dest: Path) -> None:
+        """Clone `remote` into `dest` and give the clone the fixture commit identity.
+
+        The identity comes with the clone because every caller needs one: a clone exists in these suites
+        to commit into and push from. A caller wanting a bare-handed clone can still run `git clone`
+        itself; none does.
+        """
+        self._plain(["git", "clone", str(remote), str(dest)],
+                    f"could not clone {remote} into {dest}")
+        self.configure_identity(dest)
+
+    def _plain(self, argv: list[str], what: str) -> None:
+        """Run a git command that has NO repository to be `-C`'d into, and raise the bound failure type.
+
+        `run` cannot serve `init --bare` or `clone`: both NAME their target directory as an argument and
+        neither can run inside it, because it does not exist yet. Everything else about the two matches
+        `run` — the same capture, the same `errors="replace"` decode, the same failure type — so the
+        divergence stays confined to this one method.
+        """
+        result = subprocess.run(argv,  # noqa: S603 - fixture paths we built
+                                capture_output=True, text=True, errors="replace", check=False)
+        if result.returncode != 0:
+            raise self._failure(f"{what} ({result.returncode}): {result.stderr.strip()}")

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from _gauntlet.gitfixture import GitFixture
+from _gauntlet.gitfixture import FIXTURE_EMAIL, GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
                                hostile_json_responses, legacy_view_error_cases)
@@ -368,7 +368,6 @@ def t_gh_writing_restores_an_absent_path():
 # The repository fixtures come from the shared owner, bound to THIS suite's failure type.
 _GIT = GitFixture(M.SelfTestFailure)
 _git = _GIT.run
-_configure_repo = _GIT.configure_identity
 
 
 def t_clean_view_with_stale_base_rebases():
@@ -379,13 +378,8 @@ def t_clean_view_with_stale_base_rebases():
         seed = root / "seed"
         candidate = root / "candidate"
 
-        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-        result = subprocess.run(["git", "clone", str(remote), str(seed)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-        _configure_repo(seed)
+        _GIT.init_bare(remote)
+        _GIT.clone(remote, seed)
 
         (seed / "f").write_text("base\n", encoding="utf-8")
         _git(seed, "add", "f")
@@ -405,10 +399,7 @@ def t_clean_view_with_stale_base_rebases():
         _git(seed, "commit", "-m", "second candidate")
         _git(seed, "push", "origin", "second")
 
-        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
-        _configure_repo(candidate)
+        _GIT.clone(remote, candidate)
         _git(candidate, "checkout", "second")
 
         # Simulate the first serial campaign merge advancing main after the second PR was reviewed.
@@ -438,22 +429,14 @@ def t_clean_view_with_current_base_proceeds():
         seed = root / "seed"
         candidate = root / "candidate"
 
-        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-        result = subprocess.run(["git", "clone", str(remote), str(seed)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-        _configure_repo(seed)
+        _GIT.init_bare(remote)
+        _GIT.clone(remote, seed)
         (seed / "f").write_text("base\n", encoding="utf-8")
         _git(seed, "add", "f")
         _git(seed, "commit", "-m", "base")
         _git(seed, "push", "origin", "main")
 
-        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
-        _configure_repo(candidate)
+        _GIT.clone(remote, candidate)
 
         vjson = root / "clean-view.json"
         vjson.write_text(json.dumps(view()), encoding="utf-8")
@@ -475,21 +458,14 @@ def t_force_rewritten_base_refreshes_and_rebases():
         seed = root / "seed"
         candidate = root / "candidate"
 
-        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-        result = subprocess.run(["git", "clone", str(remote), str(seed)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-        _configure_repo(seed)
+        _GIT.init_bare(remote)
+        _GIT.clone(remote, seed)
         (seed / "f").write_text("base\n", encoding="utf-8")
         _git(seed, "add", "f")
         _git(seed, "commit", "-m", "base")
         _git(seed, "push", "origin", "main")
 
-        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture candidate: {result.stderr.strip()}")
+        _GIT.clone(remote, candidate)
 
         (seed / "f").write_text("first advance\n", encoding="utf-8")
         _git(seed, "commit", "-am", "first advance")
@@ -520,13 +496,8 @@ def t_literal_head_base_does_not_follow_remote_head_symref():
         seed = root / "seed"
         candidate = root / "candidate"
 
-        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-        result = subprocess.run(["git", "clone", str(remote), str(seed)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-        _configure_repo(seed)
+        _GIT.init_bare(remote)
+        _GIT.clone(remote, seed)
         (seed / "f").write_text("main\n", encoding="utf-8")
         _git(seed, "add", "f")
         _git(seed, "commit", "-m", "main base")
@@ -539,9 +510,7 @@ def t_literal_head_base_does_not_follow_remote_head_symref():
         _git(seed, "push", "origin", "HEAD:refs/heads/HEAD")
         check(main_head != literal_head, "fixture setup: main and the literal HEAD branch must differ")
 
-        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture candidate: {result.stderr.strip()}")
+        _GIT.clone(remote, candidate)
         symbolic = _git(candidate, "symbolic-ref", "refs/remotes/origin/HEAD")
         check(symbolic.returncode == 0
               and symbolic.stdout.strip() == "refs/remotes/origin/main",
@@ -574,13 +543,8 @@ DASH_BASE = "--upload-pack=/bin/false"
 def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[int, dict, str, str, str]":
     """Drive the documented CLI against a legal dash-leading base and a real bare remote."""
     remote, seed, candidate = root / "remote.git", root / "seed", root / "candidate"
-    result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                            capture_output=True, text=True, check=False)
-    check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-    result = subprocess.run(["git", "clone", str(remote), str(seed)],
-                            capture_output=True, text=True, check=False)
-    check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-    _configure_repo(seed)
+    _GIT.init_bare(remote)
+    _GIT.clone(remote, seed)
     (seed / "f").write_text("base\n", encoding="utf-8")
     _git(seed, "add", "f")
     _git(seed, "commit", "-m", "base")
@@ -590,10 +554,7 @@ def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[int, dict, str, 
     _git(seed, "update-ref", dash_head, "HEAD")
     _git(seed, "push", "origin", f"{dash_head}:{dash_head}")
 
-    result = subprocess.run(["git", "clone", str(remote), str(candidate)],
-                            capture_output=True, text=True, check=False)
-    check(result.returncode == 0, f"could not clone fixture candidate: {result.stderr.strip()}")
-    _configure_repo(candidate)
+    _GIT.clone(remote, candidate)
     old_base = _git(candidate, "rev-parse", tracking_ref).stdout.strip()
 
     (seed / "f").write_text("advanced base\n", encoding="utf-8")
@@ -649,22 +610,14 @@ def t_candidate_revision_is_checked_instead_of_moved_head():
         seed = root / "seed"
         candidate = root / "candidate"
 
-        result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-        result = subprocess.run(["git", "clone", str(remote), str(seed)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-        _configure_repo(seed)
+        _GIT.init_bare(remote)
+        _GIT.clone(remote, seed)
         (seed / "f").write_text("base\n", encoding="utf-8")
         _git(seed, "add", "f")
         _git(seed, "commit", "-m", "base")
         _git(seed, "push", "origin", "main")
 
-        result = subprocess.run(["git", "clone", str(remote), str(candidate)],
-                                capture_output=True, text=True, check=False)
-        check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
-        _configure_repo(candidate)
+        _GIT.clone(remote, candidate)
         _git(candidate, "checkout", "-b", "reviewed")
         (candidate / "reviewed").write_text("reviewed\n", encoding="utf-8")
         _git(candidate, "add", "reviewed")
@@ -776,19 +729,13 @@ def _current_base_worktree(root: Path) -> "tuple[Path, str]":
     """A candidate clone that CONTAINS fetched main (so base-preflight reaches `proceed`). Returns (worktree,
     HEAD sha)."""
     remote, seed, candidate = root / "remote.git", root / "seed", root / "candidate"
-    result = subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)],
-                            capture_output=True, text=True, check=False)
-    check(result.returncode == 0, f"could not create fixture remote: {result.stderr.strip()}")
-    result = subprocess.run(["git", "clone", str(remote), str(seed)], capture_output=True, text=True, check=False)
-    check(result.returncode == 0, f"could not clone fixture seed: {result.stderr.strip()}")
-    _configure_repo(seed)
+    _GIT.init_bare(remote)
+    _GIT.clone(remote, seed)
     (seed / "f").write_text("base\n", encoding="utf-8")
     _git(seed, "add", "f")
     _git(seed, "commit", "-m", "base")
     _git(seed, "push", "origin", "main")
-    result = subprocess.run(["git", "clone", str(remote), str(candidate)], capture_output=True, text=True, check=False)
-    check(result.returncode == 0, f"could not clone candidate worktree: {result.stderr.strip()}")
-    _configure_repo(candidate)
+    _GIT.clone(remote, candidate)
     head = _git(candidate, "rev-parse", "HEAD").stdout.strip()
     return candidate, head
 
@@ -978,7 +925,53 @@ def t_cli_help_names_both_file_writes():
           f"`--file` help no longer names the no-write form: {help_text!r}")
 
 
+def t_shared_remote_and_clone_primitives():
+    """`GitFixture.init_bare` and `.clone`'s OWN contract, exercised directly rather than through a fixture.
+
+    Both are new shared primitives, so their semantics need a check that does not depend on any suite's
+    scenario. The load-bearing parts are that `init_bare` really produces a BARE repository on the named
+    branch (an ordinary one would accept a commit and break every push-based fixture in a way that only
+    shows up much later), that `clone` leaves a usable commit identity behind, and that BOTH raise the
+    bound failure type instead of returning a failed result — the inline blocks they replaced in this file
+    checked their own return codes, and the one in `clean-rebase-test.py` did NOT.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        remote = root / "remote.git"
+        clone = root / "clone"
+
+        _GIT.init_bare(remote, branch="trunk")
+        check((remote / "HEAD").exists() and not (remote / ".git").exists(),
+              "init_bare must produce a bare repository, not one with a working tree")
+        check(_git(remote, "symbolic-ref", "HEAD").stdout.strip() == "refs/heads/trunk",
+              "init_bare must honour the requested default branch")
+
+        _GIT.clone(remote, clone)
+        check(_git(clone, "config", "user.email").stdout.strip() == FIXTURE_EMAIL,
+              "clone must leave a commit identity behind, so the clone can commit")
+        # The identity is the point: a commit here would fail on a machine with no global git config.
+        (clone / "f").write_text("x\n", encoding="utf-8")
+        _git(clone, "add", "f")
+        _git(clone, "commit", "-m", "proves the identity works")
+
+        # Both RAISE rather than returning a failed result, which is the property the replaced inline
+        # blocks asserted by hand and the one in clean-rebase-test.py did not assert at all. The target
+        # is an existing regular FILE: `git init` happily creates missing parent directories, so a
+        # merely-absent path is not a failure at all and would prove nothing here.
+        blocker = root / "a-file"
+        blocker.write_text("not a directory\n", encoding="utf-8")
+        for label, call in (("init_bare", lambda: _GIT.init_bare(blocker)),
+                            ("clone", lambda: _GIT.clone(remote, blocker))):
+            try:
+                call()
+            except M.SelfTestFailure:
+                pass
+            else:
+                check(False, f"{label} must raise the bound failure type when git fails")
+
+
 CASES = [
+    ("shared-remote-clone", "the shared bare-remote and clone primitives: bare on the named branch, a usable identity, and a raise on failure", t_shared_remote_and_clone_primitives),
     ("clean-proceeds", "CLEAN passes the enum screen", t_clean_proceeds),
     ("has-hooks-proceeds", "HAS_HOOKS passes the enum screen", t_has_hooks_proceeds),
     ("unstable-proceeds", "UNSTABLE is a check signal and reaches the graph check", t_unstable_proceeds),

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -47,12 +47,6 @@ check = checker(M.SelfTestFailure)
 _GIT = GitFixture(M.SelfTestFailure)
 git = _GIT.run
 head = _GIT.head
-_cfg = _GIT.configure_identity
-
-
-def _run(argv, cwd=None):
-    # Only for the two commands that run OUTSIDE any repository: creating the bare remote and cloning it.
-    return subprocess.run(argv, capture_output=True, text=True, cwd=cwd)  # noqa: S603
 
 
 def _ledger(*args) -> int:
@@ -94,9 +88,8 @@ class Scenario:
         self.orig_head = ""
 
     def build(self, *, status="in_review", reviews_ok=2, repair_decision="-"):
-        _run(["git", "init", "--bare", "-b", "main", str(self.remote)])
-        _run(["git", "clone", str(self.remote), str(self.seed)])
-        _cfg(self.seed)
+        _GIT.init_bare(self.remote)
+        _GIT.clone(self.remote, self.seed)
         # base commit on main
         (self.seed / "f").write_text(_numbered({}), encoding="utf-8")
         git(self.seed, "add", "f")
@@ -118,8 +111,7 @@ class Scenario:
         git(self.seed, "push", "origin", PR_BRANCH)
         self.orig_head = head(self.seed)
         # the PR-head worktree — a fresh clone with the PR branch checked out
-        _run(["git", "clone", str(self.remote), str(self.wt)])
-        _cfg(self.wt)
+        _GIT.clone(self.remote, self.wt)
         git(self.wt, "checkout", PR_BRANCH)
         check(head(self.wt) == self.orig_head, "precondition: the worktree is at the PR head")
         # ledger: header + row, with reviews_ok earned by real verdicts at the PR head
@@ -594,9 +586,7 @@ def t_absent_remote_refused():
         tmp = Path(tmp)
         # a standalone repo with a commit but NO remote configured
         wt = tmp / "solo"
-        wt.mkdir()
-        _run(["git", "init", "-b", "pr", str(wt)])
-        _cfg(wt)
+        _GIT.init_repo(wt, branch="pr")
         (wt / "f").write_text("x\n", encoding="utf-8")
         git(wt, "add", "f")
         git(wt, "commit", "-m", "only")


### PR DESCRIPTION
- Adds `init_bare` and `clone` to `GitFixture`, the owner two suites already import.
- Converts 21 inline blocks in base-preflight-test.py and 3 in clean-rebase-test.py.
- clean-rebase-test.py's copy never checked a setup exit code; the shared one always raises.
