### PR TITLE
type-check every tracked Python file in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/crlf_marker.txt text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,142 +66,40 @@ jobs:
       # through `ast.AST`, which does not declare it — code that compiles, runs, and is a lie about what the
       # walk yields.
       #
-      # DELIBERATELY FILE-SCOPED, not repo-wide. The other scripts here are not type-clean yet, and a
-      # repo-wide gate would fail builds for reasons that have nothing to do with the change under review —
-      # a gate that is red for everyone is a gate nobody can use. Add the exact `# ci: pyright` marker
-      # to each Python source or stub file as it becomes type-clean. Never remove the marker from a covered file.
+      # REPO-WIDE. Every tracked Python source and stub file is checked, with no opt-in marker and no list
+      # to maintain: a new file is covered the moment it is committed, and there is no way to add one that
+      # is quietly not type-checked. This replaced a per-file `# ci: pyright` marker scheme that existed
+      # only because the tree was not yet clean — it is, so the scheme's whole reason is gone. Discovery is
+      # `git ls-files`, so an untracked scratch file in a working tree cannot make the gate fail or pass.
       #
       # The `filesAnalyzed` assertion is the load-bearing half of this step, not a flourish. Pyright can
       # silently skip an explicit input while still reporting "0 errors" and exiting 0. A step that trusted
-      # the exit code alone could therefore pass without covering every file discovered from the marker
-      # inventory. So the count is asserted: every discovered input must actually be analysed.
-      - name: Pyright (the type-clean files)
+      # the exit code alone could therefore pass without covering every discovered file. So the count is
+      # asserted: every discovered input must actually be analysed.
+      - name: Pyright (every tracked Python file)
         run: |
           set -o pipefail
