### PR TITLE
fix stale review dispatch heads

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -309,9 +309,9 @@ rules keep their own wording; these are illustrations of them, not a second copy
    **Review allocation journal**, then run `allocation-status` and choose the next allocation.
    **After a binary pass verifies `ok`, record `review-dispatch.py result --result reviewed` for its active
    attempt before recording its verdict.** If the allocation's head or dispatch-time scope is stale, this
-   refuses; settle it as `head-invalidated` or `scope-invalidated` before selecting the final retry. The
-   journal preserves the reserved final review across a fresh heartbeat; this completion step never infers
-   a budget from attempt filenames.
+   refuses; settle it as `head-invalidated` or `scope-invalidated` before selecting the due allocation under
+   `runtime-adapter.md`, **Review allocation journal**. The journal preserves the reserved final review
+   across a fresh heartbeat; this completion step never infers a budget from attempt filenames.
    **Then record the verdict with `scripts/ledger.py verdict --pr <N> --head-sha <sha> --verdict …`** — the
    ONLY sanctioned path, and the only thing that bumps `review_rounds` (Stage 2a, "Recording a verdict");
    never set `reviews_ok` by hand. It refuses unless the base-preflight `proceed` above stamped `base_ok_sha`

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -520,7 +520,10 @@ rules keep their own wording; these are illustrations of them, not a second copy
      `proceed` it records `base_ok_sha` for the head, without which `ledger.py verdict` refuses the verdict
      it later records (Stage 2a, "Recording a verdict"). Rebase on `rebase-first`, re-poll on `recheck`, or
      leave the ledger-held candidate alone on `park` per Stage 2a, then restart this precondition sequence.
-     With `proceed`, evaluate the verdict transport through
+     With `proceed`, pass the freshly read ledger-row `head_sha` to `review-dispatch.py prepare`. Its
+     `--file` head assertion refuses before writing an allocation or reviewer artifact if the PR moved;
+     refresh the PR state and restart this precondition sequence instead of spending a stale retry
+     (`review-dispatch.md`, "Prepare the active attempt", owns the assertion). Then evaluate the verdict transport through
      `runtime-adapter.md`'s capability/transition owner before
      building its record and take only the action it returns;
      missing native cwd/mount/sandbox controls alone are not a machine blocker. Then **ensure the pass's

--- a/plugins/gauntlet/skills/campaign/references/review-dispatch.md
+++ b/plugins/gauntlet/skills/campaign/references/review-dispatch.md
@@ -48,7 +48,10 @@ Inputs have these owners:
   neither nested inside the other; the command refuses an identical or either-way-nested pair before staging
   any artifact, so preparation never writes launch files into the candidate worktree. This is a fail-closed
   input check, not an OS boundary.
-- `pr`, `review_pass`, `head_sha`, and `dispatched_at` name this launch attempt.
+- `pr`, `review_pass`, `head_sha`, and `dispatched_at` name this launch attempt. With `--file`,
+  `head_sha` is an assertion against the selected row's live `head_sha`; a mismatch refuses before
+  preparation writes an allocation or reviewer artifact. Refresh the PR state and preconditions, then
+  retry with the live head. The ledger row is the source of truth; `--head-sha` is not a review-head source.
 - `ledger_default_non_goals` is the run header's `default_non_goals` value (its canonical JSON array, `[]`
   when the run declares none), read from `<review_root>/state.jsonl`. `prepare` BINDS it into the
   `pass_identity` as the immutable dispatch-time review scope this pass's verdict is measured against — the

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -1254,6 +1254,7 @@ def t_reviewed_result_refuses_live_head_drift() -> None:
         args.head_sha = "b" * 40
         args.review_action = "launch-external"
         args.prompt_profile = "standard"
+        args.head_sha = "b" * 40
         transport = D.prepare(args)["transport"]
         check(transport["prompt_profile"] == "standard",
               "a final external-Codex launch must use the launch-external standard profile")
