### PR TITLE
enforce the irreversible-change wait

### DIFF
--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -172,12 +172,15 @@ Work the resumable entries in this order, which is this file's own rule:
    that costs one reconcile and closes the largest hole; starting new work while it is open widens it.
 2. `accepted`, then `self-accepted`, then `reopened` — the decision is already made and only the PR is
    missing.
-3. `corroborated` — investigated already, so it resumes at the take-up decision, **not** at another
+3. `corroborated` — investigated already, so it resumes at the ACT decision, **not** at another
    investigation.
 4. `candidate` — the only state that starts with an investigation.
 
 `refuted` is **not** picked up. It is re-investigated only when new evidence may overturn it, and an
 invocation of this skill supplies none. `rejected` is the user's terminal ruling and is never resumed.
+`held` is **not** picked up either: its ACT decision is already recorded and it is waiting on the user, so
+it is **surfaced in Step 6 with its question** and never re-decided here. The store enforces that rather
+than trusting it — no edge from `held` opens a PR.
 
 At most one of `--id` and `--limit` can have reached this step — the Args block above owns which
 invocations are legal. Apply whichever one was given **after** ordering, and **say what was left unworked
@@ -258,17 +261,20 @@ that was never real (`AGENTS.md`/`CLAUDE.md`, "Your OWN diagnosis is a claim too
 **Only a `corroborated` entry reaches this step.** The other states arriving at Step 5 already carry a
 decision, and re-deciding one would overwrite a ruling that was already made.
 
-`followups.md`, "THE AUTONOMY THRESHOLD", owns the conditions and what each one does; `followups.py
-take-up` refuses the step when any is asserted without evidence. **Read them there and evidence each
-one.** This file does not restate which conditions route and which one waits.
+`followups.md`, "THE AUTONOMY THRESHOLD", owns the conditions and what each one does; the ACT edges refuse
+the step when any is asserted without evidence, and refuse a verdict they are not the edge for. **Read
+them there and evidence each one.** This file does not restate which conditions route and which one waits,
+nor the form the verdict takes.
 
 **A corroborated entry is worked, not surfaced instead of worked.** The default outcome of this step is
 `take-up` followed by Step 5, and the report says what the fixer is doing. The one class the threshold
 holds back waits for the user's ruling and is named in Step 6 with its question.
 
 - The threshold permits acting → `take-up`, then Step 5.
-- The threshold holds this entry back → record the question for Step 6 and move to the next entry. Do
-  not leave it silently undone, and do not re-decide it on a later invocation without new evidence.
+- The threshold holds this entry back → **`hold`**, which records the same evidence and leaves the entry
+  in `held`; then record the question for Step 6 and move to the next entry. Do not leave it silently
+  undone, and do not re-decide it on a later invocation without new evidence. **Do not attempt Step 5 for
+  it** — no edge from `held` opens a PR, so the store refuses that rather than relying on this line.
 - **NEVER run `accept`.** It is the user's edge and the only way into `accepted`.
 - **NEVER run `publish`.** There is no autonomous path to it, from any state.
 
@@ -338,7 +344,8 @@ entry the threshold **routes** is disclosed and dispatched, so it raises **no qu
 to hold, and "taken up with its PR" on its own reads exactly like an entry every condition held for. What
 that disclosure must say is `followups.md`, "Surfacing them" — stated once there, for this step and
 campaign's final report, the only two reporting steps that owe it. Report it from there for **every** entry
-Step 4 took up; do not reconstruct it from this step.
+Step 4 disposed of on its own — the ones it took up and the ones it held; do not reconstruct it from this
+step.
 
 Then:
 

--- a/plugins/gauntlet/skills/address-followups/SKILL.md
+++ b/plugins/gauntlet/skills/address-followups/SKILL.md
@@ -182,6 +182,21 @@ invocation of this skill supplies none. `rejected` is the user's terminal ruling
 it is **surfaced in Step 6 with its question** and never re-decided here. The store enforces that rather
 than trusting it — no edge from `held` opens a PR.
 
+Surfacing one takes an enumeration of its own, because the work list above can never contain it. Run the
+same command for the state it is in:
+
+```text
+python3 <abs>/followups.py --file <abs-store> list --where state=held
+```
+
+Carry the ids it prints as the **surfacing list** — a second list, never worked, never dispatched — and
+fetch each entry with `python3 <abs>/followups.py --file <abs-store> get --id fuN`, which prints the
+fields the `hold` edge wrote. Every entry on it is one **no step of this invocation touches**: at Step 1
+the only way an entry can already be `held` is that an EARLIER invocation held it, since this
+invocation's own `hold` happens later, at Step 4. Step 6 reports the surfacing list whether or not Step 4
+ran at all, and an empty list is reported as none. `--limit` does not cap it — that flag caps the work
+list — and `--id fuN` reduces it to that one entry when that entry is the `held` one.
+
 At most one of `--id` and `--limit` can have reached this step — the Args block above owns which
 invocations are legal. Apply whichever one was given **after** ordering, and **say what was left unworked
 and why**. A skill that silently stops at a cap reads as "the queue is clear" when it is not.
@@ -200,8 +215,7 @@ entered the work list is a different case and is reported regardless.
 shorthand, expanded by `../campaign/SKILL.md`, "Bundled Scripts".** Pasted verbatim into a shell,
 `list --where id=fu1` and `get --id fu1 --field state` were each observed to exit 127 with `command not
 found`. Both full forms are written out in this file: `list` in the synopsis block at the head of this
-step, and `get` in the entry-fetch line of the INVESTIGATE step's prompt list. Re-run either paste to
-falsify this.
+step, and `get` in the surfacing-list paragraph just above. Re-run either paste to falsify this.
 
 ## Step 2 — reconcile every `in-pr` entry against its live PR
 
@@ -339,19 +353,26 @@ Report **before** Step 7, because Step 7 ends this skill and anything unsaid is 
 entry touched, give its id, its title, and its outcome: reconciled, corroborated, refuted, taken up with
 its PR, or surfaced for a ruling.
 
+**Step 1's surfacing list is reported here too, and NOT ONE of its entries was touched.** Every step
+between Step 1 and here skips a `held` entry by design, so "every entry touched" reaches none of them and
+this is the only line that does. Give each the same id, title, and outcome — surfaced for a ruling — from
+what Step 1 fetched.
+
 **A taken-up entry carries its ACT disclosure in that outcome, never in the question bullet below** — an
 entry the threshold **routes** is disclosed and dispatched, so it raises **no question** for that bullet
 to hold, and "taken up with its PR" on its own reads exactly like an entry every condition held for. What
 that disclosure must say is `followups.md`, "Surfacing them" — stated once there, for this step and
 campaign's final report, the only two reporting steps that owe it. Report it from there for **every** entry
-Step 4 disposed of on its own — the ones it took up and the ones it held; do not reconstruct it from this
-step.
+disposed of on its own, **whichever invocation disposed of it** — the ones Step 4 took up, the ones Step 4
+held, and every entry on Step 1's surfacing list, which an earlier invocation held in exactly the same
+way; do not reconstruct it from this step.
 
 Then:
 
 - list every entry left unworked and why (`--limit`, an unresumable state, a dispatch that failed, a
   command that refused and which one, a PR another run owns);
-- list every question a user must answer, each with the entry it belongs to;
+- list every question a user must answer, each with the entry it belongs to — the surfacing list's
+  entries included, each of whose question is the ruling its `held` state is waiting on;
 - print in full the output of every deleting step this invocation ran;
 - name the PRs about to be handed to campaign.
 

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -352,8 +352,8 @@ name from one host into another.
 <!-- Refutation of a review finding against the `accepted`/`reopened` follow-up-fixer row above, which
      claimed that row still characterizes `accept`'s from-set instead of deferring to `followups.py --help`.
      `followups.py --help` prints `accept  THE USER rules:
-     candidate/corroborated/refuted/self-accepted/reopened -> accepted`, and the row names none of those
-     five states as a member: it states one negative property — the set is not confined to corroborated
+     candidate/corroborated/refuted/self-accepted/held/reopened -> accepted`, and the row names none of
+     those six states as a member: it states one negative property — the set is not confined to corroborated
      states — and cites the owner for the set itself. `references/followups.md` requires exactly that form,
      saying the legal from-states are owned by `scripts/followups.py` and printed live by
      `followups.py --help`, and that the page does not retype them. Property checked against `TRANSITIONS`

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -209,15 +209,17 @@ When the loop exits, summarize:
   that surfacing is never a substitute for that (`followups.md`, "Surfacing them"). A defect a bailout
   exposed and this run will not fix is recorded in the store **before** the report is written, not
   announced only in it — a follow-up that exists only in this report dies with it.
-  **The table is not the whole of this bullet: every entry this run DISPOSED OF ON ITS OWN — by either
-  ACT edge — also owes its ACT disclosure here.** It is owed in this bullet rather than under the ASK
-  above because that ASK belongs to a `candidate`, a claim nobody has investigated yet, while these the
-  run investigated and decided. **The one class the threshold makes WAIT was disposed of too, and the
-  question it raises is asked HERE**, beside that entry's own disclosure and its `held` row in the table:
-  no other part of this report asks it, and the user's ruling is the only thing that ever moves that entry
-  (`followups.md`, "WORKING A FOLLOW-UP"). Which entries owe the disclosure, what it must say, and which
-  of them carries that question are all `followups.md`, "Surfacing them" — report them from there; do not
-  reconstruct them from this bullet.
+  **The table is not the whole of this bullet: every entry DISPOSED OF ON ITS OWN — by either ACT edge —
+  also owes its ACT disclosure here.** It is owed in this bullet rather than under the ASK above because
+  that ASK belongs to a `candidate`, a claim nobody has investigated yet, while these a run investigated
+  and decided. **The one class the threshold makes WAIT was disposed of too, and the question it raises
+  is asked HERE**, beside that entry's own disclosure and its `held` row in the table: no other part of
+  this report asks it, and the user's ruling is the only thing that ever moves that entry
+  (`followups.md`, "WORKING A FOLLOW-UP"). **That is why this bullet is not scoped to what THIS run did**:
+  a `held` entry an earlier run left behind is still open, still in the table, and still waiting on a
+  ruling nobody has been asked for, so it owes the same disclosure and the same question here. Which
+  entries owe the disclosure, what it must say, and which of them carries that question are all
+  `followups.md`, "Surfacing them" — report them from there; do not reconstruct them from this bullet.
 - Any worktrees left for inspection.
 
 This run's durable carryover file (`.gauntlet/history/<run-id>.md`) is written on exit by

--- a/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
+++ b/plugins/gauntlet/skills/campaign/references/bailout-and-final-report.md
@@ -209,10 +209,15 @@ When the loop exits, summarize:
   that surfacing is never a substitute for that (`followups.md`, "Surfacing them"). A defect a bailout
   exposed and this run will not fix is recorded in the store **before** the report is written, not
   announced only in it — a follow-up that exists only in this report dies with it.
-  **The table is not the whole of this bullet: every entry this run TOOK UP also owes its ACT disclosure
-  here**, and it is owed in this bullet rather than under the ASK above, because an entry the threshold
-  **routes** is disclosed and dispatched and raises no question to ask. What that disclosure must say is
-  `followups.md`, "Surfacing them" — report it from there; do not reconstruct it from this bullet.
+  **The table is not the whole of this bullet: every entry this run DISPOSED OF ON ITS OWN — by either
+  ACT edge — also owes its ACT disclosure here.** It is owed in this bullet rather than under the ASK
+  above because that ASK belongs to a `candidate`, a claim nobody has investigated yet, while these the
+  run investigated and decided. **The one class the threshold makes WAIT was disposed of too, and the
+  question it raises is asked HERE**, beside that entry's own disclosure and its `held` row in the table:
+  no other part of this report asks it, and the user's ruling is the only thing that ever moves that entry
+  (`followups.md`, "WORKING A FOLLOW-UP"). Which entries owe the disclosure, what it must say, and which
+  of them carries that question are all `followups.md`, "Surfacing them" — report them from there; do not
+  reconstruct them from this bullet.
 - Any worktrees left for inspection.
 
 This run's durable carryover file (`.gauntlet/history/<run-id>.md`) is written on exit by

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -459,7 +459,8 @@ why the driver **raised** it; the other is what happened when somebody actually 
 overwrites the claim, and a second investigation never overwrites the first — it **appends**. The driver
 changing its mind is part of the record, not a thing to tidy away. The **ACT grounds** are separate again:
 they are the driver's evidence for each tier-2 condition, and nothing can edit them after the fact, because
-they are what made the self-acceptance legal.
+they are what made the ACT decision legal — the dispatch and the wait alike, since both ACT edges demand
+and write them.
 
 **There is deliberately NO severity field.** Severity is the driver's judgment about a claim nobody has
 corroborated, and a machine-readable rank is exactly what an autonomous driver would sort on and *act*

--- a/plugins/gauntlet/skills/campaign/references/followups.md
+++ b/plugins/gauntlet/skills/campaign/references/followups.md
@@ -60,12 +60,19 @@ walking away is the permanent loss this store exists to prevent, arriving by a s
 sits corroborated forever, every later run re-reads it, and the defect it names stays in the tree. The
 driver may not use uncertainty as a reason to act on nothing.
 
-The three conditions below are still **RECORDED**, and `take-up` refuses the step if any is asserted
+The three conditions below are still **RECORDED**, and an ACT edge refuses the step if any is asserted
 without evidence. What changed is what a failing one does: it **routes** the entry rather than cancelling
 the work. A failing `not-gate-machinery` or `behavior-preserved` condition is **DISCLOSED and dispatched
 without a question** — the fixer runs and the user reads about it afterwards. Only a failing `reversible`
 condition raises a **question**: that entry **WAITS** for the user's ruling before any fixer is
 dispatched.
+
+**That wait is MECHANICAL, not a promise the driver keeps.** `reversible` is the one condition whose
+answer the code itself reads, so its evidence leads with a verdict — and the verdict picks the edge: a
+`reversible` change goes to `take-up`, an `irreversible` one to `hold`, and **each edge refuses the
+other's verdict**. `hold` lands the entry in `held`, which `open-pr` does not leave from, so there is no
+driver-only path from an irreversible change to a PR at all. It is the same shape as tier 3's guarantee
+below: an **absent edge**, not a check somebody must remember to run.
 
 1. **`not-gate-machinery`** (`--act-not-gate`) — does it decide whether a PR may merge? The active
    repository instruction file (`AGENTS.md` or `CLAUDE.md`) defines the gate; do not reconstruct that
@@ -80,14 +87,28 @@ dispatched.
    has no behavioral surface. That is a legitimate answer, not a loophole.)
 3. **`reversible`** (`--act-reversible`) — does a revert restore the prior state? A schema migration does
    not. Anything already published does not. **An irreversible change is the one class that WAITS**: the
-   fixer is not dispatched until the user rules, because no gate downstream can undo it.
+   fixer is not dispatched until the user rules, because no gate downstream can undo it. **So this one
+   value must LEAD WITH ITS VERDICT** — `reversible: <why>` or `irreversible: <why>` — the way an
+   investigation's `finding` leads with its outcome. Prose alone cannot carry a condition the code has to
+   act on, and **guessing the answer out of free text is not the alternative**: a search for a negation
+   would refuse *"a revert restores the prior state, so this is not irreversible"* and wave through a
+   one-way change worded without one. So the driver states the verdict, and **the verdict picks the
+   edge.**
 
 ```
-followups.py --file <store> take-up --id fuN \
-  --act-not-gate "..." --act-behavior "..." --act-reversible "..."
+followups.py --file <store> take-up --id fuN \        # a REVERSIBLE change — dispatch the fixer
+  --act-not-gate "..." --act-behavior "..." --act-reversible "reversible: ..."
+followups.py --file <store> hold --id fuN \           # an IRREVERSIBLE one — it WAITS for the user
+  --act-not-gate "..." --act-behavior "..." --act-reversible "irreversible: ..."
 ```
 
-It lands in **`self-accepted`** — deliberately **NOT** `accepted`. A follow-up the **user** agreed to and
+**Both edges leave from `corroborated` and demand the same evidence**, so nothing is skipped by taking
+the one that waits. `hold` lands in **`held`**, where the entry sits with its ACT grounds until the user
+rules (`accept` / `reject`); no other edge leaves it, and **`open-pr` is not among the ones that do**.
+That is what the wait IS. Neither edge accepts the other's verdict, so the driver cannot route around
+this by picking the wrong command.
+
+`take-up` lands in **`self-accepted`** — deliberately **NOT** `accepted`. A follow-up the **user** agreed to and
 one the **driver** took up on its own are different things, forever, and the table says which at a glance.
 **The PR that comes out of an ACT is not self-approved**: it is gated by the review gauntlet like any
 other, which is the independent authority the driver is not. **That gate is what makes acting on a
@@ -96,6 +117,12 @@ corroborated claim safe** — a wrong fix costs its own review rounds and never 
 **So exactly one condition still stops the work before it starts, and it is `reversible`.** Everything
 else is disclosed and dispatched. A driver that surfaces a corroborated entry instead of working it has
 not been careful; it has left a reproduced defect in the tree and called that caution.
+
+**State the limit honestly, as `accept` does below.** Nothing in the store can tell whether a change
+really is reversible — a driver that judges that wrong still gets through, and no local file could do
+better. What the verdict buys is that the recorded judgment and the action taken **cannot contradict each
+other**: `irreversible` in the entry and a fixer dispatched anyway is no longer a thing that can happen.
+It is a footgun guard, **NOT** an oracle.
 
 ### Tier 3 — PUBLISH (a GitHub issue, a release). ALWAYS the user's call. Never autonomous.
 
@@ -172,10 +199,15 @@ about and one whose partial rejection strands the rest.
 
    - **`candidate`** (a fresh one) — INVESTIGATE: this is step 1, the common path above. No prior step to
      resume.
-   - **`corroborated`** — skip investigation; resume at the `take-up` decision (step 3). No campaign action
-     beyond what step 3 already does.
+   - **`corroborated`** — skip investigation; resume at the ACT decision (step 3), which lands on `take-up`
+     or `hold` by the verdict it records. No campaign action beyond what step 3 already does.
    - **`refuted`** — re-investigated **only** when new evidence may overturn it, and that re-investigation
      succeeds by `corroborate`, never `refute`.
+   - **`held`** — the driver recorded an **irreversible** verdict, so the entry is **waiting on the user**
+     and its ACT decision is already made. It does **not** resume at a step: **SURFACE it with its
+     question** (step 5) and work the next entry. The user's ruling is the only thing that moves it, and
+     the graph enforces that — no fixer is dispatched from here, because `open-pr` does not leave from
+     `held`. **Never re-decide it** without new evidence.
    - **`self-accepted`** — the driver already took it up; the entry has **no PR yet** (a `self-accepted`
      entry stores no PR reference — `open-pr` is the step that first writes one). So resume at **step 3**:
      dispatch the scoped fix subagent, which authors the fix and **opens the PR**; `open-pr` then records it
@@ -223,12 +255,12 @@ about and one whose partial rejection strands the rest.
    evidence the claim is false, never because a fix is inconvenient.
 
 3. **APPLICABLE → `take-up`, then a FIX SUBAGENT that opens a PR.** If the investigation `corroborated` it,
-   **every ACT condition is recorded with evidence** — `take-up` refuses the step without that — **and the
+   **every ACT condition is recorded with evidence** — an ACT edge refuses the step without that — **and the
    threshold above does not hold the entry back**, the driver takes it up (→ `self-accepted`)
    and dispatches a **scoped fix subagent under the fix-subagent contract**
    (`fix-subagent-contract.md`) that authors the fix **and opens a PR** for it. **An entry the threshold
-   holds back stops here — before `take-up`, and before any fixer is dispatched** — and is routed by "A
-   CONDITION THAT FAILS ROUTES THE WORK" below. The driver hands the fixer
+   holds back stops here — it goes to `hold` (→ `held`) with the same evidence, and no fixer is
+   dispatched** — and is routed by "A CONDITION THAT FAILS ROUTES THE WORK" below. The driver hands the fixer
    a **worktree branched from the base the follow-up targets**, and the fixer branches, commits, pushes,
    and opens the PR against that base — its worktree and scope requirements are owned by
    `fix-subagent-contract.md`, not restated here. **The target is per follow-up**: a follow-up **derived
@@ -261,7 +293,8 @@ about and one whose partial rejection strands the rest.
 5. **A CONDITION THAT FAILS ROUTES THE WORK — it does not cancel it.** Read the threshold above for what
    each one does; the shape is that gate machinery and a behavior change are **DISCLOSED and dispatched**,
    while an **irreversible** change is the one class that WAITS for the user's ruling
-   (`accept` / `reject`) before a fixer runs. Surfacing an entry is how the user learns what the driver is
+   (`accept` / `reject`) before a fixer runs — recorded by `hold`, and enforced by the graph rather than
+   by this instruction. Surfacing an entry is how the user learns what the driver is
    doing, never a way to leave a reproduced defect undone. And **publishing is never on the autonomous
    path**: an issue or a release always waits for the user's agreement on that specific item (Tier 3).
 
@@ -350,7 +383,10 @@ exactly as with `ledger.py` and `emit-progress.py`.
 followups.py --file <store> add --title T --evidence E --deferred-why W [--run <run-id>]  # raise a CANDIDATE
 followups.py --file <store> corroborate --id fuN --finding F   # TIER 1 — free. An investigation confirmed it
 followups.py --file <store> refute      --id fuN --finding F   # TIER 1 — free. And it stays in the store
-followups.py --file <store> take-up     --id fuN --act-...     # TIER 2 — only with EVERY condition evidenced
+followups.py --file <store> take-up     --id fuN --act-...     # TIER 2 — only with EVERY condition evidenced,
+                                                               # and only for a `reversible:` verdict
+followups.py --file <store> hold        --id fuN --act-...     # TIER 2, the class that WAITS — the same
+                                                               # evidence, an `irreversible:` verdict, no fixer
 followups.py --file <store> accept  --id fuN        # THE USER AGREED — the only edge into `accepted`
 followups.py --file <store> reject  --id fuN        # the user ruled against it — and the entry is KEPT
 followups.py --file <store> open-pr --id fuN --pr <ref>    # a PR is addressing it — the entry STAYS
@@ -437,18 +473,23 @@ Every entry enters as a **candidate**. The state moves **only** along the transi
 transition validates the state it is coming **from**. **The END of an entry is on that graph too:** a
 deleting step is an edge like any other, and it is refused from any state it does not leave from.
 
-Two structural facts carry the whole threshold, and both are **proved on the graph** by the self-test
-(`user-step-unskippable`), not asserted in prose:
+Three structural facts carry the whole threshold, and each is **proved on the graph** by the self-test,
+not asserted in prose:
 
-- **No sequence of driver-only steps reaches `accepted`, nor any state `publish` may leave from.**
-  `accepted` has exactly one in-edge and it is the user's `accept`; `publish` leaves only from `accepted`.
-  Tier 3 has no back door — not a missing check, an absent **edge**. (That `publish` **deletes** the
-  entry rather than parking it changes nothing: the guarantee was never about the state it landed in, but
-  about which states the step may leave **from**.)
-- **The driver's own edge is evidence-bearing and lands somewhere else.** `take-up` leaves only from
-  `corroborated` (tier 2's own precondition) and lands in `self-accepted`, which is never `accepted`.
+- **No sequence of driver-only steps reaches `accepted`, nor any state `publish` may leave from**
+  (`user-step-unskippable`). `accepted` has exactly one in-edge and it is the user's `accept`; `publish`
+  leaves only from `accepted`. Tier 3 has no back door — not a missing check, an absent **edge**. (That
+  `publish` **deletes** the entry rather than parking it changes nothing: the guarantee was never about
+  the state it landed in, but about which states the step may leave **from**.)
+- **The driver's own edge is evidence-bearing and lands somewhere else** (`user-step-unskippable`).
+  `take-up` leaves only from `corroborated` (tier 2's own precondition) and lands in `self-accepted`,
+  which is never `accepted`.
+- **An IRREVERSIBLE change has no driver-only path to a PR** (`irreversible-waits`). The verdict recorded
+  in `act_reversible` decides which ACT edge is legal, and the one for `irreversible` lands in `held`,
+  which `open-pr` does not leave from. Tier 2's one WAIT is an absent edge too — the same guarantee as
+  the first fact, made the same way.
 
-And a third, which is what makes DELETION safe (`delete-needs-a-record`):
+And a fourth, which is what makes DELETION safe (`delete-needs-a-record`):
 
 - **No deleting edge can be reached without a durable record in the entry.** Every legal history that
   arrives at one has already written the field that names where the record lives — the PR, or the issue —
@@ -518,12 +559,14 @@ the ledger's (`files-and-ledger.md`, "`table` is a PROJECTION"): it shows only t
 only some fields, it **escapes** every cell, and **the omission is never silent** — it states how many it
 hid and the flag that reveals them. Read a value back with `get --field`, **never** by parsing the table.
 
-**Surfacing is NOT the whole of what the user is owed for an entry the driver TOOK UP.** No ACT evidence
-reaches that table — the fields `take-up` wrote sit outside its default view — and an entry the threshold
-**routes** is disclosed and dispatched, so it raises no question to be listed under and reads exactly like
-one every condition held for. So **exactly two reporting steps owe this disclosure** — campaign's final
-report (`bailout-and-final-report.md`, **Follow-ups**) and `address-followups`' Step 6 — and each must name
-**each ACT condition that did NOT hold**, quoting the evidence `take-up` recorded for it. **No other report
+**Surfacing is NOT the whole of what the user is owed for an entry the driver DISPOSED OF ON ITS OWN.** No
+ACT evidence reaches that table — the fields an ACT edge wrote sit outside its default view — and an entry
+the threshold **routes** is disclosed and dispatched, so it raises no question to be listed under and reads
+exactly like one every condition held for. So **exactly two reporting steps owe this disclosure** —
+campaign's final report (`bailout-and-final-report.md`, **Follow-ups**) and `address-followups`' Step 6 —
+and each must name **each ACT condition that did NOT hold**, quoting the evidence the ACT edge recorded for
+it. That edge is `take-up` for an entry that was dispatched and `hold` for the one class that waits; a
+`held` entry is where the user's **question** is, so it is named with its evidence like any other. **No other report
 owes it**: not heartbeat or interim output, not the `gauntlet:followups` listing skill, not `carryover.md`,
 not the run history file.
 The THRESHOLD above already fixes what that evidence must say, condition by condition; this section does

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1027,6 +1027,12 @@ def t_the_irreversible_change_waits(tmp: Path) -> None:
 
     # 1a. A value that carries NO verdict is refused at EVERY ACT edge — including the exact prose the
     #     reproduction used, which is the whole point: it says `no` in English and nothing could read it.
+    #
+    #     …AND THE GRAMMAR IS EXACT. The value OPENS with the token and the separator follows it
+    #     IMMEDIATELY; only the CASE is free (pinned just below). A spaced token is a shape the doc's
+    #     `reversible: <why>` never shows, and a parser wider than the form the driver is told to type
+    #     is a parser the doc cannot describe — the accepted grammar and the documented one are the same
+    #     grammar, or one of them is lying.
     unreadable = (
         "NO — this is NOT reversible; it is a one-way schema migration and a revert CANNOT restore "
         "the prior state",
@@ -1036,6 +1042,9 @@ def t_the_irreversible_change_waits(tmp: Path) -> None:
         f"maybe{VERDICT_SEP} who knows",   # a separator, but no verdict the code knows
         f"{IRREVERSIBLE}{VERDICT_SEP}",    # a verdict with NO grounds is the rumor the witnesses forbid
         f"{IRREVERSIBLE}{VERDICT_SEP} {PLACEHOLDER}",
+        f"{REVERSIBLE} {VERDICT_SEP} why",     # whitespace BEFORE the separator
+        f"{IRREVERSIBLE}\t{VERDICT_SEP} why",  # …of any kind
+        f" {REVERSIBLE}{VERDICT_SEP} why",     # …and the value must OPEN with the token
     )
     for act in ACT_CMDS:
         for i, value in enumerate(unreadable):
@@ -1050,6 +1059,14 @@ def t_the_irreversible_change_waits(tmp: Path) -> None:
                   f"{value!r}\n{out}")
             check(state_of(path, fid) == "corroborated", f"a refused `{act}` moved the state anyway")
             check(verdict_of(value) is None, f"`verdict_of` reads a verdict out of {value!r}")
+
+    # …and the ONE freedom the grammar does allow is CASE, so a driver that SHOUTS its verdict is obeying
+    # the same grammar rather than a wider one. Pinned here because the refusals above would otherwise be
+    # satisfied by a parser that demanded an exact-case token too.
+    for verdict in VERDICTS:
+        shouted = f"{verdict.upper()}{VERDICT_SEP} why"
+        check(verdict_of(shouted) == verdict,
+              f"`verdict_of` reads no verdict out of {shouted!r} — the token is matched case-insensitively")
 
     # 1b. …and each edge refuses the OTHER verdict. The verdict picks the edge; the driver does not.
     for act, verdict in ACT_EDGE_VERDICT.items():

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -45,11 +45,12 @@ check = ledger_test.check
 # this resolves to the module that is actually RUNNING — not a second copy of the same file.
 import followups  # noqa: E402
 from followups import (  # noqa: E402
-    ACT_CMD, ACT_CONDITIONS, ACT_FLAGS, ACT_WITNESSES, BLANK_WHY, DEFAULTS, DELETED, DELETING,
-    DRIVER_STEPS, DURABLE_RECORD, EDITABLE, ENTRY_TYPE, EVIDENCE_FIELDS, FIELDS, FLAG, INTAKE,
-    INVESTIGATION, OPTIONAL, PLACEHOLDER, REQUIRED, SEQ_TYPE, STATES, TABLE_ALL_HIDDEN_MARKER,
-    TABLE_DEFAULT_FIELDS, TABLE_EMPTY_MARKER, TABLE_HIDDEN_STATES, TABLE_MARKERS, TERMINAL, TRANSITIONS,
-    USER_RULINGS, WRITE_CMDS, WRITES, build_parser, deletable, find, is_blank, load,
+    ACT_CMD, ACT_CMDS, ACT_CONDITIONS, ACT_EDGE_VERDICT, ACT_FLAGS, ACT_WITNESSES, BLANK_WHY, DEFAULTS,
+    DELETED, DELETING, DRIVER_STEPS, DURABLE_RECORD, EDITABLE, ENTRY_TYPE, EVIDENCE_FIELDS, FIELDS, FLAG,
+    HOLD_CMD, INTAKE, INVESTIGATION, IRREVERSIBLE, OPTIONAL, PLACEHOLDER, REQUIRED, REVERSIBLE, SEQ_TYPE,
+    STATES, TABLE_ALL_HIDDEN_MARKER, TABLE_DEFAULT_FIELDS, TABLE_EMPTY_MARKER, TABLE_HIDDEN_STATES,
+    TABLE_MARKERS, TERMINAL, TRANSITIONS, USER_RULINGS, VERDICT_FIELD, VERDICT_SEP, VERDICTS, WRITE_CMDS,
+    WRITES, build_parser, deletable, find, is_blank, load, verdict_of,
 )
 
 
@@ -81,6 +82,17 @@ def raw_line(field: str, raw: str, **over: object) -> str:
     return json.dumps(rec).replace('"@@RAW@@"', raw)
 
 
+def legal_value(cmd: str, field: str, text: str) -> str:
+    """A value `cmd` ACCEPTS for `field` — carrying the verdict token that edge requires, if any.
+
+    DERIVED from `ACT_EDGE_VERDICT`, so every fixture that builds legal argv keeps building it after a
+    field starts carrying a verdict. A fixture that hard-coded prose here would go red for the wrong
+    reason — the value form, not the rule it came to check.
+    """
+    verdict = ACT_EDGE_VERDICT.get(cmd) if field == VERDICT_FIELD else None
+    return f"{verdict}{VERDICT_SEP} {text}" if verdict else text
+
+
 def transition_args(cmd: str) -> "list[str]":
     """The flags a transition REQUIRES — derived from `WRITES`, never retyped.
 
@@ -91,7 +103,7 @@ def transition_args(cmd: str) -> "list[str]":
     for field in WRITES[cmd]:
         if field in OPTIONAL:
             continue
-        argv += [FLAG[field], f"{cmd}:{field}"]
+        argv += [FLAG[field], legal_value(cmd, field, f"{cmd}:{field}")]
     return argv
 
 
@@ -195,7 +207,7 @@ def write_argv(cmd: str, fid: str, field: str, value: str) -> "list[str]":
         elif cmd == "add" and f in REQUIRED:
             argv += [flag, f"add:{f}"]                      # the door cannot be without these
         elif cmd in TRANSITIONS and f in WRITES[cmd] and f not in OPTIONAL:
-            argv += [flag, f"{cmd}:{f}"]                    # nor these — the edge's own witnesses
+            argv += [flag, legal_value(cmd, f, f"{cmd}:{f}")]  # nor these — the edge's own witnesses
     return argv
 
 
@@ -920,63 +932,186 @@ def t_a_rejection_is_never_deleted(tmp: Path) -> None:
 
 
 def t_act_edge_needs_every_condition(tmp: Path) -> None:
-    """THE AUTONOMOUS EDGE IS EVIDENCE-BEARING, OR IT IS A BYPASS WITH A NICER NAME.
+    """AN AUTONOMOUS EDGE IS EVIDENCE-BEARING, OR IT IS A BYPASS WITH A NICER NAME.
 
-    `take-up` is the one step where the driver commits the repo to work with NO user ruling. What makes
-    that safe is not the driver's good intentions — it is that EVERY ACT condition must be witnessed IN THE
-    ENTRY, and the accessor refuses the step otherwise, exactly as `add` refuses a blank `evidence`.
+    The ACT edges are where the driver disposes of a corroborated claim with NO user ruling — `take-up`
+    commits the repo to work, `hold` parks the change the threshold says must wait. What makes either safe
+    is not the driver's good intentions: EVERY ACT condition must be witnessed IN THE ENTRY, and the
+    accessor refuses the step otherwise, exactly as `add` refuses a blank `evidence`.
 
-    Condition 1 (CORROBORATED) is enforced by the GRAPH, not by a flag: `take-up` leaves only from
-    `corroborated`, so a claim nobody investigated cannot be taken up at all. The rest are flags, and each
-    is REQUIRED and must be non-blank. Every check below is derived from ACT_CONDITIONS — a fifth condition
-    is pinned here the day it is added.
+    Condition 1 (CORROBORATED) is enforced by the GRAPH, not by a flag: an ACT edge leaves only from
+    `corroborated`, so a claim nobody investigated cannot be disposed of at all. The rest are flags, and
+    each is REQUIRED and must be non-blank. Every check below is derived from ACT_CONDITIONS and
+    ACT_CMDS — a fifth condition, or a third ACT edge, is pinned here the day it is added.
     """
-    # Condition 1: the graph. An UNINVESTIGATED claim cannot be taken up — and neither can a REFUTED one.
-    check(TRANSITIONS[ACT_CMD][0] == ("corroborated",),
-          f"`{ACT_CMD}` leaves from {TRANSITIONS[ACT_CMD][0]!r} — it must leave ONLY from `corroborated`, "
-          f"which is what makes CORROBORATION structural rather than a claim the driver types in")
-    for setup in ([], ["refute"]):
-        path = tmp / ("cond1-" + "-".join(setup or ["raw"]) + ".jsonl")
-        (fid,) = seed(path)
-        for cmd in setup:
-            run(["--file", str(path), cmd, "--id", fid, *transition_args(cmd)])
-        was = state_of(path, fid)
-        code, _, err = run(["--file", str(path), ACT_CMD, "--id", fid, *transition_args(ACT_CMD)])
-        check(code == 1, f"`{ACT_CMD}` was ACCEPTED on a {was!r} follow-up (exit {code}) — the driver took "
-                         f"up an UNCORROBORATED claim")
-        check(state_of(path, fid) == was, f"a refused `{ACT_CMD}` moved {was!r} anyway")
+    for act in ACT_CMDS:
+        # Condition 1: the graph. An UNINVESTIGATED claim cannot be acted on — and neither can a REFUTED one.
+        check(TRANSITIONS[act][0] == ("corroborated",),
+              f"`{act}` leaves from {TRANSITIONS[act][0]!r} — it must leave ONLY from `corroborated`, "
+              f"which is what makes CORROBORATION structural rather than a claim the driver types in")
+        for setup in ([], ["refute"]):
+            path = tmp / (f"{act}-cond1-" + "-".join(setup or ["raw"]) + ".jsonl")
+            (fid,) = seed(path)
+            for cmd in setup:
+                run(["--file", str(path), cmd, "--id", fid, *transition_args(cmd)])
+            was = state_of(path, fid)
+            code, _, err = run(["--file", str(path), act, "--id", fid, *transition_args(act)])
+            check(code == 1, f"`{act}` was ACCEPTED on a {was!r} follow-up (exit {code}) — the driver "
+                             f"disposed of an UNCORROBORATED claim")
+            check(state_of(path, fid) == was, f"a refused `{act}` moved {was!r} anyway")
 
-    # Conditions 2..N: each is a REQUIRED flag, and each refuses a blank.
-    for witness in ACT_FLAGS:
-        path = tmp / f"cond-{witness}.jsonl"
-        (fid,) = seed(path)
-        run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced"])
+        # Conditions 2..N: each is a REQUIRED flag, and each refuses a blank.
+        for witness in ACT_FLAGS:
+            path = tmp / f"{act}-cond-{witness}.jsonl"
+            (fid,) = seed(path)
+            run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced"])
 
-        argv = ["--file", str(path), ACT_CMD, "--id", fid]
-        omitted = [a for f in ACT_FLAGS if f != witness for a in (FLAG[f], "x")]
-        code, _, err = run([*argv, *omitted])
-        check(code == 2, f"`{ACT_CMD}` without {FLAG[witness]} was ACCEPTED (exit {code}): {err!r}")
-        for blank in BLANKS:
-            values = [a for f in ACT_FLAGS for a in (FLAG[f], blank if f == witness else "x")]
-            code, _, err = run([*argv, *values])
+            argv = ["--file", str(path), act, "--id", fid]
+            omitted = [a for f in ACT_FLAGS if f != witness
+                       for a in (FLAG[f], legal_value(act, f, "x"))]
+            code, _, err = run([*argv, *omitted])
+            check(code == 2, f"`{act}` without {FLAG[witness]} was ACCEPTED (exit {code}): {err!r}")
+            for blank in BLANKS:
+                values = [a for f in ACT_FLAGS
+                          for a in (FLAG[f], blank if f == witness else legal_value(act, f, "x"))]
+                code, _, err = run([*argv, *values])
+                check(code == 1,
+                      f"`{act}` with a BLANK {FLAG[witness]} ({blank!r}) was ACCEPTED (exit {code}) — a "
+                      f"condition asserted with no evidence is not a condition")
+                check("bypass" in err, f"`{act}` failed for the wrong reason: {err!r}")
+            check(state_of(path, fid) == "corroborated", f"a refused `{act}` moved the state anyway")
+
+        # …and with every condition evidenced, it goes through — and the evidence is IN the entry.
+        path = tmp / f"{act}-ok.jsonl"
+        (fid,) = seed(path)
+        run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced at followups.py:1"])
+        code, _, err = run(["--file", str(path), act, "--id", fid, *transition_args(act)])
+        check(code == 0, f"`{act}` exited {code} with every condition evidenced: {err!r}")
+        entry = json.loads(run(["--file", str(path), "get", "--id", fid])[1])
+        check(entry["state"] == TRANSITIONS[act][1], f"`{act}` did not reach its state: {entry!r}")
+        for witness in ACT_WITNESSES:
+            check(not is_blank(entry[witness]),
+                  f"`{act}` disposed of the entry with NO evidence for the condition witnessed by "
+                  f"{witness!r}: {entry!r}")
+
+
+def t_the_irreversible_change_waits(tmp: Path) -> None:
+    """AN IRREVERSIBLE CHANGE WAITS FOR THE USER — and the wait is an ABSENT EDGE, not an exhortation.
+
+    The threshold's third condition is the only one whose failure STOPS the work, and it used to be prose
+    ALONE. Reproduced on the parent commit of the change that added this fixture: `take-up
+    --act-reversible "NO — this is NOT reversible; it is a one-way schema migration and a revert CANNOT
+    restore the prior state"` exited 0 and landed the entry in `self-accepted` — the state a fixer is
+    dispatched from. The only check on that flag was the shared non-blank test.
+
+    What backs the guarantee now, and NEITHER half is a prose sniff (a negation search would refuse "a
+    revert restores the prior state, so this is not irreversible" and pass a one-way change worded without
+    a negation — wrong on both halves of the cases):
+
+      1. THE VALUE CARRIES A VERDICT the code can read, and the ACT edge must be the edge for that
+         verdict. Neither edge accepts the other's.
+      2. THE GRAPH does the rest. `hold` lands in `held`, and NO driver-only path leaves `held` for a PR —
+         only the USER's rulings leave it at all. Same shape as tier 3's guarantee, proved the same way.
+
+    AND THE LIMIT IS PINNED TOO, because overstating it would be the worse lie: nothing here can tell
+    whether a change really is reversible, so a driver that RECORDS `reversible` for a one-way change
+    still goes through. What is now impossible is recording `irreversible` and dispatching a fixer anyway.
+    """
+    # The verdict belongs to the `reversible` CONDITION — not to a field name that happens to look right.
+    check((REVERSIBLE, VERDICT_FIELD) in [(c, w) for c, w, _ in ACT_CONDITIONS],
+          f"{VERDICT_FIELD!r} is not the witness of the {REVERSIBLE!r} ACT condition — the verdict would "
+          f"be enforced on a field the threshold does not name")
+    check(sorted(ACT_EDGE_VERDICT.values()) == sorted(VERDICTS),
+          f"the ACT edges cover {sorted(ACT_EDGE_VERDICT.values())!r}, not every verdict {sorted(VERDICTS)!r} "
+          f"— a verdict with no edge is a corroborated follow-up with nowhere to go")
+
+    # 1a. A value that carries NO verdict is refused at EVERY ACT edge — including the exact prose the
+    #     reproduction used, which is the whole point: it says `no` in English and nothing could read it.
+    unreadable = (
+        "NO — this is NOT reversible; it is a one-way schema migration and a revert CANNOT restore "
+        "the prior state",
+        "a revert restores the prior state",
+        "not reversible",
+        REVERSIBLE,                        # the token alone, with no separator and no grounds
+        f"maybe{VERDICT_SEP} who knows",   # a separator, but no verdict the code knows
+        f"{IRREVERSIBLE}{VERDICT_SEP}",    # a verdict with NO grounds is the rumor the witnesses forbid
+        f"{IRREVERSIBLE}{VERDICT_SEP} {PLACEHOLDER}",
+    )
+    for act in ACT_CMDS:
+        for i, value in enumerate(unreadable):
+            path = tmp / f"unreadable-{act}-{i}.jsonl"
+            (fid,) = seed(path)
+            run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced"])
+            argv = [a for f in ACT_FLAGS
+                    for a in (FLAG[f], value if f == VERDICT_FIELD else legal_value(act, f, "x"))]
+            code, out, err = run(["--file", str(path), act, "--id", fid, *argv])
             check(code == 1,
-                  f"`{ACT_CMD}` with a BLANK {FLAG[witness]} ({blank!r}) was ACCEPTED (exit {code}) — a "
-                  f"condition asserted with no evidence is not a condition")
-            check("bypass" in err, f"`{ACT_CMD}` failed for the wrong reason: {err!r}")
-        check(state_of(path, fid) == "corroborated", f"a refused `{ACT_CMD}` moved the state anyway")
+                  f"`{act}` ACCEPTED an {VERDICT_FIELD} carrying no readable verdict (exit {code}): "
+                  f"{value!r}\n{out}")
+            check(state_of(path, fid) == "corroborated", f"a refused `{act}` moved the state anyway")
+            check(verdict_of(value) is None, f"`verdict_of` reads a verdict out of {value!r}")
 
-    # …and with every condition evidenced, it goes through — and the evidence is IN the entry.
-    path = tmp / "ok.jsonl"
+    # 1b. …and each edge refuses the OTHER verdict. The verdict picks the edge; the driver does not.
+    for act, verdict in ACT_EDGE_VERDICT.items():
+        for other in VERDICTS:
+            path = tmp / f"verdict-{act}-{other}.jsonl"
+            (fid,) = seed(path)
+            run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced"])
+            argv = [a for f in ACT_FLAGS
+                    for a in (FLAG[f], f"{other}{VERDICT_SEP} why" if f == VERDICT_FIELD
+                              else legal_value(act, f, "x"))]
+            code, out, err = run(["--file", str(path), act, "--id", fid, *argv])
+            if other == verdict:
+                check(code == 0, f"`{act}` refused its OWN verdict {other!r} (exit {code}): {err!r}")
+                check(state_of(path, fid) == TRANSITIONS[act][1],
+                      f"`{act}` did not reach {TRANSITIONS[act][1]!r} on its own verdict")
+            else:
+                check(code == 1,
+                      f"`{act}` ACCEPTED the verdict {other!r} it is not the edge for (exit {code}) — an "
+                      f"{IRREVERSIBLE} change reached {TRANSITIONS[act][1]!r} with no user ruling:\n{out}")
+                check(state_of(path, fid) == "corroborated", f"a refused `{act}` moved the state anyway")
+
+    # 2. THE GRAPH. From `held` no driver-only path reaches a PR at all — derived from `open-pr`, so
+    #    moving that edge cannot quietly move the guarantee.
+    held = TRANSITIONS[HOLD_CMD][1]
+    pr_states = {TRANSITIONS["open-pr"][1]} | set(TRANSITIONS["open-pr"][0])
+    reach = closure((held,), DRIVER_STEPS)
+    check(not (reach & pr_states),
+          f"a driver with NO user ruling reaches {sorted(reach & pr_states)!r} from {held!r} — an "
+          f"IRREVERSIBLE change does not WAIT (reachable: {sorted(reach)})")
+    check(held not in TERMINAL,
+          f"{held!r} is TERMINAL — an irreversible follow-up would wait forever, with no ruling able to "
+          f"release it")
+
+    # …and end to end: the PR door is shut, and the USER's ruling is what opens it.
+    path = tmp / "route.jsonl"
     (fid,) = seed(path)
-    run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced at followups.py:1"])
-    code, _, err = run(["--file", str(path), ACT_CMD, "--id", fid, *transition_args(ACT_CMD)])
-    check(code == 0, f"`{ACT_CMD}` exited {code} with every condition evidenced: {err!r}")
-    entry = json.loads(run(["--file", str(path), "get", "--id", fid])[1])
-    check(entry["state"] == TRANSITIONS[ACT_CMD][1], f"`{ACT_CMD}` did not reach its state: {entry!r}")
-    for witness in ACT_WITNESSES:
-        check(not is_blank(entry[witness]),
-              f"the entry was taken up with NO evidence for the condition witnessed by {witness!r}: "
-              f"{entry!r}")
+    run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced"])
+    code, _, err = run(["--file", str(path), HOLD_CMD, "--id", fid, *transition_args(HOLD_CMD)])
+    check(code == 0, f"`{HOLD_CMD}` exited {code} with every condition evidenced: {err!r}")
+    code, out, err = run(["--file", str(path), "open-pr", "--id", fid, "--pr", "#1"])
+    check(code == 1, f"`open-pr` was ACCEPTED on a {held!r} follow-up (exit {code}):\n{out}")
+    check(state_of(path, fid) == held, "a refused `open-pr` moved the held entry anyway")
+    check(run(["--file", str(path), "accept", "--id", fid])[0] == 0,
+          f"the USER cannot `accept` a {held!r} follow-up — the wait would never end")
+    code, _, err = run(["--file", str(path), "open-pr", "--id", fid, "--pr", "#1"])
+    check(code == 0, f"`open-pr` was refused AFTER the user ruled (exit {code}): {err!r}")
+
+    # AND THE STORE THAT ALREADY EXISTS STILL OPENS. Entries written under the old contract carry FREE
+    # PROSE in this witness, and nothing can rebuild a lost follow-up — so the verdict is enforced at the
+    # WRITE DOOR only. A row that predates it loads, reads back VERBATIM, and survives the next write.
+    legacy = "NO — this is NOT reversible; a revert CANNOT restore the prior state"
+    path = tmp / "legacy.jsonl"
+    write_lines(path, entry_line(id="fu1", state=TRANSITIONS[ACT_CMD][1], **{VERDICT_FIELD: legacy}))
+    code, out, err = run(["--file", str(path), "get", "--id", "fu1", "--field", VERDICT_FIELD])
+    check((code, out.strip()) == (0, legacy),
+          f"a follow-up written under the OLD contract no longer reads back (exit {code}): {out!r} {err!r}")
+    check(run(["--file", str(path), *add_argv()])[0] == 0,
+          "a store holding a pre-verdict follow-up can no longer be written to")
+    code, out, _ = run(["--file", str(path), "get", "--id", "fu1", "--field", VERDICT_FIELD])
+    check((code, out.strip()) == (0, legacy),
+          f"the next write REWROTE a pre-verdict witness: {out!r} — the ACT grounds are what made that "
+          f"self-acceptance legal, and nothing may edit them after the fact")
 
 
 def t_self_accepted_is_never_mistaken_for_accepted(tmp: Path) -> None:
@@ -1061,6 +1196,13 @@ def t_the_doc_and_the_code_agree(tmp: Path) -> None:
               f"ACT condition '{label}' is enforced by the store and appears NOWHERE in {doc.name} — the "
               f"driver is refused a step it was never told the rule for")
     check(ACT_CMD in text, f"`{ACT_CMD}` — the autonomous edge itself — is not documented in {doc.name}")
+
+    # …and the VERDICT the driver has to type is documented in the FORM the code demands. A condition the
+    # code refuses in a spelling the doc never shows is one the driver cannot obey on the first try.
+    for verdict in VERDICTS:
+        check(f"{verdict}{VERDICT_SEP}" in text,
+              f"the store refuses {FLAG[VERDICT_FIELD]} unless it leads with "
+              f"'{verdict}{VERDICT_SEP}', and {doc.name} never shows that form")
 
     # …and EVERY step is named there, not just the ACT one. Derived from TRANSITIONS: an edge added to the
     # graph — a deleting one above all — that the driver is never told about is an edge it never takes, and
@@ -1508,7 +1650,8 @@ CASES = [
     ("closed-pr-reopens", "a PR closed WITHOUT merging returns the entry to open work — it never vanishes with it", t_a_closed_pr_returns_the_entry_to_open_work),
     ("ruling-waits-for-the-pr", "a USER RULING is ordered AFTER the PR's disposition — it can never strand the open PR the entry names", t_a_ruling_waits_for_the_prs_disposition),
     ("rejection-kept", "a REJECTED follow-up is kept — deleting it is how the next run re-raises it", t_a_rejection_is_never_deleted),
-    ("act-needs-conditions", "the autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
+    ("act-needs-conditions", "every autonomous ACT edge must EVIDENCE every condition, or it is refused", t_act_edge_needs_every_condition),
+    ("irreversible-waits", "an IRREVERSIBLE change reaches no PR without the user — the verdict picks the edge, and `held` has no way out but a ruling", t_the_irreversible_change_waits),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
     ("pr-reference-parser", "open-pr canonicalises recognised PR references and preserves opaque text", t_pr_references_keep_legacy_bare_numbers_and_github_urls),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -176,6 +176,25 @@ def state_of(path: Path, fid: str) -> str:
     return out.strip()
 
 
+def doc_block(text: str, needle: str) -> str:
+    """The smallest block of an agent-read document holding `needle` — bounded by a blank line or the next
+    top-level bullet.
+
+    Shared by every fixture that checks a RESTATEMENT: a whole-file search would pass on a rule stated in
+    some unrelated section, and the point of those fixtures is that the SITE which restates the rule is
+    the one that has to be right.
+    """
+    lines = text.splitlines()
+    i = next((n for n, line in enumerate(lines) if needle in line), -1)
+    check(i >= 0, f"{needle!r} appears nowhere — the pointer to the owner is gone")
+    start, end = i, i + 1
+    while start > 0 and not lines[start].startswith("- ") and lines[start - 1].strip():
+        start -= 1
+    while end < len(lines) and lines[end].strip() and not lines[end].startswith("- "):
+        end += 1
+    return "\n".join(lines[start:end])
+
+
 def closure(start: "tuple[str, ...]", cmds: "tuple[str, ...]") -> "set[str]":
     """Every STATE reachable from `start` using ONLY the named transitions. A fixpoint over the graph.
 
@@ -1260,20 +1279,8 @@ def t_every_reporting_step_owes_both_act_edges(tmp: Path) -> None:
     owed_set = "disposed of on its own"
     waiting = TRANSITIONS[HOLD_CMD][1]
 
-    def block(text: str, needle: str) -> str:
-        """The smallest block holding `needle` — bounded by a blank line or the next top-level bullet."""
-        lines = text.splitlines()
-        i = next((n for n, line in enumerate(lines) if needle in line), -1)
-        check(i >= 0, f"{needle!r} appears nowhere — the pointer to the owner is gone")
-        start, end = i, i + 1
-        while start > 0 and not lines[start].startswith("- ") and lines[start - 1].strip():
-            start -= 1
-        while end < len(lines) and lines[end].strip() and not lines[end].startswith("- "):
-            end += 1
-        return "\n".join(lines[start:end])
-
     owner_text = owner.read_text(encoding="utf-8")
-    owning = block(owner_text, "reporting steps")
+    owning = doc_block(owner_text, "reporting steps")
     check(owed_set in owning.lower(),
           f"{owner.name} no longer names the owed set {owed_set!r} — every restatement below is checked "
           f"against the owner's words, so the owner must still be the one saying them")
@@ -1286,7 +1293,7 @@ def t_every_reporting_step_owes_both_act_edges(tmp: Path) -> None:
               f"this fixture is checking a file the owner stopped pointing at")
         check(path.exists(), f"the reporting step {name} is missing entirely: {path}")
         # The site's own restatement: the block that points back at the owner.
