### PR TITLE
classify the follow-up store before reading it

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -446,6 +446,29 @@ def t_absent_followups_store_still_reports_absent():
               f"an absent store must still report as absent, got {out!r}")
 
 
+def t_malformed_followups_store_is_disclosed_and_exits_zero():
+    """A malformed regular store makes the loader exit, so the nudge boundary must capture its refusal.
+
+    This runs the command in a subprocess because `followups.load()` exits its interpreter for malformed
+    JSONL. The output must remain a successful nudge and carry the loader's line-specific reason.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        led, store, _notes = _laid_out(d)
+        store.write_text("not JSON\n", encoding="utf-8")
+        check(stat.S_ISREG(store.stat().st_mode), "the fixture must create a malformed regular store")
+        done = subprocess.run(  # noqa: S603 - this suite drives its sibling command
+            [sys.executable, str(OWNER), "--file", str(led), "--followups", str(store)],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+        )
+        check(done.returncode == 0,
+              f"a malformed store must still exit 0 — a nudge never blocks, got {done.returncode}")
+        check("follow-up store NOT READ" in done.stdout,
+              f"a malformed store must be disclosed unread, got {done.stdout!r}")
+        check("followups: malformed JSON on line 1:" in done.stdout,
+              f"the disclosure must carry the loader's own reason, got {done.stdout!r}")
+        check(done.stderr == "", f"the loader refusal must be disclosed, not leaked to stderr: {done.stderr!r}")
+
+
 def t_non_regular_notes_entry_is_refused_without_blocking():
     """Anything that is not a REGULAR FILE is refused by name BEFORE any read. A FIFO is the case with
     teeth: `stat` reports size 0 and passes the byte cap, so a printer that goes straight to `read_text`
@@ -780,6 +803,8 @@ CASES = [
     ("fifo-followups-store", "a FIFO at the typed --followups path is refused by name, never waited on (fu141)", t_non_regular_followups_store_is_refused_without_blocking),
     ("dangling-followups-symlink", "a dangling --followups symlink is disclosed as one, not reported absent", t_dangling_followups_symlink_is_disclosed_not_reported_absent),
     ("absent-followups-store", "an absent --followups store still reports as absent, unchanged", t_absent_followups_store_still_reports_absent),
+    ("malformed-followups-store", "a malformed regular store is disclosed with its loader reason and exits 0",
+     t_malformed_followups_store_is_disclosed_and_exits_zero),
     ("heartbeat-always", "the heartbeat reminder fires every heartbeat", t_heartbeat_always_fires),
     ("header-always", "the header-reread reminder fires every heartbeat", t_header_reread_always_fires),
     ("labels-active-only", "the labels reminder fires only with an active PR", t_labels_fire_only_with_an_active_pr),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -48,9 +48,9 @@ def row(pr, status, **kw) -> dict:
 
 def fire(rows, *, hdr=None, n_followups: "int | None" = 0, rundir=None, now=None,
          followups_path: "Path | None" = None, notes: "list | None" = None,
-         notes_unread: "str | None" = None) -> list:
+         notes_unread: "str | None" = None, followups_unread: "str | None" = None) -> list:
     return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, now, followups_path,
-                       notes, notes_unread)
+                       notes, notes_unread, followups_unread)
 
 
 # A fixed "now" and two stamps around it, so the quiet-run rule is DETERMINISTIC: one older than
