### PR TITLE
stop a residual-risk line from voiding a verdict

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -156,10 +156,13 @@ When the loop exits, summarize:
   `Run-end snapshot only. Defaults may have changed mid-run. This is not per-PR or per-pass history.`
 - **Merged** — PR number + slug, one-line description, tier, and the **base it merged into** (its
   `effective_base`), so a mixed-base run shows which release line each PR shipped to.
-- **Residual risk** — for each merged PR, each accepting SATISFIED pass's `RESIDUAL-RISK` line (the
+- **Residual risk** — for each merged PR, each accepting SATISFIED pass's `RESIDUAL-RISK` record (the
   least-certain area it named), and a flag when two accepting passes name the same area. The line is
-  OPTIONAL, so a PR contributes at most `required(tier)` lines and may contribute none; report what the
-  passes actually wrote and never invent a line for a pass that omitted one. This is non-actionable,
+  OPTIONAL, so a PR contributes at most `required(tier)` records and may contribute none; report what the
+  passes actually wrote and never invent a line for a pass that omitted one. **Reproduce each record as
+  `verify` reports it, including one that does not match the form the prompt asked for** — the parser
+  carries the reviewer's words through unedited (Stage 2a), so tidying one here would be this report
+  rewording a reviewer. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
 - **What each base REQUIRED** — the required-check set, now **per base** (`effective_required_set`;
   `stage-2-ci.md` owns its states), over the bases **this run GATED on and READ** — not every base the

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -156,13 +156,17 @@ When the loop exits, summarize:
   `Run-end snapshot only. Defaults may have changed mid-run. This is not per-PR or per-pass history.`
 - **Merged** — PR number + slug, one-line description, tier, and the **base it merged into** (its
   `effective_base`), so a mixed-base run shows which release line each PR shipped to.
-- **Residual risk** — for each merged PR, each accepting SATISFIED pass's `RESIDUAL-RISK` record (the
-  least-certain area it named), and a flag when two accepting passes name the same area. The line is
-  OPTIONAL, so a PR contributes at most `required(tier)` records and may contribute none; report what the
-  passes actually wrote and never invent a line for a pass that omitted one. **Reproduce each record as
+- **Residual risk** — for each merged PR, every `RESIDUAL-RISK` record its accepting SATISFIED passes
+  wrote (the least-certain area each named), and a flag when two accepting passes name the same area. The
+  line is OPTIONAL and a pass that wrote several contributes several, so a PR's record count is bounded by
+  neither `required(tier)` nor anything else, and may be none; report what the passes actually wrote and
+  never invent a line for a pass that omitted one. **Reproduce each record as
   `verify` reports it, including one that does not match the form the prompt asked for** — the parser
-  carries the reviewer's words through unedited (Stage 2a), so tidying one here would be this report
-  rewording a reviewer. This is non-actionable,
+  carries the reviewer's words through unedited and never joins two records into one (Stage 2a), so
+  tidying one here, or running two of them together into a single record, would be this report rewording
+  a reviewer. `verify` prints the records of one pass separated by `; ` on its detail line, each still
+  carrying the `RESIDUAL-RISK:` token the reviewer typed, which is where one record ends and the next
+  begins. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
 - **What each base REQUIRED** — the required-check set, now **per base** (`effective_required_set`;
   `stage-2-ci.md` owns its states), over the bases **this run GATED on and READ** — not every base the

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -164,9 +164,13 @@ When the loop exits, summarize:
   `verify` reports it, including one that does not match the form the prompt asked for** — the parser
   carries the reviewer's words through unedited and never joins two records into one (Stage 2a), so
   tidying one here, or running two of them together into a single record, would be this report rewording
