### PR TITLE
fix: default new campaign ledgers to brief status

### DIFF
--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -148,8 +148,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
     work remains. NEVER sleep with due work un-launched or no path to the next reconcile. Then follow
     `references/loop-control.md`, "Reschedule or exit", exactly: a scheduled-heartbeat host renders the
     status — the `ledger.py table` output that block defines, at the verbosity the header
-    `status_verbosity` field selects (default `full`; `brief` drops the set-once run configuration and
-    nothing else) — and then schedules-or-replaces the primary
+    `status_verbosity` field selects (new runs default to `brief`; an existing ledger without the field
+    keeps the legacy `full` fallback; `brief` drops the set-once run configuration and nothing else) —
+    and then schedules-or-replaces the primary
     wake as the turn's LAST action ("Primary continuity"; scheduling ends the turn on that host:
     `references/runtime-adapter.md`, "Scheduled-heartbeat host"); a scheduler-less host renders the same
     status, performs one bounded wait, and returns to the reconcile step while non-terminal work remains.

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -258,8 +258,9 @@ the operator's own display setting. Unlike `watchdog_due` it is an **ORDINARY, h
 (`header set status_verbosity brief`): it has a real door, and **writing it IS meaningful activity** (no
 exemption — it is not a sensor). `ledger.py`'s `parse_status_verbosity` is the **ONE validator** and
 `status_verbosity(header)` the **ONE read door**; a value outside the vocabulary is **REFUSED without
-mutating the ledger** (fail closed). It **defaults to `full`**, and that default is load-bearing rather
-than a taste: an existing run renders exactly as it did until the operator opts in.
+mutating the ledger** (fail closed). New runs **default to `brief`** so each heartbeat omits the set-once
+run configuration. An existing ledger that predates this field reads the legacy `full` fallback and renders
+exactly as it did.
 
 **It is PRESENTATION and nothing else.** No verdict, CI derivation, cap, park, label or merge
 precondition reads it, and no stored value changes with it — `header get` and `list` still return every
@@ -269,8 +270,8 @@ omit and what it must always print.** Inside `table` it decides exactly one thin
 lines.** The printed block is `ledger.py`'s `TABLE_CONFIG_FIELDS` — the header fields minus the
 presentation ones (`HEADER_PRESENTATION_FIELDS`), declared in the schema rather than at the render site —
 so a **PRESENTATION** field is stored, gettable and settable like any other and simply never printed
-there. That exclusion is what makes the `full` default a true no-op: a ledger written before this field
-existed back-fills the default and still prints the block it always printed, byte for byte. Under `brief`
+there. That exclusion is what makes the legacy `full` fallback a true no-op: a ledger written before this
+field existed back-fills the fallback and still prints the block it always printed, byte for byte. Under `brief`
 the block is gone entirely, so printing the setting inside it could never have explained a missing
 preamble either. `brief` drops that block — set-once
 configuration a heartbeat would otherwise reprint every time — **and drops nothing else. It never removes

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -732,7 +732,7 @@ resume. This block OWNS when the loop continues; every other site points here, n
 
      **HOW MUCH OF THAT RENDER PRINTS IS THE OPERATOR'S SETTING — the ledger header field
      `status_verbosity`** (`files-and-ledger.md` owns the field, its vocabulary and its validation;
-     `full` is the default, `brief` the opt-in). Re-read it from the header every heartbeat like any other
+     new runs use `brief`, while old ledgers without the field use the legacy `full` fallback). Re-read it from the header every heartbeat like any other
      header field, never from memory. Under `full`, render exactly as above. Under `brief`, drop the
      **SET-ONCE RUN CONFIGURATION**: `table` omits its `# <field>: <value>` block for you, and you
      likewise stop restating those same header fields in prose. Keep the prose you write to **what moved

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2817,6 +2817,17 @@ def t_status_verbosity_defaults_to_full(L: ModuleType, tmp: Path) -> None:
           "a newly created ledger must default to brief")
 
 
