### PR TITLE
generate the command a marked block must equal

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -564,7 +564,63 @@ nothing was looking. Three checks close that, and **none is optional**:
   fetch the MOVED-HEAD rule can never fire on; that copy had drifted, and this is what caught it). It sweeps
   **every copy of the `ci-status.py derive` command across every skill doc** for a named required set
   (`--ledger`, which resolves the row's `effective_required_set`, or an explicit `--required-set`), too — the
-  set that decides a merge must not be droppable by a recap.
+  set that decides a merge must not be droppable by a recap. And it holds every **marked command block**
+  across every skill doc to the command `ci-status.py` GENERATES for that block's id. See "Marked command
+  blocks", below.
+
+##### Marked command blocks — the command is GENERATED, and the block must equal it
+
+**A fenced block whose info string is `sh gauntlet-cmd=<id>` holds one canonical `ci-status.py`
+invocation.** `<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which — with one value slot per flag —
+GENERATES the canonical string for that command. `doc-check` enforces three things and they are not
+separable:
+
+- **the block is delimited exactly as the renderer delimits it.** It opens at column 0 with that info
+  string and ends at the first line, ALSO AT COLUMN 0, of three or more backticks carrying nothing but
+  optional spaces or tabs. Any other line is BODY and is part of the string compared — including a line
+  that merely starts with backticks, which CommonMark treats as body too because a closing fence may carry
+  no info string — so no text rendering inside the block can escape the equality. An opener with no
+  conforming close before end of file is REPORTED, never dropped: the renderer swallows the rest of the
+  document into such a block, and an opener the checker cannot pair also credits no id, so its command is
+  reported as having no block at all. That report does not depend on the document ending in a newline: a
+  last line carrying none renders as a line like any other, and the scan reads the file the renderer reads
+  — it appends the missing newline once, at the read, so no pattern in it carries an end-of-file case. The
+  close is not permitted the three spaces of indent CommonMark would allow it; an indented close reads as
+  an opener that never closes, and being told to unindent is the intended fail-closed outcome;
+- **a marked block's body EQUALS the generated command**, and an id the table does not define is a failure
+  rather than an exemption. Equality is over the joined logical line with runs of whitespace collapsed, so
+  a copy may wrap across as many lines as it likes — **breaking only at a space followed by a backslash at
+  end of line**, the one wrap spelling the shell reads the same way. A backslash with no space before it
+  makes the shell join the two lines into a single invalid token, and whitespace after the backslash makes
+  the shell END the command and run the next line separately; both are a different string here, so both
+  are reported rather than passed as canonical. The check never locates the command inside the body,
+  subtracts text it dislikes, or reasons about shell: a second line, a comment line, a trailing comment, a
+  chain, a pipe, a redirection, a substitution, a wrapper that echoes the command or writes it to a file,
+  and a tail of arguments the subcommand does not take are all simply a different string, refused with no
+  list of them written anywhere. The refusal prints the exact string to paste. Put a comment outside the
+  fence, give a second command its own block, and state an optional flag in the prose beside the block
+  rather than as a `[…]` suffix inside it;
+- every id the table defines has **at least one** block somewhere, so deleting the last copy of a command
+  goes red instead of quietly narrowing the check to nothing.
+
+**This check ADDS to the three copy checks beside it and replaces none of them.** Those still sweep the
+skill's prose for copies of `derive`, `liveness` and `required-set` and still fail on finding none. What
+they cannot tell a reader is that a documented command is the command the tool ACCEPTS: they ask whether a
+copy carries the one flag each was taught to look for. Equality against a generated string answers that
+question, and `DOCUMENTED_COMMANDS` is reconciled against the real argparse parser in both directions, so a
+flag the tool REQUIRES cannot go missing from the string the docs are held to.
+
+**Why EQUALITY, rather than a token check.** Four rounds of review asked whether a documented line carried
+the tokens its id requires, and each died to a different piece of text the block's author put beside the
+command. Judging a line by searching it has no fixed point, because the author picks what else is on that
+line and can always add more. Equality has exactly one: the generated string. Do not add a case to it —
+a new carrier means the comparison stopped being equality.
+
+**Illustrating a violation:** use a HYPOTHETICAL script name, never a real one. A doc that quotes a live
+line as its bad example turns itself into a false-positive generator — the next sweeper searches for the
+example, lands on the correct site, and condemns it. Write `example-tool.py derive --pr 1`, not a real
+invocation: this repo ships no script called `example-tool.py`, so the illustration names nothing a reader
+can act on by mistake.
 
 **TWO refusals are CROSS-SOURCE and no single-fetch filter can state them** — the rollup's `StatusContext`
 **coverage**, and the **AGREEMENT** of the two sources about a check they both report. One `jq` filter sees

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -588,12 +588,20 @@ separable:
   close is not permitted the three spaces of indent CommonMark would allow it; an indented close reads as
   an opener that never closes, and being told to unindent is the intended fail-closed outcome;
 - **a marked block's body EQUALS the generated command**, and an id the table does not define is a failure
-  rather than an exemption. Equality is over the joined logical line with runs of whitespace collapsed, so
+  rather than an exemption. Equality is over the joined logical line with runs of separators collapsed, so
   a copy may wrap across as many lines as it likes — **breaking only at a space followed by a backslash at
   end of line**, the one wrap spelling the shell reads the same way. A backslash with no space before it
   makes the shell join the two lines into a single invalid token, and whitespace after the backslash makes
   the shell END the command and run the next line separately; both are a different string here, so both
-  are reported rather than passed as canonical. The check never locates the command inside the body,
+  are reported rather than passed as canonical. A trailing backslash on the body's LAST line is a wrap onto
+  a line the block does not have, and is reported for the same reason. **Every boundary in this comparison
+  is the SHELL's: a separator is an ASCII space, tab or line feed, and nothing else** — the check asks where
+  a line breaks, where a word ends and whether a line is blank exactly as `bash` answers them, never as
+  Python's Unicode-aware defaults do. So a non-breaking space between two words, a line break written with
+  U+2028, U+2029 or U+0085, and a line holding only a non-breaking space are all ordinary text in the string
+  compared, and a body carrying one differs from the generated command — which is the accurate answer,
+  because the shell does not read any of them as a separator either. The check never locates the command
+  inside the body,
   subtracts text it dislikes, or reasons about shell: a second line, a comment line, a trailing comment, a
   chain, a pipe, a redirection, a substitution, a wrapper that echoes the command or writes it to a file,
   and a tail of arguments the subcommand does not take are all simply a different string, refused with no
@@ -608,7 +616,11 @@ skill's prose for copies of `derive`, `liveness` and `required-set` and still fa
 they cannot tell a reader is that a documented command is the command the tool ACCEPTS: they ask whether a
 copy carries the one flag each was taught to look for. Equality against a generated string answers that
 question, and `DOCUMENTED_COMMANDS` is reconciled against the real argparse parser in both directions, so a
-flag the tool REQUIRES cannot go missing from the string the docs are held to.
+flag the tool REQUIRES cannot go missing from the string the docs are held to. A parser cannot state every
+requirement, though: `action.required` speaks per flag, and `derive` needs one of `--ledger` or
+`--required-set` while accepting BOTH, which no argparse construct expresses. Requirements over a SET of
+flags are therefore declared once in `REQUIRED_ONE_OF`, the CLI guard and the reconciliation both read that
+declaration, and a row that stopped recording one is reported instead of generating a command that exits 2.
 
 **Why EQUALITY, rather than a token check.** Four rounds of review asked whether a documented line carried
 the tokens its id requires, and each died to a different piece of text the block's author put beside the

--- a/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
+++ b/plugins/gauntlet/skills/campaign/references/ci-derivation-spec.md
@@ -572,7 +572,7 @@ nothing was looking. Three checks close that, and **none is optional**:
 
 **A fenced block whose info string is `sh gauntlet-cmd=<id>` holds one canonical `ci-status.py`
 invocation.** `<id>` keys `DOCUMENTED_COMMANDS` in `ci-status.py`, which — with one value slot per flag —
-GENERATES the canonical string for that command. `doc-check` enforces three things and they are not
+GENERATES the canonical string for that command. `doc-check` enforces four things and they are not
 separable:
 
 - **the block is delimited exactly as the renderer delimits it.** It opens at column 0 with that info
@@ -587,6 +587,16 @@ separable:
   — it appends the missing newline once, at the read, so no pattern in it carries an end-of-file case. The
   close is not permitted the three spaces of indent CommonMark would allow it; an indented close reads as
   an opener that never closes, and being told to unindent is the intended fail-closed outcome;
+- **no layer rewrites the bytes before the scan reads them**, so the read turns universal-newline
+  translation OFF and a **carriage return in a document holding a marked block is REPORTED**, naming the CR
+  and asking for LF line endings. The shell reads no line break in a `\r`: a wrap written
+  space-backslash-CR-LF escapes the CR into a literal argument and runs the next physical line as a
+  separate command, so a translating read would delete the very byte that makes the documented invocation
+  fail — and pass a body indistinguishable from its all-LF twin. Such a file is skipped whole, crediting no
+  id, so its commands are reported as having no block just as an unterminated opener's are. A CRLF file
+  holding no marked block is not this check's business and is passed over. This matters off Linux: Git for
+  Windows defaults to `core.autocrlf=true`, so an ordinary Windows checkout or plugin-cache clone
+  materializes every `.md` as CRLF;
 - **a marked block's body EQUALS the generated command**, and an id the table does not define is a failure
   rather than an exemption. Equality is over the joined logical line with runs of separators collapsed, so
   a copy may wrap across as many lines as it likes — **breaking only at a space followed by a backslash at
@@ -600,7 +610,9 @@ separable:
   Python's Unicode-aware defaults do. So a non-breaking space between two words, a line break written with
   U+2028, U+2029 or U+0085, and a line holding only a non-breaking space are all ordinary text in the string
   compared, and a body carrying one differs from the generated command — which is the accurate answer,
-  because the shell does not read any of them as a separator either. The check never locates the command
+  because the shell does not read any of them as a separator either. The carriage return is the one
+  character of that class this check answers at the READ rather than at the comparison, for the reason the
+  bullet above gives. The check never locates the command
   inside the body,
   subtracts text it dislikes, or reasons about shell: a second line, a comment line, a trailing comment, a
   chain, a pipe, a redirection, a substitution, a wrapper that echoes the command or writes it to a file,

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -21,7 +21,7 @@ campaign commit to the PR head resets the gate", below, through `scripts/ledger.
 
 **The heartbeat derives `ci` by RUNNING `scripts/ci-status.py`, and by nothing else:**
 
-```sh
+```sh gauntlet-cmd=derive
 python3 <skill>/scripts/ci-status.py derive --pr <N> --head-sha <the LEDGER's head_sha> --rundir <rundir> \
   --ledger <rundir>/state.jsonl
 ```
@@ -169,9 +169,14 @@ cannot see.**
 
 Run the required-set command before CI derivation on every heartbeat:
 
-```sh
-python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl [--repo <owner>/<repo>]
+```sh gauntlet-cmd=required-set
+python3 <skill>/scripts/ci-status.py required-set --ledger <rundir>/state.jsonl
 ```
+
+It takes one optional flag the block does not spell — **`--repo`, `<owner>/<repo>`** — and it defaults to
+the current checkout's repository. Pass it when the run is not standing in that repository. (A marked
+block's body must EQUAL the command generated for its id, so an optional-flag suffix belongs in this
+sentence rather than inside the fence; see "Marked command blocks" in `ci-derivation-spec.md`.)
 
 The command GROUPS the nonterminal rows by `effective_base` and reads each **distinct** base once: it
 resolves each base through `ledger.py`, URL-encodes it as an API path segment, scopes every GitHub call to
@@ -361,7 +366,7 @@ hold a **RUNNING** row, and that PR is still moving.
 
 ##### THE BOOKKEEPING IS A COMMAND — RUN IT. NEVER APPLY THE DERIVATION BLOCK BY HAND.
 