-  a reviewer. `verify` prints the records of one pass separated by `; ` on its detail line, each still
-  carrying the `RESIDUAL-RISK:` token the reviewer typed, which is where one record ends and the next
-  begins. This is non-actionable,
+  a reviewer. **How to READ the records off `verify`:** its detail line carries a `residual-risk=` field
+  holding a JSON array of that pass's records, always present and `[]` when the pass wrote none. Decode
+  that array and take one record per element — never split a record on its inner punctuation, and never
+  run two elements together. The array is where the record boundary lives, and it is the ONLY place it
+  survives: a reviewer may write a single remark containing anything the eye reads as a separator, so any
+  boundary you infer from the record text is a boundary you invented. The array ends at its own `]`, and
+  the human-readable reason follows it on the same line. This is non-actionable,
   non-gating calibration metadata — a place a human might look, never a reopened finding (Stage 2a).
 - **What each base REQUIRED** — the required-check set, now **per base** (`effective_required_set`;
   `stage-2-ci.md` owns its states), over the bases **this run GATED on and READ** — not every base the

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -288,9 +288,9 @@
   all the same (Stage 2a owns that rule). **A verdict from a pass that does not verify `ok` is NEVER tallied**, and there are
   **five** kinds of defect that make a pass `unusable` (Stage 2a, "Does this pass
   COUNT?", owns the enumeration):
-  - **the active REPORT result is unusable** — missing, empty, truncated, duplicate, nonterminal,
-    malformed, from the wrong launch attempt, or carrying a misplaced/malformed `RESIDUAL-RISK:` line —
-    OMITTING that line never makes a SATISFIED report unusable;
+  - **the active REPORT result is unusable** — the `VERDICT:` line missing, empty, truncated, duplicate,
+    nonterminal, malformed, or from the wrong launch attempt. **The `RESIDUAL-RISK:` line is NOT part of
+    this**: omitted, misspelled, doubled, or misplaced, it never makes a report unusable (Stage 2a);
   - **the ARTIFACTS are malformed** — a short SHA or any other malformed identifier, a `done` for a unit
     that was never planned, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done`
     for one unit, a hand-written line of the wrong shape, an identity naming another commit or attempt;
@@ -350,9 +350,10 @@
   BOUNDED by the threat model, not narrowed, and its findings anchor like any other), and treats "nothing
   found" as a fine result; no speculative "might be fragile" notes (Stage 2a).
 - A SATISFIED verdict SHOULD carry one `RESIDUAL-RISK: <area> — <why>` line (the least-certain part of
-  the diff), and is accepted without one. It is calibration metadata, never a finding: it never withholds
-  the gate, never enters the fix loop, and is never fed into the corroborating review. Its absence never
-  makes the pass unusable. Do not manufacture a concern to fill it; a real
+  the diff). It is calibration metadata, never a finding: it never withholds the gate, never enters the
+  fix loop, and is never fed into the corroborating review. **NOTHING about how it is written — including
+  not writing it — can make the pass unusable**; `verify` records what the reviewer wrote and judges only
+  the verdict (Stage 2a). Do not manufacture a concern to fill it; a real
   **GATING** defect found while identifying it is a normal finding → NOT SATISFIED (Stage 2a).
 - One decision at N sites is the most common root cause. Trigger the §2a-deep root-cause pass on the
   **first** "missing/wrong at site X" finding (its shape, not a round count), map the whole space with

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -289,8 +289,10 @@
   **five** kinds of defect that make a pass `unusable` (Stage 2a, "Does this pass
   COUNT?", owns the enumeration):
   - **the active REPORT result is unusable** — the `VERDICT:` line missing, empty, truncated, duplicate,
-    nonterminal, malformed, or from the wrong launch attempt. **The `RESIDUAL-RISK:` line is NOT part of
-    this**: omitted, misspelled, doubled, or misplaced, it never makes a report unusable (Stage 2a);
+    nonterminal, malformed, or from the wrong launch attempt. **A `RESIDUAL-RISK:` line standing BEFORE
+    the verdict is NOT part of this**: omitted, misspelled, doubled, or anywhere above the verdict, it
+    never makes a report unusable. One written AFTER the verdict is trailing text, so the `VERDICT:` rule
+    above — not any rule about this line — refuses that report as nonterminal (Stage 2a);
   - **the ARTIFACTS are malformed** — a short SHA or any other malformed identifier, a `done` for a unit
     that was never planned, an evidence-free `done`, a `done` that no `started` precedes, a SECOND `done`
     for one unit, a hand-written line of the wrong shape, an identity naming another commit or attempt;
@@ -351,9 +353,10 @@
   found" as a fine result; no speculative "might be fragile" notes (Stage 2a).
 - A SATISFIED verdict SHOULD carry one `RESIDUAL-RISK: <area> — <why>` line (the least-certain part of
   the diff). It is calibration metadata, never a finding: it never withholds the gate, never enters the
-  fix loop, and is never fed into the corroborating review. **NOTHING about how it is written — including
-  not writing it — can make the pass unusable**; `verify` records what the reviewer wrote and judges only
-  the verdict (Stage 2a). Do not manufacture a concern to fill it; a real
+  fix loop, and is never fed into the corroborating review. **NOTHING about how it is written ABOVE the
+  verdict — including not writing it — can make the pass unusable**; `verify` records what the reviewer
+  wrote and judges only the verdict. Below the verdict it is trailing text, and the terminal-verdict rule
+  refuses the report as nonterminal — write it above the verdict, as the prompt asks (Stage 2a). Do not manufacture a concern to fill it; a real
   **GATING** defect found while identifying it is a normal finding → NOT SATISFIED (Stage 2a).
 - One decision at N sites is the most common root cause. Trigger the §2a-deep root-cause pass on the
   **first** "missing/wrong at site X" finding (its shape, not a round count), map the whole space with

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -805,7 +805,11 @@ verdict that blocks a PR must name what blocks it, and a finding that blocks a P
 **NOTHING ABOUT A `RESIDUAL-RISK:` LINE CAN MAKE A PASS `unusable` — not its absence, not its shape, not
 its count, not where it sits.** The line is calibration metadata for the final report and never a gate
 input, so `verify` READS it and does not judge it: it is carried as the reviewer wrote it, minus only an
-invisible prefix and trailing whitespace, and two of them are carried as two remarks. `review-prompt.txt`
+invisible prefix and trailing whitespace, and two of them are carried as TWO SEPARATE RECORDS — never
+merged into one, and never with a separator the tool supplied. `verify` prints each record after its own
+`; ` on the one detail line it already writes, so the records stay distinguishable without any text being
+added inside one. Splicing two remarks into a single record is the same defect as rewriting one of them:
+the final report attributes that record's words to the reviewer. `review-prompt.txt`
 still ASKS for `RESIDUAL-RISK: <area> — <why>` standing last before the verdict, and that request is what
 keeps the line readable — it is a request, not a gate, and a reviewer who misses it has not spoiled its
 pass. On a NOT SATISFIED or DEFERRED result the line is DROPPED, not refused: the final report records
@@ -976,8 +980,9 @@ can cost the pass its verdict**; "Does this pass COUNT?" above owns that rule an
 instead. It reflects the gauntlet's purpose —
 lower the odds a defect survives stochastic variation, not claim certainty — by making residual
 uncertainty explicit instead of hidden behind a binary verdict. Record it with the verdict and carry
-**each accepting pass's** record into the final report, grouped by PR (one record per accepting pass,
-and a pass that wrote none contributes none). Its only aggregate use (when a PR has ≥2 accepting
+**every record each accepting pass wrote** into the final report, grouped by PR (a pass that wrote none
+contributes none, and one that wrote several contributes several — the parser keeps them separate rather
+than merging them, "Does this pass COUNT?" above). Its only aggregate use (when a PR has ≥2 accepting
 passes that each named an area):
 when **both** accepting passes on the same content name the same area, note that convergence in the
 report, and the orchestrator MAY add a plan unit covering it the next time the PR content changes and a

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -797,16 +797,27 @@ still runs PRE-DISPATCH, refusing a launch against an already-stale intent; it d
 
 **`verify` derives the active attempt's report path from the progress artifact and parses the result.**
 It requires exactly one terminal result on the last nonblank line: `VERDICT: SATISFIED`, `VERDICT: NOT
-SATISFIED`, or `VERDICT: DEFERRED — <one-line reason>`. Missing, empty, truncated, duplicate,
-nonterminal, malformed, and wrong-attempt reports are `unusable`. The parsed binary result is checked by
+SATISFIED`, or `VERDICT: DEFERRED — <one-line reason>`. A report whose VERDICT is missing, empty,
+truncated, duplicate, nonterminal or malformed — and one from the wrong attempt — is `unusable`. The parsed binary result is checked by
 the existing if-and-only-if rule: **`not-satisfied` exactly when at least one GATING finding stands.** A
 verdict that blocks a PR must name what blocks it, and a finding that blocks a PR cannot be waved through.
 
-**A SATISFIED report MAY carry a `RESIDUAL-RISK:` line, and its absence NEVER blocks the verdict.** The
-line is calibration metadata, never a gate input, so a SATISFIED report without one counts exactly as a
-SATISFIED report with one. When it IS present the prompt still owns its exact form, there is at most one
-of it, and it is the last nonblank line before the verdict — blank lines between the two are tolerated,
-any other line is not. The line is forbidden on NOT SATISFIED and DEFERRED results.
+**NOTHING ABOUT A `RESIDUAL-RISK:` LINE CAN MAKE A PASS `unusable` — not its absence, not its shape, not
+its count, not where it sits.** The line is calibration metadata for the final report and never a gate
+input, so `verify` READS it and does not judge it: it is carried as the reviewer wrote it, minus only an
+invisible prefix and trailing whitespace, and two of them are carried as two remarks. `review-prompt.txt`
+still ASKS for `RESIDUAL-RISK: <area> — <why>` standing last before the verdict, and that request is what
+keeps the line readable — it is a request, not a gate, and a reviewer who misses it has not spoiled its
+pass. On a NOT SATISFIED or DEFERRED result the line is DROPPED, not refused: the final report records
+the least-certain area of each ACCEPTING pass, so on any other result there is nothing to carry.
+
+**The reason that is a rule and not laxity:** a formatting check on this line can only ever lose
+evidence. It answers no question the gate asks, so refusing over it spends a whole review — a complete
+`SATISFIED` with no gating defect — to enforce punctuation. Requiring the line at all discarded four
+substantive passes across two engines; requiring its exact inner form then discarded a sixth-round
+`SATISFIED` over a hyphen where an em dash was asked for. Every rule that DOES gate — one terminal
+result, on the last nonblank line, in exactly one of the three spellings above — stays exact, because
+the verdict is the input the gate reads.
 
 **A parsed DEFERRED result routes through progress state without becoming a judgment.** An unruled
 `plan_amendment_request` returns `amended`; an unfinished pass returns `incomplete`; a complete pass with
@@ -830,7 +841,7 @@ pass is a trapdoor, not a disclosure:
 | `ok` | 0 | the artifacts are sound: one strict result from the active attempt's report; a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt, **the live head SHA**, and a bound **`default_non_goals` still equal to the run's live defaults**; a **usable intent block** for this PR; every planned unit `done` **once**, with concrete evidence, after a `started` for it; every `done` for a unit that is **actually in the plan**; no unruled amendment; and the parsed result **coheres** with the findings | tally the parsed binary result through `ledger.py verdict` |
 | `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
 | `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
-| `unusable` | 1 | the artifacts are **defective** — the active report is missing, empty, truncated, duplicate, nonterminal, malformed, or carries a misplaced or malformed residual-risk line (its ABSENCE is fine); a short SHA or other malformed identifier; invalid progress/identity/findings; **no usable intent block**; a bound `default_non_goals` that no longer matches the run's live defaults (scope drift); a parsed result that does not cohere with findings; or a spurious DEFERRED result | the pass **CANNOT count**. Fix skipped adoption inputs when named; otherwise retry — the same pass, next launch attempt (`runtime-adapter.md`, "Review preparation mapping") — or take the fresh-worker fallback |
+| `unusable` | 1 | the artifacts are **defective** — the active report is missing, empty, truncated, duplicate, nonterminal, or malformed **in its VERDICT** (its `RESIDUAL-RISK:` line never makes a report defective, however it is written); a short SHA or other malformed identifier; invalid progress/identity/findings; **no usable intent block**; a bound `default_non_goals` that no longer matches the run's live defaults (scope drift); a parsed result that does not cohere with findings; or a spurious DEFERRED result | the pass **CANNOT count**. Fix skipped adoption inputs when named; otherwise retry — the same pass, next launch attempt (`runtime-adapter.md`, "Review preparation mapping") — or take the fresh-worker fallback |
 
 **`ok` is not SATISFIED.** The tool parses the reviewer's exact terminal result but does not judge the
 report's prose, raise `reviews_ok`, or merge. `ledger.py verdict` remains the only tally writer.
@@ -960,12 +971,13 @@ structurally; the sweep finds a defect now, regardless of the plan.)
 certainty, relative to the rest. It is calibration metadata, never a finding and never a verdict
 input: a SATISFIED with a residual-risk line is a **full** SATISFIED, and the line NEVER withholds the
 gate, NEVER enters the fix loop, and is NEVER fed into the corroborating review (which stays
-context-isolated). Because it is not a gate input, **a SATISFIED report that omits it is accepted
-unchanged** — the pass counts, and nothing about the gate moves. It reflects the gauntlet's purpose —
+context-isolated). Because it is not a gate input, **no way of writing it — including not writing it —
+can cost the pass its verdict**; "Does this pass COUNT?" above owns that rule and what `verify` records
+instead. It reflects the gauntlet's purpose —
 lower the odds a defect survives stochastic variation, not claim certainty — by making residual
 uncertainty explicit instead of hidden behind a binary verdict. Record it with the verdict and carry
-**each accepting pass's** line into the final report, grouped by PR (at most one line per accepting
-pass, and a pass that wrote none contributes none). Its only aggregate use (when a PR has ≥2 accepting
+**each accepting pass's** record into the final report, grouped by PR (one record per accepting pass,
+and a pass that wrote none contributes none). Its only aggregate use (when a PR has ≥2 accepting
 passes that each named an area):
 when **both** accepting passes on the same content name the same area, note that convergence in the
 report, and the orchestrator MAY add a plan unit covering it the next time the PR content changes and a

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -807,9 +807,12 @@ absence, not its shape, not its count, not where above the verdict it sits.** Th
 metadata for the final report and never a gate
 input, so `verify` READS it and does not judge it: it is carried as the reviewer wrote it, minus only an
 invisible prefix and trailing whitespace, and two of them are carried as TWO SEPARATE RECORDS — never
-merged into one, and never with a separator the tool supplied. `verify` prints each record after its own
-`; ` on the one detail line it already writes, so the records stay distinguishable without any text being
-added inside one. Splicing two remarks into a single record is the same defect as rewriting one of them:
+merged into one, and never with a separator the tool supplied. `verify` prints that list as a JSON array
+in a named field of the one detail line it already writes, so the boundary between two records survives
+printing and a reader recovers exactly the records the parser kept — `bailout-and-final-report.md` owns
+that field's name and the recovery. Any join would lose the boundary, whatever the separator: a reviewer
+may write one remark containing the same characters, and then one record and two print
+identically. Splicing two remarks into a single record is the same defect as rewriting one of them:
 the final report attributes that record's words to the reviewer. `review-prompt.txt`
 still ASKS for `RESIDUAL-RISK: <area> — <why>` standing last before the verdict, and that request is what
 keeps the line readable — it is a request, not a gate, and a reviewer who misses it has not spoiled its

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -802,8 +802,9 @@ truncated, duplicate, nonterminal or malformed — and one from the wrong attemp
 the existing if-and-only-if rule: **`not-satisfied` exactly when at least one GATING finding stands.** A
 verdict that blocks a PR must name what blocks it, and a finding that blocks a PR cannot be waved through.
 
-**NOTHING ABOUT A `RESIDUAL-RISK:` LINE CAN MAKE A PASS `unusable` — not its absence, not its shape, not
-its count, not where it sits.** The line is calibration metadata for the final report and never a gate
+**NOTHING ABOUT A `RESIDUAL-RISK:` LINE STANDING BEFORE THE VERDICT CAN MAKE A PASS `unusable` — not its
+absence, not its shape, not its count, not where above the verdict it sits.** The line is calibration
+metadata for the final report and never a gate
 input, so `verify` READS it and does not judge it: it is carried as the reviewer wrote it, minus only an
 invisible prefix and trailing whitespace, and two of them are carried as TWO SEPARATE RECORDS — never
 merged into one, and never with a separator the tool supplied. `verify` prints each record after its own
@@ -814,6 +815,13 @@ still ASKS for `RESIDUAL-RISK: <area> — <why>` standing last before the verdic
 keeps the line readable — it is a request, not a gate, and a reviewer who misses it has not spoiled its
 pass. On a NOT SATISFIED or DEFERRED result the line is DROPPED, not refused: the final report records
 the least-certain area of each ACCEPTING pass, so on any other result there is nothing to carry.