@@ -172,10 +172,11 @@ def t_unread_followup_store_is_disclosed():
     (`.gauntlet/` is a project-root concern, not a run-directory one) and the printer always exits 0, so
     DISCLOSURE — not a default and not a refusal — is the whole fix."""
     # unit level: not-read (None) discloses; a successful read never does.
-    absent = fire([], n_followups=None)
+    absent = fire([], n_followups=None, followups_unread="no --followups given")
     check(has(absent, "follow-up store NOT READ (no --followups given)"),
           "an omitted --followups must disclose that the store was not read, and why")
-    missing = fire([], n_followups=None, followups_path=Path("/nonexistent/typo.jsonl"))
+    missing = fire([], n_followups=None, followups_path=Path("/nonexistent/typo.jsonl"),
+                   followups_unread="no file at /nonexistent/typo.jsonl")
     check(has(missing, "follow-up store NOT READ (no file at /nonexistent/typo.jsonl)"),
           "a --followups path that is not there must disclose it, NAMING the path it tried")
     # Teeth: a store that WAS read never claims it was not — neither with open entries nor empty.
@@ -373,6 +374,76 @@ def t_dangling_notes_symlink_is_disclosed():
         check("standing note: the shared note" in out and "standing notes NOT READ" not in out,
               "a symlink to a real file must be READ through — the disclosure must turn on the missing "
               "target, not on the entry being a symlink")
+
+
+def t_non_regular_followups_store_is_refused_without_blocking():
+    """The SAME classify-before-open rule on the TYPED `--followups` path, which never had it.
+
+    `open_followups` used to test `exists()` and go straight to a read. `exists()` is True for a FIFO, so
+    the printer blocked in `open()` waiting for a writer that never comes — the one outcome its contract
+    forbids, and on the store whose path the user types by hand. This is `fu141`, and it predates the
+    notes file entirely.
+
+    Driven in a SUBPROCESS under a hard timeout, so a regression fails this fixture rather than hanging
+    the suite meant to catch it. Teeth: a real store at the same path is read and counted.
+    """
+    if not hasattr(os, "mkfifo"):  # pragma: no cover - POSIX-only fixture
+        return
+    with tempfile.TemporaryDirectory() as d:
+        led, store, _notes = _laid_out(d)
+        os.mkfifo(store)
+        try:
+            check(stat.S_ISFIFO(store.lstat().st_mode), "the fixture must actually create a FIFO")
+            try:
+                done = subprocess.run(  # noqa: S603 - this suite drives its sibling command
+                    [sys.executable, str(OWNER), "--file", str(led), "--followups", str(store)],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+                    timeout=NON_REGULAR_TIMEOUT,
+                )
+            except subprocess.TimeoutExpired:
+                raise AssertionError(
+                    f"a FIFO at the follow-up store HUNG the printer past {NON_REGULAR_TIMEOUT}s — a "
+                    "non-regular entry must be refused before any read, never waited on") from None
+            check(done.returncode == 0, "a FIFO at the store must still exit 0 — a nudge never blocks")
+            check(f"follow-up store NOT READ ({store} is a FIFO, not a regular file" in done.stdout,
+                  f"a FIFO at the store must be DISCLOSED BY WHAT IT IS, got {done.stdout!r}")
+            # The disclosure must not claim the file is absent: something is plainly there.
+            check(f"no file at {store}" not in done.stdout,
+                  "a FIFO is not an absent file, and the disclosure must not say it is")
+        finally:
+            store.unlink()
+        # Built through followups.py's own writer, so this fixture never restates that store's schema.
+        N.F.dump(store, [{"id": "fu1", "title": "t", "evidence": "e", "deferred_why": "w"}], 0)
+        out = _run_main(["--file", str(led), "--followups", str(store)])
+        check("1 open follow-up(s)" in out,
+              f"a real store at the same path must be read and counted, got {out!r}")
+
+
+def t_dangling_followups_symlink_is_disclosed_not_reported_absent():
+    """A `--followups` pointing at a dangling symlink is an entry that WAS found and cannot be read.
+
+    Before the classify step this reported `no file at <path>`, because `exists()` follows the link and
+    returns False. That reads as "you have no follow-up store", when the truth is "your store's target
+    moved". The two need different fixes, so they must not print the same line.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        led, store, _notes = _laid_out(d)
+        store.symlink_to(Path(d) / "gone.jsonl")
+        out = _run_main(["--file", str(led), "--followups", str(store)])
+        check("follow-up store NOT READ" in out and "symlink whose target is missing" in out,
+              f"a dangling store symlink must be disclosed as one, got {out!r}")
+        check(f"no file at {store}" not in out,
+              "a dangling symlink is a found entry, and must not be reported as an absent file")
+
+
+def t_absent_followups_store_still_reports_absent():
+    """The ordinary absence is UNCHANGED. The classify step returns "nothing to refuse" for a path that is
+    simply not there, so the store still reports as absent and never as a refusal."""
+    with tempfile.TemporaryDirectory() as d:
+        led, store, _notes = _laid_out(d)
+        out = _run_main(["--file", str(led), "--followups", str(store)])
+        check(f"follow-up store NOT READ (no file at {store})" in out,
+              f"an absent store must still report as absent, got {out!r}")
 
 
 def t_non_regular_notes_entry_is_refused_without_blocking():
@@ -706,6 +777,9 @@ def t_a_nudge_never_blocks():
 
 
 CASES = [
+    ("fifo-followups-store", "a FIFO at the typed --followups path is refused by name, never waited on (fu141)", t_non_regular_followups_store_is_refused_without_blocking),
+    ("dangling-followups-symlink", "a dangling --followups symlink is disclosed as one, not reported absent", t_dangling_followups_symlink_is_disclosed_not_reported_absent),
+    ("absent-followups-store", "an absent --followups store still reports as absent, unchanged", t_absent_followups_store_still_reports_absent),
     ("heartbeat-always", "the heartbeat reminder fires every heartbeat", t_heartbeat_always_fires),
     ("header-always", "the header-reread reminder fires every heartbeat", t_header_reread_always_fires),
     ("labels-active-only", "the labels reminder fires only with an active PR", t_labels_fire_only_with_an_active_pr),

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -49,8 +49,8 @@ def row(pr, status, **kw) -> dict:
 def fire(rows, *, hdr=None, n_followups: "int | None" = 0, rundir=None, now=None,
          followups_path: "Path | None" = None, notes: "list | None" = None,
          notes_unread: "str | None" = None, followups_unread: "str | None" = None) -> list:
-    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, now, followups_path,
-                       notes, notes_unread, followups_unread)
+    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, followups_unread, now,
+                       followups_path, notes, notes_unread)
 
 
 # A fixed "now" and two stamps around it, so the quiet-run rule is DETERMINISTIC: one older than