-```sh
+```sh gauntlet-cmd=liveness
 python3 <skill>/scripts/ci-status.py liveness --ledger <rundir>/state.jsonl --pr <N> \
   --derive-json <the JSON derive printed, saved to a file — or - for stdin> \
   --machine-action <due | in-flight | none>

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1470,6 +1470,13 @@ def documented_commands_agree_with_argparse(ci) -> list[str]:
     an invocation the tool itself rejects. The ROW decides that, and only the parser knows the other two
     answers, so ask it rather than writing them down twice.
 
+    ARGPARSE CANNOT ANSWER A THIRD QUESTION AT ALL, AND ITS SILENCE WAS A HOLE. `action.required` says
+    whether a flag is required ON ITS OWN; nothing in a parser says which flags are required as a SET. So
+    `ci-status.py` declares those in `REQUIRED_ONE_OF` and this reconciles the declaration against both the
+    parser and the row — otherwise a rule only `main()` knew was invisible here: drop `derive`'s
+    `(--ledger, --required-set)` alternation and its now-unused value slot together and every check above
+    passes, while the generated command exits 2.
+
     A flag reachable only as an alternation's LATER member is checked for existence but never emitted, so
     it is held to the parser without being put in front of a reader.
     """
@@ -1515,6 +1522,127 @@ def documented_commands_agree_with_argparse(ci) -> list[str]:
                 f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS names {unknown}, which the "
                 f"{cmd_id} parser does not define — the doc would make every copy carry a rejected flag"
             )
+
+        # THE ONE-OF RULE, RECONCILED IN BOTH DIRECTIONS. `REQUIRED_ONE_OF` is what argparse cannot hold: a
+        # `required=True` mutually exclusive group would refuse `--ledger` TOGETHER WITH `--required-set`,
+        # which `derive` accepts. Every group is held to the parser, to the guard that reads it, and to the
+        # row; and every alternation the ROW records is held back to a declared group, so neither side can
+        # be edited alone.
+        dests = {action.dest for action in parser._actions}  # noqa: SLF001
+        row_alts = {frozenset(want) for want in wanted if isinstance(want, tuple)}
+        declared = {frozenset(group) for group in ci.REQUIRED_ONE_OF.get(cmd_id, {})}
+        for group in ci.REQUIRED_ONE_OF.get(cmd_id, {}):
+            if undefined := sorted(set(group) - defined):
+                problems.append(
+                    f"[documented commands {cmd_id}] REQUIRED_ONE_OF names {undefined}, which the {cmd_id} "
+                    f"parser does not define — main()'s guard would hold every caller to a flag that does "
+                    f"not exist"
+                )
+            if mislanded := sorted(f for f in group
+                                   if f in defined and ci.one_of_dest(f) not in dests):
+                problems.append(
+                    f"[documented commands {cmd_id}] REQUIRED_ONE_OF names {mislanded}, whose argparse dest "
+                    f"is not the one one_of_dest() derives — check_one_of() would read an attribute that is "
+                    f"always None and refuse every invocation"
+                )
+            if not spelled & set(group):
+                problems.append(
+                    f"[documented commands {cmd_id}] the CLI requires one of {sorted(group)} and the "
+                    f"canonical copy spells NONE of them — doc-check would call that copy complete and the "
+                    f"tool would exit 2"
+                )
+            if len(group) > 1 and frozenset(group) not in row_alts:
+                problems.append(
+                    f"[documented commands {cmd_id}] the row does not record {sorted(group)} as an "
+                    f"alternation, so the accepted spelling the canonical copy does NOT use is held to "
+                    f"nothing"
+                )
+        for want in wanted:
+            if isinstance(want, tuple) and frozenset(want) not in declared:
+                problems.append(
+                    f"[documented commands {cmd_id}] the row alternates {sorted(want)}, which "
+                    f"REQUIRED_ONE_OF does not declare — a stale alternation the CLI does not enforce"
+                )
+    return problems
+
+
+def one_of_reconciliation_cases(ci, tmp: Path) -> list[str]:
+    """The reconciliation above must REPORT the incomplete row that the argparse-only reading called clean.
+
+    This is the fixture the defect needed and did not have. Removing `derive`'s `(--ledger, --required-set)`
+    alternation left the argparse reading silent, because neither flag is argparse-required, and the only
+    thing that fired was the UNRELATED unused-slot check on the orphaned `--required-set` value. That cover
+    is incidental and vanishes the moment an author also deletes the slot the check just called dead — so
+    this mutates BOTH together, which is exactly the edit that used to pass, and asserts the report.
+
+    The table is a module global, so every mutation is undone in a `finally`: a fixture that left the row
+    edited would silently rewrite what every later fixture is comparing against.
+    """
+    problems: list[str] = []
+    row, slot = ci.DOCUMENTED_COMMANDS["derive"], ci.FLAG_VALUES["--required-set"]
+    group = ("--ledger", "--required-set")
+
+    def with_table(row_value, drop_slot: bool):
+        ci.DOCUMENTED_COMMANDS["derive"] = row_value
+        if drop_slot:
+            del ci.FLAG_VALUES["--required-set"]
+        try:
+            return documented_commands_agree_with_argparse(ci)
+        finally:
+            ci.DOCUMENTED_COMMANDS["derive"] = row
+            ci.FLAG_VALUES["--required-set"] = slot
+
+    if shipped := documented_commands_agree_with_argparse(ci):
+        problems.append(f"[one-of shipped] the table as shipped must reconcile clean; got {shipped!r}")
+
+    # THE EDIT THAT USED TO PASS: the alternation and its orphaned value slot, removed together.
+    dropped = tuple(want for want in row if want != group)
+    report = with_table(dropped, drop_slot=True)
+    if not any("spells NONE of them" in p for p in report):
+        problems.append(
+            f"[one-of dropped] a derive row naming NEITHER --ledger nor --required-set generates a command "
+            f"the CLI exits 2 on, and must be reported for that; got {report!r}"
+        )
+    if not any("does not record" in p for p in report):
+        problems.append(
+            f"[one-of dropped] and the row must be reported for no longer recording the group as an "
+            f"alternation; got {report!r}"
+        )
+
+    # THE HALF-EDIT: the canonical member survives, so the command still RUNS, but the other accepted
+    # spelling is recorded nowhere. The unused-slot check cannot see this one at all — the slot is still
+    # named by the row it was removed from.
+    report = with_table(tuple("--ledger" if want == group else want for want in row), drop_slot=False)
+    if not any("does not record" in p for p in report):
+        problems.append(
+            f"[one-of collapsed] a row that keeps --ledger but drops the recorded alternation must be "
+            f"reported: the spelling the CLI still accepts is then held to nothing; got {report!r}"
+        )
+
+    # THE OTHER DIRECTION: an alternation in the row that no declared group backs.
+    report = with_table(row + (("--rundir", "--pr"),), drop_slot=False)
+    if not any("stale alternation" in p for p in report):
+        problems.append(
+            f"[one-of stale] a row alternation REQUIRED_ONE_OF does not declare must be reported, or the "
+            f"row could record a one-of rule the CLI never enforces; got {report!r}"
+        )
+
+    # THE OTHER READER OF THE SAME DECLARATION. Reconciling the table against a rule `main()` no longer
+    # enforces would be the reconciliation passing about nothing, so the CLI is asked directly: with neither
+    # member given it exits 2 before any fetch, and it names both spellings so the caller can pick one.
+    rundir = tmp / "one-of-rundir"
+    rundir.mkdir()
+    proc = subprocess.run(  # noqa: S603 - this suite drives its sibling command
+        [sys.executable, str(STATUS_PY), "derive", "--pr", "1", "--head-sha", ci.FIXTURE_SHA,
+         "--rundir", str(rundir)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+    )
+    if proc.returncode != 2:
+        problems.append(f"[one-of CLI] derive with NEITHER --ledger nor --required-set must exit 2, not "
+                        f"{proc.returncode}: {proc.stderr!r}")
+    if not all(flag in proc.stderr for flag in group):
+        problems.append(f"[one-of CLI] the refusal must name both accepted spellings, so the caller can "
+                        f"choose one; got {proc.stderr!r}")
     return problems
 
 
@@ -1600,6 +1728,12 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
          "a backslash with NO space before it is not a wrap — the shell joins it into one invalid token"),
         ("continuation-trailing-space", derive.replace(" --ledger ", " \\   \n--ledger "),
          "whitespace AFTER the backslash is not a wrap either — the shell ends the command there"),
+        # THE WRAP WITH NOTHING TO WRAP ONTO, and the third reading of a physical line that has to agree
+        # with the other two. The body's LAST line ends in a continuation, so the shell joins it with
+        # whatever follows the block rather than running it as written.
+        ("continuation-dangling", derive + " \\",
+         "a trailing backslash continues onto a line this block does not have, so the body is not the "
+         "command either"),
         ("trailing-comment", liveness + "   # derive --head-sha abc --rundir run",
          "nor a trailing comment on the command's own line"),
         ("chained", liveness + " ; echo derive --head-sha abc --rundir run", "nor a `;` chain"),
@@ -1630,6 +1764,69 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     )
     for slug, body, why in carriers:
         expect(f"carrier-{slug}", every() + _marked("derive", body), 1, why)
+
+    # A SHELL SEPARATOR IS ASCII SPACE, TAB OR NEWLINE, AND THESE ARE THE BODIES THAT PIN IT. Each one asks
+    # a question about a SHELL — where does a line break, where does a word end, is this line blank — that
+    # Python's `splitlines()`, `strip()` and `split()` answer with the UNICODE notion of whitespace. Under
+    # those defaults each body below COMPARED EQUAL to the generated command while `bash` read it as
+    # something else, so `doc-check` went green on an invocation that does not run.
+    #
+    # OUTCOME ALONE CANNOT PIN THIS, and that is the trap these cases are written around: form feed and
+    # vertical tab were refused before the ASCII rule too — but only by accident, because `splitlines()`
+    # split the body THERE, so the refusal came from a bogus "two commands" reading rather than from the
+    # separator surviving into the compared string. Each case therefore asserts the REASON: the character is
+    # still in the collapsed line, and the body still cuts into the number of logical lines the SHELL sees.
+    # ESCAPED, NEVER LITERAL. A body carrying an invisible character is the point of these cases, and a
+    # source line carrying one is unreadable, un-greppable, and one editor away from being normalized
+    # into an ASCII space — at which point the fixture pins nothing and still passes.
+    nbsp, lsep, psep, nel = "\u00a0", "\u2028", "\u2029", "\u0085"
+    head, tail = derive.split(" --pr ", 1)
+
+    def wrapped_at(sep: str) -> str:
+        """The canonical command wrapped at a VALID continuation whose newline is `sep` instead of `\\n`."""
+        return head + " \\" + sep + "--pr " + tail
+
+    separators: tuple[tuple[str, str, str, int, str], ...] = (
+        ("nbsp-word", derive.replace("python3 ", "python3" + nbsp, 1), nbsp, 1,
+         "U+00A0 is no IFS separator, so bash reads `python3<U+00A0>…` as ONE word and that word is the "
+         "command NAME"),
+        ("line-separator", wrapped_at(lsep), lsep, 1,
+         "U+2028 is no shell newline, so the backslash escapes it into a literal character with `--pr` "
+         "glued on, and argparse never sees the flag"),
+        ("paragraph-separator", wrapped_at(psep), psep, 1,
+         "U+2029 is the same class of character and gets the same answer"),
+        ("next-line", wrapped_at(nel), nel, 1,
+         "and so is U+0085, which `splitlines()` also breaks at"),
+        ("nbsp-only-line-after", derive + "\n" + nbsp, nbsp, 2,
+         "a line holding only U+00A0 is a nonempty WORD to bash, so the block holds a SECOND command that "
+         "fails — while a bare strip() calls that line blank and drops it"),
+        ("nbsp-only-line-before", nbsp + "\n" + derive, nbsp, 2,
+         "and the same line ahead of the command is dropped by the very same strip()"),
+    )
+    for slug, body, sep, want_lines, why in separators:
+        expect(f"separator-{slug}", every() + _marked("derive", body), 1, why)
+        # `_collapsed_lines` is the string the equality really compares, so the reason is asserted there.
+        collapsed = ci._collapsed_lines(body)  # noqa: SLF001
+        if len(collapsed) != want_lines or not any(sep in line for line in collapsed):
+            problems.append(
+                f"[marked commands separator-{slug}] the refusal must come from the separator SURVIVING "
+                f"into the compared string, not from the body being re-cut into lines: expected "
+                f"{want_lines} logical line(s) still carrying U+{ord(sep):04X}; got {collapsed!r}"
+            )
+
+    # WHY ONLY ONE OF THE TWO BLANK TESTS IS OBSERVABLE — pinned, rather than claimed in a comment. Both
+    # flushes in `_logical_lines` ask whether a group of physical lines is blank, and both must ask it the
+    # ASCII way. But the TRAILING flush runs only when the body's last physical line CONTINUES, so its group
+    # always ends in a backslash, and no blank test of any grammar calls that blank. The two are spelled
+    # identically anyway, so they cannot drift if the reachability ever changes — and this is the reason a
+    # fixture can catch a regression at the loop flush and never at the other.
+    if disagreeing := [t for t in (" \\", "\t\\", nbsp + " \\", "  " + nbsp + "\t\\")
+                       if ci.CONTINUED_LINE.search(t) and bool(t.strip()) != bool(t.strip(" \t\n"))]:
+        problems.append(
+            f"[marked commands trailing-flush] a CONTINUED line is non-blank under both the ASCII and the "
+            f"Unicode reading, which is what makes the trailing flush's blank test unobservable; "
+            f"{disagreeing!r} disagree, so that flush now needs a fixture of its own"
+        )
 
     # THE REFUSAL STATES THE ONE REPAIR — the exact string to paste. A message that only says what is wrong
     # gets the block edited until it passes; this one leaves nothing to decide.
@@ -1785,7 +1982,18 @@ def run(ci, tmp: Path) -> int:
         print(f"FAIL     {problem}")
     if not documented_command_problems:
         print(f"ok       {'DOCUMENTED_COMMANDS vs argparse':32} -> every flag a subcommand REQUIRES is a "
-              f"token its documented copies must carry, and no row names a flag the parser rejects")
+              f"token its documented copies must carry, no row names a flag the parser rejects, and every "
+              f"REQUIRED_ONE_OF group is held to the parser, the guard and the row in both directions")
+
+    one_of_problems = one_of_reconciliation_cases(ci, tmp)
+    for problem in one_of_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not one_of_problems:
+        print(f"ok       {'REQUIRED_ONE_OF reconciliation':32} -> the reconciliation REPORTS a derive row "
+              f"that drops the (--ledger, --required-set) alternation — with its value slot or without — "
+              f"reports an alternation no declared group backs, and the CLI still refuses an invocation "
+              f"naming neither, before any fetch")
 
     marked_command_problems = marked_command_cases(ci, tmp)
     for problem in marked_command_problems:
@@ -1793,8 +2001,9 @@ def run(ci, tmp: Path) -> int:
         print(f"FAIL     {problem}")
     if not marked_command_problems:
         print(f"ok       {'marked command blocks':32} -> a block's body EQUALS the command generated for its "
-              f"id, every carrier that ever broke this check is refused, only a conforming close ends the "
-              f"body, an opener without one is reported, and an id with no block fails")
+              f"id, every carrier that ever broke this check is refused, a boundary is an ASCII shell "
+              f"separator and nothing else, only a conforming close ends the body, an opener without one "
+              f"is reported, and an id with no block fails")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1444,10 +1444,19 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
-def _docs(tmp: Path, slug: str, body: str) -> Path:
+def _docs(tmp: Path, slug: str, body: str, **extra: str) -> Path:
+    """A doc tree holding `commands.md` and any `extra` file, written BYTE FOR BYTE as given.
+
+    `newline=""` on the write, never a bare `write_text`: Python's default translates every `\\n` to
+    `os.linesep` on the way out, so on Windows a fixture that spells LF would land as CRLF and a fixture
+    that spells CRLF would land as CR-CR-LF. These fixtures are ABOUT line endings, so the writer has to be
+    as literal as `_scanned`'s reader is.
+    """
     root = tmp / f"marked-commands-{slug}"
     root.mkdir()
-    (root / "commands.md").write_text(body, encoding="utf-8")
+    for name, text in {"commands.md": body, **extra}.items():
+        with (root / name).open("w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
     return root
 
 
@@ -1890,6 +1899,51 @@ def marked_command_cases(ci, tmp: Path) -> list[str]:
     # to prove the appended newline does not swallow a close that was already conforming.
     expect("eof-close-no-newline", every()[:-1], 0,
            "a conforming close IS the last line with no newline, and still closes its block")
+
+    # NO LAYER REWRITES BYTES BEFORE THE SCAN READS THEM, and the CARRIAGE RETURN is the character that rule
+    # exists for. `bash` reads a wrap written space-backslash-CR-LF as an ESCAPED LITERAL CR: the command
+    # receives a one-character `\r` argument and the NEXT physical line runs as a command of its own, exit
+    # 127 — confirmed against GNU bash 5.2.21. A universal-newline read deletes that CR before any pattern
+    # runs, so the checker passed the exact body the shell refuses and could not tell it from its all-LF
+    # twin. Deleting the CR never made the body agree with the shell; it only removed the disagreement from
+    # view, which is why the read is raw and the refusal is explicit.
+    #
+    # THE DIAGNOSTIC IS ASSERTED, NOT JUST THE COUNT, because the raw read ALONE also fails closed and does
+    # it for the wrong reason: `MARKED_OPENER`'s id capture swallows the CR and `MARKED_CLOSE` never matches
+    # a close ending CR-LF, so the report accuses the opener of never closing — an invisible character in
+    # the message, and repair advice pointing at a fence that is perfectly well formed. A count-only fixture
+    # is green under that version, so it would pin the wrong half of the fix.
+    crlf_wrapped = {i: c.replace(" --ledger ", " \\\n    --ledger ") for i, c in canon.items()}
+    crlf_report, crlf_found = ci.check_marked_commands(
+        _docs(tmp, "crlf", every(**crlf_wrapped).replace("\n", "\r\n")))
+    want_crlf = 1 + len(ci.DOCUMENTED_COMMANDS)
+    if len(crlf_report) != want_crlf or crlf_found:
+        problems.append(
+            f"[marked commands crlf] a CRLF doc holding marked blocks must be REFUSED, and credit no id, so "
+            f"the zero-blocks rule fires beside the refusal: expected {want_crlf} problem(s) and no blocks "
+            f"found; got report={crlf_report!r} found={crlf_found!r}"
+        )
+    if not any("CARRIAGE RETURN" in problem for problem in crlf_report):
+        problems.append(
+            f"[marked commands crlf] the refusal must NAME the carriage return, because that is the byte to "
+            f"remove and it is invisible in the file; got {crlf_report!r}"
+        )
+    if any("NEVER CLOSES" in problem for problem in crlf_report):
+        problems.append(
+            f"[marked commands crlf] a CRLF doc must not be reported as an unterminated opener — its fences "
+            f"are well formed and the author would edit a correct close forever; got {crlf_report!r}"
+        )
+
+    # THE GUARD IS SCOPED TO A DOC HOLDING A MARKED BLOCK. A checkout that materializes every `.md` as CRLF
+    # (Git for Windows defaults `core.autocrlf=true`) must not go red over prose this check never reads, so
+    # the CR question is asked only of files the scan actually compares.
+    unrelated, _ = ci.check_marked_commands(
+        _docs(tmp, "crlf-unrelated", every(), **{"prose.md": "Prose with no marked block at all.\r\n"}))
+    if unrelated:
+        problems.append(
+            f"[marked commands crlf-unrelated] a CRLF file holding NO marked block is none of this check's "
+            f"business and must be passed over in silence; got {unrelated!r}"
+        )
     return problems
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1444,6 +1444,258 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
+def _docs(tmp: Path, slug: str, body: str) -> Path:
+    root = tmp / f"marked-commands-{slug}"
+    root.mkdir()
+    (root / "commands.md").write_text(body, encoding="utf-8")
+    return root
+
+
+def _marked(cmd_id: str, command: str) -> str:
+    return f"```sh gauntlet-cmd={cmd_id}\n{command}\n```\n"
+
+
+def documented_commands_agree_with_argparse(ci) -> list[str]:
+    """`DOCUMENTED_COMMANDS` and the real CLI parser state ONE contract — reconcile them, never restate them.
+
+    Every fixture below drives the table, so not one of them can notice that the table is INCOMPLETE: drop a
+    flag from a row and the case that would have caught it disappears with it. That gap is the defect this
+    pins. The `liveness` row once omitted `--derive-json` — a flag argparse REQUIRES — so `doc-check`
+    reported the documented invocation as complete, and running it exited 2.
+
+    ARGPARSE'S ROLE IS SMALL AND ONE-DIRECTIONAL, and the direction is the point. It answers two questions:
+    does every flag the canonical copy SPELLS exist, and is every flag the parser REQUIRES spelled? It does
+    NOT get to say which OPTIONAL flags a documented copy carries — generating every optional the parser
+    defines would make `derive`'s canonical copy spell `--repo`, `--ledger` and `--required-set` at once,
+    an invocation the tool itself rejects. The ROW decides that, and only the parser knows the other two
+    answers, so ask it rather than writing them down twice.
+
+    A flag reachable only as an alternation's LATER member is checked for existence but never emitted, so
+    it is held to the parser without being put in front of a reader.
+    """
+    problems: list[str] = []
+    # `_actions` because argparse exposes no public accessor for its actions or its subparser map — the
+    # same read `followups-test.py` makes of its own parser.
+    subcommands = next((action.choices for action in ci.build_parser()._actions  # noqa: SLF001
+                        if isinstance(getattr(action, "choices", None), dict)), None)
+    if not subcommands:
+        return ["[documented commands] build_parser() exposed no subcommands — the reconciliation below "
+                "would then pass by asking nothing, which is this suite's founding defect"]
+
+    # A SLOT NO ROW NAMES IS A DEAD CONSTANT, and a row naming a flag with no slot is a table the generator
+    # cannot render (`KeyError`, from a doc-check that should have reported it). Reconcile the two sets.
+    named = {alt for wanted in ci.DOCUMENTED_COMMANDS.values() for want in wanted
+             for alt in (want if isinstance(want, tuple) else (want,))}
+    if unslotted := sorted(named - set(ci.FLAG_VALUES)):
+        problems.append(f"[documented commands] DOCUMENTED_COMMANDS names {unslotted}, which FLAG_VALUES "
+                        f"gives no value slot — canonical_command() cannot render that row")
+    if unused := sorted(set(ci.FLAG_VALUES) - named):
+        problems.append(f"[documented commands] FLAG_VALUES holds a slot for {unused}, which no row names "
+                        f"— a value nobody can read is a constant that rots unnoticed")
+
+    for cmd_id, wanted in ci.DOCUMENTED_COMMANDS.items():
+        parser = subcommands.get(cmd_id)
+        if parser is None:
+            problems.append(f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS names an id that is not a "
+                            f"subcommand of ci-status.py — known: {sorted(subcommands)}. The id IS the "
+                            f"subcommand canonical_command() emits, so the generated copy would not run")
+            continue
+        documented = {alt for want in wanted for alt in (want if isinstance(want, tuple) else (want,))}
+        spelled = set(ci.canonical_flags(cmd_id))
+        defined = {opt for action in parser._actions for opt in action.option_strings}
+        required = {action.option_strings[0] for action in parser._actions
+                    if action.required and action.option_strings}
+        if missing := sorted(required - spelled):
+            problems.append(
+                f"[documented commands {cmd_id}] argparse REQUIRES {missing}, which the canonical copy does "
+                f"not spell — doc-check would call that copy correct and the tool would refuse to run it"
+            )
+        if unknown := sorted(flag for flag in documented if flag.startswith("--") and flag not in defined):
+            problems.append(
+                f"[documented commands {cmd_id}] DOCUMENTED_COMMANDS names {unknown}, which the "
+                f"{cmd_id} parser does not define — the doc would make every copy carry a rejected flag"
+            )
+    return problems
+
+
+def marked_command_cases(ci, tmp: Path) -> list[str]:
+    """Pin the marker contract: a marked block's body IS the command generated for its id, and nothing else.
+
+    THE MECHANISM IS ONE COMPARISON, SO IT IS PINNED ONCE AND THE CARRIERS ARE A TABLE. Four earlier rounds
+    asked whether a block's command CARRIED the tokens its id requires, and each died to a different piece
+    of text the author put beside it. Under equality none of those is a separate mechanism: every one of
+    them is simply a body that differs from the generated string, so they are listed as data rather than
+    written out as twenty near-identical cases. The table is kept in full anyway — it is the record of what
+    this check has already been broken by, and a future relaxation has to walk past every row of it.
+
+    WHERE THE BLOCK ENDS IS PART OF THE COMPARISON, so the fence group is pinned beside the carriers. The
+    body compared has to be the body the RENDERER shows: a delimiter looser than the rendered block lets
+    text sit inside a checked block without ever reaching the equality, which is the same escape the
+    carriers buy by other means.
+
+    HOW A WRAP IS JOINED IS PART OF IT TOO. The one latitude the comparison allows is a line continuation,
+    and a continuation the SHELL does not recognize is a body that passes here and fails there — so both
+    disagreeing spellings are pinned as carriers of their own.
+    """
+    problems: list[str] = []
+    # THE FIXTURES ARE GENERATED FROM THE TABLE, exactly as the docs are held to be. A hand-written copy
+    # here would be a fourth statement of the command, free to drift from the three the tool already
+    # reconciles. That the generated string is the one the LIVE docs hold is `doc-check`'s job, run by this
+    # same self-test over the real doc tree — so these cases are not comparing the generator to itself.
+    canon = {cmd_id: ci.canonical_command(cmd_id) for cmd_id in ci.DOCUMENTED_COMMANDS}
+    derive, liveness = canon["derive"], canon["liveness"]
+
+    def every(**override: str) -> str:
+        """Every id gets a block, so the has-at-least-one-block rule never fires for an unrelated reason."""
+        return "\n".join(_marked(i, override[i] if i in override else c) for i, c in canon.items())
+
+    def expect(slug: str, body: str, want_marked: int, why: str) -> None:
+        root = _docs(tmp, slug, body)
+        marked, _blocks = ci.check_marked_commands(root)
+        if len(marked) != want_marked:
+            problems.append(
+                f"[marked commands {slug}] {why}: expected {want_marked} marked-block problem(s); "
+                f"got marked={marked!r}"
+            )
+
+    # THE MECHANISM: the generated command passes, and the ONLY latitude is whitespace.
+    expect("all-present", every(), 0,
+           "a marked block per id, each body EQUAL to that id's generated command, is clean")
+
+    # A CONTINUED COMMAND IS ONE COMMAND. The live derive and liveness copies wrap, and a byte-exact
+    # comparison would condemn all three blocks over the `\` and the indent that continues the line —
+    # turning correct blocks red, which is how a check gets deleted by the next person in a hurry.
+    wrapped = {i: c.replace(" --ledger ", " \\\n    --ledger ") for i, c in canon.items()}
+    expect("continuation", every(**wrapped), 0,
+           "a backslash continuation joins into the same one command")
+    spaced = {i: "  " + c.replace(" --ledger ", "   --ledger  ") for i, c in canon.items()}
+    expect("whitespace-runs", every(**spaced), 0,
+           "runs of whitespace collapse, so indentation and alignment are not a difference")
+
+    # EVERY CARRIER THAT EVER BROKE THIS CHECK, AS DATA. Each row is a `gauntlet-cmd=derive` block whose
+    # body is not derive's generated command, so each must be reported — and none of them is named
+    # anywhere in `ci-status.py`, which is the property this table exists to demonstrate: the carriers are
+    # refused by construction, not by enumeration. Adding the block to a clean set means the ONE expected
+    # problem is that block, never a missing-id complaint.
+    carriers: tuple[tuple[str, str, str], ...] = (
+        ("other-script", derive.replace("/ci-status.py ", "/not-ci-status.py "),
+         "a different script — this repo ships none called `not-ci-status.py` — is not this command"),
+        ("prefixed-subcommand", derive.replace(" derive ", " rederive "),
+         "a subcommand that merely ENDS in the required one is a different command"),
+        ("comment-line", "# the derive step takes --head-sha <sha> --rundir <dir>\n" + liveness,
+         "a whole-line comment cannot supply what the invocation beside it lacks"),
+        ("second-line", liveness + "\ngrep derive --head-sha --rundir notes.txt",
+         "a second command line cannot supply it either"),
+        # THE COLLAPSE MUST NOT MERGE LINES, and this is the case that says so: the two lines CONCATENATE
+        # to the canonical string, so a comparison over the whole body joined would call them correct. A
+        # reader running this block runs an incomplete `derive` and then a `--rundir` that is no command.
+        ("split-lines", derive.replace(" --rundir ", "\n--rundir "),
+         "two lines that CONCATENATE to the command are still not one command"),
+        # THE TWO CONTINUATION SPELLINGS THE SHELL READS DIFFERENTLY FROM ANY `rstrip`-AND-SUBSTITUTE RULE,
+        # both confirmed against bash. A rule that replaced backslash-newline with a SPACE passed the first
+        # while the shell built the single invalid token `--ledger<rundir>/state.jsonl`; a rule that
+        # `rstrip`ped before looking for the backslash passed the second while the shell ended the command
+        # at the escaped space and ran the next line as a command of its own.
+        ("continuation-no-space", derive.replace(" --ledger ", " --ledger\\\n"),
+         "a backslash with NO space before it is not a wrap — the shell joins it into one invalid token"),
+        ("continuation-trailing-space", derive.replace(" --ledger ", " \\   \n--ledger "),
+         "whitespace AFTER the backslash is not a wrap either — the shell ends the command there"),
+        ("trailing-comment", liveness + "   # derive --head-sha abc --rundir run",
+         "nor a trailing comment on the command's own line"),
+        ("chained", liveness + " ; echo derive --head-sha abc --rundir run", "nor a `;` chain"),
+        ("piped", liveness + " | grep derive --head-sha --rundir", "nor a pipe"),
+        ("and-chained", liveness + " && echo derive --head-sha abc --rundir run", "nor an `&&` chain"),
+        ("substitution", liveness + " --note $(echo derive --head-sha abc --rundir run)",
+         "nor a `$(…)` substitution"),
+        ("redirection", liveness + " > /tmp/derive --head-sha abc --rundir run",
+         "nor a `>` redirection, whose OPERAND once supplied both the id and the flags it was missing"),
+        ("mislabelled-tail", liveness + " derive --head-sha abc --rundir run",
+         "nor a tail of arguments the subcommand does not take, which argparse exits 2 on"),
+        ("echo-wrapper", "echo " + derive,
+         "a block that ECHOES the command does not run it, whatever the line spells"),
+        ("heredoc", "cat > run-derive.sh <<'EOF'\n" + derive + "\nEOF",
+         "a block that WRITES the command to a file does not run it either"),
+        ("mislabelled", liveness,
+         "a liveness invocation marked gauntlet-cmd=derive is held to DERIVE's command"),
+        ("omits-flag", derive.replace(" --rundir <rundir>", ""),
+         "a flag the tool requires, dropped, is a different string"),
+        ("extra-flag", derive + " --repo <owner>/<repo>",
+         "and so is an extra one, even a real optional the parser accepts"),
+        ("bracketed-optional", derive + " [--repo <owner>/<repo>]",
+         "and so is a bracketed-optional suffix, which is literal text in a body that must BE the command"),
+        ("equals-form", derive.replace(" --ledger ", " --ledger="),
+         "argparse takes --name=value, but the doc shows ONE spelling and the block must be it"),
+        ("placeholder-edited", derive.replace("<rundir>", "<the run dir>"),
+         "a re-worded placeholder is a second spelling of a value slot the table owns"),
+    )
+    for slug, body, why in carriers:
+        expect(f"carrier-{slug}", every() + _marked("derive", body), 1, why)
+
+    # THE REFUSAL STATES THE ONE REPAIR — the exact string to paste. A message that only says what is wrong
+    # gets the block edited until it passes; this one leaves nothing to decide.
+    report, _blocks = ci.check_marked_commands(_docs(tmp, "message", every() + _marked("derive", liveness)))
+    if not any(derive in problem for problem in report):
+        problems.append(f"[marked commands message] a refused block must be told the exact command to hold; "
+                        f"got {report!r}")
+
+    # AN UNKNOWN ID IS REPORTED WHATEVER ITS SPELLING. The id pattern must not decide which ids exist: an id
+    # the pattern REJECTS is not a marked block at all, so this branch never fires and the author is instead
+    # told to move a block that already sits inside a marked fence.
+    for n, spelling in enumerate(("nonesuch", "nonesuch2", "NONESUCH", "none_such", "9")):
+        expect(f"unknown-id-{n}", every() + _marked(spelling, derive), 1,
+               f"the undefined id `{spelling}` is a failure, never an exemption")
+    expect("trailing-space", every().replace("=derive\n", "=derive  \n"), 0,
+           "CommonMark drops trailing info-string spaces, so a marked block stays marked despite them")
+
+    # A CHECK THAT FINDS NOTHING MUST NEVER PASS.
+    expect("no-blocks", "nothing here\n", len(ci.DOCUMENTED_COMMANDS),
+           "every id with zero blocks is reported")
+
+    # WHERE THE BLOCK ENDS IS PART OF THE COMPARISON, because the body is whatever the RENDERER puts inside
+    # the fence. A close ending at the first line merely STARTING with backticks would hand the author the
+    # one carrier equality cannot refuse: text after such a line renders inside the block and never reaches
+    # the comparison, and an opener with no close at all vanishes from the checker entirely while the
+    # renderer swallows the rest of the file into it. Both shapes are the SAME defect — a delimiter looser
+    # than the rendered block — so both are pinned here, against the one positive rule that fixes them.
+    hidden = _marked("derive", derive).replace("\n```\n", "\n``` x\nand this line renders inside it\n```\n")
+    expect("close-trailing-info", every() + hidden, 1,
+           "a line with anything after the backticks is BODY, so the text it hides is part of the comparison")
+    expect("close-trailing-spaces", every().replace("\n```\n", "\n```   \n"), 0,
+           "spaces and tabs after the backticks are all a conforming close may carry, and it still closes")
+    expect("indented-close", every() + f"```sh gauntlet-cmd=derive\n{derive}\n  ```\n", 1,
+           "an indented close is not a close, so the opener reads as unterminated and is REPORTED")
+    expect("unterminated-opener", every() + f"```sh gauntlet-cmd=derive\n{derive}\n", 1,
+           "an opener with no close is reported rather than dropped")
+    # THE SHARP ONE: an unterminated block holding an INCOMPLETE invocation. Before the opener-anchored scan
+    # the marked check was silent on it — a documented command that does not run, inside a block claiming to
+    # be checked, reported by nothing at all.
+    incomplete = f"{ci.COMMAND_PREFIX} derive"
+    expect("unterminated-no-long-option", every() + f"```sh gauntlet-cmd=derive\n{incomplete}\n", 1,
+           "the broken fence is reported on the fence rule alone, with no help from what the body holds")
+    others = "\n".join(_marked(i, c) for i, c in canon.items() if i != "derive")
+    expect("unterminated-only-block", others + f"```sh gauntlet-cmd=derive\n{incomplete}\n", 2,
+           "a block the checker never read cannot credit its id, so zero-blocks fires beside the broken fence")
+
+    # A LAST LINE WITH NO NEWLINE IS STILL A LINE, and the report of an unterminated opener does not depend
+    # on the file having a final one. A doc whose last byte is not `\n` renders exactly like one whose last
+    # byte is, so the scan must read it the same way — `_scanned` appends the newline once at the read
+    # rather than teaching each pattern an end-of-file case, which is how the opener came to differ from the
+    # close. These four are the whole family: the opener that renders an (empty) block, the same opener when
+    # it is its id's ONLY block, the same with the trailing spaces the info string drops, and a complete
+    # block whose CLOSE is itself the unterminated last line.
+    expect("eof-opener-no-newline", every() + "```sh gauntlet-cmd=nonesuch", 1,
+           "an opener on a last line with no newline is reported, never silently dropped")
+    expect("eof-opener-no-newline-only-block", others + "```sh gauntlet-cmd=derive", 2,
+           "and it credits nothing, so zero-blocks fires beside it")
+    expect("eof-opener-no-newline-trailing-space", every() + "```sh gauntlet-cmd=nonesuch  ", 1,
+           "trailing info-string spaces do not save it either")
+    # THE POSITIVE CONTROL on the normalization: this one passes with or without `_scanned`, and its job is
+    # to prove the appended newline does not swallow a close that was already conforming.
+    expect("eof-close-no-newline", every()[:-1], 0,
+           "a conforming close IS the last line with no newline, and still closes its block")
+    return problems
+
+
 def run(ci, tmp: Path) -> int:
     """Every fixture, then the seams, then `doc-check`. Non-zero on any failure.
 
