### PR TITLE
release gauntlet 0.7.1

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- Bumps both Gauntlet manifests from 0.7.0 to 0.7.1.
- #237–#239 keep rebase retries from using stale heads or consuming final review capacity.
- Publishes the release after the 0.7.0 tag.
