### PR TITLE
fix wrapped command anchors in doc-check

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1355,7 +1355,11 @@ def verdict_doc_cases(ci) -> list[str]:
 
 
 def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
-    """Pin standalone and ``--name=value`` forms in all three documentation validators."""
+    """Pin standalone and ``--name=value`` forms in all three documentation validators, plus the shared
+    `_command_anchor` wrap tolerance: a copy WRAPS between the script name and the subcommand (a real doc,
+    `loop-control.md`, does exactly this for `required-set`) and must still be found and checked like any
+    other copy — while a subcommand mention on the far side of a BLANK line (a different paragraph) must
+    stay unmatched, so the anchor never merges two unrelated mentions into one false copy."""
     problems: list[str] = []
     cases = [
         (
@@ -1414,6 +1418,36 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
         if len(found) != 1 or copies != ["commands.md:1"]:
             problems.append(
                 f"[documentation options {name}:missing] expected one reported copy; "
+                f"got copies={copies!r}, problems={found!r}"
+            )
+
+        # THE WRAP: the script name and the subcommand land on different physical lines — exactly what
+        # `loop-control.md` does for `required-set` (`ci-status.py\n   required-set --ledger …`). The
+        # anchor must still find and check this copy, not silently drop it from the count.
+        wrapped_root = tmp / f"documentation-options-{name}-wrapped"
+        wrapped_root.mkdir()
+        wrapped_valid = valid.replace(f"ci-status.py {name}", f"ci-status.py\n   {name}", 1)
+        if wrapped_valid == valid:
+            problems.append(f"[documentation options {name}:wrapped] fixture setup did not find "
+                             f"`ci-status.py {name}` in {valid!r} to wrap")
+        (wrapped_root / "commands.md").write_text(f"`{wrapped_valid}`\n", encoding="utf-8")
+        found, copies = check(wrapped_root)
+        if found or copies != ["commands.md:1"]:
+            problems.append(
+                f"[documentation options {name}:wrapped] expected one accepted copy despite the "
+                f"script-name/subcommand wrap; got copies={copies!r}, problems={found!r}"
+            )
+
+        # THE NON-WRAP: a BLANK line (a paragraph break) between the script name and the subcommand is NOT
+        # a wrap — it is two unrelated mentions, and the anchor must not merge them into one false copy.
+        paragraph_root = tmp / f"documentation-options-{name}-paragraph-break"
+        paragraph_root.mkdir()
+        paragraph_text = valid.replace(f"ci-status.py {name}", f"ci-status.py\n\n{name}", 1)
+        (paragraph_root / "commands.md").write_text(f"{paragraph_text}\n", encoding="utf-8")
+        found, copies = check(paragraph_root)
+        if copies:
+            problems.append(
+                f"[documentation options {name}:paragraph-break] expected NO copy across a blank line; "
                 f"got copies={copies!r}, problems={found!r}"
             )
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1358,8 +1358,14 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
     """Pin standalone and ``--name=value`` forms in all three documentation validators, plus the shared
     `_command_anchor` wrap tolerance: a copy WRAPS between the script name and the subcommand (a real doc,
     `loop-control.md`, does exactly this for `required-set`) and must still be found and checked like any
-    other copy — while a subcommand mention on the far side of a BLANK line (a different paragraph) must
-    stay unmatched, so the anchor never merges two unrelated mentions into one false copy."""
+    other copy — in EVERY spelling of that wrap, plain prose reflow and the shell's own ` \\` continuation
+    alike — while a subcommand mention on the far side of a BLANK line (a different paragraph) must stay
+    unmatched, so the anchor never merges two unrelated mentions into one false copy.
+
+    EACH WRAP IS PINNED TWICE, ON A COMPLIANT COPY *AND* ON A NON-COMPLIANT ONE. Counting the copy is the
+    weaker half: the flag checks run INSIDE the anchor's `finditer` loop, so a copy the anchor misses is
+    never asked for its required flag and its violation is reported as NOTHING — and the ZERO-copies
+    safety net cannot catch that, because it goes quiet the moment any other copy in the tree anchors."""
     problems: list[str] = []
     cases = [
         (
@@ -1424,19 +1430,49 @@ def documentation_option_form_cases(ci, tmp: Path) -> list[str]:
         # THE WRAP: the script name and the subcommand land on different physical lines — exactly what
         # `loop-control.md` does for `required-set` (`ci-status.py\n   required-set --ledger …`). The
         # anchor must still find and check this copy, not silently drop it from the count.
-        wrapped_root = tmp / f"documentation-options-{name}-wrapped"
-        wrapped_root.mkdir()
-        wrapped_valid = valid.replace(f"ci-status.py {name}", f"ci-status.py\n   {name}", 1)
-        if wrapped_valid == valid:
-            problems.append(f"[documentation options {name}:wrapped] fixture setup did not find "
-                             f"`ci-status.py {name}` in {valid!r} to wrap")
-        (wrapped_root / "commands.md").write_text(f"`{wrapped_valid}`\n", encoding="utf-8")
-        found, copies = check(wrapped_root)
-        if found or copies != ["commands.md:1"]:
-            problems.append(
-                f"[documentation options {name}:wrapped] expected one accepted copy despite the "
-                f"script-name/subcommand wrap; got copies={copies!r}, problems={found!r}"
-            )
+        #
+        # AND A DOC THAT WRAPS A LONG INVOCATION USUALLY WRITES THE SHELL'S OWN CONTINUATION — a `\` before
+        # the newline, the form a reader can paste and run — which whitespace-only tolerance never matches.
+        # Both spellings, with and without the space the shell wants before that backslash: the anchor only
+        # LOCATES a copy, so refusing to look is the one outcome it can never afford. `_SHELL_BLANK` owns
+        # the shell's grammar for the byte-EQUALITY check; this is deliberately looser than that.
+        for label, wrap in (
+            ("wrapped", f"ci-status.py\n   {name}"),
+            ("wrapped-backslash", f"ci-status.py \\\n   {name}"),
+            ("wrapped-backslash-nospace", f"ci-status.py\\\n   {name}"),
+        ):
+            wrapped_root = tmp / f"documentation-options-{name}-{label}"
+            wrapped_root.mkdir()
+            wrapped_valid = valid.replace(f"ci-status.py {name}", wrap, 1)
+            if wrapped_valid == valid:
+                problems.append(f"[documentation options {name}:{label}] fixture setup did not find "
+                                 f"`ci-status.py {name}` in {valid!r} to wrap")
+            (wrapped_root / "commands.md").write_text(f"`{wrapped_valid}`\n", encoding="utf-8")
+            found, copies = check(wrapped_root)
+            if found or copies != ["commands.md:1"]:
+                problems.append(
+                    f"[documentation options {name}:{label}] expected one accepted copy despite the "
+                    f"script-name/subcommand wrap; got copies={copies!r}, problems={found!r}"
+                )
+
+            # THE HALF THAT ACTUALLY GATES: the same wrap around a copy that DROPS the required flag. The
+            # flag checks live inside the anchor's loop, so a missed anchor does not merely undercount —
+            # it swallows the violation whole. **AND A COMPLIANT COPY SITS BESIDE IT ON PURPOSE**, because
+            # the ZERO-copies safety net is what would otherwise notice: it fires only when NOTHING in the
+            # tree anchors, so one good copy anywhere silences it and the miss becomes literally no output
+            # at all. That is the real tree's shape, and the only fixture shape that can see this defect.
+            bad_root = tmp / f"documentation-options-{name}-{label}-missing"
+            bad_root.mkdir()
+            wrapped_missing = missing.replace(f"ci-status.py {name}", wrap, 1)
+            (bad_root / "bad.md").write_text(f"`{wrapped_missing}`\n", encoding="utf-8")
+            (bad_root / "good.md").write_text(f"`{valid}`\n", encoding="utf-8")
+            found, copies = check(bad_root)
+            if len(found) != 1 or copies != ["bad.md:1", "good.md:1"]:
+                problems.append(
+                    f"[documentation options {name}:{label}:missing] expected the WRAPPED copy's missing "
+                    f"flag to be reported ALONGSIDE a compliant copy, which silences the ZERO-copies net; "
+                    f"got copies={copies!r}, problems={found!r}"
+                )
 
         # THE NON-WRAP: a BLANK line (a paragraph break) between the script name and the subcommand is NOT
         # a wrap — it is two unrelated mentions, and the anchor must not merge them into one false copy.

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2249,6 +2249,19 @@ def _has_long_option(command: str, option: str) -> bool:
     return re.search(rf"(?<![\w-]){re.escape(option)}(?=[=\s]|$)", command) is not None
 
 
+def _command_anchor(subcommand: str) -> re.Pattern[str]:
+    """Locate ``ci-status.py <subcommand>`` even when prose or a shell continuation WRAPS the line BETWEEN
+    the script name and the subcommand — e.g. ``scripts/ci-status.py\\n   required-set --ledger …`` — which
+    a literal single space between the two tokens never matches, so the copy is never anchored and every
+    downstream check (the paragraph read, the flag checks) never runs against it.
+
+    The tolerated gap is ONE wrap only: same-line spaces/tabs, or spaces/tabs around a single newline. A
+    blank line (a paragraph break, `\\n\\n`) is NOT absorbed, so an unrelated later mention of the
+    subcommand in a different paragraph is never merged into a false single copy.
+    """
+    return re.compile(rf"ci-status\.py(?:[ \t]+|[ \t]*\n[ \t]*){re.escape(subcommand)}")
+
+
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:
     """EVERY COPY OF THE DERIVE COMMAND, IN EVERY SKILL DOC — not just the one in the doc under test.
 
@@ -2261,8 +2274,11 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
 
     A copy is any occurrence that RUNS the command (`ci-status.py derive` carrying `--pr`) — prose that
     merely NAMES the command is not a copy, and is not checked. **THE UNIT IS THE COMMAND, NOT THE LINE**:
-    an invocation WRAPS (a shell `\\`, or plain prose reflow), and a line-by-line check would report the
-    continuation line as a violation of itself. So each copy is read to the end of its PARAGRAPH.
+    an invocation WRAPS (a shell `\\`, or plain prose reflow) — including BETWEEN the script name and the
+    subcommand itself (`ci-status.py\n  derive`) — and a line-by-line check would report the continuation
+    line as a violation of itself, or, worse, never anchor the copy at all when the wrap falls inside the
+    two tokens the anchor matches. So each copy is located by `_command_anchor` (which tolerates that one
+    wrap) and then read to the end of its PARAGRAPH.
 
     FINDING ZERO COPIES IS A FAILURE: the command is prescribed by at least `stage-2-ci.md` and
     `critical-rules.md`, and a check that cannot find its subject never passes.
@@ -2270,7 +2286,7 @@ def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]
     problems, copies = [], []
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        for m in re.finditer(r"ci-status\.py derive", text):
+        for m in re.finditer(_command_anchor("derive"), text):
             end = text.find("\n\n", m.start())
             command = text[m.start(): end if end > 0 else len(text)]
             if not _has_long_option(command, "--pr"):
@@ -2302,7 +2318,7 @@ def check_liveness_copies(root: Path | None = None) -> tuple[list[str], list[str
     problems, copies = [], []
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        for match in re.finditer(r"ci-status\.py liveness", text):
+        for match in re.finditer(_command_anchor("liveness"), text):
             end = text.find("\n\n", match.start())
             command = text[match.start(): end if end > 0 else len(text)]
             # `--ledger`, not `--pr`, is the runnable-copy gate here: prose about liveness routinely sits
@@ -2331,7 +2347,7 @@ def check_required_set_copies(root: Path | None = None) -> tuple[list[str], list
     problems, copies = [], []
     for md in sorted((root or HERE.parent).rglob("*.md")):
         text = md.read_text(encoding="utf-8")
-        for match in re.finditer(r"ci-status\.py required-set", text):
+        for match in re.finditer(_command_anchor("required-set"), text):
             end = text.find("\n\n", match.start())
             command = text[match.start(): end if end > 0 else len(text)]
             if not _has_long_option(command, "--ledger"):

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -2255,11 +2255,22 @@ def _command_anchor(subcommand: str) -> re.Pattern[str]:
     a literal single space between the two tokens never matches, so the copy is never anchored and every
     downstream check (the paragraph read, the flag checks) never runs against it.
 
-    The tolerated gap is ONE wrap only: same-line spaces/tabs, or spaces/tabs around a single newline. A
-    blank line (a paragraph break, `\\n\\n`) is NOT absorbed, so an unrelated later mention of the
-    subcommand in a different paragraph is never merged into a false single copy.
+    The tolerated gap is ONE wrap only: same-line spaces/tabs, or spaces/tabs around a single newline —
+    with an OPTIONAL shell-continuation `\\` immediately before that newline, because a doc that wraps a
+    long invocation writes the wrap the way a reader would run it (`ci-status.py \\\\n   required-set …`),
+    and whitespace-only tolerance never matches that. A blank line (a paragraph break, `\\n\\n`) is NOT
+    absorbed, so an unrelated later mention of the subcommand in a different paragraph is never merged
+    into a false single copy.
+
+    **THIS LOCATES A COPY; IT DOES NOT JUDGE ONE.** Being permissive here can only ADD copies to the
+    flag checks — the failure it prevents is a non-compliant copy going UNCHECKED and its violation
+    disappearing with no diagnostic at all (the ZERO-copies safety net is silent as soon as any other
+    copy anchors). It is therefore deliberately looser than `_SHELL_BLANK`, which owns the shell's own
+    continuation grammar for the BYTE-EQUALITY check (`check_marked_commands`) — there a `\\` with no
+    space before it is not a wrap, because the shell joins it into one invalid token. That question is
+    the equality check's; this anchor must not answer it by refusing to look.
     """
-    return re.compile(rf"ci-status\.py(?:[ \t]+|[ \t]*\n[ \t]*){re.escape(subcommand)}")
+    return re.compile(rf"ci-status\.py(?:[ \t]+|[ \t]*\\?\n[ \t]*){re.escape(subcommand)}")
 
 
 def check_derive_copies(root: Path | None = None) -> tuple[list[str], list[str]]:


### PR DESCRIPTION
## Summary

`ci-status.py doc-check` scans the skill's docs for runnable copies of `ci-status.py derive` /
`liveness` / `required-set`, but the anchor regex required a literal single space between the
script name and the subcommand. `references/loop-control.md` wraps its `required-set` command
across a markdown line reflow (`scripts/ci-status.py\n   required-set --ledger …`), so that anchor
never matched and the copy was silently excluded from the scan.

Reproduced on this branch's base (main @ b0d6204) before any change:

```
ok       the required-set invocations     3 runnable copies, every one persisting to state.jsonl
```

Only 3 copies were found; `loop-control.md`'s wrapped copy was missing from the count, so it was
never checked for the required `--ledger`/`state.jsonl` flags a runnable copy must carry.

## Change

Added a shared `_command_anchor()` helper used by all three copy scanners
(`check_derive_copies`, `check_liveness_copies`, `check_required_set_copies` — they all shared the
same broken anchor pattern). It tolerates one line wrap between the script name and the
subcommand (same-line spacing, or spacing around a single newline) but does not cross a blank
line, so two unrelated mentions in different paragraphs are never merged into a false single copy.

After the fix, `doc-check` finds all 4 copies:

```
ok       the required-set invocations     4 runnable copies, every one persisting to state.jsonl
```

## Test plan

- Added a table-driven fixture in `ci-status-test.py` (`documentation_option_form_cases`) that
  pins, for all three subcommands: a wrapped copy is still found and checked, and a copy split by
  a blank line (paragraph break) is correctly NOT treated as one command.
- Verified the new fixture fails against the old anchor (all three roles) and passes with the fix.
- `python3 plugins/gauntlet/skills/campaign/scripts/ci-status.py self-test` — 37 checks, all ok.
- `python3 plugins/gauntlet/skills/campaign/scripts/ci-status-test.py` — all fixtures pass, no
  failures.
- `python3 plugins/gauntlet/skills/campaign/scripts/self-test-runner-test.py` and
  `ledger.py self-test` — unaffected, still pass.
- `npx pyright@1.1.410` over every tracked `*.py`/`*.pyi` file (as CI runs it): 74/74 files
  analyzed, 0 errors, 0 warnings.