@@ -1526,6 +1778,23 @@ def run(ci, tmp: Path) -> int:
     if not documentation_option_problems:
         print(f"ok       {'documentation option forms':32} -> standalone and --name=value forms are "
               f"recognized without accepting option-name lookalikes")
+
+    documented_command_problems = documented_commands_agree_with_argparse(ci)
+    for problem in documented_command_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not documented_command_problems:
+        print(f"ok       {'DOCUMENTED_COMMANDS vs argparse':32} -> every flag a subcommand REQUIRES is a "
+              f"token its documented copies must carry, and no row names a flag the parser rejects")
+
+    marked_command_problems = marked_command_cases(ci, tmp)
+    for problem in marked_command_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not marked_command_problems:
+        print(f"ok       {'marked command blocks':32} -> a block's body EQUALS the command generated for its "
+              f"id, every carrier that ever broke this check is refused, only a conforming close ends the "
+              f"body, an opener without one is reported, and an id with no block fails")
 
     print()
     print(f"--- doc-check: {ci.SPEC_DOC.name} + {ci.DRIVER_DOC.name} vs the code that runs ---")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2365,8 +2365,10 @@ def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list
 # line has no fixed point, because the author picks what else is on that line and can always add more.
 # EQUALITY has one: exactly one string passes, this file writes it, and every carrier above fails BY
 # CONSTRUCTION instead of by enumeration. Nothing here parses shell, subtracts text, or locates a window —
