### PR TITLE
validate --repo at every CLI boundary

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/repository.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/repository.py
@@ -1,0 +1,34 @@
+"""The `owner/name` check every Gauntlet campaign tool applies to an explicit `--repo`."""
+
+from __future__ import annotations
+
+import re
+
+# GitHub repository coordinates are ASCII identifiers. Owners use alphanumerics and single, non-edge
+# hyphens; repository names add `.`, `_`, and unrestricted hyphens. GitHub owns both length limits; the
+# named constants below are this repository's defining sites for them.
+OWNER_RE = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9._-]+")
+OWNER_MAX_LENGTH = 39
+REPOSITORY_MAX_LENGTH = 100
+
+
+def repo_problem(repo: str) -> "str | None":
+    """`None` if `repo` is a well-formed `owner/name`; otherwise why it is not. PURE — no I/O, no raising.
+
+    An explicit `--repo` is a CALLER INPUT, not a GitHub read result, and it is interpolated into `gh`
+    argument vectors by every tool that takes it. Six tools took it; one checked it. The other five
+    accepted anything at all and handed it to `gh`, which answers with its own error about a repository
+    the caller never meant to name — or, for a value that happens to resolve, about the WRONG one.
+
+    This owns the CHECK and its WORDING. Each caller keeps its own refusal: they exit through different
+    doors — `fail`, a `Refusal`, an `argparse` error — and which door a tool uses is that tool's business.
+    """
+    parts = repo.split("/")
+    if (len(parts) != 2
+            or not 1 <= len(parts[0]) <= OWNER_MAX_LENGTH
+            or not 1 <= len(parts[1]) <= REPOSITORY_MAX_LENGTH
+            or OWNER_RE.fullmatch(parts[0]) is None
+            or REPOSITORY_RE.fullmatch(parts[1]) is None):
+        return f"--repo {repo!r} is not a valid GitHub owner/name"
+    return None

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+from _gauntlet import repository as REPO_MOD
 from _gauntlet.gitfixture import FIXTURE_EMAIL, GitFixture
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import (capture_cli, checker, deeply_nested_json, gh_writing,
@@ -969,7 +970,62 @@ def t_shared_remote_and_clone_primitives():
                 check(False, f"{label} must raise the bound failure type when git fails")
 
 
+def t_malformed_repo_rechecks_before_any_fetch():
+    """A malformed `--repo` fails closed to `recheck` at the CLI boundary, before any `gh` runs.
+
+    This tool had NO validation at all: the value went straight into a `gh` argv, and gh answered about a
+    repository the caller never named. The refusal exits non-zero like every other non-`proceed` verdict,
+    so a caller gating on `$?` cannot mistake it for a cleared base.
+    """
+    code, out, _err = capture_cli(M.main, ["check", "--pr", "9", "--repo", "not-a-repo"])
+    check(code != 0, "a malformed --repo must exit non-zero")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck", f"a malformed --repo must fail closed to recheck, got {result!r}")
+    check("'not-a-repo'" in result["reason"], f"the reason must quote the value, got {result!r}")
+
+
+def t_shared_repo_validator_semantics():
+    """`_gauntlet/repository.py`'s OWN contract, exercised directly rather than through a caller.
+
+    Six tools now refuse a malformed `--repo` through this one check, so its semantics need a fixture that
+    does not depend on any caller's door. Five of those tools had NO validation at all before, which is
+    what makes the accept side matter as much as the reject side: a check that refuses a legitimate
+    repository would break every one of them at once.
+    """
+    fp = REPO_MOD.repo_problem
+    for good in ("lestrrat-ai/claude-code-plugins", "a/b", "o/name.with.dots",
+                 "o/name_with_underscores", "o/-leading-hyphen-is-legal-in-a-NAME",
+                 "A0/b9", "a" * REPO_MOD.OWNER_MAX_LENGTH + "/" + "r" * REPO_MOD.REPOSITORY_MAX_LENGTH):
+        check(fp(good) is None, f"{good!r} is a legal owner/name and must be accepted")
+
+    for bad, why in (
+        ("", "empty"),
+        ("owner", "no slash at all"),
+        ("owner/", "empty name"),
+        ("/name", "empty owner"),
+        ("a/b/c", "two slashes is not owner/name"),
+        ("-lead/b", "an owner may not START with a hyphen"),
+        ("trail-/b", "an owner may not END with a hyphen"),
+        ("a--b/c", "an owner's hyphens are single, never doubled"),
+        ("a b/c", "a space is not an identifier character"),
+        ("o/na me", "a space is not an identifier character in a name either"),
+        ("o/na/me", "a slash inside the name is a third field"),
+        ("a" * (REPO_MOD.OWNER_MAX_LENGTH + 1) + "/b", "over GitHub's owner length limit"),
+        ("a/" + "r" * (REPO_MOD.REPOSITORY_MAX_LENGTH + 1), "over GitHub's name length limit"),
+    ):
+        problem = fp(bad)
+        check(problem is not None, f"{bad!r} must be refused ({why})")
+        assert problem is not None  # narrow for the type checker; `check` above is the readable guard
+        check(repr(bad) in problem, f"the refusal must QUOTE what it refused, got {problem!r}")
+
+    # A shell-metacharacter value is refused like any other malformed one. It reaches `gh` argv, and the
+    # point of checking at the boundary is that it never gets that far.
+    check(fp("o/$(touch pwned)") is not None, "a shell-metacharacter name must be refused")
+
+
 CASES = [
+    ("malformed-repo-rechecks", "a malformed --repo fails closed to recheck at the CLI boundary, before any gh call", t_malformed_repo_rechecks_before_any_fetch),
+    ("shared-repo-validator", "the shared --repo validator's own semantics: what it accepts, what it refuses, and that it quotes the value", t_shared_repo_validator_semantics),
     ("shared-remote-clone", "the shared bare-remote and clone primitives: bare on the named branch, a usable identity, and a raise on failure", t_shared_remote_and_clone_primitives),
     ("clean-proceeds", "CLEAN passes the enum screen", t_clean_proceeds),
     ("has-hooks-proceeds", "HAS_HOOKS passes the enum screen", t_has_hooks_proceeds),

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -984,6 +984,43 @@ def t_malformed_repo_rechecks_before_any_fetch():
     check("'not-a-repo'" in result["reason"], f"the reason must quote the value, got {result!r}")
 
 
+def t_empty_repo_rechecks_before_view_and_absent_still_fetches():
+    """An explicit empty `--repo` refuses before the view read, while an omitted flag still fetches.
+
+    The guard must distinguish the two argparse values: `""` means the caller supplied an invalid repository;
+    `None` means the optional flag was absent and permits the current-checkout fetch path.
+    """
+    calls = []
+
+    def fetch(pr, *, fields, repo=None, cwd=None, view_json=None):
+        calls.append((pr, fields, repo, cwd, view_json))
+        return view(mergeStateStatus="DIRTY"), None
+
+    old = M.pr_view_json
+    setattr(M, "pr_view_json", fetch)
+    try:
+        empty = capture_cli(M.main, ["check", "--pr", "9", "--repo", ""])
+        empty_calls = list(calls)
+        absent = capture_cli(M.main, ["check", "--pr", "9"])
+    finally:
+        setattr(M, "pr_view_json", old)
+
+    code, out, _err = empty
+    check(code != 0, "an empty --repo must exit non-zero")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck", f"an empty --repo must fail closed to recheck, got {result!r}")
+    check(repr("") in result["reason"], f"the refusal must quote the empty value, got {result!r}")
+    check(empty_calls == [], f"an empty --repo must refuse before the view read, got {empty_calls!r}")
+
+    code, out, _err = absent
+    check(code != 0, "an omitted --repo may reach its normal non-proceed result")
+    result = json.loads(out)
+    check(result["verdict"] == "rebase-first",
+          f"an omitted --repo must retain the current-checkout fetch path, got {result!r}")
+    check(calls == [("9", M.VIEW_FIELDS, None, None, None)],
+          f"an omitted --repo must fetch with repo=None, got {calls!r}")
+
+
 def t_shared_repo_validator_semantics():
     """`_gauntlet/repository.py`'s OWN contract, exercised directly rather than through a caller.
 
@@ -1025,6 +1062,7 @@ def t_shared_repo_validator_semantics():
 
 CASES = [
     ("malformed-repo-rechecks", "a malformed --repo fails closed to recheck at the CLI boundary, before any gh call", t_malformed_repo_rechecks_before_any_fetch),
+    ("empty-repo-rechecks", "an empty --repo refuses before the view read; an omitted --repo still fetches", t_empty_repo_rechecks_before_view_and_absent_still_fetches),
     ("shared-repo-validator", "the shared --repo validator's own semantics: what it accepts, what it refuses, and that it quotes the value", t_shared_repo_validator_semantics),
     ("shared-remote-clone", "the shared bare-remote and clone primitives: bare on the named branch, a usable identity, and a raise on failure", t_shared_remote_and_clone_primitives),
     ("clean-proceeds", "CLEAN passes the enum screen", t_clean_proceeds),

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -50,6 +50,7 @@ from _gauntlet.argv import bind_separate_option_value
 from _gauntlet.gh import pr_view_json
 from _gauntlet.git_refs import select_base_fetch_refs
 from _gauntlet.modules import load_module_from_path, load_sibling
+from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
 from _gauntlet.view import field_problem
 
@@ -395,6 +396,13 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.cmd == "self-test":
         return self_test()
+    # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked at
+    # the CLI boundary before anything runs. `_gauntlet/repository.py` owns the check and its wording.
+    if args.repo:
+        problem = repo_problem(args.repo)
+        if problem is not None:
+            print(json.dumps(_verdict(RECHECK, problem)))
+            return 1
     return check(args.pr, args.repo, args.view_json, args.project_root,
                  args.worktree, args.base, args.remote, args.file)
 

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -398,7 +398,7 @@ def main(argv: "list[str] | None" = None) -> int:
         return self_test()
     # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked at
     # the CLI boundary before anything runs. `_gauntlet/repository.py` owns the check and its wording.
-    if args.repo:
+    if args.repo is not None:
         problem = repo_problem(args.repo)
         if problem is not None:
             print(json.dumps(_verdict(RECHECK, problem)))

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -156,6 +156,7 @@ from typing import Callable, NamedTuple, NoReturn, cast
 from urllib.parse import quote
 
 from _gauntlet.modules import load_module_from_path
+from _gauntlet.repository import repo_problem
 
 HERE = Path(__file__).resolve().parent
 SNAPSHOT_PY = HERE / "ci-snapshot.py"
@@ -173,13 +174,6 @@ FIXTURES = HERE / "fixtures" / "ci-status"
 # ERROR (exit 2), never a verdict.
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
-# GitHub repository coordinates are ASCII identifiers. Owners use alphanumerics and single, non-edge
-# hyphens; repository names add `.`, `_`, and unrestricted hyphens. GitHub owns both length limits; the
-# named constants below are this tool's defining sites for them.
-OWNER_RE = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
-REPOSITORY_RE = re.compile(r"[A-Za-z0-9._-]+")
-OWNER_MAX_LENGTH = 39
-REPOSITORY_MAX_LENGTH = 100
 
 # "this source's response carried no commit oid" — the artifact's word for it, never a sha we made up.
 NO_OID = "-"
@@ -389,14 +383,12 @@ def check_rundir(rundir: Path) -> Path:
 
 
 def check_repo(repo: str) -> str:
-    """An explicit repository is a caller input, not a GitHub read result."""
-    parts = repo.split("/")
-    if (len(parts) != 2
-            or not 1 <= len(parts[0]) <= OWNER_MAX_LENGTH
-            or not 1 <= len(parts[1]) <= REPOSITORY_MAX_LENGTH
-            or OWNER_RE.fullmatch(parts[0]) is None
-            or REPOSITORY_RE.fullmatch(parts[1]) is None):
-        fail(f"--repo {repo!r} is not a valid GitHub owner/name")
+    """An explicit repository is a caller input, not a GitHub read result.
+
+    `_gauntlet/repository.py` owns the check and its wording; this exits through THIS tool's door."""
+    problem = repo_problem(repo)
+    if problem is not None:
+        fail(problem)
     return repo
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
@@ -20,7 +20,7 @@ from io import StringIO
 from pathlib import Path
 
 from _gauntlet.modules import load_sibling
-from _gauntlet.testing import checker
+from _gauntlet.testing import capture_cli, checker
 
 OWNER = Path(__file__).resolve().parent / "label-mirror.py"
 
@@ -273,7 +273,22 @@ def t_required_boundary():
         check(out["desired"] == desired, f"[{tier} {ok}/{out['required']}] desired must be {desired}, got {out!r}")
 
 
+def t_malformed_repo_fails_before_any_gh_call():
+    """A malformed `--repo` is refused at the CLI boundary, before the mirror touches GitHub.
+
+    This tool had NO validation, and `--repo` here is documented as NEVER resolved from the checkout — so
+    an unvalidated value was the only thing naming the repository whose labels get edited.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
+        code, _out, err = capture_cli(M.main, ["mirror", "--ledger", str(led), "--pr", "9",
+                                               "--repo", "not-a-repo"])
+        check(code != 0, "a malformed --repo must be refused")
+        check("'not-a-repo'" in err, f"the refusal must quote the value, got {err!r}")
+
+
 CASES = [
+    ("malformed-repo-refused", "a malformed --repo is refused at the CLI boundary, before any gh call", t_malformed_repo_fails_before_any_gh_call),
     ("reviewing-to-accepted", "a met gate swaps reviewing->accepted with the exact argv", t_reviewing_to_accepted_swaps),
     ("readopt-escalation", "a re-adoption tier escalation flips a stale accepted->reviewing with the exact argv", t_readopt_escalation_flips_accepted_to_reviewing),
     ("accepted-stays", "an already-accepted PR is a no-op — no edit call", t_accepted_stays),

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Callable, NoReturn
 
 from _gauntlet.modules import load_sibling
+from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
 
 _HERE = Path(__file__).resolve().parent
@@ -236,6 +237,11 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.cmd == "self-test":
         return self_test()
+    # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked at
+    # the CLI boundary before anything runs. `_gauntlet/repository.py` owns the check and its wording.
+    problem = repo_problem(args.repo)
+    if problem is not None:
+        fail(problem)
     return mirror(args.ledger, args.pr, args.repo, dry_run=args.dry_run)
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -678,8 +678,42 @@ def t_malformed_repo_is_not_yet_before_any_fetch():
           f"the repo guard must fire before the ledger read, got {result!r}")
 
 
+def t_empty_repo_is_not_yet_before_ledger_and_absent_still_reads_ledger():
+    """An explicit empty `--repo` refuses before the ledger read, while omission retains that read path."""
+    loads = []
+
+    def load(path):
+        loads.append(path)
+        return dict(_HEADER), []
+
+    old = M.L.load
+    setattr(M.L, "load", load)
+    try:
+        empty = capture_cli(M.main, ["check", "--pr", "9", "--file", "/ignored/state.jsonl", "--repo", ""])
+        empty_loads = list(loads)
+        absent = capture_cli(M.main, ["check", "--pr", "9", "--file", "/ignored/state.jsonl"])
+    finally:
+        setattr(M.L, "load", old)
+
+    code, out, _err = empty
+    check(code != 0, "an empty --repo must exit non-zero")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet", f"an empty --repo must fail closed to not-yet, got {result!r}")
+    check(repr("") in result["reason"], f"the refusal must quote the empty value, got {result!r}")
+    check(empty_loads == [], f"an empty --repo must refuse before the ledger read, got {empty_loads!r}")
+
+    code, out, _err = absent
+    check(code == 0, f"an omitted --repo must retain its normal ledger path, got {code}")
+    result = json.loads(out)
+    check(result == {"verdict": "not-yet", "reason": "no ledger row"},
+          f"an omitted --repo must retain the normal no-row result, got {result!r}")
+    check(loads == [Path("/ignored/state.jsonl")],
+          f"an omitted --repo must read its ledger, got {loads!r}")
+
+
 CASES = [
     ("malformed-repo-not-yet", "a malformed --repo fails closed to not-yet at the CLI boundary, before the ledger read", t_malformed_repo_is_not_yet_before_any_fetch),
+    ("empty-repo-not-yet", "an empty --repo refuses before the ledger read; an omitted --repo still reads it", t_empty_repo_is_not_yet_before_ledger_and_absent_still_reads_ledger),
     ("shared-field-problem", "the shared view validator's own semantics: order, empty request, and every missing/wrong-type message", t_shared_field_problem_semantics),
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check-test.py
@@ -662,7 +662,24 @@ def t_shared_field_problem_semantics():
           "reordering the request must reorder the report")
 
 
+def t_malformed_repo_is_not_yet_before_any_fetch():
+    """A malformed `--repo` fails closed to `not-yet` at the CLI boundary, before any `gh` runs.
+
+    This tool had NO validation at all. It decides whether a PR may MERGE, so an unvalidated value here
+    reached a `gh` argv on the path to the most irreversible act the campaign performs."""
+    code, out, _err = capture_cli(M.main, ["check", "--pr", "9", "--file", "/nonexistent/state.jsonl",
+                                           "--repo", "not-a-repo"])
+    check(code != 0, "a malformed --repo must exit non-zero")
+    result = json.loads(out)
+    check(result["verdict"] == "not-yet", f"a malformed --repo must fail closed to not-yet, got {result!r}")
+    check("'not-a-repo'" in result["reason"], f"the reason must quote the value, got {result!r}")
+    # The repo check runs BEFORE the ledger is opened: the deliberately absent --file never surfaces.
+    check("state.jsonl" not in result["reason"],
+          f"the repo guard must fire before the ledger read, got {result!r}")
+
+
 CASES = [
+    ("malformed-repo-not-yet", "a malformed --repo fails closed to not-yet at the CLI boundary, before the ledger read", t_malformed_repo_is_not_yet_before_any_fetch),
     ("shared-field-problem", "the shared view validator's own semantics: order, empty request, and every missing/wrong-type message", t_shared_field_problem_semantics),
     ("clean-all-met", "CLEAN + every precondition met -> merge", t_clean_and_all_met),
     ("has-hooks", "HAS_HOOKS -> merge", t_has_hooks_merges),

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -332,7 +332,7 @@ def main(argv: "list[str] | None" = None) -> int:
         return self_test()
     # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked at
     # the CLI boundary before anything runs. `_gauntlet/repository.py` owns the check and its wording.
-    if args.repo:
+    if args.repo is not None:
         problem = repo_problem(args.repo)
         if problem is not None:
             print(json.dumps(_not_yet(problem)))

--- a/plugins/gauntlet/skills/campaign/scripts/merge-check.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-check.py
@@ -44,6 +44,7 @@ from typing import cast
 
 from _gauntlet.gh import pr_view_json
 from _gauntlet.modules import load_sibling
+from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
 from _gauntlet.view import field_problem
 
@@ -329,6 +330,13 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.cmd == "self-test":
         return self_test()
+    # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked at
+    # the CLI boundary before anything runs. `_gauntlet/repository.py` owns the check and its wording.
+    if args.repo:
+        problem = repo_problem(args.repo)
+        if problem is not None:
+            print(json.dumps(_not_yet(problem)))
+            return 1
     return check(args.pr, args.file, args.repo, args.view_json)
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/merge-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge-test.py
@@ -1796,7 +1796,30 @@ def t_realgit_main_stderr_preserves_raw_git_byte():
               f"the JSON-quoted tailored path must render as one intact ASCII, line-safe item: {err!r}")
 
 
+def t_malformed_repo_refuses_before_any_phase():
+    """A malformed `--repo` is refused before the merge runner does anything at all.
+
+    `merge.py` performs the irreversible act in this repository. It had NO validation of `--repo`, so the
+    value went into a `gh pr merge` argv unchecked. The guard runs before `execute`, which is why no fake
+    process boundary is needed here: nothing gets far enough to call one.
+    """
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        led = d / "state.jsonl"
+        led.write_text('{"type": "header", "run_id": "g1", "required_set": "none"}\n', encoding="utf-8")
+        # A SUBPROCESS, because merge's refusal writes to `sys.stderr.buffer` for byte-exactness and an
+        # in-process StringIO has no `.buffer`. Its existing raw-byte fixture drives main the same way.
+        done = subprocess.run(  # noqa: S603 - this suite drives its sibling command
+            [sys.executable, str(OWNER), "run", "--ledger", str(led), "--pr", "9",
+             "--project-root", str(d), "--repo", "not-a-repo"],
+            capture_output=True, text=True, check=False)
+        check(done.returncode != 0, "a malformed --repo must be refused")
+        check("REFUSED" in done.stderr and "'not-a-repo'" in done.stderr,
+              f"the refusal must use merge's own door and quote the value, got {done.stderr!r}")
+
+
 CASES = [
+    ("malformed-repo-refused", "a malformed --repo is refused through merge's own door before any phase runs", t_malformed_repo_refuses_before_any_phase),
     ("happy-owned", "exact merge argv, owned cleanup, terminal write", t_happy_owned_cleanup_and_command),
     ("repo-identity", "a --repo that does not name the checkout's own repository is refused before any live view (case-insensitive match)", t_repo_identity_mismatch_refused_before_view),
     ("merged-live-row", "MERGED with live ledger resumes without another merge", t_merge_landed_ledger_live_resumes),

--- a/plugins/gauntlet/skills/campaign/scripts/merge.py
+++ b/plugins/gauntlet/skills/campaign/scripts/merge.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import cast
 
 from _gauntlet.modules import load_sibling
+from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
 from _gauntlet.view import field_problem
 
@@ -840,7 +841,12 @@ def main(argv: "list[str] | None" = None) -> int:
     args = parser.parse_args(argv)
     if args.cmd == "self-test":
         return self_test()
+    # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked at
+    # the CLI boundary before anything runs. `_gauntlet/repository.py` owns the check and its wording.
     try:
+        problem = repo_problem(args.repo)
+        if problem is not None:
+            raise Refusal(problem)
         result = execute(args.ledger, str(args.pr), args.project_root, args.repo,
                          merge_method=args.merge_method)
     except (Refusal, SystemExit) as exc:

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -1265,7 +1265,35 @@ def t_foreign_ledger_base_mismatch_refuses_without_mutation():
               "a foreign-run refusal must not change the owning row's status")
 
 
+def t_malformed_repo_is_refused_before_any_gh_call():
+    """A malformed `--repo` is refused before adoption touches anything.
+
+    This tool had NO validation at all, and it is the one that CREATES the ledger row and applies labels,
+    so an unvalidated value would have labelled whatever repository `gh` resolved it to. The refusal must
+    land before the first `gh pr view`, which is what the empty call recorder proves.
+    """
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        rec = Recorder(view=view())
+        old = M._run
+        setattr(M, "_run", rec)
+        try:
+            code, _out, err = capture_cli(M.main, [
+                "adopt", "--pr", "9", "--run-id", "g1", "--file", str(ledger), "--tier", "HIGH",
+                "--worktrees-root", str(d / "wt"), "--project-root", str(d), "--repo", "not-a-repo"])
+        finally:
+            setattr(M, "_run", old)
+        check(code != 0, "a malformed --repo must be refused")
+        check("'not-a-repo'" in err, f"the refusal must quote the value, got {err!r}")
+        check(rec.calls == [], f"the refusal must land before ANY gh or git call, got {rec.calls!r}")
+        _, rows = M.L.load(ledger)
+        check(M.L.find_row(rows, "9") is None, "a refused adoption must register no row")
+
+
 CASES = [
+    ("malformed-repo-refused", "a malformed --repo is refused before any gh call and registers no row", t_malformed_repo_is_refused_before_any_gh_call),
     ("adopt_records_run_id", "adoption writes the ledger run_id header and refuses another run's ledger (fu121)", t_adopt_records_the_run_id_in_the_header),
     ("foreign_ledger_base_mismatch", "a foreign run cannot park an owning row through a base mismatch", t_foreign_ledger_base_mismatch_refuses_without_mutation),
     ("mixed_base_end_to_end", "one mixed-base run walks adopt -> grouped required-set -> merge door -> "

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -1292,8 +1292,40 @@ def t_malformed_repo_is_refused_before_any_gh_call():
         check(M.L.find_row(rows, "9") is None, "a refused adoption must register no row")
 
 
+def t_empty_repo_is_refused_before_any_gh_call_and_absent_still_adopts():
+    """An explicit empty `--repo` refuses before `gh`, while an omitted flag retains adoption."""
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        rec = Recorder(view=view())
+        old = M._run
+        setattr(M, "_run", rec)
+        try:
+            empty = capture_cli(M.main, [
+                "adopt", "--pr", "9", "--run-id", "g1", "--file", str(ledger), "--tier", "HIGH",
+                "--worktrees-root", str(d / "wt"), "--project-root", str(d), "--repo", ""])
+        finally:
+            setattr(M, "_run", old)
+        check(rec.calls == [], f"an empty --repo must refuse before ANY gh or git call, got {rec.calls!r}")
+        code, _out, err = empty
+        check(code != 0, "an empty --repo must be refused")
+        check(repr("") in err, f"the refusal must quote the empty value, got {err!r}")
+        _, rows = M.L.load(ledger)
+        check(M.L.find_row(rows, "9") is None, "an empty --repo must register no row")
+
+        code, _out, err, absent = _adopt(d, ledger, view(), wroot=d / "wt")
+        check(code == 0, f"an omitted --repo must retain adoption, got {code}: {err}")
+        first_view = absent.one("gh", "pr", "view")
+        check(first_view is not None, "an omitted --repo must still read the PR")
+        assert first_view is not None
+        check("--repo" not in first_view,
+              f"an omitted --repo must use the current-checkout gh path, got {first_view!r}")
+
+
 CASES = [
     ("malformed-repo-refused", "a malformed --repo is refused before any gh call and registers no row", t_malformed_repo_is_refused_before_any_gh_call),
+    ("empty-repo-refused", "an empty --repo refuses before gh; an omitted --repo still adopts", t_empty_repo_is_refused_before_any_gh_call_and_absent_still_adopts),
     ("adopt_records_run_id", "adoption writes the ledger run_id header and refuses another run's ledger (fu121)", t_adopt_records_the_run_id_in_the_header),
     ("foreign_ledger_base_mismatch", "a foreign run cannot park an owning row through a base mismatch", t_foreign_ledger_base_mismatch_refuses_without_mutation),
     ("mixed_base_end_to_end", "one mixed-base run walks adopt -> grouped required-set -> merge door -> "

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -307,7 +307,7 @@ def cmd_adopt(args) -> int:
     pr = str(args.pr)
     # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked before
     # anything runs. `_gauntlet/repository.py` owns the check and its wording.
-    if args.repo:
+    if args.repo is not None:
         problem = repo_problem(args.repo)
         if problem is not None:
             return _refuse(problem)

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -45,6 +45,7 @@ from pathlib import Path
 
 from _gauntlet.atomic import replace_text
 from _gauntlet.modules import load_sibling
+from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
@@ -304,6 +305,12 @@ def cmd_intent_sync(args) -> int:
 
 def cmd_adopt(args) -> int:
     pr = str(args.pr)
+    # An explicit --repo is interpolated into every `gh` argv this tool builds, so it is checked before
+    # anything runs. `_gauntlet/repository.py` owns the check and its wording.
+    if args.repo:
+        problem = repo_problem(args.repo)
+        if problem is not None:
+            return _refuse(problem)
     run_label = f"{RUN_LABEL_PREFIX}{args.run_id}"
     # gh resolves its target repo from the CWD when `--repo` is absent, but git and the ledger run in
     # `--project-root`. Left in the invoking checkout, gh would label a DIFFERENT repo than the one the


### PR DESCRIPTION
- Adds `_gauntlet/repository.py`, which owns the `owner/name` check and its wording.
- Five tools accepted any `--repo` with no validation and passed it straight to `gh`.
- Each keeps its own refusal door; a fixture per tool pins that it fires before any call.