--- a/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge-test.py
@@ -46,11 +46,11 @@ def row(pr, status, **kw) -> dict:
     return r
 
 
-def fire(rows, *, hdr=None, n_followups: "int | None" = 0, rundir=None, now=None,
+def fire(rows, *, hdr=None, followups=N.FollowupsRead(0, None), rundir=None, now=None,
          followups_path: "Path | None" = None, notes: "list | None" = None,
-         notes_unread: "str | None" = None, followups_unread: "str | None" = None) -> list:
-    return N.reminders(hdr or header(run_id="g1"), rows, n_followups, rundir, followups_unread, now,
-                       followups_path, notes, notes_unread)
+         notes_unread: "str | None" = None) -> list:
+    return N.reminders(hdr or header(run_id="g1"), rows, followups, rundir, now, followups_path, notes,
+                       notes_unread)
 
 
 # A fixed "now" and two stamps around it, so the quiet-run rule is DETERMINISTIC: one older than
@@ -159,9 +159,9 @@ def t_fanout_fires_only_with_open_work():
 
 
 def t_followups_fire_only_when_open():
-    check(has(fire([], n_followups=3), "3 open follow-up"),
+    check(has(fire([], followups=N.FollowupsRead(3, None)), "3 open follow-up"),
           "open follow-ups must nudge, with the count")
-    check(not has(fire([], n_followups=0), "open follow-up"),
+    check(not has(fire([], followups=N.FollowupsRead(0, None)), "open follow-up"),
           "zero open follow-ups must NOT nudge")
 
 
@@ -172,17 +172,17 @@ def t_unread_followup_store_is_disclosed():
     (`.gauntlet/` is a project-root concern, not a run-directory one) and the printer always exits 0, so
     DISCLOSURE — not a default and not a refusal — is the whole fix."""
     # unit level: not-read (None) discloses; a successful read never does.
-    absent = fire([], n_followups=None, followups_unread="no --followups given")
+    absent = fire([], followups=N.FollowupsRead(None, "no --followups given"))
     check(has(absent, "follow-up store NOT READ (no --followups given)"),
           "an omitted --followups must disclose that the store was not read, and why")
-    missing = fire([], n_followups=None, followups_path=Path("/nonexistent/typo.jsonl"),
-                   followups_unread="no file at /nonexistent/typo.jsonl")
+    missing = fire([], followups=N.FollowupsRead(None, "no file at /nonexistent/typo.jsonl"),
+                   followups_path=Path("/nonexistent/typo.jsonl"))
     check(has(missing, "follow-up store NOT READ (no file at /nonexistent/typo.jsonl)"),
           "a --followups path that is not there must disclose it, NAMING the path it tried")
     # Teeth: a store that WAS read never claims it was not — neither with open entries nor empty.
-    check(not has(fire([], n_followups=3), "NOT READ"),
+    check(not has(fire([], followups=N.FollowupsRead(3, None)), "NOT READ"),
           "a store that was read must report its count, never the not-read disclosure")
-    check(not has(fire([], n_followups=0), "NOT READ"),
+    check(not has(fire([], followups=N.FollowupsRead(0, None)), "NOT READ"),
           "an EMPTY store that was read is genuinely zero — it must stay silent, not disclose")
     # main() plumbing: the same two invocations end to end, plus a real store proving the count wins.
     with tempfile.TemporaryDirectory() as d:

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -29,6 +29,7 @@ The design and the full obligation inventory it was trimmed from live in `.gaunt
 from __future__ import annotations
 
 import argparse
+import os
 import stat
 import sys
 from datetime import datetime, timedelta, timezone
@@ -104,6 +105,41 @@ def entry_kind(mode: int) -> str:
     return "of an unknown type"
 
 
+def classify_entry(path: Path) -> "tuple[os.stat_result | None, str | None]":
+    """`(the entry's stat, why it must NOT be opened)` — at most one of the two is ever set.
+
+    Both `None` means there is NO ENTRY at `path`. That is not "readable" and not "refused"; it is
+    "nothing was there", and each caller decides what an absence means for its own file. The follow-up
+    store treats it as NOT READ, because its path is TYPED and a typo is the likely explanation. The notes
+    file treats it as a completed look that found nothing, because its path is DERIVED and its absence is
+    the normal state. Deciding that here would take the choice from both.
+
+    CLASSIFY BEFORE OPENING, ALWAYS. `read_text` on a FIFO waits for a writer FOREVER, and this printer
+    promises it always exits 0 and never blocks — a heartbeat printer that never returns stalls the
+    campaign loop rather than misreporting one line. `exists()` is not that check: it is True for a FIFO,
+    a socket, a device and a directory alike, and False for a dangling symlink that plainly IS an entry.
+
+    The returned stat is the one this walk already took, so a caller that needs the size (the notes cap)
+    does not stat again — and cannot drift into asking a second, different question.
+    """
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return None, None
+    except OSError as exc:
+        return None, f"{path} could not be checked ({type(exc).__name__})"
+    if stat.S_ISLNK(info.st_mode):
+        try:
+            info = path.stat()
+        except FileNotFoundError:
+            return None, f"{path} is a symlink whose target is missing — repoint it or remove it"
+        except OSError as exc:
+            return None, f"{path} could not be checked ({type(exc).__name__})"
+    if not stat.S_ISREG(info.st_mode):
+        return None, f"{path} is {entry_kind(info.st_mode)}, not a regular file — replace it with one"
+    return info, None
+
+
 def _activity_age(last_activity: str, now: datetime) -> "timedelta | None":
     """How long since the run last did something — or None if that is UNKNOWABLE, in which case the
     quiet-run rule stays silent. This is advisory and NEVER raises: a `-` (an old ledger that predates the
@@ -127,28 +163,46 @@ def required(tier: str) -> int:
     return 1 if tier == "TRIVIAL" else 2
 
 
-def open_followups(followups_path: "Path | None") -> "int | None":
-    """How many follow-ups are OPEN — or `None` when the store was NOT READ (no `--followups` was given,
-    or the path given is not there). `None` is NOT `0`, and keeping them apart is the whole point: an
-    unread store counted as zero is INDISTINGUISHABLE in the output from a genuinely empty queue, so an
-    omitted or mistyped flag retired the durable follow-up queue with no error, no warning, and a
-    confident header above it. The caller DISCLOSES the `None` (`followups_line`); it never invents a
-    count from a store it did not open.
+def open_followups(followups_path: "Path | None") -> "tuple[int | None, str | None]":
+    """`(open count, why it was NOT READ)` — and the second is `None` exactly when the first is a real count.
+
+    A count of `None` is NOT `0`, and keeping them apart is the whole point: an unread store counted as
+    zero is INDISTINGUISHABLE in the output from a genuinely empty queue, so an omitted or mistyped flag
+    retired the durable follow-up queue with no error, no warning, and a confident header above it. The
+    caller DISCLOSES the `None` (`followups_line`); it never invents a count from a store it did not open.
+
+    The reason rides along because `not there` is no longer the only way this fails. `classify_entry`
+    refuses a FIFO, a socket, a device, a directory and a dangling symlink BEFORE anything opens the path
+    — a FIFO here used to hang the printer forever, which is the one outcome its contract forbids. Those
+    all say what they are; only a genuinely absent file still reports as absent.
     """
-    if followups_path is None or not followups_path.exists():
-        return None
-    entries = F.load(followups_path)
-    return sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN)
+    if followups_path is None:
+        return None, "no --followups given"
+    info, refusal = classify_entry(followups_path)
+    if refusal is not None:
+        return None, refusal
+    if info is None:
+        return None, f"no file at {followups_path}"
+    try:
+        entries = F.load(followups_path)
+    except (OSError, ValueError) as exc:
+        # The store is malformed or unreadable. It is still NOT READ, which is what the caller discloses;
+        # what it must never become is a confident zero, and it never does.
+        return None, f"{followups_path} could not be read ({type(exc).__name__})"
+    return sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN), None
 
 
-def followups_line(n_followups: "int | None", followups_path: "Path | None") -> "str | None":
+def followups_line(n_followups: "int | None", unread: "str | None") -> "str | None":
     """The one follow-up reminder: a COUNT when the store was read, a DISCLOSURE naming why when it was
     not, and silence ONLY for a read that genuinely found nothing open. An unread store is never silent —
     that silence is what a caller reads as "this run has no open follow-ups".
+
+    The reason comes FROM the read (`open_followups`), never re-derived here. Re-deriving it is how a
+    refusal that knew exactly what was wrong — a FIFO, a dangling symlink — printed `no file at <path>`
+    about a path that plainly had something at it.
     """
     if n_followups is None:
-        where = f"no file at {followups_path}" if followups_path is not None else "no --followups given"
-        return f"follow-up store NOT READ ({where}) — open follow-ups are UNKNOWN, not zero."
+        return f"follow-up store NOT READ ({unread}) — open follow-ups are UNKNOWN, not zero."
     if n_followups:
         return f"{n_followups} open follow-up(s) — start any you can."
     return None
@@ -213,28 +267,18 @@ def read_notes(path: "Path | None") -> "tuple[list, str | None]":
     and it stays SILENT. A disclosure every heartbeat of a run whose user never wrote a note is a false
     alarm, and a disclosure line that is usually noise is one the driver learns to skip past. That
     exemption is the FILE's alone: an unusable containing directory is not an absent file, it is a look
-    that never happened, and it discloses with everything else in (1) below.
+    that never happened, and it discloses with everything else.
 
     It NEVER raises AND IT NEVER BLOCKS. A permissions error, invalid UTF-8, or a file too large to hold
-    all degrade to a named reason — the printer must always exit 0. What is at the path is CLASSIFIED
-    before anything opens it, because `read_text` on a FIFO waits for a writer FOREVER, and a heartbeat
-    printer that never returns stalls the campaign loop rather than misreporting one line.
+    all degrade to a named reason — the printer must always exit 0. `classify_entry` owns what is at the
+    path and what may not be opened; do not restate its rules here.
 
-    The classification is what keeps the "not read" / "nothing there" split honest, and it turns on
-    whether the entry could be LOOKED AT, never on whether a file was FOUND:
-
-    1. `lstat` first, so the link itself is examined rather than what it points at. `FileNotFoundError`
-       here splits on THE CONTAINING DIRECTORY, because the silent case is only ever "a look happened and
-       found no file". A directory that IS there and holds no `nudges.md` is that look — the normal,
-       silent case above. A containing directory that is NOT a directory (missing, or something else
-       entirely) means the look never happened at all, so it is DISCLOSED like every other unusable path.
-       `errno` cannot draw this line: a missing file inside an existing directory and a missing directory
-       both raise `FileNotFoundError` with `ENOENT`. One extra stat on the parent draws it exactly.
-    2. An entry that IS a symlink is resolved with `stat`. A missing target is a found entry that cannot
-       be read, so it is DISCLOSED — never reported as the absence in (1), which is how a moved shared
-       notes file would drop out of every heartbeat with nothing saying so.
-    3. Anything that is not a REGULAR FILE is refused by name before any read. That covers FIFOs (the
-       hang), sockets, devices and directories.
+    ONE decision is this function's alone, and it is why the classify result is not simply returned. When
+    `classify_entry` reports NO ENTRY, this splits on THE CONTAINING DIRECTORY. A directory that IS there
+    and holds no `nudges.md` is a look that COMPLETED and found nothing — the normal, silent case. A
+    containing directory that is not a directory at all means the look never happened, so it DISCLOSES.
+    `errno` cannot draw that line: a missing file inside an existing directory and a missing directory
+    both raise `FileNotFoundError` with `ENOENT`. One stat on the parent draws it exactly.
 
     ACCEPTED RESIDUAL, deliberately not defended against: the entry can change type between the
     classification and the read. Closing it would mean an `os.open` with `O_NONBLOCK` and an `fstat` type
@@ -243,9 +287,10 @@ def read_notes(path: "Path | None") -> "tuple[list, str | None]":
     """
     if path is None:
         return [], "no --followups given, so the .gauntlet/ directory is unknown"
-    try:
-        info = path.lstat()
-    except FileNotFoundError:
+    info, refusal = classify_entry(path)
+    if refusal is not None:
+        return [], refusal
+    if info is None:
         if path.parent.is_dir():
             return [], None  # the look SUCCEEDED and found no file — the normal case, and it says nothing
         # The directory the notes live in is not a directory, so nothing was ever looked at. This is a
@@ -253,17 +298,6 @@ def read_notes(path: "Path | None") -> "tuple[list, str | None]":
         # is exactly why it is worth saying: it fires only for a wrong project root or a deleted
         # `.gauntlet/`, never for the user who simply keeps no notes.
         return [], f"{path.parent} is not a directory, so the notes file could not be looked for"
-    except OSError as exc:
-        return [], f"{path} could not be checked ({type(exc).__name__})"
-    if stat.S_ISLNK(info.st_mode):
-        try:
-            info = path.stat()
-        except FileNotFoundError:
-            return [], f"{path} is a symlink whose target is missing — repoint it or remove it"
-        except OSError as exc:
-            return [], f"{path} could not be checked ({type(exc).__name__})"
-    if not stat.S_ISREG(info.st_mode):
-        return [], f"{path} is {entry_kind(info.st_mode)}, not a regular file — replace it with one"
     size = info.st_size
     if size > NOTES_MAX_BYTES:
         return [], f"{path} is {size} bytes, over the {NOTES_MAX_BYTES}-byte cap — trim it"
@@ -317,15 +351,20 @@ def resolve_rundir(file_arg: str, rundir_arg: "str | None") -> Path:
 
 def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
               now: "datetime | None" = None, followups_path: "Path | None" = None,
-              notes: "list | None" = None, notes_unread: "str | None" = None) -> list:
+              notes: "list | None" = None, notes_unread: "str | None" = None,
+              followups_unread: "str | None" = None) -> list:
     """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings.
 
     `now` is the current UTC time, injectable so the quiet-run rule is testable; it defaults to
     `datetime.now(timezone.utc)` when a caller (main) does not pass one.
 
     `followups_path` is only what the follow-up store was LOOKED FOR at — it is never read here, and it
-    exists so an unread store can name the path it tried (`followups_line`) and so the notes file's path
-    can be named in its own disclosures (`notes_path`).
+    exists so the notes file's path can be named in its own disclosures (`notes_path`).
+
+    `followups_unread` is `open_followups`'s reason, and it is what an unread store discloses. It is
+    passed in rather than re-derived from the path, because only the read knows WHY: a path that could not
+    be opened at all — a FIFO, a socket, a dangling symlink — is not the same as one with nothing at it,
+    and re-deriving turned every one of those into `no file at <path>`.
 
     `notes` / `notes_unread` are `read_notes`'s result, read by the caller (main) exactly as
     `n_followups` is — the store reads stay in one place and this stays renderable from fixed inputs. The
@@ -369,7 +408,7 @@ def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path
             out.append(f"base {base} (PR(s) {prs}): required set {rset}.")
     if active:
         out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
-    fu_line = followups_line(n_followups, followups_path)
+    fu_line = followups_line(n_followups, followups_unread)
     if fu_line:
         out.append(fu_line)
 
@@ -458,8 +497,10 @@ def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path
 
 def render(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
            now: "datetime | None" = None, followups_path: "Path | None" = None,
-           notes: "list | None" = None, notes_unread: "str | None" = None) -> str:
-    lines = reminders(header, rows, n_followups, rundir, now, followups_path, notes, notes_unread)
+           notes: "list | None" = None, notes_unread: "str | None" = None,
+           followups_unread: "str | None" = None) -> str:
+    lines = reminders(header, rows, n_followups, rundir, now, followups_path, notes, notes_unread,
+                      followups_unread)
     run_id = header.get("run_id", "-")
     head = f"NUDGE (run {run_id}) — {len(lines)} reminder(s):"
     body = "\n".join(f"  - {line}" for line in lines)
@@ -491,11 +532,11 @@ def main(argv: "list[str] | None" = None) -> int:
         parser.error("the following arguments are required: --file")
     header, rows = L.load(Path(args.file))
     followups_path = Path(args.followups) if args.followups else None
-    n_followups = open_followups(followups_path)
+    n_followups, followups_unread = open_followups(followups_path)
     notes, notes_unread = read_notes(notes_path(followups_path))
     rundir = resolve_rundir(args.file, args.rundir)
     print(render(header, rows, n_followups, rundir, followups_path=followups_path,
-                 notes=notes, notes_unread=notes_unread))
+                 notes=notes, notes_unread=notes_unread, followups_unread=followups_unread))
     return 0  # a nudge NEVER blocks — it only reminds
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -29,9 +29,11 @@ The design and the full obligation inventory it was trimmed from live in `.gaunt
 from __future__ import annotations
 
 import argparse
+import io
 import os
 import stat
 import sys
+from contextlib import redirect_stderr
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -184,10 +186,15 @@ def open_followups(followups_path: "Path | None") -> "tuple[int | None, str | No
     if info is None:
         return None, f"no file at {followups_path}"
     try:
-        entries = F.load(followups_path)
-    except (OSError, ValueError) as exc:
+        loader_stderr = io.StringIO()
+        with redirect_stderr(loader_stderr):
+            entries = F.load(followups_path)
+    except (OSError, ValueError, SystemExit) as exc:
         # The store is malformed or unreadable. It is still NOT READ, which is what the caller discloses;
         # what it must never become is a confident zero, and it never does.
+        refusal = loader_stderr.getvalue().strip()
+        if refusal:
+            return None, f"{followups_path} could not be read ({refusal})"
         return None, f"{followups_path} could not be read ({type(exc).__name__})"
     return sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN), None
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -357,9 +357,9 @@ def resolve_rundir(file_arg: str, rundir_arg: "str | None") -> Path:
 
 
 def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
-              now: "datetime | None" = None, followups_path: "Path | None" = None,
-              notes: "list | None" = None, notes_unread: "str | None" = None,
-              followups_unread: "str | None" = None) -> list:
+              followups_unread: "str | None", now: "datetime | None" = None,
+              followups_path: "Path | None" = None,
+              notes: "list | None" = None, notes_unread: "str | None" = None) -> list:
     """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings.
 
     `now` is the current UTC time, injectable so the quiet-run rule is testable; it defaults to
@@ -503,11 +503,11 @@ def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path
 
 
 def render(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
-           now: "datetime | None" = None, followups_path: "Path | None" = None,
-           notes: "list | None" = None, notes_unread: "str | None" = None,
-           followups_unread: "str | None" = None) -> str:
-    lines = reminders(header, rows, n_followups, rundir, now, followups_path, notes, notes_unread,
-                      followups_unread)
+           followups_unread: "str | None", now: "datetime | None" = None,
+           followups_path: "Path | None" = None,
+           notes: "list | None" = None, notes_unread: "str | None" = None) -> str:
+    lines = reminders(header, rows, n_followups, rundir, followups_unread, now, followups_path, notes,
+                      notes_unread)
     run_id = header.get("run_id", "-")
     head = f"NUDGE (run {run_id}) — {len(lines)} reminder(s):"
     body = "\n".join(f"  - {line}" for line in lines)
