### PR TITLE
release gauntlet 0.8.0

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat"

--- a/plugins/gauntlet/.codex-plugin/plugin.json
+++ b/plugins/gauntlet/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gauntlet",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Adversarial review-to-merge pipeline: sweep, verify, fan out, gate, merge.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- bumps both gauntlet manifests from 0.7.1 to 0.8.0
- ships the 8 plugin changes merged since #240