@@ -1262,6 +1263,59 @@ def t_reviewed_result_refuses_live_head_drift() -> None:
         identity = D.RP.check_identity(events, args.pr, args.review_pass, args.launch_attempt)
         check(identity["head_sha"] == "b" * 40,
               "a head-invalidated final retry did not bind the current ledger head")
+
+
+def _head_invalidated_final_retry(root: Path) -> tuple[SimpleNamespace, str]:
+    """Prepare a settled stale attempt and return its still-stale final retry inputs."""
+    args = _fixture(
+        root, head_sha="a" * 40, route="external-codex", review_action="launch-external",
+    )
+    live_head = "b" * 40
+    ledger = _build_ledger_scope(Path(args.run_dir), args.pr, "main", "[]", head_sha=args.head_sha)
+    args.file = os.fspath(ledger)
+    D.prepare(args)
+    code, _out, err = capture_cli(D.L.main, [
+        "--file", os.fspath(ledger), "set", "--pr", args.pr, "--head-sha", live_head,
+    ])
+    check(code == 0 and err == "", f"head-drift fixture could not update the ledger: {err!r}")
+    _record_result(args, D.HEAD_INVALIDATED)
+    args.launch_attempt = "2"
+    args.allocation_purpose = "final"
+    args.review_action = "launch-external"
+    args.prompt_profile = "standard"
+    return args, live_head
+
+
+def t_stale_head_final_retry_refuses_before_writing_attempt_artifacts() -> None:
+    """A rebase-invalidated retry must not consume its final allocation on the old head."""
+    with tempfile.TemporaryDirectory() as raw:
+        args, _live_head = _head_invalidated_final_retry(Path(raw))
+        rundir = Path(args.run_dir)
+        paths = D.attempt_paths(rundir, args.pr, args.review_pass, args.launch_attempt)
+        journal = D.allocation_path(rundir, args.pr, args.review_pass)
+        before = journal.read_bytes()
+        _refused(args, "live ledger head")
+        check(not any(paths[name].exists() for name in ("prompt", "progress", "findings", "report")),
+              "a stale final retry wrote attempt-2 reviewer artifacts")
+        check(journal.read_bytes() == before,
+              "a stale final retry recorded an allocation after the ledger-head refusal")
+
+
+def t_live_head_final_retry_records_current_identity() -> None:
+    """The same final retry launches after its supplied head catches up with the ledger."""
+    with tempfile.TemporaryDirectory() as raw:
+        args, live_head = _head_invalidated_final_retry(Path(raw))
+        args.head_sha = live_head
+        D.prepare(args)
+        paths = D.attempt_paths(Path(args.run_dir), args.pr, args.review_pass, args.launch_attempt)
+        events = D.RP.parse_lines(paths["progress"].read_text(encoding="utf-8"), paths["progress"].name)
+        identity = D.RP.check_identity(events, args.pr, args.review_pass, args.launch_attempt)
+        check(identity["head_sha"] == live_head,
+              "the final retry did not bind its pass identity to the live ledger head")
+        _path, _text, _records, allocations, _results = D.load_allocations(
+            Path(args.run_dir), args.pr, args.review_pass)
+        check(allocations["2"]["head_sha"] == live_head,
+              "the final retry allocation did not record the same live head as its identity")
 
 
 def t_binary_review_is_journaled_before_verdict_tally() -> None:
@@ -1578,7 +1632,7 @@ def t_ledger_unresolved_base_refuses() -> None:
             proc = subprocess.run([sys.executable, os.fspath(D.LEDGER), "--file", os.fspath(ledger), *argv],  # noqa: S603
                                   capture_output=True, text=True, check=False)
             check(proc.returncode == 0, f"ledger {' '.join(argv)} failed: {proc.stderr.strip()}")
-        args = _fixture(root, base="v3", file=os.fspath(ledger))
+        args = _fixture(root, base="v3", file=os.fspath(ledger), head_sha="a" * 40)
         _refused(args, "no usable effective base")
 
 
@@ -1672,6 +1726,10 @@ CASES = [
      t_reviewed_result_refuses_scope_drift),
     ("reviewed-refuses-head-drift", "reviewed settles a changed ledger head without consuming the final reserve",
      t_reviewed_result_refuses_live_head_drift),