@@ -542,8 +542,8 @@ def main(argv: "list[str] | None" = None) -> int:
     n_followups, followups_unread = open_followups(followups_path)
     notes, notes_unread = read_notes(notes_path(followups_path))
     rundir = resolve_rundir(args.file, args.rundir)
-    print(render(header, rows, n_followups, rundir, followups_path=followups_path,
-                 notes=notes, notes_unread=notes_unread, followups_unread=followups_unread))
+    print(render(header, rows, n_followups, rundir, followups_unread, followups_path=followups_path,
+                 notes=notes, notes_unread=notes_unread))
     return 0  # a nudge NEVER blocks — it only reminds
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -185,8 +185,8 @@ def open_followups(followups_path: "Path | None") -> "tuple[int | None, str | No
         return None, refusal
     if info is None:
         return None, f"no file at {followups_path}"
+    loader_stderr = io.StringIO()
     try:
-        loader_stderr = io.StringIO()
         with redirect_stderr(loader_stderr):
             entries = F.load(followups_path)
     except (OSError, ValueError, SystemExit) as exc:

--- a/plugins/gauntlet/skills/campaign/scripts/nudge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/nudge.py
@@ -165,8 +165,16 @@ def required(tier: str) -> int:
     return 1 if tier == "TRIVIAL" else 2
 
 