-# the only latitude is `_collapsed_lines`, which joins continuations and collapses whitespace runs so a
-# wrapped copy is the same command as an unwrapped one.
+# the only latitude is `_collapsed_lines`, which joins continuations and collapses separator runs so a
+# wrapped copy is the same command as an unwrapped one. EVERY BOUNDARY IN THAT LATITUDE IS THE SHELL'S, NOT
+# PYTHON'S — see `_SHELL_BLANK`, which owns that rule: a body carrying a separator the shell does not
+# recognize is a different string here too, exactly as it is a different command there.
 #
 # A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
 # is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
@@ -2375,6 +2377,10 @@ def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list
 # argparse's remaining job is exactly that reconciliation: the row, never the parser, decides which
 # OPTIONAL flags a documented copy spells, because `derive` alone would otherwise gain `--repo`,
 # `--ledger` and `--required-set` all at once.
+#
+# ARGPARSE CANNOT STATE EVERY REQUIREMENT, AND THE ONES IT CANNOT WERE INVISIBLE TO THAT RECONCILIATION.
+# `action.required` is per-flag; a requirement over a SET of flags has no argparse spelling here. Those are
+# declared in `REQUIRED_ONE_OF` below and reconciled from the same declaration `main()` enforces.
 #
 # WHY THE MARKER, RATHER THAN A CLEVERER SCAN. Checking a command by hunting it in free Markdown means
 # deciding, for arbitrary prose, whether a stretch of text is a command or a sentence about one. That