+
+**The one exception is a line written AFTER the terminal verdict, and it is the VERDICT rule refusing it,
+not this one.** A `RESIDUAL-RISK:` line below the `VERDICT:` line is trailing text like any other, so the
+unchanged terminal rule — one result, on the **last nonblank line** — refuses that report as nonterminal
+and the pass is `unusable`. Nothing is special-cased for this line there, in either direction: it buys no
+exemption from the verdict rule, and it triggers no refusal a postscript of ordinary prose would not.
+Above the verdict, the paragraph above holds without qualification.
 
 **The reason that is a rule and not laxity:** a formatting check on this line can only ever lose
 evidence. It answers no question the gate asks, so refusing over it spends a whole review — a complete
@@ -845,7 +853,7 @@ pass is a trapdoor, not a disclosure:
 | `ok` | 0 | the artifacts are sound: one strict result from the active attempt's report; a `pass_identity` naming **this** PR, **this** pass, **this** launch attempt, **the live head SHA**, and a bound **`default_non_goals` still equal to the run's live defaults**; a **usable intent block** for this PR; every planned unit `done` **once**, with concrete evidence, after a `started` for it; every `done` for a unit that is **actually in the plan**; no unruled amendment; and the parsed result **coheres** with the findings | tally the parsed binary result through `ledger.py verdict` |
 | `incomplete` | 1 | sound, but a planned unit has no `done` — the pass has not covered its plan | it is still working (or it stopped early — the meaningful-progress rule decides which). **Never tally a verdict from it** |
 | `amended` | 1 | sound, but the reviewer raised a `plan_amendment_request` nobody has ruled on | fold it into the plan and restart the pass, or ignore it with a note — then re-run with `--amendments-ruled N` |
-| `unusable` | 1 | the artifacts are **defective** — the active report is missing, empty, truncated, duplicate, nonterminal, or malformed **in its VERDICT** (its `RESIDUAL-RISK:` line never makes a report defective, however it is written); a short SHA or other malformed identifier; invalid progress/identity/findings; **no usable intent block**; a bound `default_non_goals` that no longer matches the run's live defaults (scope drift); a parsed result that does not cohere with findings; or a spurious DEFERRED result | the pass **CANNOT count**. Fix skipped adoption inputs when named; otherwise retry — the same pass, next launch attempt (`runtime-adapter.md`, "Review preparation mapping") — or take the fresh-worker fallback |
+| `unusable` | 1 | the artifacts are **defective** — the active report is missing, empty, truncated, duplicate, nonterminal, or malformed **in its VERDICT** (a `RESIDUAL-RISK:` line standing BEFORE the verdict never makes a report defective, however it is written; one written AFTER it is trailing text and lands in `nonterminal` above); a short SHA or other malformed identifier; invalid progress/identity/findings; **no usable intent block**; a bound `default_non_goals` that no longer matches the run's live defaults (scope drift); a parsed result that does not cohere with findings; or a spurious DEFERRED result | the pass **CANNOT count**. Fix skipped adoption inputs when named; otherwise retry — the same pass, next launch attempt (`runtime-adapter.md`, "Review preparation mapping") — or take the fresh-worker fallback |
 
 **`ok` is not SATISFIED.** The tool parses the reviewer's exact terminal result but does not judge the
 report's prose, raise `reviews_ok`, or merge. `ledger.py verdict` remains the only tally writer.
@@ -975,9 +983,10 @@ structurally; the sweep finds a defect now, regardless of the plan.)
 certainty, relative to the rest. It is calibration metadata, never a finding and never a verdict
 input: a SATISFIED with a residual-risk line is a **full** SATISFIED, and the line NEVER withholds the
 gate, NEVER enters the fix loop, and is NEVER fed into the corroborating review (which stays
-context-isolated). Because it is not a gate input, **no way of writing it — including not writing it —
-can cost the pass its verdict**; "Does this pass COUNT?" above owns that rule and what `verify` records
-instead. It reflects the gauntlet's purpose —
+context-isolated). Because it is not a gate input, **no way of writing it ABOVE the verdict — including
+not writing it — can cost the pass its verdict**; written BELOW the verdict it is trailing text and the
+unchanged terminal-verdict rule refuses the report as nonterminal. "Does this pass COUNT?" above owns
+that rule, that one exception, and what `verify` records instead. It reflects the gauntlet's purpose —
 lower the odds a defect survives stochastic variation, not claim certainty — by making residual
 uncertainty explicit instead of hidden behind a binary verdict. Record it with the verdict and carry
 **every record each accepting pass wrote** into the final report, grouped by PR (a pass that wrote none

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -979,8 +979,8 @@ def t_bundle_exempts_every_prior_cap_round(tmp: Path) -> None:
 
     # The repair landed, the row returned to review, two more rounds ran, and round 3 is the SECOND cap.
     head = case["head_sha"]
-    # A clean intermediate round: SATISFIED coheres with 0 gating findings, and #126's `parse_report`
-    # accepts an optional RESIDUAL-RISK line last before the verdict. No audit is owed (0 gating).
+    # A clean intermediate round: SATISFIED coheres with 0 gating findings, and `parse_report` carries the
+    # optional RESIDUAL-RISK line without judging it. No audit is owed (0 gating).
     write_review_attempt(case["rundir"], 2, 1, head,
                          "round 2\n\nRESIDUAL-RISK: feature.txt — the clean re-review after the repair "
                          "landed\nVERDICT: SATISFIED\n")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -2227,43 +2227,51 @@ def _write_ledger(path: Path, defaults: "list[str] | str") -> Path:
     return path
 
 
-def check_residual_salvage(R: types.ModuleType, tmp: Path) -> int:
+def check_residual_salvage(R: types.ModuleType, T: Tables, tmp: Path) -> int:
     """What each report CONTRIBUTES to the residual-risk record — the half `REPORT_CASES` cannot see.
 
     Those cases pin that no shape of this line costs a verdict; a verdict is all `evaluate` returns, so
     they cannot say what was KEPT. Salvage that keeps nothing would satisfy every one of them while
     quietly emptying the final report's calibration section, which is the only consumer the line has.
 
-    The rule pinned here is one sentence: the line is carried AS WRITTEN, minus the prefix and trailing
-    whitespace a reader cannot see. Not repaired, not split into fields, not chosen between — every one
-    of those would be this tool putting words in a reviewer's mouth.
+    The rule pinned here is one sentence: every such line is carried AS WRITTEN, as its OWN record, minus
+    the prefix and trailing whitespace a reader cannot see. Not repaired, not split into fields, not
+    chosen between, and not joined to the next one — every one of those would be this tool putting words
+    in a reviewer's mouth, and the join did exactly that with the ` | ` it spliced between two records.
+
+    The last case leaves the fixtures and drives the real `verify` CLI, because the record is only ever
+    consumed through what that command PRINTS: the final report reproduces each record as `verify` reports
+    it, so a list kept faithfully in memory and re-joined on the way to stdout would be the same defect
+    one layer down.
     """
     # U+FEFF, spelled rather than typed: a fixture whose point is an INVISIBLE prefix must not depend on
     # an invisible byte surviving every editor that touches this file.
     bom = chr(0xFEFF)
-    # report text -> the record it must produce (`None` = this report contributes nothing).
-    cases: "dict[str, tuple[str, str | None]]" = {
+    # report text -> the records it must produce (`[]` = this report contributes nothing).
+    cases: "dict[str, tuple[str, list[str]]]" = {
         "canonical": ("Body.\nRESIDUAL-RISK: parser — hard\nVERDICT: SATISFIED\n",
-                      "RESIDUAL-RISK: parser — hard"),
+                      ["RESIDUAL-RISK: parser — hard"]),
         "wrong-separator": ("Body.\nRESIDUAL-RISK: parser contract - hard\nVERDICT: SATISFIED\n",
-                            "RESIDUAL-RISK: parser contract - hard"),
+                            ["RESIDUAL-RISK: parser contract - hard"]),
         "no-separator": ("Body.\nRESIDUAL-RISK: the whole diff read once\nVERDICT: SATISFIED\n",
-                         "RESIDUAL-RISK: the whole diff read once"),
+                         ["RESIDUAL-RISK: the whole diff read once"]),
         "invisible-prefix-and-trailing-space": (
             "Body.\n" + bom + "  RESIDUAL-RISK: parser — hard  \nVERDICT: SATISFIED\n",
-            "RESIDUAL-RISK: parser — hard"),
+            ["RESIDUAL-RISK: parser — hard"]),
         "midstream": ("RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",
-                      "RESIDUAL-RISK: parser — hard"),
+                      ["RESIDUAL-RISK: parser — hard"]),
+        # TWO LINES ARE TWO RECORDS. The joined form put a ` | ` the reviewer never typed inside the text
+        # the final report attributes to it; two elements carry both remarks with nothing added between.
         "two-lines": ("RESIDUAL-RISK: first — hard\nRESIDUAL-RISK: second — harder\n"
                       "VERDICT: SATISFIED\n",
-                      "RESIDUAL-RISK: first — hard | RESIDUAL-RISK: second — harder"),
-        "none-written": ("Body.\nVERDICT: SATISFIED\n", None),
+                      ["RESIDUAL-RISK: first — hard", "RESIDUAL-RISK: second — harder"]),
+        "none-written": ("Body.\nVERDICT: SATISFIED\n", []),
         # SATISFIED-only: the final report records the least-certain area of each ACCEPTING pass, so on a
         # blocking result there is no consumer and the line is dropped — dropped, never refused.
-        "not-satisfied": ("RESIDUAL-RISK: parser — hard\nVERDICT: NOT SATISFIED\n", None),
+        "not-satisfied": ("RESIDUAL-RISK: parser — hard\nVERDICT: NOT SATISFIED\n", []),
         # A VISIBLE prefix is the reviewer QUOTING the instruction, not obeying it (`visible_start`).
         "quoted-bullet": ("- RESIDUAL-RISK: <area> — <why> is asked of a SATISFIED report\n"
-                          "VERDICT: SATISFIED\n", None),
+                          "VERDICT: SATISFIED\n", []),
     }
     failures = 0
     for name, (text, want) in cases.items():
@@ -2274,7 +2282,43 @@ def check_residual_salvage(R: types.ModuleType, tmp: Path) -> int:
             failures += 1
         else:
             print(f"ok       [residual] {name:36} -> {got!r}")
+    failures += check_residual_rendering(R, T, tmp)
     return failures