-def open_followups(followups_path: "Path | None") -> "tuple[int | None, str | None]":
-    """`(open count, why it was NOT READ)` — and the second is `None` exactly when the first is a real count.
+class FollowupsRead:
+    """The open count and unread reason from one follow-up-store read."""
+
+    def __init__(self, open_count: int | None, unread_reason: str | None):
+        self.open_count = open_count
+        self.unread_reason = unread_reason
+
+
+def open_followups(followups_path: "Path | None") -> FollowupsRead:
+    """A `FollowupsRead` whose reason is `None` exactly when its count is real.
 
     A count of `None` is NOT `0`, and keeping them apart is the whole point: an unread store counted as
     zero is INDISTINGUISHABLE in the output from a genuinely empty queue, so an omitted or mistyped flag
@@ -179,12 +187,12 @@ def open_followups(followups_path: "Path | None") -> "tuple[int | None, str | No
     all say what they are; only a genuinely absent file still reports as absent.
     """
     if followups_path is None:
-        return None, "no --followups given"
+        return FollowupsRead(None, "no --followups given")
     info, refusal = classify_entry(followups_path)
     if refusal is not None:
-        return None, refusal
+        return FollowupsRead(None, refusal)
     if info is None:
-        return None, f"no file at {followups_path}"
+        return FollowupsRead(None, f"no file at {followups_path}")
     loader_stderr = io.StringIO()
     try:
         with redirect_stderr(loader_stderr):
@@ -194,12 +202,12 @@ def open_followups(followups_path: "Path | None") -> "tuple[int | None, str | No
         # what it must never become is a confident zero, and it never does.
         refusal = loader_stderr.getvalue().strip()
         if refusal:
-            return None, f"{followups_path} could not be read ({refusal})"
-        return None, f"{followups_path} could not be read ({type(exc).__name__})"
-    return sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN), None
+            return FollowupsRead(None, f"{followups_path} could not be read ({refusal})")
+        return FollowupsRead(None, f"{followups_path} could not be read ({type(exc).__name__})")
+    return FollowupsRead(sum(1 for e in entries if e.get("state") not in OPEN_FOLLOWUP_HIDDEN), None)
 
 
-def followups_line(n_followups: "int | None", unread: "str | None") -> "str | None":
+def followups_line(followups: FollowupsRead) -> "str | None":
     """The one follow-up reminder: a COUNT when the store was read, a DISCLOSURE naming why when it was
     not, and silence ONLY for a read that genuinely found nothing open. An unread store is never silent —
     that silence is what a caller reads as "this run has no open follow-ups".