@@ -2407,7 +2413,8 @@ FLAG_VALUES: dict[str, str] = {
 DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
     # The required set is what makes `green` mean *the required set passed*, and it is the ROW's
     # `effective_required_set`: name it with `--ledger` (resolve the row's set — the production form) or
-    # with an explicit `--required-set`. A copy carrying NEITHER reconstructs an invocation the tool refuses.
+    # with an explicit `--required-set`. A copy carrying NEITHER reconstructs an invocation the tool refuses,
+    # and `REQUIRED_ONE_OF` below is what holds this alternation to that refusal in both directions.
     "derive": ("--pr", "--head-sha", "--rundir", ("--ledger", "--required-set")),
     # `--machine-action` is the one judgment the command asks of its caller. A reader who drops the question
     # and invents a default strikes the very PR a fix is about to move. `--derive-json` is the evidence the
@@ -2418,6 +2425,50 @@ DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
     # is literal text in a body that must BE the command, so the block would no longer equal it.
     "required-set": ("--ledger",),
 }
+# THE REQUIREMENT ARGPARSE CANNOT HOLD: at least ONE member of each group must be given. `required=True` on
+# a mutually exclusive group is the wrong shape here, because `--ledger` TOGETHER WITH `--required-set` is a
+# legal `derive` invocation — the explicit set is then an assertion about the row's. So the rule is declared
+# HERE, and both of its readers read it: `check_one_of` enforces it in `main()`, and
+# `ci-status-test.documented_commands_agree_with_argparse` reconciles it against the row and the parser.
+#
+# THE DECLARATION EXISTS BECAUSE A RULE ONLY `main()` KNEW WAS INVISIBLE TO THE RECONCILIATION. That check
+# derives "required" from argparse's `action.required` alone, and neither flag is argparse-required, so a
+# `derive` row that dropped the alternation AND its value slot left every check clean while the generated
+# command exited 2 — an incomplete row is exactly what the two-way reconciliation is for.
+#
+# Each group maps to WHY it exists, in the words the refusal shows its caller: ONE structure, so a group and
+# its reason cannot drift apart, and a group added with no reason is a syntax error rather than a silence.
+REQUIRED_ONE_OF: dict[str, dict[tuple[str, ...], str]] = {
+    "derive": {
+        ("--ledger", "--required-set"):
+            "--ledger resolves the row's effective required set (the production form) and --required-set "
+            "states one explicitly. A derive with NEITHER has no set to decide under, and defaulting one "
+            "is the false green this whole tool exists to kill",
+    },
+}
+
+
+def one_of_dest(flag: str) -> str:
+    """The `argparse` attribute a long option lands in — `--required-set` reads as `required_set`.
+
+    argparse derives a dest from an option's long spelling exactly this way, and nothing here relies on that
+    quietly: `documented_commands_agree_with_argparse` asserts every `REQUIRED_ONE_OF` member is defined by
+    its subparser AND lands on this dest, so a `dest=` override is a REPORTED failure rather than a guard
+    reading an attribute that is always None.
+    """
+    return flag.lstrip("-").replace("-", "_")
+
+
+def check_one_of(cmd_id: str, args: argparse.Namespace) -> None:
+    """Refuse an invocation that gives NO member of a `REQUIRED_ONE_OF` group — the one-of rule, enforced
+    from the declaration rather than restated beside the branch that consumes the answer.
+
+    Reading an absent dest as "not given" is deliberate and FAIL-CLOSED: a mis-derived dest refuses a legal
+    invocation, which the caller sees, instead of accepting an invocation the tool cannot serve.
+    """
+    for group, why in REQUIRED_ONE_OF.get(cmd_id, {}).items():
+        if all(getattr(args, one_of_dest(flag), None) is None for flag in group):
+            fail(f"{cmd_id} needs one of {' or '.join(group)} — {why}")
 
 
 def canonical_flags(cmd_id: str) -> list[str]:
@@ -2540,6 +2591,29 @@ _CONTINUATION = r"[ \t]\\"
 CONTINUED_LINE = re.compile(_CONTINUATION + r"\Z")
 CONTINUATION_JOIN = re.compile(_CONTINUATION + r"\n")
 
+# THE WHOLE SCAN DECIDES ITS LINE BREAKS, TOKEN BOUNDARIES AND BLANKNESS THE WAY A SHELL DOES: ASCII SPACE,
+# TAB AND LINE FEED, AND NOTHING ELSE. Python's own defaults are UNICODE-aware, and every one of them is a
+# question about a SHELL answered with a different grammar than the shell uses — so a body that Python reads
+# as the canonical command is one `bash` reads as something else, and the block passes while the documented
+# invocation does not run. All three of those disagreements were confirmed against `bash`:
+#
+#   - `str.splitlines()` breaks at U+2028, U+2029, U+0085 and the C0 breaks. To the shell none of those is a
+#     newline, so a `\` before one ESCAPES it into a literal character glued onto the next word, and the flag
+#     that follows never reaches argparse.
+#   - a bare `str.strip()` treats a line holding only U+00A0 as blank and DROPS it. The shell treats that
+#     line as one nonempty WORD and runs it as a second command, so the block holds two commands while the
+#     comparison sees one.
+#   - a bare `str.split()` splits on `str.isspace()`, which is True for U+00A0, and NORMALIZES it to a space.
+#     The shell does not: `python3<U+00A0>…` is a single word and it is the command NAME.
+#
+# `CONTINUED_LINE`/`CONTINUATION_JOIN` above were already written this way (`[ \t]` literals), and
+# `MARKED_OPENER`/`MARKED_CLOSE` are too — `re.M` anchors break only at `\n`. These two constants extend the
+# same discipline to the three places that had reached for a Python default, so ONE grammar decides every
+# boundary in the scan. Anything outside `[ \t\n]` is ORDINARY TEXT here, exactly as it is to the shell, and
+# a body carrying it is simply a different string from the generated command.
+_SHELL_BLANK = " \t\n"          # all a logical line may hold and still be blank
+_SHELL_RUN = re.compile(r"[ \t]+")   # the separator run the collapse folds to one space
+
 
 def _logical_lines(body: str) -> list[str]:
     """A fenced body's non-blank LOGICAL lines: backslash continuations joined into the line they continue.
@@ -2550,18 +2624,34 @@ def _logical_lines(body: str) -> list[str]:
 
     A line continues only when it ends `CONTINUED_LINE`'s way. Anything else ENDS its logical line, which
     is what keeps two commands the shell would run separately from being joined into one here.
+
+    **A LINE BREAK IS `\\n` AND BLANK IS `_SHELL_BLANK`** — never `splitlines()` and never a bare `strip()`,
+    for the reason stated where those constants are defined. Both flushes below strip the same way, because
+    a trailing pending group is as much a logical line as any other. Only the LOOP flush can be caught
+    misbehaving, though: the trailing one runs only when the last physical line CONTINUES, so its group
+    always ends in a backslash and no blank test of any grammar calls that blank. `ci-status-test`'s
+    `trailing-flush` case pins exactly that, so the day it stops being true is the day it is reported.
     """
     lines: list[str] = []
     pending: list[str] = []