-        site = block(path.read_text(encoding="utf-8"), '"Surfacing them"')
+        site = doc_block(path.read_text(encoding="utf-8"), '"Surfacing them"')
         check(owed_set in site.lower(),
               f"{path.name} restates the owed set in its OWN words instead of the owner's "
               f"({owed_set!r}) — a paraphrase is what silently goes stale:\n{site}")
@@ -1294,6 +1301,87 @@ def t_every_reporting_step_owes_both_act_edges(tmp: Path) -> None:
               f"{path.name} owes the ACT disclosure and never names {waiting!r} — a {waiting!r} entry is "
               f"disclosed nowhere, so the user is never asked for the ruling that is the only thing that "
               f"moves it:\n{site}")
+
+
+def t_a_held_entry_is_surfaced_on_a_later_invocation(tmp: Path) -> None:
+    """A `held` ENTRY IS SURFACED BY THE INVOCATION THAT **FINDS** IT, NOT ONLY BY THE ONE THAT HELD IT.
+
+    `hold` persists, so the entry outlives the invocation that recorded it. Every later invocation of
+    `address-followups` therefore opens on a store where that entry is ALREADY `held` — and that is the
+    only way an entry can be `held` while the work list is being built, because the skill's own `hold`
+    happens later, at its ACT step. The later invocation is the ordinary case, not an edge one.
+
+    What that costs, reproduced below on this store: once `hold` has run, the entry answers to no state
+    query but its own. A work list built from the RESUMABLE states cannot contain it, so no step touches
+    it, so a report of "the entries this invocation touched" reaches it — and its ACT disclosure and the
+    user's question with it — never. The user is then not asked for the one ruling that moves it.
+
+    Both halves are executed:
+
+      1. THE STORE, over EVERY state in the graph: only the `held` query returns it, the ACT witnesses
+         the `hold` edge wrote are all still there (so there IS a disclosure to make), and the default
+         table carries none of them (so an enumeration and a `get` are the only way to it).
+      2. THE PROCEDURE: `address-followups` runs that enumeration with the real command, NAMES the list
+         it builds, and its ACT-disclosure block consumes that same list by name. A reporting step that
+         covers only what this invocation disposed of goes red here.
+    """
+    held = TRANSITIONS[HOLD_CMD][1]
+
+    # 1. THE STORE. Drive one entry to `held`, exactly as an EARLIER invocation's Step 4 would leave it.
+    path = tmp / "later-invocation.jsonl"
+    (fid,) = seed(path)
+    run(["--file", str(path), "corroborate", "--id", fid, "--finding", "reproduced"])
+    code, _, err = run(["--file", str(path), HOLD_CMD, "--id", fid, *transition_args(HOLD_CMD)])
+    check(code == 0, f"`{HOLD_CMD}` exited {code} with every condition evidenced: {err!r}")
+
+    # Every state the graph has — so the day a state is added, this fixture asks about it too. Only the
+    # one the WAITING edge lands in returns the entry; a work list built from any other set misses it.
+    for state in STATES:
+        code, out, err = run(["--file", str(path), "list", "--where", f"state={state}"])
+        check(code == 0, f"`list --where state={state}` exited {code}: {err!r}")
+        found = out.split()
+        check(found == ([fid] if state == held else []),
+              f"`list --where state={state}` printed {found!r} for an entry sitting in {held!r} — the "
+              f"enumeration a later invocation depends on disagrees with the state the entry is in")
+
+    # …and there IS something to disclose: the evidence outlives the invocation that recorded it.
+    entry = json.loads(run(["--file", str(path), "get", "--id", fid])[1])
+    check(entry["state"] == held, f"the entry did not settle in {held!r}: {entry!r}")
+    for witness in ACT_WITNESSES:
+        check(not is_blank(entry[witness]),
+              f"a {held!r} entry a LATER invocation owes a disclosure for carries no evidence for the "
+              f"condition witnessed by {witness!r}: {entry!r} — there would be nothing to report")
+
+    # …and the table is not that disclosure. Derived from the default field set, so a field promoted into
+    # the table tomorrow retires this check honestly instead of leaving it asserting a stale shape.
+    check(not (set(ACT_FLAGS) & set(TABLE_DEFAULT_FIELDS)),
+          f"an ACT witness is in the table's default fields {TABLE_DEFAULT_FIELDS!r} — this fixture's "
+          f"premise, that the ACT evidence is reachable only by enumerating and FETCHING, no longer holds")
+
+    # 2. THE PROCEDURE. The skill that runs on a store like the one above.
+    skill = Path(__file__).resolve().parent.parent.parent / "address-followups" / "SKILL.md"
+    check(skill.exists(), f"the on-demand follow-up skill is missing entirely: {skill}")
+    text = skill.read_text(encoding="utf-8")
+
+    enumeration = f"list --where state={held}"
+    check(enumeration in text,
+          f"{skill.name} never runs `{enumeration}`. Part 1 above shows no other state query returns a "
+          f"{held!r} entry, so one an EARLIER invocation held is enumerated nowhere, touched by no step, "
+          f"and reported by nothing")
+
+    # The list that enumeration builds is named ONCE and consumed BY THAT NAME, which is what carries an
+    # untouched entry from the selection step to the report. Rename it in one place and this goes red.
+    listed = "surfacing list"
+    at = text.index(enumeration)
+    named = text.find(listed)
+    check(named > at,
+          f"{skill.name} enumerates {held!r} entries without naming the resulting list after it — its "
+          f"reporting step has nothing to carry an untouched entry in")
+    reporting = doc_block(text, '"Surfacing them"')
+    check(listed in reporting,
+          f"{skill.name}'s ACT-disclosure block never names the {listed!r} its selection step builds, so "
+          f"the disclosure reaches only entries THIS invocation disposed of and a {held!r} entry from an "
+          f"earlier one is disclosed nowhere:\n{reporting}")
 
 
 def t_ids_are_assigned_and_never_reused(tmp: Path) -> None:
@@ -1738,6 +1826,7 @@ CASES = [
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
     ("reporting-covers-both-acts", "every reporting step that owes the ACT disclosure owes it for BOTH ACT edges — the `held` entry's question included", t_every_reporting_step_owes_both_act_edges),
+    ("held-survives-the-invocation", "a `held` entry is enumerated and disclosed by a LATER invocation — no state query but its own returns it", t_a_held_entry_is_surfaced_on_a_later_invocation),
     ("pr-reference-parser", "open-pr canonicalises recognised PR references and preserves opaque text", t_pr_references_keep_legacy_bare_numbers_and_github_urls),
     ("investigation-evidence", "an investigation shows its work; the finding APPENDS and never clobbers", t_investigation_shows_its_work),
     ("refutation-stays", "a refuted follow-up stays in the store, stays visible, and stays overturnable", t_refutation_stays_in_the_store),

--- a/plugins/gauntlet/skills/campaign/scripts/followups-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups-test.py
@@ -1213,6 +1213,72 @@ def t_the_doc_and_the_code_agree(tmp: Path) -> None:
               f"step it has not been told exists")
 
 
+def t_every_reporting_step_owes_both_act_edges(tmp: Path) -> None:
+    """EVERY REPORTING STEP THAT OWES THE ACT DISCLOSURE OWES IT FOR **BOTH** ACT EDGES.
+
+    `followups.md`, "Surfacing them", owns which entries owe this disclosure — an entry the driver
+    DISPOSED OF ON ITS OWN, by either ACT edge — and it names the reporting steps that owe it. Those
+    steps live in OTHER files, so the definition is restated at each of them, which is the exact shape
+    this repo keeps being bitten by: the owner moved to cover `hold`, and a restatement that still said
+    "every entry this run took up" silently dropped the `held` entry — the one entry that carries a
+    QUESTION for the user, whose ruling is the only thing that ever moves it. The user is then never
+    asked, and the entry waits forever.
+
+    So the agreement is EXECUTED rather than trusted, on two axes:
+
+      1. Each site describes the owed set in the OWNER'S WORDS. A paraphrase is what drifts, and it
+         drifts silently because it shares no string with the rule it summarises.
+      2. Each site names the state the WAITING edge lands in — derived from the graph, so a renamed or
+         added waiting state pins every reporting step the day it lands.
+    """
+    references = Path(__file__).resolve().parent.parent / "references"
+    owner = references / "followups.md"
+    # The reporting steps `followups.md`, "Surfacing them", names — checked below to be the ones it still
+    # names, so a step that moves cannot leave this list pointing at a file that no longer owes anything.
+    reporting_steps = {
+        "bailout-and-final-report.md": references / "bailout-and-final-report.md",
+        "address-followups": (references.parent.parent / "address-followups" / "SKILL.md"),
+    }
+    # The owner's own name for the owed set. Every site must use it rather than restate the membership.
+    owed_set = "disposed of on its own"
+    waiting = TRANSITIONS[HOLD_CMD][1]
+
+    def block(text: str, needle: str) -> str:
+        """The smallest block holding `needle` — bounded by a blank line or the next top-level bullet."""
+        lines = text.splitlines()
+        i = next((n for n, line in enumerate(lines) if needle in line), -1)
+        check(i >= 0, f"{needle!r} appears nowhere — the pointer to the owner is gone")
+        start, end = i, i + 1
+        while start > 0 and not lines[start].startswith("- ") and lines[start - 1].strip():
+            start -= 1
+        while end < len(lines) and lines[end].strip() and not lines[end].startswith("- "):
+            end += 1
+        return "\n".join(lines[start:end])
+
+    owner_text = owner.read_text(encoding="utf-8")
+    owning = block(owner_text, "reporting steps")
+    check(owed_set in owning.lower(),
+          f"{owner.name} no longer names the owed set {owed_set!r} — every restatement below is checked "
+          f"against the owner's words, so the owner must still be the one saying them")
+    check(waiting in owning,
+          f"{owner.name} defines the disclosure without naming {waiting!r}, the state the WAITING ACT "
+          f"edge lands in — the entry that carries the user's question would owe nothing")
+    for name, path in reporting_steps.items():
+        check(name in owning,
+              f"{owner.name} no longer names {name} as a reporting step that owes the ACT disclosure — "
+              f"this fixture is checking a file the owner stopped pointing at")
+        check(path.exists(), f"the reporting step {name} is missing entirely: {path}")
+        # The site's own restatement: the block that points back at the owner.
+        site = block(path.read_text(encoding="utf-8"), '"Surfacing them"')
+        check(owed_set in site.lower(),
+              f"{path.name} restates the owed set in its OWN words instead of the owner's "
+              f"({owed_set!r}) — a paraphrase is what silently goes stale:\n{site}")
+        check(waiting in site,
+              f"{path.name} owes the ACT disclosure and never names {waiting!r} — a {waiting!r} entry is "
+              f"disclosed nowhere, so the user is never asked for the ruling that is the only thing that "
+              f"moves it:\n{site}")
+
+
 def t_ids_are_assigned_and_never_reused(tmp: Path) -> None:
     """`id` is assigned by the STORE (`fu<N>`, one past the highest EVER HANDED OUT) — never by the caller,
     and NEVER REUSED, not even after the entry that held it was DELETED.
@@ -1654,6 +1720,7 @@ CASES = [
     ("irreversible-waits", "an IRREVERSIBLE change reaches no PR without the user — the verdict picks the edge, and `held` has no way out but a ruling", t_the_irreversible_change_waits),
     ("self-accept-distinct", "a DRIVER-accepted follow-up is never mistaken for a USER-accepted one", t_self_accepted_is_never_mistaken_for_accepted),
     ("doc-and-code-agree", "the ACT conditions the driver READS are the ones the code ENFORCES", t_the_doc_and_the_code_agree),
+    ("reporting-covers-both-acts", "every reporting step that owes the ACT disclosure owes it for BOTH ACT edges — the `held` entry's question included", t_every_reporting_step_owes_both_act_edges),
     ("pr-reference-parser", "open-pr canonicalises recognised PR references and preserves opaque text", t_pr_references_keep_legacy_bare_numbers_and_github_urls),
     ("investigation-evidence", "an investigation shows its work; the finding APPENDS and never clobbers", t_investigation_shows_its_work),
     ("refutation-stays", "a refuted follow-up stays in the store, stays visible, and stays overturnable", t_refutation_stays_in_the_store),

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -122,7 +122,10 @@ ACT_CONDITIONS = (
     ("reversible", "act_reversible",
      "WHETHER a revert restores the prior state. A schema migration does not; anything already published "
      "does not. This is the one condition whose failure makes the entry WAIT for the user's ruling instead "
-     "of routing it — read the THRESHOLD for that."),
+     "of routing it — read the THRESHOLD for that. So it is the one whose value must LEAD WITH A VERDICT "
+     "the code can read: 'reversible: <why>' or 'irreversible: <why>' (see VERDICTS). The verdict picks "
+     "the edge — `take-up` takes a reversible change up for work, `hold` parks an irreversible one for "
+     "the user's ruling — and each edge REFUSES the other's verdict"),
 )
 
 # Every ACT condition's witness field, and the subset `take-up` must carry in itself. Condition 1's
@@ -130,6 +133,50 @@ ACT_CONDITIONS = (
 # `corroborated` — so it takes no flag. Both are DERIVED from ACT_CONDITIONS; neither is a second list.
 ACT_WITNESSES = tuple(w for _, w, _ in ACT_CONDITIONS)
 ACT_FLAGS = tuple(w for w in ACT_WITNESSES if w != "finding")
+
+# --- the REVERSIBLE verdict: the one ACT condition the code must READ ---------
+#
+# The third condition is the only one whose failure STOPS the work (`references/followups.md`, "THE
+# AUTONOMY THRESHOLD"), and prose alone could not carry that: `take-up --act-reversible "NO — a revert
+# CANNOT restore the prior state"` used to exit 0 and land the entry in `self-accepted`, dispatching a
+# fixer at the one change class the threshold says must WAIT.
+#
+# SNIFFING THE PROSE IS NOT THE FIX. The evidence is free text the driver writes, and a negation search
+# fails BOTH ways: it refuses "a revert restores the prior state, so this is not irreversible", and it
+# passes a genuinely one-way change worded without a negation. A guard that fires on the wrong half of
+# the cases is worse than the prose it replaced.
+#
+# So the value carries a MACHINE-READABLE VERDICT *and* its prose — the same shape a `finding` already
+# has, where `[<outcome> <at>]` leads and the account follows. The verdict then picks the EDGE, and the
+# two edges refuse each other's verdict, so the wait is an ABSENT EDGE rather than a check somebody must
+# remember: from `held` there is no driver-only path to `open-pr` at all (`TRANSITIONS`).
+#
+# STATE THE LIMIT HONESTLY, exactly as `accept` does. Nothing here can tell whether a change really is
+# reversible; a driver that MIS-JUDGES it still gets through. What is now impossible is RECORDING
+# `irreversible` and dispatching a fixer anyway — the recorded judgment and the action taken can no
+# longer contradict each other. It is a footgun guard, NOT an oracle.
+REVERSIBLE = "reversible"      # the `reversible` condition HOLDS — a revert restores the prior state
+IRREVERSIBLE = "irreversible"  # it does NOT — the one class that waits for the user
+VERDICTS = (REVERSIBLE, IRREVERSIBLE)
+VERDICT_SEP = ":"
+
+# The witness that carries a verdict. DERIVED from the condition it belongs to, never retyped beside it:
+# rename that witness and this follows, rather than pointing at a field that no longer exists.
+VERDICT_FIELD = next(w for c, w, _ in ACT_CONDITIONS if c == REVERSIBLE)
+
+
+def verdict_of(value: str) -> "str | None":
+    """The verdict `value` LEADS WITH — or None if it carries none the code can act on.
+
+    `<verdict><VERDICT_SEP> <prose>`, case-insensitive. The prose after the separator must itself carry
+    something: a bare `irreversible:` is a verdict with no grounds, which is the same rumor a blank
+    witness is, and the whole point of the ACT witnesses is that an assertion comes with its evidence.
+    """
+    token, sep, rest = value.strip().partition(VERDICT_SEP)
+    if not sep or is_blank(rest):
+        return None
+    token = token.strip().lower()
+    return token if token in VERDICTS else None
 
 # --- schema (owned here, once) ------------------------------------------------
 
@@ -220,6 +267,11 @@ def project(rec: "dict", where: str = "") -> "dict[str, str]":
 #   * The driver's own edge for taking work up, `take-up`, leaves ONLY from `corroborated` and lands in
 #     `self-accepted` — a state that is NOT `accepted` and never becomes indistinguishable from it. Its
 #     ACT witnesses stay in the entry forever, and `decided` (the user's stamp) stays `-`.
+#   * AND AN IRREVERSIBLE CHANGE HAS NO DRIVER-ONLY PATH TO A PR AT ALL. The verdict the driver records in
+#     `act_reversible` picks which ACT edge is legal (`ACT_EDGE_VERDICT`), and `hold` lands in `held`,
+#     which `open-pr` does NOT leave from — the only edges out are the USER's rulings. So the threshold's
+#     "an IRREVERSIBLE change WAITS" is an ABSENT EDGE, the same way tier 3's guarantee is, rather than a
+#     check somebody must remember to run (`t_the_irreversible_change_waits`).
 #
 # This is why the lifecycle is a graph and not a settable string.
 #
@@ -244,8 +296,10 @@ TRANSITIONS = {
     "corroborate":     (("candidate", "refuted", "reopened"), "corroborated"),
     "refute":          (("candidate", "corroborated", "reopened"), "refuted"),
     "take-up":         (("corroborated",), "self-accepted"),
-    "accept":          (("candidate", "corroborated", "refuted", "self-accepted", "reopened"), "accepted"),
-    "reject":          (("candidate", "corroborated", "refuted", "self-accepted", "accepted",
+    "hold":            (("corroborated",), "held"),
+    "accept":          (("candidate", "corroborated", "refuted", "self-accepted", "held",
+                        "reopened"), "accepted"),
+    "reject":          (("candidate", "corroborated", "refuted", "self-accepted", "held", "accepted",
                         "reopened"), "rejected"),
     "open-pr":         (("accepted", "self-accepted", "reopened"), "in-pr"),
     "closed-unmerged": (("in-pr",), "reopened"),
@@ -267,6 +321,13 @@ DRIVER_STEPS = tuple(c for c in TRANSITIONS if c not in USER_RULINGS)
 # what they may do is still whatever the graph above says.
 INVESTIGATION = ("corroborate", "refute")
 ACT_CMD = "take-up"
+HOLD_CMD = "hold"
+
+# THE TWO ACT EDGES, and the verdict each one is the edge FOR. One entry per verdict, so the driver never
+# picks between them on judgment: whichever it runs, the store refuses the pairing the verdict does not
+# license. `take-up` dispatches the work; `hold` parks it for the user (see the graph comment above).
+ACT_EDGE_VERDICT = {ACT_CMD: REVERSIBLE, HOLD_CMD: IRREVERSIBLE}
+ACT_CMDS = tuple(ACT_EDGE_VERDICT)
 
 # The edges that END an entry. DERIVED — an edge deletes because its target is DELETED, never because a
 # list here says so, so a deleting edge added tomorrow is enforced and pinned the day it is added.
@@ -287,7 +348,9 @@ TERMINAL = tuple(s for s in STATES if not any(s in frm for frm, _ in TRANSITIONS
 WRITES = {
     "corroborate":     ("finding",),
     "refute":          ("finding",),
-    ACT_CMD:           ACT_FLAGS,
+    # BOTH ACT edges carry the SAME witnesses — an entry the threshold holds back is EVIDENCED exactly as
+    # one it dispatches. Derived from ACT_CMDS: an edge that skipped a witness would be the bypass.
+    **{c: ACT_FLAGS for c in ACT_CMDS},
     "accept":          ("decided",),
     "reject":          ("decided",),
     "open-pr":         ("pr",),
@@ -360,7 +423,11 @@ def role(cmd: str) -> str:
     if cmd in INVESTIGATION:
         return "an INVESTIGATION found (autonomous: it is READ-ONLY)"
     if cmd == ACT_CMD:
-        return "the DRIVER takes it up for work (autonomous ONLY with every ACT condition EVIDENCED)"
+        return (f"the DRIVER takes it up for work (autonomous ONLY with every ACT condition EVIDENCED, and "
+                f"only for a '{REVERSIBLE}' verdict)")
+    if cmd == HOLD_CMD:
+        return (f"the DRIVER parks an '{IRREVERSIBLE}' change for the USER's ruling (every ACT condition "
+                f"EVIDENCED; no edge from here opens a PR)")
     if cmd in DELETING:
         return "the record now lives ELSEWHERE, so the ENTRY IS DELETED"
     return "the driver records (it is already past the user)"
@@ -687,6 +754,11 @@ def taken(cmd: str, args) -> "dict[str, str]":
 
     A flag not passed is absent from the result: the field keeps its default (`-`, or a stamp of `now`).
     That is UNSET, which is not the same thing as a caller handing in something that carries nothing.
+
+    AND THE ONE VALUE THE CODE MUST READ — not merely store — IS CHECKED HERE TOO, for the same reason
+    and at the same door: `VERDICT_FIELD` must LEAD WITH a verdict (`verdict_of`), and the ACT edge it
+    was handed to must be the edge for that verdict (`ACT_EDGE_VERDICT`). Both refusals are about the
+    VALUE, so they belong where every other value check is; what the verdict then MEANS is the graph's.
     """
     values: "dict[str, str]" = {}
     for field, flag in INTAKE[cmd].items():