+    ("stale-final-retry-refused", "a stale final retry writes no reviewer artifacts or allocation",
+     t_stale_head_final_retry_refuses_before_writing_attempt_artifacts),
+    ("live-final-retry-identity", "a final retry binds its identity and allocation to the live ledger head",
+     t_live_head_final_retry_records_current_identity),
     ("binary-result-before-verdict", "verified binary outcomes are journaled before the tally instruction",
      t_binary_review_is_journaled_before_verdict_tally),
     ("killed-session-settlement", "dead attempts settle before resumed recovery allocation",

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch.py
@@ -3,10 +3,10 @@
 
 This command is the executable boundary between campaign policy and host dispatch. The host first chooses
 an available route through ``runtime-adapter.md``. ``prepare`` then validates that route's report owner,
-the complete earlier review history, and the existing plan and intent through ``review-pass.py``. It derives
-every attempt-scoped path from one identity, creates the progress identity and bound prompt, and prints the
-canonical JSON record the host launches. It does not select a route, test route availability, or launch a
-reviewer.
+the complete earlier review history, the existing plan and intent through ``review-pass.py``, and, with a
+ledger, the selected row's live head. It derives every attempt-scoped path from one identity, creates the
+progress identity and bound prompt, and prints the canonical JSON record the host launches. It does not
+select a route, test route availability, or launch a reviewer.
 """
 
 from __future__ import annotations
@@ -952,6 +952,11 @@ def prepare(args) -> dict:
         row = L.find_row(rows, str(args.pr))
         if row is None:
             refuse(f"no ledger row for pr {args.pr} — its base cannot be resolved")
+        if args.head_sha != row["head_sha"]:
+            refuse(
+                f"--head-sha {args.head_sha} disagrees with pr {args.pr}'s live ledger head "
+                f"{row['head_sha']} — --head-sha is an assertion, not a review-head source"
+            )
         effective_base, base_problem = L.require_effective_base(header, row, str(args.pr))
         if base_problem is not None:
             refuse(base_problem)
@@ -1118,7 +1123,8 @@ def build_parser() -> argparse.ArgumentParser:
                          help="typed prompt framing selected by the review preparation mapping")
     command.add_argument("--report-producer", required=True, choices=REPORT_PRODUCERS,
                          help="sole report producer; must match the selected route")
-    command.add_argument("--head-sha", required=True, help="40-character lowercase review head SHA")
+    command.add_argument("--head-sha", required=True, help="40-character lowercase review head SHA; with "
+                                                        "--file it must equal the selected row's live head")
     command.add_argument("--dispatched-at", required=True, help="UTC timestamp YYYY-MM-DDThh:mm:ssZ")
     command.add_argument("--default-non-goals", required=True,
                          help="the run header's `default_non_goals` value (a canonical JSON array, `[]` when "

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -777,6 +777,14 @@ def check_document_contract() -> None:
         "### Record allocation outcomes",
     ):
         require(needle in dispatch, f"review-dispatch.md lost preparation handoff: {needle}")
+    dispatch_flat = " ".join(dispatch.split())
+    loop_control_flat = " ".join(loop_control.split())
+    require("`head_sha` is an assertion against the selected row's live `head_sha`" in dispatch_flat and
+            "mismatch refuses before preparation writes an allocation or reviewer artifact" in dispatch_flat,
+            "review-dispatch.md lost the pre-artifact live-head assertion")
+    require("pass the freshly read ledger-row `head_sha` to `review-dispatch.py prepare`" in loop_control_flat and
+            "`--file` head assertion refuses before writing an allocation or reviewer artifact" in loop_control_flat,
+            "loop-control.md lost the stale-head dispatch recovery")
 
     for needle in (
         "TRANSPORT is this JSON-decoded ReviewTransport record:",


### PR DESCRIPTION
- Refuse `prepare --file` when its supplied head differs from the ledger.
- Keep stale retries from creating allocation or reviewer artifacts.
- Cover rebased retry identity and document the recovery.