-    for line in body.splitlines():
+    # `split("\n")` and NOT `splitlines()`, for the reason `_SHELL_BLANK` states. On ASCII input the two
+    # differ in exactly one way — `split` yields an empty final element for a body ending in `\n` and
+    # `splitlines` does not — and that difference is not cosmetic: it would make the body's last physical
+    # line a blank one, so a DANGLING continuation at the end of the body would join with nothing and
+    # collapse into the canonical string. Dropping the element keeps every ASCII body reading exactly as it
+    # read before, and leaves the Unicode question the only thing this rule changes.
+    physical = body.split("\n")
+    if physical and physical[-1] == "":
+        physical.pop()
+    for line in physical:
         pending.append(line)
         if CONTINUED_LINE.search(line):
             continue
         joined = "\n".join(pending)
         pending = []
-        if joined.strip():
+        if joined.strip(_SHELL_BLANK):
             lines.append(joined)
-    if pending and "\n".join(pending).strip():
+    if pending and "\n".join(pending).strip(_SHELL_BLANK):
         lines.append("\n".join(pending))
     return lines
 
@@ -2578,8 +2668,13 @@ def _collapsed_lines(body: str) -> list[str]:
     LIST against a one-element list, so a body split across two commands cannot pass by concatenating into
     the canonical string. A backslash that is NOT a continuation by `CONTINUATION_JOIN`'s rule survives into
     the collapsed line, so a body the shell would read as one invalid token is a different string here too.
