### PR TITLE
act on a corroborated follow-up

### DIFF
--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -333,14 +333,12 @@ Report **before** Step 7, because Step 7 ends this skill and anything unsaid is 
 entry touched, give its id, its title, and its outcome: reconciled, corroborated, refuted, taken up with
 its PR, or surfaced for a ruling.
 
-**A taken-up entry carries its ACT disclosure in that outcome, never in the question bullet below.** An
+**A taken-up entry carries its ACT disclosure in that outcome, never in the question bullet below** — an
 entry the threshold **routes** is disclosed and dispatched, so it raises **no question** for that bullet
-to hold, and "taken up with its PR" on its own reads exactly like an entry every condition held for. So
-for **every** entry Step 4 took up, name each ACT condition that did **not** hold, with the evidence
-`take-up` recorded for it and in the threshold's own terms — a behavior change is named with the
-behavior that changes and the test that pins it. Say so explicitly when none failed: those are different
-outcomes and this report is the only place they are told apart. Which conditions route and which one
-waits remains `followups.md`'s, as Step 4 says.
+to hold, and "taken up with its PR" on its own reads exactly like an entry every condition held for. What
+that disclosure must say is `followups.md`, "Surfacing them" — stated once there, for every report that
+names such an entry. Report it from there for **every** entry Step 4 took up; do not reconstruct it from
+this step.
 
 Then:
 

--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -336,9 +336,9 @@ its PR, or surfaced for a ruling.
 **A taken-up entry carries its ACT disclosure in that outcome, never in the question bullet below** — an
 entry the threshold **routes** is disclosed and dispatched, so it raises **no question** for that bullet
 to hold, and "taken up with its PR" on its own reads exactly like an entry every condition held for. What
-that disclosure must say is `followups.md`, "Surfacing them" — stated once there, for every report that
-names such an entry. Report it from there for **every** entry Step 4 took up; do not reconstruct it from
-this step.
+that disclosure must say is `followups.md`, "Surfacing them" — stated once there, for this step and
+campaign's final report, the only two reporting steps that owe it. Report it from there for **every** entry
+Step 4 took up; do not reconstruct it from this step.
 
 Then:
 

--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -331,7 +331,18 @@ rejection strands the rest.
 
 Report **before** Step 7, because Step 7 ends this skill and anything unsaid is lost with it. For every
 entry touched, give its id, its title, and its outcome: reconciled, corroborated, refuted, taken up with
-its PR, or surfaced for a ruling. Then:
+its PR, or surfaced for a ruling.
+
+**A taken-up entry carries its ACT disclosure in that outcome, never in the question bullet below.** An
+entry the threshold **routes** is disclosed and dispatched, so it raises **no question** for that bullet
+to hold, and "taken up with its PR" on its own reads exactly like an entry every condition held for. So
+for **every** entry Step 4 took up, name each ACT condition that did **not** hold, with the evidence
+`take-up` recorded for it and in the threshold's own terms — a behavior change is named with the
+behavior that changes and the test that pins it. Say so explicitly when none failed: those are different
+outcomes and this report is the only place they are told apart. Which conditions route and which one
+waits remains `followups.md`'s, as Step 4 says.
+
+Then:
 
 - list every entry left unworked and why (`--limit`, an unresumable state, a dispatch that failed, a
   command that refused and which one, a PR another run owns);

