### PR TITLE
mark documented command blocks

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -130,8 +130,8 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
    adapter's advisory inspections (`references/runtime-adapter.md`, "Session watchdog nudge") and runs the
    health pass only when one of those normal triggers applies; it never decides the primary re-arm —
    `references/loop-control.md`, "Primary continuity", owns continuing the loop.
-9. `ci-status.py required-set --ledger <rundir>/state.jsonl`: refresh the required set before any CI
-   derivation this heartbeat.
+9. The required-set command (`references/stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?", owns the exact
+   invocation): refresh the required set before any CI derivation this heartbeat.
 10. Mutating action due on a PR -> `ledger.py … dispatch-check --pr <N>`: run before ANY action that
     mutates a PR. It is an ALLOW-LIST — only an `in_review` row exits zero; HELD, terminal and
     unrecognised rows all refuse, and the refusal says which (`references/files-and-ledger.md`,

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -573,19 +573,23 @@ nothing was looking. Three checks close that, and **none is optional**:
 `doc-check` enforces three things and they are not separable:
 
 - the **command a marked block RUNS** carries every token its id requires, and an id the table does not
-  define is a failure rather than an exemption. The tokens are required of the invocation — the script
-  name to the end of its backslash-continued command line — never of the fenced body around it, so a
-  comment or a second command line in the block cannot supply what the invocation itself lacks. **A marked
-  block's command line may carry only the invocation**, so a comment, a chain, a pipe or a substitution ON
-  that line is refused rather than parsed: it sits inside the invocation's own line, which is how it would
-  otherwise supply the missing tokens. Put the comment outside the fence and give a second command its own
-  line. A block that runs no `ci-status.py` command at all is reported as such;
+  define is a failure rather than an exemption. **A marked block IS that one invocation** — one
+  backslash-continued command line, beginning with the script name (after an optional `python3` and an
+  optional path) and carrying nothing after it but the command's own arguments. It does not merely CONTAIN
+  the command: a second line, a comment line, a trailing comment, a chain, a pipe or a substitution, and a
+  wrapper that echoes the command or writes it to a file, are all refused rather than parsed, because each
+  is text a reader does not run that would otherwise supply the tokens the invocation itself lacks. Put a
+  comment outside the fence and give a second command its own block. A block that runs no `ci-status.py`
+  command at all is reported as such, in its own words;
 - every id the table defines has **at least one** block somewhere, so deleting the last copy of a command
   goes red instead of quietly narrowing the check to nothing;
 - **no runnable copy sits outside a marked block.** Prose may still NAME a command — `` `ci-status.py
   liveness` `` is a mention, and a reader who runs it verbatim is REFUSED by the tool, which fails closed.
   A `--flag` after the script name and before the closing backtick makes it a copy, and a copy belongs in a
-  block. To recap a command in prose, name it and point at its block; do not respell its flags.
+  block. To recap a command in prose, name it and point at its block; do not respell its flags. The script
+  name is matched whole, so a DIFFERENT tool whose name merely ends in it (`example-ci-status.py` —
+  invented; it appears nowhere in this repo) is not a copy of this one, while a name written inside a code
+  span, or after a `/`, still is.
 
 **Why the marker, rather than a cleverer scan.** The check used to hunt runnable copies in free Markdown,
 which meant deciding — for arbitrary prose — whether a stretch of text was a command or a sentence about

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -575,8 +575,11 @@ nothing was looking. Three checks close that, and **none is optional**:
 - the **command a marked block RUNS** carries every token its id requires, and an id the table does not
   define is a failure rather than an exemption. The tokens are required of the invocation — the script
   name to the end of its backslash-continued command line — never of the fenced body around it, so a
-  comment or a second command line in the block cannot supply what the invocation itself lacks. A block
-  that runs no `ci-status.py` command at all is reported as such;
+  comment or a second command line in the block cannot supply what the invocation itself lacks. **A marked
+  block's command line may carry only the invocation**, so a comment, a chain, a pipe or a substitution ON
+  that line is refused rather than parsed: it sits inside the invocation's own line, which is how it would
+  otherwise supply the missing tokens. Put the comment outside the fence and give a second command its own
+  line. A block that runs no `ci-status.py` command at all is reported as such;
 - every id the table defines has **at least one** block somewhere, so deleting the last copy of a command
   goes red instead of quietly narrowing the check to nothing;
 - **no runnable copy sits outside a marked block.** Prose may still NAME a command — `` `ci-status.py

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -598,8 +598,12 @@ canonical string for that command. `doc-check` enforces four things and they are
 - **no runnable copy sits outside a marked block.** Prose may still NAME a command — `` `ci-status.py
   liveness` `` is a mention, and a reader who runs it verbatim is REFUSED by the tool, which fails closed.
   A `--flag` after the script name and before the closing backtick makes it a copy, and a copy belongs in a
-  block. To recap a command in prose, name it and point at its block; do not respell its flags. The script
-  name is matched as a WHOLE FILE NAME on both sides, so neither a longer name ending in it
+  block. That window has a FLOOR: when no backtick follows the name anywhere in the REST OF THE FILE, it
+  runs to the end of that paragraph — to the end of the file for the last one — rather than to nothing, so
+  a copy with no later backtick, whether inside an opener that never closes or in a backtick-free tail, is
+  still reported instead of exempted, at the disclosed cost of reporting prose in such a tail that only
+  explains a flag. To recap a command in prose, name it and point at its block; do not respell its flags.
+  The script name is matched as a WHOLE FILE NAME on both sides, so neither a longer name ending in it
   (`example-ci-status.py`) nor a different file beginning with it (`ci-status.py.bak`) is a copy of this
   one — this repo ships no script by either name — while a name written inside a code span, or after a
   `/`, still is.

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -561,10 +561,36 @@ nothing was looking. Three checks close that, and **none is optional**:
   union, and the atomic ledger result.
 - **`ci-status.py doc-check` checks every `gh` INVOCATION in this file against the argv the code really
   issues** — *every copy of them*, not just the spec block (a recap that drops `,headRefOid` reconstructs a
-  fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It sweeps
-  **every copy of the `ci-status.py derive` command across every skill doc** for a named required set
-  (`--ledger`, which resolves the row's `effective_required_set`, or an explicit `--required-set`), too — the
-  set that decides a merge must not be droppable by a recap.
+  fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It holds
+  every **marked command block** across every skill doc to the tokens `DOCUMENTED_COMMANDS` requires of it,
+  too — the set that decides a merge must not be droppable by a recap. See "Marked command blocks", below.
+
+##### Marked command blocks — a runnable command copy is DECLARED, never guessed at
+
+**A runnable `ci-status.py` copy lives in a fenced block whose info string is `sh gauntlet-cmd=<id>`.**
+`<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which owns what tokens that command must carry.
+`doc-check` enforces three things and they are not separable:
+
+- every marked block carries every token its id requires, and an id the table does not define is a failure
+  rather than an exemption;
+- every id the table defines has **at least one** block somewhere, so deleting the last copy of a command
+  goes red instead of quietly narrowing the check to nothing;
+- **no runnable copy sits outside a marked block.** Prose may still NAME a command — `` `ci-status.py
+  liveness` `` is a mention, and a reader who runs it verbatim is REFUSED by the tool, which fails closed.
+  A `--flag` after the script name and before the closing backtick makes it a copy, and a copy belongs in a
+  block. To recap a command in prose, name it and point at its block; do not respell its flags.
+
+**Why the marker, rather than a cleverer scan.** The check used to hunt runnable copies in free Markdown,
+which meant deciding — for arbitrary prose — whether a stretch of text was a command or a sentence about
+one. Three PRs grew hand-written CommonMark and shell-word-splitting subsets reaching for that answer, two
+died at their repair cap, and 793 lines of it were deleted unmerged. The marker moves the decision from the
+checker to the author, where it costs one info string and cannot be wrong. Forgetting it is LOUD: the
+unmarked copy is reported, not skipped.
+
+**Illustrating a violation:** use an INVENTED script name, never a real one. A doc that quotes a live line
+as its bad example turns itself into a false-positive generator — the next sweeper searches for the
+example, lands on the correct site, and condemns it. Write `example-tool.py derive --pr 1` (invented; it
+exists nowhere in this repo), not a real invocation.
 
 **TWO refusals are CROSS-SOURCE and no single-fetch filter can state them** — the rollup's `StatusContext`
 **coverage**, and the **AGREEMENT** of the two sources about a check they both report. One `jq` filter sees

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -562,8 +562,9 @@ nothing was looking. Three checks close that, and **none is optional**:
 - **`ci-status.py doc-check` checks every `gh` INVOCATION in this file against the argv the code really
   issues** — *every copy of them*, not just the spec block (a recap that drops `,headRefOid` reconstructs a
   fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It holds
-  every **marked command block** across every skill doc to the tokens `DOCUMENTED_COMMANDS` requires of it,
-  too — the set that decides a merge must not be droppable by a recap. See "Marked command blocks", below.
+  the command every **marked command block** across every skill doc RUNS to the tokens
+  `DOCUMENTED_COMMANDS` requires of it, too — the set that decides a merge must not be droppable by a
+  recap. See "Marked command blocks", below.
 
 ##### Marked command blocks — a runnable command copy is DECLARED, never guessed at
 
@@ -571,8 +572,11 @@ nothing was looking. Three checks close that, and **none is optional**:
 `<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which owns what tokens that command must carry.
 `doc-check` enforces three things and they are not separable:
 
-- every marked block carries every token its id requires, and an id the table does not define is a failure
-  rather than an exemption;
+- the **command a marked block RUNS** carries every token its id requires, and an id the table does not
+  define is a failure rather than an exemption. The tokens are required of the invocation — the script
+  name to the end of its backslash-continued command line — never of the fenced body around it, so a
+  comment or a second command line in the block cannot supply what the invocation itself lacks. A block
+  that runs no `ci-status.py` command at all is reported as such;
 - every id the table defines has **at least one** block somewhere, so deleting the last copy of a command
   goes red instead of quietly narrowing the check to nothing;
 - **no runnable copy sits outside a marked block.** Prose may still NAME a command — `` `ci-status.py

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -570,8 +570,18 @@ nothing was looking. Three checks close that, and **none is optional**:
 
 **A runnable `ci-status.py` copy lives in a fenced block whose info string is `sh gauntlet-cmd=<id>`.**
 `<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which — with one value slot per flag — GENERATES the
-canonical string for that command. `doc-check` enforces three things and they are not separable:
+canonical string for that command. `doc-check` enforces four things and they are not separable:
 
+- **the block is delimited exactly as the renderer delimits it.** It opens at column 0 with that info
+  string and ends at the first line, ALSO AT COLUMN 0, of three or more backticks carrying nothing but
+  optional spaces or tabs. Any other line is BODY and is part of the string compared — including a line
+  that merely starts with backticks, which CommonMark treats as body too because a closing fence may carry
+  no info string — so no text rendering inside the block can escape the equality. An opener with no
+  conforming close before end of file is REPORTED, never dropped: the renderer swallows the rest of the
+  document into such a block, and an opener the checker cannot pair also credits no id, so its command is
+  reported as having no block at all. The close is not permitted the three spaces of indent CommonMark
+  would allow it; an indented close reads as an opener that never closes, and being told to unindent is
+  the intended fail-closed outcome;
 - **a marked block's body EQUALS the generated command**, and an id the table does not define is a failure
   rather than an exemption. Equality is over the joined logical line with runs of whitespace collapsed, so
   a copy may wrap across as many backslash-continued lines as it likes and nothing else differs. The check

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -579,9 +579,11 @@ canonical string for that command. `doc-check` enforces four things and they are
   no info string — so no text rendering inside the block can escape the equality. An opener with no
   conforming close before end of file is REPORTED, never dropped: the renderer swallows the rest of the
   document into such a block, and an opener the checker cannot pair also credits no id, so its command is
-  reported as having no block at all. The close is not permitted the three spaces of indent CommonMark
-  would allow it; an indented close reads as an opener that never closes, and being told to unindent is
-  the intended fail-closed outcome;
+  reported as having no block at all. That report does not depend on the document ending in a newline: a
+  last line carrying none renders as a line like any other, and the scan reads the file the renderer reads
+  — it appends the missing newline once, at the read, so no pattern in it carries an end-of-file case. The
+  close is not permitted the three spaces of indent CommonMark would allow it; an indented close reads as
+  an opener that never closes, and being told to unindent is the intended fail-closed outcome;
 - **a marked block's body EQUALS the generated command**, and an id the table does not define is a failure
   rather than an exemption. Equality is over the joined logical line with runs of whitespace collapsed, so
   a copy may wrap across as many backslash-continued lines as it likes and nothing else differs. The check

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -562,34 +562,35 @@ nothing was looking. Three checks close that, and **none is optional**:
 - **`ci-status.py doc-check` checks every `gh` INVOCATION in this file against the argv the code really
   issues** — *every copy of them*, not just the spec block (a recap that drops `,headRefOid` reconstructs a
   fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It holds
-  the command every **marked command block** across every skill doc RUNS to the tokens
-  `DOCUMENTED_COMMANDS` requires of it, too — the set that decides a merge must not be droppable by a
-  recap. See "Marked command blocks", below.
+  every **marked command block** across every skill doc to the command `ci-status.py` GENERATES for that
+  block's id, too — the set that decides a merge must not be droppable by a recap. See "Marked command
+  blocks", below.
 
-##### Marked command blocks — a runnable command copy is DECLARED, never guessed at
+##### Marked command blocks — the command is GENERATED, and the block must equal it
 
 **A runnable `ci-status.py` copy lives in a fenced block whose info string is `sh gauntlet-cmd=<id>`.**
-`<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which owns what tokens that command must carry.
-`doc-check` enforces three things and they are not separable:
+`<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which — with one value slot per flag — GENERATES the
+canonical string for that command. `doc-check` enforces three things and they are not separable:
 
-- the **command a marked block RUNS** carries every token its id requires, and an id the table does not
-  define is a failure rather than an exemption. **A marked block IS that one invocation** — one
-  backslash-continued command line, beginning with the script name (after an optional `python3` and an
-  optional path) and carrying nothing after it but the command's own arguments. It does not merely CONTAIN
-  the command: a second line, a comment line, a trailing comment, a chain, a pipe or a substitution, and a
-  wrapper that echoes the command or writes it to a file, are all refused rather than parsed, because each
-  is text a reader does not run that would otherwise supply the tokens the invocation itself lacks. Put a
-  comment outside the fence and give a second command its own block. A block that runs no `ci-status.py`
-  command at all is reported as such, in its own words;
+- **a marked block's body EQUALS the generated command**, and an id the table does not define is a failure
+  rather than an exemption. Equality is over the joined logical line with runs of whitespace collapsed, so
+  a copy may wrap across as many backslash-continued lines as it likes and nothing else differs. The check
+  never locates the command inside the body, subtracts text it dislikes, or reasons about shell: a second
+  line, a comment line, a trailing comment, a chain, a pipe, a redirection, a substitution, a wrapper that
+  echoes the command or writes it to a file, and a tail of arguments the subcommand does not take are all
+  simply a different string, refused with no list of them written anywhere. The refusal prints the exact
+  string to paste. Put a comment outside the fence, give a second command its own block, and state an
+  optional flag in the prose beside the block rather than as a `[…]` suffix inside it;
 - every id the table defines has **at least one** block somewhere, so deleting the last copy of a command
   goes red instead of quietly narrowing the check to nothing;
 - **no runnable copy sits outside a marked block.** Prose may still NAME a command — `` `ci-status.py
   liveness` `` is a mention, and a reader who runs it verbatim is REFUSED by the tool, which fails closed.
   A `--flag` after the script name and before the closing backtick makes it a copy, and a copy belongs in a
   block. To recap a command in prose, name it and point at its block; do not respell its flags. The script
-  name is matched whole, so a DIFFERENT tool whose name merely ends in it (`example-ci-status.py` —
-  invented; it appears nowhere in this repo) is not a copy of this one, while a name written inside a code
-  span, or after a `/`, still is.
+  name is matched as a WHOLE FILE NAME on both sides, so neither a longer name ending in it
+  (`example-ci-status.py`) nor a different file beginning with it (`ci-status.py.bak`) is a copy of this
+  one — this repo ships no script by either name — while a name written inside a code span, or after a
+  `/`, still is.
 
 **Why the marker, rather than a cleverer scan.** The check used to hunt runnable copies in free Markdown,
 which meant deciding — for arbitrary prose — whether a stretch of text was a command or a sentence about
@@ -598,10 +599,18 @@ died at their repair cap, and 793 lines of it were deleted unmerged. The marker 
 checker to the author, where it costs one info string and cannot be wrong. Forgetting it is LOUD: the
 unmarked copy is reported, not skipped.
 
-**Illustrating a violation:** use an INVENTED script name, never a real one. A doc that quotes a live line
-as its bad example turns itself into a false-positive generator — the next sweeper searches for the
-example, lands on the correct site, and condemns it. Write `example-tool.py derive --pr 1` (invented; it
-exists nowhere in this repo), not a real invocation.
+**Why EQUALITY, rather than a token check.** Four further rounds asked whether a documented line carried
+the tokens its id requires, and each died to a different piece of text the block's author put beside the
+command. Judging a line by searching it has no fixed point, because the author picks what else is on that
+line and can always add more. Equality has exactly one: the generated string. Do not add a case to it —
+a new carrier means the comparison stopped being equality.
+
+**Illustrating a violation:** use a HYPOTHETICAL script name, never a real one. A doc that quotes a live
+line as its bad example turns itself into a false-positive generator — the next sweeper searches for the
+example, lands on the correct site, and condemns it. Write `example-tool.py derive --pr 1`, not a real
+invocation: this repo ships no script called `example-tool.py`, so the illustration names nothing a reader
+can act on by mistake. That stays true when a fixture quotes the name, which is why the claim is about the
+scripts this repo SHIPS rather than about where the characters appear.
 
 **TWO refusals are CROSS-SOURCE and no single-fetch filter can state them** — the rollup's `StatusContext`
 **coverage**, and the **AGREEMENT** of the two sources about a check they both report. One `jq` filter sees

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -462,16 +462,15 @@
 - Apply `reviewer.md`'s external-review retry budget, then take `runtime-adapter.md`'s owned transition.
   The gate is unchanged; report reviewer routing and retry-profile use through
   `bailout-and-final-report.md`, "Final report". See "The reviewer".
-- **RUN `scripts/ci-status.py required-set --ledger <rundir>/state.jsonl` before CI derivation on every
-  heartbeat.** It groups nonterminal rows by `effective_base`, owns both declaration reads per **distinct
-  base**, their strict parse and union, and the atomic per-row ledger write. A settled group is reused; only
-  an `unknown` group is retried. See `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?".
-- **DERIVE `ci` BY RUNNING `scripts/ci-status.py derive --pr <N> --head-sha <the ledger's> --rundir
-  <rundir> --ledger <rundir>/state.jsonl`, and by NOTHING ELSE.** It fetches, promotes, verifies and
+- **RUN the required-set command before CI derivation on every heartbeat**, exactly as `stage-2-ci.md`,
+  "WHAT WERE WE EXPECTING TO SEE?", spells it. It groups nonterminal rows by `effective_base`, owns both
+  declaration reads per **distinct base**, their strict parse and union, and the atomic per-row ledger
+  write. A settled group is reused; only an `unknown` group is retried.
+- **DERIVE `ci` BY RUNNING the derive command, and by NOTHING ELSE.** It fetches, promotes, verifies and
   decides, and prints the verdict, the `ci` value and the liveness `fingerprint` as JSON (`stage-2-ci.md`,
   "THE DERIVATION IS A COMMAND", which owns the exact invocation — **the required set is NAMED, never
-  defaulted**: `--ledger` resolves the row's `effective_required_set`; the evidence says what
-  showed up, and only the base branch's declared set says what was SUPPOSED to).  **NEVER derive `ci` by
+  defaulted**; the evidence says what showed up, and only the base branch's declared set says what was
+  SUPPOSED to).  **NEVER derive `ci` by
   READING the output of a command and judging it.** That is not a style preference: every rule below was already
   correct when a driver ran `gh pr checks`, saw that no checks were reported, and wrote **`ci = green`** —
   **zero evidence is not green**. A program cannot decide that "no checks" is close enough to "passing".

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -255,9 +255,9 @@ rules keep their own wording; these are illustrations of them, not a second copy
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
 
-   **Settle the base branch's required-check set before any CI derivation:** run `scripts/ci-status.py
-   required-set --ledger <rundir>/state.jsonl`. Run it every heartbeat; the command reuses a settled value and
-   only retries `unknown`. `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?", owns its states and behavior.
+   **Settle the base branch's required-check set before any CI derivation:** run the required-set command
+   as `stage-2-ci.md`, "WHAT WERE WE EXPECTING TO SEE?", spells it. Run it every heartbeat; the command
+   reuses a settled value and only retries `unknown`. That section owns its states and behavior.
 ### Step 2 — Fold in completions
 
 2. **Fold in completions.** For any background task that finished (CI watch → **a HEARTBEAT, not an artifact**:

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -21,7 +21,7 @@ campaign commit to the PR head resets the gate", below, through `scripts/ledger.
 
 **The heartbeat derives `ci` by RUNNING `scripts/ci-status.py`, and by nothing else:**
 
-```sh
+```sh gauntlet-cmd=derive
 python3 <skill>/scripts/ci-status.py derive --pr <N> --head-sha <the LEDGER's head_sha> --rundir <rundir> \
   --ledger <rundir>/state.jsonl
 ```
@@ -169,7 +169,7 @@ cannot see.**
 
 Run the required-set command before CI derivation on every heartbeat:
 
-```sh
+```sh gauntlet-cmd=required-set
 python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl [--repo <owner>/<repo>]
 ```
 
@@ -361,7 +361,7 @@ hold a **RUNNING** row, and that PR is still moving.
 
 ##### THE BOOKKEEPING IS A COMMAND — RUN IT. NEVER APPLY THE DERIVATION BLOCK BY HAND.
 
-```sh
+```sh gauntlet-cmd=liveness
 python3 <skill>/scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr <N> \
   --derive-json <the JSON derive printed, saved to a file — or - for stdin> \
   --machine-action <due | in-flight | none>

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -170,8 +170,13 @@ cannot see.**
 Run the required-set command before CI derivation on every heartbeat:
 
 ```sh gauntlet-cmd=required-set
-python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl [--repo <owner>/<repo>]
+python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl
 ```
+
+It takes one optional flag the block does not spell — **`--repo`, `<owner>/<repo>`** — and it defaults to
+the current checkout's repository. Pass it when the run is not standing in that repository. (A marked
+block's body must EQUAL the command generated for its id, so an optional-flag suffix belongs in this
+sentence rather than inside the fence; see "Marked command blocks" in `ci-derivation-spec.md`.)
 
 The command GROUPS the nonterminal rows by `effective_base` and reads each **distinct** base once: it
 resolves each base through `ledger.py`, URL-encodes it as an API path segment, scopes every GitHub call to

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1440,12 +1440,15 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
 
     The unmarked-copy group is the one this scheme lives or dies on. A marker that only checks what was
     MARKED is strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success
-    — so that rule is pinned in both directions, including the fenced-but-unmarked shape.
+    — so that rule is pinned in both directions, including the fenced-but-unmarked shape. It is pinned
+    against a false positive too: a boundary loose enough to call an invented `example-ci-status.py` a copy
+    of this script sends authors to move someone else's command, and the obvious tightening (reusing the
+    locator's `[\\s/=]` left boundary) excludes the backtick and silences the real check instead.
 
-    The scope group is the second, and it has two halves because scoping to the command LINE is not scoping
-    to the COMMAND: the requirements are read from the invocation, so no other line of the fenced body may
-    hand a mislabelled block the tokens its real command lacks, AND a command line carrying anything besides
-    the command is refused outright instead of parsed. A wrapped command still stays one command.
+    The BLOCK-IS-ONE-INVOCATION group is the second, and it is a group rather than a case because every
+    round of this check died to a different piece of surrounding text: another line, a comment, a tail on
+    the command's own line, and then text to the LEFT of the command. A block does not CONTAIN its command,
+    it IS its command — a wrapped one still being a single command.
     """
     problems: list[str] = []
 
@@ -1509,45 +1512,55 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
                      "a liveness command marked gauntlet-cmd=derive must fail on the SUBCOMMAND token")
     # ...AND CANNOT LIE BY PREFIXING EITHER. A plain substring test accepts a longer word that merely CONTAINS
     # the required token, so a block whose subcommand only ENDS in the required one passed clean. The script
-    # name is checked the same way, one layer earlier: `example-tool.py` (invented — it appears nowhere in
-    # this repo) opens no invocation window at all, which the no-invocation case below pins.
+    # name is checked the same way, one layer earlier: a block opening `example-tool.py` (invented — it
+    # appears nowhere in this repo) is not this script's invocation at all, which the no-invocation case
+    # below pins.
     lying = "python3 s/ci-status.py rederive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl"
     expect_omissions("prefixed", _marked("derive", lying), ("derive",),
                      "a token that is only a SUFFIX of a longer word satisfies nothing")
 
-    # THE TOKENS ARE REQUIRED OF THE COMMAND, NOT OF THE FENCED BODY. Any other line in the block can spell
-    # the tokens the real invocation lacks, and a whole-body search then reads a mislabel as complete. Both
-    # SEPARATE-LINE carriers are pinned here because a comment-stripping fix would pass the first case and
-    # fail the second — neither needs Markdown of any kind, they are just more lines inside the fence. The
-    # same-LINE carriers are the group below, and they are refused rather than reported as an omission.
-    masked = ("# the derive step takes --head-sha <sha> --rundir <dir> ; see above\n"
-              + FULL_COMMANDS["liveness"])
-    expect_omissions("scope-comment", _marked("derive", masked), ("derive", "--head-sha", "--rundir"),
-                     "a COMMENT in the block must not supply tokens the invocation omits")
-    second_line = FULL_COMMANDS["liveness"] + "\ngrep derive --head-sha --rundir notes.txt"
-    expect_omissions("scope-second-line", _marked("derive", second_line),
-                     ("derive", "--head-sha", "--rundir"),
-                     "a second COMMAND LINE in the block must not supply them either")
-
-    # ...AND THE SAME LINE IS A CARRIER TOO, which is why the block is REFUSED rather than dissected. Scoping
-    # to the command line is not scoping to the command: a trailing comment and a `;` chain both sit inside
-    # the window, and both handed a `gauntlet-cmd=derive` block marked over a `liveness` invocation the
-    # tokens it lacks. Cutting each line at an unquoted `#` closes the first carrier and leaves the second,
-    # so what is pinned is the REFUSAL — these blocks must not be reported as merely omitting a token, or the
-    # author is told to add flags to a line that has to lose its tail instead.
-    def expect_extraneous(slug: str, block: str, why: str) -> None:
+    # THE BLOCK IS THE COMMAND — IT DOES NOT MERELY CONTAIN IT, AND EVERY EARLIER ROUND OF THIS CHECK
+    # ASSUMED OTHERWISE. Each carrier below once handed a `gauntlet-cmd=derive` block marked over a
+    # `liveness` invocation the tokens that invocation lacks, and each one killed the round before it: a
+    # whole-body search fell to another LINE; scoping to the command line fell to a tail ON that line;
+    # refusing the tail fell to text to the LEFT of the command. None of them needs Markdown of any kind.
+    # What is pinned is the REFUSAL, never an omission report — an author told to add `--head-sha` to a
+    # block that has to lose its surrounding text makes the block lie harder.
+    def expect_refusal(slug: str, block: str, why: str) -> None:
         marked, _blocks = ci.check_marked_commands(_docs(tmp, slug, _every_command_marked() + block))
         if not any("text the invocation does not consist of" in problem for problem in marked):
             problems.append(
-                f"[marked commands {slug}] {why}: expected the extraneous-text refusal; got {marked!r}"
+                f"[marked commands {slug}] {why}: expected the not-one-invocation refusal; got {marked!r}"
             )
 
-    trailing = FULL_COMMANDS["liveness"] + "   # derive --head-sha abc --rundir run"
-    expect_extraneous("scope-trailing-comment", _marked("derive", trailing),
-                      "a comment on the COMMAND LINE is refused, never read as part of the invocation")
-    chained = FULL_COMMANDS["liveness"] + " ; echo derive --head-sha abc --rundir run"
-    expect_extraneous("scope-chained-command", _marked("derive", chained),
-                      "a second command chained onto the same line is refused too")
+    masked = ("# the derive step takes --head-sha <sha> --rundir <dir> ; see above\n"
+              + FULL_COMMANDS["liveness"])
+    expect_refusal("scope-comment", _marked("derive", masked),
+                   "a COMMENT line in the block is refused, never stripped and then ignored")
+    second_line = FULL_COMMANDS["liveness"] + "\ngrep derive --head-sha --rundir notes.txt"
+    expect_refusal("scope-second-line", _marked("derive", second_line),
+                   "a second COMMAND LINE in the block is refused too")
+    for slug, tail in (
+        ("comment", "   # derive --head-sha abc --rundir run"),
+        ("chained", " ; echo derive --head-sha abc --rundir run"),
+        ("piped", " | grep derive --head-sha --rundir"),
+        ("and-chained", " && echo derive --head-sha abc --rundir run"),
+        ("substitution", " --note $(echo derive --head-sha abc --rundir run)"),
+    ):
+        expect_refusal(f"scope-trailing-{slug}", _marked("derive", FULL_COMMANDS["liveness"] + tail),
+                       f"a trailing {slug} on the COMMAND LINE is refused, not read as part of it")
+
+    # ...AND THE LEFT OF THE TOKEN IS A CARRIER TOO, which is why the rule is that the block IS the command
+    # rather than that its command line has a clean tail. Both of these are complete, correct `derive`
+    # invocations by every token test — and a reader RUNS neither: the first echoes the command as text,
+    # the second writes it to a file. A check that only subtracts text to the RIGHT of the script name calls
+    # both of them clean, because the author chose what sits to the left.
+    echoed = "echo " + FULL_COMMANDS["derive"]
+    expect_refusal("wrapper-echo", _marked("derive", echoed),
+                   "a block that ECHOES the command does not run it, whatever tokens the line spells")
+    heredoc = "cat > run-derive.sh <<'EOF'\n" + FULL_COMMANDS["derive"] + "\nEOF"
+    expect_refusal("wrapper-heredoc", _marked("derive", heredoc),
+                   "a block that WRITES the command to a file does not run it either")
 
     # A `<…>` PLACEHOLDER IS PROSE, NOT SHELL. The live `liveness` copy documents `--machine-action <due |
     # in-flight | none>`, so a refusal reading that `|` as a pipe would condemn a correct block — which is
@@ -1568,10 +1581,11 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     expect("continuation", _every_command_marked(**wrapped_commands), 0, 0,
            "a backslash continuation keeps the flags on later lines inside the same invocation")
 
-    # A BLOCK THAT RUNS NOTHING IS NOT A CHECKED BLOCK — and THE LOCATOR IS WHOLE-TOKEN TOO. This body is a
+    # A BLOCK THAT RUNS NOTHING IS NOT A CHECKED BLOCK, AND IT GETS ITS OWN MESSAGE. This body is a
     # complete, correct derive invocation of a DIFFERENT script (`example-ci-status.py` is invented; it
-    # exists nowhere in this repo). A substring locator would open a window at the script-name SUFFIX and
-    # then find every required token inside it, which is round-1's defect returning one layer up.
+    # exists nowhere in this repo), so a substring test would find every required token in it — round-1's
+    # defect one layer up. It is also the case that separates the two refusals: telling THIS author to
+    # remove text surrounding the invocation names nothing they wrote, because there is no invocation.
     no_command = _marked("derive", "python3 s/example-ci-status.py derive --pr 1 --head-sha abc "
                                    "--rundir run --ledger run/state.jsonl")
     no_invocation = ci.check_marked_commands(_docs(tmp, "no-invocation",
@@ -1607,6 +1621,18 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
            "a copy WRAPPED across two lines is still a copy — the window ends at the backtick, not the line")
     expect("flag-after-span", _every_command_marked() + "\n`ci-status.py derive` needs `--ledger`.\n", 0, 0,
            "a flag in a LATER code span does not make an earlier mention a copy")
+
+    # ...AND THE OCCURRENCE ITSELF IS BOUNDED, IN BOTH DIRECTIONS AT ONCE. These two cases must hold
+    # TOGETHER or the boundary is wrong: a substring scan calls another script's command a copy of this one
+    # and sends the author to move it, while the locator's boundary — which does not admit a backtick —
+    # stops seeing the code-span copies that are nearly all of the real ones, and a forgotten marker then
+    # reads as success. The second case is what proves the first was not bought by silencing the check.
+    other_tool = "\nSee `example-ci-status.py derive --pr 1` for the other tool.\n"
+    expect("prose-other-script", _every_command_marked() + other_tool, 0, 0,
+           "a longer script name that merely ENDS in ours is not a copy of ours (example-ci-status.py is "
+           "invented and appears nowhere in this repo)")
+    expect("prose-copy-backticked", _every_command_marked() + "\nRun `ci-status.py derive --pr 1`.\n", 0, 1,
+           "a copy inside a code span is still a copy — nearly every real one is written that way")
     return problems
 
 
@@ -1698,9 +1724,9 @@ def run(ci, tmp: Path) -> int:
         failures += 1
         print(f"FAIL     {problem}")
     if not marked_command_problems:
-        print(f"ok       {'marked command blocks':32} -> the command a block RUNS carries every token its id "
-              f"requires and nothing besides the invocation, an id with no block fails, and no runnable copy "
-              f"may sit outside a marked block")
+        print(f"ok       {'marked command blocks':32} -> a block IS one invocation carrying every token its "
+              f"id requires and nothing besides, an id with no block fails, and no runnable copy may sit "
+              f"outside a marked block while another script's command is not one")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1354,14 +1354,6 @@ def verdict_doc_cases(ci) -> list[str]:
     return problems
 
 
-FULL_COMMANDS = {
-    "derive": "python3 s/ci-status.py derive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl",
-    "liveness": ("python3 s/ci-status.py liveness --ledger run/state.jsonl --pr 1 "
-                 "--derive-json out.json --machine-action none"),
-    "required-set": "python3 s/ci-status.py required-set --ledger run/state.jsonl",
-}
-
-
 def _docs(tmp: Path, slug: str, body: str) -> Path:
     root = tmp / f"marked-commands-{slug}"
     root.mkdir()
@@ -1373,35 +1365,23 @@ def _marked(cmd_id: str, command: str) -> str:
     return f"```sh gauntlet-cmd={cmd_id}\n{command}\n```\n"
 
 
-def _without(command: str, tokens: tuple[str, ...]) -> str:
-    """Drop the tokens that satisfy ONE requirement, keeping every value the command spelled.
-
-    Keeping values is what isolates the omission: `--ledger` and `run/state.jsonl` satisfy two DIFFERENT
-    requirements of `required-set`, so dropping a flag together with its value would remove two at once and
-    the fixture could no longer say which one the checker actually caught.
-    """
-    def drop(token: str) -> bool:
-        return any(token == t or token.endswith(f"/{t}") or token.startswith(f"{t}=") for t in tokens)
-
-    return " ".join(token for token in command.split() if not drop(token))
-
-
-def _every_command_marked(**override: str) -> str:
-    """Every id gets a block, so the has-at-least-one-block rule never fires for an unrelated reason."""
-    return "\n".join(_marked(i, override.get(i, c)) for i, c in FULL_COMMANDS.items())
-
-
 def documented_commands_agree_with_argparse(ci) -> list[str]:
     """`DOCUMENTED_COMMANDS` and the real CLI parser state ONE contract — reconcile them, never restate them.
 
     Every fixture below drives the table, so not one of them can notice that the table is INCOMPLETE: drop a
-    requirement from a row and the case that would have caught it disappears with it. That gap is the defect
-    this pins. The `liveness` row once omitted `--derive-json` — a flag argparse REQUIRES — so `doc-check`
-    reported the documented invocation as carrying every token it needs, and running it exited 2.
+    flag from a row and the case that would have caught it disappears with it. That gap is the defect this
+    pins. The `liveness` row once omitted `--derive-json` — a flag argparse REQUIRES — so `doc-check`
+    reported the documented invocation as complete, and running it exited 2.
 
-    Both directions matter. A required flag missing from a row is a documented copy the tool refuses; a
-    `--flag` in a row that the parser does not define is a token the doc makes authors write and the tool
-    rejects. Only the parser knows either answer, so ask it rather than writing the answer down twice.
+    ARGPARSE'S ROLE IS SMALL AND ONE-DIRECTIONAL, and the direction is the point. It answers two questions:
+    does every flag the canonical copy SPELLS exist, and is every flag the parser REQUIRES spelled? It does
+    NOT get to say which OPTIONAL flags a documented copy carries — generating every optional the parser
+    defines would make `derive`'s canonical copy spell `--repo`, `--ledger` and `--required-set` at once,
+    an invocation the tool itself rejects. The ROW decides that, and only the parser knows the other two
+    answers, so ask it rather than writing them down twice.
+
+    A flag reachable only as an alternation's LATER member is checked for existence but never emitted, so
+    it is held to the parser without being put in front of a reader.
     """
     problems: list[str] = []
     # `_actions` because argparse exposes no public accessor for its actions or its subparser map — the
@@ -1412,45 +1392,72 @@ def documented_commands_agree_with_argparse(ci) -> list[str]:
         return ["[documented commands] build_parser() exposed no subcommands — the reconciliation below "
                 "would then pass by asking nothing, which is this suite's founding defect"]
 
+    # A SLOT NO ROW NAMES IS A DEAD CONSTANT, and a row naming a flag with no slot is a table the generator
+    # cannot render (`KeyError`, from a doc-check that should have reported it). Reconcile the two sets.
+    named = {alt for wanted in ci.DOCUMENTED_COMMANDS.values() for want in wanted
+             for alt in (want if isinstance(want, tuple) else (want,))}
+    if unslotted := sorted(named - set(ci.FLAG_VALUES)):
+        problems.append(f"[documented commands] DOCUMENTED_COMMANDS names {unslotted}, which FLAG_VALUES "
+                        f"gives no value slot — canonical_command() cannot render that row")
+    if unused := sorted(set(ci.FLAG_VALUES) - named):
+        problems.append(f"[documented commands] FLAG_VALUES holds a slot for {unused}, which no row names "
+                        f"— a value nobody can read is a constant that rots unnoticed")
+
     for cmd_id, wanted in ci.DOCUMENTED_COMMANDS.items():
         parser = subcommands.get(cmd_id)
         if parser is None:
             problems.append(f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS names an id that is not a "
-                            f"subcommand of ci-status.py — known: {sorted(subcommands)}")
+                            f"subcommand of ci-status.py — known: {sorted(subcommands)}. The id IS the "
+                            f"subcommand canonical_command() emits, so the generated copy would not run")
             continue
         documented = {alt for want in wanted for alt in (want if isinstance(want, tuple) else (want,))}
+        spelled = set(ci.canonical_flags(cmd_id))
         defined = {opt for action in parser._actions for opt in action.option_strings}
         required = {action.option_strings[0] for action in parser._actions
                     if action.required and action.option_strings}
-        if missing := sorted(required - documented):
+        if missing := sorted(required - spelled):
             problems.append(
-                f"[documented commands {cmd_id}] argparse REQUIRES {missing}, which no DOCUMENTED_COMMANDS "
-                f"entry names — a documented copy without it passes doc-check and the tool refuses to run it"
+                f"[documented commands {cmd_id}] argparse REQUIRES {missing}, which the canonical copy does "
+                f"not spell — doc-check would call that copy correct and the tool would refuse to run it"
             )
         if unknown := sorted(flag for flag in documented if flag.startswith("--") and flag not in defined):
             problems.append(
-                f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS requires {unknown}, which the "
+                f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS names {unknown}, which the "
                 f"{cmd_id} parser does not define — the doc would make every copy carry a rejected flag"
             )
     return problems
 
 
 def marked_command_cases(ci, tmp: Path) -> list[str]:
-    """Pin the marker contract: what a block's COMMAND must carry, and what may not sit outside one.
+    """Pin the marker contract: a marked block's body IS the generated command, and what may sit outside one.
+
+    THE MECHANISM IS ONE COMPARISON, SO IT IS PINNED ONCE AND THE CARRIERS ARE A TABLE. Four earlier rounds
+    asked whether a block's command CARRIED the tokens its id requires, and each died to a different piece
+    of text the author put beside it. Under equality none of those is a separate mechanism: every one of
+    them is simply a body that differs from the generated string, so they are listed as data rather than
+    written out as ten near-identical cases. The table is kept in full anyway — it is the record of what
+    this check has already been broken by, and a future relaxation has to walk past every row of it.
 
     The unmarked-copy group is the one this scheme lives or dies on. A marker that only checks what was
     MARKED is strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success
-    — so that rule is pinned in both directions, including the fenced-but-unmarked shape. It is pinned
-    against a false positive too: a boundary loose enough to call an invented `example-ci-status.py` a copy
-    of this script sends authors to move someone else's command, and the obvious tightening (reusing the
-    locator's `[\\s/=]` left boundary) excludes the backtick and silences the real check instead.
-
-    The BLOCK-IS-ONE-INVOCATION group is the second, and it is a group rather than a case because every
-    round of this check died to a different piece of surrounding text: another line, a comment, a tail on
-    the command's own line, and then text to the LEFT of the command. A block does not CONTAIN its command,
-    it IS its command — a wrapped one still being a single command.
+    — so that rule is pinned in both directions, including the fenced-but-unmarked shape. Its boundary is
+    pinned in both directions too, and the three cases must hold TOGETHER: a boundary loose on the left
+    calls `example-ci-status.py` a copy of this script, a boundary loose on the right calls
+    `ci-status.py.bak` one (this repo ships no script by either name), and the obvious tightening — a
+    shell-token boundary excluding the backtick — silences the code-span copies that are nearly all the
+    real ones. The backticked case is what proves the other two were not bought by silencing the check.
     """
     problems: list[str] = []
+    # THE FIXTURES ARE GENERATED FROM THE TABLE, exactly as the docs are held to be. A hand-written copy
+    # here would be a fourth statement of the command, free to drift from the three the tool already
+    # reconciles. That the generated string is the one the LIVE docs hold is `doc-check`'s job, run by this
+    # same self-test over the real doc tree — so these cases are not comparing the generator to itself.
+    canon = {cmd_id: ci.canonical_command(cmd_id) for cmd_id in ci.DOCUMENTED_COMMANDS}
+    derive, liveness = canon["derive"], canon["liveness"]
+
+    def every(**override: str) -> str:
+        """Every id gets a block, so the has-at-least-one-block rule never fires for an unrelated reason."""
+        return "\n".join(_marked(i, override[i] if i in override else c) for i, c in canon.items())
 
     def expect(slug: str, body: str, want_marked: int, want_unmarked: int, why: str) -> None:
         root = _docs(tmp, slug, body)
@@ -1462,147 +1469,84 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
                 f"{want_unmarked} unmarked-copy problem(s); got marked={marked!r}, unmarked={unmarked!r}"
             )
 
-    expect("all-present", _every_command_marked(), 0, 0,
-           "a marked block per id, each RUNNING a command that carries every required token, is clean")
+    # THE MECHANISM: the generated command passes, and the ONLY latitude is whitespace.
+    expect("all-present", every(), 0, 0,
+           "a marked block per id, each body EQUAL to that id's generated command, is clean")
 
-    # WHAT A BLOCK MUST CARRY — EVERY entry of EVERY table row, not the one a hand-written case happened to
-    # drop. Driving the table itself is what makes adding a requirement to DOCUMENTED_COMMANDS self-covering:
-    # a row entry the checker does not really enforce fails here the day it is added, with no fixture edit.
-    for cmd_id, wanted in ci.DOCUMENTED_COMMANDS.items():
-        for want in wanted:
-            alternatives = want if isinstance(want, tuple) else (want,)
-            slug = "-".join(alt.lstrip("-") for alt in alternatives)
-            expect(f"omits-{cmd_id}-{slug}",
-                   _every_command_marked(**{cmd_id: _without(FULL_COMMANDS[cmd_id], alternatives)}), 1, 0,
-                   f"a {cmd_id} block missing {' / '.join(alternatives)} is reported")
-    equals = {i: c.replace(" --ledger ", " --ledger=").replace(" --pr ", " --pr=")
-              for i, c in FULL_COMMANDS.items()}
-    expect("equals-form", _every_command_marked(**equals), 0, 0,
-           "argparse's --name=value form satisfies a long-option requirement")
-
-    # `derive` alone accepts either flag for the required set — the drop loop above pins that NEITHER fails,
-    # so pin the other member of the alternation here.
-    alt = FULL_COMMANDS["derive"].replace("--ledger run/state.jsonl", "--required-set unknown")
-    expect("derive-alternation", _every_command_marked(derive=alt), 0, 0,
-           "an explicit --required-set satisfies derive's alternation")
-
-    # A PATH-SUFFIX REQUIREMENT SURVIVES THE WHOLE-TOKEN RULE. `state.jsonl` is required of `required-set`
-    # and every real copy writes it inside a path, so the token rule counts a leading `/` as a token start —
-    # while a LONGER file name is a different file and must not satisfy it.
-    for slug, ledger, want_marked, why in (
-        ("path", "run/state.jsonl", 0, "a <dir>/state.jsonl path satisfies the state.jsonl requirement"),
-        ("bare", "state.jsonl", 0, "an unprefixed state.jsonl satisfies it too"),
-        ("longer", "run/state.jsonl.bak", 1, "state.jsonl.bak is a DIFFERENT file and does not satisfy it"),
-    ):
-        ledger_copy = f"python3 s/ci-status.py required-set --ledger {ledger}"
-        expect(f"suffix-{slug}", _every_command_marked(**{"required-set": ledger_copy}), want_marked, 0, why)
-
-    # A LABEL CANNOT LIE: the script name and subcommand are ordinary required tokens. Assert WHICH tokens
-    # are reported rather than a total — a mislabelled block also misses that id's other flags, and pinning
-    # the count would just re-pin DOCUMENTED_COMMANDS' length in a second place.
-    def expect_omissions(slug: str, block: str, tokens: tuple[str, ...], why: str) -> None:
-        marked, _blocks = ci.check_marked_commands(_docs(tmp, slug, _every_command_marked() + block))
-        missing = [t for t in tokens if not any(f"omits `{t}`" in problem for problem in marked)]
-        if missing:
-            problems.append(
-                f"[marked commands {slug}] {why}: expected the report to name {missing}; got {marked!r}"
-            )
-
-    expect_omissions("mislabelled", _marked("derive", FULL_COMMANDS["liveness"]), ("derive",),
-                     "a liveness command marked gauntlet-cmd=derive must fail on the SUBCOMMAND token")
-    # ...AND CANNOT LIE BY PREFIXING EITHER. A plain substring test accepts a longer word that merely CONTAINS
-    # the required token, so a block whose subcommand only ENDS in the required one passed clean. The script
-    # name is checked the same way, one layer earlier: a block opening `example-tool.py` (invented — it
-    # appears nowhere in this repo) is not this script's invocation at all, which the no-invocation case
-    # below pins.
-    lying = "python3 s/ci-status.py rederive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl"
-    expect_omissions("prefixed", _marked("derive", lying), ("derive",),
-                     "a token that is only a SUFFIX of a longer word satisfies nothing")
-
-    # THE BLOCK IS THE COMMAND — IT DOES NOT MERELY CONTAIN IT, AND EVERY EARLIER ROUND OF THIS CHECK
-    # ASSUMED OTHERWISE. Each carrier below once handed a `gauntlet-cmd=derive` block marked over a
-    # `liveness` invocation the tokens that invocation lacks, and each one killed the round before it: a
-    # whole-body search fell to another LINE; scoping to the command line fell to a tail ON that line;
-    # refusing the tail fell to text to the LEFT of the command. None of them needs Markdown of any kind.
-    # What is pinned is the REFUSAL, never an omission report — an author told to add `--head-sha` to a
-    # block that has to lose its surrounding text makes the block lie harder.
-    def expect_refusal(slug: str, block: str, why: str) -> None:
-        marked, _blocks = ci.check_marked_commands(_docs(tmp, slug, _every_command_marked() + block))
-        if not any("text the invocation does not consist of" in problem for problem in marked):
-            problems.append(
-                f"[marked commands {slug}] {why}: expected the not-one-invocation refusal; got {marked!r}"
-            )
-
-    masked = ("# the derive step takes --head-sha <sha> --rundir <dir> ; see above\n"
-              + FULL_COMMANDS["liveness"])
-    expect_refusal("scope-comment", _marked("derive", masked),
-                   "a COMMENT line in the block is refused, never stripped and then ignored")
-    second_line = FULL_COMMANDS["liveness"] + "\ngrep derive --head-sha --rundir notes.txt"
-    expect_refusal("scope-second-line", _marked("derive", second_line),
-                   "a second COMMAND LINE in the block is refused too")
-    for slug, tail in (
-        ("comment", "   # derive --head-sha abc --rundir run"),
-        ("chained", " ; echo derive --head-sha abc --rundir run"),
-        ("piped", " | grep derive --head-sha --rundir"),
-        ("and-chained", " && echo derive --head-sha abc --rundir run"),
-        ("substitution", " --note $(echo derive --head-sha abc --rundir run)"),
-    ):
-        expect_refusal(f"scope-trailing-{slug}", _marked("derive", FULL_COMMANDS["liveness"] + tail),
-                       f"a trailing {slug} on the COMMAND LINE is refused, not read as part of it")
-
-    # ...AND THE LEFT OF THE TOKEN IS A CARRIER TOO, which is why the rule is that the block IS the command
-    # rather than that its command line has a clean tail. Both of these are complete, correct `derive`
-    # invocations by every token test — and a reader RUNS neither: the first echoes the command as text,
-    # the second writes it to a file. A check that only subtracts text to the RIGHT of the script name calls
-    # both of them clean, because the author chose what sits to the left.
-    echoed = "echo " + FULL_COMMANDS["derive"]
-    expect_refusal("wrapper-echo", _marked("derive", echoed),
-                   "a block that ECHOES the command does not run it, whatever tokens the line spells")
-    heredoc = "cat > run-derive.sh <<'EOF'\n" + FULL_COMMANDS["derive"] + "\nEOF"
-    expect_refusal("wrapper-heredoc", _marked("derive", heredoc),
-                   "a block that WRITES the command to a file does not run it either")
-
-    # A `<…>` PLACEHOLDER IS PROSE, NOT SHELL. The live `liveness` copy documents `--machine-action <due |
-    # in-flight | none>`, so a refusal reading that `|` as a pipe would condemn a correct block — which is
-    # why `_extraneous` blanks placeholders first, and why the blanking must stay LOCAL to it. Requirements
-    # are read from the original window, so `--ledger <rundir>/state.jsonl` keeps its `state.jsonl` suffix.
-    placeheld = {
-        "liveness": FULL_COMMANDS["liveness"].replace("--machine-action none",
-                                                      "--machine-action <due | in-flight | none>"),
-        "required-set": "python3 s/ci-status.py required-set --ledger <rundir>/state.jsonl",
-    }
-    expect("placeholder", _every_command_marked(**placeheld), 0, 0,
-           "a `|` inside a placeholder is a documented choice, and a placeholder path keeps its suffix")
-
-    # A CONTINUED COMMAND IS ONE COMMAND. The live derive and liveness copies wrap, and a window that ended
-    # at the newline would lose `--ledger` from one and `--derive-json`/`--machine-action` from the other —
+    # A CONTINUED COMMAND IS ONE COMMAND. The live derive and liveness copies wrap, and a byte-exact
+    # comparison would condemn all three blocks over the `\` and the indent that continues the line —
     # turning correct blocks red, which is how a check gets deleted by the next person in a hurry.
-    wrapped_commands = {i: c.replace(" --ledger ", " \\\n    --ledger ") for i, c in FULL_COMMANDS.items()}
-    expect("continuation", _every_command_marked(**wrapped_commands), 0, 0,
-           "a backslash continuation keeps the flags on later lines inside the same invocation")
+    wrapped = {i: c.replace(" --ledger ", " \\\n    --ledger ") for i, c in canon.items()}
+    expect("continuation", every(**wrapped), 0, 0,
+           "a backslash continuation joins into the same one command")
+    spaced = {i: "  " + c.replace(" --ledger ", "   --ledger  ") for i, c in canon.items()}
+    expect("whitespace-runs", every(**spaced), 0, 0,
+           "runs of whitespace collapse, so indentation and alignment are not a difference")
 
-    # A BLOCK THAT RUNS NOTHING IS NOT A CHECKED BLOCK, AND IT GETS ITS OWN MESSAGE. This body is a
-    # complete, correct derive invocation of a DIFFERENT script (`example-ci-status.py` is invented; it
-    # exists nowhere in this repo), so a substring test would find every required token in it — round-1's
-    # defect one layer up. It is also the case that separates the two refusals: telling THIS author to
-    # remove text surrounding the invocation names nothing they wrote, because there is no invocation.
-    no_command = _marked("derive", "python3 s/example-ci-status.py derive --pr 1 --head-sha abc "
-                                   "--rundir run --ledger run/state.jsonl")
-    no_invocation = ci.check_marked_commands(_docs(tmp, "no-invocation",
-                                                   _every_command_marked() + no_command))[0]
-    if not any("RUNS no `ci-status.py` command" in problem for problem in no_invocation):
-        problems.append(
-            f"[marked commands no-invocation] a block whose body runs no ci-status.py command must say so "
-            f"plainly; got {no_invocation!r}"
-        )
+    # EVERY CARRIER THAT EVER BROKE THIS CHECK, AS DATA. Each row is a `gauntlet-cmd=derive` block whose
+    # body is not derive's generated command, so each must be reported — and none of them is named
+    # anywhere in `ci-status.py`, which is the property this table exists to demonstrate: the carriers are
+    # refused by construction, not by enumeration. Adding the block to a clean set means the ONE expected
+    # problem is that block, never a missing-id complaint.
+    carriers: tuple[tuple[str, str, str], ...] = (
+        ("other-script", derive.replace("/ci-status.py ", "/not-ci-status.py "),
+         "a different script — this repo ships none called `not-ci-status.py` — is not this command"),
+        ("prefixed-subcommand", derive.replace(" derive ", " rederive "),
+         "a subcommand that merely ENDS in the required one is a different command"),
+        ("comment-line", "# the derive step takes --head-sha <sha> --rundir <dir>\n" + liveness,
+         "a whole-line comment cannot supply what the invocation beside it lacks"),
+        ("second-line", liveness + "\ngrep derive --head-sha --rundir notes.txt",
+         "a second command line cannot supply it either"),
+        # THE COLLAPSE MUST NOT MERGE LINES, and this is the case that says so: the two lines CONCATENATE
+        # to the canonical string, so a comparison over the whole body joined would call them correct. A
+        # reader running this block runs an incomplete `derive` and then a `--rundir` that is no command.
+        ("split-lines", derive.replace(" --rundir ", "\n--rundir "),
+         "two lines that CONCATENATE to the command are still not one command"),
+        ("trailing-comment", liveness + "   # derive --head-sha abc --rundir run",
+         "nor a trailing comment on the command's own line"),
+        ("chained", liveness + " ; echo derive --head-sha abc --rundir run", "nor a `;` chain"),
+        ("piped", liveness + " | grep derive --head-sha --rundir", "nor a pipe"),
+        ("and-chained", liveness + " && echo derive --head-sha abc --rundir run", "nor an `&&` chain"),
+        ("substitution", liveness + " --note $(echo derive --head-sha abc --rundir run)",
+         "nor a `$(…)` substitution"),
+        ("redirection", liveness + " > /tmp/derive --head-sha abc --rundir run",
+         "nor a `>` redirection, whose OPERAND once supplied both the id and the flags it was missing"),
+        ("mislabelled-tail", liveness + " derive --head-sha abc --rundir run",
+         "nor a tail of arguments the subcommand does not take, which argparse exits 2 on"),
+        ("echo-wrapper", "echo " + derive,
+         "a block that ECHOES the command does not run it, whatever the line spells"),
+        ("heredoc", "cat > run-derive.sh <<'EOF'\n" + derive + "\nEOF",
+         "a block that WRITES the command to a file does not run it either"),
+        ("mislabelled", liveness,
+         "a liveness invocation marked gauntlet-cmd=derive is held to DERIVE's command"),
+        ("omits-flag", derive.replace(" --rundir <rundir>", ""),
+         "a flag the tool requires, dropped, is a different string"),
+        ("extra-flag", derive + " --repo <owner>/<repo>",
+         "and so is an extra one, even a real optional the parser accepts"),
+        ("bracketed-optional", derive + " [--repo <owner>/<repo>]",
+         "and so is a bracketed-optional suffix, which is literal text in a body that must BE the command"),
+        ("equals-form", derive.replace(" --ledger ", " --ledger="),
+         "argparse takes --name=value, but the doc shows ONE spelling and the block must be it"),
+        ("placeholder-edited", derive.replace("<rundir>", "<the run dir>"),
+         "a re-worded placeholder is a second spelling of a value slot the table owns"),
+    )
+    for slug, body, why in carriers:
+        expect(f"carrier-{slug}", every() + _marked("derive", body), 1, 0, why)
+
+    # THE REFUSAL STATES THE ONE REPAIR — the exact string to paste. A message that only says what is wrong
+    # gets the block edited until it passes; this one leaves nothing to decide.
+    report, _blocks = ci.check_marked_commands(_docs(tmp, "message", every() + _marked("derive", liveness)))
+    if not any(derive in problem for problem in report):
+        problems.append(f"[marked commands message] a refused block must be told the exact command to hold; "
+                        f"got {report!r}")
 
     # AN UNKNOWN ID IS REPORTED WHATEVER ITS SPELLING. The id pattern must not decide which ids exist: an id
     # the pattern REJECTS is not a marked block at all, so this branch never fires and the author is instead
     # told to move a block that already sits inside a marked fence.
     for n, spelling in enumerate(("nonesuch", "nonesuch2", "NONESUCH", "none_such", "9")):
-        expect(f"unknown-id-{n}", _every_command_marked() + _marked(spelling, FULL_COMMANDS["derive"]), 1, 0,
+        expect(f"unknown-id-{n}", every() + _marked(spelling, derive), 1, 0,
                f"the undefined id `{spelling}` is a failure, never an exemption")
-    expect("trailing-space", _every_command_marked().replace("=derive\n", "=derive  \n"), 0, 0,
+    expect("trailing-space", every().replace("=derive\n", "=derive  \n"), 0, 0,
            "CommonMark drops trailing info-string spaces, so a marked block stays marked despite them")
 
     # A CHECK THAT FINDS NOTHING MUST NEVER PASS.
@@ -1610,28 +1554,33 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
            "every id with zero blocks is reported")
 
     # WHAT MAY SIT OUTSIDE A BLOCK. Prose NAMING a command is fine; a runnable copy is not.
-    expect("prose-mention", _every_command_marked() + "\nWritten by `ci-status.py liveness`.\n", 0, 0,
+    expect("prose-mention", every() + "\nWritten by `ci-status.py liveness`.\n", 0, 0,
            "prose naming the command without a flag is a mention, not a copy")
-    expect("prose-copy", _every_command_marked() + "\nRun `ci-status.py required-set --ledger x`.\n", 0, 1,
+    expect("prose-copy", every() + "\nRun `ci-status.py required-set --ledger x`.\n", 0, 1,
            "a flag before the closing backtick makes it a runnable copy outside a block")
-    expect("fenced-unmarked", _every_command_marked() + "\n```sh\n" + FULL_COMMANDS["derive"] + "\n```\n",
-           0, 1, "a fenced block WITHOUT the marker is reported, not silently skipped")
-    wrapped = "\nRun `scripts/ci-status.py\nrequired-set --ledger run/state.jsonl`.\n"
-    expect("prose-copy-wrapped", _every_command_marked() + wrapped, 0, 1,
+    expect("fenced-unmarked", every() + "\n```sh\n" + derive + "\n```\n", 0, 1,
+           "a fenced block WITHOUT the marker is reported, not silently skipped")
+    expect("prose-copy-wrapped", every() + "\nRun `scripts/ci-status.py\nrequired-set --ledger x`.\n", 0, 1,
            "a copy WRAPPED across two lines is still a copy — the window ends at the backtick, not the line")
-    expect("flag-after-span", _every_command_marked() + "\n`ci-status.py derive` needs `--ledger`.\n", 0, 0,
+    expect("flag-after-span", every() + "\n`ci-status.py derive` needs `--ledger`.\n", 0, 0,
            "a flag in a LATER code span does not make an earlier mention a copy")
+    # A flag named in PROSE, with no script name before it in the same window, is not a copy — which is
+    # what lets `stage-2-ci.md` state `required-set`'s optional `--repo` beside its block instead of in it.
+    expect("prose-optional-flag", every() + "\nIt also takes `--repo`, `<owner>/<repo>`.\n", 0, 0,
+           "prose naming a FLAG without the script name in the same window is not a copy")
 
-    # ...AND THE OCCURRENCE ITSELF IS BOUNDED, IN BOTH DIRECTIONS AT ONCE. These two cases must hold
-    # TOGETHER or the boundary is wrong: a substring scan calls another script's command a copy of this one
-    # and sends the author to move it, while the locator's boundary — which does not admit a backtick —
-    # stops seeing the code-span copies that are nearly all of the real ones, and a forgotten marker then
-    # reads as success. The second case is what proves the first was not bought by silencing the check.
-    other_tool = "\nSee `example-ci-status.py derive --pr 1` for the other tool.\n"
-    expect("prose-other-script", _every_command_marked() + other_tool, 0, 0,
-           "a longer script name that merely ENDS in ours is not a copy of ours (example-ci-status.py is "
-           "invented and appears nowhere in this repo)")
-    expect("prose-copy-backticked", _every_command_marked() + "\nRun `ci-status.py derive --pr 1`.\n", 0, 1,
+    # ...AND THE OCCURRENCE ITSELF IS BOUNDED, ON BOTH SIDES AT ONCE. These three cases must hold TOGETHER
+    # or the boundary is wrong: a scan loose on the left calls another tool's command a copy of this one, a
+    # scan loose on the right does the same for a backup of a different file, and the tightening that
+    # excludes the backtick stops seeing the code-span copies that are nearly all the real ones — a
+    # forgotten marker would then read as success. The last case proves the first two were not bought by
+    # silencing the check. Both hypothetical names are safe to write here: this repo ships no script called
+    # either, which a `find` for those file names confirms and which this fixture cannot change.
+    expect("prose-other-script", every() + "\nSee `example-ci-status.py derive --pr 1` for the other tool.\n",
+           0, 0, "a longer script name that merely ENDS in ours is not a copy of ours")
+    expect("prose-backup-file", every() + "\nSee `ci-status.py.bak derive --pr 1` for the old copy.\n", 0, 0,
+           "a DIFFERENT file whose name merely BEGINS with ours is not a copy of ours either")
+    expect("prose-copy-backticked", every() + "\nRun `ci-status.py derive --pr 1`.\n", 0, 1,
            "a copy inside a code span is still a copy — nearly every real one is written that way")
     return problems
 
@@ -1724,9 +1673,9 @@ def run(ci, tmp: Path) -> int:
         failures += 1
         print(f"FAIL     {problem}")
     if not marked_command_problems:
-        print(f"ok       {'marked command blocks':32} -> a block IS one invocation carrying every token its "
-              f"id requires and nothing besides, an id with no block fails, and no runnable copy may sit "
-              f"outside a marked block while another script's command is not one")
+        print(f"ok       {'marked command blocks':32} -> a block's body EQUALS the command generated for its "
+              f"id, every carrier that ever broke this check is refused, an id with no block fails, and no "
+              f"runnable copy may sit outside a marked block while another script's command is not one")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1438,6 +1438,11 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     written out as ten near-identical cases. The table is kept in full anyway — it is the record of what
     this check has already been broken by, and a future relaxation has to walk past every row of it.
 
+    WHERE THE BLOCK ENDS IS PART OF THE COMPARISON, so the fence group is pinned beside the carriers. The
+    body compared has to be the body the RENDERER shows: a delimiter looser than the rendered block lets
+    text sit inside a checked block without ever reaching the equality, which is the same escape the
+    carriers buy by other means.
+
     The unmarked-copy group is the one this scheme lives or dies on. A marker that only checks what was
     MARKED is strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success
     — so that rule is pinned in both directions, including the fenced-but-unmarked shape. Its boundary is
@@ -1552,6 +1557,30 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     # A CHECK THAT FINDS NOTHING MUST NEVER PASS.
     expect("no-blocks", "nothing here\n", len(ci.DOCUMENTED_COMMANDS), 0,
            "every id with zero blocks is reported")
+
+    # WHERE THE BLOCK ENDS IS PART OF THE COMPARISON, because the body is whatever the RENDERER puts inside
+    # the fence. A close ending at the first line merely STARTING with backticks would hand the author the
+    # one carrier equality cannot refuse: text after such a line renders inside the block and never reaches
+    # the comparison, and an opener with no close at all vanishes from the checker entirely while the
+    # renderer swallows the rest of the file into it. Both shapes are the SAME defect — a delimiter looser
+    # than the rendered block — so both are pinned here, against the one positive rule that fixes them.
+    hidden = _marked("derive", derive).replace("\n```\n", "\n``` x\nand this line renders inside it\n```\n")
+    expect("close-trailing-info", every() + hidden, 1, 0,
+           "a line with anything after the backticks is BODY, so the text it hides is part of the comparison")
+    expect("close-trailing-spaces", every().replace("\n```\n", "\n```   \n"), 0, 0,
+           "spaces and tabs after the backticks are all a conforming close may carry, and it still closes")
+    expect("unterminated-opener", every() + f"```sh gauntlet-cmd=derive\n{derive}\n", 1, 1,
+           "an opener with no close is reported, and exempts nothing behind it from the unmarked-copy rule")
+    # THE SHARP ONE: an unterminated block holding an INCOMPLETE invocation. Its body carries no long
+    # option, so the unmarked-copy heuristic is silent by design, and before the opener-anchored scan the
+    # marked check was silent too — a documented command that does not run, inside a block claiming to be
+    # checked, reported by nothing at all.
+    incomplete = f"{ci.COMMAND_PREFIX} derive"
+    expect("unterminated-no-long-option", every() + f"```sh gauntlet-cmd=derive\n{incomplete}\n", 1, 0,
+           "the broken fence is reported on its own, without help from the flag heuristic")
+    others = "\n".join(_marked(i, c) for i, c in canon.items() if i != "derive")
+    expect("unterminated-only-block", others + f"```sh gauntlet-cmd=derive\n{incomplete}\n", 2, 0,
+           "a block the checker never read cannot credit its id, so zero-blocks fires beside the broken fence")
 
     # WHAT MAY SIT OUTSIDE A BLOCK. Prose NAMING a command is fine; a runnable copy is not.
     expect("prose-mention", every() + "\nWritten by `ci-status.py liveness`.\n", 0, 0,
@@ -1674,8 +1703,9 @@ def run(ci, tmp: Path) -> int:
         print(f"FAIL     {problem}")
     if not marked_command_problems:
         print(f"ok       {'marked command blocks':32} -> a block's body EQUALS the command generated for its "
-              f"id, every carrier that ever broke this check is refused, an id with no block fails, and no "
-              f"runnable copy may sit outside a marked block while another script's command is not one")
+              f"id, every carrier that ever broke this check is refused, only a conforming close ends the "
+              f"body and an opener without one is reported, an id with no block fails, and no runnable copy "
+              f"may sit outside a marked block while another script's command is not one")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1442,8 +1442,10 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     MARKED is strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success
     — so that rule is pinned in both directions, including the fenced-but-unmarked shape.
 
-    The scope group is the second: the requirements are read from the invocation, so a fenced body cannot
-    hand a mislabelled block the tokens its real command lacks, and a wrapped command stays one command.
+    The scope group is the second, and it has two halves because scoping to the command LINE is not scoping
+    to the COMMAND: the requirements are read from the invocation, so no other line of the fenced body may
+    hand a mislabelled block the tokens its real command lacks, AND a command line carrying anything besides
+    the command is refused outright instead of parsed. A wrapped command still stays one command.
     """
     problems: list[str] = []
 
@@ -1515,8 +1517,9 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
 
     # THE TOKENS ARE REQUIRED OF THE COMMAND, NOT OF THE FENCED BODY. Any other line in the block can spell
     # the tokens the real invocation lacks, and a whole-body search then reads a mislabel as complete. Both
-    # carriers are pinned because a comment-stripping fix would pass the first case and fail the second —
-    # neither needs Markdown of any kind, they are just more lines inside the fence.
+    # SEPARATE-LINE carriers are pinned here because a comment-stripping fix would pass the first case and
+    # fail the second — neither needs Markdown of any kind, they are just more lines inside the fence. The
+    # same-LINE carriers are the group below, and they are refused rather than reported as an omission.
     masked = ("# the derive step takes --head-sha <sha> --rundir <dir> ; see above\n"
               + FULL_COMMANDS["liveness"])
     expect_omissions("scope-comment", _marked("derive", masked), ("derive", "--head-sha", "--rundir"),
@@ -1525,6 +1528,38 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     expect_omissions("scope-second-line", _marked("derive", second_line),
                      ("derive", "--head-sha", "--rundir"),
                      "a second COMMAND LINE in the block must not supply them either")
+
+    # ...AND THE SAME LINE IS A CARRIER TOO, which is why the block is REFUSED rather than dissected. Scoping
+    # to the command line is not scoping to the command: a trailing comment and a `;` chain both sit inside
+    # the window, and both handed a `gauntlet-cmd=derive` block marked over a `liveness` invocation the
+    # tokens it lacks. Cutting each line at an unquoted `#` closes the first carrier and leaves the second,
+    # so what is pinned is the REFUSAL — these blocks must not be reported as merely omitting a token, or the
+    # author is told to add flags to a line that has to lose its tail instead.
+    def expect_extraneous(slug: str, block: str, why: str) -> None:
+        marked, _blocks = ci.check_marked_commands(_docs(tmp, slug, _every_command_marked() + block))
+        if not any("text the invocation does not consist of" in problem for problem in marked):
+            problems.append(
+                f"[marked commands {slug}] {why}: expected the extraneous-text refusal; got {marked!r}"
+            )
+
+    trailing = FULL_COMMANDS["liveness"] + "   # derive --head-sha abc --rundir run"
+    expect_extraneous("scope-trailing-comment", _marked("derive", trailing),
+                      "a comment on the COMMAND LINE is refused, never read as part of the invocation")
+    chained = FULL_COMMANDS["liveness"] + " ; echo derive --head-sha abc --rundir run"
+    expect_extraneous("scope-chained-command", _marked("derive", chained),
+                      "a second command chained onto the same line is refused too")
+
+    # A `<…>` PLACEHOLDER IS PROSE, NOT SHELL. The live `liveness` copy documents `--machine-action <due |
+    # in-flight | none>`, so a refusal reading that `|` as a pipe would condemn a correct block — which is
+    # why `_extraneous` blanks placeholders first, and why the blanking must stay LOCAL to it. Requirements
+    # are read from the original window, so `--ledger <rundir>/state.jsonl` keeps its `state.jsonl` suffix.
+    placeheld = {
+        "liveness": FULL_COMMANDS["liveness"].replace("--machine-action none",
+                                                      "--machine-action <due | in-flight | none>"),
+        "required-set": "python3 s/ci-status.py required-set --ledger <rundir>/state.jsonl",
+    }
+    expect("placeholder", _every_command_marked(**placeheld), 0, 0,
+           "a `|` inside a placeholder is a documented choice, and a placeholder path keeps its suffix")
 
     # A CONTINUED COMMAND IS ONE COMMAND. The live derive and liveness copies wrap, and a window that ended
     # at the newline would lose `--ledger` from one and `--derive-json`/`--machine-action` from the other —
@@ -1664,7 +1699,8 @@ def run(ci, tmp: Path) -> int:
         print(f"FAIL     {problem}")
     if not marked_command_problems:
         print(f"ok       {'marked command blocks':32} -> the command a block RUNS carries every token its id "
-              f"requires, an id with no block fails, and no runnable copy may sit outside a marked block")
+              f"requires and nothing besides the invocation, an id with no block fails, and no runnable copy "
+              f"may sit outside a marked block")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1354,93 +1354,102 @@ def verdict_doc_cases(ci) -> list[str]:
     return problems
 
 
-def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
-    """Pin standalone and ``--name=value`` forms in all three documentation validators."""
+FULL_COMMANDS = {
+    "derive": "python3 s/ci-status.py derive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl",
+    "liveness": "python3 s/ci-status.py liveness --ledger run/state.jsonl --pr 1 --machine-action none",
+    "required-set": "python3 s/ci-status.py required-set --ledger run/state.jsonl",
+}
+
+
+def _docs(tmp: Path, slug: str, body: str) -> Path:
+    root = tmp / f"marked-commands-{slug}"
+    root.mkdir()
+    (root / "commands.md").write_text(body, encoding="utf-8")
+    return root
+
+
+def _marked(cmd_id: str, command: str) -> str:
+    return f"```sh gauntlet-cmd={cmd_id}\n{command}\n```\n"
+
+
+def _every_command_marked(**override: str) -> str:
+    """Every id gets a block, so the has-at-least-one-block rule never fires for an unrelated reason."""
+    return "\n".join(_marked(i, override.get(i, c)) for i, c in FULL_COMMANDS.items())
+
+
+def marked_command_cases(ci, tmp: Path) -> list[str]:
+    """Pin the marker contract: what a block must carry, and what may not sit outside one.
+
+    The third group is the one this scheme lives or dies on. A marker that only checks what was MARKED is
+    strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success — so the
+    unmarked-copy rule is pinned in both directions, including the fenced-but-unmarked shape.
+    """
     problems: list[str] = []
-    cases = [
-        (
-            "derive",
-            ci.check_derive_copies,
-            "ci-status.py derive --pr=1 --required-set=unknown",
-            "ci-status.py derive --pr=1",
-            "--practical",
-            (
-                "--pr/foo=1",
-                "--pr:1",
-                "--pr=1 --required-set/foo=unknown",
-                "--pr=1 --required-set:unknown",
-            ),
-        ),
-        (
-            "liveness",
-            ci.check_liveness_copies,
-            "ci-status.py liveness --ledger=run/state.jsonl --pr=1 --machine-action=none",
-            "ci-status.py liveness --ledger=run/state.jsonl --pr=1",
-            "--ledger-file",
-            (
-                "--ledger/run/state.jsonl --pr=1 --machine-action=none",
-                "--ledger:run/state.jsonl --pr=1 --machine-action=none",
-                "--ledger=run/state.jsonl --pr=1 --machine-action/foo=none",
-                "--ledger=run/state.jsonl --pr=1 --machine-action:none",
-            ),
-        ),
-        (
-            "required-set",
-            ci.check_required_set_copies,
-            "ci-status.py required-set --ledger=run/state.jsonl",
-            "ci-status.py required-set --ledger=",
-            "--ledger-file",
-            (
-                "--ledger/run/state.jsonl",
-                "--ledger:run/state.jsonl",
-            ),
-        ),
-    ]
-    for name, check, valid, missing, lookalike, invalid_forms in cases:
-        valid_root = tmp / f"documentation-options-{name}-valid"
-        valid_root.mkdir()
-        (valid_root / "commands.md").write_text(f"`{valid}`\n", encoding="utf-8")
-        found, copies = check(valid_root)
-        if found or copies != ["commands.md:1"]:
+
+    def expect(slug: str, body: str, want_marked: int, want_unmarked: int, why: str) -> None:
+        root = _docs(tmp, slug, body)
+        marked, _blocks = ci.check_marked_commands(root)
+        unmarked = ci.check_unmarked_commands(root)
+        if len(marked) != want_marked or len(unmarked) != want_unmarked:
             problems.append(
-                f"[documentation options {name}:valid] expected one accepted copy; "
-                f"got copies={copies!r}, problems={found!r}"
+                f"[marked commands {slug}] {why}: expected {want_marked} marked-block problem(s) and "
+                f"{want_unmarked} unmarked-copy problem(s); got marked={marked!r}, unmarked={unmarked!r}"
             )
 
-        missing_root = tmp / f"documentation-options-{name}-missing"
-        missing_root.mkdir()
-        (missing_root / "commands.md").write_text(f"`{missing}`\n", encoding="utf-8")
-        found, copies = check(missing_root)
-        if len(found) != 1 or copies != ["commands.md:1"]:
-            problems.append(
-                f"[documentation options {name}:missing] expected one reported copy; "
-                f"got copies={copies!r}, problems={found!r}"
-            )
+    expect("all-present", _every_command_marked(), 0, 0,
+           "a marked block per id, each carrying every required token, is clean")
 
-        lookalike_root = tmp / f"documentation-options-{name}-lookalike"
-        lookalike_root.mkdir()
-        (lookalike_root / "commands.md").write_text(
-            f"`ci-status.py {name} {lookalike}=value`\n", encoding="utf-8"
+    # WHAT A BLOCK MUST CARRY — one omission per id, and the `--name=value` form counts as present.
+    for cmd_id, command in FULL_COMMANDS.items():
+        dropped = " ".join(t for t in command.split() if not t.startswith("--machine-action")
+                           and not (cmd_id == "derive" and t == "--ledger")
+                           and not (cmd_id == "required-set" and t == "--ledger"))
+        if dropped != command:
+            expect(f"omits-{cmd_id}", _every_command_marked(**{cmd_id: dropped}), 1, 0,
+                   f"a {cmd_id} block missing a required token is reported")
+    equals = {i: c.replace(" --ledger ", " --ledger=").replace(" --pr ", " --pr=")
+              for i, c in FULL_COMMANDS.items()}
+    expect("equals-form", _every_command_marked(**equals), 0, 0,
+           "argparse's --name=value form satisfies a long-option requirement")
+
+    # `derive` alone accepts either flag for the required set — pin BOTH members of the alternation.
+    alt = FULL_COMMANDS["derive"].replace("--ledger run/state.jsonl", "--required-set unknown")
+    expect("derive-alternation", _every_command_marked(derive=alt), 0, 0,
+           "an explicit --required-set satisfies derive's alternation")
+    neither = FULL_COMMANDS["derive"].replace(" --ledger run/state.jsonl", "")
+    expect("derive-neither", _every_command_marked(derive=neither), 1, 0,
+           "derive naming NEITHER --ledger nor --required-set is reported")
+
+    # A LABEL CANNOT LIE: the script name and subcommand are ordinary required tokens. Assert the SUBCOMMAND
+    # is among what is reported rather than a total — a mislabelled block also misses that id's other flags,
+    # and pinning the count would just re-pin DOCUMENTED_COMMANDS' length in a second place.
+    mislabelled = _docs(tmp, "mislabelled", _every_command_marked()
+                        + _marked("derive", FULL_COMMANDS["liveness"]))
+    marked, _blocks = ci.check_marked_commands(mislabelled)
+    if not any("omits `derive`" in problem for problem in marked):
+        problems.append(
+            f"[marked commands mislabelled] a liveness command marked gauntlet-cmd=derive must fail on the "
+            f"SUBCOMMAND token, so a block cannot lie about which command it is; got {marked!r}"
         )
-        found, copies = check(lookalike_root)
-        if len(found) != 1 or copies:
-            problems.append(
-                f"[documentation options {name}:lookalike] expected no accepted copy; "
-                f"got copies={copies!r}, problems={found!r}"
-            )
+    expect("unknown-id", _every_command_marked() + _marked("nonesuch", FULL_COMMANDS["derive"]), 1, 0,
+           "an id DOCUMENTED_COMMANDS does not define is a failure, never an exemption")
 
-        for invalid in invalid_forms:
-            invalid_root = tmp / f"documentation-options-{name}-{invalid.replace('/', '-')}"
-            invalid_root.mkdir()
-            (invalid_root / "commands.md").write_text(
-                f"`ci-status.py {name} {invalid}`\n", encoding="utf-8"
-            )
-            found, copies = check(invalid_root)
-            if not found:
-                problems.append(
-                    f"[documentation options {name}:invalid-boundary {invalid!r}] expected the "
-                    f"punctuation-separated form to be rejected; got copies={copies!r}, problems={found!r}"
-                )
+    # A CHECK THAT FINDS NOTHING MUST NEVER PASS.
+    expect("no-blocks", "nothing here\n", len(ci.DOCUMENTED_COMMANDS), 0,
+           "every id with zero blocks is reported")
+
+    # WHAT MAY SIT OUTSIDE A BLOCK. Prose NAMING a command is fine; a runnable copy is not.
+    expect("prose-mention", _every_command_marked() + "\nWritten by `ci-status.py liveness`.\n", 0, 0,
+           "prose naming the command without a flag is a mention, not a copy")
+    expect("prose-copy", _every_command_marked() + "\nRun `ci-status.py required-set --ledger x`.\n", 0, 1,
+           "a flag before the closing backtick makes it a runnable copy outside a block")
+    expect("fenced-unmarked", _every_command_marked() + "\n```sh\n" + FULL_COMMANDS["derive"] + "\n```\n",
+           0, 1, "a fenced block WITHOUT the marker is reported, not silently skipped")
+    wrapped = "\nRun `scripts/ci-status.py\nrequired-set --ledger run/state.jsonl`.\n"
+    expect("prose-copy-wrapped", _every_command_marked() + wrapped, 0, 1,
+           "a copy WRAPPED across two lines is still a copy — the window ends at the backtick, not the line")
+    expect("flag-after-span", _every_command_marked() + "\n`ci-status.py derive` needs `--ledger`.\n", 0, 0,
+           "a flag in a LATER code span does not make an earlier mention a copy")
     return problems
 
 
@@ -1519,13 +1528,13 @@ def run(ci, tmp: Path) -> int:
         print(f"ok       {'DECIDE verdict terminology':32} -> UNUSABLE and UNVERIFIABLE both remain explicit "
               f"before liveness groups them")
 
-    documentation_option_problems = documentation_option_form_cases(ci, tmp)
-    for problem in documentation_option_problems:
+    marked_command_problems = marked_command_cases(ci, tmp)
+    for problem in marked_command_problems:
         failures += 1
         print(f"FAIL     {problem}")
-    if not documentation_option_problems:
-        print(f"ok       {'documentation option forms':32} -> standalone and --name=value forms are "
-              f"recognized without accepting option-name lookalikes")
+    if not marked_command_problems:
+        print(f"ok       {'marked command blocks':32} -> a block carries every token its id requires, an id "
+              f"with no block fails, and no runnable copy may sit outside a marked block")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1356,7 +1356,8 @@ def verdict_doc_cases(ci) -> list[str]:
 
 FULL_COMMANDS = {
     "derive": "python3 s/ci-status.py derive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl",
-    "liveness": "python3 s/ci-status.py liveness --ledger run/state.jsonl --pr 1 --machine-action none",
+    "liveness": ("python3 s/ci-status.py liveness --ledger run/state.jsonl --pr 1 "
+                 "--derive-json out.json --machine-action none"),
     "required-set": "python3 s/ci-status.py required-set --ledger run/state.jsonl",
 }
 
@@ -1372,9 +1373,66 @@ def _marked(cmd_id: str, command: str) -> str:
     return f"```sh gauntlet-cmd={cmd_id}\n{command}\n```\n"
 
 
+def _without(command: str, tokens: tuple[str, ...]) -> str:
+    """Drop the tokens that satisfy ONE requirement, keeping every value the command spelled.
+
+    Keeping values is what isolates the omission: `--ledger` and `run/state.jsonl` satisfy two DIFFERENT
+    requirements of `required-set`, so dropping a flag together with its value would remove two at once and
+    the fixture could no longer say which one the checker actually caught.
+    """
+    def drop(token: str) -> bool:
+        return any(token == t or token.endswith(f"/{t}") or token.startswith(f"{t}=") for t in tokens)
+
+    return " ".join(token for token in command.split() if not drop(token))
+
+
 def _every_command_marked(**override: str) -> str:
     """Every id gets a block, so the has-at-least-one-block rule never fires for an unrelated reason."""
     return "\n".join(_marked(i, override.get(i, c)) for i, c in FULL_COMMANDS.items())
+
+
+def documented_commands_agree_with_argparse(ci) -> list[str]:
+    """`DOCUMENTED_COMMANDS` and the real CLI parser state ONE contract — reconcile them, never restate them.
+
+    Every fixture below drives the table, so not one of them can notice that the table is INCOMPLETE: drop a
+    requirement from a row and the case that would have caught it disappears with it. That gap is the defect
+    this pins. The `liveness` row once omitted `--derive-json` — a flag argparse REQUIRES — so `doc-check`
+    reported the documented invocation as carrying every token it needs, and running it exited 2.
+
+    Both directions matter. A required flag missing from a row is a documented copy the tool refuses; a
+    `--flag` in a row that the parser does not define is a token the doc makes authors write and the tool
+    rejects. Only the parser knows either answer, so ask it rather than writing the answer down twice.
+    """
+    problems: list[str] = []
+    # `_actions` because argparse exposes no public accessor for its actions or its subparser map — the
+    # same read `followups-test.py` makes of its own parser.
+    subcommands = next((action.choices for action in ci.build_parser()._actions  # noqa: SLF001
+                        if isinstance(getattr(action, "choices", None), dict)), None)
+    if not subcommands:
+        return ["[documented commands] build_parser() exposed no subcommands — the reconciliation below "
+                "would then pass by asking nothing, which is this suite's founding defect"]
+
+    for cmd_id, wanted in ci.DOCUMENTED_COMMANDS.items():
+        parser = subcommands.get(cmd_id)
+        if parser is None:
+            problems.append(f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS names an id that is not a "
+                            f"subcommand of ci-status.py — known: {sorted(subcommands)}")
+            continue
+        documented = {alt for want in wanted for alt in (want if isinstance(want, tuple) else (want,))}
+        defined = {opt for action in parser._actions for opt in action.option_strings}
+        required = {action.option_strings[0] for action in parser._actions
+                    if action.required and action.option_strings}
+        if missing := sorted(required - documented):
+            problems.append(
+                f"[documented commands {cmd_id}] argparse REQUIRES {missing}, which no DOCUMENTED_COMMANDS "
+                f"entry names — a documented copy without it passes doc-check and the tool refuses to run it"
+            )
+        if unknown := sorted(flag for flag in documented if flag.startswith("--") and flag not in defined):
+            problems.append(
+                f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS requires {unknown}, which the "
+                f"{cmd_id} parser does not define — the doc would make every copy carry a rejected flag"
+            )
+    return problems
 
 
 def marked_command_cases(ci, tmp: Path) -> list[str]:
@@ -1399,40 +1457,65 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     expect("all-present", _every_command_marked(), 0, 0,
            "a marked block per id, each carrying every required token, is clean")
 
-    # WHAT A BLOCK MUST CARRY — one omission per id, and the `--name=value` form counts as present.
-    for cmd_id, command in FULL_COMMANDS.items():
-        dropped = " ".join(t for t in command.split() if not t.startswith("--machine-action")
-                           and not (cmd_id == "derive" and t == "--ledger")
-                           and not (cmd_id == "required-set" and t == "--ledger"))
-        if dropped != command:
-            expect(f"omits-{cmd_id}", _every_command_marked(**{cmd_id: dropped}), 1, 0,
-                   f"a {cmd_id} block missing a required token is reported")
+    # WHAT A BLOCK MUST CARRY — EVERY entry of EVERY table row, not the one a hand-written case happened to
+    # drop. Driving the table itself is what makes adding a requirement to DOCUMENTED_COMMANDS self-covering:
+    # a row entry the checker does not really enforce fails here the day it is added, with no fixture edit.
+    for cmd_id, wanted in ci.DOCUMENTED_COMMANDS.items():
+        for want in wanted:
+            alternatives = want if isinstance(want, tuple) else (want,)
+            slug = "-".join(alt.lstrip("-") for alt in alternatives)
+            expect(f"omits-{cmd_id}-{slug}",
+                   _every_command_marked(**{cmd_id: _without(FULL_COMMANDS[cmd_id], alternatives)}), 1, 0,
+                   f"a {cmd_id} block missing {' / '.join(alternatives)} is reported")
     equals = {i: c.replace(" --ledger ", " --ledger=").replace(" --pr ", " --pr=")
               for i, c in FULL_COMMANDS.items()}
     expect("equals-form", _every_command_marked(**equals), 0, 0,
            "argparse's --name=value form satisfies a long-option requirement")
 
-    # `derive` alone accepts either flag for the required set — pin BOTH members of the alternation.
+    # `derive` alone accepts either flag for the required set — the drop loop above pins that NEITHER fails,
+    # so pin the other member of the alternation here.
     alt = FULL_COMMANDS["derive"].replace("--ledger run/state.jsonl", "--required-set unknown")
     expect("derive-alternation", _every_command_marked(derive=alt), 0, 0,
            "an explicit --required-set satisfies derive's alternation")
-    neither = FULL_COMMANDS["derive"].replace(" --ledger run/state.jsonl", "")
-    expect("derive-neither", _every_command_marked(derive=neither), 1, 0,
-           "derive naming NEITHER --ledger nor --required-set is reported")
 
-    # A LABEL CANNOT LIE: the script name and subcommand are ordinary required tokens. Assert the SUBCOMMAND
-    # is among what is reported rather than a total — a mislabelled block also misses that id's other flags,
-    # and pinning the count would just re-pin DOCUMENTED_COMMANDS' length in a second place.
-    mislabelled = _docs(tmp, "mislabelled", _every_command_marked()
-                        + _marked("derive", FULL_COMMANDS["liveness"]))
-    marked, _blocks = ci.check_marked_commands(mislabelled)
-    if not any("omits `derive`" in problem for problem in marked):
-        problems.append(
-            f"[marked commands mislabelled] a liveness command marked gauntlet-cmd=derive must fail on the "
-            f"SUBCOMMAND token, so a block cannot lie about which command it is; got {marked!r}"
-        )
-    expect("unknown-id", _every_command_marked() + _marked("nonesuch", FULL_COMMANDS["derive"]), 1, 0,
-           "an id DOCUMENTED_COMMANDS does not define is a failure, never an exemption")
+    # A PATH-SUFFIX REQUIREMENT SURVIVES THE WHOLE-TOKEN RULE. `state.jsonl` is required of `required-set`
+    # and every real copy writes it inside a path, so the token rule counts a leading `/` as a token start —
+    # while a LONGER file name is a different file and must not satisfy it.
+    for slug, ledger, want_marked, why in (
+        ("path", "run/state.jsonl", 0, "a <dir>/state.jsonl path satisfies the state.jsonl requirement"),
+        ("bare", "state.jsonl", 0, "an unprefixed state.jsonl satisfies it too"),
+        ("longer", "run/state.jsonl.bak", 1, "state.jsonl.bak is a DIFFERENT file and does not satisfy it"),
+    ):
+        ledger_copy = f"python3 s/ci-status.py required-set --ledger {ledger}"
+        expect(f"suffix-{slug}", _every_command_marked(**{"required-set": ledger_copy}), want_marked, 0, why)
+
+    # A LABEL CANNOT LIE: the script name and subcommand are ordinary required tokens. Assert WHICH tokens
+    # are reported rather than a total — a mislabelled block also misses that id's other flags, and pinning
+    # the count would just re-pin DOCUMENTED_COMMANDS' length in a second place.
+    def expect_omissions(slug: str, block: str, tokens: tuple[str, ...], why: str) -> None:
+        marked, _blocks = ci.check_marked_commands(_docs(tmp, slug, _every_command_marked() + block))
+        missing = [t for t in tokens if not any(f"omits `{t}`" in problem for problem in marked)]
+        if missing:
+            problems.append(
+                f"[marked commands {slug}] {why}: expected the report to name {missing}; got {marked!r}"
+            )
+
+    expect_omissions("mislabelled", _marked("derive", FULL_COMMANDS["liveness"]), ("derive",),
+                     "a liveness command marked gauntlet-cmd=derive must fail on the SUBCOMMAND token")
+    # ...AND CANNOT LIE BY PREFIXING EITHER. A plain substring test accepts a longer word that merely CONTAINS
+    # the required token, so a block naming neither the real script nor the real subcommand passed clean.
+    lying = "python3 s/not-ci-status.py rederive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl"
+    expect_omissions("prefixed", _marked("derive", lying), ("ci-status.py", "derive"),
+                     "a token that is only a SUFFIX of a longer word satisfies nothing")
+
+    # AN UNKNOWN ID IS REPORTED WHATEVER ITS SPELLING. The id pattern must not decide which ids exist: an id
+    # the pattern REJECTS is not a marked block at all, so this branch never fires and the author is instead
+    # told to move a block that already sits inside a marked fence.
+    for n, spelling in enumerate(("nonesuch", "nonesuch2", "NONESUCH", "none_such", "9")):
+        expect(f"unknown-id-{n}", _every_command_marked() + _marked(spelling, FULL_COMMANDS["derive"]), 1, 0,
+               f"the undefined id `{spelling}` is a failure, never an exemption")
+    expect("trailing-space", _every_command_marked().replace("=derive\n", "=derive  \n"), 0, 0,
+           "CommonMark drops trailing info-string spaces, so a marked block stays marked despite them")
 
     # A CHECK THAT FINDS NOTHING MUST NEVER PASS.
     expect("no-blocks", "nothing here\n", len(ci.DOCUMENTED_COMMANDS), 0,
@@ -1527,6 +1610,14 @@ def run(ci, tmp: Path) -> int:
     if not verdict_doc_problems:
         print(f"ok       {'DECIDE verdict terminology':32} -> UNUSABLE and UNVERIFIABLE both remain explicit "
               f"before liveness groups them")
+
+    documented_command_problems = documented_commands_agree_with_argparse(ci)
+    for problem in documented_command_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not documented_command_problems:
+        print(f"ok       {'DOCUMENTED_COMMANDS vs argparse':32} -> every flag a subcommand REQUIRES is a token "
+              f"its documented copies must carry, and no row requires a flag the parser rejects")
 
     marked_command_problems = marked_command_cases(ci, tmp)
     for problem in marked_command_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1582,6 +1582,24 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     expect("unterminated-only-block", others + f"```sh gauntlet-cmd=derive\n{incomplete}\n", 2, 0,
            "a block the checker never read cannot credit its id, so zero-blocks fires beside the broken fence")
 
+    # A LAST LINE WITH NO NEWLINE IS STILL A LINE, and the report of an unterminated opener does not depend
+    # on the file having a final one. A doc whose last byte is not `\n` renders exactly like one whose last
+    # byte is, so the scan must read it the same way — `_scanned` appends the newline once at the read
+    # rather than teaching each pattern an end-of-file case, which is how the opener came to differ from the
+    # close. These four are the whole family: the opener that renders an (empty) block, the same opener when
+    # it is its id's ONLY block, the same with the trailing spaces the info string drops, and a complete
+    # block whose CLOSE is itself the unterminated last line.
+    expect("eof-opener-no-newline", every() + "```sh gauntlet-cmd=nonesuch", 1, 0,
+           "an opener on a last line with no newline is reported, never silently dropped")
+    expect("eof-opener-no-newline-only-block", others + "```sh gauntlet-cmd=derive", 2, 0,
+           "and it credits nothing, so zero-blocks fires beside it")
+    expect("eof-opener-no-newline-trailing-space", every() + "```sh gauntlet-cmd=nonesuch  ", 1, 0,
+           "trailing info-string spaces do not save it either")
+    # THE POSITIVE CONTROL on the normalization: this one passes with or without `_scanned`, and its job is
+    # to prove the appended newline does not swallow a close that was already conforming.
+    expect("eof-close-no-newline", every()[:-1], 0, 0,
+           "a conforming close IS the last line with no newline, and still closes its block")
+
     # WHAT MAY SIT OUTSIDE A BLOCK. Prose NAMING a command is fine; a runnable copy is not.
     expect("prose-mention", every() + "\nWritten by `ci-status.py liveness`.\n", 0, 0,
            "prose naming the command without a flag is a mention, not a copy")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1436,11 +1436,14 @@ def documented_commands_agree_with_argparse(ci) -> list[str]:
 
 
 def marked_command_cases(ci, tmp: Path) -> list[str]:
-    """Pin the marker contract: what a block must carry, and what may not sit outside one.
+    """Pin the marker contract: what a block's COMMAND must carry, and what may not sit outside one.
 
-    The third group is the one this scheme lives or dies on. A marker that only checks what was MARKED is
-    strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success — so the
-    unmarked-copy rule is pinned in both directions, including the fenced-but-unmarked shape.
+    The unmarked-copy group is the one this scheme lives or dies on. A marker that only checks what was
+    MARKED is strictly worse than the copy-hunting it replaced, because a forgotten marker reads as success
+    — so that rule is pinned in both directions, including the fenced-but-unmarked shape.
+
+    The scope group is the second: the requirements are read from the invocation, so a fenced body cannot
+    hand a mislabelled block the tokens its real command lacks, and a wrapped command stays one command.
     """
     problems: list[str] = []
 
@@ -1455,7 +1458,7 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
             )
 
     expect("all-present", _every_command_marked(), 0, 0,
-           "a marked block per id, each carrying every required token, is clean")
+           "a marked block per id, each RUNNING a command that carries every required token, is clean")
 
     # WHAT A BLOCK MUST CARRY — EVERY entry of EVERY table row, not the one a hand-written case happened to
     # drop. Driving the table itself is what makes adding a requirement to DOCUMENTED_COMMANDS self-covering:
@@ -1503,10 +1506,46 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     expect_omissions("mislabelled", _marked("derive", FULL_COMMANDS["liveness"]), ("derive",),
                      "a liveness command marked gauntlet-cmd=derive must fail on the SUBCOMMAND token")
     # ...AND CANNOT LIE BY PREFIXING EITHER. A plain substring test accepts a longer word that merely CONTAINS
-    # the required token, so a block naming neither the real script nor the real subcommand passed clean.
-    lying = "python3 s/not-ci-status.py rederive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl"
-    expect_omissions("prefixed", _marked("derive", lying), ("ci-status.py", "derive"),
+    # the required token, so a block whose subcommand only ENDS in the required one passed clean. The script
+    # name is checked the same way, one layer earlier: `example-tool.py` (invented — it appears nowhere in
+    # this repo) opens no invocation window at all, which the no-invocation case below pins.
+    lying = "python3 s/ci-status.py rederive --pr 1 --head-sha abc --rundir run --ledger run/state.jsonl"
+    expect_omissions("prefixed", _marked("derive", lying), ("derive",),
                      "a token that is only a SUFFIX of a longer word satisfies nothing")
+
+    # THE TOKENS ARE REQUIRED OF THE COMMAND, NOT OF THE FENCED BODY. Any other line in the block can spell
+    # the tokens the real invocation lacks, and a whole-body search then reads a mislabel as complete. Both
+    # carriers are pinned because a comment-stripping fix would pass the first case and fail the second —
+    # neither needs Markdown of any kind, they are just more lines inside the fence.
+    masked = ("# the derive step takes --head-sha <sha> --rundir <dir> ; see above\n"
+              + FULL_COMMANDS["liveness"])
+    expect_omissions("scope-comment", _marked("derive", masked), ("derive", "--head-sha", "--rundir"),
+                     "a COMMENT in the block must not supply tokens the invocation omits")
+    second_line = FULL_COMMANDS["liveness"] + "\ngrep derive --head-sha --rundir notes.txt"
+    expect_omissions("scope-second-line", _marked("derive", second_line),
+                     ("derive", "--head-sha", "--rundir"),
+                     "a second COMMAND LINE in the block must not supply them either")
+
+    # A CONTINUED COMMAND IS ONE COMMAND. The live derive and liveness copies wrap, and a window that ended
+    # at the newline would lose `--ledger` from one and `--derive-json`/`--machine-action` from the other —
+    # turning correct blocks red, which is how a check gets deleted by the next person in a hurry.
+    wrapped_commands = {i: c.replace(" --ledger ", " \\\n    --ledger ") for i, c in FULL_COMMANDS.items()}
+    expect("continuation", _every_command_marked(**wrapped_commands), 0, 0,
+           "a backslash continuation keeps the flags on later lines inside the same invocation")
+
+    # A BLOCK THAT RUNS NOTHING IS NOT A CHECKED BLOCK — and THE LOCATOR IS WHOLE-TOKEN TOO. This body is a
+    # complete, correct derive invocation of a DIFFERENT script (`example-ci-status.py` is invented; it
+    # exists nowhere in this repo). A substring locator would open a window at the script-name SUFFIX and
+    # then find every required token inside it, which is round-1's defect returning one layer up.
+    no_command = _marked("derive", "python3 s/example-ci-status.py derive --pr 1 --head-sha abc "
+                                   "--rundir run --ledger run/state.jsonl")
+    no_invocation = ci.check_marked_commands(_docs(tmp, "no-invocation",
+                                                   _every_command_marked() + no_command))[0]
+    if not any("RUNS no `ci-status.py` command" in problem for problem in no_invocation):
+        problems.append(
+            f"[marked commands no-invocation] a block whose body runs no ci-status.py command must say so "
+            f"plainly; got {no_invocation!r}"
+        )
 
     # AN UNKNOWN ID IS REPORTED WHATEVER ITS SPELLING. The id pattern must not decide which ids exist: an id
     # the pattern REJECTS is not a marked block at all, so this branch never fires and the author is instead
@@ -1624,8 +1663,8 @@ def run(ci, tmp: Path) -> int:
         failures += 1
         print(f"FAIL     {problem}")
     if not marked_command_problems:
-        print(f"ok       {'marked command blocks':32} -> a block carries every token its id requires, an id "
-              f"with no block fails, and no runnable copy may sit outside a marked block")
+        print(f"ok       {'marked command blocks':32} -> the command a block RUNS carries every token its id "
+              f"requires, an id with no block fails, and no runnable copy may sit outside a marked block")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -118,9 +118,9 @@ The enums, the CLASSIFY buckets and the DECIDE order are stated in `ci-derivatio
 one a reader believed. `doc-check` PARSES the doc's own enum block, its two CLASSIFY tables and its DECIDE
 bullet order, and asserts they agree with the sets `ci-snapshot.py` actually classifies with — and that the
 classification is TOTAL over the enums the doc declares. It also checks every copy of a `gh` command the doc
-prints against the argv this code really issues, every MARKED `ci-status.py` command block against the tokens
-its `gauntlet-cmd` id requires — with no runnable copy sitting OUTSIDE such a block — and the moved-head owner
-block's retained-artifact/trust/result contract. Drift is a RED BUILD, not a discovery.
+prints against the argv this code really issues, the command every MARKED `ci-status.py` block RUNS against
+the tokens its `gauntlet-cmd` id requires — with no runnable copy sitting OUTSIDE such a block — and the
+moved-head owner block's retained-artifact/trust/result contract. Drift is a RED BUILD, not a discovery.
 
 **A check that finds nothing MUST NOT PASS.** If the doc cannot be found, or a block cannot be parsed, or
 zero rules are extracted, `doc-check` FAILS. An extractor that silently matches nothing and reports success
@@ -2252,7 +2252,9 @@ def _has_long_option(command: str, option: str) -> bool:
 # WHICH TEXT IS A COMMAND. A marked block opens with the info string ```sh gauntlet-cmd=<id>`; `<id>` keys
 # this table, whose value is every token that copy MUST carry. A nested tuple is an alternation — any one of
 # its members satisfies it. A `--flag` requirement is matched as a long option (argparse's `--name=value`
-# form included); anything else must appear as a WHOLE command token — see `_requirement_met`.
+# form included); anything else must appear as a WHOLE command token — see `_requirement_met`. The tokens
+# are required of the block's `ci-status.py` INVOCATION, never merely of its fenced body — see
+# `_invocations`, which is what stops other text in the block from supplying them.
 #
 # A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
 # is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
@@ -2287,21 +2289,80 @@ DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
 MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n(?P<body>.*?)^```", re.M | re.S)
 LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
 COMMAND_NAME = "ci-status.py"
+# The SAME whole-token rule `_requirement_met` applies, used to LOCATE the invocation. A substring locator
+# would let a longer word that merely ends in the script name open a window, and the block would then be
+# checked against text that runs something else entirely.
+COMMAND_TOKEN = re.compile(rf"(?:\A|[\s/=]){re.escape(COMMAND_NAME)}(?=\s|\Z)")
 
 
-def _requirement_met(body: str, want: str) -> bool:
+def _requirement_met(command: str, want: str) -> bool:
     """A `--flag` is matched as a long option; every other requirement as a WHOLE command token.
 
     Whole-token, not substring, is what stops a block from LYING about which command it is. Plain
-    `want in body` accepts `not-ci-status.py rederive` for both `ci-status.py` and `derive`, so a block
-    marked `gauntlet-cmd=derive` that runs neither the script nor the subcommand passes clean. A leading
-    `/` or `=` still counts as a token start, which is what keeps the path-SUFFIX requirements working:
-    `--ledger <rundir>/state.jsonl` satisfies `state.jsonl`, and `python3 <skill>/scripts/ci-status.py`
-    satisfies `ci-status.py`.
+    `want in command` accepts an invented `example-tool.py rederive` (it appears nowhere in this repo) for
+    both `ci-status.py` and `derive`, so a block marked `gauntlet-cmd=derive` that runs neither the script
+    nor the subcommand passes clean. A leading `/` or `=` still counts as a token start, which is what keeps
+    the path-SUFFIX requirements working: `--ledger <rundir>/state.jsonl` satisfies `state.jsonl`, and
+    `python3 <skill>/scripts/ci-status.py` satisfies `ci-status.py`.
+
+    WHERE a token may be found is a separate question, answered by `_invocations`: this decides only WHAT
+    counts as one. Both are load-bearing — whole-token matching over a whole fenced body still accepts a
+    comment that spells the missing tokens, and an invocation-scoped substring match still accepts a
+    subcommand that merely ENDS in the required one.
     """
     if want.startswith("--"):
-        return _has_long_option(body, want)
-    return re.search(rf"(?:\A|[\s/=]){re.escape(want)}(?=\s|\Z)", body) is not None
+        return _has_long_option(command, want)
+    return re.search(rf"(?:\A|[\s/=]){re.escape(want)}(?=\s|\Z)", command) is not None
+
+
+def _invocations(body: str) -> list[str]:
+    """Every INVOCATION inside a marked block: a `ci-status.py` command token to the end of its command.
+
+    **THE UNIT OF THE CHECK IS THE INVOCATION, NOT THE BLOCK, AND THIS CHECK USED TO THINK OTHERWISE.**
+    Searching a whole fenced body for the required tokens lets text a reader never RUNS supply them: mark a
+    block `gauntlet-cmd=derive`, run `ci-status.py liveness …` in it, and any second line of the block that
+    happens to spell `derive`, `--head-sha` and `--rundir` — a comment ABOUT the derive step, or an
+    unrelated `grep` — completes the set, and the mislabel passes clean. Neither carrier needs Markdown of
+    any kind; both are just more lines inside the fence. So the requirements are checked against the
+    command itself, and a block passes when SOME invocation in it carries everything.
+
+    Two things this must not get wrong, each of which turns correct docs red or lying docs green:
+
+    - **A command is not a line.** A shell invocation WRAPS with a trailing `\\`, and the live copies do:
+      stopping at the newline loses `--ledger` from `derive` and `--derive-json`/`--machine-action` from
+      `liveness`, condemning three correct blocks.
+    - **The locator is whole-token too.** An invented `example-tool.py derive --pr 1` (it exists nowhere in
+      this repo) must not open a window; a substring locator would let it, and the mislabel it was meant to
+      catch would then be checked against the wrong text.
+
+    Comment lines are dropped before any of that, because a comment is text the block does not run.
+    """
+    text = "\n".join("" if line.lstrip().startswith("#") else line for line in body.splitlines())
+    windows: list[str] = []
+    for match in COMMAND_TOKEN.finditer(text):
+        cursor = match.end()
+        while True:
+            newline = text.find("\n", cursor)
+            if newline < 0:
+                end = len(text)
+                break
+            if text[cursor:newline].rstrip().endswith("\\"):
+                cursor = newline + 1
+                continue
+            end = newline
+            break
+        windows.append(text[match.end() - len(COMMAND_NAME):end])
+    return windows
+
+
+def _unmet(command: str, wanted: tuple[str | tuple[str, ...], ...]) -> list[tuple[str, ...]]:
+    """The requirements this one invocation does not carry, each as its alternation."""
+    unmet: list[tuple[str, ...]] = []
+    for want in wanted:
+        alternatives: tuple[str, ...] = want if isinstance(want, tuple) else (want,)
+        if not any(_requirement_met(command, alt) for alt in alternatives):
+            unmet.append(alternatives)
+    return unmet
 
 
 def _blank(text: str) -> str:
@@ -2310,15 +2371,19 @@ def _blank(text: str) -> str:
 
 
 def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every marked command block carries every token its `gauntlet-cmd` id requires.
+    """Every marked block runs an INVOCATION carrying every token its `gauntlet-cmd` id requires.
 
-    Three ways to fail, and the third is the one a marker scheme invites: the block omits a required token;
-    an id is claimed that this table does not define; or an id this table defines has NO block anywhere.
-    That last one is what stops the marker from quietly narrowing the check — delete the only marked copy of
-    a command and the build goes red, exactly as it did when the checker hunted copies for itself.
+    Four ways to fail, and the last two are the ones a marker scheme invites: an invocation omits a required
+    token; the block runs no `ci-status.py` command at all; an id is claimed that this table does not
+    define; or an id this table defines has NO block anywhere. That last one is what stops the marker from
+    quietly narrowing the check — delete the only marked copy of a command and the build goes red, exactly
+    as it did when the checker hunted copies for itself.
 
     A block also cannot lie about which command it is, because the script name and the subcommand are
-    ordinary required tokens: label a `liveness` block `gauntlet-cmd=derive` and it fails on `derive`.
+    ordinary required tokens: label a `liveness` block `gauntlet-cmd=derive` and it fails on `derive`. That
+    holds only because the tokens are looked for in the COMMAND (`_invocations`) rather than anywhere in the
+    fenced body — a comment or a second line elsewhere in the block would otherwise hand the mislabel the
+    tokens its real invocation does not have.
     """
     problems, found = [], []
     seen: set[str] = set()
@@ -2338,12 +2403,19 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
                 continue
             seen.add(cmd_id)
             found.append(f"{where} ({cmd_id})")
-            for want in wanted:
-                alternatives: tuple[str, ...] = want if isinstance(want, tuple) else (want,)
-                if any(_requirement_met(body, alt) for alt in alternatives):
-                    continue
+            windows = _invocations(body)
+            if not windows:
                 problems.append(
-                    f"{where} is marked `gauntlet-cmd={cmd_id}` but the block omits "
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but the block RUNS no `{COMMAND_NAME}` "
+                    f"command — the marker promises a copy a reader can run, and there is none to check, "
+                    f"so every token the id requires would be looked for in text nobody executes."
+                )
+                continue
+            # A block passes when ONE of its invocations carries everything, and is reported against the
+            # CLOSEST one — naming what that copy is short of, not the union of every command in the block.
+            for alternatives in min((_unmet(window, wanted) for window in windows), key=len):
+                problems.append(
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but its invocation omits "
                     f"{' or '.join(f'`{alt}`' for alt in alternatives)} — a reader runs what this block "
                     f"says, and the tool refuses an invocation missing it."
                 )
@@ -2407,8 +2479,9 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          paragraphs. A value in a hole matches NO branch: not green, not red, not pending — the PR can never
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
-         every MARKED `ci-status.py` command block against the tokens `DOCUMENTED_COMMANDS` requires of it,
-         and that no runnable copy sits OUTSIDE such a block (prose may NAME a command, never run one).
+         the command every MARKED `ci-status.py` block RUNS against the tokens `DOCUMENTED_COMMANDS`
+         requires of that id, and that no runnable copy sits OUTSIDE such a block (prose may NAME a
+         command, never run one).
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.
@@ -2555,7 +2628,7 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
     problems += marked_problems
     if not marked_problems:
         held.append(f"{'the marked command blocks':32} {len(marked_blocks)} blocks across the skill's docs, "
-                    f"every one carrying every token its gauntlet-cmd id requires")
+                    f"every one RUNNING a command that carries every token its gauntlet-cmd id requires")
     # AND THAT NO RUNNABLE COPY ESCAPED THE MARKER — the check that keeps a forgotten marker LOUD.
     unmarked_problems = check_unmarked_commands()
     problems += unmarked_problems

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1896,7 +1896,10 @@ class DocError(Exception):
 
 
 def fenced_blocks(text: str) -> list[str]:
-    return re.findall(r"^```[a-z]*\n(.*?)^```", text, re.MULTILINE | re.DOTALL)
+    # The info string is `[^\n]*`, not `[a-z]*`: a marked command fence carries `sh gauntlet-cmd=<id>`, and
+    # an opener this regex cannot match is not skipped — it is swallowed, so the NEXT fence's closing ```
+    # terminates the wrong block and the owner blocks below stop being findable.
+    return re.findall(r"^```[^\n]*\n(.*?)^```", text, re.MULTILINE | re.DOTALL)
 
 
 def parse_enums(blocks: list[str]) -> dict[str, set[str]]:
@@ -2244,106 +2247,124 @@ def _has_long_option(command: str, option: str) -> bool:
     return re.search(rf"(?<![\w-]){re.escape(option)}(?=[=\s]|$)", command) is not None
 
 
-def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """EVERY COPY OF THE DERIVE COMMAND, IN EVERY SKILL DOC — not just the one in the doc under test.
+# EVERY RUNNABLE COPY OF A `ci-status.py` COMMAND LIVES IN A MARKED BLOCK, AND THE CHECKER NEVER GUESSES
+# WHICH TEXT IS A COMMAND. A marked block opens with the info string ```sh gauntlet-cmd=<id>`; `<id>` keys
+# this table, whose value is every token that copy MUST carry. A nested tuple is an alternation — any one of
+# its members satisfies it. A `--flag` requirement is matched as a long option (argparse's `--name=value`
+# form included); anything else is matched as a plain substring.
+#
+# WHY THE MARKER EXISTS AT ALL. The checker used to hunt runnable copies in free Markdown, which meant
+# deciding, for arbitrary prose, whether a stretch of text was a command or a sentence about one. That
+# question has no small answer: three PRs grew hand-written CommonMark and shell-word subsets trying to
+# reach it, two of them died at their repair cap, and 793 lines of that parsing were deleted unmerged. The
+# marker moves the decision from the checker to the author, where it costs one info string and cannot be
+# wrong. What remains here recognizes fences and backticks, and nothing else about Markdown.
+DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
+    # The required set is what makes `green` mean *the required set passed*, and it is the ROW's
+    # `effective_required_set`: name it with `--ledger` (resolve the row's set — the production form) or
+    # with an explicit `--required-set`. A copy carrying NEITHER reconstructs an invocation the tool refuses.
+    "derive": ("ci-status.py", "derive", "--pr", "--head-sha", "--rundir", ("--ledger", "--required-set")),
+    # `--machine-action` is the one judgment the command asks of its caller. A reader who drops the question
+    # and invents a default strikes the very PR a fix is about to move.
+    "liveness": ("ci-status.py", "liveness", "--ledger", "--pr", "--machine-action"),
+    # The command must persist the value it read, so the copy names the run ledger it persists to.
+    "required-set": ("ci-status.py", "required-set", "--ledger", "state.jsonl"),
+}
 
-    THE FLAG THAT NAMES THE REQUIRED SET MUST NOT BE DROPPABLE BY A RECAP. The required set is what makes
-    `green` mean *the required set passed*, and it is now the ROW's `effective_required_set`: a copy names it
-    with `--ledger` (resolve the row's set — the production form) OR with an explicit `--required-set`. A copy
-    carrying NEITHER is a reader reconstructing an invocation the tool REFUSES. This repo has already paid for
-    the class TWICE: a fourth copy of a canonical command that had gone stale, and a doc recap that dropped
-    `,headRefOid` from the rollup fetch.
+MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[a-z][a-z-]*)\n(?P<body>.*?)^```", re.M | re.S)
+LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
+COMMAND_NAME = "ci-status.py"
 
-    A copy is any occurrence that RUNS the command (`ci-status.py derive` carrying `--pr`) — prose that
-    merely NAMES the command is not a copy, and is not checked. **THE UNIT IS THE COMMAND, NOT THE LINE**:
-    an invocation WRAPS (a shell `\\`, or plain prose reflow), and a line-by-line check would report the
-    continuation line as a violation of itself. So each copy is read to the end of its PARAGRAPH.
 
-    FINDING ZERO COPIES IS A FAILURE: the command is prescribed by at least `stage-2-ci.md` and
-    `critical-rules.md`, and a check that cannot find its subject never passes.
+def _requirement_met(body: str, want: str) -> bool:
+    return _has_long_option(body, want) if want.startswith("--") else want in body
+
+
+def _blank(text: str) -> str:
+    """Blank a span to spaces, KEEPING newlines — so every later offset still names its real line."""
+    return re.sub(r"[^\n]", " ", text)
+
+
+def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
+    """Every marked command block carries every token its `gauntlet-cmd` id requires.
+
+    Three ways to fail, and the third is the one a marker scheme invites: the block omits a required token;
+    an id is claimed that this table does not define; or an id this table defines has NO block anywhere.
+    That last one is what stops the marker from quietly narrowing the check — delete the only marked copy of
+    a command and the build goes red, exactly as it did when the checker hunted copies for itself.
+
+    A block also cannot lie about which command it is, because the script name and the subcommand are
+    ordinary required tokens: label a `liveness` block `gauntlet-cmd=derive` and it fails on `derive`.
     """
-    problems, copies = [], []
+    problems, found = [], []
+    seen: set[str] = set()
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        for m in re.finditer(r"ci-status\.py derive", text):
-            end = text.find("\n\n", m.start())
-            command = text[m.start(): end if end > 0 else len(text)]
-            if not _has_long_option(command, "--pr"):
-                continue  # prose that NAMES the command, not a copy of it
-            n = text.count("\n", 0, m.start()) + 1
-            copies.append(f"{md.name}:{n}")
-            if not _has_long_option(command, "--ledger") and not _has_long_option(command, "--required-set"):
+        for match in MARKED_FENCE.finditer(text):
+            cmd_id, body = match.group("id"), match.group("body")
+            line = text.count("\n", 0, match.start()) + 1
+            where = f"{md.name}:{line}"
+            wanted = DOCUMENTED_COMMANDS.get(cmd_id)
+            if wanted is None:
                 problems.append(
-                    f"{md.name}:{n} runs `ci-status.py derive` WITHOUT `--ledger` OR `--required-set` — the "
-                    f"flag that makes `green` mean the REQUIRED SET passed. A reader following this copy "
-                    f"issues a command the tool refuses; a reader who 'fixes' it by dropping the set gets a "
-                    f"verdict about the rows that showed up, which is the registration gap, reopened by a recap."
+                    f"{where} is marked `gauntlet-cmd={cmd_id}`, which DOCUMENTED_COMMANDS does not define "
+                    f"— known ids are {', '.join(sorted(DOCUMENTED_COMMANDS))}. An unknown id is checked "
+                    f"against nothing, so the marker would buy the block an exemption instead of a check."
                 )
-    if not copies:
+                continue
+            seen.add(cmd_id)
+            found.append(f"{where} ({cmd_id})")
+            for want in wanted:
+                alternatives: tuple[str, ...] = want if isinstance(want, tuple) else (want,)
+                if any(_requirement_met(body, alt) for alt in alternatives):
+                    continue
+                problems.append(
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but the block omits "
+                    f"{' or '.join(f'`{alt}`' for alt in alternatives)} — a reader runs what this block "
+                    f"says, and the tool refuses an invocation missing it."
+                )
+    for cmd_id in sorted(set(DOCUMENTED_COMMANDS) - seen):
         problems.append(
-            "ZERO copies of `ci-status.py derive` were found in the skill's docs — the command is "
-            "prescribed by stage-2-ci.md and critical-rules.md, so finding none means this check has lost "
-            "its subject, and a check that finds nothing must never pass"
+            f"ZERO blocks marked `gauntlet-cmd={cmd_id}` were found in the skill's docs — the command is "
+            f"prescribed, so finding none means this check has lost its subject, and a check that finds "
+            f"nothing must never pass"
         )
-    return problems, copies
+    return problems, found
 
 
-def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every runnable liveness copy carries `--machine-action` — the judgment flag a recap must not drop.
+def check_unmarked_commands(root: Path | None = None) -> list[str]:
+    """No RUNNABLE `ci-status.py` copy may sit outside a marked block. Prose may still NAME the command.
 
-    Same class as `check_derive_copies`: a copy without the flag is a command the tool refuses, and a
-    reader who "fixes" it by inventing a default answers the one question the tool deliberately asks.
+    The discrimination is the whole design, and it is one character wide: read from the script name to the
+    next backtick, and ask whether a long option appears in that window. `` `ci-status.py liveness` `` is a
+    mention — it names the command, and a reader who runs it verbatim is REFUSED by the tool, which fails
+    closed. `` `ci-status.py liveness --ledger …` `` is a copy, and a copy that has drifted is a reader
+    running the wrong thing and believing the answer.
+
+    Marked blocks are blanked first, so their contents are exempt. Every OTHER fence is not: an unmarked
+    fenced command has no backtick before the closing fence, so its flags land in the window and it is
+    reported — which is what makes forgetting the marker loud instead of silently unchecked.
     """
-    problems, copies = [], []
+    problems: list[str] = []
     for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = md.read_text(encoding="utf-8")
-        for match in re.finditer(r"ci-status\.py liveness", text):
-            end = text.find("\n\n", match.start())
-            command = text[match.start(): end if end > 0 else len(text)]
-            # `--ledger`, not `--pr`, is the runnable-copy gate here: prose about liveness routinely sits
-            # in the same paragraph as a `ledger.py … set --pr` command, and `--pr` alone would condemn
-            # every such mention as a flagless invocation.
-            if not _has_long_option(command, "--ledger"):
-                continue  # prose that names the subcommand, not a runnable copy
+        text = MARKED_FENCE.sub(lambda m: _blank(m.group(0)), md.read_text(encoding="utf-8"))
+        for match in re.finditer(re.escape(COMMAND_NAME), text):
+            tick = text.find("`", match.end())
+            if tick < 0:  # unbackticked tail: fall back to the paragraph, never to an empty window
+                para = text.find("\n\n", match.end())
+                tick = para if para > 0 else len(text)
+            window = text[match.end():tick]
+            option = LONG_OPTION.search(window)
+            if not option:
+                continue  # prose NAMING the command, which the tool refuses if run verbatim
             line = text.count("\n", 0, match.start()) + 1
-            copies.append(f"{md.name}:{line}")
-            if not _has_long_option(command, "--machine-action"):
-                problems.append(
-                    f"{md.name}:{line} runs `ci-status.py liveness` WITHOUT `--machine-action` — the one "
-                    f"judgment the command asks of its caller. The tool refuses the invocation; a reader "
-                    f"who drops the flag's question strikes the very PR a fix is about to move."
-                )
-    if not copies:
-        problems.append(
-            "ZERO runnable copies of `ci-status.py liveness` were found in the skill's docs — the command "
-            "is prescribed by stage-2-ci.md, so finding none means this check has lost its subject"
-        )
-    return problems, copies
-
-
-def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every runnable required-set copy names the ledger whose per-row required sets the command persists."""
-    problems, copies = [], []
-    for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = md.read_text(encoding="utf-8")
-        for match in re.finditer(r"ci-status\.py required-set", text):
-            end = text.find("\n\n", match.start())
-            command = text[match.start(): end if end > 0 else len(text)]
-            if not _has_long_option(command, "--ledger"):
-                continue  # prose that names the subcommand, not a runnable copy
-            line = text.count("\n", 0, match.start()) + 1
-            copies.append(f"{md.name}:{line}")
-            if "state.jsonl" not in command:
-                problems.append(
-                    f"{md.name}:{line} runs `ci-status.py required-set` without the run ledger's "
-                    f"`state.jsonl` — the command must persist the value it read before the value exists"
-                )
-    if not copies:
-        problems.append(
-            "ZERO runnable copies of `ci-status.py required-set` were found in the skill's docs — finding "
-            "nothing means this check has lost its subject"
-        )
-    return problems, copies
+            problems.append(
+                f"{md.name}:{line} runs `{COMMAND_NAME} {' '.join(window.split())[:40]}…` outside a marked "
+                f"block — a runnable copy carrying `{option.group(0)}`. Move it into a fenced block opening "
+                f"```sh gauntlet-cmd=<id>` (ids: {', '.join(sorted(DOCUMENTED_COMMANDS))}), or reword the "
+                f"prose to NAME the command without its flags."
+            )
+    return problems
 
 
 def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) -> int:
@@ -2362,7 +2383,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          paragraphs. A value in a hole matches NO branch: not green, not red, not pending — the PR can never
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
-         every copy of the derive and required-set commands and their required ledger inputs.
+         every MARKED `ci-status.py` command block against the tokens `DOCUMENTED_COMMANDS` requires of it,
+         and that no runnable copy sits OUTSIDE such a block (prose may NAME a command, never run one).
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.
@@ -2504,22 +2526,18 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
         held.append(f"{'the gh invocations':32} every copy in the doc: --paginate --slurp, "
                     f"--json {json_fields}, and REPO-SCOPED")
 
-    # AND EVERY COPY OF THE DERIVE COMMAND ITSELF, ACROSS EVERY SKILL DOC — the class, not the instance.
-    derive_problems, derive_copies = check_derive_copies()
-    problems += derive_problems
-    if not derive_problems:
-        held.append(f"{'the derive invocations':32} {len(derive_copies)} copies across the skill's docs, "
-                    f"every one naming the required set (--ledger or --required-set)")
-    required_problems, required_copies = check_required_set_copies()
-    problems += required_problems
-    if not required_problems:
-        held.append(f"{'the required-set invocations':32} {len(required_copies)} runnable copies, every one "
-                    f"persisting to state.jsonl")
-    liveness_problems, liveness_copies = check_liveness_copies()
-    problems += liveness_problems
-    if not liveness_problems:
-        held.append(f"{'the liveness invocations':32} {len(liveness_copies)} runnable copies, every one "
-                    f"answering --machine-action")
+    # AND EVERY MARKED COMMAND BLOCK, ACROSS EVERY SKILL DOC — the class, not the instance.
+    marked_problems, marked_blocks = check_marked_commands()
+    problems += marked_problems
+    if not marked_problems:
+        held.append(f"{'the marked command blocks':32} {len(marked_blocks)} blocks across the skill's docs, "
+                    f"every one carrying every token its gauntlet-cmd id requires")
+    # AND THAT NO RUNNABLE COPY ESCAPED THE MARKER — the check that keeps a forgotten marker LOUD.
+    unmarked_problems = check_unmarked_commands()
+    problems += unmarked_problems
+    if not unmarked_problems:
+        held.append(f"{'no unmarked command copies':32} every runnable {COMMAND_NAME} copy sits in a marked "
+                    f"block; prose only NAMES the command")
     for line in held:
         print(f"ok       {line}")
     for problem in problems:
@@ -2533,7 +2551,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
         return 1
     print(f"{len(checks) + len(held)} checks: {spec_doc.name}, {driver_doc.name}, ci-snapshot.py and "
           f"ci-status.py agree — enums, CLASSIFY buckets, TOTALITY, the DECIDE order, the caps, the "
-          f"FINGERPRINT lines, moved-head and liveness contracts, and every copy of every command.")
+          f"FINGERPRINT lines, moved-head and liveness contracts, every `gh` copy, and every marked "
+          f"command block with no runnable copy outside one.")
     return 0
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2245,8 +2245,9 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
 
 
 # EVERY RUNNABLE COPY OF A `ci-status.py` COMMAND LIVES IN A MARKED BLOCK, AND THE CHECKER NEVER GUESSES
-# WHICH TEXT IS A COMMAND. A marked block opens with the info string ```sh gauntlet-cmd=<id>`; `<id>` keys
-# this table, and the block's body must BE the string `canonical_command()` GENERATES for that id.
+# WHICH TEXT IS A COMMAND. A marked block opens with the info string ```sh gauntlet-cmd=<id>` and ends
+# where `MARKED_CLOSE` says it ends; `<id>` keys this table, and the block's body must BE the string
+# `canonical_command()` GENERATES for that id.
 #
 # **THE REFERENCE IS GENERATED, SO NO CODE PATH JUDGES A COMMAND LINE BY SEARCHING IT.** Four rounds asked
 # instead whether a documented line CARRIED the tokens its id requires, and every one of them died to text
@@ -2340,7 +2341,60 @@ def canonical_command(cmd_id: str) -> str:
 # DOCUMENTED_COMMANDS be the only thing that decides which ids exist. Trailing spaces are dropped because
 # CommonMark drops them from the info string, so a fence this checker rejected over one would be a fence the
 # renderer accepted.
-MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n(?P<body>.*?)^```", re.M | re.S)
+MARKED_OPENER = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n", re.M)
+# THE CLOSE IS HALF THE DEFINITION OF THE BODY, SO IT IS AS STRICT AS THE EQUALITY IS. A closing fence is a
+# line AT COLUMN 0 of three or more backticks carrying nothing but optional spaces or tabs. Any other line
+# is BODY — including one that merely STARTS with backticks, which CommonMark also treats as body because
+# it forbids an info string on a closing fence. A close that ended at `^```` would hand the author the
+# carrier the equality exists to refuse: write ```` ``` anything ```` and every line after it renders inside
+# the block while none of it reaches the comparison. This is stated as ONE POSITIVE RULE and must stay one:
+# a list of the malformed spellings that are NOT a close is the enumeration that has no fixed point.
+#
+# COLUMN 0 IS DELIBERATE AND FAIL-CLOSED. CommonMark permits up to three spaces of indent on a closing
+# fence; this checker does not, so an indented close reads as an opener that never closes and is REPORTED.
+# The scheme recognizes a marked fence written at column 0 and its conforming close, and nothing else about
+# fence placement — being told to unindent is the correct outcome, never a false pass.
+MARKED_CLOSE = re.compile(r"^```+[ \t]*$", re.M)
+
+
+class MarkedBlock(NamedTuple):
+    """One marked opener and the span it delimits. `body` is None when the opener NEVER closes."""
+
+    cmd_id: str
+    body: str | None
+    line: int
+    start: int
+    end: int
+
+
+def marked_blocks(text: str) -> list[MarkedBlock]:
+    """Every marked opener in `text`, paired with the body its conforming close delimits.
+
+    **THE OPENER IS THE ANCHOR, NOT THE PAIR.** One regex spanning opener-to-close cannot report what it
+    cannot match: an opener with no conforming close simply fails to match, and the whole block DISAPPEARS
+    from every caller — no comparison, no unknown-id complaint, and (when another block already covers the
+    id) no zero-blocks complaint either. To the renderer that same opener swallows the REST OF THE FILE into
+    a marked block, so a document could hold an incomplete invocation, inside a block that claims to be
+    checked, and pass. Scanning FROM the opener makes the missing close a reportable fact instead of a
+    silent non-match.
+
+    An unterminated opener is always the LAST block: everything after it is inside its body, so there is
+    nothing further to find.
+    """
+    blocks: list[MarkedBlock] = []
+    pos = 0
+    while (opener := MARKED_OPENER.search(text, pos)) is not None:
+        line = text.count("\n", 0, opener.start()) + 1
+        close = MARKED_CLOSE.search(text, opener.end())
+        if close is None:
+            blocks.append(MarkedBlock(opener.group("id"), None, line, opener.start(), len(text)))
+            break
+        blocks.append(MarkedBlock(opener.group("id"), text[opener.end():close.start()], line,
+                                  opener.start(), close.end()))
+        pos = close.end()
+    return blocks
+
+
 LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
 # A prose occurrence of the script name, for the copies that must sit OUTSIDE a marked block. The boundary
 # is a WHOLE FILE NAME ON BOTH SIDES, and both halves are load-bearing in opposite directions. Without the
@@ -2401,10 +2455,14 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
     """Every marked block's body EQUALS the command `canonical_command()` generates for its `gauntlet-cmd`
     id.
 
-    Three ways to fail: the body is not that command; an id is claimed that `DOCUMENTED_COMMANDS` does not
-    define; or an id it does define has NO block anywhere. That last one is what stops the marker from
-    quietly narrowing the check — delete the only marked copy of a command and the build goes red, exactly
-    as it did when the checker hunted copies for itself.
+    Four ways to fail: the body is not that command; an id is claimed that `DOCUMENTED_COMMANDS` does not
+    define; a marked opener never closes; or an id the table defines has NO block anywhere. That last one is
+    what stops the marker from quietly narrowing the check — delete the only marked copy of a command and
+    the build goes red, exactly as it did when the checker hunted copies for itself.
+
+    AN UNTERMINATED OPENER CREDITS NOTHING. It is reported and its id is NOT marked as seen, so when the
+    broken block is the only one claiming that id the zero-blocks failure fires beside it: a block whose
+    body the checker never read must never be the reason a command counts as documented.
 
     **THE COMPARISON IS EQUALITY, AND THAT IS THE WHOLE DESIGN.** It does not locate the command inside the
     body, subtract text it dislikes, or reason about shell. A body holding anything besides the generated
@@ -2421,10 +2479,19 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
     seen: set[str] = set()
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        for match in MARKED_FENCE.finditer(text):
-            cmd_id, body = match.group("id"), match.group("body")
-            line = text.count("\n", 0, match.start()) + 1
-            where = f"{md.name}:{line}"
+        for block in marked_blocks(text):
+            cmd_id, body = block.cmd_id, block.body
+            where = f"{md.name}:{block.line}"
+            if body is None:
+                problems.append(
+                    f"{where} opens `gauntlet-cmd={cmd_id}` and NEVER CLOSES — no line of three or more "
+                    f"backticks, at column 0 and carrying nothing but optional spaces or tabs, follows it. "
+                    f"The renderer swallows the rest of the file into this block, so text that never "
+                    f"reaches the comparison renders inside a block that claims to be checked. Close the "
+                    f"fence with a line reading exactly ```` ``` ````, and remember that a closing fence "
+                    f"may not be indented or carry an info string."
+                )
+                continue
             if cmd_id not in DOCUMENTED_COMMANDS:
                 problems.append(
                     f"{where} is marked `gauntlet-cmd={cmd_id}`, which DOCUMENTED_COMMANDS does not define "
@@ -2466,9 +2533,11 @@ def check_unmarked_commands(root: Path | None = None) -> list[str]:
     closed. `` `ci-status.py liveness --ledger …` `` is a copy, and a copy that has drifted is a reader
     running the wrong thing and believing the answer.
 
-    Marked blocks are blanked first, so their contents are exempt. Every OTHER fence is not: an unmarked
-    fenced command has no backtick before the closing fence, so its flags land in the window and it is
-    reported — which is what makes forgetting the marker loud instead of silently unchecked.
+    CLOSED marked blocks are blanked first, so their contents are exempt. Every OTHER fence is not: an
+    unmarked fenced command has no backtick before the closing fence, so its flags land in the window and
+    it is reported — which is what makes forgetting the marker loud instead of silently unchecked. An
+    opener that never closes buys no exemption either: `check_marked_commands` reports the broken fence,
+    and nothing behind it is blanked, so a runnable copy sitting inside it is still reported here.
 
     The occurrence is matched with `PROSE_TOKEN`, which requires a WHOLE FILE NAME on both sides. A bare
     substring scan reports a hypothetical `example-ci-status.py derive --pr 1` as a copy of THIS script,
@@ -2481,7 +2550,16 @@ def check_unmarked_commands(root: Path | None = None) -> list[str]:
     """
     problems: list[str] = []
     for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = MARKED_FENCE.sub(lambda m: _blank(m.group(0)), md.read_text(encoding="utf-8"))
+        raw = md.read_text(encoding="utf-8")
+        kept: list[str] = []
+        pos = 0
+        for block in marked_blocks(raw):
+            if block.body is None:
+                continue  # never closed: not a block, so not exempt
+            kept += [raw[pos:block.start], _blank(raw[block.start:block.end])]
+            pos = block.end
+        kept.append(raw[pos:])
+        text = "".join(kept)
         for match in PROSE_TOKEN.finditer(text):
             tick = text.find("`", match.end())
             if tick < 0:  # unbackticked tail: fall back to the paragraph, never to an empty window
@@ -2518,8 +2596,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
          every MARKED `ci-status.py` block against the command `canonical_command()` generates for its id,
-         which its body must EQUAL, and that no runnable copy sits OUTSIDE such a block (prose may NAME a
-         command, never run one).
+         which its body must EQUAL, that every marked opener has a conforming CLOSE, and that no runnable
+         copy sits OUTSIDE such a block (prose may NAME a command, never run one).
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.
@@ -2662,11 +2740,11 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
                     f"--json {json_fields}, and REPO-SCOPED")
 
     # AND EVERY MARKED COMMAND BLOCK, ACROSS EVERY SKILL DOC — the class, not the instance.
-    marked_problems, marked_blocks = check_marked_commands()
+    marked_problems, marked_found = check_marked_commands()
     problems += marked_problems
     if not marked_problems:
-        held.append(f"{'the marked command blocks':32} {len(marked_blocks)} blocks across the skill's docs, "
-                    f"every body EQUAL to the command generated for its gauntlet-cmd id")
+        held.append(f"{'the marked command blocks':32} {len(marked_found)} blocks across the skill's docs, "
+                    f"every one CLOSED and its body EQUAL to the command generated for its gauntlet-cmd id")
     # AND THAT NO RUNNABLE COPY ESCAPED THE MARKER — the check that keeps a forgotten marker LOUD.
     unmarked_problems = check_unmarked_commands()
     problems += unmarked_problems

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -119,8 +119,9 @@ one a reader believed. `doc-check` PARSES the doc's own enum block, its two CLAS
 bullet order, and asserts they agree with the sets `ci-snapshot.py` actually classifies with — and that the
 classification is TOTAL over the enums the doc declares. It also checks every copy of a `gh` command the doc
 prints against the argv this code really issues, the command every MARKED `ci-status.py` block RUNS against
-the tokens its `gauntlet-cmd` id requires — with no runnable copy sitting OUTSIDE such a block — and the
-moved-head owner block's retained-artifact/trust/result contract. Drift is a RED BUILD, not a discovery.
+the tokens its `gauntlet-cmd` id requires — carrying nothing on that line but the invocation, and with no
+runnable copy sitting OUTSIDE such a block — and the moved-head owner block's retained-artifact/trust/result
+contract. Drift is a RED BUILD, not a discovery.
 
 **A check that finds nothing MUST NOT PASS.** If the doc cannot be found, or a block cannot be parsed, or
 zero rules are extracted, `doc-check` FAILS. An extractor that silently matches nothing and reports success
@@ -2253,8 +2254,9 @@ def _has_long_option(command: str, option: str) -> bool:
 # this table, whose value is every token that copy MUST carry. A nested tuple is an alternation — any one of
 # its members satisfies it. A `--flag` requirement is matched as a long option (argparse's `--name=value`
 # form included); anything else must appear as a WHOLE command token — see `_requirement_met`. The tokens
-# are required of the block's `ci-status.py` INVOCATION, never merely of its fenced body — see
-# `_invocations`, which is what stops other text in the block from supplying them.
+# are required of the block's `ci-status.py` INVOCATION, never merely of its fenced body: `_invocations`
+# scopes the search to a command line and `_extraneous` refuses a command line carrying anything but the
+# command, and it takes both to stop other text in the block from supplying them.
 #
 # A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
 # is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
@@ -2287,6 +2289,13 @@ DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
 # CommonMark drops them from the info string, so a fence this checker rejected over one would be a fence the
 # renderer accepted.
 MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n(?P<body>.*?)^```", re.M | re.S)
+# A `<…>` PLACEHOLDER IS PROSE, NOT SHELL — this doc set's own convention for a value the reader supplies
+# (`<rundir>`, `<the LEDGER's head_sha>`, `--machine-action <due | in-flight | none>`). `_extraneous` blanks
+# them before it looks for shell, or that documented choice would read as a pipe.
+PLACEHOLDER = re.compile(r"<[^<>\n]*>")
+# The shell this checker refuses to read: a comment, a chain, a pipe, a background/`&&` chain, and the two
+# substitution forms. See `_extraneous` for why the answer is refusal rather than parsing.
+NOT_INVOCATION = ("#", ";", "|", "&", "`", "$(")
 LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
 COMMAND_NAME = "ci-status.py"
 # The SAME whole-token rule `_requirement_met` applies, used to LOCATE the invocation. A substring locator
@@ -2305,10 +2314,10 @@ def _requirement_met(command: str, want: str) -> bool:
     the path-SUFFIX requirements working: `--ledger <rundir>/state.jsonl` satisfies `state.jsonl`, and
     `python3 <skill>/scripts/ci-status.py` satisfies `ci-status.py`.
 
-    WHERE a token may be found is a separate question, answered by `_invocations`: this decides only WHAT
-    counts as one. Both are load-bearing — whole-token matching over a whole fenced body still accepts a
-    comment that spells the missing tokens, and an invocation-scoped substring match still accepts a
-    subcommand that merely ENDS in the required one.
+    WHERE a token may be found is a separate question, answered by `_invocations` and `_extraneous`: this
+    decides only WHAT counts as one. Both are load-bearing — whole-token matching over a whole fenced body
+    still accepts a comment that spells the missing tokens, and an invocation-scoped substring match still
+    accepts a subcommand that merely ENDS in the required one.
     """
     if want.startswith("--"):
         return _has_long_option(command, want)
@@ -2335,7 +2344,10 @@ def _invocations(body: str) -> list[str]:
       this repo) must not open a window; a substring locator would let it, and the mislabel it was meant to
       catch would then be checked against the wrong text.
 
-    Comment lines are dropped before any of that, because a comment is text the block does not run.
+    WHOLE comment LINES are dropped before any of that, because a comment is text the block does not run.
+    That is only half the carrier: a comment on the same line as the command is INSIDE the window this
+    returns, and so are `;`, `|`, `&&` and `$(…)`. `_extraneous` refuses those rather than parse them, and
+    this function must not try to — deciding where a shell command ends is the parsing this scheme replaced.
     """
     text = "\n".join("" if line.lstrip().startswith("#") else line for line in body.splitlines())
     windows: list[str] = []
@@ -2370,20 +2382,50 @@ def _blank(text: str) -> str:
     return re.sub(r"[^\n]", " ", text)
 
 
+def _extraneous(window: str) -> str | None:
+    """The first mark of text an invocation does not CONSIST of, or `None`. REFUSE it; never parse it.
+
+    `_invocations` decides where a command STARTS. Nothing decided where it stops being ONE command, and a
+    window runs to the end of the backslash-continued command LINE — so everything a shell would treat as a
+    separate thing on that line is still inside it. A trailing `# …` comment, a `; …` chain, a `| …` pipe, a
+    `&& …` chain and a `$(…)` substitution are all the same carrier, and each one breaks the anti-lie
+    property rather than merely relaxing the check: mark a block `gauntlet-cmd=derive`, run
+    `ci-status.py liveness …` in it, append `# derive --head-sha … --rundir …` to that same line, and the
+    mislabel passes clean. Cutting each line at an unquoted `#` closes the comment and none of the rest.
+
+    SO THE BLOCK IS REFUSED, NOT PARSED. Telling the invocation from the text after it means splitting shell
+    words, and that is the exact spiral this scheme exists to end (see `DOCUMENTED_COMMANDS`, "WHY THE
+    MARKER EXISTS AT ALL"). `shlex` is not the escape hatch: `shlex.split` raises `ValueError: No closing
+    quotation` on the live `<the LEDGER's head_sha>` placeholder, and `shlex.shlex(punctuation_chars=True)`
+    shreds `<rundir>` into three tokens. A documented command line has no need of shell syntax, so requiring
+    it to carry NONE is a rule an author can satisfy and this checker can enforce with no parser at all.
+
+    Placeholders are blanked first because they are prose, not shell: the live `liveness` copy documents
+    `--machine-action <due | in-flight | none>`, whose `|` is a choice offered to the reader. Requirements
+    are still matched against the ORIGINAL window (`check_marked_commands`), so `--ledger
+    <rundir>/state.jsonl` goes on satisfying the `state.jsonl` path suffix.
+    """
+    bare = PLACEHOLDER.sub(lambda match: _blank(match.group()), window)
+    found = [(bare.find(mark), mark) for mark in NOT_INVOCATION if mark in bare]
+    return min(found)[1] if found else None
+
+
 def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
     """Every marked block runs an INVOCATION carrying every token its `gauntlet-cmd` id requires.
 
-    Four ways to fail, and the last two are the ones a marker scheme invites: an invocation omits a required
-    token; the block runs no `ci-status.py` command at all; an id is claimed that this table does not
-    define; or an id this table defines has NO block anywhere. That last one is what stops the marker from
-    quietly narrowing the check — delete the only marked copy of a command and the build goes red, exactly
-    as it did when the checker hunted copies for itself.
+    Five ways to fail, and the last two are the ones a marker scheme invites: an invocation omits a required
+    token; the command line carries text that is not part of the invocation (`_extraneous`); the block runs
+    no `ci-status.py` command at all; an id is claimed that this table does not define; or an id this table
+    defines has NO block anywhere. That last one is what stops the marker from quietly narrowing the check —
+    delete the only marked copy of a command and the build goes red, exactly as it did when the checker
+    hunted copies for itself.
 
     A block also cannot lie about which command it is, because the script name and the subcommand are
     ordinary required tokens: label a `liveness` block `gauntlet-cmd=derive` and it fails on `derive`. That
-    holds only because the tokens are looked for in the COMMAND (`_invocations`) rather than anywhere in the
-    fenced body — a comment or a second line elsewhere in the block would otherwise hand the mislabel the
-    tokens its real invocation does not have.
+    holds only because the tokens are looked for in the COMMAND rather than anywhere in the fenced body,
+    which takes BOTH halves: `_invocations` scopes the search to a command line, and `_extraneous` refuses a
+    command line that carries anything besides the command. Drop either and a comment or a second line hands
+    the mislabel the tokens its real invocation does not have.
     """
     problems, found = [], []
     seen: set[str] = set()
@@ -2409,6 +2451,18 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
                     f"{where} is marked `gauntlet-cmd={cmd_id}` but the block RUNS no `{COMMAND_NAME}` "
                     f"command — the marker promises a copy a reader can run, and there is none to check, "
                     f"so every token the id requires would be looked for in text nobody executes."
+                )
+                continue
+            # THE WINDOW CAN HOLD TEXT THE INVOCATION DOES NOT CONSIST OF. Reported BEFORE the token check
+            # and instead of it: the tokens such a line supplies are the whole reason it is refused, so
+            # naming what it "omits" would describe the wrong defect and invite the wrong repair.
+            if marks := [mark for window in windows if (mark := _extraneous(window))]:
+                problems.append(
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but its command line carries `{marks[0]}` "
+                    f"— text the invocation does not consist of. This checker refuses shell it does not "
+                    f"parse, because a comment, a chain, a pipe or a substitution ON the command line hands "
+                    f"the block tokens the command a reader RUNS does not carry. Move the comment outside "
+                    f"the fence, or give the second command its own line."
                 )
                 continue
             # A block passes when ONE of its invocations carries everything, and is reported against the
@@ -2480,8 +2534,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
          the command every MARKED `ci-status.py` block RUNS against the tokens `DOCUMENTED_COMMANDS`
-         requires of that id, and that no runnable copy sits OUTSIDE such a block (prose may NAME a
-         command, never run one).
+         requires of that id, that its command line carries nothing but that invocation, and that no
+         runnable copy sits OUTSIDE such a block (prose may NAME a command, never run one).
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.
@@ -2628,7 +2682,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
     problems += marked_problems
     if not marked_problems:
         held.append(f"{'the marked command blocks':32} {len(marked_blocks)} blocks across the skill's docs, "
-                    f"every one RUNNING a command that carries every token its gauntlet-cmd id requires")
+                    f"every one RUNNING a command line that carries every token its gauntlet-cmd id "
+                    f"requires and nothing besides the invocation")
     # AND THAT NO RUNNABLE COPY ESCAPED THE MARKER — the check that keeps a forgotten marker LOUD.
     unmarked_problems = check_unmarked_commands()
     problems += unmarked_problems

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -118,10 +118,10 @@ The enums, the CLASSIFY buckets and the DECIDE order are stated in `ci-derivatio
 one a reader believed. `doc-check` PARSES the doc's own enum block, its two CLASSIFY tables and its DECIDE
 bullet order, and asserts they agree with the sets `ci-snapshot.py` actually classifies with — and that the
 classification is TOTAL over the enums the doc declares. It also checks every copy of a `gh` command the doc
-prints against the argv this code really issues, the command every MARKED `ci-status.py` block RUNS against
-the tokens its `gauntlet-cmd` id requires — such a block being ONE invocation and nothing else, and with no
-runnable copy sitting OUTSIDE such a block — and the moved-head owner block's retained-artifact/trust/result
-contract. Drift is a RED BUILD, not a discovery.
+prints against the argv this code really issues, every MARKED `ci-status.py` block against the command this
+file GENERATES for its `gauntlet-cmd` id — which the block's body must EQUAL, with no runnable copy sitting
+OUTSIDE such a block — and the moved-head owner block's retained-artifact/trust/result contract. Drift is a
+RED BUILD, not a discovery.
 
 **A check that finds nothing MUST NOT PASS.** If the doc cannot be found, or a block cannot be parsed, or
 zero rules are extracted, `doc-check` FAILS. An extractor that silently matches nothing and reports success
@@ -2244,24 +2244,28 @@ def check_gh_invocations(text: str, argv: dict[str, list[str]]) -> list[str]:
     return problems
 
 
-def _has_long_option(command: str, option: str) -> bool:
-    """Recognize one long-option token, including argparse's ``--name=value`` form."""
-    return re.search(rf"(?<![\w-]){re.escape(option)}(?=[=\s]|$)", command) is not None
-
-
 # EVERY RUNNABLE COPY OF A `ci-status.py` COMMAND LIVES IN A MARKED BLOCK, AND THE CHECKER NEVER GUESSES
 # WHICH TEXT IS A COMMAND. A marked block opens with the info string ```sh gauntlet-cmd=<id>`; `<id>` keys
-# this table, whose value is every token that copy MUST carry. A nested tuple is an alternation — any one of
-# its members satisfies it. A `--flag` requirement is matched as a long option (argparse's `--name=value`
-# form included); anything else must appear as a WHOLE command token — see `_requirement_met`. The tokens
-# are required of the block's `ci-status.py` INVOCATION, never merely of its fenced body: a marked block
-# must BE one invocation (`_sole_invocation`) and `_extraneous` refuses even that one line when it carries
-# anything besides the command, and it takes both to stop other text in the block from supplying them.
+# this table, and the block's body must BE the string `canonical_command()` GENERATES for that id.
+#
+# **THE REFERENCE IS GENERATED, SO NO CODE PATH JUDGES A COMMAND LINE BY SEARCHING IT.** Four rounds asked
+# instead whether a documented line CARRIED the tokens its id requires, and every one of them died to text
+# the block's author put beside the command: a second line, a comment line, a trailing comment, a `;`, `|`,
+# `&&` or `$(…)` chain, an `echo` in front, a heredoc around it, a mislabelled tail of extra arguments, and
+# a `>` redirection whose operand spelled the very tokens the invocation lacked. Searching a line has no
+# fixed point, because the author picks what else is on that line and can always add more. EQUALITY has
+# one: exactly one string passes, this file writes it, and every carrier above fails BY CONSTRUCTION
+# instead of by enumeration. Nothing here parses shell, subtracts text, or locates a window — the only
+# latitude is `_collapsed_lines`, which joins continuations and collapses whitespace runs so a wrapped copy
+# is the same command as an unwrapped one.
 #
 # A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
 # is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
 # each row against `build_parser()` instead (`ci-status-test.documented_commands_agree_with_argparse`). A
 # flag the parser REQUIRES and a row omits is a copy this checker calls complete and the tool then refuses.
+# argparse's remaining job is exactly that reconciliation: the row, never the parser, decides which
+# OPTIONAL flags a documented copy spells, because `derive` alone would otherwise gain `--repo`,
+# `--ledger` and `--required-set` all at once.
 #
 # WHY THE MARKER EXISTS AT ALL. The checker used to hunt runnable copies in free Markdown, which meant
 # deciding, for arbitrary prose, whether a stretch of text was a command or a sentence about one. That
@@ -2269,18 +2273,66 @@ def _has_long_option(command: str, option: str) -> bool:
 # reach it, two of them died at their repair cap, and 793 lines of that parsing were deleted unmerged. The
 # marker moves the decision from the checker to the author, where it costs one info string and cannot be
 # wrong. What remains here recognizes fences and backticks, and nothing else about Markdown.
+COMMAND_NAME = "ci-status.py"
+# THE FIXED PREFIX EVERY GENERATED COMMAND OPENS WITH. `<skill>` is this doc set's own convention for the
+# directory holding the active SKILL.md, so the string this file writes is the one a reader really types.
+COMMAND_PREFIX = f"python3 <skill>/scripts/{COMMAND_NAME}"
+# ONE VALUE SLOT PER FLAG — a property of the FLAG, not of the subcommand that takes it, so `--ledger`
+# reads the same in every command that names it. These are the doc set's `<…>` placeholder convention:
+# prose telling the reader what to supply, never shell, and nothing here reads them as shell because
+# nothing here reads shell at all. A flag `DOCUMENTED_COMMANDS` names with no slot here is a table
+# `canonical_command()` cannot render, which the argparse reconciliation refuses.
+FLAG_VALUES: dict[str, str] = {
+    "--pr": "<N>",
+    "--head-sha": "<the LEDGER's head_sha>",
+    "--rundir": "<rundir>",
+    "--ledger": "<rundir>/state.jsonl",
+    "--required-set": "<declared:… | none | unknown>",
+    "--derive-json": "<the JSON derive printed, saved to a file — or - for stdin>",
+    "--machine-action": "<due | in-flight | none>",
+}
+# The FLAGS each documented command spells, in the order the canonical copy spells them. The subcommand is
+# the id itself, and the script name comes from `COMMAND_PREFIX`, so neither can be stated here and drift.
+# A nested tuple is an alternation: its FIRST member is the form the canonical copy uses, and the rest
+# record the other spellings the tool accepts, which the argparse reconciliation still holds to the parser.
 DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
     # The required set is what makes `green` mean *the required set passed*, and it is the ROW's
     # `effective_required_set`: name it with `--ledger` (resolve the row's set — the production form) or
     # with an explicit `--required-set`. A copy carrying NEITHER reconstructs an invocation the tool refuses.
-    "derive": ("ci-status.py", "derive", "--pr", "--head-sha", "--rundir", ("--ledger", "--required-set")),
+    "derive": ("--pr", "--head-sha", "--rundir", ("--ledger", "--required-set")),
     # `--machine-action` is the one judgment the command asks of its caller. A reader who drops the question
     # and invents a default strikes the very PR a fix is about to move. `--derive-json` is the evidence the
     # bookkeeping is ABOUT: argparse requires it, so a copy without it is an invocation the tool refuses.
-    "liveness": ("ci-status.py", "liveness", "--ledger", "--pr", "--derive-json", "--machine-action"),
-    # The command must persist the value it read, so the copy names the run ledger it persists to.
-    "required-set": ("ci-status.py", "required-set", "--ledger", "state.jsonl"),
+    "liveness": ("--ledger", "--pr", "--derive-json", "--machine-action"),
+    # The command persists the value it read to the run ledger, which `--ledger` names. Its optional
+    # `--repo` belongs in the PROSE beside the block and never in it: a bracketed `[--repo <owner>/<repo>]`
+    # is literal text in a body that must BE the command, so the block would no longer equal it.
+    "required-set": ("--ledger",),
 }
+
+
+def canonical_flags(cmd_id: str) -> list[str]:
+    """The flags the canonical copy of `cmd_id` SPELLS, in the row's order.
+
+    THE ONE PLACE THE ALTERNATION RULE LIVES: a nested tuple contributes its FIRST member and nothing else.
+    Both the generator and the argparse reconciliation read it from here, so neither can restate it wrong.
+    """
+    return [want[0] if isinstance(want, tuple) else want for want in DOCUMENTED_COMMANDS[cmd_id]]
+
+
+def canonical_command(cmd_id: str) -> str:
+    """THE one string a block marked `gauntlet-cmd=<cmd_id>` must hold, generated rather than transcribed.
+
+    This is the whole reference the checker owns. The subcommand IS the id — every id is held to a real
+    subparser by `documented_commands_agree_with_argparse`, so the two cannot drift — and each flag the row
+    spells is emitted with its `FLAG_VALUES` slot. A `KeyError` here is a row naming a flag with no slot,
+    which the same reconciliation reports before it can ever be reached from a doc.
+    """
+    parts = [COMMAND_PREFIX, cmd_id]
+    for flag in canonical_flags(cmd_id):
+        parts += [flag, FLAG_VALUES[flag]]
+    return " ".join(parts)
+
 
 # The id is ANY nonempty run of characters, never a spelling this checker approves of: an id the regex
 # REJECTS is not a marked block at all, so the unknown-id branch below cannot fire and the author is told to
@@ -2289,51 +2341,18 @@ DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
 # CommonMark drops them from the info string, so a fence this checker rejected over one would be a fence the
 # renderer accepted.
 MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n(?P<body>.*?)^```", re.M | re.S)
-# A `<…>` PLACEHOLDER IS PROSE, NOT SHELL — this doc set's own convention for a value the reader supplies
-# (`<rundir>`, `<the LEDGER's head_sha>`, `--machine-action <due | in-flight | none>`). `_extraneous` blanks
-# them before it looks for shell, or that documented choice would read as a pipe.
-PLACEHOLDER = re.compile(r"<[^<>\n]*>")
-# The shell this checker refuses to read: a comment, a chain, a pipe, a background/`&&` chain, and the two
-# substitution forms. See `_extraneous` for why the answer is refusal rather than parsing.
-NOT_INVOCATION = ("#", ";", "|", "&", "`", "$(")
 LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
-COMMAND_NAME = "ci-status.py"
-# The SAME whole-token rule `_requirement_met` applies. It no longer LOCATES anything — `_sole_invocation`
-# decides that — and is used only to tell a block that runs a DIFFERENT script from one that runs ours
-# amid other text, so the two refusals name the right defect. A substring test would call
-# `example-ci-status.py` (invented; it appears nowhere in this repo) an occurrence of this script.
-COMMAND_TOKEN = re.compile(rf"(?:\A|[\s/=]){re.escape(COMMAND_NAME)}(?=\s|\Z)")
-# A MARKED BLOCK **IS** ONE INVOCATION: optional leading whitespace, an optional `python3` interpreter word,
-# an optional path, then the script name as a whole token. Anchored at the START of the block's one logical
-# line, which is what makes the rule have a fixed point — see `_sole_invocation`.
-SOLE_INVOCATION = re.compile(rf"^[ \t]*(?:python3?[ \t]+)?(?:\S*/)?{re.escape(COMMAND_NAME)}(?=[ \t]|$)")
-# A prose occurrence of the script name, for the copies that must sit OUTSIDE a marked block. Its boundary
-# is deliberately NOT `COMMAND_TOKEN`'s: prose writes the name inside a code span, and `COMMAND_TOKEN`'s
-# `[\s/=]` left boundary does not admit the backtick that opens almost every real copy — swapping it in
-# here silences the check the marker scheme lives on. This one rejects `example-ci-status.py` and
-# `myci-status.py` (both invented; neither appears in this repo) while still admitting `` `ci-status.py ``,
-# `scripts/ci-status.py` and `./ci-status.py`.
-PROSE_TOKEN = re.compile(rf"(?<![\w.-]){re.escape(COMMAND_NAME)}(?![\w-])")
-
-
-def _requirement_met(command: str, want: str) -> bool:
-    """A `--flag` is matched as a long option; every other requirement as a WHOLE command token.
-
-    Whole-token, not substring, is what stops a block from LYING about which command it is. Plain
-    `want in command` accepts an invented `example-tool.py rederive` (it appears nowhere in this repo) for
-    both `ci-status.py` and `derive`, so a block marked `gauntlet-cmd=derive` that runs neither the script
-    nor the subcommand passes clean. A leading `/` or `=` still counts as a token start, which is what keeps
-    the path-SUFFIX requirements working: `--ledger <rundir>/state.jsonl` satisfies `state.jsonl`, and
-    `python3 <skill>/scripts/ci-status.py` satisfies `ci-status.py`.
-
-    WHERE a token may be found is a separate question, answered by `_sole_invocation` and `_extraneous`:
-    this decides only WHAT counts as one. Both are load-bearing — whole-token matching over a whole fenced
-    body still accepts a comment that spells the missing tokens, and an invocation-scoped substring match
-    still accepts a subcommand that merely ENDS in the required one.
-    """
-    if want.startswith("--"):
-        return _has_long_option(command, want)
-    return re.search(rf"(?:\A|[\s/=]){re.escape(want)}(?=\s|\Z)", command) is not None
+# A prose occurrence of the script name, for the copies that must sit OUTSIDE a marked block. The boundary
+# is a WHOLE FILE NAME ON BOTH SIDES, and both halves are load-bearing in opposite directions. Without the
+# left half a hypothetical `example-ci-status.py derive --pr 1` is reported as a copy of THIS script, which
+# sends an author to move someone else's command. Without the right half a hypothetical `ci-status.py.bak
+# derive --pr 1` is too — a different file, reported under this one's name. Both names are hypothetical:
+# this repo ships no script called either, which `find` confirms and which adding a fixture cannot change.
+# The character class is NOT the one a shell-token boundary would use: prose writes the name inside a code
+# span, so a boundary excluding the backtick would stop reporting the code-span copies that are nearly all
+# the real ones, and a forgotten marker would then read as success. This one still admits
+# `` `ci-status.py ``, `scripts/ci-status.py` and `./ci-status.py`.
+PROSE_TOKEN = re.compile(rf"(?<![\w.-]){re.escape(COMMAND_NAME)}(?![\w.-])")
 
 
 def _logical_lines(body: str) -> list[str]:
@@ -2358,47 +2377,19 @@ def _logical_lines(body: str) -> list[str]:
     return lines
 
 
-def _sole_invocation(body: str) -> tuple[str | None, str]:
-    """A marked block's ONE invocation, from the script-name token on — or `(None, why it is refused)`.
+def _collapsed_lines(body: str) -> list[str]:
+    """A fenced body as the command lines it holds: continuations JOINED, whitespace runs COLLAPSED.
 
-    **THE BLOCK MUST *BE* THE COMMAND, NOT MERELY CONTAIN IT, AND THIS CHECK USED TO THINK OTHERWISE.**
-    Three rounds located a command WINDOW inside a free-form body and then subtracted the text that should
-    not be there. Subtraction has no fixed point, because the block's author picks the surrounding text: a
-    whole-body token search fell to a comment line and to an unrelated second command; scoping to the
-    command line and refusing `#`, `;`, `|`, `&`, `` ` `` and `$(` on it fell to text to the LEFT of the
-    token, which nothing looked at — `echo ci-status.py derive …` runs `echo` and passed clean. Requiring
-    the token to OPEN its line does not close it either: a heredoc (`cat > c.sh <<'EOF'` / the command /
-    `EOF`) WRITES the invocation to a file, never runs it, and passes.
+    This is the ONLY latitude the equality comparison allows, and it is not a relaxation of it. All three
+    live copies WRAP, so a byte-exact test would condemn every one of them over the `\\` and the indent
+    that continues the line — turning correct blocks red, which is how a check gets deleted by the next
+    person in a hurry.
 
-    So the rule is not "the block contains a command that carries the tokens" but **"the block IS one
-    invocation"**: exactly one logical line, and that line begins with the script name (after an optional
-    `python3` word and an optional path). Everything else is refused unparsed. There is nothing left to the
-    left of the token, no second line to supply what the command lacks, and — since a documented command
-    line has no need of shell syntax — no author is inconvenienced. `_extraneous` still runs over the
-    returned window, because the RIGHT of the token remains a carrier (`… liveness … # derive --rundir …`).
-
-    A comment line is refused with everything else. It is text the block does not run, so a block whose
-    body is a comment plus a command is not one invocation, and the earlier round that DROPPED comment
-    lines before looking is exactly how `# the derive step takes --head-sha … --rundir …` kept a
-    mislabelled block alive.
+    Two lines never collapse into one. `_logical_lines` decides what a line is, and the caller compares the
+    LIST against a one-element list, so a body split across two commands cannot pass by concatenating into
+    the canonical string.
     """
-    lines = _logical_lines(body)
-    if len(lines) != 1:
-        return None, f"the block holds {len(lines)} lines of shell rather than ONE invocation"
-    match = SOLE_INVOCATION.match(lines[0])
-    if not match:
-        return None, f"the block does not BEGIN with a `{COMMAND_NAME}` invocation"
-    return lines[0][match.end() - len(COMMAND_NAME):], ""
-
-
-def _unmet(command: str, wanted: tuple[str | tuple[str, ...], ...]) -> list[tuple[str, ...]]:
-    """The requirements this one invocation does not carry, each as its alternation."""
-    unmet: list[tuple[str, ...]] = []
-    for want in wanted:
-        alternatives: tuple[str, ...] = want if isinstance(want, tuple) else (want,)
-        if not any(_requirement_met(command, alt) for alt in alternatives):
-            unmet.append(alternatives)
-    return unmet
+    return [" ".join(re.sub(r"\\[ \t]*\n", " ", line).split()) for line in _logical_lines(body)]
 
 
 def _blank(text: str) -> str:
@@ -2406,50 +2397,25 @@ def _blank(text: str) -> str:
     return re.sub(r"[^\n]", " ", text)
 
 
-def _extraneous(window: str) -> str | None:
-    """The first mark of text an invocation does not CONSIST of, or `None`. REFUSE it; never parse it.
-
-    `_sole_invocation` decides that the block's one line STARTS with the command. Nothing decides where it
-    stops being ONE command, and the window runs to the end of that backslash-continued line — so everything
-    a shell would treat as a separate thing on it is still inside. A trailing `# …` comment, a `; …` chain, a
-    `&& …` chain and a `$(…)` substitution are all the same carrier, and each one breaks the anti-lie
-    property rather than merely relaxing the check: mark a block `gauntlet-cmd=derive`, run
-    `ci-status.py liveness …` in it, append `# derive --head-sha … --rundir …` to that same line, and the
-    mislabel passes clean. Cutting each line at an unquoted `#` closes the comment and none of the rest.
-
-    SO THE BLOCK IS REFUSED, NOT PARSED. Telling the invocation from the text after it means splitting shell
-    words, and that is the exact spiral this scheme exists to end (see `DOCUMENTED_COMMANDS`, "WHY THE
-    MARKER EXISTS AT ALL"). `shlex` is not the escape hatch: `shlex.split` raises `ValueError: No closing
-    quotation` on the live `<the LEDGER's head_sha>` placeholder, and `shlex.shlex(punctuation_chars=True)`
-    shreds `<rundir>` into three tokens. A documented command line has no need of shell syntax, so requiring
-    it to carry NONE is a rule an author can satisfy and this checker can enforce with no parser at all.
-
-    Placeholders are blanked first because they are prose, not shell: the live `liveness` copy documents
-    `--machine-action <due | in-flight | none>`, whose `|` is a choice offered to the reader. Requirements
-    are still matched against the ORIGINAL window (`check_marked_commands`), so `--ledger
-    <rundir>/state.jsonl` goes on satisfying the `state.jsonl` path suffix.
-    """
-    bare = PLACEHOLDER.sub(lambda match: _blank(match.group()), window)
-    found = [(bare.find(mark), mark) for mark in NOT_INVOCATION if mark in bare]
-    return min(found)[1] if found else None
-
-
 def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every marked block IS one INVOCATION, carrying every token its `gauntlet-cmd` id requires.
+    """Every marked block's body EQUALS the command `canonical_command()` generates for its `gauntlet-cmd`
+    id.
 
-    Five ways to fail, and the last two are the ones a marker scheme invites: the invocation omits a
-    required token; the block is not one invocation — it holds other lines, or its line does not begin with
-    the command (`_sole_invocation`), or that line carries a tail the invocation does not consist of
-    (`_extraneous`); the block runs no `ci-status.py` command at all; an id is claimed that this table does
-    not define; or an id this table defines has NO block anywhere. That last one is what stops the marker
-    from quietly narrowing the check — delete the only marked copy of a command and the build goes red,
-    exactly as it did when the checker hunted copies for itself.
+    Three ways to fail: the body is not that command; an id is claimed that `DOCUMENTED_COMMANDS` does not
+    define; or an id it does define has NO block anywhere. That last one is what stops the marker from
+    quietly narrowing the check — delete the only marked copy of a command and the build goes red, exactly
+    as it did when the checker hunted copies for itself.
 
-    A block also cannot lie about which command it is, because the script name and the subcommand are
-    ordinary required tokens: label a `liveness` block `gauntlet-cmd=derive` and it fails on `derive`. That
-    holds only because the tokens are read from a block that IS the command rather than from anywhere in a
-    fenced body: any other line, and any text to either side of the command on its own line, would
-    otherwise hand the mislabel the tokens its real invocation does not have.
+    **THE COMPARISON IS EQUALITY, AND THAT IS THE WHOLE DESIGN.** It does not locate the command inside the
+    body, subtract text it dislikes, or reason about shell. A body holding anything besides the generated
+    command is a DIFFERENT STRING, so every carrier that killed an earlier round — a second line, a comment
+    line, a trailing comment, a `;`/`|`/`&&`/`$(…)` chain, an `echo` in front, a heredoc around it, a tail
+    of arguments the subcommand does not take, a `>` redirection whose operand spells the missing flags —
+    fails by construction, with none of them enumerated anywhere. A block cannot lie about which command it
+    is either, because the id picks the string it is compared against: mark a `liveness` invocation
+    `gauntlet-cmd=derive` and it is held to `derive`'s command.
+
+    There is one repair for every failure, and the message states it: replace the body with the string.
     """
     problems, found = [], []
     seen: set[str] = set()
@@ -2459,48 +2425,28 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
             cmd_id, body = match.group("id"), match.group("body")
             line = text.count("\n", 0, match.start()) + 1
             where = f"{md.name}:{line}"
-            wanted = DOCUMENTED_COMMANDS.get(cmd_id)
-            if wanted is None:
+            if cmd_id not in DOCUMENTED_COMMANDS:
                 problems.append(
                     f"{where} is marked `gauntlet-cmd={cmd_id}`, which DOCUMENTED_COMMANDS does not define "
-                    f"— known ids are {', '.join(sorted(DOCUMENTED_COMMANDS))}. An unknown id is checked "
-                    f"against nothing, so the marker would buy the block an exemption instead of a check."
+                    f"— known ids are {', '.join(sorted(DOCUMENTED_COMMANDS))}. An unknown id names no "
+                    f"command to compare against, so the marker would buy the block an exemption "
+                    f"instead of a check."
                 )
                 continue
             seen.add(cmd_id)
             found.append(f"{where} ({cmd_id})")
-            window, refusal = _sole_invocation(body)
-            # TWO DIFFERENT DEFECTS, TWO DIFFERENT MESSAGES. A body with no `ci-status.py` token in it at
-            # all runs some other script, and telling that author to remove extra text names nothing they
-            # wrote; a body that DOES spell the command somewhere is one this checker refuses to read.
-            if window is None and not COMMAND_TOKEN.search(body):
+            want = canonical_command(cmd_id)
+            got = _collapsed_lines(body)
+            if got != [want]:
+                shown = " / ".join(got) or "(nothing)"
                 problems.append(
-                    f"{where} is marked `gauntlet-cmd={cmd_id}` but the block RUNS no `{COMMAND_NAME}` "
-                    f"command — the marker promises a copy a reader can run, and there is none to check, "
-                    f"so every token the id requires would be looked for in text nobody executes."
-                )
-                continue
-            # THE BLOCK MUST BE THE INVOCATION. Reported BEFORE the token check and instead of it: the
-            # tokens the surrounding text supplies are the whole reason the block is refused, so naming what
-            # it "omits" would describe the wrong defect and invite the wrong repair.
-            mark = _extraneous(window) if window is not None else None
-            if window is None or mark:
-                carries = f"its command line carries `{mark}`" if window is not None else refusal
-                problems.append(
-                    f"{where} is marked `gauntlet-cmd={cmd_id}` but {carries} — text the invocation does "
-                    f"not consist of. A marked block must BE one `{COMMAND_NAME}` invocation and nothing "
-                    f"else: no comment, no second command, no chain, pipe or substitution, and no wrapper "
-                    f"that merely writes or echoes the command instead of running it. Anything else in the "
-                    f"block hands it tokens the command a reader RUNS does not carry, and this checker "
-                    f"refuses shell it does not parse. Move the comment outside the fence, and give any "
-                    f"second command its own block."
-                )
-                continue
-            for alternatives in _unmet(window, wanted):
-                problems.append(
-                    f"{where} is marked `gauntlet-cmd={cmd_id}` but its invocation omits "
-                    f"{' or '.join(f'`{alt}`' for alt in alternatives)} — a reader runs what this block "
-                    f"says, and the tool refuses an invocation missing it."
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but its body is NOT that command. A marked "
+                    f"block must BE the one canonical invocation and nothing else — no comment, no second "
+                    f"line, no chain, pipe, redirection or substitution, no wrapper that echoes the "
+                    f"command or writes it to a file instead of running it, and no argument the command "
+                    f"does not take. Replace the body with exactly:  {want}  (wrap it over as many lines "
+                    f"as you like with a trailing backslash; joined continuations and collapsed whitespace "
+                    f"runs are the only differences allowed). This body reads:  {shown}"
                 )
     for cmd_id in sorted(set(DOCUMENTED_COMMANDS) - seen):
         problems.append(
@@ -2524,12 +2470,14 @@ def check_unmarked_commands(root: Path | None = None) -> list[str]:
     fenced command has no backtick before the closing fence, so its flags land in the window and it is
     reported — which is what makes forgetting the marker loud instead of silently unchecked.
 
-    The occurrence is matched with `PROSE_TOKEN`, whose boundary is its own and neither of the other two.
-    A bare substring scan reported an invented `example-ci-status.py derive --pr 1` as a copy of THIS
-    script — a false positive that sends an author to move someone else's command. `COMMAND_TOKEN` is the
-    wrong repair for it: its `[\\s/=]` left boundary does not admit a backtick, and almost every real copy
-    is written inside a code span, so the check would stop reporting genuine copies and a forgotten marker
-    would read as success — the one failure that makes this scheme worse than the copy-hunting it replaced.
+    The occurrence is matched with `PROSE_TOKEN`, which requires a WHOLE FILE NAME on both sides. A bare
+    substring scan reports a hypothetical `example-ci-status.py derive --pr 1` as a copy of THIS script,
+    and a scan bounded on the left alone reports a hypothetical `ci-status.py.bak derive --pr 1` the same
+    way: both are false positives that send an author to move some other tool's command. This repo ships
+    no script by either name. The obvious tightening — a shell-token boundary that excludes the backtick —
+    is the WRONG repair, because almost every real copy is written inside a code span: the check would
+    stop reporting genuine copies and a forgotten marker would read as success, the one failure that makes
+    this scheme worse than the copy-hunting it replaced.
     """
     problems: list[str] = []
     for md in sorted((root or HERE.parent).rglob("*.md")):
@@ -2569,9 +2517,9 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          paragraphs. A value in a hole matches NO branch: not green, not red, not pending — the PR can never
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
-         the command every MARKED `ci-status.py` block RUNS against the tokens `DOCUMENTED_COMMANDS`
-         requires of that id, that the block IS that one invocation and nothing else, and that no
-         runnable copy sits OUTSIDE such a block (prose may NAME a command, never run one).
+         every MARKED `ci-status.py` block against the command `canonical_command()` generates for its id,
+         which its body must EQUAL, and that no runnable copy sits OUTSIDE such a block (prose may NAME a
+         command, never run one).
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.
@@ -2718,8 +2666,7 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
     problems += marked_problems
     if not marked_problems:
         held.append(f"{'the marked command blocks':32} {len(marked_blocks)} blocks across the skill's docs, "
-                    f"every one BEING a single invocation that carries every token its gauntlet-cmd id "
-                    f"requires and nothing besides")
+                    f"every body EQUAL to the command generated for its gauntlet-cmd id")
     # AND THAT NO RUNNABLE COPY ESCAPED THE MARKER — the check that keeps a forgotten marker LOUD.
     unmarked_problems = check_unmarked_commands()
     problems += unmarked_problems
@@ -2814,11 +2761,13 @@ def resolve_repo(fetch: Fetch) -> str:
 def build_parser() -> argparse.ArgumentParser:
     """The CLI surface, built apart from `main` so a test can ASK it what each subcommand requires.
 
-    `DOCUMENTED_COMMANDS` says what a documented copy must carry and this parser says what the tool will
+    `DOCUMENTED_COMMANDS` says which flags a documented copy SPELLS and this parser says what the tool will
     actually accept. Two statements of one contract drift, and the drift is silent in the direction that
     matters: a flag only the parser insists on is a copy `doc-check` calls complete and the tool then
     REFUSES. The fixture suite reconciles the two, which it can only do if the parser exists without
-    running.
+    running. The reconciliation runs one way only — the row decides which OPTIONAL flags the documented
+    copy carries, because generating every optional the parser defines would make `derive`'s canonical copy
+    spell `--repo`, `--ledger` and `--required-set` at once.
     """
     p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
     sub = p.add_subparsers(dest="cmd", required=True)

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -118,8 +118,9 @@ The enums, the CLASSIFY buckets and the DECIDE order are stated in `ci-derivatio
 one a reader believed. `doc-check` PARSES the doc's own enum block, its two CLASSIFY tables and its DECIDE
 bullet order, and asserts they agree with the sets `ci-snapshot.py` actually classifies with — and that the
 classification is TOTAL over the enums the doc declares. It also checks every copy of a `gh` command the doc
-prints against the argv this code really issues, every copy of the derive command for `--required-set`, and
-the moved-head owner block's retained-artifact/trust/result contract. Drift is a RED BUILD, not a discovery.
+prints against the argv this code really issues, every MARKED `ci-status.py` command block against the tokens
+its `gauntlet-cmd` id requires — with no runnable copy sitting OUTSIDE such a block — and the moved-head owner
+block's retained-artifact/trust/result contract. Drift is a RED BUILD, not a discovery.
 
 **A check that finds nothing MUST NOT PASS.** If the doc cannot be found, or a block cannot be parsed, or
 zero rules are extracted, `doc-check` FAILS. An extractor that silently matches nothing and reports success
@@ -2251,7 +2252,12 @@ def _has_long_option(command: str, option: str) -> bool:
 # WHICH TEXT IS A COMMAND. A marked block opens with the info string ```sh gauntlet-cmd=<id>`; `<id>` keys
 # this table, whose value is every token that copy MUST carry. A nested tuple is an alternation — any one of
 # its members satisfies it. A `--flag` requirement is matched as a long option (argparse's `--name=value`
-# form included); anything else is matched as a plain substring.
+# form included); anything else must appear as a WHOLE command token — see `_requirement_met`.
+#
+# A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
+# is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
+# each row against `build_parser()` instead (`ci-status-test.documented_commands_agree_with_argparse`). A
+# flag the parser REQUIRES and a row omits is a copy this checker calls complete and the tool then refuses.
 #
 # WHY THE MARKER EXISTS AT ALL. The checker used to hunt runnable copies in free Markdown, which meant
 # deciding, for arbitrary prose, whether a stretch of text was a command or a sentence about one. That
@@ -2265,19 +2271,37 @@ DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
     # with an explicit `--required-set`. A copy carrying NEITHER reconstructs an invocation the tool refuses.
     "derive": ("ci-status.py", "derive", "--pr", "--head-sha", "--rundir", ("--ledger", "--required-set")),
     # `--machine-action` is the one judgment the command asks of its caller. A reader who drops the question
-    # and invents a default strikes the very PR a fix is about to move.
-    "liveness": ("ci-status.py", "liveness", "--ledger", "--pr", "--machine-action"),
+    # and invents a default strikes the very PR a fix is about to move. `--derive-json` is the evidence the
+    # bookkeeping is ABOUT: argparse requires it, so a copy without it is an invocation the tool refuses.
+    "liveness": ("ci-status.py", "liveness", "--ledger", "--pr", "--derive-json", "--machine-action"),
     # The command must persist the value it read, so the copy names the run ledger it persists to.
     "required-set": ("ci-status.py", "required-set", "--ledger", "state.jsonl"),
 }
 
-MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[a-z][a-z-]*)\n(?P<body>.*?)^```", re.M | re.S)
+# The id is ANY nonempty run of characters, never a spelling this checker approves of: an id the regex
+# REJECTS is not a marked block at all, so the unknown-id branch below cannot fire and the author is told to
+# move a block that is already inside a marked fence. Capture whatever was written and let
+# DOCUMENTED_COMMANDS be the only thing that decides which ids exist. Trailing spaces are dropped because
+# CommonMark drops them from the info string, so a fence this checker rejected over one would be a fence the
+# renderer accepted.
+MARKED_FENCE = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n(?P<body>.*?)^```", re.M | re.S)
 LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
 COMMAND_NAME = "ci-status.py"
 
 
 def _requirement_met(body: str, want: str) -> bool:
-    return _has_long_option(body, want) if want.startswith("--") else want in body
+    """A `--flag` is matched as a long option; every other requirement as a WHOLE command token.
+
+    Whole-token, not substring, is what stops a block from LYING about which command it is. Plain
+    `want in body` accepts `not-ci-status.py rederive` for both `ci-status.py` and `derive`, so a block
+    marked `gauntlet-cmd=derive` that runs neither the script nor the subcommand passes clean. A leading
+    `/` or `=` still counts as a token start, which is what keeps the path-SUFFIX requirements working:
+    `--ledger <rundir>/state.jsonl` satisfies `state.jsonl`, and `python3 <skill>/scripts/ci-status.py`
+    satisfies `ci-status.py`.
+    """
+    if want.startswith("--"):
+        return _has_long_option(body, want)
+    return re.search(rf"(?:\A|[\s/=]){re.escape(want)}(?=\s|\Z)", body) is not None
 
 
 def _blank(text: str) -> str:
@@ -2623,7 +2647,15 @@ def resolve_repo(fetch: Fetch) -> str:
                            "nameWithOwner", str))
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
+    """The CLI surface, built apart from `main` so a test can ASK it what each subcommand requires.
+
+    `DOCUMENTED_COMMANDS` says what a documented copy must carry and this parser says what the tool will
+    actually accept. Two statements of one contract drift, and the drift is silent in the direction that
+    matters: a flag only the parser insists on is a copy `doc-check` calls complete and the tool then
+    REFUSES. The fixture suite reconciles the two, which it can only do if the parser exists without
+    running.
+    """
     p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
     sub = p.add_subparsers(dest="cmd", required=True)
 
@@ -2671,14 +2703,17 @@ def main() -> int:
 
     c = sub.add_parser("doc-check", help="assert the CI docs (ci-derivation-spec.md + stage-2-ci.md) "
                                          "agree with the code that runs — enums, CLASSIFY, DECIDE order, "
-                                         "caps, fingerprint, moved-head artifact contract, and every copy "
-                                         "of every command")
+                                         "caps, fingerprint, moved-head artifact contract, every `gh` copy, "
+                                         "and every marked command block with no runnable copy outside one")
     c.add_argument("--spec-doc", type=Path, default=SPEC_DOC)
     c.add_argument("--driver-doc", type=Path, default=DRIVER_DOC)
 
     sub.add_parser("self-test", help="run every fixture (ci-status-test.py), then doc-check")
+    return p
 
-    args = p.parse_args()
+
+def main() -> int:
+    args = build_parser().parse_args()
 
     if args.cmd == "doc-check":
         return doc_check(args.spec_doc, args.driver_doc)

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2367,6 +2367,24 @@ class MarkedBlock(NamedTuple):
     end: int
 
 
+def _scanned(md: Path) -> str:
+    """A doc's text as the fence scan reads it: a FINAL NEWLINE is appended when the file ends without one.
+
+    THIS EXISTS SO NO PATTERN IN THE SCAN NEEDS AN END-OF-FILE CASE. A last line with no newline renders
+    exactly like one with it, so the scan has to read it the same way — and the reliable way to make every
+    pattern do that is to leave no pattern the question. Teaching each pattern to accept `\\n` OR end-of-
+    input instead spreads one fact about files across every regex, and the pattern that forgets it drops
+    its match in SILENCE: a marked opener on such a last line matched nothing, so it was neither compared,
+    nor reported unclosed, nor reported for an unknown id, while the renderer showed a block. Normalize
+    once here and every pattern added later is correct without being told.
+
+    Carriage returns need no handling of their own either: `read_text` translates CRLF to `\\n` on the way
+    in, so `\\r` never reaches a pattern.
+    """
+    text = md.read_text(encoding="utf-8")
+    return text if not text or text.endswith("\n") else text + "\n"
+
+
 def marked_blocks(text: str) -> list[MarkedBlock]:
     """Every marked opener in `text`, paired with the body its conforming close delimits.
 
@@ -2478,7 +2496,7 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
     problems, found = [], []
     seen: set[str] = set()
     for md in sorted((root or HERE.parent).rglob("*.md")):
-        text = md.read_text(encoding="utf-8")
+        text = _scanned(md)
         for block in marked_blocks(text):
             cmd_id, body = block.cmd_id, block.body
             where = f"{md.name}:{block.line}"
@@ -2550,7 +2568,7 @@ def check_unmarked_commands(root: Path | None = None) -> list[str]:
     """
     problems: list[str] = []
     for md in sorted((root or HERE.parent).rglob("*.md")):
-        raw = md.read_text(encoding="utf-8")
+        raw = _scanned(md)
         kept: list[str] = []
         pos = 0
         for block in marked_blocks(raw):

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -119,7 +119,7 @@ one a reader believed. `doc-check` PARSES the doc's own enum block, its two CLAS
 bullet order, and asserts they agree with the sets `ci-snapshot.py` actually classifies with — and that the
 classification is TOTAL over the enums the doc declares. It also checks every copy of a `gh` command the doc
 prints against the argv this code really issues, the command every MARKED `ci-status.py` block RUNS against
-the tokens its `gauntlet-cmd` id requires — carrying nothing on that line but the invocation, and with no
+the tokens its `gauntlet-cmd` id requires — such a block being ONE invocation and nothing else, and with no
 runnable copy sitting OUTSIDE such a block — and the moved-head owner block's retained-artifact/trust/result
 contract. Drift is a RED BUILD, not a discovery.
 
@@ -2254,9 +2254,9 @@ def _has_long_option(command: str, option: str) -> bool:
 # this table, whose value is every token that copy MUST carry. A nested tuple is an alternation — any one of
 # its members satisfies it. A `--flag` requirement is matched as a long option (argparse's `--name=value`
 # form included); anything else must appear as a WHOLE command token — see `_requirement_met`. The tokens
-# are required of the block's `ci-status.py` INVOCATION, never merely of its fenced body: `_invocations`
-# scopes the search to a command line and `_extraneous` refuses a command line carrying anything but the
-# command, and it takes both to stop other text in the block from supplying them.
+# are required of the block's `ci-status.py` INVOCATION, never merely of its fenced body: a marked block
+# must BE one invocation (`_sole_invocation`) and `_extraneous` refuses even that one line when it carries
+# anything besides the command, and it takes both to stop other text in the block from supplying them.
 #
 # A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
 # is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
@@ -2298,10 +2298,22 @@ PLACEHOLDER = re.compile(r"<[^<>\n]*>")
 NOT_INVOCATION = ("#", ";", "|", "&", "`", "$(")
 LONG_OPTION = re.compile(r"(?<![\w-])--[a-z][a-z-]+")
 COMMAND_NAME = "ci-status.py"
-# The SAME whole-token rule `_requirement_met` applies, used to LOCATE the invocation. A substring locator
-# would let a longer word that merely ends in the script name open a window, and the block would then be
-# checked against text that runs something else entirely.
+# The SAME whole-token rule `_requirement_met` applies. It no longer LOCATES anything — `_sole_invocation`
+# decides that — and is used only to tell a block that runs a DIFFERENT script from one that runs ours
+# amid other text, so the two refusals name the right defect. A substring test would call
+# `example-ci-status.py` (invented; it appears nowhere in this repo) an occurrence of this script.
 COMMAND_TOKEN = re.compile(rf"(?:\A|[\s/=]){re.escape(COMMAND_NAME)}(?=\s|\Z)")
+# A MARKED BLOCK **IS** ONE INVOCATION: optional leading whitespace, an optional `python3` interpreter word,
+# an optional path, then the script name as a whole token. Anchored at the START of the block's one logical
+# line, which is what makes the rule have a fixed point — see `_sole_invocation`.
+SOLE_INVOCATION = re.compile(rf"^[ \t]*(?:python3?[ \t]+)?(?:\S*/)?{re.escape(COMMAND_NAME)}(?=[ \t]|$)")
+# A prose occurrence of the script name, for the copies that must sit OUTSIDE a marked block. Its boundary
+# is deliberately NOT `COMMAND_TOKEN`'s: prose writes the name inside a code span, and `COMMAND_TOKEN`'s
+# `[\s/=]` left boundary does not admit the backtick that opens almost every real copy — swapping it in
+# here silences the check the marker scheme lives on. This one rejects `example-ci-status.py` and
+# `myci-status.py` (both invented; neither appears in this repo) while still admitting `` `ci-status.py ``,
+# `scripts/ci-status.py` and `./ci-status.py`.
+PROSE_TOKEN = re.compile(rf"(?<![\w.-]){re.escape(COMMAND_NAME)}(?![\w-])")
 
 
 def _requirement_met(command: str, want: str) -> bool:
@@ -2314,57 +2326,69 @@ def _requirement_met(command: str, want: str) -> bool:
     the path-SUFFIX requirements working: `--ledger <rundir>/state.jsonl` satisfies `state.jsonl`, and
     `python3 <skill>/scripts/ci-status.py` satisfies `ci-status.py`.
 
-    WHERE a token may be found is a separate question, answered by `_invocations` and `_extraneous`: this
-    decides only WHAT counts as one. Both are load-bearing — whole-token matching over a whole fenced body
-    still accepts a comment that spells the missing tokens, and an invocation-scoped substring match still
-    accepts a subcommand that merely ENDS in the required one.
+    WHERE a token may be found is a separate question, answered by `_sole_invocation` and `_extraneous`:
+    this decides only WHAT counts as one. Both are load-bearing — whole-token matching over a whole fenced
+    body still accepts a comment that spells the missing tokens, and an invocation-scoped substring match
+    still accepts a subcommand that merely ENDS in the required one.
     """
     if want.startswith("--"):
         return _has_long_option(command, want)
     return re.search(rf"(?:\A|[\s/=]){re.escape(want)}(?=\s|\Z)", command) is not None
 
 
-def _invocations(body: str) -> list[str]:
-    """Every INVOCATION inside a marked block: a `ci-status.py` command token to the end of its command.
+def _logical_lines(body: str) -> list[str]:
+    """A fenced body's non-blank LOGICAL lines: backslash continuations joined into the line they continue.
 
-    **THE UNIT OF THE CHECK IS THE INVOCATION, NOT THE BLOCK, AND THIS CHECK USED TO THINK OTHERWISE.**
-    Searching a whole fenced body for the required tokens lets text a reader never RUNS supply them: mark a
-    block `gauntlet-cmd=derive`, run `ci-status.py liveness …` in it, and any second line of the block that
-    happens to spell `derive`, `--head-sha` and `--rundir` — a comment ABOUT the derive step, or an
-    unrelated `grep` — completes the set, and the mislabel passes clean. Neither carrier needs Markdown of
-    any kind; both are just more lines inside the fence. So the requirements are checked against the
-    command itself, and a block passes when SOME invocation in it carries everything.
-
-    Two things this must not get wrong, each of which turns correct docs red or lying docs green:
-
-    - **A command is not a line.** A shell invocation WRAPS with a trailing `\\`, and the live copies do:
-      stopping at the newline loses `--ledger` from `derive` and `--derive-json`/`--machine-action` from
-      `liveness`, condemning three correct blocks.
-    - **The locator is whole-token too.** An invented `example-tool.py derive --pr 1` (it exists nowhere in
-      this repo) must not open a window; a substring locator would let it, and the mislabel it was meant to
-      catch would then be checked against the wrong text.
-
-    WHOLE comment LINES are dropped before any of that, because a comment is text the block does not run.
-    That is only half the carrier: a comment on the same line as the command is INSIDE the window this
-    returns, and so are `;`, `|`, `&&` and `$(…)`. `_extraneous` refuses those rather than parse them, and
-    this function must not try to — deciding where a shell command ends is the parsing this scheme replaced.
+    **A command is not a physical line.** A shell invocation WRAPS with a trailing `\\`, and all three live
+    copies do: counting physical lines would read one correct command as two or three, and condemn every
+    block in the doc set for holding more than one.
     """
-    text = "\n".join("" if line.lstrip().startswith("#") else line for line in body.splitlines())
-    windows: list[str] = []
-    for match in COMMAND_TOKEN.finditer(text):
-        cursor = match.end()
-        while True:
-            newline = text.find("\n", cursor)
-            if newline < 0:
-                end = len(text)
-                break
-            if text[cursor:newline].rstrip().endswith("\\"):
-                cursor = newline + 1
-                continue
-            end = newline
-            break
-        windows.append(text[match.end() - len(COMMAND_NAME):end])
-    return windows
+    lines: list[str] = []
+    pending: list[str] = []
+    for line in body.splitlines():
+        pending.append(line)
+        if line.rstrip().endswith("\\"):
+            continue
+        joined = "\n".join(pending)
+        pending = []
+        if joined.strip():
+            lines.append(joined)
+    if pending and "\n".join(pending).strip():
+        lines.append("\n".join(pending))
+    return lines
+
+
+def _sole_invocation(body: str) -> tuple[str | None, str]:
+    """A marked block's ONE invocation, from the script-name token on — or `(None, why it is refused)`.
+
+    **THE BLOCK MUST *BE* THE COMMAND, NOT MERELY CONTAIN IT, AND THIS CHECK USED TO THINK OTHERWISE.**
+    Three rounds located a command WINDOW inside a free-form body and then subtracted the text that should
+    not be there. Subtraction has no fixed point, because the block's author picks the surrounding text: a
+    whole-body token search fell to a comment line and to an unrelated second command; scoping to the
+    command line and refusing `#`, `;`, `|`, `&`, `` ` `` and `$(` on it fell to text to the LEFT of the
+    token, which nothing looked at — `echo ci-status.py derive …` runs `echo` and passed clean. Requiring
+    the token to OPEN its line does not close it either: a heredoc (`cat > c.sh <<'EOF'` / the command /
+    `EOF`) WRITES the invocation to a file, never runs it, and passes.
+
+    So the rule is not "the block contains a command that carries the tokens" but **"the block IS one
+    invocation"**: exactly one logical line, and that line begins with the script name (after an optional
+    `python3` word and an optional path). Everything else is refused unparsed. There is nothing left to the
+    left of the token, no second line to supply what the command lacks, and — since a documented command
+    line has no need of shell syntax — no author is inconvenienced. `_extraneous` still runs over the
+    returned window, because the RIGHT of the token remains a carrier (`… liveness … # derive --rundir …`).
+
+    A comment line is refused with everything else. It is text the block does not run, so a block whose
+    body is a comment plus a command is not one invocation, and the earlier round that DROPPED comment
+    lines before looking is exactly how `# the derive step takes --head-sha … --rundir …` kept a
+    mislabelled block alive.
+    """
+    lines = _logical_lines(body)
+    if len(lines) != 1:
+        return None, f"the block holds {len(lines)} lines of shell rather than ONE invocation"
+    match = SOLE_INVOCATION.match(lines[0])
+    if not match:
+        return None, f"the block does not BEGIN with a `{COMMAND_NAME}` invocation"
+    return lines[0][match.end() - len(COMMAND_NAME):], ""
 
 
 def _unmet(command: str, wanted: tuple[str | tuple[str, ...], ...]) -> list[tuple[str, ...]]:
@@ -2385,9 +2409,9 @@ def _blank(text: str) -> str:
 def _extraneous(window: str) -> str | None:
     """The first mark of text an invocation does not CONSIST of, or `None`. REFUSE it; never parse it.
 
-    `_invocations` decides where a command STARTS. Nothing decided where it stops being ONE command, and a
-    window runs to the end of the backslash-continued command LINE — so everything a shell would treat as a
-    separate thing on that line is still inside it. A trailing `# …` comment, a `; …` chain, a `| …` pipe, a
+    `_sole_invocation` decides that the block's one line STARTS with the command. Nothing decides where it
+    stops being ONE command, and the window runs to the end of that backslash-continued line — so everything
+    a shell would treat as a separate thing on it is still inside. A trailing `# …` comment, a `; …` chain, a
     `&& …` chain and a `$(…)` substitution are all the same carrier, and each one breaks the anti-lie
     property rather than merely relaxing the check: mark a block `gauntlet-cmd=derive`, run
     `ci-status.py liveness …` in it, append `# derive --head-sha … --rundir …` to that same line, and the
@@ -2411,21 +2435,21 @@ def _extraneous(window: str) -> str | None:
 
 
 def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
-    """Every marked block runs an INVOCATION carrying every token its `gauntlet-cmd` id requires.
+    """Every marked block IS one INVOCATION, carrying every token its `gauntlet-cmd` id requires.
 
-    Five ways to fail, and the last two are the ones a marker scheme invites: an invocation omits a required
-    token; the command line carries text that is not part of the invocation (`_extraneous`); the block runs
-    no `ci-status.py` command at all; an id is claimed that this table does not define; or an id this table
-    defines has NO block anywhere. That last one is what stops the marker from quietly narrowing the check —
-    delete the only marked copy of a command and the build goes red, exactly as it did when the checker
-    hunted copies for itself.
+    Five ways to fail, and the last two are the ones a marker scheme invites: the invocation omits a
+    required token; the block is not one invocation — it holds other lines, or its line does not begin with
+    the command (`_sole_invocation`), or that line carries a tail the invocation does not consist of
+    (`_extraneous`); the block runs no `ci-status.py` command at all; an id is claimed that this table does
+    not define; or an id this table defines has NO block anywhere. That last one is what stops the marker
+    from quietly narrowing the check — delete the only marked copy of a command and the build goes red,
+    exactly as it did when the checker hunted copies for itself.
 
     A block also cannot lie about which command it is, because the script name and the subcommand are
     ordinary required tokens: label a `liveness` block `gauntlet-cmd=derive` and it fails on `derive`. That
-    holds only because the tokens are looked for in the COMMAND rather than anywhere in the fenced body,
-    which takes BOTH halves: `_invocations` scopes the search to a command line, and `_extraneous` refuses a
-    command line that carries anything besides the command. Drop either and a comment or a second line hands
-    the mislabel the tokens its real invocation does not have.
+    holds only because the tokens are read from a block that IS the command rather than from anywhere in a
+    fenced body: any other line, and any text to either side of the command on its own line, would
+    otherwise hand the mislabel the tokens its real invocation does not have.
     """
     problems, found = [], []
     seen: set[str] = set()
@@ -2445,29 +2469,34 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
                 continue
             seen.add(cmd_id)
             found.append(f"{where} ({cmd_id})")
-            windows = _invocations(body)
-            if not windows:
+            window, refusal = _sole_invocation(body)
+            # TWO DIFFERENT DEFECTS, TWO DIFFERENT MESSAGES. A body with no `ci-status.py` token in it at
+            # all runs some other script, and telling that author to remove extra text names nothing they
+            # wrote; a body that DOES spell the command somewhere is one this checker refuses to read.
+            if window is None and not COMMAND_TOKEN.search(body):
                 problems.append(
                     f"{where} is marked `gauntlet-cmd={cmd_id}` but the block RUNS no `{COMMAND_NAME}` "
                     f"command — the marker promises a copy a reader can run, and there is none to check, "
                     f"so every token the id requires would be looked for in text nobody executes."
                 )
                 continue
-            # THE WINDOW CAN HOLD TEXT THE INVOCATION DOES NOT CONSIST OF. Reported BEFORE the token check
-            # and instead of it: the tokens such a line supplies are the whole reason it is refused, so
-            # naming what it "omits" would describe the wrong defect and invite the wrong repair.
-            if marks := [mark for window in windows if (mark := _extraneous(window))]:
+            # THE BLOCK MUST BE THE INVOCATION. Reported BEFORE the token check and instead of it: the
+            # tokens the surrounding text supplies are the whole reason the block is refused, so naming what
+            # it "omits" would describe the wrong defect and invite the wrong repair.
+            mark = _extraneous(window) if window is not None else None
+            if window is None or mark:
+                carries = f"its command line carries `{mark}`" if window is not None else refusal
                 problems.append(
-                    f"{where} is marked `gauntlet-cmd={cmd_id}` but its command line carries `{marks[0]}` "
-                    f"— text the invocation does not consist of. This checker refuses shell it does not "
-                    f"parse, because a comment, a chain, a pipe or a substitution ON the command line hands "
-                    f"the block tokens the command a reader RUNS does not carry. Move the comment outside "
-                    f"the fence, or give the second command its own line."
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but {carries} — text the invocation does "
+                    f"not consist of. A marked block must BE one `{COMMAND_NAME}` invocation and nothing "
+                    f"else: no comment, no second command, no chain, pipe or substitution, and no wrapper "
+                    f"that merely writes or echoes the command instead of running it. Anything else in the "
+                    f"block hands it tokens the command a reader RUNS does not carry, and this checker "
+                    f"refuses shell it does not parse. Move the comment outside the fence, and give any "
+                    f"second command its own block."
                 )
                 continue
-            # A block passes when ONE of its invocations carries everything, and is reported against the
-            # CLOSEST one — naming what that copy is short of, not the union of every command in the block.
-            for alternatives in min((_unmet(window, wanted) for window in windows), key=len):
+            for alternatives in _unmet(window, wanted):
                 problems.append(
                     f"{where} is marked `gauntlet-cmd={cmd_id}` but its invocation omits "
                     f"{' or '.join(f'`{alt}`' for alt in alternatives)} — a reader runs what this block "
@@ -2494,11 +2523,18 @@ def check_unmarked_commands(root: Path | None = None) -> list[str]:
     Marked blocks are blanked first, so their contents are exempt. Every OTHER fence is not: an unmarked
     fenced command has no backtick before the closing fence, so its flags land in the window and it is
     reported — which is what makes forgetting the marker loud instead of silently unchecked.
+
+    The occurrence is matched with `PROSE_TOKEN`, whose boundary is its own and neither of the other two.
+    A bare substring scan reported an invented `example-ci-status.py derive --pr 1` as a copy of THIS
+    script — a false positive that sends an author to move someone else's command. `COMMAND_TOKEN` is the
+    wrong repair for it: its `[\\s/=]` left boundary does not admit a backtick, and almost every real copy
+    is written inside a code span, so the check would stop reporting genuine copies and a forgotten marker
+    would read as success — the one failure that makes this scheme worse than the copy-hunting it replaced.
     """
     problems: list[str] = []
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = MARKED_FENCE.sub(lambda m: _blank(m.group(0)), md.read_text(encoding="utf-8"))
-        for match in re.finditer(re.escape(COMMAND_NAME), text):
+        for match in PROSE_TOKEN.finditer(text):
             tick = text.find("`", match.end())
             if tick < 0:  # unbackticked tail: fall back to the paragraph, never to an empty window
                 para = text.find("\n\n", match.end())
@@ -2534,7 +2570,7 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
          the command every MARKED `ci-status.py` block RUNS against the tokens `DOCUMENTED_COMMANDS`
-         requires of that id, that its command line carries nothing but that invocation, and that no
+         requires of that id, that the block IS that one invocation and nothing else, and that no
          runnable copy sits OUTSIDE such a block (prose may NAME a command, never run one).
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
@@ -2682,8 +2718,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
     problems += marked_problems
     if not marked_problems:
         held.append(f"{'the marked command blocks':32} {len(marked_blocks)} blocks across the skill's docs, "
-                    f"every one RUNNING a command line that carries every token its gauntlet-cmd id "
-                    f"requires and nothing besides the invocation")
+                    f"every one BEING a single invocation that carries every token its gauntlet-cmd id "
+                    f"requires and nothing besides")
     # AND THAT NO RUNNABLE COPY ESCAPED THE MARKER — the check that keeps a forgotten marker LOUD.
     unmarked_problems = check_unmarked_commands()
     problems += unmarked_problems

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2557,6 +2557,18 @@ def check_unmarked_commands(root: Path | None = None) -> list[str]:
     opener that never closes buys no exemption either: `check_marked_commands` reports the broken fence,
     and nothing behind it is blanked, so a runnable copy sitting inside it is still reported here.
 
+    THAT CLAIM RESTS ON A FLOOR UNDER THE WINDOW, so "to the next backtick" is not the whole rule. The
+    next backtick has no answer when NO backtick follows the occurrence ANYWHERE IN THE REST OF THE FILE —
+    not merely in its sentence, which is the trigger a reader most often mistakes it for, and why no doc
+    this repo ships reaches the branch at all. There the window runs to the end of that PARAGRAPH, and to
+    the end of the FILE for the last paragraph, instead of collapsing to nothing. An empty window holds no
+    long option, so it would report nothing, and reporting nothing would EXEMPT the only two shapes that
+    have no later backtick: a copy inside a marked opener that never closes — the claim just above — and a
+    copy in a backtick-free tail. The cost of the floor is disclosed and it runs the other way: prose in
+    such a tail that names the script and then a long option is reported although it only explains the
+    flag. That trade is deliberate, because a false report costs one reworded sentence while the silence
+    would let a forgotten marker read as success.
+
     The occurrence is matched with `PROSE_TOKEN`, which requires a WHOLE FILE NAME on both sides. A bare
     substring scan reports a hypothetical `example-ci-status.py derive --pr 1` as a copy of THIS script,
     and a scan bounded on the left alone reports a hypothetical `ci-status.py.bak derive --pr 1` the same


### PR DESCRIPTION
- Runnable `ci-status.py` copies now live in fences marked `sh gauntlet-cmd=<id>`, keyed to `DOCUMENTED_COMMANDS`.
- `doc-check` refuses any runnable copy outside a marked block; prose may still name a command flagless.
- Replaces the copy hunters whose Markdown scanning aborted #184 and #185; fixes fu15's wrapped copy.
