### PR TITLE
release fusion 0.0.1

### DIFF
--- a/plugins/fusion/.claude-plugin/plugin.json
+++ b/plugins/fusion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Query the Autodesk Fusion 360 Python API from a pre-compiled reference database.",
   "author": {
     "name": "lestrrat"

--- a/plugins/fusion/.codex-plugin/plugin.json
+++ b/plugins/fusion/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Query the Autodesk Fusion 360 Python API from a pre-compiled reference database.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- Set both `fusion` manifests to `0.0.1` for its first release.
- It shipped as `0.1.0` in #232; nothing installed that, so the lower number costs no refresh.