@@ -208,10 +216,10 @@ def followups_line(n_followups: "int | None", unread: "str | None") -> "str | No
     refusal that knew exactly what was wrong — a FIFO, a dangling symlink — printed `no file at <path>`
     about a path that plainly had something at it.
     """
-    if n_followups is None:
-        return f"follow-up store NOT READ ({unread}) — open follow-ups are UNKNOWN, not zero."
-    if n_followups:
-        return f"{n_followups} open follow-up(s) — start any you can."
+    if followups.open_count is None:
+        return f"follow-up store NOT READ ({followups.unread_reason}) — open follow-ups are UNKNOWN, not zero."
+    if followups.open_count:
+        return f"{followups.open_count} open follow-up(s) — start any you can."
     return None
 
 
@@ -356,8 +364,8 @@ def resolve_rundir(file_arg: str, rundir_arg: "str | None") -> Path:
     return Path(file_arg).resolve().parent
 
 
-def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
-              followups_unread: "str | None", now: "datetime | None" = None,
+def reminders(header: dict, rows: list, followups: FollowupsRead, rundir: "Path | None",
+              now: "datetime | None" = None,
               followups_path: "Path | None" = None,
               notes: "list | None" = None, notes_unread: "str | None" = None) -> list:
     """Compute the reminder lines. Pure: same inputs → same output. Returns a list of strings.
