### PR TITLE
give the base-preflight current fixture teeth

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -564,10 +564,20 @@ def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[int, dict, str, 
     check(old_base != advanced_base, "fixture setup: the candidate tracking ref must be stale")
 
     if current:
-        # Import the advanced base through a separate local ref so HEAD contains it while origin/<base>
-        # stays stale until the operation under test refreshes that tracking ref.
+        # Import the advanced base through a separate local ref so HEAD contains it. That fetch NAMES the
+        # configured remote, so Git ALSO opportunistically updates `tracking_ref` as a side effect — which
+        # would pre-satisfy the very refresh this fixture exists to prove. Force the tracking ref back to
+        # the stale tip so the operation under test is the only thing that can refresh it.
         _git(candidate, "fetch", "origin", f"{dash_head}:refs/heads/current-dash-base")
         _git(candidate, "checkout", "current-dash-base")
+        _git(candidate, "update-ref", tracking_ref, old_base)
+
+    # BOTH callers depend on this: the `refreshed == advanced_base` assertion below proves nothing unless the
+    # tracking ref is STALE at the moment the CLI runs. Assert the stale pre-state here and the fixture cannot
+    # silently lose its teeth to a setup step that refreshes the ref first.
+    check(_git(candidate, "rev-parse", tracking_ref).stdout.strip() == old_base,
+          "fixture setup: the base tracking ref must still be stale when the CLI runs, or the refresh "
+          "assertion is pre-satisfied and proves nothing")
 
     vjson = root / "clean-view.json"
     vjson.write_text(json.dumps(view()), encoding="utf-8")


### PR DESCRIPTION
- `dash-base-current`'s setup fetched by remote name, so Git refreshed the tracking ref first.
- The `refreshed == remote_head` assertion was pre-satisfied and passed with no production fetch.
- Setup now resets that ref to the stale tip, and both callers assert the stale pre-state.