+def t_table_help_describes_verbosity_defaults(L: ModuleType, tmp: Path) -> None:
+    """`table --help` identifies both the new-run default and the legacy existing-ledger fallback."""
+    code, out, err = cli(L, ["--file", str(tmp / "help.jsonl"), "table", "--help"])
+    check(code == 0, f"table --help exited {code}: {err!r}")
+    help_text = " ".join(out.split())
+    check("new runs default to brief" in help_text,
+          f"table --help omitted the new-run brief default: {out!r}")
+    check("existing ledgers without the field use the legacy full fallback" in help_text,
+          f"table --help omitted the existing-ledger full fallback: {out!r}")
+
+
 def t_legacy_config_block_is_unchanged(L: ModuleType, tmp: Path) -> None:
     """A ledger written before `status_verbosity` existed prints the SAME run-config block it always did.
 
@@ -3324,6 +3335,7 @@ CASES = [
     ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
     ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
     ("verbosity-defaults", "new status_verbosity runs use `brief`; existing ledgers keep the `full` fallback", t_status_verbosity_defaults_to_full),
+    ("verbosity-help-defaults", "table help names the new-run `brief` default and existing-ledger `full` fallback", t_table_help_describes_verbosity_defaults),
     ("verbosity-legacy-block-frozen", "a pre-status_verbosity ledger prints the SAME block — pinned against a frozen, retyped list", t_legacy_config_block_is_unchanged),
     ("verbosity-refuses-unknown", "a value outside STATUS_VERBOSITIES is refused at the write door, store unchanged", t_status_verbosity_refuses_an_unknown_value),
     ("verbosity-brief-drops-config", "`brief` is the full render MINUS the run-config block, byte for byte", t_brief_drops_the_run_config_block_and_nothing_else),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -594,14 +594,14 @@ def t_truncation_is_display_only(L: ModuleType, tmp: Path) -> None:
 
 
 def t_table_missing_file(L: ModuleType, tmp: Path) -> None:
-    """A ledger that does not exist yet is a FRESH START, not an error: defaults, and no rows."""
+    """A ledger that does not exist yet is a FRESH START, not an error: brief defaults, and no rows."""
     code, out, err = cli(L, ["--file", str(tmp / "nope.jsonl"), "table"])
     check(code == 0, f"table on a missing file exited {code}: {err!r}")
-    config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
+    config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS, config_fields=())
     check(cells == [], f"a missing file produced rows: {cells!r}")
     check(out.rstrip().endswith(L.TABLE_EMPTY_MARKER),
           f"a missing file must still say {L.TABLE_EMPTY_MARKER!r}: {out!r}")
-    check(config[0] == "# run_id: -", f"a missing file must fall back to the defaults; got {config[0]!r}")
+    check(config == [], f"a missing file must use the brief default; got {config!r}")
 
 
 def t_table_no_rows(L: ModuleType, tmp: Path) -> None:
@@ -2780,10 +2780,10 @@ def t_pending_adoption_is_an_ordinary_field(L: ModuleType, tmp: Path) -> None:
 # the run-config block and NOTHING else — least of all the disclosure lines that say the view is a subset.
 
 def t_status_verbosity_defaults_to_full(L: ModuleType, tmp: Path) -> None:
-    """The default is `full`, so an existing run renders exactly as it did until the operator opts in.
+    """New runs default to `brief`; existing runs and old ledgers retain the `full` fallback.
 
-    Pinned on both sides: the stored default reads back `full`, and the table really does print the WHOLE
-    run-config block — one line per `TABLE_CONFIG_FIELDS` member, read from the accessor.
+    Pinned on both sides: existing stored ledgers read back `full`, new ledgers read back `brief`, and the
+    full table prints the WHOLE run-config block — one line per `TABLE_CONFIG_FIELDS` member.
 
     That oracle is DERIVED from the schema, so it proves the block is complete but can say NOTHING about
     which names belong in it: it would follow the tuple anywhere it moved. What the printed names must
@@ -2805,7 +2805,16 @@ def t_status_verbosity_defaults_to_full(L: ModuleType, tmp: Path) -> None:
         config, _, cells = grid(L, out, L.TABLE_DEFAULT_FIELDS)
         check(len(config) == len(L.TABLE_CONFIG_FIELDS),
               f"[{name}] the default view printed {len(config)} run-config lines, not one per printed field")
-        check(len(cells) == 1, f"[{name}] the row vanished from the default view: {out}")
+    check(len(cells) == 1, f"[{name}] the row vanished from the default view: {out}")
+
+    # A missing ledger is a new run. Its first write uses the quieter default without changing the legacy
+    # fallback for an existing ledger that predates this field.
+    new = tmp / "verb-new.jsonl"
+    check(not new.exists(), "the new-run fixture must start without a ledger")
+    code, _, err = cli(L, ["--file", str(new), "header", "set", "run_id", "new"])
+    check(code == 0, f"initializing a new ledger exited {code}: {err!r}")
+    check(header_field(L, new, "status_verbosity") == L.STATUS_VERBOSITY_BRIEF,
+          "a newly created ledger must default to brief")
 
 
 def t_legacy_config_block_is_unchanged(L: ModuleType, tmp: Path) -> None:
@@ -3314,7 +3323,7 @@ CASES = [
     ("watchdog-due-no-door", "`header set watchdog_due` is refused and writes nothing", t_watchdog_due_has_no_door),
     ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
     ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
-    ("verbosity-defaults-full", "status_verbosity defaults to `full` — an existing run renders as it did", t_status_verbosity_defaults_to_full),
+    ("verbosity-defaults", "new status_verbosity runs use `brief`; existing ledgers keep the `full` fallback", t_status_verbosity_defaults_to_full),
     ("verbosity-legacy-block-frozen", "a pre-status_verbosity ledger prints the SAME block — pinned against a frozen, retyped list", t_legacy_config_block_is_unchanged),
     ("verbosity-refuses-unknown", "a value outside STATUS_VERBOSITIES is refused at the write door, store unchanged", t_status_verbosity_refuses_an_unknown_value),
     ("verbosity-brief-drops-config", "`brief` is the full render MINUS the run-config block, byte for byte", t_brief_drops_the_run_config_block_and_nothing_else),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -179,12 +179,16 @@ HEADER_DEFAULTS = {
     # otherwise reprint on every wake. It drops NOTHING else: not a row, not an empty-grid marker, and
     # never the hidden-count disclosure line, which is what tells a reader the view is a SUBSET.
     #
-    # The default is `full`, and that is load-bearing rather than a taste: an existing run renders exactly
-    # as it did until the operator opts in. A stored value the validator refuses degrades to `full` on READ
+    # A new run starts with `brief`; an old ledger missing this field is back-filled from HEADER_DEFAULTS as
+    # `full`, preserving its existing render. A stored value the validator refuses degrades to `full` on READ
     # (`status_verbosity`) — the only thing this setting can do is HIDE output, so a setting nobody can read
     # must hide nothing.
     "status_verbosity": STATUS_VERBOSITY_FULL,
 }
+
+# A missing path is a new run. Existing ledgers still use HEADER_DEFAULTS when a field is absent, so the
+# legacy fallback above remains full while the first write for a new run starts with the quieter view.
+NEW_HEADER_DEFAULTS = {**HEADER_DEFAULTS, "status_verbosity": STATUS_VERBOSITY_BRIEF}
 
 ROW_FIELDS = (
     "id", "slug", "branch", "worktree", "worktree_owned", "branch_owned", "pr",
@@ -639,7 +643,7 @@ def load(path: Path) -> "tuple[dict, list[dict]]":
     # (a bare JSON `null` read as `None`, or a native array read as a `list`) so the fail-closed decode door
     # sees it un-healed. That transient non-str only lives here until `parse_default_non_goals` validates it;
     # every other field is still `_coerce_field`-d to `str`.
-    header: dict[str, object] = dict(HEADER_DEFAULTS)
+    header: dict[str, object] = dict(NEW_HEADER_DEFAULTS)
     rows: list[dict] = []
     if not path.exists():
         return header, rows

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -1998,9 +1998,10 @@ def build_parser() -> argparse.ArgumentParser:
     t = sub.add_parser(
         "table",
         help="print the run header and the live rows as an aligned table",
-        epilog=f"the header `status_verbosity` field ({'/'.join(STATUS_VERBOSITIES)}, default "
-               f"{STATUS_VERBOSITY_FULL}) decides whether the `# <field>: <value>` run-config block is "
-               f"printed above the grid; {STATUS_VERBOSITY_BRIEF} omits that block and nothing else — "
+        epilog=f"the header `status_verbosity` field ({'/'.join(STATUS_VERBOSITIES)}) decides whether the "
+               f"`# <field>: <value>` run-config block is printed above the grid; new runs default to "
+               f"{STATUS_VERBOSITY_BRIEF}, while existing ledgers without the field use the legacy "
+               f"{STATUS_VERBOSITY_FULL} fallback; {STATUS_VERBOSITY_BRIEF} omits that block and nothing else — "
                f"never a row, a marker, or the hidden-count line",
     )
     t.add_argument("--fields", help=f"comma-separated row fields to show (default: {','.join(TABLE_DEFAULT_FIELDS)})")


### PR DESCRIPTION
- Gauntlet UX-3: new ledgers use brief status output, while old ledgers keep the full fallback.
- Verification: the ledger test passes 91 fixtures.