@@ -368,13 +376,13 @@ def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path
     `followups_path` is only what the follow-up store was LOOKED FOR at — it is never read here, and it
     exists so the notes file's path can be named in its own disclosures (`notes_path`).
 
-    `followups_unread` is `open_followups`'s reason, and it is what an unread store discloses. It is
-    passed in rather than re-derived from the path, because only the read knows WHY: a path that could not
-    be opened at all — a FIFO, a socket, a dangling symlink — is not the same as one with nothing at it,
-    and re-deriving turned every one of those into `no file at <path>`.
+    `followups` is `open_followups`'s one result, including its count and unread reason. The reason is not
+    re-derived from the path, because only the read knows WHY: a path that could not be opened at all — a
+    FIFO, a socket, a dangling symlink — is not the same as one with nothing at it, and re-deriving turned
+    every one of those into `no file at <path>`.
 
     `notes` / `notes_unread` are `read_notes`'s result, read by the caller (main) exactly as
-    `n_followups` is — the store reads stay in one place and this stays renderable from fixed inputs. The
+    `followups` is — the store reads stay in one place and this stays renderable from fixed inputs. The
     default `([], None)` is "read, and there was nothing", which is silent.
     """
     if now is None:
@@ -415,7 +423,7 @@ def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path
             out.append(f"base {base} (PR(s) {prs}): required set {rset}.")
     if active:
         out.append(f"{len(active)} PR(s) open — reconcile and fan out work up to caps.")
-    fu_line = followups_line(n_followups, followups_unread)
+    fu_line = followups_line(followups)
     if fu_line:
         out.append(fu_line)
 
@@ -502,12 +510,11 @@ def reminders(header: dict, rows: list, n_followups: "int | None", rundir: "Path
     return out
 
 
-def render(header: dict, rows: list, n_followups: "int | None", rundir: "Path | None",
-           followups_unread: "str | None", now: "datetime | None" = None,
+def render(header: dict, rows: list, followups: FollowupsRead, rundir: "Path | None",
+           now: "datetime | None" = None,
            followups_path: "Path | None" = None,
            notes: "list | None" = None, notes_unread: "str | None" = None) -> str:
-    lines = reminders(header, rows, n_followups, rundir, followups_unread, now, followups_path, notes,
-                      notes_unread)
+    lines = reminders(header, rows, followups, rundir, now, followups_path, notes, notes_unread)
     run_id = header.get("run_id", "-")
     head = f"NUDGE (run {run_id}) — {len(lines)} reminder(s):"
     body = "\n".join(f"  - {line}" for line in lines)
@@ -539,10 +546,10 @@ def main(argv: "list[str] | None" = None) -> int:
         parser.error("the following arguments are required: --file")
     header, rows = L.load(Path(args.file))
     followups_path = Path(args.followups) if args.followups else None
-    n_followups, followups_unread = open_followups(followups_path)
+    followups = open_followups(followups_path)
     notes, notes_unread = read_notes(notes_path(followups_path))
     rundir = resolve_rundir(args.file, args.rundir)
-    print(render(header, rows, n_followups, rundir, followups_unread, followups_path=followups_path,
+    print(render(header, rows, followups, rundir, followups_path=followups_path,
                  notes=notes, notes_unread=notes_unread))
     return 0  # a nudge NEVER blocks — it only reminds
 


### PR DESCRIPTION
- A FIFO at the typed `--followups` path hung `nudge.py` forever, which its contract forbids.
- `classify_entry` now refuses non-regular entries before any read, and both inputs share it.
- An unread store discloses the real reason instead of always claiming no file is there.