@@ -696,6 +768,22 @@ def taken(cmd: str, args) -> "dict[str, str]":
         if is_blank(value):  # THE one blank predicate — see `is_blank()`. Called HERE, once, for every door.
             fail(f"{flag} must not be empty — {BLANK_WHY[field]}")
         values[field] = value
+    if VERDICT_FIELD in values:
+        flag = INTAKE[cmd][VERDICT_FIELD]
+        verdict = verdict_of(values[VERDICT_FIELD])
+        if verdict is None:
+            fail(f"{flag} must LEAD WITH a verdict the code can read — "
+                 f"{' or '.join(f'{v}{VERDICT_SEP} <why>' for v in VERDICTS)} — and then say why. "
+                 f"Prose alone cannot carry this condition: it is the one whose answer decides whether a "
+                 f"fixer may be dispatched at all, and no reading of free text can be trusted with that.")
+        wanted = ACT_EDGE_VERDICT.get(cmd)
+        if wanted is not None and verdict != wanted:
+            other = next(c for c, v in ACT_EDGE_VERDICT.items() if v == verdict)
+            fail(f"`{cmd}` is the edge for a '{wanted}' change, and {flag} records '{verdict}' — "
+                 f"`{other}` is the edge for that ({'/'.join(TRANSITIONS[other][0])} -> "
+                 f"{TRANSITIONS[other][1]}). The verdict picks the edge; the driver does not. "
+                 f"An '{IRREVERSIBLE}' change WAITS for the user's ruling, which is why no edge from "
+                 f"'{TRANSITIONS[HOLD_CMD][1]}' opens a PR.")
     return values
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -172,6 +172,13 @@ def verdict_of(value: str) -> "str | None":
     something: a bare `irreversible:` is a verdict with no grounds, which is the same rumor a blank
     witness is, and the whole point of the ACT witnesses is that an assertion comes with its evidence.
     """
+    # The token is STRIPPED, so `reversible : why` is accepted, and that is not a hole: the two verdicts
+    # differ by the `ir` prefix, so no amount of surrounding whitespace can turn one into the other. The
+    # verdict returned is always the word the driver led with, and `ACT_EDGE_VERDICT` then refuses the
+    # edge that verdict does not license. Verified end to end against a real store: `take-up` with
+    # `irreversible : spaced one-way` exits 1 and leaves the entry `corroborated`, `hold` with
+    # `reversible : why` exits 1, and `take-up` with `reversible : spaced verdict` lands `self-accepted`.
+    # This is also the ONLY parser of `act_reversible` in the repo, so no other reader sees a raw prefix.
     token, sep, rest = value.strip().partition(VERDICT_SEP)
     if not sep or is_blank(rest):
         return None

--- a/plugins/gauntlet/skills/campaign/scripts/followups.py
+++ b/plugins/gauntlet/skills/campaign/scripts/followups.py
@@ -168,21 +168,20 @@ VERDICT_FIELD = next(w for c, w, _ in ACT_CONDITIONS if c == REVERSIBLE)
 def verdict_of(value: str) -> "str | None":
     """The verdict `value` LEADS WITH — or None if it carries none the code can act on.
 
