### PR TITLE
write the ledger run_id header at adoption

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -191,7 +191,7 @@ rules keep their own wording; these are illustrations of them, not a second copy
      returned directory's final path component; **then** take the run per `run-identity-and-lease.md`,
      "Take a run" (which, BEFORE arming, records `pending_adoption` = this set's PR list; then token,
      heartbeat arming, `lease.py acquire` — in that order),
-     and write the `state.jsonl` header with `run_id` set. **The header `base_branch` stays its `-`
+     — the `state.jsonl` header's `run_id` is written by adoption below, not here. **The header `base_branch` stays its `-`
      default** — the base is per-row now, recorded on each row at adoption from that PR's live
      `baseRefName`, never a run-wide header value (`files-and-ledger.md`, the row `base_branch` field).
      Then **adopt** each PR

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -58,14 +58,17 @@ Invoke it through `runtime-adapter.md`'s `create_run_directory(repository)`, whi
 host-specific `repository.scratch_root` and owns that invocation. The atomic create and the collision
 retry live in `run-id.py`; the caller no longer mints an id or retries. Do not unpack that operation here.
 
-Record it in the ledger header field `run_id` (`ledger.py --file <state.jsonl> header set run_id
-<run-id>`) and re-read it every heartbeat (`ledger.py … header get run_id`, like `reviewer`); never trust
+The ledger header field `run_id` records it, and **adoption writes that field itself** — `pr-adopt.py
+adopt` sets it when the header has none and REFUSES a ledger that already names a different run. The
+driver does not set it by hand: it used to, and a driver that forgot left the field unset until
+`merge.py` refused a fully-gated PR with `ledger run_id is unresolved`, after every review had been
+spent. Re-read it every heartbeat (`ledger.py … header get run_id`, like `reviewer`); never trust
 in-context memory for it — a heartbeat may be a fresh agent instance. It flows into:
 
 | Owned by the run | Namespaced form |
 |------------------|-----------------|
 | tmp working dir  | `<rundir>` from the runtime adapter's run-directory operation (all state/pr/review/ci/abort/lease files) |
-| ledger header    | the `run_id` header field (set/read via `ledger.py … header set/get run_id`) |
+| ledger header    | the `run_id` header field (written by `pr-adopt.py adopt`; read via `ledger.py … header get run_id`) |
 | PR owner label   | `gauntlet-run-<run-id>` — the **authoritative "mine" marker**. Every adopted PR is tagged with it; it, not any branch name, is what makes a PR this run's. |
 | branch           | the **adopted PR's own `headRefName`** — campaign reuses the PR's existing branch and does NOT mint a `fix-<run-id>-...` branch, so ownership can't be read off the branch name (that's the label's job). |
 | worktree         | the ledger-recorded `worktree` path resolved by the repository-context-aware adoption operation; only a campaign-created worktree (`worktree_owned = yes`) is ever removed (see "PR adoption" / Stage 3) |

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -1245,8 +1245,29 @@ def t_adopt_records_the_run_id_in_the_header():
         check(M.L.find_row(rows, "42") is None, "a refused adoption must not register its row")
 
 
+def t_foreign_ledger_base_mismatch_refuses_without_mutation():
+    """A foreign run cannot park the owning run's row through the base-change path."""
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger, run_id="g-alpha", base_branch="main")
+        _add_row(ledger, 12, head_sha="a" * 40, base_branch="main", tier="HIGH", status="in_review")
+        header_before, _ = M.L.load(ledger)
+        status_before = _field(ledger, 12, "status")
+
+        code, _, err, _rec = _adopt(d, ledger, view(baseRefName="release"), wroot=d / "wt", run_id="g-beta")
+        check(code != 0, "a foreign ledger must refuse before the base-change parking path")
+        check("g-alpha" in err and "g-beta" in err,
+              f"the refusal must name both runs so the mix-up is obvious, got {err!r}")
+        header_after, _ = M.L.load(ledger)
+        check(header_after == header_before, "a foreign-run refusal must leave the ledger header unchanged")
+        check(_field(ledger, 12, "status") == status_before,
+              "a foreign-run refusal must not change the owning row's status")
+
+
 CASES = [
     ("adopt_records_run_id", "adoption writes the ledger run_id header and refuses another run's ledger (fu121)", t_adopt_records_the_run_id_in_the_header),
+    ("foreign_ledger_base_mismatch", "a foreign run cannot park an owning row through a base mismatch", t_foreign_ledger_base_mismatch_refuses_without_mutation),
     ("mixed_base_end_to_end", "one mixed-base run walks adopt -> grouped required-set -> merge door -> "
                               "reconcile park -> distill on ONE ledger", t_mixed_base_end_to_end),
     ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -1205,7 +1205,48 @@ def t_adopt_readoption_invokes_sync():
               f"a fresh adoption with no intent reports pending-intent: {out2}")
 
 
