### PR TITLE
skip stale-index ghost entries in reconcile fetch

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -84,7 +84,9 @@ LOCAL state against that same PR / its head; the PR itself is left in place.
   ever touch this run's own PRs (ownership = the `gauntlet-run-<run-id>` label). **Terminal detection
   relies on label removal, not closure**: loop control gates the finished-run branch on "no open PR
   still carrying this run's label", so once this run's owner label is removed the still-open PR no
-  longer carries it and can no longer block terminal exit — an aborted row is terminal and lacks its
+  longer carries it and can no longer block terminal exit — and `loop-control.md`'s **"Live work (this
+  run)"** definition owns what *carrying this run's label* means, because GitHub's label QUERY keeps
+  answering with a PR after the removal — an aborted row is terminal and lacks its
   `required(tier)` SATISFIED verdicts, so reconcile will never merge or keep driving it, and the
   un-labelled open PR is simply left for its owner.
 - **Not converging → the REASSESSMENT PASS takes over. `repair-pass.md` owns this, and it SUPERSEDES the

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -41,15 +41,18 @@ run_argv(
 ```
 
 `fetch` builds the fixed `gh pr list` argv internally. It captures stdout as bytes without shell source,
-validates JSON shape + every required field + every row's run label, rejects a response at its result cap,
-then promotes those bytes through a same-directory atomic rename. Any command, validation, or promotion
-failure leaves the previous `prs.json` intact.
+validates the complete snapshot contract on EVERY entry, and rejects a response at its result cap. Every
+check refuses the WHOLE response except the run-label check, which in `fetch` alone SKIPS the entry (see
+GHOST below). What it promotes through a same-directory atomic rename therefore depends on the response:
+a CLEAN one promotes the captured bytes unchanged, and one carrying a ghost promotes a re-serialized,
+ghost-free array. Any command, validation, or promotion failure leaves the previous `prs.json` intact.
 
 Every part is load-bearing:
 
 - **Use the typed project root + output path.** `fetch` refuses relative paths and output paths outside
   project root before it launches GitHub CLI.
-- **Use the exact run ID.** `fetch` forms the owner label as an argv value and verifies it on every row.
+- **Use the exact run ID.** `fetch` forms the owner label as an argv value and checks it on every row; the
+  GHOST paragraph below owns what a row failing that check costs.
 - **Treat exit 0 as promotion success.** A refusal emits no replacement artifact.
 
 **`fetch` refuses the query's result-cap boundary.** At that exact row count, completeness is unknown and

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -42,7 +42,7 @@ run_argv(
 
 `fetch` builds the fixed `gh pr list` argv internally. It captures stdout as bytes without shell source,
 validates JSON shape + every required field + every row's run label, rejects a response at its result cap,
-then promotes the exact bytes through a same-directory atomic rename. Any command, validation, or promotion
+then promotes those bytes through a same-directory atomic rename. Any command, validation, or promotion
 failure leaves the previous `prs.json` intact.
 
 Every part is load-bearing:
@@ -54,6 +54,16 @@ Every part is load-bearing:
 
 **`fetch` refuses the query's result-cap boundary.** At that exact row count, completeness is unknown and
 absence cannot be evidence. Split campaign into smaller runs; NEVER detect against the refused response.
+
+**An entry GitHub returns for the label while its OWN labels omit it is a GHOST, and `fetch` SKIPS it.**
+GitHub's issue search index — which `--label` compiles to — does not durably apply label REMOVALS, so it
+keeps listing a PR whose label is already gone until that PR gets a later label write. `fetch` cannot be
+mis-scoped (it builds the selector and the check from the same run ID), so it drops the entry, promotes
+the rest, and reports each skip on stderr and in the result JSON's `skipped_unlabelled` — one ghost must
+never cost the run drift detection on every other PR. **DISCLOSED COST: a run label removed BY HAND from
+a still-live PR looks exactly like a ghost, so that PR reads as `absent_from_snapshot` rather than
+refusing the fetch.** The promoted file is ghost-free, and `detect` still refuses a `--prs` file whose
+entries escape the run's label scope — the tool's `--run-id` docstring owns both halves.
 
 Store ALL reviewer and `gh` output under `<rundir>` first, then Read/Grep it. NEVER `/tmp/`.
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -75,7 +75,17 @@ rules keep their own wording; these are illustrations of them, not a second copy
    PRs are never mistaken for your own (adopted PRs keep their OWN head branch, so ownership is the
    LABEL only — never a branch prefix). Live work (this run) = any open PR carrying this run's label,
    **OR** any non-terminal row in this run's `state.jsonl` (any status that is not terminal `merged`/`aborted`).
-   Three cases:
+
+   **"Carrying this run's label" means the PR's OWN `labels` carry it — NOT that a `--label` query
+   returned it.** GitHub answers a label query out of its issue search index, which does not durably
+   apply label REMOVALS, so it keeps listing a PR whose label an abort or a merge already took off. Such
+   an entry is a GHOST and is **not live work**; counted as live it would deny this run its finished
+   classification for as long as the index stays stale, and that is not a timer — it clears only when
+   that PR gets a later label write. So **whatever asks the question must read each candidate's own
+   `labels` and drop the ones that do not carry `gauntlet-run-<run-id>`**: `scripts/reconcile.py fetch`
+   already does this for the snapshot below (`files-and-ledger.md` owns the rule and what skipping a
+   ghost gives up), and a hand-run query must ask for `--json number,labels` and match locally, the way
+   `run-identity-and-lease.md`'s no-arg **discover runs** step already does. Three cases:
 
    - **This run has live work → resume.** Resolve a dead review pass — no verdict, no live task — from its
      highest-numbered `launch_attempt` through `runtime-adapter.md`, **Review preparation mapping**, **NOT
@@ -107,7 +117,10 @@ rules keep their own wording; these are illustrations of them, not a second copy
      Produce **one batched snapshot per heartbeat** through **"The canonical `prs.json` command"** in
      `files-and-ledger.md`. Its executable owner is `scripts/reconcile.py fetch`; NEVER reconstruct its
      GitHub query. A refusal leaves the prior file intact, but that prior file is not current evidence →
-     stop this reconcile and handle the reported blocker.
+     stop this reconcile and handle the reported blocker. A **skipped ghost is not a refusal**: the fetch
+     exits 0, promotes the run's other PRs, and names each skip on stderr and in `skipped_unlabelled`
+     (`files-and-ledger.md` owns what a ghost is and what skipping it gives up). A skipped PR then
+     reaches you below as `absent_from_snapshot`, and routes exactly like any other absence.
 
      — then **compare that snapshot against the ledger by running
      `scripts/reconcile.py detect --ledger <rundir>/state.jsonl --prs <rundir>/prs.json --run-id

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -9,12 +9,16 @@ a refused run), and that stderr NAMES the specific thing wrong (the missing fiel
 suite that only checked `code == 0` would pass against a detector that emitted the wrong facts, and the
 facts are what the skill routes on.
 
-Two decisions this suite PINS, because they are the ones a reader would otherwise have to guess:
+Three decisions this suite PINS, because they are the ones a reader would otherwise have to guess:
 - **A TERMINAL row is not compared at all.** `merged`/`aborted` rows emit `{"terminal": status}` and
   nothing else — even when the snapshot still shows the PR (a reopened-after-merge oddity). Presence is not
   reported, absence is not reported, no change is computed. The fixtures drive both branches.
 - **`absent_from_snapshot` is a FACT, never an error.** A live row missing from the snapshot exits 0 with
   `{"absent_from_snapshot": true}` — the merged/closed-by-absence signal — not a non-zero "PR vanished".
+- **An unlabelled entry is answered DIFFERENTLY by the two commands, and both halves are pinned.** `fetch`
+  SKIPS it as a stale-search-index ghost, reports it, and promotes the rest; `detect` refuses the WHOLE
+  file, because only there can the snapshot and the run-id have come from different runs. One fixture
+  drives both over the SAME bytes, so neither half can drift into the other.
 """
 
 from __future__ import annotations
@@ -200,13 +204,113 @@ def t_fetch_non_utf8_preserves_old():
         check(output.read_bytes() == b"old", "non-UTF-8 response replaced the previous snapshot")
 
 
-def t_fetch_wrong_label_preserves_old():
+def t_fetch_skips_ghost_and_promotes_the_rest():
+    # THE GHOST: `gh pr list --label X` compiles to the issues search index, which does not durably apply
+    # label REMOVALS, so it keeps returning a PR whose own `labels` (from the primary DB) no longer carry
+    # the run label. fetch cannot be mis-scoped — its selector and its validator are the same `run_id` —
+    # so it skips the ghost and promotes the run's real PRs instead of losing the whole response.
     with tempfile.TemporaryDirectory() as d:
         project_root, output = fetch_paths(d)
-        output.write_bytes(b"old")
+        ghost = entry(201, label_names=[])                 # label REMOVED; the index has not caught up
+        live = entry(199)
+        ghosts: list[dict] = []
+        count = M.fetch_snapshot(project_root, output, RUN_ID,
+                                 runner=completed(response_bytes([ghost, live])), ghosts=ghosts)
+        check(count == 1, f"the labelled remainder must still be promoted, got count {count}")
+        promoted = json.loads(output.read_text(encoding="utf-8"))
+        check([e["number"] for e in promoted] == [199],
+              f"the promoted snapshot must hold the labelled entry ONLY, got {promoted!r}")
+        check(ghosts == [{"index": 0, "number": 201, "labels": []}],
+              f"the skip must be recorded with WHY it was skipped (its labels), got {ghosts!r}")
+        # The promoted file is ghost-free, so `detect` — whose refusal is deliberately unchanged — reads it.
+        ledger = build_ledger(output.parent, [row(199)])
+        facts = M.detect(ledger, output, RUN_ID)
+        check(facts["rows"]["199"]["absent_from_snapshot"] is False,
+              f"detect must consume the ghost-free promotion, got {facts['rows']['199']!r}")
+
+
+def t_fetch_skips_another_runs_ghost():
+    # A ghost belonging to ANOTHER run is self-identifying: its labels name that other run. Skipping it is
+    # right for the same reason — this query asked for OUR label, so the entry is the index disagreeing.
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
         foreign = entry(41, label_names=["gauntlet-run-other", REVIEWING])
-        expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes([foreign])), RUN_LABEL)
-        check(output.read_bytes() == b"old", "wrong-label response replaced the previous snapshot")
+        ghosts: list[dict] = []
+        count = M.fetch_snapshot(project_root, output, RUN_ID,
+                                 runner=completed(response_bytes([foreign, entry(199)])), ghosts=ghosts)
+        check(count == 1, f"the foreign ghost must not cost the run its own row, got count {count}")
+        check(ghosts == [{"index": 0, "number": 41, "labels": ["gauntlet-run-other", REVIEWING]}],
+              f"the skip must carry the OTHER run's label as its reason, got {ghosts!r}")
+        check([e["number"] for e in json.loads(output.read_text(encoding="utf-8"))] == [199],
+              "the foreign ghost was promoted into this run's snapshot")
+
+
+def t_fetch_reports_every_skip():
+    # A skip can NEVER be silent: stderr names it, and `skipped_unlabelled` is in the result JSON. The key
+    # is present even on a clean fetch, so a reader tests its contents, never a missing key.
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+
+        def cli_over(payload: bytes) -> "tuple[int, str, str]":
+            # `cmd_fetch` OWNS the reporting under test, and only the gh call is stubbed: the real
+            # `fetch_snapshot` underneath still validates, skips, and promotes.
+            return capture_cli(
+                lambda _argv: M.cmd_fetch(project_root, output, RUN_ID, runner=completed(payload)), [])
+
+        code, out, err = cli_over(response_bytes([entry(201, label_names=[]), entry(199)]))
+        _clean_code, clean_out, _clean_err = cli_over(response_bytes([entry(199)]))
+    check(code == 0, f"a skipped ghost is not a failure; fetch must exit 0, got {code} (stderr {err!r})")
+    result = json.loads(out)
+    check(result["entries"] == 1, f"the result must count the PROMOTED rows, got {result!r}")
+    check(result["skipped_unlabelled"] == [{"index": 0, "number": 201, "labels": []}],
+          f"the result JSON must carry the skip and its reason, got {result!r}")
+    check("201" in err and "search index" in err and RUN_LABEL in err,
+          f"stderr must name the skipped PR, the run label, and WHY it was skipped, got {err!r}")
+    check(json.loads(clean_out)["skipped_unlabelled"] == [],
+          f"a clean fetch must still carry an EMPTY skipped_unlabelled, got {clean_out!r}")
+
+
+def t_fetch_all_ghosts_promotes_an_empty_snapshot():
+    # EVERY entry a ghost — what a run looks like after its last PR's labels were removed (an abort or a
+    # merge). The right answer is an EMPTY snapshot, not a refusal: absence is the terminal signal, and
+    # refusing here would deny the run the very completion signal loop-control gates the finished branch
+    # on. Promoting `[]` is also what a genuinely empty run promotes, so detect needs no special case.
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"stale")
+        ghosts: list[dict] = []
+        count = M.fetch_snapshot(project_root, output, RUN_ID, ghosts=ghosts,
+                                 runner=completed(response_bytes([entry(201, label_names=[]),
+                                                                  entry(199, label_names=[REVIEWING])])))
+        check(count == 0, f"an all-ghost response promotes nothing, got count {count}")
+        check(json.loads(output.read_text(encoding="utf-8")) == [],
+              f"an all-ghost response must promote an EMPTY array, got {output.read_bytes()!r}")
+        check([g["number"] for g in ghosts] == [201, 199], f"every ghost must be reported, got {ghosts!r}")
+        ledger = build_ledger(output.parent, [row(199)])
+        facts = M.detect(ledger, output, RUN_ID)
+        check(facts["rows"]["199"] == {"absent_from_snapshot": True},
+              f"an all-ghost snapshot reads as plain absence, got {facts['rows']['199']!r}")
+
+
+def t_fetch_ghost_still_refused_by_detect():
+    # THE ASYMMETRY, on ONE set of bytes. fetch skips the ghost; the SAME snapshot handed to detect through
+    # --prs is refused whole. detect's --prs and --run-id are independent arguments, so an unlabelled entry
+    # there can mean a run was pointed at another run's file — the isolation violation the label prevents.
+    payload = response_bytes([entry(201, label_names=[]), entry(199)])
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        ghosts: list[dict] = []
+        M.fetch_snapshot(project_root, output, RUN_ID, runner=completed(payload), ghosts=ghosts)
+        check(len(ghosts) == 1, f"fetch must skip the ghost, got {ghosts!r}")
+
+        unfiltered = output.parent / "handed-in.json"
+        unfiltered.write_bytes(payload)
+        ledger = build_ledger(output.parent, [row(199)])
+        code, out, err = capture_cli(M.main, [
+            "detect", "--ledger", str(ledger), "--prs", str(unfiltered), "--run-id", RUN_ID])
+    check(code == 2, f"detect must still refuse the WHOLE mis-scoped file, got {code}")
+    check(out.strip() == "", f"a refused detect leaks no facts, got {out!r}")
+    check("run-isolation" in err, f"detect's refusal must still name the isolation property, got {err!r}")
 
 
 def t_fetch_limit_boundary_refused():
@@ -216,6 +320,18 @@ def t_fetch_limit_boundary_refused():
         rows = [entry(n) for n in range(M.SNAPSHOT_LIMIT)]
         expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes(rows)), "may be truncated")
         check(output.read_bytes() == b"old", "limit-boundary response replaced the previous snapshot")
+
+
+def t_fetch_limit_boundary_counts_ghosts():
+    # The truncation guard counts what the QUERY RETURNED, not the survivors. Counting survivors would let
+    # a capped response carrying one ghost slip under the boundary, and absence read off a truncated list
+    # is not evidence.
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        rows = [entry(n) for n in range(M.SNAPSHOT_LIMIT - 1)] + [entry(9999, label_names=[])]
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(response_bytes(rows)), "may be truncated")
+        check(output.read_bytes() == b"old", "a ghost let a limit-boundary response through the guard")
 
 
 def t_fetch_command_failures_preserve_old():
@@ -587,10 +703,20 @@ CASES = [
     ("fetch-refuse-malformed", "malformed/missing-field output preserves the old snapshot",
      t_fetch_malformed_and_missing_field_preserve_old),
     ("fetch-refuse-non-utf8", "non-UTF-8 output preserves the old snapshot", t_fetch_non_utf8_preserves_old),
-    ("fetch-refuse-wrong-label", "every fetched row must carry this run's label",
-     t_fetch_wrong_label_preserves_old),
+    ("fetch-skip-ghost", "an unlabelled ghost is skipped and the labelled remainder is promoted",
+     t_fetch_skips_ghost_and_promotes_the_rest),
+    ("fetch-skip-foreign-ghost", "a ghost carrying ANOTHER run's label is skipped too",
+     t_fetch_skips_another_runs_ghost),
+    ("fetch-report-skip", "every skip lands on stderr and in skipped_unlabelled — never silent",
+     t_fetch_reports_every_skip),
+    ("fetch-all-ghosts", "an all-ghost response promotes an EMPTY snapshot, not a refusal",
+     t_fetch_all_ghosts_promotes_an_empty_snapshot),
+    ("fetch-skip-detect-refuses", "the SAME bytes fetch skips are refused whole by detect",
+     t_fetch_ghost_still_refused_by_detect),
     ("fetch-refuse-limit", "a response at the limit boundary may be truncated and is refused",
      t_fetch_limit_boundary_refused),
+    ("fetch-limit-counts-ghosts", "the limit guard counts the response, so a ghost cannot slip it",
+     t_fetch_limit_boundary_counts_ghosts),
     ("fetch-command-failures", "non-zero and spawn failures preserve the old snapshot",
      t_fetch_command_failures_preserve_old),
     ("fetch-atomic-preserve", "failed atomic promotion preserves old bytes and cleans its temp",

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -313,6 +313,41 @@ def t_fetch_ghost_still_refused_by_detect():
     check("run-isolation" in err, f"detect's refusal must still name the isolation property, got {err!r}")
 
 
+def t_fetch_ghost_is_validated_not_skipped_instead():
+    # A GHOST IS VALIDATED AND *THEN* SKIPPED — never skipped INSTEAD of validated. The skip relaxes the
+    # scope check and nothing else, so a ghost from a DRIFTED command (a `--json` set that lost a field, a
+    # field at the wrong shape) still refuses the WHOLE response. Only the ORDER inside `_validated_entries`
+    # makes that true: validate every canonical field, then decide the entry's outcome.
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        old = b"previous snapshot\n"
+        output.write_bytes(old)
+
+        missing = entry(201, label_names=[])
+        del missing["headRefName"]
+        expect_fetch_refusal(project_root, output, RUN_ID,
+                             completed(response_bytes([missing, entry(199)])), "headRefName")
+        check(output.read_bytes() == old, "a ghost missing a canonical field replaced the old snapshot")
+
+        wrong_shape = entry(201, headRefOid=12345, label_names=[])  # type: ignore[arg-type]
+        expect_fetch_refusal(project_root, output, RUN_ID,
+                             completed(response_bytes([wrong_shape, entry(199)])), "headRefOid")
+        check(output.read_bytes() == old, "a wrong-shaped ghost field replaced the old snapshot")
+
+
+def t_fetch_ghost_duplicate_number_refused():
+    # A ghost registers its `number` like any other entry, so a response naming one PR twice is refused
+    # even when one of the two is unlabelled. Dropping the ghost's registration would make the ambiguity
+    # depend on which of the pair the search index went stale on.
+    with tempfile.TemporaryDirectory() as d:
+        project_root, output = fetch_paths(d)
+        output.write_bytes(b"old")
+        payload = response_bytes([entry(199, label_names=[]), entry(199)])
+        expect_fetch_refusal(project_root, output, RUN_ID, completed(payload),
+                             "lists PR #199 at both entry #0 and #1")
+        check(output.read_bytes() == b"old", "a duplicate naming a ghost replaced the old snapshot")
+
+
 def t_fetch_limit_boundary_refused():
     with tempfile.TemporaryDirectory() as d:
         project_root, output = fetch_paths(d)
@@ -713,6 +748,10 @@ CASES = [
      t_fetch_all_ghosts_promotes_an_empty_snapshot),
     ("fetch-skip-detect-refuses", "the SAME bytes fetch skips are refused whole by detect",
      t_fetch_ghost_still_refused_by_detect),
+    ("fetch-ghost-still-validated", "a ghost is validated and THEN skipped, so a drifted one still refuses",
+     t_fetch_ghost_is_validated_not_skipped_instead),
+    ("fetch-ghost-duplicate-number", "a ghost registers its number, so a duplicated PR still refuses",
+     t_fetch_ghost_duplicate_number_refused),
     ("fetch-refuse-limit", "a response at the limit boundary may be truncated and is refused",
      t_fetch_limit_boundary_refused),
     ("fetch-limit-counts-ghosts", "the limit guard counts the response, so a ghost cannot slip it",

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -212,24 +212,21 @@ def _validated_entries(data: "list[object]", run_id: str, source: str,
       `fetch_snapshot`), so an unlabelled entry there is a stale-search-index GHOST, not an escaped query.
 
     Skipping is the ONLY thing the scope check relaxes. Every other refusal — shape, null, malformed
-    label, duplicate PR — still fails the whole response on both paths, ghost entries included.
+    label, duplicate PR — still fails the whole response on both paths, ghost entries included. What
+    makes that TRUE rather than merely intended is the ORDER: the scope check runs LAST, after the entry
+    has been validated for every canonical field and has registered its number. Move it earlier and a
+    ghost stops being validated at all — it is skipped INSTEAD of validated, and the missing-field and
+    duplicate-PR refusals quietly stop applying to it. **Validate first, then decide the outcome.**
     """
     run_label = RUN_LABEL_PREFIX + run_id
     entries: list[dict] = []
     seen: dict[str, int] = {}
     for index, entry in enumerate(data):
         names = label_names(entry, index)          # reads `labels` through sfield; refuses malformed
-        if run_label not in names:
-            if ghosts is None:
-                raise Refusal(
-                    f"prs.json entry #{index} does not carry this run's label {run_label!r} (it has "
-                    f"{names!r}) — the snapshot escaped the run's label scope, which is the run-isolation "
-                    f"violation the canonical fetch's `--label` exists to prevent ({CANONICAL_BLOCK}). "
-                    f"Refusing the whole response; a snapshot scoped to the wrong PRs is not evidence.")
-            # A ghost is still named by its `number`, which enters through `sfield` like any other field:
-            # a ghost we cannot name is a drifted command, not a stale index.
-            ghosts.append({"index": index, "number": sfield(entry, "number", index), "labels": names})
-            continue
+        # EVERY entry is validated in FULL and registers its number BEFORE the scope check decides its
+        # outcome. That order is what makes the guarantee below true: a ghost from a DRIFTED command is
+        # still a drifted command, and a snapshot naming one PR twice is still ambiguous, whether or not
+        # the second entry happens to be unlabelled.
         fact = {k: sfield(entry, k, index) for k in CANONICAL_FIELDS if k != "labels"}
         fact["label_names"] = names
         number_key = str(fact["number"])
@@ -239,6 +236,15 @@ def _validated_entries(data: "list[object]", run_id: str, source: str,
                 f"snapshot that names one PR twice cannot be reconciled deterministically. Refusing the "
                 f"whole response.")
         seen[number_key] = index
+        if run_label not in names:
+            if ghosts is None:
+                raise Refusal(
+                    f"prs.json entry #{index} does not carry this run's label {run_label!r} (it has "
+                    f"{names!r}) — the snapshot escaped the run's label scope, which is the run-isolation "
+                    f"violation the canonical fetch's `--label` exists to prevent ({CANONICAL_BLOCK}). "
+                    f"Refusing the whole response; a snapshot scoped to the wrong PRs is not evidence.")
+            ghosts.append({"index": index, "number": fact["number"], "labels": names})
+            continue
         entries.append(fact)
     return entries
 

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -16,10 +16,23 @@ the query whose bytes detection consumes.
     reconcile.py fetch --project-root <project-root> --run-id <id> --output <rundir>/prs.json
     reconcile.py detect --ledger <state.jsonl> --prs <rundir>/prs.json --run-id <id>
 
-`--run-id` selects the label for `fetch` and validates label scope for both commands: every snapshot entry
-MUST carry this run's `gauntlet-run-<run-id>` label. A snapshot that escaped that scope is the run-isolation
-violation the label exists to prevent, so the whole file is refused — never silently reconciled against
-another run's PRs.
+`--run-id` selects the label for `fetch` and validates label scope for both commands: every entry the
+snapshot KEEPS carries this run's `gauntlet-run-<run-id>` label. What an entry WITHOUT it means differs
+between the two commands, so the two commands answer it differently:
+
+* In `detect`, `--prs` and `--run-id` are INDEPENDENT arguments, so an unlabelled entry can mean the caller
+  pointed one run at another run's snapshot. That is the run-isolation violation the label exists to
+  prevent, so the WHOLE file is refused — never partly trusted, never silently reconciled against another
+  run's PRs. **That refusal is load-bearing and unconditional.**
+* In `fetch`, the `--label` selector and this validator are built from the SAME `run_id` (`fetch_argv` and
+  `fetch_snapshot`), so they cannot disagree about scope at runtime. An unlabelled entry there can only
+  mean GitHub's two sources disagree about that one PR: `gh pr list --label` compiles to the issues SEARCH
+  INDEX, while each entry's `labels` field resolves from the primary database, and the search index does
+  not durably apply label REMOVALS — it clears only when that PR receives a later label write, so the
+  disagreement does not time out. Such an entry is a GHOST. `fetch` SKIPS it, reports it on stderr and in
+  `skipped_unlabelled`, and promotes the rest — one ghost must not destroy drift detection for every other
+  PR in the run. DISCLOSED COST: a run label removed BY HAND from a still-live PR is indistinguishable
+  from a ghost here, so that PR now reads as `absent_from_snapshot` instead of refusing the fetch.
 
 FACTS ONLY, and NEUTRAL. The headline signal — a live row that is ABSENT from the snapshot — is the
 MERGED/CLOSED-BY-ABSENCE fact: the canonical command lists `--state open`, so a merged or closed PR simply
@@ -31,8 +44,9 @@ active work — see the repo's CLAUDE.md. Absence is a FACT to report, not a bug
 
 `detect` performs NO NETWORK or writes. It is a pure function of two files to one JSON object on stdout.
 `fetch` performs one fixed `gh` read and one atomic local promotion. Both fail closed with exit 2 when an
-input or response is not evidence. A failed command, malformed response, wrong-label row, possible
-limit-boundary truncation, or failed promotion leaves any previous `prs.json` byte-for-byte intact.
+input or response is not evidence. A failed command, malformed response, possible limit-boundary
+truncation, or failed promotion leaves any previous `prs.json` byte-for-byte intact — as does a
+wrong-label row in `detect`'s `--prs` file (in `fetch` a wrong-label row is a skipped ghost, above).
 
 The fixture suite is the SIBLING `reconcile-test.py`, this tool's executable contract; `self-test` loads
 it by a `__file__`-relative path and FAILS LOUDLY if it is missing — a self-test that passes because it
@@ -180,28 +194,42 @@ def label_names(entry: object, index: int) -> list[str]:
     return names
 
 
-def _validated_entries(data: object, run_id: str, source: str) -> "list[dict]":
-    """Validate decoded snapshot JSON and return typed fact dictionaries.
+def _validated_entries(data: "list[object]", run_id: str, source: str,
+                       *, ghosts: "list[dict] | None" = None) -> "list[dict]":
+    """Validate a decoded snapshot ARRAY and return typed fact dictionaries.
 
     Each returned dict carries ONLY the canonical fields, at their validated shapes, plus the extracted
-    `label_names`. The run-label scope check runs here: an entry that does not carry `gauntlet-run-<run-id>`
-    refuses the WHOLE response because a snapshot that escaped the run's scope cannot be partly trusted.
+    `label_names`.
+
+    The run-label scope check runs here, and the CALLER chooses its outcome, because the same observation
+    means different things on the two paths (module docstring, `--run-id`):
+
+    * `ghosts is None` — the default, used by `read_snapshot` and therefore by `detect`. An entry that
+      does not carry `gauntlet-run-<run-id>` refuses the WHOLE response, because a snapshot that escaped
+      the run's scope cannot be partly trusted. **Unconditional; do not add a skip here.**
+    * `ghosts` is a list — used by `fetch` only. The entry is SKIPPED and a `{index, number, labels}`
+      record is appended to that list, so the caller can report it. `fetch` cannot be mis-scoped (see
+      `fetch_snapshot`), so an unlabelled entry there is a stale-search-index GHOST, not an escaped query.
+
+    Skipping is the ONLY thing the scope check relaxes. Every other refusal — shape, null, malformed
+    label, duplicate PR — still fails the whole response on both paths, ghost entries included.
     """
-    if not isinstance(data, list):
-        raise Refusal(
-            f"{source} is {_SHAPE_NAME.get(type(data), type(data).__name__)}, not a JSON array — "
-            f"the canonical `gh pr list --json …` response is an ARRAY of PR objects ({CANONICAL_BLOCK}).")
     run_label = RUN_LABEL_PREFIX + run_id
     entries: list[dict] = []
     seen: dict[str, int] = {}
     for index, entry in enumerate(data):
         names = label_names(entry, index)          # reads `labels` through sfield; refuses malformed
         if run_label not in names:
-            raise Refusal(
-                f"prs.json entry #{index} does not carry this run's label {run_label!r} (it has "
-                f"{names!r}) — the snapshot escaped the run's label scope, which is the run-isolation "
-                f"violation the canonical fetch's `--label` exists to prevent ({CANONICAL_BLOCK}). "
-                f"Refusing the whole response; a snapshot scoped to the wrong PRs is not evidence.")
+            if ghosts is None:
+                raise Refusal(
+                    f"prs.json entry #{index} does not carry this run's label {run_label!r} (it has "
+                    f"{names!r}) — the snapshot escaped the run's label scope, which is the run-isolation "
+                    f"violation the canonical fetch's `--label` exists to prevent ({CANONICAL_BLOCK}). "
+                    f"Refusing the whole response; a snapshot scoped to the wrong PRs is not evidence.")
+            # A ghost is still named by its `number`, which enters through `sfield` like any other field:
+            # a ghost we cannot name is a drifted command, not a stale index.
+            ghosts.append({"index": index, "number": sfield(entry, "number", index), "labels": names})
+            continue
         fact = {k: sfield(entry, k, index) for k in CANONICAL_FIELDS if k != "labels"}
         fact["label_names"] = names
         number_key = str(fact["number"])
@@ -215,8 +243,13 @@ def _validated_entries(data: object, run_id: str, source: str) -> "list[dict]":
     return entries
 
 
-def validate_snapshot_bytes(payload: bytes, run_id: str, source: str = "gh response") -> "list[dict]":
-    """Decode and validate raw fetch bytes. No write happens until this returns successfully."""
+def _decode_snapshot(payload: bytes, source: str) -> "list[object]":
+    """Decode raw snapshot bytes to the JSON ARRAY the canonical response is. Refuses anything else.
+
+    Split out from `validate_snapshot_bytes` because `fetch` needs the decoded entries themselves — it
+    promotes a snapshot with its ghost entries removed, and re-decoding the same bytes a second time to
+    get them would be a second reader of the same contract.
+    """
     try:
         raw = payload.decode("utf-8")
     except UnicodeDecodeError as exc:
@@ -226,7 +259,20 @@ def validate_snapshot_bytes(payload: bytes, run_id: str, source: str = "gh respo
     except json.JSONDecodeError as exc:
         raise Refusal(f"{source} is not valid JSON ({exc}) — the canonical fetch must return a JSON array "
                       f"({CANONICAL_BLOCK}).") from exc
-    return _validated_entries(data, run_id, source)
+    if not isinstance(data, list):
+        raise Refusal(
+            f"{source} is {_SHAPE_NAME.get(type(data), type(data).__name__)}, not a JSON array — "
+            f"the canonical `gh pr list --json …` response is an ARRAY of PR objects ({CANONICAL_BLOCK}).")
+    return data
+
+
+def validate_snapshot_bytes(payload: bytes, run_id: str, source: str = "gh response") -> "list[dict]":
+    """Decode and validate raw snapshot bytes, REFUSING any entry outside the run's label scope.
+
+    This is the `read_snapshot`/`detect` door, so the whole-file scope refusal applies. `fetch` does not
+    come through here — it decodes and validates in two steps so it can skip ghosts (`fetch_snapshot`).
+    """
+    return _validated_entries(_decode_snapshot(payload, source), run_id, source)
 
 
 def read_snapshot(prs_path: Path, run_id: str) -> "list[dict]":
@@ -276,8 +322,21 @@ def fetch_snapshot(
     run_id: str,
     *,
     runner: "Callable[..., subprocess.CompletedProcess[bytes]]" = subprocess.run,
+    ghosts: "list[dict] | None" = None,
 ) -> int:
-    """Fetch, validate, and atomically promote one canonical snapshot. Return validated row count."""
+    """Fetch, validate, and atomically promote one canonical snapshot. Return the PROMOTED row count.
+
+    The `--label` selector and the scope validator are both built from THIS `run_id`, so they cannot
+    disagree at runtime and the query cannot escape its scope. An entry GitHub returned for the label
+    while its own `labels` omit that label is therefore a stale-search-index GHOST (module docstring):
+    it is SKIPPED, left out of the promoted bytes, and appended to `ghosts` when a list is passed. The
+    caller reports them; skipping happens whether or not anyone is listening, because one ghost must not
+    cost the run drift detection on every other PR.
+
+    Pass a list for `ghosts` to see them; `cmd_fetch` does. Nothing else about the response is relaxed —
+    the promoted file still satisfies `read_snapshot` in full, ghost-free, so `detect` reads it without
+    ever meeting a skipped entry.
+    """
     _validate_fetch_paths(project_root, output)
     argv = fetch_argv(run_id)
     try:
@@ -287,15 +346,29 @@ def fetch_snapshot(
     if proc.returncode != 0:
         stderr = proc.stderr.decode("utf-8", errors="replace").strip()
         raise Refusal(f"canonical `gh pr list` exited {proc.returncode}: {stderr}")
-    entries = validate_snapshot_bytes(proc.stdout, run_id)
-    if len(entries) >= SNAPSHOT_LIMIT:
+    data = _decode_snapshot(proc.stdout, "gh response")
+    # Collected LOCALLY and handed to the caller only on success: the indices below must describe THIS
+    # response, and a refusal must not leave a report of a promotion that did not happen.
+    found: list[dict] = []
+    entries = _validated_entries(data, run_id, "gh response", ghosts=found)
+    # The truncation guard counts the RESPONSE, not the survivors. The result cap applies to what the
+    # query RETURNED, so skipped ghosts still count toward it — otherwise a capped response carrying one
+    # ghost would slip under the boundary and absence would be read as evidence from a truncated list.
+    if len(data) >= SNAPSHOT_LIMIT:
         raise Refusal(
-            f"canonical `gh pr list` returned {len(entries)} rows at its --limit {SNAPSHOT_LIMIT} boundary; "
+            f"canonical `gh pr list` returned {len(data)} rows at its --limit {SNAPSHOT_LIMIT} boundary; "
             "the response may be truncated, so absence is not evidence and no snapshot was promoted.")
+    payload = proc.stdout
+    if found:
+        # Only a response WITH ghosts is re-serialized; a clean one promotes gh's exact captured bytes.
+        dropped = {ghost["index"] for ghost in found}
+        payload = json.dumps([e for i, e in enumerate(data) if i not in dropped]).encode("utf-8")
     try:
-        _replace_bytes(output, proc.stdout)
+        _replace_bytes(output, payload)
     except OSError as exc:
         raise Refusal(f"could not atomically promote the validated snapshot to {output}: {exc}") from exc
+    if ghosts is not None:
+        ghosts.extend(found)
     return len(entries)
 
 
@@ -416,17 +489,41 @@ def cmd_detect(ledger_path: Path, prs_path: Path, run_id: str) -> int:
     return 0
 
 
-def cmd_fetch(project_root: Path, output: Path, run_id: str) -> int:
-    """Run the canonical fetch and print its result. A refusal emits no stdout and preserves `output`."""
+def cmd_fetch(
+    project_root: Path,
+    output: Path,
+    run_id: str,
+    *,
+    runner: "Callable[..., subprocess.CompletedProcess[bytes]]" = subprocess.run,
+) -> int:
+    """Run the canonical fetch and print its result. A refusal emits no stdout and preserves `output`.
+
+    A skipped ghost is REPORTED TWICE and can never happen silently: once per entry on stderr, where a
+    driver reading the log sees it, and as `skipped_unlabelled` in the result JSON, which is ALWAYS
+    present (empty on a clean fetch) so a machine reader can test it without guessing at a missing key.
+
+    `runner` is forwarded to `fetch_snapshot` for the same reason it exists there — the fixtures drive
+    THIS reporting over a fixed response instead of monkey-patching the module.
+    """
+    ghosts: list[dict] = []
     try:
-        entries = fetch_snapshot(project_root, output, run_id)
+        entries = fetch_snapshot(project_root, output, run_id, runner=runner, ghosts=ghosts)
     except Refusal as exc:
         print(f"reconcile: {exc}", file=sys.stderr)
         return 2
+    run_label = RUN_LABEL_PREFIX + run_id
+    for ghost in ghosts:
+        print(f"reconcile: SKIPPED GHOST PR #{ghost['number']} (response entry #{ghost['index']}): "
+              f"`gh pr list --label {run_label}` returned it, but its own labels are {ghost['labels']!r} "
+              f"and do not carry {run_label!r}. GitHub's issue search index does not durably apply label "
+              f"REMOVALS, so it keeps listing a PR whose label is already gone. The entry was left OUT of "
+              f"the promoted snapshot; the rest of the run was promoted normally, and this PR now reads "
+              f"as `absent_from_snapshot` in `detect`.", file=sys.stderr)
     print(json.dumps({
         "entries": entries,
         "output": str(output),
         "run_id": run_id,
+        "skipped_unlabelled": ghosts,
     }, sort_keys=True))
     return 0
 


### PR DESCRIPTION
- one stale-search-index ghost made `reconcile.py fetch` refuse its whole response, killing drift detection run-wide
- `fetch` now skips ghosts, promotes the rest, reports each on stderr and in `skipped_unlabelled`
- `detect`'s whole-file refusal stays unchanged: only there can `--prs` and `--run-id` disagree