-          marker_args=(-e '^# ci: pyright$' -e $'^# ci: pyright\r$')
-
-          # This is the coverage floor: every previously type-clean source or stub file must retain the exact marker.
-          # Marker discovery below remains open-ended, so newly type-clean files are analysed without a
-          # second list edit.
-          baseline=(
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/review_door.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
-            plugins/gauntlet/skills/campaign/scripts/_gauntlet/view.py
-            plugins/gauntlet/skills/campaign/scripts/ledger.py
-            plugins/gauntlet/skills/campaign/scripts/ledger-test.py
-            plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
-            plugins/gauntlet/skills/campaign/scripts/review-pass.py
-            plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
-            plugins/gauntlet/skills/campaign/scripts/emit-finding.py
-            plugins/gauntlet/skills/campaign/scripts/finding-audit.py
-            plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py
-            plugins/gauntlet/skills/campaign/scripts/repair-pass.py
-            plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
-            plugins/gauntlet/skills/campaign/scripts/followups.py
-            plugins/gauntlet/skills/campaign/scripts/followups-test.py
-            plugins/gauntlet/skills/campaign/scripts/nudge.py
-            plugins/gauntlet/skills/campaign/scripts/nudge-test.py
-            plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
-            plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
-            plugins/gauntlet/skills/campaign/scripts/triage.py
-            plugins/gauntlet/skills/campaign/scripts/triage-test.py
-            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
-            plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
-            plugins/gauntlet/skills/campaign/scripts/lease.py
-            plugins/gauntlet/skills/campaign/scripts/lease-test.py
-            plugins/gauntlet/skills/campaign/scripts/heartbeat.py
-            plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
-            plugins/gauntlet/skills/campaign/scripts/run-id.py
-            plugins/gauntlet/skills/campaign/scripts/run-id-test.py
-            plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/marked_stub.pyi
-            plugins/gauntlet/skills/campaign/scripts/script-table-test.py
-            plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py
-            plugins/gauntlet/skills/campaign/scripts/base-preflight.py
-            plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
-            plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
-            plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
-            plugins/gauntlet/skills/campaign/scripts/merge-check.py
-            plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
-            plugins/gauntlet/skills/campaign/scripts/merge.py
-            plugins/gauntlet/skills/campaign/scripts/merge-test.py
-          )
-          missing=()
-          for file in "${baseline[@]}"; do
-            if ! git grep -q "${marker_args[@]}" -- "${file}"; then
-              missing+=("${file}")
-            fi
-          done
-          if ((${#missing[@]} != 0)); then
-            printf '::error::covered Python source or stub file lacks the exact # ci: pyright marker: %s\n' "${missing[@]}"
-            exit 1
-          fi
-
-          # Exact marker lines, with either LF or CRLF endings, define the current type-clean source and stub set.
-          # filesAnalyzed is derived from this discovered set, never from the baseline.
-          discovery_file=$(mktemp "${RUNNER_TEMP}/pyright-markers.XXXXXX")
+          discovery_file=$(mktemp "${RUNNER_TEMP}/pyright-files.XXXXXX")
           trap 'rm -f "${discovery_file}" pyright.json' EXIT
-          if git grep -l -z "${marker_args[@]}" -- '*.py' '*.pyi' > "${discovery_file}"; then
-            mapfile -d '' -t files < "${discovery_file}"
-          else
-            grep_status=$?
-            if [ "${grep_status}" -ne 1 ]; then
-              exit "${grep_status}"
-            fi
-            files=()
-          fi
+          git ls-files -z -- '*.py' '*.pyi' > "${discovery_file}"
+          mapfile -d '' -t files < "${discovery_file}"
           if ((${#files[@]} == 0)); then
-            echo "::error::no Python source or stub files carry the exact # ci: pyright marker"
+            echo "::error::no tracked Python source or stub files were discovered — check the ls-files patterns"
             exit 1
           fi
-          declare -A discovered
-          for file in "${files[@]}"; do
-            discovered["${file}"]=1
-          done
-          missing_from_discovery=()
-          for file in "${baseline[@]}"; do
-            if [[ ! -v discovered["${file}"] ]]; then
-              missing_from_discovery+=("${file}")
-            fi
-          done
-          if ((${#missing_from_discovery[@]} != 0)); then
-            printf '::error::covered Python source or stub file was not discovered: %s\n' "${missing_from_discovery[@]}"
-            exit 1
-          fi
-          crlf_fixture='plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/crlf_marker.txt'
-          if crlf_match=$(git grep -l "${marker_args[@]}" -- "${crlf_fixture}"); then
-            :
-          else
-            grep_status=$?
-            if [ "${grep_status}" -eq 1 ]; then
-              crlf_match=''
-            else
-              exit "${grep_status}"
-            fi
-          fi
-          if [ "${crlf_match}" != "${crlf_fixture}" ]; then
-            echo "::error::the tracked CRLF marker fixture did not match exactly: ${crlf_fixture}"
-            exit 1
-          fi
+          printf 'type-checking %s\n' "${files[@]}"
+
           npx --yes pyright@1.1.410 --outputjson "${files[@]/#/./}" | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           expected=${#files[@]}
           echo "filesAnalyzed=${analyzed} expected=${expected}"
           if [ "${analyzed}" != "${expected}" ]; then
             echo "::error::pyright analysed ${analyzed} file(s), not the ${expected} it was pointed at — it checked" \
-                 "an incomplete marker inventory. Inspect marker discovery and Pyright input handling;" \
+                 "an incomplete inventory. Inspect discovery and Pyright input handling;" \
                  " every discovered file must be analysed."
             exit 1
           fi
+
 
       # The CI-snapshot contract, executed. The rules it pins are prose in stage-2-ci.md, and prose
       # cannot be run — three defects shipped in that prose, each of which dies instantly against a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,27 @@ jobs:
           fi
           printf 'type-checking %s\n' "${files[@]}"
 
+          # STUB COVERAGE, CHECKED INDEPENDENTLY OF DISCOVERY. The filesAnalyzed assertion below compares
+          # pyright's count against the DISCOVERED count, so it cannot notice a discovery that stopped
+          # looking for something: drop `*.pyi` from the pathspec above and both numbers fall together and
+          # the step still passes. This asks a separate question with its own pathspec — are the tracked
+          # stubs in the input set? — which is the only way the two can disagree.
+          mapfile -d '' -t stubs < <(git ls-files -z -- '*.pyi')
+          if ((${#stubs[@]} == 0)); then
+            echo "::error::no tracked .pyi stub was found; this repository keeps one so stub coverage stays checked"
+            exit 1
+          fi
+          for stub in "${stubs[@]}"; do
+            found=0
+            for file in "${files[@]}"; do
+              if [ "${file}" = "${stub}" ]; then found=1; break; fi
+            done
+            if ((found == 0)); then
+              echo "::error::tracked stub ${stub} is not in the type-check input set — discovery dropped stub files"
+              exit 1
+            fi
+          done
+
           npx --yes pyright@1.1.410 --outputjson "${files[@]/#/./}" | tee pyright.json
           analyzed=$(jq '.summary.filesAnalyzed' pyright.json)
           expected=${#files[@]}

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/__init__.py
@@ -1,2 +1,1 @@
-# ci: pyright
 """Private shared implementation for Gauntlet campaign scripts."""

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Argument-vector helpers shared by Gauntlet campaign scripts."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Atomic text-file replacement shared by Gauntlet's local stores."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/clock.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """The `Z`-suffixed UTC stamp shared by Gauntlet campaign stores."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gh.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """The `gh pr view` fetch shared by Gauntlet campaign deciders."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/gitfixture.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """One owner for the throwaway Git repositories the campaign self-test suites build.
 
 Several suites here prove their claims against a REAL git, not a mock: they build a repository in a

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/jsonl.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Shared JSONL object reader for Gauntlet campaign stores."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/modules.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Load sibling Gauntlet scripts whose filenames are not importable module names."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/mutation.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Shared mechanics for Gauntlet's source-mutation test harnesses."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/review_door.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/review_door.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Shared dispatch for the two public reviewer entry-point scripts."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/table.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Shared rendering for human-readable Gauntlet state tables."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/testing.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """Narrow helpers shared by Gauntlet's in-process CLI tests."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/view.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/view.py
@@ -1,4 +1,3 @@
-# ci: pyright
 """The field-shape check every Gauntlet campaign decider applies to a `gh pr view` payload."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `base-preflight.py` — the base-currency decider.
 
 They live in a SIBLING file, and `base-preflight.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """DECIDE whether a PR's branch is current with its base BEFORE a review or a fix is authored on it.
 
 This enforces the rebase-before-review/fix precondition `stage-2-review-gate.md` states in prose: if a PR

--- a/plugins/gauntlet/skills/campaign/scripts/carryover-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/carryover-test.py
@@ -286,7 +286,7 @@ def t_malformed_ledger_is_refused() -> None:
         ledger_path = tmp / "state.jsonl"
         out_dir = tmp / "history"
         ledger_path.write_text("this is not json at all\n", encoding="utf-8")
-        code, out, err = capture_cli(
+        code, out, _err = capture_cli(
             C.main, ["distill", "--ledger", str(ledger_path), "--out-dir", str(out_dir), "--now", NOW])
         check(code == C.EXIT_OPERATOR,
               f"a malformed ledger is an operator error ({C.EXIT_OPERATOR}); got {code}")
@@ -301,7 +301,7 @@ def t_header_without_run_id_is_refused() -> None:
         # A header whose run_id is unset (`-`) is not a run's ledger. (The base is no longer gated here.)
         header = dict(L.HEADER_DEFAULTS)  # run_id defaults to "-"
         rows = [_row("41", slug="s", status="merged", head_sha=SHA_A, tier="TRIVIAL", review_rounds="1")]
-        code, out, err, out_dir = _distill(tmp, header, rows)
+        code, out, err, _out_dir = _distill(tmp, header, rows)
         check(code == C.EXIT_OPERATOR,
               f"a header with no run_id is an operator error ({C.EXIT_OPERATOR}); got {code}")
         check("run_id" in err, f"the refusal says the run identity is missing: {err!r}")
@@ -319,7 +319,7 @@ def t_missing_now_is_an_operator_error() -> None:
                       [_row("41", slug="s", status="merged", head_sha=SHA_A, tier="TRIVIAL",
                             review_rounds="1")])
         # No --now at all: argparse REQUIRES it and exits 2 (the operator-error code) before any work.
-        code, out, err = capture_cli(
+        code, _out, _err = capture_cli(
             C.main, ["distill", "--ledger", str(ledger_path), "--out-dir", str(out_dir)])
         check(code == C.EXIT_OPERATOR,
               f"a missing --now is an operator error ({C.EXIT_OPERATOR}); got {code}")
@@ -335,7 +335,7 @@ def t_blank_now_is_refused() -> None:
         _write_ledger(ledger_path, _header(),
                       [_row("41", slug="s", status="merged", head_sha=SHA_A, tier="TRIVIAL",
                             review_rounds="1")])
-        code, out, err = capture_cli(
+        code, _out, _err = capture_cli(
             C.main, ["distill", "--ledger", str(ledger_path), "--out-dir", str(out_dir), "--now", "   "])
         check(code == C.EXIT_OPERATOR, f"a whitespace --now is refused ({C.EXIT_OPERATOR}); got {code}")
         check(not (out_dir / "g260704-0915-a3f29c1b.md").exists(), "a blank clock writes no file")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -47,7 +47,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable
+from typing import IO, Callable
 
 HERE = Path(__file__).resolve().parent
 STATUS_PY = HERE / "ci-status.py"
@@ -450,8 +450,11 @@ def required_set_cli_cases(ci, tmp: Path) -> list[str]:
     cli_tmp = tmp / "required-set-cli"
     cli_tmp.mkdir()
 
+    # `stdout` is whatever subprocess accepts there: the PIPE constant, or a real file object when a
+    # fixture needs the child's stdout to fail on write. Both forms are used here, so the annotation
+    # names both rather than the default's type alone.
     def run_cli(ledger: Path, *, repo: str = "o/r", env: "dict[str, str] | None" = None,
-                stdout=subprocess.PIPE, preexec_fn=None):
+                stdout: "int | IO[str] | None" = subprocess.PIPE, preexec_fn=None):
         return subprocess.run(  # noqa: S603 - this suite drives its sibling command
             [sys.executable, str(STATUS_PY), "required-set", "--ledger", str(ledger), "--repo", repo],
             stdout=stdout, stderr=subprocess.PIPE, text=True, check=False, env=env,

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -152,7 +152,7 @@ import sys
 import textwrap
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, NamedTuple, NoReturn
+from typing import Callable, NamedTuple, NoReturn, cast
 from urllib.parse import quote
 
 from _gauntlet.modules import load_module_from_path
@@ -450,7 +450,10 @@ def resolve_required_for_derive(ledger_file: str, pr: str, required_set_arg: "st
 
 def required_check(source: str, value: object, app_key: str) -> tuple[str, str]:
     """Parse one GitHub required-check declaration without turning absence into an empty value."""
-    context = field(source, value, "context", str)
+    # `field` has already REFUSED anything but the declared shape, so each cast below records a fact the
+    # runtime check established and the type checker cannot see. A cast is never a second opinion about the
+    # shape: change the shape argument and the cast must change with it.
+    context = cast(str, field(source, value, "context", str))
     app = field(source, value, app_key, int, NULL, ABSENT)
     if app is None:
         app = SNAP.ANY_APP
@@ -467,7 +470,7 @@ def classic_required_set(payload: object) -> list[tuple[str, str]]:
     if not enabled:
         return []
     status_checks = field(source, protection, "required_status_checks", dict)
-    checks = field(source, status_checks, "checks", list)
+    checks = cast(list, field(source, status_checks, "checks", list))
     return [required_check(source, check, "app_id") for check in checks]
 
 
@@ -485,7 +488,7 @@ def ruleset_required_set(payload: object) -> list[tuple[str, str]]:
             if rule_type != "required_status_checks":
                 continue
             parameters = field(source, rule, "parameters", dict)
-            declared = field(source, parameters, "required_status_checks", list)
+            declared = cast(list, field(source, parameters, "required_status_checks", list))
             checks.extend(required_check(source, check, "integration_id") for check in declared)
     return checks
 
@@ -1042,9 +1045,9 @@ def read_pages(fetch: Fetch, source: str, argv: list[str], rows_key: str) -> tup
     # we cannot read). Delete that member from an otherwise-green fixture and the count still matched the rows
     # collected — zero — containment still held, and `derive()` returned **GREEN**. A page missing the key, or
     # carrying anything but a LIST there, is REFUSED — never defaulted, never coerced.
-    rows = [row for page in pages for row in field(source, page, rows_key, list, why=(
+    rows = [row for page in pages for row in cast(list, field(source, page, rows_key, list, why=(
         f"Every page of this response carries its rows under {rows_key!r}; a page that does not is not a "
-        f"page with NO rows, and the row it is hiding could be the FAILING one."))]
+        f"page with NO rows, and the row it is hiding could be the FAILING one.")))]
 
     first = next(iter(pages))
     # A COUNT WE CANNOT READ IS REFUSED, for the same reason `headRefOid` is: the completeness test below
@@ -1059,11 +1062,11 @@ def read_pages(fetch: Fetch, source: str, argv: list[str], rows_key: str) -> tup
     # and cross-source rules already fail closed on. So the count is read off every page (`field` refuses an
     # absent/non-integer count on ANY page, not only the first), and the collected rows are checked against
     # ALL of them.
-    totals = [field(source, page, "total_count", int, why=(
+    totals = [cast(int, field(source, page, "total_count", int, why=(
         "That is GitHub's own count of the rows it holds for this commit, and it is the ONLY thing we can "
         "check our read against: without it we cannot tell a complete read from a truncated one, and "
         "cannot-tell is not a green. It is read off EVERY page — a later page reporting a different count is "
-        "a check that registered mid-fetch, and the row it added could be the failing one.")) for page in pages]
+        "a check that registered mid-fetch, and the row it added could be the failing one."))) for page in pages]
 
     # WHAT WE COLLECTED MUST BE WHAT GITHUB SAYS IT HOLDS, ON EVERY PAGE. A page whose count disagrees with
     # the rows we collected is a short read (or a response whose pages contradict each other), and a hole we
@@ -1243,10 +1246,10 @@ def fetch_rollup(fetch: Fetch, pr: str) -> tuple[list[dict], dict, object, list[
     # suites are all dynamic-event legitimately looks like that. A MISSING (or non-list) key is a response we
     # did not understand, and reading it as "no witnesses" makes CONTAINMENT VACUOUS: "REST saw everything
     # the rollup saw" is then a claim about the empty set, and it passes trivially.
-    entries = field("rollup", data, "statusCheckRollup", list, why=(
+    entries = cast(list, field("rollup", data, "statusCheckRollup", list, why=(
         "That is not an EMPTY rollup (a fact GitHub can state), it is a response we cannot read. Treating "
         "it as 'no witnesses' would make the containment test a claim about the empty set, which passes "
-        "TRIVIALLY: an absence read as 'nothing wrong'."))
+        "TRIVIALLY: an absence read as 'nothing wrong'.")))
 
     witnesses: list[dict] = []
     status_rollup: list[RollupStatus] = []
@@ -2595,7 +2598,7 @@ def self_test() -> int:
         return tests.run(sys.modules[__name__], Path(tmp))
 
 
-def resolve_repo(fetch: Fetch) -> object:
+def resolve_repo(fetch: Fetch) -> str:
     """WHICH REPOSITORY IS THIS CHECKOUT? The one fetch that happens outside `derive` — and it goes THROUGH
     THE DOOR, like every other read of a GitHub response.
 
@@ -2605,8 +2608,8 @@ def resolve_repo(fetch: Fetch) -> object:
     instead of the caller's actual problem. It failed closed, and it lied about why. `field()` refuses it,
     and the operator gets the error that is true: we cannot tell which repo this is.
     """
-    return field("repo", fetch("repo", ["gh", "repo", "view", "--json", "nameWithOwner"]),
-                 "nameWithOwner", str)
+    return cast(str, field("repo", fetch("repo", ["gh", "repo", "view", "--json", "nameWithOwner"]),
+                           "nameWithOwner", str))
 
 
 def main() -> int:

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -268,7 +268,7 @@ def t_decided_repair_rebases_clean_base():
         s = Scenario(Path(tmp)).build(status=L.REPAIR_STATUS, reviews_ok=0,
                                       repair_decision=RECORDED_REPAIR)
         s.advance_base({12: "12-BASE"})
-        code, out, err = s.invoke()
+        code, _out, err = s.invoke()
         check(code == M.EXIT_OK,
               f"a decided repair's clean base-only rebase must exit 0 (code={code}, err={err})")
         new_head = head(s.wt)

--- a/plugins/gauntlet/skills/campaign/scripts/emit-finding.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-finding.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Record ONE review finding — the reviewer's door into `review-pass.py`, and the ONLY way to report one.
 
 **A FINDING USED TO BE A PARAGRAPH.** It was prose in `review-<pr>-<n>.txt`: no schema, no citation rule,

--- a/plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/finding-audit-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for ``finding-audit.py``'s complete-audit and fix-scope contract."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/finding-audit.py
+++ b/plugins/gauntlet/skills/campaign/scripts/finding-audit.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Schema-owning accessor for campaign finding audits and review-fix scope.
 
 The reviewer finding schema and gating rule belong to ``review-pass.py``. This accessor imports that

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/crlf_marker.txt
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/crlf_marker.txt
@@ -1,2 +1,0 @@
-# ci: pyright
-CRLF_MARKER_SELECTED: bool = True

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/marked_stub.pyi
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/marked_stub.pyi
@@ -1,3 +1,5 @@
-# The one tracked `.pyi` in this repository. It exists so CI's type-check step proves it discovers STUB
-# files and not only `.py` sources: delete the `*.pyi` pattern from that step's `git ls-files` and the
-# discovered count drops, which the `filesAnalyzed` assertion reports. It declares nothing on purpose.
+# The one tracked `.pyi` in this repository. It exists so CI's type-check step has a stub to prove it
+# covers stub files and not only `.py` sources. The step checks that separately from its file discovery,
+# with its own `git ls-files -- '*.pyi'` query: the `filesAnalyzed` count alone could NOT catch a
+# discovery that stopped looking for stubs, because dropping the pattern lowers the expected count too.
+# It declares nothing on purpose.

--- a/plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/marked_stub.pyi
+++ b/plugins/gauntlet/skills/campaign/scripts/fixtures/pyright/marked_stub.pyi
@@ -1,1 +1,3 @@
-# ci: pyright
+# The one tracked `.pyi` in this repository. It exists so CI's type-check step proves it discovers STUB
+# files and not only `.py` sources: delete the `*.pyi` pattern from that step's `git ls-files` and the
+# discovered count drops, which the `filesAnalyzed` assertion reports. It declares nothing on purpose.

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """THE FOLLOW-UP STORE'S CONTRACT, EXECUTED — the fixtures for `followups.py`.
 
 RUN IT THROUGH THE SCRIPT IT TESTS: `python3 followups.py self-test`. That is what CI invokes, and it is

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Schema-owning accessor for the FOLLOW-UP ledger (.gauntlet/followups.jsonl).
 
 A follow-up is work the campaign DISCOVERED and deliberately did not do: a defect out of scope for the

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `heartbeat.py` — the scheduled heartbeat and session-watchdog wake prompts.
 
 They live in a SIBLING file, and `heartbeat.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
+++ b/plugins/gauntlet/skills/campaign/scripts/heartbeat.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Emit the scheduled heartbeat and session-watchdog wake prompts.
 
 A scheduled wake fires INTO THE SAME LIVE SESSION — it is the SAME owner resuming its own run, one turn

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
@@ -75,7 +75,19 @@ def build_ledger(d: Path, *, status="in_review", tier="STANDARD", reviews_ok="0"
     return led
 
 
-def drive(led: Path, pr: str, repo: str, fake: FakeGh, *, dry_run=False) -> tuple:
+def verdict(parsed: "dict | None") -> dict:
+    """The printed verdict JSON, or a fixture failure saying it was absent.
+
+    `drive` returns `None` for empty stdout because the REFUSAL fixtures assert exactly that. The
+    success-path fixtures need the dict, so they come through here rather than each restating the
+    None check before subscripting."""
+    if parsed is None:
+        raise M.SelfTestFailure("expected verdict JSON on stdout, got nothing")
+    return parsed
+
+
+def drive(led: Path, pr: str, repo: str, fake: FakeGh, *,
+          dry_run=False) -> "tuple[int, dict | None, str]":
     """Run the REAL `mirror()` with the fake seam; return (exit_code, parsed_stdout_or_None, stderr)."""
     out, err = StringIO(), StringIO()
     try:
@@ -102,8 +114,10 @@ def t_reviewing_to_accepted_swaps():
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")   # 2/2 -> accepted
         fake = FakeGh(view=view_with("gauntlet-reviewing", "gauntlet-run-g1"))
         code, out, _err = drive(led, "9", REPO, fake)
+        out = verdict(out)
     check(code == 0, f"a met gate must reconcile and exit 0, got {code}")
-    check(out is not None and out["changed"] is True, f"a reviewing->accepted swap must report changed, got {out!r}")
+    out = verdict(out)
+    check(out["changed"] is True, f"a reviewing->accepted swap must report changed, got {out!r}")
     check(out["desired"] == "gauntlet-accepted", f"desired must be accepted, got {out!r}")
     check(out["required"] == 2 and out["reviews_ok"] == 2, f"tier/tally must be reported, got {out!r}")
     check(out["current"] == ["gauntlet-reviewing", "gauntlet-run-g1"], f"current labels must be reported, got {out!r}")
@@ -118,6 +132,7 @@ def t_accepted_stays():
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
         fake = FakeGh(view=view_with("gauntlet-accepted"), edit=None)  # edit=None => any edit is a failure
         code, out, _err = drive(led, "9", REPO, fake)
+        out = verdict(out)
     check(code == 0, f"an already-accepted PR reconciles to a no-op, got {code}")
     check(out["changed"] is False, f"no swap is needed, got {out!r}")
     check("argv" not in out, f"a no-op reconcile prints no argv, got {out!r}")
@@ -129,6 +144,7 @@ def t_reviewing_stays():
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="1")   # 1/2 -> reviewing
         fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=None)
         code, out, _err = drive(led, "9", REPO, fake)
+        out = verdict(out)
     check(code == 0, f"a short gate already reviewing is a no-op, got {code}")
     check(out["desired"] == "gauntlet-reviewing" and out["changed"] is False, f"expected reviewing no-op, got {out!r}")
     check(not fake.edited, "an already-reviewing label must trigger NO edit")
@@ -146,8 +162,10 @@ def t_readopt_escalation_flips_accepted_to_reviewing():
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="1")   # 1/2 -> reviewing
         fake = FakeGh(view=view_with("gauntlet-accepted", "gauntlet-run-g1"))
         code, out, _err = drive(led, "9", REPO, fake)
+        out = verdict(out)
     check(code == 0, f"a short gate after escalation must reconcile and exit 0, got {code}")
-    check(out is not None and out["changed"] is True,
+    out = verdict(out)
+    check(out["changed"] is True,
           f"an accepted->reviewing swap must report changed, got {out!r}")
     check(out["desired"] == "gauntlet-reviewing", f"desired must be reviewing after escalation, got {out!r}")
     check(out["required"] == 2 and out["reviews_ok"] == 1, f"tier/tally must be reported, got {out!r}")
@@ -226,6 +244,7 @@ def t_dry_run_no_edit():
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
         fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=None)  # any edit fails the fixture
         code, out, _err = drive(led, "9", REPO, fake, dry_run=True)
+        out = verdict(out)
     check(code == 0, f"a dry-run exits 0, got {code}")
     check(out["changed"] is True and out["argv"] == SWAP_TO_ACCEPTED,
           f"a dry-run must show the swap it WOULD apply, got {out!r}")
@@ -249,6 +268,7 @@ def t_required_boundary():
             other = "gauntlet-reviewing" if desired == "gauntlet-accepted" else "gauntlet-accepted"
             fake = FakeGh(view=view_with(other))
             code, out, _err = drive(led, "9", REPO, fake)
+            out = verdict(out)
         check(code == 0, f"[{tier} {ok}] exit 0, got {code}")
         check(out["desired"] == desired, f"[{tier} {ok}/{out['required']}] desired must be {desired}, got {out!r}")
 

--- a/plugins/gauntlet/skills/campaign/scripts/lease-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `lease.py` — the check-and-set, the heartbeat precondition, and the refusals.
 
 They live in a SIBLING file, and `lease.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/lease.py
+++ b/plugins/gauntlet/skills/campaign/scripts/lease.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Schema-owning accessor for the campaign run lease (lease.json).
 
 The lease is what stops two agents driving one run — `run-identity-and-lease.md` calls that "the bug this

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """THE EXECUTABLE CONTRACT FOR `ledger.py` — every rule the accessor claims, pinned by a fixture.
 
 Run it through the tool it tests (this is what CI runs):

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Schema-owning accessor for the campaign ledger (state.jsonl).
 
 The store is a plaintext, cat/grep/jq-able JSONL file: one JSON object per line.

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `merge-check.py` — the merge-readiness decider.
 
 They live in a SIBLING file, and `merge-check.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """DECIDE whether a PR may merge — from its ledger row, live GitHub view, and fetched base ancestry. GATE MACHINERY.
 
 It prints ONE verdict: `merge` (every precondition met) or `not-yet` with a concrete `reason`. It NEVER

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Mocked fixtures for `merge.py`; no fixture contacts GitHub or merges a real PR."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Execute one already-approved campaign merge and its owned local cleanup.
 
 `merge-check.py` remains the owner of merge readiness. This command imports that gate, re-evaluates it

--- a/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Mutation test for `ci-snapshot.py`: WHICH RULES ARE PINNED BY NO FIXTURE?
 
 `ci-snapshot.py self-test` answers "do the fixtures still produce their expected verdicts?" — and a suite

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `nudge.py` — the sticky-note reminder rules.
 
 They live in a SIBLING file, and `nudge.py --self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """The nudge printer — sticky-note reminders the campaign orchestrator prints at the top of every heartbeat.
 
 Every heartbeat is a fresh agent instance, and the campaign's obligations live in prose it re-derives by hand.

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `pr-adopt.py` — the mechanical PR-adoption decision, pinned WITHOUT live GitHub.
 
 Every case drives the PURE surface (`build_plan` / `slugify`) or the `plan` CLI (via `capture_cli` and a

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Adopt a PR into a run — the MECHANICAL half, as a command instead of a shell block in a doc.
 
 `references/pr-adoption.md` is the authority; this tool performs its steps 1, 2, 4, 5 and the row of

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -48,7 +48,9 @@ check = checker(M.SelfTestFailure)
 
 # --- fixture builders ---------------------------------------------------------
 
-def entry(number, *, head=None, headRefOid=SHA_A, title=None, base="main", state="OPEN",
+# `headRefOid` is typed to admit None on purpose: the null-canonical-field fixture builds a
+# deliberately malformed entry to prove the refusal, and that null IS the input under test.
+def entry(number, *, head=None, headRefOid: "str | None" = SHA_A, title=None, base="main", state="OPEN",
           mergeable="MERGEABLE", mergeStateStatus="CLEAN", label_names=None, raw_labels=_UNSET) -> dict:
     """A canonical `prs.json` entry. Defaults carry the run label + `gauntlet-reviewing`, so the happy path
     passes the run-scope check; `label_names`/`raw_labels` override for the scope and malformed fixtures."""
@@ -84,11 +86,19 @@ def build_prs(tmp, entries) -> Path:
     return prs
 
 
-def run(ledger: Path, prs: Path, run_id=RUN_ID):
+def run(ledger: Path, prs: Path, run_id=RUN_ID) -> "tuple[int, dict, str]":
+    """Drive `detect` through the CLI and return (exit code, parsed stdout, stderr).
+
+    Every caller here is a SUCCESS-path fixture that goes straight on to subscript the parse, so empty or
+    unparseable stdout is a fixture failure and is raised as one. Returning `None` for it, as this used to,
+    only deferred the report to a confusing subscript of nothing several lines later. The refusal fixtures
+    do not come through here: they drive `capture_cli` themselves and assert on stderr.
+    """
     code, out, err = capture_cli(
         M.main, ["detect", "--ledger", str(ledger), "--prs", str(prs), "--run-id", run_id])
-    parsed = json.loads(out) if out.strip() else None
-    return code, parsed, err
+    if not out.strip():
+        raise M.SelfTestFailure(f"detect printed nothing on stdout (exit {code}, stderr {err!r})")
+    return code, json.loads(out), err
 
 
 def scenario(rows, entries, *, base_branch="main", run_id=RUN_ID):
@@ -473,7 +483,7 @@ def t_missing_canonical_field_refused():
 
 
 def t_null_canonical_field_refused():
-    code, out, err = _refusal([row(41)], [entry(41, headRefOid=None)])
+    code, _out, err = _refusal([row(41)], [entry(41, headRefOid=None)])
     check(code == 2, f"a null canonical field must exit 2, got {code}")
     check("null" in err and "headRefOid" in err, f"the refusal must name null + field, got {err!r}")
 
@@ -481,7 +491,7 @@ def t_null_canonical_field_refused():
 def t_wrong_type_canonical_field_refused():
     bad = entry(41)
     bad["number"] = "41"          # a string where an int is required
-    code, out, err = _refusal([row(41)], [bad])
+    code, _out, err = _refusal([row(41)], [bad])
     check(code == 2, f"a wrong-typed field must exit 2, got {code}")
     check("number" in err and "integer" in err, f"the refusal must name field + expected shape, got {err!r}")
 
@@ -489,7 +499,7 @@ def t_wrong_type_canonical_field_refused():
 def t_boolean_number_refused():
     bad = entry(41)
     bad["number"] = True          # bool is a subclass of int — must be refused, not read as a number
-    code, out, err = _refusal([row(41)], [bad])
+    code, _out, err = _refusal([row(41)], [bad])
     check(code == 2, f"a boolean number must exit 2, got {code}")
     check("number" in err and "boolean" in err, f"the refusal must name the boolean, got {err!r}")
 
@@ -504,25 +514,25 @@ def t_foreign_label_refuses_whole_file():
 
 def t_one_foreign_entry_refuses_the_whole_file():
     # A good entry FOLLOWED by a foreign one — the whole file is refused, the good row is NOT reconciled.
-    code, out, err = _refusal([row(41)], [entry(41), entry(99, label_names=["gauntlet-run-OTHER"])])
+    code, out, _err = _refusal([row(41)], [entry(41), entry(99, label_names=["gauntlet-run-OTHER"])])
     check(code == 2, f"one foreign entry refuses the whole file, got {code}")
     check(out.strip() == "", "a partly-foreign snapshot yields no facts at all")
 
 
 def t_labels_not_a_list_refused():
-    code, out, err = _refusal([row(41)], [entry(41, raw_labels="gauntlet-reviewing")])
+    code, _out, err = _refusal([row(41)], [entry(41, raw_labels="gauntlet-reviewing")])
     check(code == 2, f"a non-list `labels` must exit 2, got {code}")
     check("labels" in err, f"the refusal must name `labels`, got {err!r}")
 
 
 def t_malformed_label_element_refused():
-    code, out, err = _refusal([row(41)], [entry(41, raw_labels=[{"name": RUN_LABEL}, 123])])
+    code, _out, err = _refusal([row(41)], [entry(41, raw_labels=[{"name": RUN_LABEL}, 123])])
     check(code == 2, f"a malformed label element must exit 2, got {code}")
     check("label" in err, f"the refusal must name the label problem, got {err!r}")
 
 
 def t_duplicate_number_refused():
-    code, out, err = _refusal([row(41)], [entry(41), entry(41, head="dup")])
+    code, _out, err = _refusal([row(41)], [entry(41), entry(41, head="dup")])
     check(code == 2, f"a duplicate PR number in the snapshot must exit 2, got {code}")
     check("41" in err and "twice" in err, f"the refusal must name the duplicated PR, got {err!r}")
 
@@ -531,7 +541,7 @@ def t_prs_not_json_refused():
     with tempfile.TemporaryDirectory() as d:
         ledger = build_ledger(d, [row(41)])
         prs = build_prs(d, "{ not json")
-        code, out, err = capture_cli(
+        code, _out, err = capture_cli(
             M.main, ["detect", "--ledger", str(ledger), "--prs", str(prs), "--run-id", RUN_ID])
     check(code == 2, f"invalid JSON must exit 2, got {code}")
     check("not valid JSON" in err, f"the refusal must say the JSON is invalid, got {err!r}")
@@ -541,7 +551,7 @@ def t_prs_not_an_array_refused():
     with tempfile.TemporaryDirectory() as d:
         ledger = build_ledger(d, [row(41)])
         prs = build_prs(d, {"number": 41})     # an object, not an array
-        code, out, err = capture_cli(
+        code, _out, err = capture_cli(
             M.main, ["detect", "--ledger", str(ledger), "--prs", str(prs), "--run-id", RUN_ID])
     check(code == 2, f"a non-array prs.json must exit 2, got {code}")
     check("not a JSON array" in err, f"the refusal must say it is not an array, got {err!r}")
@@ -551,7 +561,7 @@ def t_missing_ledger_refused():
     with tempfile.TemporaryDirectory() as d:
         prs = build_prs(d, [entry(41)])
         missing = Path(d) / "nope.jsonl"
-        code, out, err = capture_cli(
+        code, _out, err = capture_cli(
             M.main, ["detect", "--ledger", str(missing), "--prs", str(prs), "--run-id", RUN_ID])
     check(code == 2, f"a missing ledger must exit 2, got {code}")
     check("no ledger" in err, f"the refusal must name the missing ledger, got {err!r}")

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `repair-pass.py` — the reassessment bundle, decision, ownership guardrail, and repair cap.
 
 They live in a SIBLING file, and `repair-pass.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """The REASSESSMENT PASS's door — the only sanctioned way to record what to do about a PR that has stopped
 converging.
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -429,7 +429,10 @@ def t_second_install_failure_rolls_back_first_file() -> None:
                 raise OSError("injected second-stage failure")
             return real_stage(path, content)
 
-        D._stage_bytes = fail_second_stage
+        # The suite swaps a private module attribute to inject the failure. `setattr` is how that is
+        # spelled for a ModuleType the checker knows nothing about; the assignment form claims an
+        # attribute the type does not declare.
+        setattr(D, "_stage_bytes", fail_second_stage)
         try:
             D.install_pair(prompt, b"prompt", progress, b"identity")
         except OSError as exc:
@@ -437,7 +440,7 @@ def t_second_install_failure_rolls_back_first_file() -> None:
         else:
             check(False, "second staging failure must refuse preparation")
         finally:
-            D._stage_bytes = real_stage
+            setattr(D, "_stage_bytes", real_stage)
         check(not prompt.exists() and not progress.exists(), "staging failure created a target file")
         check(not list(root.glob(".review-dispatch-*.tmp")), "staging failure left a temp file")
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -543,7 +543,10 @@ def self_test() -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    # `__doc__` is this module's docstring, which is present; the guard states that for the checker and
+    # would name the impossible case loudly rather than crashing on None.
+    doc = __doc__ or ""
+    parser = argparse.ArgumentParser(description=doc.splitlines()[0])
     sub = parser.add_subparsers(dest="cmd", required=True)
     command = sub.add_parser("prepare", help="materialize one fresh review launch attempt")
     command.add_argument("--run-dir", required=True, help="absolute active run-artifact directory")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """THE EXECUTABLE CONTRACT FOR `review-pass.py` — every rule pinned by a fixture, and every fixture proved
 to pin one by DELETING the rule and watching it fail.
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 # THE EXEC BIT: mode 100644 is DELIBERATE, and TWO separate reviews have now proposed `chmod +x` here. The
 # answer is the same both times: nothing invokes this as `./review-pass.py`. Every caller runs it as
 # `python3 <path>` — CI does (`.github/workflows/ci.yml`), and so does the reviewer's emit call — so the

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `reviewer-liveness.py` — the stdout-stream liveness probe.
 
 They live in a SIBLING file, and `reviewer-liveness.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reviewer-liveness.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Report whether a dispatched reviewer's OUTPUT STREAM is still moving.
 
 The review gate already declares a reviewer stalled when no MEANINGFUL PROGRESS —

--- a/plugins/gauntlet/skills/campaign/scripts/run-id-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/run-id-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for `run-id.py` — the run-id minter and atomic run-directory creator.
 
 They live in a SIBLING file, and `run-id.py self-test` FAILS LOUDLY if it cannot load them.

--- a/plugins/gauntlet/skills/campaign/scripts/run-id.py
+++ b/plugins/gauntlet/skills/campaign/scripts/run-id.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Mint a campaign run-id and ATOMICALLY create its run directory.
 
 A run-id namespaces everything a run owns — its `<rundir>`, its ledger, and its `gauntlet-run-<run-id>`

--- a/plugins/gauntlet/skills/campaign/scripts/script-table-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/script-table-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """SKILL.md's Bundled Scripts table vs scripts/ — the COMPLETE-by-contract claim, executed.
 
 The table in SKILL.md ("Bundled Scripts") declares itself COMPLETE: one row per bundled script,

--- a/plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for the shared fixture runner in `_gauntlet/testing.py`.
 
 MOST `self-test` SUBCOMMANDS IN THIS DIRECTORY NOW GET THEIR EXIT CODE FROM THAT ONE RUNNER. That

--- a/plugins/gauntlet/skills/campaign/scripts/triage-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Fixtures for ``triage.py`` — the mechanical file inventory and FLOOR tier for one pinned diff.
 
 The suite uses real temporary Git repositories for the file, mode, rename, delete, modification,

--- a/plugins/gauntlet/skills/campaign/scripts/triage.py
+++ b/plugins/gauntlet/skills/campaign/scripts/triage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Emit the mechanical FLOOR and file inventory for one immutable PR-head diff.
 
 ``references/stage-2-review-gate.md`` (``2a-triage``) owns the policy.  This command is a mechanical

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt-test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Executable fixtures for `worker-prompt.py` and its canonical prompt template."""
 
 from __future__ import annotations

--- a/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/worker-prompt.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ci: pyright
 """Materialize one complete, host-neutral fix-worker prompt as an atomic artifact bundle.
 
     worker-prompt.py fix --role review|ci-session|ci-economy \


### PR DESCRIPTION
- CI type-checks every tracked `.py` and `.pyi` file, discovered by `git ls-files`.
- Fixes the 103 errors in the 8 files that were not yet clean; no behavior changes.
- Drops the `# ci: pyright` opt-in marker and its baseline list, whose whole reason is gone.