-    `<verdict><VERDICT_SEP> <prose>`, case-insensitive. The prose after the separator must itself carry
-    something: a bare `irreversible:` is a verdict with no grounds, which is the same rumor a blank
-    witness is, and the whole point of the ACT witnesses is that an assertion comes with its evidence.
+    `<verdict><VERDICT_SEP><prose>`, and LEADS WITH is meant LITERALLY: the value OPENS with the verdict
+    token and the separator follows it IMMEDIATELY. Only the token's CASE is free — whitespace before the
+    token, or between the token and the separator, is REFUSED. So the grammar the code accepts is exactly
+    the one the driver is told to type (`references/followups.md`, the THRESHOLD's third condition), and
+    a parser wider than the documented form is one the doc cannot describe.
+
+    The prose after the separator must itself carry something: a bare `irreversible:` is a verdict with no
+    grounds, which is the same rumor a blank witness is, and the whole point of the ACT witnesses is that
+    an assertion comes with its evidence.
     """
-    # The token is STRIPPED, so `reversible : why` is accepted, and that is not a hole: the two verdicts
-    # differ by the `ir` prefix, so no amount of surrounding whitespace can turn one into the other. The
-    # verdict returned is always the word the driver led with, and `ACT_EDGE_VERDICT` then refuses the
-    # edge that verdict does not license. Verified end to end against a real store: `take-up` with
-    # `irreversible : spaced one-way` exits 1 and leaves the entry `corroborated`, `hold` with
-    # `reversible : why` exits 1, and `take-up` with `reversible : spaced verdict` lands `self-accepted`.
-    # This is also the ONLY parser of `act_reversible` in the repo, so no other reader sees a raw prefix.
-    token, sep, rest = value.strip().partition(VERDICT_SEP)
+    token, sep, rest = value.partition(VERDICT_SEP)
     if not sep or is_blank(rest):
         return None
-    token = token.strip().lower()
+    token = token.lower()
     return token if token in VERDICTS else None
 
 # --- schema (owned here, once) ------------------------------------------------
@@ -441,8 +440,8 @@ def role(cmd: str) -> str:
 
 
 # Every field some transition writes. NONE of them may be editable: `set` does not check where an entry
-# came from, so a settable witness would let the grounds that made a self-acceptance legal be rewritten
-# after the fact — or erased.
+# came from, so a settable witness would let the grounds that made an ACT decision legal — a dispatch or a
+# wait — be rewritten after the fact, or erased.
 EVIDENCE_FIELDS = tuple(dict.fromkeys(f for w in WRITES.values() for f in w))
 
 # Fields a caller may EDIT after the fact. `state` is deliberately ABSENT: it moves only through the


### PR DESCRIPTION
## Defect (fu171, reproduced on main `e62883c`)

- `take-up --act-reversible "NO — ... a revert CANNOT restore the prior state"` exited 0 → `self-accepted`.
- That is the state a fixer is dispatched from; the flag's only check was the shared non-blank test.

## Fix

- `--act-reversible` must lead with a verdict: `reversible: <why>` or `irreversible: <why>`.
- The verdict picks the edge — `take-up` for reversible, new `hold` (→ `held`) for irreversible.
- `open-pr` does not leave `held`, so the wait is an absent edge, as tier 3's guarantee is.

## Notes

- Prose-sniffing rejected: a negation search misreads both "not irreversible" and unnegated one-way changes.
- Existing rows untouched — the verdict is checked at the write door; `load()` never validates witnesses.