+
+    **THE RUN COLLAPSED IS `_SHELL_RUN`** — never a bare `split()`, for the reason stated where that
+    constant is defined. A character the shell does not separate words on stays in the string and makes the
+    body differ from the generated command, which is the correct answer and not a special case.
     """
-    return [" ".join(CONTINUATION_JOIN.sub(" ", line).split()) for line in _logical_lines(body)]
+    return [" ".join(_SHELL_RUN.split(CONTINUATION_JOIN.sub(" ", line).strip(" \t")))
+            for line in _logical_lines(body)]
 
 
 def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
@@ -2949,8 +3044,10 @@ def build_parser() -> argparse.ArgumentParser:
     # per-row, so its required set is too), resolved from the ledger:
     #   --ledger <rundir>/state.jsonl
     # `--required-set` remains for the pure/explicit path (tests, an out-of-run spec): with `--ledger` it is
-    # an ASSERTION that must equal the row's effective set; without `--ledger` it IS the set, verbatim. One of
-    # the two is REQUIRED. `unknown` is a legal value that can NEVER go green (a `pending` bullet in DECIDE) —
+    # an ASSERTION that must equal the row's effective set; without `--ledger` it IS the set, verbatim. THAT
+    # ONE OF THEM IS REQUIRED IS `REQUIRED_ONE_OF`'S TO SAY, and it says it for both readers — neither flag
+    # can be marked `required=True` here, because either alone is a complete invocation and both together
+    # are a legal one. `unknown` is a legal value that can NEVER go green (a `pending` bullet in DECIDE) —
     # exactly what makes a run that never performed the read merge NOTHING, instead of merging everything.
     d.add_argument("--ledger", type=Path,
                    help="the run's state.jsonl — resolve the row's `effective_required_set` (its explicit "
@@ -3061,15 +3158,14 @@ def main() -> int:
     if args.repo is not None:
         check_repo(args.repo)
     # The required set is the ROW's effective set when a ledger is named (the production form); an explicit
-    # `--required-set` is the pure/test path AND, with `--ledger`, an assertion. One of the two is required —
-    # a derive with NEITHER would have no set to decide under, and defaulting one is the false green this
-    # whole tool exists to kill.
+    # `--required-set` is the pure/test path AND, with `--ledger`, an assertion. THAT ONE OF THE TWO IS
+    # REQUIRED is `REQUIRED_ONE_OF`'s to say, not this branch's — stated in both places it would be a rule
+    # the doc reconciliation could not see, which is how a row that dropped the alternation stayed clean.
+    check_one_of("derive", args)
     if args.ledger is not None:
         required = resolve_required_for_derive(str(args.ledger), args.pr, args.required_set)
-    elif args.required_set is not None:
-        required = check_required_set(args.required_set)
     else:
-        fail("derive needs --ledger (resolve the row's effective required set) or an explicit --required-set")
+        required = check_required_set(args.required_set)
 
     repo = args.repo
     if not repo:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -118,8 +118,10 @@ The enums, the CLASSIFY buckets and the DECIDE order are stated in `ci-derivatio
 one a reader believed. `doc-check` PARSES the doc's own enum block, its two CLASSIFY tables and its DECIDE
 bullet order, and asserts they agree with the sets `ci-snapshot.py` actually classifies with — and that the
 classification is TOTAL over the enums the doc declares. It also checks every copy of a `gh` command the doc
-prints against the argv this code really issues, every copy of the derive command for `--required-set`, and
-the moved-head owner block's retained-artifact/trust/result contract. Drift is a RED BUILD, not a discovery.
+prints against the argv this code really issues, every copy of the derive command for `--required-set`, every
+MARKED `ci-status.py` block against the command this file GENERATES for its `gauntlet-cmd` id — which the
+block's body must EQUAL — and the moved-head owner block's retained-artifact/trust/result contract. Drift is
+a RED BUILD, not a discovery.
 
 **A check that finds nothing MUST NOT PASS.** If the doc cannot be found, or a block cannot be parsed, or
 zero rules are extracted, `doc-check` FAILS. An extractor that silently matches nothing and reports success
@@ -1896,7 +1898,10 @@ class DocError(Exception):
 
 
 def fenced_blocks(text: str) -> list[str]:
-    return re.findall(r"^```[a-z]*\n(.*?)^```", text, re.MULTILINE | re.DOTALL)
+    # The info string is `[^\n]*`, not `[a-z]*`: a marked command fence carries `sh gauntlet-cmd=<id>`, and
+    # an opener this regex cannot match is not skipped — it is swallowed, so the NEXT fence's closing ```
+    # terminates the wrong block and the owner blocks below stop being findable.
+    return re.findall(r"^```[^\n]*\n(.*?)^```", text, re.MULTILINE | re.DOTALL)
 
 
 def parse_enums(blocks: list[str]) -> dict[str, set[str]]:
@@ -2346,6 +2351,311 @@ def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list
     return problems, copies
 
 
+# A MARKED COMMAND BLOCK IS A FENCE WHOSE INFO STRING NAMES THE COMMAND IT HOLDS: ```sh gauntlet-cmd=<id>`.
+# `<id>` keys this table, and the block's body must BE the string `canonical_command()` GENERATES for that
+# id. This check ADDS a guarantee the three `check_*_copies` above cannot give, and replaces none of them:
+# they ask whether a copy carries the one flag each was taught to look for, which cannot tell a reader that
+# the documented command is the command the TOOL ACCEPTS. Equality against a generated string can.
+#
+# **THE REFERENCE IS GENERATED, SO NO CODE PATH JUDGES A MARKED BLOCK BY SEARCHING IT.** Four rounds of
+# review asked instead whether a documented line CARRIED the tokens its id requires, and every one of them
+# died to text the block's author put beside the command: a second line, a comment line, a trailing comment,
+# a `;`, `|`, `&&` or `$(…)` chain, an `echo` in front, a heredoc around it, a mislabelled tail of extra
+# arguments, and a `>` redirection whose operand spelled the very tokens the invocation lacked. Searching a
+# line has no fixed point, because the author picks what else is on that line and can always add more.
+# EQUALITY has one: exactly one string passes, this file writes it, and every carrier above fails BY
+# CONSTRUCTION instead of by enumeration. Nothing here parses shell, subtracts text, or locates a window —
+# the only latitude is `_collapsed_lines`, which joins continuations and collapses whitespace runs so a
+# wrapped copy is the same command as an unwrapped one.
+#
+# A ROW IS NOT HAND-MAINTAINED AGAINST THE CLI. Every fixture that drives this table is blind to a row that
+# is INCOMPLETE, because the omission deletes the case that would have caught it — so the suite reconciles
+# each row against `build_parser()` instead (`ci-status-test.documented_commands_agree_with_argparse`). A
+# flag the parser REQUIRES and a row omits is a copy this checker calls complete and the tool then refuses.
+# argparse's remaining job is exactly that reconciliation: the row, never the parser, decides which
+# OPTIONAL flags a documented copy spells, because `derive` alone would otherwise gain `--repo`,
+# `--ledger` and `--required-set` all at once.
+#
+# WHY THE MARKER, RATHER THAN A CLEVERER SCAN. Checking a command by hunting it in free Markdown means
+# deciding, for arbitrary prose, whether a stretch of text is a command or a sentence about one. That
+# question has no small answer: three PRs grew hand-written CommonMark and shell-word subsets trying to
+# reach it, two of them died at their repair cap, and 793 lines of that parsing were deleted unmerged. The
+# marker moves the decision from the checker to the author, where it costs one info string and cannot be
+# wrong. What this scheme recognizes is fences, and nothing else about Markdown.
+COMMAND_NAME = "ci-status.py"
+# THE FIXED PREFIX EVERY GENERATED COMMAND OPENS WITH. `<skill>` is this doc set's own convention for the
+# directory holding the active SKILL.md, so the string this file writes is the one a reader really types.
+COMMAND_PREFIX = f"python3 <skill>/scripts/{COMMAND_NAME}"
+# ONE VALUE SLOT PER FLAG — a property of the FLAG, not of the subcommand that takes it, so `--ledger`
+# reads the same in every command that names it. These are the doc set's `<…>` placeholder convention:
+# prose telling the reader what to supply, never shell, and nothing here reads them as shell because
+# nothing here reads shell at all. A flag `DOCUMENTED_COMMANDS` names with no slot here is a table
+# `canonical_command()` cannot render, which the argparse reconciliation refuses.
+FLAG_VALUES: dict[str, str] = {
+    "--pr": "<N>",
+    "--head-sha": "<the LEDGER's head_sha>",
+    "--rundir": "<rundir>",
+    "--ledger": "<rundir>/state.jsonl",
+    "--required-set": "<declared:… | none | unknown>",
+    "--derive-json": "<the JSON derive printed, saved to a file — or - for stdin>",
+    "--machine-action": "<due | in-flight | none>",
+}
+# The FLAGS each documented command spells, in the order the canonical copy spells them. The subcommand is
+# the id itself, and the script name comes from `COMMAND_PREFIX`, so neither can be stated here and drift.
+# A nested tuple is an alternation: its FIRST member is the form the canonical copy uses, and the rest
+# record the other spellings the tool accepts, which the argparse reconciliation still holds to the parser.
+DOCUMENTED_COMMANDS: dict[str, tuple[str | tuple[str, ...], ...]] = {
+    # The required set is what makes `green` mean *the required set passed*, and it is the ROW's
+    # `effective_required_set`: name it with `--ledger` (resolve the row's set — the production form) or
+    # with an explicit `--required-set`. A copy carrying NEITHER reconstructs an invocation the tool refuses.
+    "derive": ("--pr", "--head-sha", "--rundir", ("--ledger", "--required-set")),
+    # `--machine-action` is the one judgment the command asks of its caller. A reader who drops the question
+    # and invents a default strikes the very PR a fix is about to move. `--derive-json` is the evidence the
+    # bookkeeping is ABOUT: argparse requires it, so a copy without it is an invocation the tool refuses.
+    "liveness": ("--ledger", "--pr", "--derive-json", "--machine-action"),
+    # The command persists the value it read to the run ledger, which `--ledger` names. Its optional
+    # `--repo` belongs in the PROSE beside the block and never in it: a bracketed `[--repo <owner>/<repo>]`
+    # is literal text in a body that must BE the command, so the block would no longer equal it.
+    "required-set": ("--ledger",),
+}
+
+
+def canonical_flags(cmd_id: str) -> list[str]:
+    """The flags the canonical copy of `cmd_id` SPELLS, in the row's order.
+
+    THE ONE PLACE THE ALTERNATION RULE LIVES: a nested tuple contributes its FIRST member and nothing else.
+    Both the generator and the argparse reconciliation read it from here, so neither can restate it wrong.
+    """
+    return [want[0] if isinstance(want, tuple) else want for want in DOCUMENTED_COMMANDS[cmd_id]]
+
+
+def canonical_command(cmd_id: str) -> str:
+    """THE one string a block marked `gauntlet-cmd=<cmd_id>` must hold, generated rather than transcribed.
+
+    This is the whole reference the checker owns. The subcommand IS the id — every id is held to a real
+    subparser by `documented_commands_agree_with_argparse`, so the two cannot drift — and each flag the row
+    spells is emitted with its `FLAG_VALUES` slot. A `KeyError` here is a row naming a flag with no slot,
+    which the same reconciliation reports before it can ever be reached from a doc.
+    """
+    parts = [COMMAND_PREFIX, cmd_id]
+    for flag in canonical_flags(cmd_id):
+        parts += [flag, FLAG_VALUES[flag]]
+    return " ".join(parts)
+
+
+# The id is ANY nonempty run of characters, never a spelling this checker approves of: an id the regex
+# REJECTS is not a marked block at all, so the unknown-id branch below cannot fire and the author is told to
+# move a block that is already inside a marked fence. Capture whatever was written and let
+# DOCUMENTED_COMMANDS be the only thing that decides which ids exist. Trailing spaces are dropped because
+# CommonMark drops them from the info string, so a fence this checker rejected over one would be a fence the
+# renderer accepted.
+MARKED_OPENER = re.compile(r"^```sh gauntlet-cmd=(?P<id>[^\n]+?)[ \t]*\n", re.M)
+# THE CLOSE IS HALF THE DEFINITION OF THE BODY, SO IT IS AS STRICT AS THE EQUALITY IS. A closing fence is a
+# line AT COLUMN 0 of three or more backticks carrying nothing but optional spaces or tabs. Any other line
+# is BODY — including one that merely STARTS with backticks, which CommonMark also treats as body because
+# it forbids an info string on a closing fence. A close that ended at `^```` would hand the author the
+# carrier the equality exists to refuse: write ```` ``` anything ```` and every line after it renders inside
+# the block while none of it reaches the comparison. This is stated as ONE POSITIVE RULE and must stay one:
+# a list of the malformed spellings that are NOT a close is the enumeration that has no fixed point.
+#
+# COLUMN 0 IS DELIBERATE AND FAIL-CLOSED. CommonMark permits up to three spaces of indent on a closing
+# fence; this checker does not, so an indented close reads as an opener that never closes and is REPORTED.
+# The scheme recognizes a marked fence written at column 0 and its conforming close, and nothing else about
+# fence placement — being told to unindent is the correct outcome, never a false pass.
+MARKED_CLOSE = re.compile(r"^```+[ \t]*$", re.M)
+
+
+class MarkedBlock(NamedTuple):
+    """One marked opener and the span it delimits. `body` is None when the opener NEVER closes."""
+
+    cmd_id: str
+    body: str | None
+    line: int
+    start: int
+    end: int
+
+
+def _scanned(md: Path) -> str:
+    """A doc's text as the fence scan reads it: a FINAL NEWLINE is appended when the file ends without one.
+
+    THIS EXISTS SO NO PATTERN IN THE SCAN NEEDS AN END-OF-FILE CASE. A last line with no newline renders
+    exactly like one with it, so the scan has to read it the same way — and the reliable way to make every
+    pattern do that is to leave no pattern the question. Teaching each pattern to accept `\\n` OR end-of-
+    input instead spreads one fact about files across every regex, and the pattern that forgets it drops
+    its match in SILENCE: a marked opener on such a last line matched nothing, so it was neither compared,
+    nor reported unclosed, nor reported for an unknown id, while the renderer showed a block. Normalize
+    once here and every pattern added later is correct without being told.
+
+    Carriage returns need no handling of their own either: `read_text` translates CRLF to `\\n` on the way
+    in, so `\\r` never reaches a pattern.
+    """
+    text = md.read_text(encoding="utf-8")
+    return text if not text or text.endswith("\n") else text + "\n"
+
+
+def marked_blocks(text: str) -> list[MarkedBlock]:
+    """Every marked opener in `text`, paired with the body its conforming close delimits.
+
+    **THE OPENER IS THE ANCHOR, NOT THE PAIR.** One regex spanning opener-to-close cannot report what it
+    cannot match: an opener with no conforming close simply fails to match, and the whole block DISAPPEARS
+    from every caller — no comparison, no unknown-id complaint, and (when another block already covers the
+    id) no zero-blocks complaint either. To the renderer that same opener swallows the REST OF THE FILE into
+    a marked block, so a document could hold an incomplete invocation, inside a block that claims to be
+    checked, and pass. Scanning FROM the opener makes the missing close a reportable fact instead of a
+    silent non-match.
+
+    An unterminated opener is always the LAST block: everything after it is inside its body, so there is
+    nothing further to find.
+    """
+    blocks: list[MarkedBlock] = []
+    pos = 0
+    while (opener := MARKED_OPENER.search(text, pos)) is not None:
+        line = text.count("\n", 0, opener.start()) + 1
+        close = MARKED_CLOSE.search(text, opener.end())
+        if close is None:
+            blocks.append(MarkedBlock(opener.group("id"), None, line, opener.start(), len(text)))
+            break
+        blocks.append(MarkedBlock(opener.group("id"), text[opener.end():close.start()], line,
+                                  opener.start(), close.end()))
+        pos = close.end()
+    return blocks
+
+
+# A CONTINUATION IS EXACTLY WHITESPACE, BACKSLASH, NEWLINE — the one spelling that agrees with the shell,
+# written ONCE here so its two readers below cannot drift apart. A looser rule disagrees with the shell in
+# BOTH directions at once, and each direction passes a marked block the shell will not run as documented:
+#
+#   - `--ledger\` immediately before the newline, with NO space in front of the backslash. The shell removes
+#     both characters and receives the single invalid token `--ledger<rundir>/state.jsonl`, while a rule
+#     that substitutes a SPACE for the pair reads the body as the canonical command and passes it.
+#   - whitespace AFTER the backslash. There the backslash escapes the space, so the shell ENDS the command
+#     and runs the next physical line as a SEPARATE command, while a rule that strips the trailing run
+#     before looking for the backslash joins two shell commands into one logical line.
+#
+# Both were confirmed against `bash`. Neither needs shell parsing to refuse, because a wrap has exactly one
+# spelling and this demands it; `shlex` could not read these bodies anyway, since the `<…>` placeholders are
+# prose and `<the LEDGER's head_sha>` alone makes `shlex.split` raise. Every live marked block already wraps
+# this way, so the strict rule reports nothing that was passing for a good reason.
+_CONTINUATION = r"[ \t]\\"
+CONTINUED_LINE = re.compile(_CONTINUATION + r"\Z")
+CONTINUATION_JOIN = re.compile(_CONTINUATION + r"\n")
+
+
+def _logical_lines(body: str) -> list[str]:
+    """A fenced body's non-blank LOGICAL lines: backslash continuations joined into the line they continue.
+
+    **A command is not a physical line.** A shell invocation WRAPS with a trailing `\\`, and all three live
+    copies do: counting physical lines would read one correct command as two or three, and condemn every
+    block in the doc set for holding more than one.
+
+    A line continues only when it ends `CONTINUED_LINE`'s way. Anything else ENDS its logical line, which
+    is what keeps two commands the shell would run separately from being joined into one here.
+    """
+    lines: list[str] = []
+    pending: list[str] = []
+    for line in body.splitlines():
+        pending.append(line)
+        if CONTINUED_LINE.search(line):
+            continue
+        joined = "\n".join(pending)
+        pending = []
+        if joined.strip():
+            lines.append(joined)
+    if pending and "\n".join(pending).strip():
+        lines.append("\n".join(pending))
+    return lines
+
+
+def _collapsed_lines(body: str) -> list[str]:
+    """A fenced body as the command lines it holds: continuations JOINED, whitespace runs COLLAPSED.
+
+    This is the ONLY latitude the equality comparison allows, and it is not a relaxation of it. All three
+    live copies WRAP, so a byte-exact test would condemn every one of them over the `\\` and the indent
+    that continues the line — turning correct blocks red, which is how a check gets deleted by the next
+    person in a hurry.
+
+    Two lines never collapse into one. `_logical_lines` decides what a line is, and the caller compares the
+    LIST against a one-element list, so a body split across two commands cannot pass by concatenating into
+    the canonical string. A backslash that is NOT a continuation by `CONTINUATION_JOIN`'s rule survives into
+    the collapsed line, so a body the shell would read as one invalid token is a different string here too.
+    """
+    return [" ".join(CONTINUATION_JOIN.sub(" ", line).split()) for line in _logical_lines(body)]
+
+
+def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str]]:
+    """Every marked block's body EQUALS the command `canonical_command()` generates for its `gauntlet-cmd`
+    id.
+
+    Four ways to fail: the body is not that command; an id is claimed that `DOCUMENTED_COMMANDS` does not
+    define; a marked opener never closes; or an id the table defines has NO block anywhere. That last one is
+    what stops the marker from quietly narrowing the check — delete the only marked copy of a command and
+    the build goes red.
+
+    AN UNTERMINATED OPENER CREDITS NOTHING. It is reported and its id is NOT marked as seen, so when the
+    broken block is the only one claiming that id the zero-blocks failure fires beside it: a block whose
+    body the checker never read must never be the reason a command counts as documented.
+
+    **THE COMPARISON IS EQUALITY, AND THAT IS THE WHOLE DESIGN.** It does not locate the command inside the
+    body, subtract text it dislikes, or reason about shell. A body holding anything besides the generated
+    command is a DIFFERENT STRING, so every carrier that killed an earlier round — a second line, a comment
+    line, a trailing comment, a `;`/`|`/`&&`/`$(…)` chain, an `echo` in front, a heredoc around it, a tail
+    of arguments the subcommand does not take, a `>` redirection whose operand spells the missing flags —
+    fails by construction, with none of them enumerated anywhere. A block cannot lie about which command it
+    is either, because the id picks the string it is compared against: mark a `liveness` invocation
+    `gauntlet-cmd=derive` and it is held to `derive`'s command.
+
+    There is one repair for every failure, and the message states it: replace the body with the string.
+    """
+    problems, found = [], []
+    seen: set[str] = set()
+    for md in sorted((root or HERE.parent).rglob("*.md")):
+        text = _scanned(md)
+        for block in marked_blocks(text):
+            cmd_id, body = block.cmd_id, block.body
+            where = f"{md.name}:{block.line}"
+            if body is None:
+                problems.append(
+                    f"{where} opens `gauntlet-cmd={cmd_id}` and NEVER CLOSES — no line of three or more "
+                    f"backticks, at column 0 and carrying nothing but optional spaces or tabs, follows it. "
+                    f"The renderer swallows the rest of the file into this block, so text that never "
+                    f"reaches the comparison renders inside a block that claims to be checked. Close the "
+                    f"fence with a line reading exactly ```` ``` ````, and remember that a closing fence "
+                    f"may not be indented or carry an info string."
+                )
+                continue
+            if cmd_id not in DOCUMENTED_COMMANDS:
+                problems.append(
+                    f"{where} is marked `gauntlet-cmd={cmd_id}`, which DOCUMENTED_COMMANDS does not define "
+                    f"— known ids are {', '.join(sorted(DOCUMENTED_COMMANDS))}. An unknown id names no "
+                    f"command to compare against, so the marker would buy the block an exemption "
+                    f"instead of a check."
+                )
+                continue
+            seen.add(cmd_id)
+            found.append(f"{where} ({cmd_id})")
+            want = canonical_command(cmd_id)
+            got = _collapsed_lines(body)
+            if got != [want]:
+                shown = " / ".join(got) or "(nothing)"
+                problems.append(
+                    f"{where} is marked `gauntlet-cmd={cmd_id}` but its body is NOT that command. A marked "
+                    f"block must BE the one canonical invocation and nothing else — no comment, no second "
+                    f"line, no chain, pipe, redirection or substitution, no wrapper that echoes the "
+                    f"command or writes it to a file instead of running it, and no argument the command "
+                    f"does not take. Replace the body with exactly:  {want}  (wrap it over as many lines "
+                    f"as you like, breaking only at a space followed by a backslash at end of line; joined "
+                    f"continuations and collapsed whitespace runs are the only differences allowed). This "
+                    f"body reads:  {shown}"
+                )
+    for cmd_id in sorted(set(DOCUMENTED_COMMANDS) - seen):
+        problems.append(
+            f"ZERO blocks marked `gauntlet-cmd={cmd_id}` were found in the skill's docs — the command is "
+            f"prescribed, so finding none means this check has lost its subject, and a check that finds "
+            f"nothing must never pass"
+        )
+    return problems, found
+
+
 def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) -> int:
     """Assert the DOC, the CODE, and this tool's DECIDE_ORDER all say the same thing.
 