+def t_adopt_records_the_run_id_in_the_header():
+    """Adoption writes the ledger's `run_id` header, and refuses a ledger that belongs to another run.
+
+    Nothing wrote that field before. The omission was invisible until `merge.py` refused a fully-gated PR
+    with `ledger run_id is unresolved` — after every review had already been spent. The two halves below are
+    what make the field trustworthy: an unset header takes this run's id, and a header naming a DIFFERENT
+    run is refused HERE rather than at the merge.
+    """
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        # NOT `_init_ledger`: that seeds a run_id, which is exactly why nothing ever noticed this field was
+        # unwritten in production. Build the header the way a real run does — base only.
+        _ledger("--file", str(ledger), "header", "set", "base_branch", "main")
+        header, _ = M.L.load(ledger)
+        check(header.get("run_id", "-") in ("", "-"),
+              f"precondition: a fresh ledger has no run_id, got {header.get('run_id')!r}")
+
+        code, _, err, _rec = _adopt(d, ledger, view(), wroot=d / "wt", run_id="g-alpha")
+        check(code == 0, f"a clean adopt succeeds (got {code}: {err})")
+        header, _ = M.L.load(ledger)
+        check(header.get("run_id") == "g-alpha",
+              f"adoption must record its run in the header, got {header.get('run_id')!r}")
+
+        # Re-adopting the SAME run is a no-op on the field, not a rewrite that could mask a mix-up.
+        code, _, err, _rec = _adopt(d, ledger, view(), wroot=d / "wt", run_id="g-alpha")
+        check(code == 0, f"re-adoption by the owning run succeeds (got {code}: {err})")
+        header, _ = M.L.load(ledger)
+        check(header.get("run_id") == "g-alpha", "re-adoption must leave the recorded run alone")
+
+        # A DIFFERENT run is refused, and refused BEFORE it writes anything.
+        code, _, err, _rec = _adopt(d, ledger, view(number=42), wroot=d / "wt", run_id="g-beta")
+        check(code != 0, "a ledger owned by another run must be refused")
+        check("g-alpha" in err and "g-beta" in err,
+              f"the refusal must name both runs so the mix-up is obvious, got {err!r}")
+        header, rows = M.L.load(ledger)
+        check(header.get("run_id") == "g-alpha", "a refused adoption must not rewrite the recorded run")
+        check(M.L.find_row(rows, "42") is None, "a refused adoption must not register its row")
+
+
 CASES = [
+    ("adopt_records_run_id", "adoption writes the ledger run_id header and refuses another run's ledger (fu121)", t_adopt_records_the_run_id_in_the_header),
     ("mixed_base_end_to_end", "one mixed-base run walks adopt -> grouped required-set -> merge door -> "
                               "reconcile park -> distill on ONE ledger", t_mixed_base_end_to_end),
     ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -337,6 +337,17 @@ def cmd_adopt(args) -> int:
 
     # Load the ledger ONCE for the re-adoption checks here and the row refresh in step 4.
     header, rows = L.load(Path(args.file))
+
+    # THE LEDGER RECORDS WHICH RUN IT BELONGS TO, and adoption is where that happens: it is the first thing
+    # to write the ledger, and the only writer that is handed the run-id. Before this, nothing wrote the
+    # header field at all, and the omission stayed invisible until `merge.py` refused a fully-gated PR with
+    # `ledger run_id is unresolved` — at the very last step, after every review had been spent. An unset
+    # header takes this run's id; a header naming a DIFFERENT run refuses here, where the mix-up is cheap
+    # to fix, rather than at the merge.
+    recorded_run = header.get("run_id", "-")
+    if recorded_run and recorded_run != "-" and recorded_run != args.run_id:
+        return _refuse(f"ledger {args.file} belongs to run {recorded_run}, not {args.run_id}")
+
     existing = L.find_row(rows, pr)
 
     # TERMINAL ROW GATE — runs before every label, ledger and worktree mutation. A terminal row records
@@ -384,15 +395,6 @@ def cmd_adopt(args) -> int:
     # `existing`/`rows` were loaded above (the re-adoption base gate needs them); nothing has written the
     # ledger since, so they are still current.
     #
-    # THE LEDGER RECORDS WHICH RUN IT BELONGS TO, and adoption is where that happens: it is the first thing
-    # to write the ledger, and the only writer that is handed the run-id. Before this, nothing wrote the
-    # header field at all, and the omission stayed invisible until `merge.py` refused a fully-gated PR with
-    # `ledger run_id is unresolved` — at the very last step, after every review had been spent. An unset
-    # header takes this run's id; a header naming a DIFFERENT run refuses here, where the mix-up is cheap
-    # to fix, rather than at the merge.
-    recorded_run = header.get("run_id", "-")
-    if recorded_run and recorded_run != "-" and recorded_run != args.run_id:
-        return _refuse(f"ledger {args.file} belongs to run {recorded_run}, not {args.run_id}")
     if not recorded_run or recorded_run == "-":
         proc = _run(["python3", str(LEDGER_PY), "--file", args.file, "header", "set",
                      "run_id", args.run_id], cwd=args.project_root)

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -344,6 +344,11 @@ def cmd_adopt(args) -> int:
     # `ledger run_id is unresolved` — at the very last step, after every review had been spent. An unset
     # header takes this run's id; a header naming a DIFFERENT run refuses here, where the mix-up is cheap
     # to fix, rather than at the merge.
+    #
+    # This run-ownership check and its untouched-on-refusal promise apply when the lease-confirmed single
+    # campaign driver serializes adoption, which is how the campaign runs. Two adoptions hand-started
+    # against ONE ledger at the same moment can both read an unset header; the later write wins. That is an
+    # accepted residual under this repository's single-user calibration, outside this guard's promise.
     recorded_run = header.get("run_id", "-")
     if recorded_run and recorded_run != "-" and recorded_run != args.run_id:
         return _refuse(f"ledger {args.file} belongs to run {recorded_run}, not {args.run_id}")

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -383,6 +383,22 @@ def cmd_adopt(args) -> int:
     #     same-value `--head-sha` write is a no-op, so the counters are untouched).
     # `existing`/`rows` were loaded above (the re-adoption base gate needs them); nothing has written the
     # ledger since, so they are still current.
+    #
+    # THE LEDGER RECORDS WHICH RUN IT BELONGS TO, and adoption is where that happens: it is the first thing
+    # to write the ledger, and the only writer that is handed the run-id. Before this, nothing wrote the
+    # header field at all, and the omission stayed invisible until `merge.py` refused a fully-gated PR with
+    # `ledger run_id is unresolved` — at the very last step, after every review had been spent. An unset
+    # header takes this run's id; a header naming a DIFFERENT run refuses here, where the mix-up is cheap
+    # to fix, rather than at the merge.
+    recorded_run = header.get("run_id", "-")
+    if recorded_run and recorded_run != "-" and recorded_run != args.run_id:
+        return _refuse(f"ledger {args.file} belongs to run {recorded_run}, not {args.run_id}")
+    if not recorded_run or recorded_run == "-":
+        proc = _run(["python3", str(LEDGER_PY), "--file", args.file, "header", "set",
+                     "run_id", args.run_id], cwd=args.project_root)
+        if proc.returncode != 0:
+            return _refuse(f"ledger header run_id write failed: {proc.stderr.strip()}")
+
     head_changed = existing is not None and existing.get("head_sha") != planned_head
     verb = "set" if existing is not None else "add-row"
     ledger_argv = ["python3", str(LEDGER_PY), "--file", args.file, verb, "--pr", pr,


### PR DESCRIPTION
- `pr-adopt.py adopt` writes the ledger's `run_id` header, which nothing wrote before.
- It refuses a ledger already naming a different run, so a mix-up surfaces at adoption.
- Previously the unset field stayed invisible until `merge.py` refused a fully-gated PR.