--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -258,12 +258,17 @@ that was never real (`AGENTS.md`/`CLAUDE.md`, "Your OWN diagnosis is a claim too
 **Only a `corroborated` entry reaches this step.** The other states arriving at Step 5 already carry a
 decision, and re-deciding one would overwrite a ruling that was already made.
 
-`followups.md`, "THE AUTONOMY THRESHOLD", owns the conditions and `followups.py take-up` enforces them,
-refusing the step when any is asserted without evidence. **Read them there and evidence each one.**
+`followups.md`, "THE AUTONOMY THRESHOLD", owns the conditions and what each one does; `followups.py
+take-up` refuses the step when any is asserted without evidence. **Read them there and evidence each
+one.** This file does not restate which conditions route and which one waits.
 
-- Every condition holds and is evidenced → `take-up`, then Step 5.
-- Any condition fails, **or you are unsure whether it holds** → surface the entry to the user with its
-  question and move to the next entry. That is the normal outcome, not a failure state.
+**A corroborated entry is worked, not surfaced instead of worked.** The default outcome of this step is
+`take-up` followed by Step 5, and the report says what the fixer is doing. The one class the threshold
+holds back waits for the user's ruling and is named in Step 6 with its question.
+
+- The threshold permits acting → `take-up`, then Step 5.
+- The threshold holds this entry back → record the question for Step 6 and move to the next entry. Do
+  not leave it silently undone, and do not re-decide it on a later invocation without new evidence.
 - **NEVER run `accept`.** It is the user's edge and the only way into `accepted`.
 - **NEVER run `publish`.** There is no autonomous path to it, from any state.
 

--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -3,9 +3,9 @@ name: address-followups
 description: >-
   Works Gauntlet's durable follow-up queue end to end instead of only listing it. Each open entry is
   resumed at the step its lifecycle state has already reached: a fresh read-only subagent must reproduce
-  or refute a still-unverified claim, only a corroborated entry meeting every autonomy-threshold condition
-  is taken up, a separate scoped subagent then authors the fix and opens ONE PR for that follow-up, and the PRs
-  opened this invocation are handed to gauntlet:campaign to gate and merge. Use when the user asks to
+  or refute a still-unverified claim, only a corroborated entry is taken up, a separate scoped subagent
+  then authors the fix and opens ONE PR for that follow-up, and the PRs opened this invocation are
+  handed to gauntlet:campaign to gate and merge. Use when the user asks to
   work, drive, clear, action, or process follow-ups. To only SEE the queue, use gauntlet:followups.
   Args (distinct modes): (no args) | --id fuN | --limit N
 ---

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -411,6 +411,6 @@ Read stage refs only when that stage/action is due:
 - Public API changes require user confirmation unless the ledger's `api_changes` field is `allowed`
   (`references/scope-and-constraints.md`).
 - **What the driver may do with a follow-up WITHOUT ASKING is the THREE-TIER AUTONOMY THRESHOLD**,
-  owned by `references/followups.md` — investigate freely, ACT only on a corroborated claim that meets
-  every one of its conditions, and **NEVER PUBLISH** without the USER's agreement on that specific
-  item. Read the threshold before touching one; do not reconstruct it from here.
+  owned by `references/followups.md` — investigate freely, ACT only on a corroborated claim, and
+  **NEVER PUBLISH** without the USER's agreement on that specific item. Read the threshold before
+  touching one; do not reconstruct it from here.

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -204,6 +204,10 @@ When the loop exits, summarize:
   that list**: no issue, no release, without the user's agreement on that specific item. A defect a bailout
   exposed and this run will not fix is recorded in the store **before** the report is written, not
   announced only in it — a follow-up that exists only in this report dies with it.
+  **The table is not the whole of this bullet: every entry this run TOOK UP also owes its ACT disclosure
+  here**, and it is owed in this bullet rather than under the ASK above, because an entry the threshold
+  **routes** is disclosed and dispatched and raises no question to ask. What that disclosure must say is
+  `followups.md`, "Surfacing them" — report it from there; do not reconstruct it from this bullet.
 - Any worktrees left for inspection.
 
 This run's durable carryover file (`.gauntlet/history/<run-id>.md`) is written on exit by

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -201,7 +201,12 @@ When the loop exits, summarize:
   (`followups.md`): the work this run FOUND and deliberately did not do. A `candidate` is a claim the user
   has not agreed to and the driver has not investigated — so **surface it and ASK**. What the run may do
   with one instead of asking is the **autonomy threshold** (`followups.md`), and **PUBLISHING is never on
-  that list**: no issue, no release, without the user's agreement on that specific item. A defect a bailout
+  that list**: no issue, no release, without the user's agreement on that specific item. **That ASK cannot
+  hold up a Tier-1 investigation, and the claim is checkable at the sites it names**: this bullet is
+  written under "When the loop exits, summarize" above, so the loop has already exited and there is no
+  pending investigation for it to gate; and it routes what the run may DO with a candidate away from
+  itself, to the threshold whose owner says the first move on a fresh candidate is to INVESTIGATE it and
+  that surfacing is never a substitute for that (`followups.md`, "Surfacing them"). A defect a bailout
   exposed and this run will not fix is recorded in the store **before** the report is written, not
   announced only in it — a follow-up that exists only in this report dies with it.
   **The table is not the whole of this bullet: every entry this run TOOK UP also owes its ACT disclosure

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -49,8 +49,8 @@
 - NEVER PUBLISH a follow-up — open a GitHub issue, cut a release — without the USER's agreement on that
   SPECIFIC item. An issue is a PUBLISHED claim, and a follow-up is the **driver's own** uncorroborated
   claim: filing one launders an unvalidated self-diagnosis into a public statement of fact. What the driver
-  MAY do on its own (investigate freely; ACT on a corroborated claim that meets every condition) is the
-  **three-tier autonomy threshold**, owned by `followups.md` — read it there, never reconstruct it here.
+  MAY do on its own (investigate freely; ACT on a corroborated claim) is the **three-tier autonomy
+  threshold**, owned by `followups.md` — read it there, never reconstruct it here.
   Recording a follow-up **NEVER** discharges a finding — a CONFIRMED finding is still fixed ("I'll file a
   follow-up instead" is refuting by deferral).
 - NEVER pass destructive instructions (delete, force-push, reset) to an external reviewer command

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -32,7 +32,7 @@
   adopted PRs — PR update, labels/checks/comments, and merge. Campaign ADOPTS existing PRs; it does not
   invent work. It opens a PR of its own in exactly ONE case: a **follow-up it has TAKEN UP** under the
   autonomy threshold (`followups.md`) — which requires a corroborated claim and every ACT condition
-  evidenced, and whose PR is then gated by the review gauntlet like any other. Otherwise PR creation lives
+  recorded, and whose PR is then gated by the review gauntlet like any other. Otherwise PR creation lives
   only in the `gauntlet:review` handoff. Ask for public API changes, active-run takeover, uncertain
   carryover pruning, or out-of-scope/destructive work.
 - NEVER commit the run's own bookkeeping — **the whole `.gauntlet/**` tree**, run scratch and every

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -47,26 +47,37 @@ audit. The user can overturn it (`accept`), and so can a **later, better investi
 again): the finding **APPENDS**, so the record of the driver changing its mind survives, and nobody has to
 take the latest verdict on trust.
 
-### Tier 2 — ACT (write a fix, open a PR). ALL FOUR conditions, or ASK.
+### Tier 2 — ACT (write a fix, open a PR). A CORROBORATED entry IS ACTED ON.
 
-The driver may take a follow-up up for work with no user ruling — **only** when **every one** of these
-holds. They are not a checklist to feel good about; each is **EVIDENCED IN THE ENTRY**, and
-`followups.py take-up` **REFUSES the step** if any is asserted without evidence.
+**Corroboration is the whole precondition. Once an investigation has reproduced a claim, the driver takes
+it up and dispatches a fixer — it does not need a further ruling to begin.** `take-up` leaves **only**
+from `corroborated`, so a claim nobody investigated still cannot be taken up at all, and the
+investigation's own `finding` is what earns the step.
 
-1. **`corroborated`** — an independent reviewer confirmed it, **or** the driver reproduced the failure.
-   This one is structural: `take-up` leaves **only** from the `corroborated` state, so a claim nobody
-   investigated cannot be taken up at all, and the investigation's own `finding` is its evidence.
-2. **`not-gate-machinery`** (`--act-not-gate`) — it does not decide whether a PR may merge. The active
+**A corroborated follow-up is NEVER left undone because a condition below is unclear.** Recording one and
+walking away is the permanent loss this store exists to prevent, arriving by a slower route: the entry
+sits corroborated forever, every later run re-reads it, and the defect it names stays in the tree. The
+driver may **CONFIRM** with the user, and for the classes below it **must**. It may not use uncertainty as
+a reason to act on nothing.
+
+The three conditions below are still **RECORDED**, and `take-up` refuses the step if any is asserted
+without evidence. What changed is what a failing one does: it **routes** the entry and **raises a
+question**, rather than cancelling the work.
+
+1. **`not-gate-machinery`** (`--act-not-gate`) — does it decide whether a PR may merge? The active
    repository instruction file (`AGENTS.md` or `CLAUDE.md`) defines the gate; do not reconstruct that
-   definition here. **WHEN IT IS UNCLEAR, IT IS GATE
-   MACHINERY** — the ambiguous case resolves toward **ask**, never toward act.
-3. **`behavior-preserved`** (`--act-behavior`) — it preserves user-facing behavior. If it **has** a
-   behavioral surface, **name the test that proves it**. If it has **none**, say so and name why — *an
-   assertion of no-behavioral-surface is itself a claim*, and it is recorded like any other. (A docs-only
-   change has no behavioral surface. That is a legitimate answer, not a loophole — but it must be
-   **stated**, because it is the thing that could be wrong.)
-4. **`reversible`** (`--act-reversible`) — a revert restores the prior state. A schema migration is not
-   reversible. Anything already published is not.
+   definition here. **When it does, or when that is unclear, the fixer is still dispatched — and the
+   entry is named to the user in the same report, as a change to the machinery that judges changes.**
+   The PR waits for nothing, because the gauntlet judges it either way; what the user gets is notice, not
+   a veto.
+2. **`behavior-preserved`** (`--act-behavior`) — does it change user-facing behavior? Record what the
+   change does either way. A fix that deliberately changes behavior is the ordinary case, not a
+   disqualification: **name the behavior that changes and the test that pins it**. If it has **none**,
+   say so and name why — *an assertion of no-behavioral-surface is itself a claim*. (A docs-only change
+   has no behavioral surface. That is a legitimate answer, not a loophole.)
+3. **`reversible`** (`--act-reversible`) — does a revert restore the prior state? A schema migration does
+   not. Anything already published does not. **An irreversible change is the one class that WAITS**: the
+   fixer is not dispatched until the user rules, because no gate downstream can undo it.
 
 ```
 followups.py --file <store> take-up --id fuN \
@@ -76,10 +87,12 @@ followups.py --file <store> take-up --id fuN \
 It lands in **`self-accepted`** — deliberately **NOT** `accepted`. A follow-up the **user** agreed to and
 one the **driver** took up on its own are different things, forever, and the table says which at a glance.
 **The PR that comes out of an ACT is not self-approved**: it is gated by the review gauntlet like any
-other, which is the independent authority the driver is not.
+other, which is the independent authority the driver is not. **That gate is what makes acting on a
+corroborated claim safe** — a wrong fix costs its own review rounds and never reaches `main` unjudged.
 
-If any condition fails — or you are unsure whether it holds — **the follow-up is a candidate you surface
-and ASK about.** That is not a failure state. It is the normal one.
+**So exactly one condition still stops the work before it starts, and it is `reversible`.** Everything
+else is disclosed and dispatched. A driver that surfaces a corroborated entry instead of working it has
+not been careful; it has left a reproduced defect in the tree and called that caution.
 
 ### Tier 3 — PUBLISH (a GitHub issue, a release). ALWAYS the user's call. Never autonomous.
 
@@ -239,12 +252,12 @@ about and one whose partial rejection strands the rest.
    authority. When that PR **merges**, run `followups.py merged --id fuN`: the merged PR is the durable
    record now, so the entry is deleted (`closed-unmerged` if the PR dies instead — back to open work).
 
-5. **ANY TIER-2 CONDITION FAILS OR IS UNCLEAR → SURFACE AND ASK.** If the fix would touch gate machinery,
-   **change user-facing behavior at all** (Tier-2 condition 3 requires it **preserved** — a named test is
-   evidence the behavior is unchanged, never licence to change it), be irreversible — or you are simply
-   unsure — it is **not** the driver's to take up. Surface it in the report and let the user rule (`accept` / `reject`). That is
-   the normal case, not a failure. And **publishing is never on the autonomous path**: an issue or a
-   release always waits for the user's agreement on that specific item (Tier 3).
+5. **A CONDITION THAT FAILS ROUTES THE WORK — it does not cancel it.** Read the threshold above for what
+   each one does; the shape is that gate machinery and a behavior change are **DISCLOSED and dispatched**,
+   while an **irreversible** change is the one class that WAITS for the user's ruling
+   (`accept` / `reject`) before a fixer runs. Surfacing an entry is how the user learns what the driver is
+   doing, never a way to leave a reproduced defect undone. And **publishing is never on the autonomous
+   path**: an issue or a release always waits for the user's agreement on that specific item (Tier 3).
 
 **The two subagents are the load-bearing part.** The investigation reproduces before anything is changed,
 and the fix authors code that the gauntlet judges — never the same worker doing both, and never the driver
@@ -496,7 +509,8 @@ Surfacing an entry to the user *is* how consensus gets reached, and it must neve
 report and fold any answer in as its own heartbeat. **A `candidate` is a question, not a task**: the driver has
 not investigated it yet, so it has nothing to act on and nothing to say. The FIRST move on a fresh
 candidate is to INVESTIGATE it — the active loop above, when there is spare capacity — because that is
-how the question gets answered. Surfacing it to the user is the THRESHOLD fallback (when the driver
-cannot act autonomously or a user ruling is required), never a substitute for investigating it.
+how the question gets answered. Surfacing it to the user is never a substitute for investigating it, and
+**a CORROBORATED entry is not surfaced INSTEAD of being worked** — the threshold above dispatches a fixer
+for it and reports what that fixer is doing, holding back only the one class it names.
 
 ---

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -50,9 +50,10 @@ take the latest verdict on trust.
 ### Tier 2 — ACT (write a fix, open a PR). A CORROBORATED entry IS ACTED ON.
 
 **Corroboration is the whole precondition. Once an investigation has reproduced a claim, the driver takes
-it up and dispatches a fixer — it does not need a further ruling to begin.** `take-up` leaves **only**
-from `corroborated`, so a claim nobody investigated still cannot be taken up at all, and the
-investigation's own `finding` is what earns the step.
+it up and dispatches a fixer — it does not need a further ruling to begin, unless the change is
+irreversible (condition 3 below).** `take-up` leaves **only** from `corroborated`, so a claim nobody
+investigated still cannot be taken up at all, and the investigation's own `finding` is what earns the
+step.
 
 **A corroborated follow-up is NEVER left undone because a condition below is unclear.** Recording one and
 walking away is the permanent loss this store exists to prevent, arriving by a slower route: the entry
@@ -93,15 +94,6 @@ corroborated claim safe** — a wrong fix costs its own review rounds and never 
 **So exactly one condition still stops the work before it starts, and it is `reversible`.** Everything
 else is disclosed and dispatched. A driver that surfaces a corroborated entry instead of working it has
 not been careful; it has left a reproduced defect in the tree and called that caution.
-
-**Checked claim about how this tier reads, not about the tool: its opening paragraph never directs an
-irreversible entry to a fixer without the user's ruling.** The whole tier was read for that conflict. The
-exception is announced twice **before** condition 3 states it — "for the classes below it **must**", and
-"it **routes** the entry and **raises a question**" — and the sentence directly above is what reconciles
-the two, not a second half of a contradiction. The mechanism cannot occur either: `self-accepted` is
-reachable only through the `take-up` command above, whose `--act-reversible` value condition 3 alone
-defines. Falsify this by producing a reading path from the opening paragraph to a dispatched fixer that
-never passes condition 3.
 
 ### Tier 3 — PUBLISH (a GitHub issue, a release). ALWAYS the user's call. Never autonomous.
 

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -220,11 +220,13 @@ about and one whose partial rejection strands the rest.
    investigation) can overturn it. The driver then moves on. **Refuting is not declining** — refute only on
    evidence the claim is false, never because a fix is inconvenient.
 
-3. **APPLICABLE → `take-up`, then a FIX SUBAGENT that opens a PR.** If the investigation `corroborated` it
-   **and every ACT condition is recorded with evidence** — `take-up` refuses the step without that, and the
-   threshold above owns what a failing one does — the driver takes it up (→ `self-accepted`)
+3. **APPLICABLE → `take-up`, then a FIX SUBAGENT that opens a PR.** If the investigation `corroborated` it,
+   **every ACT condition is recorded with evidence** — `take-up` refuses the step without that — **and the
+   threshold above does not hold the entry back**, the driver takes it up (→ `self-accepted`)
    and dispatches a **scoped fix subagent under the fix-subagent contract**
-   (`fix-subagent-contract.md`) that authors the fix **and opens a PR** for it. The driver hands the fixer
+   (`fix-subagent-contract.md`) that authors the fix **and opens a PR** for it. **An entry the threshold
+   holds back stops here — before `take-up`, and before any fixer is dispatched** — and is routed by "A
+   CONDITION THAT FAILS ROUTES THE WORK" below. The driver hands the fixer
    a **worktree branched from the base the follow-up targets**, and the fixer branches, commits, pushes,
    and opens the PR against that base — its worktree and scope requirements are owned by
    `fix-subagent-contract.md`, not restated here. **The target is per follow-up**: a follow-up **derived
@@ -433,7 +435,7 @@ Two structural facts carry the whole threshold, and both are **proved on the gra
   entry rather than parking it changes nothing: the guarantee was never about the state it landed in, but
   about which states the step may leave **from**.)
 - **The driver's own edge is evidence-bearing and lands somewhere else.** `take-up` leaves only from
-  `corroborated` (tier 2, condition 1) and lands in `self-accepted`, which is never `accepted`.
+  `corroborated` (tier 2's own precondition) and lands in `self-accepted`, which is never `accepted`.
 
 And a third, which is what makes DELETION safe (`delete-needs-a-record`):
 

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -58,12 +58,14 @@ step.
 **A corroborated follow-up is NEVER left undone because a condition below is unclear.** Recording one and
 walking away is the permanent loss this store exists to prevent, arriving by a slower route: the entry
 sits corroborated forever, every later run re-reads it, and the defect it names stays in the tree. The
-driver may **CONFIRM** with the user, and for the classes below it **must**. It may not use uncertainty as
-a reason to act on nothing.
+driver may not use uncertainty as a reason to act on nothing.
 
 The three conditions below are still **RECORDED**, and `take-up` refuses the step if any is asserted
-without evidence. What changed is what a failing one does: it **routes** the entry and **raises a
-question**, rather than cancelling the work.
+without evidence. What changed is what a failing one does: it **routes** the entry rather than cancelling
+the work. A failing `not-gate-machinery` or `behavior-preserved` condition is **DISCLOSED and dispatched
+without a question** — the fixer runs and the user reads about it afterwards. Only a failing `reversible`
+condition raises a **question**: that entry **WAITS** for the user's ruling before any fixer is
+dispatched.
 
 1. **`not-gate-machinery`** (`--act-not-gate`) — does it decide whether a PR may merge? The active
    repository instruction file (`AGENTS.md` or `CLAUDE.md`) defines the gate; do not reconstruct that
@@ -510,9 +512,11 @@ hid and the flag that reveals them. Read a value back with `get --field`, **neve
 **Surfacing is NOT the whole of what the user is owed for an entry the driver TOOK UP.** No ACT evidence
 reaches that table — the fields `take-up` wrote sit outside its default view — and an entry the threshold
 **routes** is disclosed and dispatched, so it raises no question to be listed under and reads exactly like
-one every condition held for. So **wherever a report tells the user about an entry the driver took up** —
-campaign's final report (`bailout-and-final-report.md`, **Follow-ups**) and `address-followups`' own report
-step alike — name **each ACT condition that did NOT hold**, quoting the evidence `take-up` recorded for it.
+one every condition held for. So **exactly two reporting steps owe this disclosure** — campaign's final
+report (`bailout-and-final-report.md`, **Follow-ups**) and `address-followups`' Step 6 — and each must name
+**each ACT condition that did NOT hold**, quoting the evidence `take-up` recorded for it. **No other report
+owes it**: not heartbeat or interim output, not the `gauntlet:followups` listing skill, not `carryover.md`,
+not the run history file.
 The THRESHOLD above already fixes what that evidence must say, condition by condition; this section does
 not retype it. Read those values back with `get --field`, never by parsing the table. **Say so explicitly
 when none failed** — those are different outcomes, and the report is the only place they are told apart.

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -507,6 +507,17 @@ the ledger's (`files-and-ledger.md`, "`table` is a PROJECTION"): it shows only t
 only some fields, it **escapes** every cell, and **the omission is never silent** — it states how many it
 hid and the flag that reveals them. Read a value back with `get --field`, **never** by parsing the table.
 
+**Surfacing is NOT the whole of what the user is owed for an entry the driver TOOK UP.** No ACT evidence
+reaches that table — the fields `take-up` wrote sit outside its default view — and an entry the threshold
+**routes** is disclosed and dispatched, so it raises no question to be listed under and reads exactly like
+one every condition held for. So **wherever a report tells the user about an entry the driver took up** —
+campaign's final report (`bailout-and-final-report.md`, **Follow-ups**) and `address-followups`' own report
+step alike — name **each ACT condition that did NOT hold**, quoting the evidence `take-up` recorded for it.
+The THRESHOLD above already fixes what that evidence must say, condition by condition; this section does
+not retype it. Read those values back with `get --field`, never by parsing the table. **Say so explicitly
+when none failed** — those are different outcomes, and the report is the only place they are told apart.
+Which conditions route and which one waits is the THRESHOLD's as well, not this section's.
+
 **What the driver may do with what it surfaces is the THRESHOLD above — do not re-derive it here.**
 Surfacing an entry to the user *is* how consensus gets reached, and it must never hold the run hostage
 (`run-identity-and-lease.md`, "Never hold the run hostage on a user prompt"): raise them alongside the

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -94,6 +94,15 @@ corroborated claim safe** — a wrong fix costs its own review rounds and never 
 else is disclosed and dispatched. A driver that surfaces a corroborated entry instead of working it has
 not been careful; it has left a reproduced defect in the tree and called that caution.
 
+**Checked claim about how this tier reads, not about the tool: its opening paragraph never directs an
+irreversible entry to a fixer without the user's ruling.** The whole tier was read for that conflict. The
+exception is announced twice **before** condition 3 states it — "for the classes below it **must**", and
+"it **routes** the entry and **raises a question**" — and the sentence directly above is what reconciles
+the two, not a second half of a contradiction. The mechanism cannot occur either: `self-accepted` is
+reachable only through the `take-up` command above, whose `--act-reversible` value condition 3 alone
+defines. Falsify this by producing a reading path from the opening paragraph to a dispatched fixer that
+never passes condition 3.
+
 ### Tier 3 — PUBLISH (a GitHub issue, a release). ALWAYS the user's call. Never autonomous.
 
 An issue is a **published claim**: it asserts to anyone reading the repo that the thing is real and worth
@@ -145,8 +154,9 @@ about and one whose partial rejection strands the rest.
 
 1. **VERIFY the claim — the main line, and where a fresh `candidate` starts.** The common path is one line:
    a `candidate` → **INVESTIGATE** (dispatch a context-isolated Tier-1, read-only subagent) → `corroborate`
-   or `refute` → if corroborated and every Tier-2 condition holds, `take-up` → a fix subagent opens a PR →
-   `open-pr` → adopt into the run → `merged`. A follow-up is a CLAIM, and the driver's own diagnosis needs
+   or `refute` → if corroborated and the threshold above does not hold the entry back, `take-up` → a fix
+   subagent opens a PR → `open-pr` → adopt into the run → `merged`.
+   A follow-up is a CLAIM, and the driver's own diagnosis needs
    corroboration exactly like a reviewer's finding does (`AGENTS.md`/`CLAUDE.md`, "Your OWN diagnosis is a
    claim too"). So the driver does **not** verify inline and does **not** skip to a fix: the investigation
    subagent's sole job is to **reproduce the claim** — read the code, run the commands, walk the causal
@@ -219,9 +229,9 @@ about and one whose partial rejection strands the rest.
    evidence the claim is false, never because a fix is inconvenient.
 
 3. **APPLICABLE → `take-up`, then a FIX SUBAGENT that opens a PR.** If the investigation `corroborated` it
-   **and every Tier-2 condition holds and is evidenced** (`corroborated`, `not-gate-machinery`,
-   `behavior-preserved`, `reversible` — `take-up` refuses without them), the driver takes it up
-   (→ `self-accepted`) and dispatches a **scoped fix subagent under the fix-subagent contract**
+   **and every ACT condition is recorded with evidence** — `take-up` refuses the step without that, and the
+   threshold above owns what a failing one does — the driver takes it up (→ `self-accepted`)
+   and dispatches a **scoped fix subagent under the fix-subagent contract**
    (`fix-subagent-contract.md`) that authors the fix **and opens a PR** for it. The driver hands the fixer
    a **worktree branched from the base the follow-up targets**, and the fixer branches, commits, pushes,
    and opens the PR against that base — its worktree and scope requirements are owned by

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -518,17 +518,21 @@ report (`bailout-and-final-report.md`, **Follow-ups**) and `address-followups`' 
 owes it**: not heartbeat or interim output, not the `gauntlet:followups` listing skill, not `carryover.md`,
 not the run history file.
 The THRESHOLD above already fixes what that evidence must say, condition by condition; this section does
-not retype it. Read those values back with `get --field`, never by parsing the table. **Say so explicitly
-when none failed** — those are different outcomes, and the report is the only place they are told apart.
+not retype it. Read those values back with `get --field`, never by parsing the table. **An entry whose PR
+has MERGED is DELETED, so `get` fails for it** — what discharges its disclosure instead is the `merged`
+step's own printed output, owned above by "**A DELETING step still PRINTS the entry it removed, in
+full**" and not restated here. **Say so explicitly when none failed** — those are different outcomes, and
+the report is the only place they are told apart.
 Which conditions route and which one waits is the THRESHOLD's as well, not this section's.
 
 **What the driver may do with what it surfaces is the THRESHOLD above — do not re-derive it here.**
 Surfacing an entry to the user *is* how consensus gets reached, and it must never hold the run hostage
 (`run-identity-and-lease.md`, "Never hold the run hostage on a user prompt"): raise them alongside the
-report and fold any answer in as its own heartbeat. **A `candidate` is a question, not a task**: the driver has
-not investigated it yet, so it has nothing to act on and nothing to say. The FIRST move on a fresh
-candidate is to INVESTIGATE it — the active loop above, when there is spare capacity — because that is
-how the question gets answered. Surfacing it to the user is never a substitute for investigating it, and
+report and fold any answer in as its own heartbeat. **A `candidate` is an UNINVESTIGATED CLAIM, not a
+task**: the driver has not investigated it yet, so it has nothing to act on and nothing to say. The FIRST
+move on a fresh candidate is to INVESTIGATE it — the active loop above, when there is spare capacity —
+because that is what turns the claim into evidence, and investigating needs no permission (Tier 1).
+Surfacing it to the user is never a substitute for investigating it, and
 **a CORROBORATED entry is not surfaced INSTEAD of being worked** — the threshold above dispatches a fixer
 for it and reports what that fixer is doing, holding back only the one class it names.
 

--- a/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
+++ b/plugins/gauntlet/skills/campaign/references/scope-and-constraints.md
@@ -4,7 +4,7 @@ Invoking this skill authorizes the git/GitHub operations it performs on the bran
 (existing PRs the run adopted and tagged with its owner label): `add`, `commit`, `push`, PR update,
 labels/checks/comments, and merge. The campaign does not invent work: it opens a PR of its own only for a
 **follow-up it has TAKEN UP** under the autonomy threshold (`followups.md` — a corroborated claim, every
-ACT condition evidenced, and the resulting PR gated like any other); otherwise PR creation lives in the
+ACT condition recorded, and the resulting PR gated like any other); otherwise PR creation lives in the
 gauntlet:review handoff. **Passing a `#PR` (or discovering one under this run's label) authorizes the
 campaign to gate and merge that PR** — adopt it, run the review gauntlet on it, push review/CI fixes to
 its branch, and merge it when the gate and CI are green.

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -94,8 +94,9 @@ DESCRIPTION = "Schema-owning accessor for the follow-up ledger (.gauntlet/follow
 
 # --- the ACT conditions (owned here, once) ------------------------------------
 #
-# The FOUR conditions that let the driver take a follow-up up FOR WORK with no user ruling. The tier and
-# its rationale are owned by `references/followups.md`; what lives here is the one thing code can enforce:
+# The FOUR conditions a driver must RECORD to take a follow-up up FOR WORK with no user ruling. Which of
+# them route the work and which one holds it back is the THRESHOLD's, owned by `references/followups.md`,
+# "THE AUTONOMY THRESHOLD" — not restated here. What lives here is the one thing code can enforce:
 # EVERY CONDITION MUST BE WITNESSED BY EVIDENCE IN THE ENTRY, or the take-up is refused. A condition
 # ASSERTED but not EVIDENCED is not a condition — it is a bypass with a nicer name, and the whole tier
 # collapses into "the driver decided it was fine".
@@ -110,15 +111,17 @@ ACT_CONDITIONS = (
      "This one is enforced by the GRAPH (`take-up` leaves only from `corroborated`) and its witness is the "
      "investigation's own `finding`, so it takes no flag: the evidence is already in the entry."),
     ("not-gate-machinery", "act_not_gate",
-     "It does not decide whether a PR may merge (the active `AGENTS.md` or `CLAUDE.md` defines the gate). WHEN UNCLEAR IT IS GATE "
-     "MACHINERY — the ambiguous case resolves toward ASK, never toward act."),
+     "WHETHER it decides whether a PR may merge (the active `AGENTS.md` or `CLAUDE.md` defines the gate). "
+     "Record the answer either way, including that it is unclear. What a failing condition does is the "
+     "THRESHOLD's (`references/followups.md`, \"THE AUTONOMY THRESHOLD\")."),
     ("behavior-preserved", "act_behavior",
-     "It preserves user-facing behavior. If it HAS a behavioral surface, name the TEST that proves so. If "
-     "it has NONE, say so and name why — an assertion of no-behavioral-surface is itself a claim, and it "
-     "is recorded like any other."),
+     "WHETHER it changes user-facing behavior. Record what the change does either way: name the behavior "
+     "that changes and the TEST that pins it, or say it has NONE and why — an assertion of "
+     "no-behavioral-surface is itself a claim. What a failing condition does is the THRESHOLD's."),
     ("reversible", "act_reversible",
-     "A revert restores the prior state. A schema migration is not reversible; anything already published "
-     "is not."),
+     "WHETHER a revert restores the prior state. A schema migration does not; anything already published "
+     "does not. This is the one condition whose failure makes the entry WAIT for the user's ruling instead "
+     "of routing it — read the THRESHOLD for that."),
 )
 
 # Every ACT condition's witness field, and the subset `take-up` must carry in itself. Condition 1's


### PR DESCRIPTION
- a corroborated follow-up is now taken up and dispatched to a fixer, not surfaced instead of worked
- gate machinery and a behaviour change are disclosed and dispatched; only an irreversible change waits
- updates the three sites that restate the threshold: the skill's Step 4, critical-rules, scope-and-constraints