+
+
+def check_residual_rendering(R: types.ModuleType, T: Tables, tmp: Path) -> int:
+    """What `verify` PRINTS for a pass that wrote two residual-risk lines — the human-facing end of the
+    record, and the only form the final report ever copies.
+
+    A complete pass (`T.PLAN` + `T.WORKED`) is required: `verify` prints the detail line only for a report
+    it could parse, so a bare fixture would exercise nothing here. What this pins is that both records
+    reach stdout whole, that the line stays ONE line (the detail is a field of a single printed line), and
+    that no ` | ` — the delimiter the old join spliced in — appears anywhere in the output.
+    """
+    first, second = "RESIDUAL-RISK: first — hard", "RESIDUAL-RISK: second — harder"
+    path = build(tmp, "residual-render", T.PLAN, T.WORKED,
+                 report=f"Body.\n{first}\n{second}\nVERDICT: SATISFIED\n")
+    ledger = _write_ledger(path.parent / "state.jsonl", [])
+    code, text = run_cli(R, ["verify", "--file", str(path), "--head-sha", SHA,
+                             "--ledger", str(ledger)])
+    problems = []
+    if code != 0:
+        problems.append(f"verify exited {code}, so it never reached the detail line: {text.strip()!r}")
+    detail = [line for line in text.splitlines() if "report-verdict=" in line]
+    if len(detail) != 1:
+        problems.append(f"expected exactly one detail line, got {len(detail)}: {text.strip()!r}")
+    else:
+        line = detail[0]
+        for record in (first, second):
+            if record not in line:
+                problems.append(f"the detail line dropped {record!r}: {line!r}")
+        if " | " in text:
+            problems.append(f"the output splices a delimiter no reviewer wrote: {line!r}")
+    for problem in problems:
+        print(f"FAIL     [residual] two-records-rendered: {problem}")
+    if not problems:
+        print(f"ok       [residual] {'two-records-rendered':36} -> {detail[0].strip()!r}")
+    return len(problems)
 
 
 def check_intent_door(R: types.ModuleType, tmp: Path) -> int:
@@ -2675,7 +2719,7 @@ def run(R: types.ModuleType, tmp: Path) -> int:
     print()
     failures += check_docs(R)
     print()
-    failures += check_residual_salvage(R, tmp)
+    failures += check_residual_salvage(R, T, tmp)
     print()
     failures += check_intent_door(R, tmp)
     print()

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -781,14 +781,18 @@ class Tables:
                 "want": OK, "needle": "report verdict satisfied",
                 "why": "the active attempt's result wins while the dead attempt stays inert",
             },
-            # THE CALIBRATION LINE DECIDES NOTHING, SO NOTHING ABOUT IT CAN COST A PASS. The seven cases
-            # below are ONE claim in seven shapes: the line absent, misspelled, invisibly prefixed,
-            # misplaced, doubled, or written under a blocking verdict — and the pass counts every time,
-            # because the gate reads the VERDICT line and this one is metadata for the final report.
+            # THE CALIBRATION LINE DECIDES NOTHING, SO NOTHING ABOUT ONE WRITTEN ABOVE THE VERDICT CAN
+            # COST A PASS. The `OK` cases below are ONE claim in many shapes: the line absent, misspelled,
+            # invisibly prefixed, anywhere above the verdict, doubled, or written under a blocking verdict
+            # — and the pass counts every time, because the gate reads the VERDICT line and this one is
+            # metadata for the final report.
             # Requiring the line at all discarded four complete review passes across two engines;
             # requiring its exact inner form then discarded a SIXTH-round SATISFIED that had found no