@@ -2362,7 +2672,9 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          paragraphs. A value in a hole matches NO branch: not green, not red, not pending — the PR can never
          resolve, and it WEDGES. This is the check that catches that, and nothing else in the repo does.
       5. the doc's `gh` INVOCATIONS, in every copy of them, against the argv the code really issues — plus
-         every copy of the derive and required-set commands and their required ledger inputs.
+         every copy of the derive and required-set commands and their required ledger inputs, and every
+         MARKED `ci-status.py` block against the command `canonical_command()` generates for its id, which
+         its body must EQUAL and whose opener must have a conforming CLOSE.
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
          untrusted result increments the refetch counter while trusted current-head evidence resets it.
@@ -2520,6 +2832,13 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
     if not liveness_problems:
         held.append(f"{'the liveness invocations':32} {len(liveness_copies)} runnable copies, every one "
                     f"answering --machine-action")
+    # AND EVERY MARKED COMMAND BLOCK, ACROSS EVERY SKILL DOC — the class, not the instance. The three checks
+    # above ask whether a copy carries one flag; this one asks whether the block IS the command.
+    marked_problems, marked_found = check_marked_commands()
+    problems += marked_problems
+    if not marked_problems:
+        held.append(f"{'the marked command blocks':32} {len(marked_found)} blocks across the skill's docs, "
+                    f"every one CLOSED and its body EQUAL to the command generated for its gauntlet-cmd id")
     for line in held:
         print(f"ok       {line}")
     for problem in problems:
@@ -2533,7 +2852,8 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
         return 1
     print(f"{len(checks) + len(held)} checks: {spec_doc.name}, {driver_doc.name}, ci-snapshot.py and "
           f"ci-status.py agree — enums, CLASSIFY buckets, TOTALITY, the DECIDE order, the caps, the "
-          f"FINGERPRINT lines, moved-head and liveness contracts, and every copy of every command.")
+          f"FINGERPRINT lines, moved-head and liveness contracts, every copy of every command, and every "
+          f"marked command block.")
     return 0
 
 
@@ -2604,7 +2924,17 @@ def resolve_repo(fetch: Fetch) -> str:
                            "nameWithOwner", str))
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
+    """The CLI surface, built apart from `main` so a test can ASK it what each subcommand requires.
+
+    `DOCUMENTED_COMMANDS` says which flags a documented copy SPELLS and this parser says what the tool will
+    actually accept. Two statements of one contract drift, and the drift is silent in the direction that
+    matters: a flag only the parser insists on is a copy `doc-check` calls complete and the tool then
+    REFUSES. The fixture suite reconciles the two, which it can only do if the parser exists without
+    running. The reconciliation runs one way only — the row decides which OPTIONAL flags the documented
+    copy carries, because generating every optional the parser defines would make `derive`'s canonical copy
+    spell `--repo`, `--ledger` and `--required-set` at once.
+    """
     p = argparse.ArgumentParser(description=next(iter((__doc__ or "").splitlines()), ""))
     sub = p.add_subparsers(dest="cmd", required=True)
 
@@ -2652,14 +2982,17 @@ def main() -> int:
 
     c = sub.add_parser("doc-check", help="assert the CI docs (ci-derivation-spec.md + stage-2-ci.md) "
                                          "agree with the code that runs — enums, CLASSIFY, DECIDE order, "
-                                         "caps, fingerprint, moved-head artifact contract, and every copy "
-                                         "of every command")
+                                         "caps, fingerprint, moved-head artifact contract, every copy of "
+                                         "every command, and every marked command block")
     c.add_argument("--spec-doc", type=Path, default=SPEC_DOC)
     c.add_argument("--driver-doc", type=Path, default=DRIVER_DOC)
 
     sub.add_parser("self-test", help="run every fixture (ci-status-test.py), then doc-check")
+    return p
 
-    args = p.parse_args()
+
+def main() -> int:
+    args = build_parser().parse_args()
 
     if args.cmd == "doc-check":
         return doc_check(args.spec_doc, args.driver_doc)

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2537,10 +2537,27 @@ def _scanned(md: Path) -> str:
     nor reported unclosed, nor reported for an unknown id, while the renderer showed a block. Normalize
     once here and every pattern added later is correct without being told.
 
-    Carriage returns need no handling of their own either: `read_text` translates CRLF to `\\n` on the way
-    in, so `\\r` never reaches a pattern.
+    **NO LAYER MAY REWRITE BYTES BEFORE THE SHELL-GRAMMAR SCAN READS THEM.** That is why the read passes
+    `newline=""` and turns universal-newline translation OFF. `_SHELL_BLANK` states the rule the whole scan
+    obeys — anything outside space, tab and line feed is ORDINARY TEXT, exactly as it is to the shell — so a
+    body carrying a `\\r` has to compare as a DIFFERENT STRING, and a translating read voids that rule one
+    layer earlier than any pattern can see. It does not make such a body agree with the shell; it only
+    blinds the checker to the disagreement. `bash` reads a wrap written `<space>\\<CR><LF>` as an ESCAPED
+    LITERAL CR and runs the next physical line as a SEPARATE command, exit 127, while the translated text
+    reads as one clean continuation and compares equal. `check_marked_commands` REFUSES a `\\r` outright, so
+    reading the bytes as they are is never mistaken for accepting them.
+
+    Appending the final newline is not such a rewrite: a file that already ends in a line break is returned
+    untouched, and a CRLF file does end in `\\n`.
+
+    THE THREE `check_*_copies` FUNCTIONS READ THE SAME FILES WITH TRANSLATION STILL ON, AND THAT IS CORRECT
+    FOR THEM. They ask a different question — does this copy of the command carry the flag it must carry —
+    and answer it by searching a paragraph for a token, never by holding a body EQUAL to a generated string.
+    A `\\r` cannot change that answer, so translating it away costs them nothing. Only the equality needs the
+    bytes, so only the equality reads them raw. Do not "fix" those three to match this one.
     """
-    text = md.read_text(encoding="utf-8")
+    with md.open(encoding="utf-8", newline="") as fh:
+        text = fh.read()
     return text if not text or text.endswith("\n") else text + "\n"
 
 
@@ -2611,6 +2628,11 @@ CONTINUATION_JOIN = re.compile(_CONTINUATION + r"\n")
 # same discipline to the three places that had reached for a Python default, so ONE grammar decides every
 # boundary in the scan. Anything outside `[ \t\n]` is ORDINARY TEXT here, exactly as it is to the shell, and
 # a body carrying it is simply a different string from the generated command.
+#
+# THIS RULE IS ONLY AS TRUE AS THE READ THAT FEEDS IT: no layer may rewrite bytes before the scan sees them,
+# or a character outside the set is gone before any of the above can call it ordinary text. `_scanned` owns
+# that, and the carriage return — the one character an ordinary checkout is configured to insert — is
+# refused there and in `check_marked_commands` rather than reaching the comparison at all.
 _SHELL_BLANK = " \t\n"          # all a logical line may hold and still be blank
 _SHELL_RUN = re.compile(r"[ \t]+")   # the separator run the collapse folds to one space
 
@@ -2681,14 +2703,16 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
     """Every marked block's body EQUALS the command `canonical_command()` generates for its `gauntlet-cmd`
     id.
 
-    Four ways to fail: the body is not that command; an id is claimed that `DOCUMENTED_COMMANDS` does not
-    define; a marked opener never closes; or an id the table defines has NO block anywhere. That last one is
+    Five ways to fail: the body is not that command; an id is claimed that `DOCUMENTED_COMMANDS` does not
+    define; a marked opener never closes; the file holding the block carries a CARRIAGE RETURN, which the
+    shell reads as no line break at all; or an id the table defines has NO block anywhere. That last one is
     what stops the marker from quietly narrowing the check — delete the only marked copy of a command and
     the build goes red.
 
-    AN UNTERMINATED OPENER CREDITS NOTHING. It is reported and its id is NOT marked as seen, so when the
-    broken block is the only one claiming that id the zero-blocks failure fires beside it: a block whose
-    body the checker never read must never be the reason a command counts as documented.
+    A BLOCK THE CHECKER NEVER READ CREDITS NOTHING. An unterminated opener is reported and its id is NOT
+    marked as seen, and a CR-bearing file is reported and skipped whole, so when the broken block is the
+    only one claiming that id the zero-blocks failure fires beside it: a body the checker never compared
+    must never be the reason a command counts as documented.
 
     **THE COMPARISON IS EQUALITY, AND THAT IS THE WHOLE DESIGN.** It does not locate the command inside the
     body, subtract text it dislikes, or reason about shell. A body holding anything besides the generated
@@ -2705,6 +2729,29 @@ def check_marked_commands(root: Path | None = None) -> tuple[list[str], list[str
     seen: set[str] = set()
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = _scanned(md)
+        # A CARRIAGE RETURN IS REFUSED, NOT TRANSLATED AWAY — see `_scanned`, which owns the rule that no
+        # layer rewrites bytes before this scan reads them. The RAW READ alone already fails closed here,
+        # but it fails closed for the WRONG REASON and says so out loud: `MARKED_OPENER`'s id capture
+        # swallows the CR and `MARKED_CLOSE` never matches a close ending CR-LF, so a CRLF doc is reported
+        # as an opener that NEVER CLOSES — an invisible character in the message and a repair instruction
+        # pointing at a fence that is perfectly well formed. Naming the cause is the whole reason this guard
+        # exists beside the raw read rather than instead of it.
+        #
+        # SCOPED TO A DOC HOLDING A MARKED OPENER. Line endings elsewhere in the tree are nobody's business
+        # here, and a checkout that materializes every `.md` as CRLF (Git for Windows defaults
+        # `core.autocrlf=true`) must not turn red over prose this check never reads. The file is then
+        # SKIPPED, so it credits no id and the ZERO-blocks rule fires beside this, exactly as it does for an
+        # opener that never closes: a body the checker refused to read must never be why a command counts as
+        # documented.
+        if "\r" in text and MARKED_OPENER.search(text) is not None:
+            problems.append(
+                f"{md.name} holds CARRIAGE RETURNS and holds a marked block, so NO block in it was "
+                f"compared. A shell reads no line break in a `\\r`: a wrap written space-backslash-CR-LF "
+                f"escapes the CR into a literal argument and runs the next physical line as a SEPARATE "
+                f"command, which is not the documented invocation however the rendered page looks. Rewrite "
+                f"the file with LF line endings."
+            )
+            continue
         for block in marked_blocks(text):
             cmd_id, body = block.cmd_id, block.body
             where = f"{md.name}:{block.line}"


### PR DESCRIPTION
- `doc-check` generates each documented command and requires a `sh gauntlet-cmd=<id>` block to equal it
- main's three `check_*_copies` stay untouched — this adds a check and deletes nothing
- first of two PRs; the free-text scanner replacing those checks is deferred, on explicit ruling
