### PR TITLE
order a follow-up ruling after its PR

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -296,6 +296,15 @@ time. So:
 - The PR is **closed WITHOUT merging** → `closed-unmerged` returns it to **open work** (`reopened`), with
   its history intact — the finding, the ACT grounds or the user's ruling, and the PR that died. It never
   vanishes with the PR, and it is never stuck in "being worked on" forever.
+- **The user rules while that PR is open** → **dispose of the PR first.** Close it, record the close
+  (`closed-unmerged`, the bullet above), and rule on the entry then. **Neither ruling leaves from `in-pr`**,
+  so this is the graph's order and not a convention the driver could forget: `rejected` is terminal *and*
+  hidden, and a `no` recorded while the PR was open would leave that PR open with **no campaign action that
+  ever looks at it again** — the store's own dead end. The ruling is **not blocked, only ordered**: the
+  entry keeps the PR in its history and the user's stamp lands the moment the PR is disposed of. A turn
+  that disposes of the PR and dies before recording the ruling leaves the entry in `reopened` — **visible
+  open work**, which the user rules on again. That is the disclosed cost of the order, and it is the
+  failure this store prefers: a ruling that has to be repeated, never a PR nothing will ever look at.
 
 **Move it in the heartbeat that SAW the event** — the same rule as recording one the moment it is noticed, and
 for the same reason: the driver's memory of it dies with the driver's context. The heartbeat that opens the PR

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -379,10 +379,16 @@ def t_ruling_is_recorded(tmp: Path) -> None:
           f"`open-pr` overwrote the USER's ruling timestamp: {after!r}")
     check(after["pr"] == "77", f"open-pr did not record WHICH PR is addressing it: {after!r}")
 
+    # …and the user changing their mind RE-STAMPS it — once the PR that entry names has been disposed of,
+    # which is the order the graph enforces (`t_a_ruling_waits_for_the_prs_disposition`).
+    run(["--file", str(path), "closed-unmerged", "--id", a])
+    code, out, err = run(["--file", str(path), "reject", "--id", a, "--at", "2026-07-14T11:00:00Z"])
+    check(code == 0, f"reject exited {code}: {err!r}")
+    check(json.loads(out)["decided"] == "2026-07-14T11:00:00Z",
+          f"the user's second ruling did not re-stamp `decided`: {out!r}")
+
     # …and so does the step that DELETES it: the record it prints is the handoff, and it still says the
     # user ruled, and when.
-    code, out, err = run(["--file", str(path), "reject", "--id", a, "--at", "2026-07-14T11:00:00Z"])
-    check(code == 0, f"reject exited {code}: {err!r}")  # the user changed their mind while the PR was open
     (b2,) = seed(path)
     run(["--file", str(path), "accept", "--id", b2, "--at", "2026-07-14T12:00:00Z"])
     code, out, _ = run(["--file", str(path), "publish", "--id", b2, "--ref", "#88"])
@@ -810,6 +816,64 @@ def t_a_closed_pr_returns_the_entry_to_open_work(tmp: Path) -> None:
         code, _, err = run(["--file", str(path), "merged", "--id", fid])
         check(code == 0, f"[{lineage}] `merged` exited {code}: {err!r}")
         check(load(path) == [], f"[{lineage}] the second PR merged and the entry was kept anyway")