-            # gating defect. What each of these reports CONTRIBUTES to the record is
-            # `check_residual_salvage`'s to pin; these pin only that none of them costs a verdict.
+            # gating defect. `residual-after-verdict` is the BOUNDARY of that claim and the reason it is
+            # stated as "above the verdict": below it, the line is trailing text and the untouched
+            # terminal-verdict rule refuses the report, exactly as `trailing-text` above shows it doing
+            # for ordinary prose. What each of these reports CONTRIBUTES to the record is
+            # `check_residual_salvage`'s to pin; these pin only what each one costs the verdict.
             "satisfied-without-residual-risk": {
                 "report": "Report body.\nVERDICT: SATISFIED\n", "want": OK,
                 "needle": "report verdict satisfied",
@@ -832,7 +836,18 @@ class Tables:
             "misplaced-residual-risk": {
                 "report": "RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",
                 "want": OK, "needle": "report verdict satisfied",
-                "why": "where the reviewer put the line is not a question the gate asks",
+                "why": "where above the verdict the reviewer put the line is not a question the gate asks",
+            },
+            # THE BOUNDARY of the claim its neighbours make, and the reason that claim says ABOVE the
+            # verdict. Nothing here is a rule about this line: the report is refused because SOMETHING
+            # follows the verdict, and `trailing-text` above pins the same refusal for ordinary prose. The
+            # two cases must keep agreeing — if this one ever returns OK while `trailing-text` does not,
+            # the token has been special-cased into an exemption from the terminal rule.
+            "residual-after-verdict": {
+                "report": "Report body.\nVERDICT: SATISFIED\nRESIDUAL-RISK: parser — hard\n",
+                "want": UNUSABLE, "needle": "not the last nonblank line",
+                "why": "a calibration line below the verdict is trailing text, so the terminal result is "
+                       "nonterminal",
             },
             # Real reviewers on two engines separated the two with a blank line.
             "blank-line-above-verdict-residual-risk": {
@@ -2230,7 +2245,8 @@ def _write_ledger(path: Path, defaults: "list[str] | str") -> Path:
 def check_residual_salvage(R: types.ModuleType, T: Tables, tmp: Path) -> int:
     """What each report CONTRIBUTES to the residual-risk record — the half `REPORT_CASES` cannot see.
 
-    Those cases pin that no shape of this line costs a verdict; a verdict is all `evaluate` returns, so
+    Those cases pin what each shape of this line costs the verdict — nothing, wherever it stands above
+    the verdict, and the pass itself when it stands below one; a verdict is all `evaluate` returns, so
     they cannot say what was KEPT. Salvage that keeps nothing would satisfy every one of them while
     quietly emptying the final report's calibration section, which is the only consumer the line has.
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -2255,10 +2255,10 @@ def check_residual_salvage(R: types.ModuleType, T: Tables, tmp: Path) -> int:
     chosen between, and not joined to the next one — every one of those would be this tool putting words
     in a reviewer's mouth, and the join did exactly that with the ` | ` it spliced between two records.
 
-    The last case leaves the fixtures and drives the real `verify` CLI, because the record is only ever
-    consumed through what that command PRINTS: the final report reproduces each record as `verify` reports
-    it, so a list kept faithfully in memory and re-joined on the way to stdout would be the same defect
-    one layer down.
+    Then `check_residual_rendering` leaves the fixtures and drives the real `verify` CLI, because the
+    record is only ever consumed through what that command PRINTS: the final report reproduces each record
+    as `verify` reports it, so a list kept faithfully in memory and flattened on the way to stdout would
+    be the same defect one layer down.
     """
     # U+FEFF, spelled rather than typed: a fixture whose point is an INVISIBLE prefix must not depend on
     # an invisible byte surviving every editor that touches this file.
@@ -2302,38 +2302,103 @@ def check_residual_salvage(R: types.ModuleType, T: Tables, tmp: Path) -> int:
     return failures
 
 
+def recover_residual(R: types.ModuleType, line: str) -> "list[str]":
+    """The recovery `bailout-and-final-report.md` hands a driver, EXECUTED rather than described.
+
+    Find the field the tool names (`RESIDUAL_RISK_FIELD`, never a spelling retyped here), JSON-decode the
+    array that begins there, and stop where the array
+    ends — `raw_decode` returns at the closing `]`, so the human-readable reason printed after it is never
+    read as record text. The doc's procedure and this function must stay the same procedure: a doc that
+    says one thing while the suite proves another is how a driver ends up quoting a reviewer wrongly with
+    a green suite behind it.
+    """
+    marker = f"{R.RESIDUAL_RISK_FIELD}="
+    at = line.index(marker) + len(marker)
+    records, _ = json.JSONDecoder().raw_decode(line, at)
+    return records
+
+
 def check_residual_rendering(R: types.ModuleType, T: Tables, tmp: Path) -> int:
-    """What `verify` PRINTS for a pass that wrote two residual-risk lines — the human-facing end of the
-    record, and the only form the final report ever copies.
+    """What `verify` PRINTS — the only form the final report ever copies, and therefore the only form in
+    which the record boundary can survive at all.
 
     A complete pass (`T.PLAN` + `T.WORKED`) is required: `verify` prints the detail line only for a report
-    it could parse, so a bare fixture would exercise nothing here. What this pins is that both records
-    reach stdout whole, that the line stays ONE line (the detail is a field of a single printed line), and
-    that no ` | ` — the delimiter the old join spliced in — appears anywhere in the output.
+    it could parse, so a bare fixture would exercise nothing here.
+
+    **THE PROPERTY IS LOSSLESSNESS, NOT PRESENCE.** "Both records appear in the line" is satisfied by a
+    rendering that has already destroyed the boundary between them, which is exactly how the joined form
+    passed: `first-vs-one-record` below is TWO reports whose record lists differ (one element against
+    two), and under any separator-joined rendering their detail lines are BYTE-IDENTICAL. So every case
+    decodes the printed field back (`recover_residual`) and requires it to equal what `parse_report`
+    returned for that same report, and the pair is additionally required to print DIFFERENTLY.
+
+    `punctuated` carries `]`, `"`, `\\` and the old `; ` inside ONE record: a rendering that survives a
+    tidy record and loses one holding its own delimiter is a rendering that fails on precisely the
+    reviewer whose words most need carrying.
+
+    Each case also pins that stdout stays ONE line, since the detail is a field of a single printed line.
     """
-    first, second = "RESIDUAL-RISK: first — hard", "RESIDUAL-RISK: second — harder"
-    path = build(tmp, "residual-render", T.PLAN, T.WORKED,
-                 report=f"Body.\n{first}\n{second}\nVERDICT: SATISFIED\n")
-    ledger = _write_ledger(path.parent / "state.jsonl", [])
-    code, text = run_cli(R, ["verify", "--file", str(path), "--head-sha", SHA,
-                             "--ledger", str(ledger)])
-    problems = []
-    if code != 0:
-        problems.append(f"verify exited {code}, so it never reached the detail line: {text.strip()!r}")
-    detail = [line for line in text.splitlines() if "report-verdict=" in line]
-    if len(detail) != 1:
-        problems.append(f"expected exactly one detail line, got {len(detail)}: {text.strip()!r}")
+    reports = {
+        # THE DEFECT'S OWN REPRODUCTION, both halves. One reviewer wrote a single remark that happens to
+        # contain the separator; the other wrote two remarks. `parse_report` tells them apart; before this
+        # rendering, `verify` printed the same bytes for both.
+        "one-record": "Body.\nRESIDUAL-RISK: first — hard; RESIDUAL-RISK: second — harder\n"
+                      "VERDICT: SATISFIED\n",
+        "two-records": "Body.\nRESIDUAL-RISK: first — hard\nRESIDUAL-RISK: second — harder\n"
+                       "VERDICT: SATISFIED\n",
+        "punctuated": 'Body.\nRESIDUAL-RISK: parser["x"] — holds ], a quote, a \\ and a ; too\n'
+                      "VERDICT: SATISFIED\n",
+        # The field is printed even when the reviewer wrote nothing, so a reader never has to tell "no
+        # records" apart from "the field is somewhere else".
+        "none-written": "Body.\nVERDICT: SATISFIED\n",
+    }
+    problems: "list[str]" = []
+    printed: "dict[str, str]" = {}
+    for name, text in reports.items():
+        path = build(tmp, f"residual-render-{name}", T.PLAN, T.WORKED, report=text)
+        ledger = _write_ledger(path.parent / "state.jsonl", [])
+        code, out = run_cli(R, ["verify", "--file", str(path), "--head-sha", SHA,
+                                "--ledger", str(ledger)])
+        if code != 0:
+            problems.append(f"{name}: verify exited {code}, so it never reached the detail line: "
+                            f"{out.strip()!r}")
+            continue
+        lines = out.splitlines()
+        if len(lines) != 1:
+            problems.append(f"{name}: verify printed {len(lines)} lines, not one: {out!r}")
+            continue
+        printed[name] = lines[0]
+        want = R.parse_report(path)["residual_risk"]
+        try:
+            got = recover_residual(R, lines[0])
+        except (ValueError, json.JSONDecodeError) as exc:
+            problems.append(f"{name}: the printed field does not decode ({exc}): {lines[0]!r}")
+            continue
+        if got != want:
+            problems.append(f"{name}: the line decodes to {got!r}, but the pass recorded {want!r}: "
+                            f"{lines[0]!r}")
+        elif " | " in out:
+            problems.append(f"{name}: the output splices a delimiter no reviewer wrote: {lines[0]!r}")
+        else:
+            print(f"ok       [residual] {'rendered ' + name:36} -> {lines[0].strip()!r}")
+    if printed.get("one-record") is not None and printed["one-record"] == printed.get("two-records"):
+        problems.append("one record and two records print the SAME line, so the boundary between the "
+                        f"reviewer's remarks cannot be recovered: {printed['one-record']!r}")
+    elif "one-record" in printed and "two-records" in printed:
+        print(f"ok       [residual] {'one record != two records':36} -> the detail lines differ")
+    # THE FIELD NAME IS ONE FACT IN TWO PLACES — the tool that prints it and the reference that tells a
+    # driver to look for it — so the link is made MECHANICAL rather than left to a sweep. Rename
+    # `RESIDUAL_RISK_FIELD` without touching that reference and a driver hunts a field that is no longer
+    # printed; nothing above this line would notice, because every case here asks the tool what it calls
+    # the field.
+    doc = OWNER.parent.parent / "references" / "bailout-and-final-report.md"
+    if f"{R.RESIDUAL_RISK_FIELD}=" in doc.read_text(encoding="utf-8"):
+        print(f"ok       [residual] {'final report names the field':36} -> {doc.name}")
     else:
-        line = detail[0]
-        for record in (first, second):
-            if record not in line:
-                problems.append(f"the detail line dropped {record!r}: {line!r}")
-        if " | " in text:
-            problems.append(f"the output splices a delimiter no reviewer wrote: {line!r}")
+        problems.append(f"{doc.name} no longer names the `{R.RESIDUAL_RISK_FIELD}=` field `verify` "
+                        f"prints, so its recovery procedure points at nothing")
     for problem in problems:
-        print(f"FAIL     [residual] two-records-rendered: {problem}")
-    if not problems:
-        print(f"ok       [residual] {'two-records-rendered':36} -> {detail[0].strip()!r}")
+        print(f"FAIL     [residual] {problem}")
     return len(problems)
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -723,7 +723,7 @@ class Tables:
         self.REPORT_CASES: "dict[str, dict]" = {
             "valid-satisfied": {
                 "report": SAT_REPORT, "want": OK, "needle": "report verdict satisfied",
-                "why": "the parser derives SATISFIED and the residual risk last before the verdict",
+                "why": "the parser derives SATISFIED and carries the line the reviewer wrote with it",
             },
             "valid-not-satisfied": {
                 "report": NOT_SAT_REPORT, "findings": [finding()], "want": OK,
@@ -781,9 +781,14 @@ class Tables:
                 "want": OK, "needle": "report verdict satisfied",
                 "why": "the active attempt's result wins while the dead attempt stays inert",
             },
-            # The calibration line is OPTIONAL. It never was a gate input, so its absence never made a
-            # verdict less usable — but requiring it discarded four complete review passes across two
-            # engines. A SATISFIED report without one counts.
+            # THE CALIBRATION LINE DECIDES NOTHING, SO NOTHING ABOUT IT CAN COST A PASS. The seven cases
+            # below are ONE claim in seven shapes: the line absent, misspelled, invisibly prefixed,
+            # misplaced, doubled, or written under a blocking verdict — and the pass counts every time,
+            # because the gate reads the VERDICT line and this one is metadata for the final report.
+            # Requiring the line at all discarded four complete review passes across two engines;
+            # requiring its exact inner form then discarded a SIXTH-round SATISFIED that had found no
+            # gating defect. What each of these reports CONTRIBUTES to the record is
+            # `check_residual_salvage`'s to pin; these pin only that none of them costs a verdict.
             "satisfied-without-residual-risk": {
                 "report": "Report body.\nVERDICT: SATISFIED\n", "want": OK,
                 "needle": "report verdict satisfied",
@@ -791,22 +796,20 @@ class Tables:
             },
             "malformed-residual-risk": {
                 "report": "RESIDUAL-RISK: parser contract - wrong separator\nVERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "residual risk must be exactly",
-                "why": "the residual-risk fields and em dash have one exact shape",
+                "want": OK, "needle": "report verdict satisfied",
+                "why": "a separator the prompt did not ask for does not unmake a complete review",
             },
-            # The line being OPTIONAL is exactly what makes these three load-bearing: a detector that only
-            # sees column 0 reads an INVISIBLY PREFIXED line as ABSENT, so a malformed line is silently
-            # accepted instead of refused. Present-but-malformed and never-written must stay
-            # distinguishable. `visible_start` in review-pass.py owns which prefixes count as invisible;
-            # these three sample one prefix per branch of its rule: whitespace a reader sees as blank space
-            # (`isspace`), a format character that renders nothing (`not isprintable`), and a
-            # Default_Ignorable code point that is printable and non-space, which only the named Unicode
-            # property reaches. A VISIBLE prefix (`- `, `> `, a spacing combining mark) is NOT in this set:
-            # such a line does not present as the exact token, so it is read as absent by contract.
+            # `visible_start` in review-pass.py owns which prefixes count as invisible; these three sample
+            # one prefix per branch of its rule: whitespace a reader sees as blank space (`isspace`), a
+            # format character that renders nothing (`not isprintable`), and a Default_Ignorable code
+            # point that is printable and non-space, which only the named Unicode property reaches. What
+            # they pin is the DETECTOR, whose job is to CARRY such a line into the record rather than lose
+            # it. A VISIBLE prefix (`- `, `> `, a spacing combining mark) stays outside that set: a line a
+            # reader sees as quoted or bulleted is one the reviewer is talking ABOUT, not writing.
             "indented-residual-risk": {
                 "report": "Report body.\n  RESIDUAL-RISK: parser — hard\nVERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "residual risk must be exactly",
-                "why": "an indented line is present and malformed, not absent",
+                "want": OK, "needle": "report verdict satisfied",
+                "why": "an indented line is the reviewer's line, indented",
             },
             # U+FEFF is Cf, so `str.lstrip()` never removes it. Placed MID-FILE deliberately: reading the
             # report as `utf-8-sig` would not reach this line, so the case pins the DETECTOR, not a
@@ -814,8 +817,8 @@ class Tables:
             "bom-prefixed-residual-risk": {
                 "report": "Report body.\n\ufeffRESIDUAL-RISK: parser contract - wrong separator\n"
                           "VERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "residual risk must be exactly",
-                "why": "an invisible prefix hides a malformed line from the detector, not from the report",
+                "want": OK, "needle": "report verdict satisfied",
+                "why": "an invisible prefix is invisible to the reader and must not hide the line",
             },
             # U+034F COMBINING GRAPHEME JOINER is Mn, so it is BOTH printable and non-space: neither
             # `isspace()` nor `not isprintable()` reaches it, only Default_Ignorable_Code_Point does. Its
@@ -823,31 +826,31 @@ class Tables:
             "default-ignorable-prefixed-residual-risk": {
                 "report": "Report body.\n\u034fRESIDUAL-RISK: parser contract - wrong separator\n"
                           "VERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "residual risk must be exactly",
+                "want": OK, "needle": "report verdict satisfied",
                 "why": "a code point that renders as nothing is a prefix the reader cannot see",
             },
             "misplaced-residual-risk": {
                 "report": "RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "last nonblank line",
-                "why": "prose between the line and the verdict detaches the signal from the verdict",
+                "want": OK, "needle": "report verdict satisfied",
+                "why": "where the reviewer put the line is not a question the gate asks",
             },
-            # Real reviewers on two engines separated the two with a blank line. Nothing of substance
-            # intervenes, so the line still belongs to this verdict and the pass counts.
+            # Real reviewers on two engines separated the two with a blank line.
             "blank-line-above-verdict-residual-risk": {
                 "report": "Report body.\nRESIDUAL-RISK: parser — hard\n\nVERDICT: SATISFIED\n",
                 "want": OK, "needle": "report verdict satisfied",
-                "why": "blank lines between the residual risk and the verdict do not detach it",
+                "why": "blank lines between the residual risk and the verdict change nothing",
             },
             "duplicate-residual-risk": {
                 "report": "RESIDUAL-RISK: first — hard\nRESIDUAL-RISK: second — hard\n"
                           "VERDICT: SATISFIED\n",
-                "want": UNUSABLE, "needle": "at most one `RESIDUAL-RISK:`",
-                "why": "one accepting pass contributes at most one residual-risk record",
+                "want": OK, "needle": "report verdict satisfied",
+                "why": "two calibration lines are two remarks, not two verdicts to choose between",
             },
             "residual-on-not-satisfied": {
                 "report": "RESIDUAL-RISK: parser — hard\nVERDICT: NOT SATISFIED\n",
-                "want": UNUSABLE, "needle": "SATISFIED-only",
-                "why": "residual risk is forbidden on a blocking result",
+                "findings": [finding()], "want": OK, "needle": "report verdict not-satisfied",
+                "why": "a blocking verdict stands on its gating finding; the stray line is dropped, "
+                       "not fatal",
             },
             "deferred-without-reason": {
                 "report": "VERDICT: DEFERRED\n", "want": UNUSABLE,
@@ -2224,6 +2227,56 @@ def _write_ledger(path: Path, defaults: "list[str] | str") -> Path:
     return path
 
 
+def check_residual_salvage(R: types.ModuleType, tmp: Path) -> int:
+    """What each report CONTRIBUTES to the residual-risk record — the half `REPORT_CASES` cannot see.
+
+    Those cases pin that no shape of this line costs a verdict; a verdict is all `evaluate` returns, so
+    they cannot say what was KEPT. Salvage that keeps nothing would satisfy every one of them while
+    quietly emptying the final report's calibration section, which is the only consumer the line has.
+
+    The rule pinned here is one sentence: the line is carried AS WRITTEN, minus the prefix and trailing
+    whitespace a reader cannot see. Not repaired, not split into fields, not chosen between — every one
+    of those would be this tool putting words in a reviewer's mouth.
+    """
+    # U+FEFF, spelled rather than typed: a fixture whose point is an INVISIBLE prefix must not depend on
+    # an invisible byte surviving every editor that touches this file.
+    bom = chr(0xFEFF)
+    # report text -> the record it must produce (`None` = this report contributes nothing).
+    cases: "dict[str, tuple[str, str | None]]" = {
+        "canonical": ("Body.\nRESIDUAL-RISK: parser — hard\nVERDICT: SATISFIED\n",
+                      "RESIDUAL-RISK: parser — hard"),
+        "wrong-separator": ("Body.\nRESIDUAL-RISK: parser contract - hard\nVERDICT: SATISFIED\n",
+                            "RESIDUAL-RISK: parser contract - hard"),
+        "no-separator": ("Body.\nRESIDUAL-RISK: the whole diff read once\nVERDICT: SATISFIED\n",
+                         "RESIDUAL-RISK: the whole diff read once"),
+        "invisible-prefix-and-trailing-space": (
+            "Body.\n" + bom + "  RESIDUAL-RISK: parser — hard  \nVERDICT: SATISFIED\n",
+            "RESIDUAL-RISK: parser — hard"),
+        "midstream": ("RESIDUAL-RISK: parser — hard\nand then more prose\nVERDICT: SATISFIED\n",
+                      "RESIDUAL-RISK: parser — hard"),
+        "two-lines": ("RESIDUAL-RISK: first — hard\nRESIDUAL-RISK: second — harder\n"
+                      "VERDICT: SATISFIED\n",
+                      "RESIDUAL-RISK: first — hard | RESIDUAL-RISK: second — harder"),
+        "none-written": ("Body.\nVERDICT: SATISFIED\n", None),
+        # SATISFIED-only: the final report records the least-certain area of each ACCEPTING pass, so on a
+        # blocking result there is no consumer and the line is dropped — dropped, never refused.
+        "not-satisfied": ("RESIDUAL-RISK: parser — hard\nVERDICT: NOT SATISFIED\n", None),
+        # A VISIBLE prefix is the reviewer QUOTING the instruction, not obeying it (`visible_start`).
+        "quoted-bullet": ("- RESIDUAL-RISK: <area> — <why> is asked of a SATISFIED report\n"
+                          "VERDICT: SATISFIED\n", None),
+    }
+    failures = 0
+    for name, (text, want) in cases.items():
+        path = build(tmp, f"residual-{name}", None, [], report=text)
+        got = R.parse_report(path)["residual_risk"]
+        if got != want:
+            print(f"FAIL     [residual] {name}: recorded {got!r}, expected {want!r}")
+            failures += 1
+        else:
+            print(f"ok       [residual] {name:36} -> {got!r}")
+    return failures
+
+
 def check_intent_door(R: types.ModuleType, tmp: Path) -> int:
     """Drive intent-check through its real CLI: structural refusals, AND the run-default sync enforcement.
 
@@ -2621,6 +2674,8 @@ def run(R: types.ModuleType, tmp: Path) -> int:
     failures += check_boundaries(R, T)
     print()
     failures += check_docs(R)
+    print()
+    failures += check_residual_salvage(R, tmp)
     print()
     failures += check_intent_door(R, tmp)
     print()

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1455,10 +1455,52 @@ def salvage_residual(lines: "list[str]") -> "list[str]":
     joined form was the same invention by another route: it returned `first | second` for two lines, and
     the ` | ` in the middle was text no reviewer typed, carried into the final report attributed to that
     reviewer. A list has no delimiter to invent, so nothing the reviewer wrote is dropped and nothing it
-    did not write is added. Each record is a single line, because that is what the caller prints them on.
+    did not write is added. Keeping that property through PRINTING is a separate job, and
+    `render_residual` owns it: a boundary this function preserves and the printer then loses is a boundary
+    the final report never had.
     """
     return [line[visible_start(line):].rstrip() for line in lines
             if line.startswith(RESIDUAL_RISK_TOKEN, visible_start(line))]
+
+
+# The field name the `verify` detail line prints the records under. Named once, beside the encoder that
+# owns the format, because a reader is told to FIND this field before it decodes anything.
+RESIDUAL_RISK_FIELD = "residual-risk"
+
+
+def render_residual(records: "list[str]") -> str:
+    """`salvage_residual`'s list as ONE printable field — JSON, so the LIST survives being printed.
+
+    **The record boundary has to be recoverable from the printed line ALONE**, because the printed line is
+    the only form anything downstream ever sees: the final report reproduces each record as `verify`
+    reports it (`bailout-and-final-report.md`), and no consumer re-reads the report file. So a rendering
+    that cannot be decoded back to the list this function was handed is a rendering that invents or
+    destroys a reviewer's records one layer below `salvage_residual`, which exists to do neither.
+
+    **JOINING THE RECORDS WITH A SEPARATOR CANNOT DO THAT, AND NO CHOICE OF SEPARATOR CAN.** Whatever
+    string stands between two records is a string a reviewer may also have typed INSIDE one, and then the
+    two cases print the same bytes: one reviewer writing a single record that contains the separator and
+    another writing two records rendered identically under `; `, so a reader splitting on that separator
+    turns one remark into two — with the reviewer's name on the result. Escaping the separator inside the
+    records is the same problem again, one level down, and is just JSON with fewer readers.
+
+    **JSON answers all three requirements at once.** It is LOSSLESS — `json.loads` of this field is `==`
+    the list handed in. It is SELF-DELIMITING — the array ends at its own `]`, so the human-readable
+    reason printed after it can never be read as part of a record, and a record containing `; `, `]`, or a
+    quote needs no cooperation from the reader. And it stays ONE LINE: `parse_report` splits the report
+    with `str.splitlines()`, which ends a line at EVERY character that could begin a new one (LF, CR,
+    U+001C–U+001E, U+0085, U+2028, U+2029 among them), so no record can contain one; `json.dumps` escapes
+    the C0 controls, `"` and `\\` that remain.
+
+    `ensure_ascii=False` is deliberate: this field is printed for a human as well as decoded by a driver,
+    and the records are the reviewer's own words. Escaping every em dash and every non-Latin character
+    would be equally lossless and unreadable. Nothing it leaves unescaped can end the line or the array,
+    per the paragraph above.
+
+    An empty list renders `[]` rather than vanishing, so the field is present on EVERY parsed report and a
+    reader never has to tell "this pass wrote no records" apart from "the field is somewhere else".
+    """
+    return json.dumps(records, ensure_ascii=False)
 
 
 class ReportResult(TypedDict):
@@ -2600,15 +2642,13 @@ def cmd_verify(args) -> int:
     verdict, reason, report = evaluate_detail(path, args.head_sha, args.amendments_ruled, ledger)
     detail = ""
     if report is not None:
-        detail = f" report-verdict={report['verdict']}"
-        # EVERY record the reviewer wrote, each after this line's own `; ` — the same separator that
-        # already stands between the verdict field and the first record, and the tool's framing rather
-        # than anything spliced INTO a record. Each record still begins with the `RESIDUAL-RISK:` token
-        # the reviewer typed, so a reader (and the final report, which reproduces each record as this
-        # line reports it) can tell where one ends and the next begins without this tool inventing a
-        # delimiter of its own. The detail stays ONE line: every record is a single rstripped line.
-        for record in report["residual_risk"]:
-            detail += f"; {record}"
+        # EVERY record the reviewer wrote, in ONE self-delimiting JSON field (`render_residual`, which
+        # owns the format and the reasons for it). The final report reproduces each record as this line
+        # reports it, so what it prints has to be decodable back to the list `parse_report` returned —
+        # `json.loads` of the field is exactly that list, however a reviewer punctuated its own text. The
+        # field is always present, `[]` included, and the detail stays ONE line.
+        detail = (f" report-verdict={report['verdict']} "
+                  f"{RESIDUAL_RISK_FIELD}={render_residual(report['residual_risk'])}")
     print(f"{verdict}:{detail} {reason}")
     # `ok` is the ONLY exit-0 verdict — and it still is NOT `SATISFIED`.
     return 0 if verdict == OK else 1

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1536,6 +1536,15 @@ def parse_report(progress: Path) -> ReportResult:
     # records the least-certain area of each ACCEPTING pass, `bailout-and-final-report.md`). On any other
     # result the line is dropped rather than refused: dropping metadata nobody consumes costs nothing,
     # while refusing costs the whole review.
+    #
+    # **The `[]` on a blocking verdict is a SCOPE, not a loss, and both halves of that are checkable here.**
+    # Nothing consumes such a record: `residual_risk` is read at exactly one site in this tree — the
+    # `verify` detail line below — and the one document that carries records onward takes them from a
+    # merged PR's ACCEPTING passes (`bailout-and-final-report.md`), so a record from a NOT SATISFIED or
+    # DEFERRED pass has no reader to lose it. And nothing regressed: on the base this same input raised a
+    # SATISFIED-only `Defect` and destroyed the whole pass, so dropping the line keeps strictly more of the
+    # reviewer's work, not less. To falsify either half, name a second reader of `residual_risk`, or show
+    # the base preserving that record.
     residual = salvage_residual(lines) if verdict == SATISFIED else []
 
     return {

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1488,6 +1488,14 @@ def parse_report(progress: Path) -> ReportResult:
     """
     path = report_path(progress)
     text = read_text(path, "active review report")
+    # `splitlines()` — the SAME line reader every other artifact in this file uses, and deliberately so.
+    # It ends a line at more than LF (U+001C, U+0085, U+2028 and the rest), so a record holding one of
+    # those loses its tail. That is NOT a residual-risk rule and NOT this change's to alter: the SAME
+    # split decides which line the terminal `VERDICT:` is, so a scan that ended lines only at LF would
+    # splice the verdict into a preceding record — a report reading `RESIDUAL-RISK: x<U+001C>VERDICT:
+    # SATISFIED` would file the gate's own answer as calibration text. The base voids the entire pass on
+    # those same bytes, so nothing here lost a record the base kept. To falsify: show a line reader this
+    # file uses that splits differently, or a base run preserving that tail.
     lines = text.splitlines()
     nonblank = [n for n, line in enumerate(lines) if line.strip()]
     if not nonblank:

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -552,19 +552,25 @@ PLAN_NAME_RE = re.compile(rf"^review-{COUNT}-{COUNT}\.plan\.jsonl\Z")
 PROGRESS_SUFFIX, FINDINGS_SUFFIX, REPORT_SUFFIX = ".progress.jsonl", ".findings.jsonl", ".txt"
 FINDINGS_NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-{COUNT}(?:\.a{ATTEMPT})?\.findings\.jsonl\Z")
 
-# The strict terminal report contract. The prompt owns these exact lines; `parse_report` is their executable
-# reader. A deferred result includes a reason because it is a request the orchestrator must route. A
-# SATISFIED result MAY carry a residual-risk line, which is carried into the campaign's final report. That
-# line is calibration metadata, never a gate input, so its ABSENCE has never made a verdict less usable —
-# yet requiring it discarded four complete, substantive review passes across two engines. It is optional
-# now; when present it must still be well-formed and stand last before the verdict, and it stays forbidden
-# on every non-SATISFIED result.
+# The strict terminal report contract — and what it is strict about is THE VERDICT. The prompt owns these
+# exact lines; `parse_report` is their executable reader. A deferred result includes a reason because it is
+# a request the orchestrator must route.
+#
+# **THE RESIDUAL-RISK LINE IS NOT PART OF THAT CONTRACT: NOTHING ABOUT IT CAN MAKE A PASS UNUSABLE.** It is
+# calibration metadata carried into the campaign's final report — never a gate input — so its inner shape,
+# its count, and its placement decide no question this tool answers, and `parse_report` SALVAGES whatever
+# the reviewer wrote (`salvage_residual`) instead of judging it. The rule reached that form the expensive
+# way, twice: REQUIRING the line discarded four complete, substantive review passes across two engines, and
+# requiring its exact inner form then discarded a sixth-round SATISFIED whose only defect was a hyphen
+# where an em dash was asked for. A formatting rule that decides nothing but can void a substantive review
+# only ever destroys evidence, and the evidence it destroys is the whole point of running the review.
+# `review-prompt.txt` still ASKS for the exact form — that request is what keeps the line readable, and it
+# is not a gate. Every rule that DOES gate — one terminal result, on the last nonblank line, in exactly one
+# of three spellings — is unchanged and stays exact: the verdict is the input the gate reads.
 REPORT_SATISFIED = "VERDICT: SATISFIED"
 REPORT_NOT_SATISFIED = "VERDICT: NOT SATISFIED"
 REPORT_DEFERRED_RE = re.compile(r"^VERDICT: DEFERRED — (?P<reason>\S(?:.*\S)?)\Z")
-RESIDUAL_RISK_RE = re.compile(
-    r"^RESIDUAL-RISK: (?P<area>\S(?:.*\S)?) — (?P<why>\S(?:.*\S)?)\Z"
-)
+RESIDUAL_RISK_TOKEN = "RESIDUAL-RISK:"
 
 # The INTENT — what this PR is FOR. One per PR, written at adoption (`pr-adoption.md`), re-read every heartbeat
 # and never re-derived: a heartbeat is a fresh agent instance, and an intent held only in context is one that
@@ -1387,6 +1393,12 @@ def _default_ignorable(ch: str) -> bool:
 def visible_start(line: str) -> int:
     """Index of the first character of `line` a READER CAN SEE — where a token may legitimately begin.
 
+    It serves ONE caller: finding the reviewer's `RESIDUAL-RISK:` line so `salvage_residual` can carry it
+    into the final report. Nothing it finds can refuse a pass, so the cost of the two ways it can be wrong
+    is no longer symmetric. Missing a line costs a calibration record. Finding one that is not there
+    puts SOMEBODY ELSE'S text into this pass's record, which is a false report — that is the harm the
+    boundary below is drawn against.
+
     Two KINDS of test, and together they are COMPLETE for that meaning. The CATEGORY tests carry the
     open-ended part, so a character nobody has thought of yet is not a new hole: `str.isspace()` covers
     Zs/Zl/Zp and the ASCII whitespace controls, and `not str.isprintable()` covers the rest of Cc plus all
@@ -1402,16 +1414,16 @@ def visible_start(line: str) -> int:
 
     THE BOUNDARY IS "INVISIBLE", AND IT MUST NOT MOVE OUTWARD — a claim about this code, checkable here.
     A VISIBLE prefix (a markdown bullet or quote marker, bold markers, a spacing combining mark such as
-    U+0301, a lowercase spelling) is read as ABSENT on purpose: such a line does not present as the exact
-    token, and the exact form is `RESIDUAL_RISK_RE`'s to own. The wider rule that would close that whole
-    prefix class — skip every leading non-alphanumeric — was trialled, and it REFUSES VALID REPORTS. A
-    reviewer's SATISFIED report that quotes the intent bullet forbidding a residual-risk line on a
-    NOT SATISFIED or DEFERRED result (a bullet handed verbatim to every reviewer in the review prompt, so
-    quoting it is ordinary) is refused EVEN WHEN that report also carries a well-formed residual-risk line
-    of its own: the wider rule skips the quoted bullet's leading punctuation, counts the quotation as a
-    second occurrence, and the at-most-one check in `parse_report` fires. To falsify this, swap the loop
-    condition below for `not line[i].isalnum()` and count the detections in such a report — two, not one.
-    Destroying complete passes is the exact harm this parser exists to prevent.
+    U+0301) is read as ABSENT on purpose: a line a reader sees as quoted or bulleted is a line the
+    reviewer is TALKING ABOUT, not the line it is WRITING. The wider rule that would close that whole
+    prefix class — skip every leading non-alphanumeric — was trialled, and it reads a reviewer's PROSE as
+    its calibration record. A SATISFIED report that quotes the intent bullet forbidding a residual-risk
+    line on a NOT SATISFIED or DEFERRED result (a bullet handed verbatim to every reviewer in the review
+    prompt, so quoting it is ordinary) has that quotation counted as an occurrence EVEN WHEN the report
+    also carries a residual-risk line of its own: the wider rule skips the quoted bullet's leading
+    punctuation, and the prompt's own instruction ends up filed as what this pass found hardest to verify.
+    To falsify this, swap the loop condition below for `not line[i].isalnum()` and count the detections in
+    such a report — two, not one.
     """
     i = 0
     while i < len(line) and (
@@ -1421,13 +1433,35 @@ def visible_start(line: str) -> int:
     return i
 
 
+def salvage_residual(lines: "list[str]") -> "str | None":
+    """The reviewer's calibration text, TAKEN AS WRITTEN — or `None` when it wrote none.
+
+    **This function cannot fail, and that is its entire job.** It reads a line no gate question depends
+    on, so there is no defect for it to report: a line whose fields the prompt's form would reject still
+    says, in the reviewer's own words, which part of the diff it was least sure about, and a human reading
+    the final report gets that whether or not the separator was the one asked for. Refusing it instead
+    threw away the SIXTH pass of a review — a complete SATISFIED with no gating defects — over a hyphen.
+
+    So it neither refuses nor repairs. It strips the invisible prefix (`visible_start`) and trailing
+    whitespace, and otherwise records the line VERBATIM: rewriting a separator, splitting the text into
+    the fields the prompt asks for, or picking one of several lines as the "real" one would each be this
+    tool inventing a reviewer's words. Several lines are joined, in the order written, so nothing the
+    reviewer wrote is dropped and nothing it did not write is added. The result is one line, because that
+    is what the caller prints.
+    """
+    found = [line[visible_start(line):].rstrip() for line in lines
+             if line.startswith(RESIDUAL_RISK_TOKEN, visible_start(line))]
+    return " | ".join(found) if found else None
+
+
 def parse_report(progress: Path) -> "dict[str, str | None]":
     """Read one exact terminal result from the active attempt's report.
 
     Report prose remains the reviewer's judgment. This parser owns only the framing that makes that
-    judgment usable: one terminal result on the last nonblank line, a reason for DEFERRED, and — for
-    SATISFIED only, and only when the reviewer wrote one — the optional residual-risk line that stands
-    last before the verdict, blank lines between the two tolerated.
+    judgment usable, and that framing is the VERDICT: one terminal result, on the last nonblank line, in
+    exactly one of three spellings, with a reason for DEFERRED. Nothing else in the file can refuse the
+    pass — the residual-risk line is read (`salvage_residual`) and never judged, because no answer this
+    function gives depends on it.
     """
     path = report_path(progress)
     text = read_text(path, "active review report")
@@ -1476,47 +1510,17 @@ def parse_report(progress: Path) -> "dict[str, str | None]":
             "'VERDICT: DEFERRED — <one-line reason>'"
         )
 
-    # DETECT past every INVISIBLE prefix (`visible_start` owns which those are), JUDGE the original.
-    # Detection has to see a line the token does not start at column 0 of — indented, or led by a decoded
-    # byte-order mark or any other character that leaves no mark on screen — because the line is optional
-    # now: a line the detector misses is indistinguishable from one that was never written, so a malformed
-    # `RESIDUAL-RISK:` would be silently read as absent instead of refused. Everything below — the count,
-    # the placement, and `RESIDUAL_RISK_RE` — still reads the ORIGINAL unstripped line, so such a line is
-    # detected and then refused for its shape. This WIDENS refusal; it is not whitespace tolerance.
-    residual_lines = [n for n, line in enumerate(lines)
-                      if line.startswith("RESIDUAL-RISK:", visible_start(line))]
-    residual: "str | None" = None
-    if verdict == SATISFIED:
-        if len(residual_lines) > 1:
-            # MUTATE:report-residual-count:pass
-            raise Defect(
-                f"{path.name}: SATISFIED carries at most one `RESIDUAL-RISK:` line; found "
-                f"{len(residual_lines)}"
-            )
-        if residual_lines:
-            # ATTACHED, not adjacent. When the line IS there it must belong to THIS verdict — nothing of
-            # substance may stand between them. A blank line does not defeat that, and insisting on
-            # adjacency discarded four complete, substantive review passes across two engines.
-            # `nonblank[-2]` is always in range here: the residual line is nonblank and is not the verdict.
-            if residual_lines[0] != nonblank[-2]:
-                # MUTATE:report-residual-position:pass
-                raise Defect(
-                    f"{path.name}: a SATISFIED report's `RESIDUAL-RISK:` line must be the last nonblank "
-                    f"line before the verdict; only blank lines may separate the two"
-                )
-            residual = lines[residual_lines[0]]
-            if RESIDUAL_RISK_RE.match(residual) is None:
-                # MUTATE:report-residual-shape:pass
-                raise Defect(
-                    f"{path.name}: residual risk must be exactly "
-                    "'RESIDUAL-RISK: <area or file> — <why this was hardest to verify fully>'"
-                )
-    elif residual_lines:
-        # MUTATE:report-residual-binary-only:pass
-        raise Defect(
-            f"{path.name}: `RESIDUAL-RISK:` is SATISFIED-only and must not accompany "
-            f"{result_line!r}"
-        )
+    # The verdict is settled ABOVE, from the terminal line alone. What follows cannot reach it: this is a
+    # READ of the calibration line, and there is deliberately no branch here that raises. A pass whose
+    # reviewer wrote the line crookedly, wrote it twice, wrote it in the middle of its prose, or wrote it
+    # under a blocking verdict is a pass that answered the gate's question — the answer is on the verdict
+    # line, and the gate reads nothing else from this file.
+    #
+    # It is still SATISFIED-only, because that is the only result the line is carried for (the final report
+    # records the least-certain area of each ACCEPTING pass, `bailout-and-final-report.md`). On any other
+    # result the line is dropped rather than refused: dropping metadata nobody consumes costs nothing,
+    # while refusing costs the whole review.
+    residual = salvage_residual(lines) if verdict == SATISFIED else None
 
     return {
         "verdict": verdict,

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -117,7 +117,7 @@ from collections import Counter
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import NamedTuple, NoReturn
+from typing import NamedTuple, NoReturn, TypedDict
 
 from _gauntlet.clock import TS_FORMAT
 from _gauntlet.modules import load_module_from_path
@@ -1433,8 +1433,8 @@ def visible_start(line: str) -> int:
     return i
 
 
-def salvage_residual(lines: "list[str]") -> "str | None":
-    """The reviewer's calibration text, TAKEN AS WRITTEN — or `None` when it wrote none.
+def salvage_residual(lines: "list[str]") -> "list[str]":
+    """The reviewer's calibration text, TAKEN AS WRITTEN — one record per line it wrote, empty when none.
 
     **This function cannot fail, and that is its entire job.** It reads a line no gate question depends
     on, so there is no defect for it to report: a line whose fields the prompt's form would reject still
@@ -1445,16 +1445,32 @@ def salvage_residual(lines: "list[str]") -> "str | None":
     So it neither refuses nor repairs. It strips the invisible prefix (`visible_start`) and trailing
     whitespace, and otherwise records the line VERBATIM: rewriting a separator, splitting the text into
     the fields the prompt asks for, or picking one of several lines as the "real" one would each be this
-    tool inventing a reviewer's words. Several lines are joined, in the order written, so nothing the
-    reviewer wrote is dropped and nothing it did not write is added. The result is one line, because that
-    is what the caller prints.
+    tool inventing a reviewer's words.
+
+    **SEVERAL LINES STAY SEVERAL RECORDS, IN THE ORDER WRITTEN — they are never joined into one.** The
+    joined form was the same invention by another route: it returned `first | second` for two lines, and
+    the ` | ` in the middle was text no reviewer typed, carried into the final report attributed to that
+    reviewer. A list has no delimiter to invent, so nothing the reviewer wrote is dropped and nothing it
+    did not write is added. Each record is a single line, because that is what the caller prints them on.
     """
-    found = [line[visible_start(line):].rstrip() for line in lines
-             if line.startswith(RESIDUAL_RISK_TOKEN, visible_start(line))]
-    return " | ".join(found) if found else None
+    return [line[visible_start(line):].rstrip() for line in lines
+            if line.startswith(RESIDUAL_RISK_TOKEN, visible_start(line))]
 
 
-def parse_report(progress: Path) -> "dict[str, str | None]":
+class ReportResult(TypedDict):
+    """What one report YIELDS: the verdict the gate reads, a DEFERRED result's routing reason, and the
+    reviewer's residual-risk records.
+
+    `residual_risk` is a LIST because a report may carry several `RESIDUAL-RISK:` lines and each is its
+    own record (`salvage_residual`) — no element ever holds two of them spliced together. An empty list is
+    the ordinary "wrote none", and it is also what every non-SATISFIED result yields.
+    """
+    verdict: str
+    deferred_reason: "str | None"
+    residual_risk: "list[str]"
+
+
+def parse_report(progress: Path) -> ReportResult:
     """Read one exact terminal result from the active attempt's report.
 
     Report prose remains the reviewer's judgment. This parser owns only the framing that makes that
@@ -1520,7 +1536,7 @@ def parse_report(progress: Path) -> "dict[str, str | None]":
     # records the least-certain area of each ACCEPTING pass, `bailout-and-final-report.md`). On any other
     # result the line is dropped rather than refused: dropping metadata nobody consumes costs nothing,
     # while refusing costs the whole review.
-    residual = salvage_residual(lines) if verdict == SATISFIED else None
+    residual = salvage_residual(lines) if verdict == SATISFIED else []
 
     return {
         "verdict": verdict,
@@ -1995,7 +2011,7 @@ def plan_path(progress: Path) -> Path:
 
 def evaluate_detail(progress: Path, head_sha: str, ruled: int = 0,
                     ledger: "Path | None" = None) -> \
-        "tuple[str, str, dict[str, str | None] | None]":
+        "tuple[str, str, ReportResult | None]":
     """The whole read side. Every exception a rule can raise lands here as a VERDICT — never as a crash.
 
     **THE INTENT IS AN INPUT TO EVERY PASS, AND IT IS LOADED HERE FOR EXACTLY THAT REASON.** A pass is
@@ -2561,8 +2577,14 @@ def cmd_verify(args) -> int:
     detail = ""
     if report is not None:
         detail = f" report-verdict={report['verdict']}"
-        if report["residual_risk"] is not None:
-            detail += f"; {report['residual_risk']}"
+        # EVERY record the reviewer wrote, each after this line's own `; ` — the same separator that
+        # already stands between the verdict field and the first record, and the tool's framing rather
+        # than anything spliced INTO a record. Each record still begins with the `RESIDUAL-RISK:` token
+        # the reviewer typed, so a reader (and the final report, which reproduces each record as this
+        # line reports it) can tell where one ends and the next begins without this tool inventing a
+        # delimiter of its own. The detail stays ONE line: every record is a single rstripped line.
+        for record in report["residual_risk"]:
+            detail += f"; {record}"
     print(f"{verdict}:{detail} {reason}")
     # `ok` is the ONLY exit-0 verdict — and it still is NOT `SATISFIED`.
     return 0 if verdict == OK else 1

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -556,10 +556,14 @@ FINDINGS_NAME_RE = re.compile(rf"^review-(?P<pr>{COUNT})-{COUNT}(?:\.a{ATTEMPT})
 # exact lines; `parse_report` is their executable reader. A deferred result includes a reason because it is
 # a request the orchestrator must route.
 #
-# **THE RESIDUAL-RISK LINE IS NOT PART OF THAT CONTRACT: NOTHING ABOUT IT CAN MAKE A PASS UNUSABLE.** It is
-# calibration metadata carried into the campaign's final report — never a gate input — so its inner shape,
-# its count, and its placement decide no question this tool answers, and `parse_report` SALVAGES whatever
-# the reviewer wrote (`salvage_residual`) instead of judging it. The rule reached that form the expensive
+# **THE RESIDUAL-RISK LINE IS NOT PART OF THAT CONTRACT: NOTHING ABOUT ONE WRITTEN ABOVE THE VERDICT CAN
+# MAKE A PASS UNUSABLE.** It is calibration metadata carried into the campaign's final report — never a
+# gate input — so its inner shape, its count, and where above the verdict it sits decide no question this
+# tool answers, and `parse_report` SALVAGES whatever the reviewer wrote (`salvage_residual`) instead of
+# judging it. The one placement that costs the pass is BELOW the verdict, and the VERDICT contract is what
+# refuses it: such a line is trailing text, so the terminal rule below ("last nonblank line") reports the
+# result as nonterminal exactly as it would for a postscript of prose. No branch here treats this token
+# specially in either direction. The rule reached that form the expensive
 # way, twice: REQUIRING the line discarded four complete, substantive review passes across two engines, and
 # requiring its exact inner form then discarded a sixth-round SATISFIED whose only defect was a hyphen
 # where an em dash was asked for. A formatting rule that decides nothing but can void a substantive review
@@ -1475,9 +1479,12 @@ def parse_report(progress: Path) -> ReportResult:
 
     Report prose remains the reviewer's judgment. This parser owns only the framing that makes that
     judgment usable, and that framing is the VERDICT: one terminal result, on the last nonblank line, in
-    exactly one of three spellings, with a reason for DEFERRED. Nothing else in the file can refuse the
-    pass — the residual-risk line is read (`salvage_residual`) and never judged, because no answer this
-    function gives depends on it.
+    exactly one of three spellings, with a reason for DEFERRED. No CONTENT above that result can refuse
+    the pass — a residual-risk line there is read (`salvage_residual`) and never judged, because no answer
+    this function gives depends on it. Content BELOW the result is a different question and the terminal
+    rule already answers it: anything after the verdict, a residual-risk line included, makes the claimed
+    result nonterminal. That is the trailing-text rule, not a rule about this line, and it is why the
+    prompt asks for the line LAST BEFORE the verdict rather than after it.
     """
     path = report_path(progress)
     text = read_text(path, "active review report")


### PR DESCRIPTION
- A `RESIDUAL-RISK:` line can no longer make a review pass unusable.
- The line is salvaged verbatim; the `VERDICT:` line stays as strict.
- Fixtures pin the salvage; four reference docs updated.
