### PR TITLE
release gauntlet 0.7.0

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- Bumps both gauntlet manifests from 0.6.0 to 0.7.0.
- Minor, not patch: #235 changed the report artifact, its producer, and the reviewer's contract.
- Refreshing the cache mid-run is unsafe; finish in-flight campaigns first.