+
+
+def t_a_ruling_waits_for_the_prs_disposition(tmp: Path) -> None:
+    """A USER RULING NEVER LANDS ON AN ENTRY WHOSE PR IS STILL OPEN — the ruling is ORDERED AFTER the PR's
+    disposition, and the graph is what orders it.
+
+    `rejected` is terminal AND hidden from the default view. So a `no` recorded straight from `in-pr` used to
+    produce the one shape this store cannot recover from: a closed entry that still NAMES a PR, sitting in
+    the one state no campaign action ever reads again. The entry says a PR is addressing it; the PR is open;
+    nothing on either side will ever touch it. Nothing else in the graph can strand an open PR — every other
+    exit from `in-pr` acts on the PR (`merged`, `closed-unmerged`).
+
+    THE RULING IS NOT BLOCKED, ONLY ORDERED. `closed-unmerged` records the close and returns the entry to
+    open work with the dead PR still in its history, and every ruling applies there — so the user's `no`
+    lands, on an entry that no longer names anything open.
+
+    Checked on the GRAPH first (an edge added tomorrow that rules from `in-pr` goes red here), then end to
+    end through the real CLI, including the refusal's own route.
+    """
+    open_pr_state = TRANSITIONS["open-pr"][1]
+    disposed = TRANSITIONS["closed-unmerged"][1]
+    for ruling in USER_RULINGS:
+        check(open_pr_state not in TRANSITIONS[ruling][0],
+              f"`{ruling}` applies to {open_pr_state!r} — a ruling recorded while the PR is open leaves an "
+              f"entry naming a PR that no campaign action ever looks at again")
+        check(disposed in TRANSITIONS[ruling][0],
+              f"`{ruling}` does not apply to {disposed!r} — the disposition would BLOCK the user's ruling "
+              f"instead of merely ordering it after the PR")
+    # …and the disposition edges are the ONLY way out of an open PR, so ordering the rulings after them
+    # leaves nothing that can end an entry with its PR untouched.
+    exits = {c for c, (frm, _) in TRANSITIONS.items() if open_pr_state in frm}
+    check(exits == {"merged", "closed-unmerged"},
+          f"{open_pr_state!r} has exits {sorted(exits)} — an exit that is not a disposition of the PR can "
+          f"end the entry while the PR it names stays open")
+
+    path = tmp / "ruling.jsonl"
+    (fid,) = seed(path)
+    run(["--file", str(path), "accept", "--id", fid])          # the user agreed; a fixer opened the PR
+    code, _, err = run(["--file", str(path), "open-pr", "--id", fid, "--pr", "#999"])
+    check(code == 0, f"open-pr exited {code}: {err!r}")
+    check(state_of(path, fid) == open_pr_state, "the setup did not reach an OPEN PR")
+    for ruling in USER_RULINGS:
+        code, out, err = run(["--file", str(path), ruling, "--id", fid, *transition_args(ruling)])
+        check(code == 1, f"`{ruling}` was ACCEPTED on an entry whose PR is open (exit {code}):\n{out}")
+        check(state_of(path, fid) == open_pr_state, f"a refused `{ruling}` moved the entry anyway")
+        # …and the refusal names the ROUTE, not just the refusal: the caller holds a ruling it must record.
+        check("999" in err and "closed-unmerged" in err and disposed in err,
+              f"the refusal does not tell the caller how to proceed: {err!r}")
+
+    # …and once the PR IS disposed of, the very same ruling lands — with the dead PR still in the history.
+    code, _, err = run(["--file", str(path), "closed-unmerged", "--id", fid])
+    check(code == 0, f"`closed-unmerged` exited {code}: {err!r}")
+    code, out, err = run(["--file", str(path), "reject", "--id", fid, "--at", "2026-07-30T09:00:00Z"])
+    check(code == 0, f"the ruling was BLOCKED rather than ordered: exit {code}, {err!r}")
+    entry = json.loads(out)
+    check(entry["state"] == "rejected", f"the ruling did not land: {entry!r}")
+    check(entry["decided"] == "2026-07-30T09:00:00Z", f"the user's `no` lost its stamp: {entry!r}")
+    check(entry["pr"] == "999", f"the disposed PR left the entry's history: {entry!r}")
 
 
 def t_a_rejection_is_never_deleted(tmp: Path) -> None:
@@ -1442,6 +1506,7 @@ CASES = [
     ("user-step-unskippable", "no driver-only path reaches `accepted`, nor any state `publish` leaves from — proved on the graph", t_user_ruling_is_unskippable),
     ("delete-needs-a-record", "an entry is deleted only once a DURABLE RECORD exists elsewhere — never on take-up", t_deletion_needs_a_durable_record),
     ("closed-pr-reopens", "a PR closed WITHOUT merging returns the entry to open work — it never vanishes with it", t_a_closed_pr_returns_the_entry_to_open_work),
+    ("ruling-waits-for-the-pr", "a USER RULING is ordered AFTER the PR's disposition — it can never strand the open PR the entry names", t_a_ruling_waits_for_the_prs_disposition),
     ("rejection-kept", "a REJECTED follow-up is kept — deleting it is how the next run re-raises it", t_a_rejection_is_never_deleted),
     ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -51,7 +51,8 @@ file that grows.
     rejected PR takes down with it — the work still undone, and nothing left to remember it. So while a PR
     is OPEN the entry STAYS and records which PR is addressing it (`in-pr`), and a PR CLOSED WITHOUT
     MERGING returns it to OPEN WORK (`reopened`) — never a silent vanish, never stuck in "being worked on"
-    forever.
+    forever. A USER RULING waits on that same disposition: neither ruling leaves from `in-pr`, so a `no`
+    cannot land on an entry whose PR is still open and leave that PR behind it (see TRANSITIONS).
   * REJECTIONS STAY. A rejection is worth remembering PRECISELY so it is not re-raised: delete it and the
     next run rediscovers the same thing, records it again, and asks the user again. It is hidden from the
     default view; it is not deleted. (A published one CAN be deleted for the same test: the ISSUE is the
@@ -228,6 +229,13 @@ def project(rec: "dict", where: str = "") -> "dict[str, str]":
 # being lost: `in-pr` (a PR is open on it — the entry STAYS, and names the PR) and `reopened` (that PR was
 # closed WITHOUT merging — the work is undone, so the entry is OPEN WORK again, with its history intact).
 #
+# AND A USER RULING IS ORDERED AFTER THE PR'S DISPOSITION — which is why NEITHER ruling leaves from `in-pr`.
+# `rejected` is terminal AND hidden from the default view, so a `no` recorded while the PR was still open
+# would leave a PR nothing ever looks at again: the entry names it, and no campaign action reads a rejection.
+# The ruling is NOT BLOCKED, only ORDERED — dispose of the PR, record that (`closed-unmerged`, which keeps
+# the dead PR in the entry's history), and rule on the `reopened` entry. `accept` has always required this;
+# `reject` was the one edge that did not, and an `in-pr` rejection was the one way to strand an open PR.
+#
 # `<subcommand>: (states it may be applied FROM, the state it moves TO — or DELETED)`.
 DELETED = "deleted"  # NOT a state: the entry is REMOVED. It exists only in the CLI's output for that step,
                      # never on disk — `load()` refuses it as an unknown state, so a tombstone cannot linger.
@@ -237,7 +245,7 @@ TRANSITIONS = {
     "refute":          (("candidate", "corroborated", "reopened"), "refuted"),
     "take-up":         (("corroborated",), "self-accepted"),
     "accept":          (("candidate", "corroborated", "refuted", "self-accepted", "reopened"), "accepted"),
-    "reject":          (("candidate", "corroborated", "refuted", "self-accepted", "accepted", "in-pr",
+    "reject":          (("candidate", "corroborated", "refuted", "self-accepted", "accepted",
                         "reopened"), "rejected"),
     "open-pr":         (("accepted", "self-accepted", "reopened"), "in-pr"),
     "closed-unmerged": (("in-pr",), "reopened"),
@@ -745,6 +753,24 @@ def append_finding(existing: str, outcome: str, at: str, text: str) -> str:
     return record if is_blank(existing) else existing + "\n" + record
 
 
+def ruling_route(cmd: str, entry: "dict[str, str]") -> str:
+    """The ONE refusal a caller cannot act on from the graph alone: a USER RULING on an entry whose PR is
+    still open.
+
+    Every other refusal names the states the step applies to and that is the whole answer. Here the answer
+    is a CAMPAIGN ACTION the store cannot see — somebody must dispose of the PR — so the route is spelled
+    out at the moment it is needed. It is DERIVED from the graph (the state `open-pr` reaches, the state
+    `closed-unmerged` reaches), so it cannot go stale behind an edge that moves.
+    """
+    if cmd not in USER_RULINGS or entry["state"] != TRANSITIONS["open-pr"][1]:
+        return ""
+    return (f" It names PR {entry['pr']}, and nothing has disposed of that PR yet: close it, record the "
+            f"close (`closed-unmerged` -> '{TRANSITIONS['closed-unmerged'][1]}', which keeps the dead PR in "
+            f"the entry's history), then rule. The ruling is not blocked, only ORDERED after the PR's "
+            f"disposition — recorded while the PR was open it would leave that PR open with no campaign "
+            f"action that ever looks at it again.")
+
+
 def cmd_transition(path: Path, args) -> int:
     """The ONLY things that move `state` — or END an entry — and every one checks the state it comes FROM.
 
@@ -776,6 +802,7 @@ def cmd_transition(path: Path, args) -> int:
             fail(
                 f"{args.id} is '{entry['state']}' — `{cmd}` applies only to: {', '.join(frm)}. "
                 f"A follow-up reaches '{to}' only along the transition graph; nothing else moves `state`."
+                + ruling_route(cmd, entry)
             )
         # WHEN this step was taken. The user's ruling is DURABLE DATA, exactly like the ledger's
         # `api_approval`: a later run — or a fresh agent that never saw the conversation — reads it and does


### PR DESCRIPTION
- a `reject` from `in-pr` left a terminal entry naming an open PR nothing ever touches
- reproduced on main `b0d6204`: `open-pr --pr #999` then `reject` exited 0, `pr=999`
- the ruling now waits for `closed-unmerged`; fixture `ruling-waits-for-the-pr` pins it
