### PR TITLE
fix: silence successful review artifact emitters

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -761,9 +761,9 @@ not retell it. The verifier still **cannot raise `reviews_ok`** or judge whether
 **THE VERDICT/FINDINGS RULE IS AN IF AND ONLY IF, AND BOTH HALVES ARE ENFORCED: `NOT SATISFIED` exactly
 when at least one GATING finding stands.** The reviewer decided the finding gates **when it chose that
 `writer`, that `purpose` and that `base`**; the verdict may not then ignore it. A finding the reviewer does
-**not** intend to block on is said so where it is **said**, in those fields — and `emit-finding.py` prints
-`GATING` or `NON-GATING` when it writes the line, so the reviewer learns which it recorded in time to act. A `SATISFIED` pass carrying only non-gating findings is the ordinary, intended
-shape and passes untouched.
+**not** intend to block on is said so where it is **said**, in those fields. A `SATISFIED` pass carrying only
+non-gating findings is the ordinary, intended shape and passes untouched. Successful finding writes produce
+no stdout; invalid calls still report their diagnostics on stderr.
 
 **AND THE INTENT IS CHECKED FOR EVERY PASS — whatever it found, and even when it found nothing.** A
 guard whose input can be absent never fires, and the pass with no findings is precisely the ordinary

--- a/plugins/gauntlet/skills/campaign/scripts/emit-finding.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-finding.py
@@ -47,12 +47,14 @@ identically on the base, which the new loop had copied faithfully. All three gat
 no version of that code had ever had, and the PR died at the round cap. Being true was never the question.
 
 **A finding that anchors to NEITHER is NON-GATING.** So is one whose mechanism the base already has. It is
-still RECORDED — as a follow-up, for a human — and the tool says so on stdout when you write it. What it may not do is produce NOT SATISFIED, and no fix is
+still RECORDED — as a follow-up, for a human — but successful writes are silent; invalid calls report
+diagnostics on stderr and return non-zero. What it may not do is produce NOT SATISFIED, and no fix is
 dispatched for it. That is not a loophole and it is not a licence to lower your bar: it is the difference
 between the findings that were worth 21 rounds and the ones that were not, and it is the only reason this
 gate can ever finish.
 
-**AND A FINDING THAT DOES ANCHOR — GATES. The tool says that too, on the same stdout.** The rule is an IF
+**AND A FINDING THAT DOES ANCHOR — GATES. Successful writes are silent; invalid calls report diagnostics
+on stderr and return non-zero.** The rule is an IF
 AND ONLY IF: **NOT SATISFIED exactly when at least one GATING finding stands.** So the anchor you type here
 IS your verdict — record a gating finding and return SATISFIED anyway and the pass is UNUSABLE and gets
 thrown away, because a finding cannot read as blocking in the artifact and as ignorable in the verdict. If

--- a/plugins/gauntlet/skills/campaign/scripts/emit-report.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-report.py
@@ -29,8 +29,9 @@ or writing that path by hand, produces NO report — and a pass with no report c
 The flags:
 
   * `--verdict` — `satisfied` or `not-satisfied`. The rule is an IF AND ONLY IF: **`not-satisfied` exactly
-    when at least one GATING finding stands.** `emit-finding.py` tells you which kind each finding was as
-    it wrote it, so you are never guessing. `deferred` is NOT a verdict — it says you rendered none because
+    when at least one GATING finding stands.** The recorded fields and validation rules determine each
+    finding's kind; successful writes are silent, so read those fields rather than a success message.
+    `deferred` is NOT a verdict — it says you rendered none because
     you raised a request the orchestrator must handle first (a plan amendment, or a broken dispatch you are
     stopping on).
   * `--deferred-reason` — the one line the orchestrator routes a `deferred` result on, and the literal `-`

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -970,7 +970,7 @@ class Tables:
 
             # THE AMENDMENT WRITE DOOR — the one progress event a reviewer used to hand-write, now with a door.
             (["amend", "--reason", "no unit covers the harness", "--id", "u09", "--kind", "file",
-              "--target", "harness.py", "--check", "it runs"], DISPATCHED, 0, "# amendment raised",
+              "--target", "harness.py", "--check", "it runs"], DISPATCHED, 0, "",
              "**THE FIX, AT THE WRITE DOOR.** The dispatch prompt never stated the amendment's schema, so "
              "reviewers invented `{type, gap}` and `verify` refused the malformed line — taking the WHOLE "
              "pass down. Now the amendment goes through a door like every other event: the `ts` is "
@@ -1094,19 +1094,15 @@ class Tables:
         self.FINDING_CLI_CASES = [
             (FINDINGS_FILE, FIND_OK, 0, "",
              "the call the reviewer prompt makes — a finding that DEFENDS a stated purpose and names a real actor"),
-            (FINDINGS_FILE, FIND_OK, 0, "# GATING:",
-             "**AND THE TOOL SAYS SO, AT THE WRITE DOOR.** The same call, and what the reviewer is TOLD: "
-             "this finding ANCHORS, so it BLOCKS, so the verdict must be NOT SATISFIED while it stands. The "
-             "NON-GATING notice below has always existed so a follow-up could not become a block by "
-             "accident; this is its mirror, and the direction that actually merged a PR over a recorded "
-             "defect — `verify` refuses that pass, and this is where the reviewer learns the rule instead "
-             "of losing the pass to it fifteen minutes later"),
+            (FINDINGS_FILE, FIND_OK, 0, "",
+             "the same anchored finding is recorded without success chatter; its fields still require a "
+             "NOT SATISFIED verdict while it stands"),
             (FINDINGS_FILE, ["--path", "scripts/followups.py", "--line", "1815", "--writer", "dev-time",
                              "--purpose", "-", "--repro", "I mutated EXCEPTIONS in memory and self_test() still exited 0",
                              "--fix", "bound the exception table",
                              "--base", R.INTRODUCED, "--base-repro", R.NO_BASE_REPRO],
-             0, "NON-GATING",
-             "**THE SPIRAL FINDING, RECORDED AND DISCHARGED.** It is WRITTEN — this is not censorship, and the reviewer is not told to stop looking. The tool tells it, on stdout, that the finding anchors to nothing and MUST NOT produce NOT SATISFIED. It becomes a follow-up"),
+             0, "",
+             "**THE SPIRAL FINDING, RECORDED AND DISCHARGED.** It is WRITTEN and becomes a follow-up without success chatter"),
             (FINDINGS_FILE, [*FIND_OK[:6], "--purpose", "-", *FIND_OK[8:12],
                              "--base", R.PRE_EXISTING,
                              # An INVENTED base sha and an INVENTED output line. Neither exists anywhere in
@@ -1115,7 +1111,7 @@ class Tables:
                              # reader who greps for it and lands on the live site that prints it.
                              "--base-repro", "checked out the base at 0000000 and ran the same probe: "
                                              "it printed `all 1 probes agree` and exited 0 there too"],
-             0, "NON-GATING",
+             0, "",
              "**THE PR-207 FINDING, RECORDED AND DISCHARGED.** True, reproduced, `writer=repo-content` — "
              "and the BASE does exactly the same thing. Under the old two-question rule this GATED, and a "
              "refactor was made to pay for main's history: the fix added detection no version of that code "
@@ -1134,7 +1130,7 @@ class Tables:
              "reader cannot tell which half to believe, so neither is accepted"),
             (FINDINGS_FILE, [*FIND_OK[:12], "--base", R.PRE_EXISTING,
                              "--base-repro", "the base prints the same thing at 0000000"],
-             0, "# GATING:",
+             0, "",
              "**THE BOUND ON THE WHOLE RULE.** Pre-existing, measured, and it STILL gates — because this "
              "one anchors to a `## Purpose` line. A PR that promised to fix the thing cannot plead that "
              "the thing was already broken"),
@@ -1616,16 +1612,21 @@ def check(cond: bool, msg: str) -> None:
         raise SelfTestFailure(msg)
 
 
-def run_cli(mod: types.ModuleType, argv: "list[str]") -> "tuple[int, str]":
-    """Drive the REAL CLI in-process: (exit code, stdout+stderr). Never the internals — so argparse, the
-    `Defect`/`OperatorError` -> exit-code mapping, and `main()`'s wiring are all under test too."""
+def run_cli_streams(mod: types.ModuleType, argv: "list[str]") -> "tuple[int, str, str]":
+    """Drive the REAL CLI in-process: (exit code, stdout, stderr), never its internals."""
     out, err = io.StringIO(), io.StringIO()
     try:
         with redirect_stdout(out), redirect_stderr(err):
             code = mod.main(argv)
     except SystemExit as exc:  # argparse -> 2
         code = exc.code if isinstance(exc.code, int) else 1
-    return code, out.getvalue() + err.getvalue()
+    return code, out.getvalue(), err.getvalue()
+
+
+def run_cli(mod: types.ModuleType, argv: "list[str]") -> "tuple[int, str]":
+    """Drive the REAL CLI in-process and return combined output for existing diagnostics."""
+    code, stdout, stderr = run_cli_streams(mod, argv)
+    return code, stdout + stderr
 
 
 def write_intent(d: Path, text: "str | None" = INTENT) -> None:
@@ -1836,7 +1837,11 @@ def run_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[s
         if argv[0] == "verify" and "--ledger" not in argv[1:]:
             extra = ["--ledger", str(_write_ledger(path.parent / "state.jsonl", []))]
         try:
-            code, text = run_cli(mod, [argv[0], "--file", str(path), *argv[1:], *extra])
+            code, stdout, stderr = run_cli_streams(mod, [argv[0], "--file", str(path), *argv[1:], *extra])
+            text = stdout + stderr
+            if argv[0] == "amend" and code == 0 and stdout:
+                got[cli_key(i, argv)] = ("non-empty success stdout", text)
+                continue
             got[cli_key(i, argv)] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
             got[cli_key(i, argv)] = (f"crash:{type(exc).__name__}", str(exc))
@@ -1864,7 +1869,11 @@ def run_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[s
     for i, (fname, argv, _, _, _) in enumerate(T.FINDING_CLI_CASES):  # drops want, needle, why
         d = build(tmp, f"find-cli-{i}", T.PLAN, T.DISPATCHED, None, INTENT).parent
         try:
-            code, text = run_cli(mod, ["finding-add", "--file", str(d / fname), *argv])
+            code, stdout, stderr = run_cli_streams(mod, ["finding-add", "--file", str(d / fname), *argv])
+            text = stdout + stderr
+            if code == 0 and stdout:
+                got[find_key(i, fname)] = ("non-empty success stdout", text)
+                continue
             got[find_key(i, fname)] = (f"exit{code}", text)
         except Exception as exc:  # noqa: BLE001
             got[find_key(i, fname)] = (f"crash:{type(exc).__name__}", str(exc))
@@ -2708,10 +2717,11 @@ def check_amendment_door(R: types.ModuleType, tmp: Path) -> int:
     d = seed("owner")
     progress = d / PROGRESS_FILE
     run_cli(R, ["identity", "--file", str(progress), "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", "[]"])
-    code, out = run_cli(R, ["amend", "--file", str(progress), "--reason", "no unit covers the harness",
-                            "--id", "u09", "--kind", "file", "--target", "harness.py", "--check", "it runs"])
-    if code != 0 or "u09" not in out:
-        print(f"FAIL     [amend] the owner's door refused a valid amendment (exit {code}): {out.strip()}")
+    code, stdout, stderr = run_cli_streams(R, ["amend", "--file", str(progress), "--reason", "no unit covers the harness",
+                                               "--id", "u09", "--kind", "file", "--target", "harness.py", "--check", "it runs"])
+    if code != 0 or stdout:
+        print(f"FAIL     [amend] the owner's valid door was not quiet (exit {code}, stdout={stdout!r}): "
+              f"{stderr.strip()}")
         failures += 1
     (d / REPORT_FILE).write_text(DEFERRED_REPORT, encoding="utf-8")
     # `verify --ledger` is REQUIRED (F2); the identity above is bound to [], so a same-dir []-defaults ledger
@@ -2747,9 +2757,9 @@ def check_amendment_door(R: types.ModuleType, tmp: Path) -> int:
         [sys.executable, str(AMENDMENT_WRAPPER), "--file", str(progress), "--reason", "harness gap",
          "--id", "u09", "--kind", "docs", "--target", "y.md", "--check", "b"],
         capture_output=True, text=True, check=False)
-    if run.returncode != 0:
-        print(f"FAIL     [amend] the `emit-amendment.py` shim refused a valid amendment "
-              f"(exit {run.returncode}): {(run.stdout + run.stderr).strip()}")
+    if run.returncode != 0 or run.stdout:
+        print(f"FAIL     [amend] the `emit-amendment.py` shim was not quiet for a valid amendment "
+              f"(exit {run.returncode}, stdout={run.stdout!r}): {run.stderr.strip()}")
         failures += 1
     (d / REPORT_FILE).write_text(DEFERRED_REPORT, encoding="utf-8")
     ledger = _write_ledger(d / "state.jsonl", [])  # in-sync []-scope ledger for the now-required --ledger (F2)

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -911,8 +911,8 @@ class Tables:
         self.EMPTY, self.DISPATCHED, self.BEGUN, self.FINISHED = EMPTY, DISPATCHED, BEGUN, FINISHED
 
         self.CLI_CASES = [
-            (["emit", "--unit", "u01", "--status", "started"], DISPATCHED, 0, '"status":"started"', "the call every reviewer prompt makes"),
-            (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], BEGUN, 0, '"evidence":"f.py:1"',
+            (["emit", "--unit", "u01", "--status", "started"], DISPATCHED, 0, "", "the call every reviewer prompt makes"),
+            (["emit", "--unit", "u01", "--status", "done", "--evidence", "f.py:1"], BEGUN, 0, "",
              "…and its done form, on the file that HAS the matching `started` — the only file the done form was ever meant to be run against"),
             (["emit", "--unit", "u01", "--status", "started"], EMPTY, 1, "NO `pass_identity`",
              "HEADLINE, WRITE DOOR: THE FILE THIS TOOL WROTE AND WOULD NOT READ. `emit` on an EMPTY progress file exited 0 — it never looked for the identity — and `verify` then called that same file `unusable: NO pass_identity`. The reviewer was told its work landed, and the pass could not count"),
@@ -932,9 +932,9 @@ class Tables:
              "HEADLINE, WRITE DOOR: THE FINDING. `plan-add --id ' u01 '` used to exit 0 while this door silently STRIPPED the padding — so the plan held a unit whose progress could never be recorded"),
             (["emit", "--unit", "u02", "--status", "started"], [ident(), '{"type":"progress","unit_id":"u01","status":"done","evidence":"x"}'], 1, "carries EXACTLY",
              "the file it is APPENDING TO is evidence too: a hand-written line already in it makes the pass unusable"),
-            (["identity", "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", "[]"], EMPTY, 0, '"launch_attempt":"1"',
+            (["identity", "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", "[]"], EMPTY, 0, "",
              "the line that was a `printf` — pr/pass/attempt now come from the FILENAME"),
-            (["identity", "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", '["area X"]'], EMPTY, 0, '"default_non_goals":["area X"]',
+            (["identity", "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", '["area X"]'], EMPTY, 0, "",
              "the dispatch-time scope binding is stored DIRECTLY as a JSON array — the immutable value the tally compares to the run's current defaults"),
             (["identity", "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", "not-json"], EMPTY, 1, "canonical JSON array",
              "a malformed `--default-non-goals`: the run scope must decode through the ledger's ONE validator, or the binding names no scope"),
@@ -970,7 +970,7 @@ class Tables:
 
             # THE AMENDMENT WRITE DOOR — the one progress event a reviewer used to hand-write, now with a door.
             (["amend", "--reason", "no unit covers the harness", "--id", "u09", "--kind", "file",
-              "--target", "harness.py", "--check", "it runs"], DISPATCHED, 0, "plan_amendment_request",
+              "--target", "harness.py", "--check", "it runs"], DISPATCHED, 0, "# amendment raised",
              "**THE FIX, AT THE WRITE DOOR.** The dispatch prompt never stated the amendment's schema, so "
              "reviewers invented `{type, gap}` and `verify` refused the malformed line — taking the WHOLE "
              "pass down. Now the amendment goes through a door like every other event: the `ts` is "
@@ -1001,7 +1001,7 @@ class Tables:
         # repeatable `--check`; a seven-flag finding), and the ARTIFACT'S NAME is under test too.
         self.PLAN_CLI_CASES = [
             (PLAN_FILE, ["--id", "u03", "--kind", "cross-cutting", "--target", "both doors", "--check", "a", "--check", "b"],
-             0, '"checks":["a","b"]', "the plan stops being a shell heredoc"),
+             0, "", "the plan stops being a shell heredoc"),
             (PLAN_FILE, ["--id", "u01", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "duplicate unit id",
              "a duplicate id — refused by the SAME statement `load_plan` refuses it with"),
             (PLAN_FILE, ["--id", "  ", "--kind", "file", "--target", "x.py", "--check", "a"], 1, "NOT AN ID", "a blank id"),
@@ -1021,7 +1021,7 @@ class Tables:
 
         # plan-waive: (plan name, argv, exit, needle, why) — the waiver's own write door.
         self.WAIVE_CLI_CASES = [
-            (PLAN_FILE, ["--dimension", "docs", "--reason", "internal-only change"], 0, '"dimension":"docs"',
+            (PLAN_FILE, ["--dimension", "docs", "--reason", "internal-only change"], 0, "",
              "the waiver door: a default dimension is dropped OUT LOUD, validated as it lands"),
             (PLAN_FILE, ["--dimension", "docs", "--reason", "   "], 1, "a waiver IS its reason",
              "the check argparse cannot make: a --reason that is present and BLANK"),
@@ -1063,11 +1063,11 @@ class Tables:
         REPORT_OK = ["--verdict", R.SATISFIED, "--deferred-reason", R.NO_DEFERRED_REASON,
                      "--summary", "Report body."]
         self.REPORT_CLI_CASES = [
-            (REPORT_FILE, None, REPORT_OK, 0, '"verdict":"satisfied"',
+            (REPORT_FILE, None, REPORT_OK, 0, "",
              "the call every reviewer prompt makes, on the file the orchestrator derived for it"),
             (REPORT_FILE, None, [*REPORT_OK[:4], "--summary", "Report body.",
                                  "--residual-risk", RESIDUAL_ONE],
-             0, '"residual_risk":["' + RESIDUAL_ONE[:12],
+             0, "",
              "…and the same call carrying one calibration record, which is OPTIONAL and does not weaken it"),
             # **THE NAME.** A report written where `verify` will never DERIVE it is a report nothing reads,
             # and the pass is then refused for having none while its verdict sits on disk one filename
@@ -1092,7 +1092,7 @@ class Tables:
         ]
 
         self.FINDING_CLI_CASES = [
-            (FINDINGS_FILE, FIND_OK, 0, '"writer":"network"',
+            (FINDINGS_FILE, FIND_OK, 0, "",
              "the call the reviewer prompt makes — a finding that DEFENDS a stated purpose and names a real actor"),
             (FINDINGS_FILE, FIND_OK, 0, "# GATING:",
              "**AND THE TOOL SAYS SO, AT THE WRITE DOOR.** The same call, and what the reviewer is TOLD: "

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -2058,6 +2058,25 @@ def check_docs(R: types.ModuleType) -> int:
     return failures
 
 
+def check_quiet_finding_docs() -> int:
+    """The reviewer-facing finding docs must match the silent write door and its recorded fields."""
+    cases = (
+        ("review-prompt.txt", HERE / "review-prompt.txt",
+         "successful finding writes are silent"),
+        ("emit-report.py", REPORT_WRAPPER,
+         "recorded fields and validation rules determine each finding's kind; successful writes are silent"),
+    )
+    failures = 0
+    for name, path, current in cases:
+        text = " ".join(path.read_text(encoding="utf-8").split())
+        if current in text:
+            print(f"ok       [quiet-finding] {name:24} documents silent successful writes")
+        else:
+            print(f"FAIL     [quiet-finding] {name} still promises a success verdict message")
+            failures += 1
+    return failures
+
+
 # --- EVERY DOOR'S HELP: what it SAYS must be what the tool TAKES ---------------------------------
 #
 # `emit-progress.py --help` printed `usage: emit-progress.py emit [-h] --file …`, and running that exact
@@ -3022,6 +3041,8 @@ def run(R: types.ModuleType, tmp: Path) -> int:
     failures += check_boundaries(R, T)
     print()
     failures += check_docs(R)
+    print()
+    failures += check_quiet_finding_docs()
     print()
     failures += check_residual_records(R, T, tmp)
     print()

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -1985,9 +1985,9 @@ def decide(events: "list[dict]", units: "dict[str, dict]", ruled: int,
         contract was enforced and this half was not, so exactly that pass verified `ok`: the finding is
         real, it gates by the rule the reviewer itself applied when it recorded it, and the gate waved it
         through. If the reviewer believes it does NOT gate, the fix is to say so where it is SAID — a
-        finding that anchors to nothing is `purpose = -` and a no-adversary `writer`, and `finding-add`
-        prints NON-GATING when it writes one. What may never happen is a finding that reads as gating in
-        the artifact and as ignorable in the verdict.
+        finding that anchors to nothing is `purpose = -` and a no-adversary `writer`, and those fields make
+        it NON-GATING. What may never happen is a finding that reads as gating in the artifact and as
+        ignorable in the verdict.
 
     Note which direction EITHER half can move a pass — both can only ever REFUSE one. Nothing here can turn
     a NOT SATISFIED into a pass, raise `reviews_ok`, or merge anything; a tool that could accept would merge
@@ -2440,14 +2440,6 @@ def cmd_amend(args) -> int:
     # just hands it back. An amendment names no planned unit itself (`walk_progress` skips it), so nothing is
     # re-derived; the readback is the whole-file guarantee, not a second copy of the amendment's own rules.
     write_line(path, text, rec, lambda after: check_progress_file(after, path, lambda: units))
-    # A short confirmation, naming the proposed unit — the mirror of `finding-add`'s note. The pass now
-    # verifies `amended` until the orchestrator folds the unit into the plan and restarts the pass (or
-    # records why not); the reviewer writes its report with `--verdict deferred`.
-    sys.stdout.write(
-        f"# amendment raised: the plan is missing {args.id!r} ({args.kind} / {args.target}). This pass now "
-        f"verifies `amended` until the orchestrator rules on it — folds the unit into the plan and restarts "
-        f"the pass, or records why not. Write your report with `--verdict deferred`.\n"
-    )
     return 0
 
 
@@ -2603,17 +2595,6 @@ def cmd_finding_add(args) -> int:
                   load_intent(intent_path(path.parent, pr))[PURPOSE_H])
     write_line(path, before_text(path), rec,
                lambda after: check_findings_file(after, path))
-    # NEITHER of these is an error or a refusal — the finding is RECORDED either way. They are the tool
-    # telling the reviewer WHAT IT JUST WROTE, because the verdict/findings rule is an IF AND ONLY IF and
-    # a reviewer can get it wrong in BOTH directions: a NON-GATING finding turned into a NOT SATISFIED, or
-    # a GATING one left out of the verdict. `verify` refuses the pass either way, fifteen minutes later,
-    # by a tool the reviewer never sees; this is where it learns it, while it can still act.
-    if not gating(rec):
-        reason = ("the base already does this" if rec["base"] == PRE_EXISTING else
-                  "it has no purpose anchor or external writer")
-        sys.stdout.write(f"# NON-GATING: follow-up; {reason}. It cannot make the verdict NOT SATISFIED.\n")
-    else:
-        sys.stdout.write("# GATING: finding anchors a purpose or writable input; verdict MUST be NOT SATISFIED.\n")
     return 0
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -2391,7 +2391,7 @@ def cmd_emit(args) -> int:
     check_progress(rec, units, announced, done, "the event you asked to emit")
     # …and the file it would PRODUCE, through that same function. `units` is already loaded, so the thunk
     # just hands it back; nothing is re-derived, and nothing is re-stated.
-    sys.stdout.write(write_line(path, text, rec, lambda after: check_progress_file(after, path, lambda: units)))
+    write_line(path, text, rec, lambda after: check_progress_file(after, path, lambda: units))
     return 0
 
 
@@ -2439,7 +2439,7 @@ def cmd_amend(args) -> int:
     # …and the file it would PRODUCE, through that same function — `units` is already loaded, so the thunk
     # just hands it back. An amendment names no planned unit itself (`walk_progress` skips it), so nothing is
     # re-derived; the readback is the whole-file guarantee, not a second copy of the amendment's own rules.
-    sys.stdout.write(write_line(path, text, rec, lambda after: check_progress_file(after, path, lambda: units)))
+    write_line(path, text, rec, lambda after: check_progress_file(after, path, lambda: units))
     # A short confirmation, naming the proposed unit — the mirror of `finding-add`'s note. The pass now
     # verifies `amended` until the orchestrator folds the unit into the plan and restarts the pass (or
     # records why not); the reviewer writes its report with `--verdict deferred`.
@@ -2498,7 +2498,7 @@ def cmd_identity(args) -> int:
     # also why `identity` does not require the plan to exist yet: the orchestrator writes both before
     # dispatch, and this door has no business imposing an order between them. (If the guard above is ever
     # weakened, this still refuses whatever was in the file: an event no plan names.)
-    sys.stdout.write(write_line(path, text, rec, lambda after: check_progress_file(after, path, dict)))
+    write_line(path, text, rec, lambda after: check_progress_file(after, path, dict))
     return 0
 
 
@@ -2518,7 +2518,7 @@ def cmd_plan_add(args) -> int:
     # The name is checked BEFORE the file is read, and by the same statement: a path that is not a plan's
     # name is not a file this tool reads at all, so `before_text` is not asked about it.
     text = before_text(path) if PLAN_NAME_RE.match(path.name) else ""
-    sys.stdout.write(write_line(path, text, rec, lambda after: check_plan_file(after, path)))
+    write_line(path, text, rec, lambda after: check_plan_file(after, path))
     return 0
 
 
@@ -2533,7 +2533,7 @@ def cmd_plan_waive(args) -> int:
     rec: "dict[str, object]" = {"type": WAIVER, "dimension": args.dimension, "reason": args.reason}
     check_waiver(rec, "the waiver you asked to record")
     text = before_text(path) if PLAN_NAME_RE.match(path.name) else ""
-    sys.stdout.write(write_line(path, text, rec, lambda after: check_plan_file(after, path)))
+    write_line(path, text, rec, lambda after: check_plan_file(after, path))
     return 0
 
 
@@ -2601,8 +2601,8 @@ def cmd_finding_add(args) -> int:
     # fifteen minutes later by a `verify` it never sees.
     check_finding(rec, "the finding you asked to record",
                   load_intent(intent_path(path.parent, pr))[PURPOSE_H])
-    sys.stdout.write(write_line(path, before_text(path), rec,
-                                lambda after: check_findings_file(after, path)))
+    write_line(path, before_text(path), rec,
+               lambda after: check_findings_file(after, path))
     # NEITHER of these is an error or a refusal — the finding is RECORDED either way. They are the tool
     # telling the reviewer WHAT IT JUST WROTE, because the verdict/findings rule is an IF AND ONLY IF and
     # a reviewer can get it wrong in BOTH directions: a NON-GATING finding turned into a NOT SATISFIED, or
@@ -2650,7 +2650,7 @@ def cmd_report_write(args) -> int:
     # The SAME function the read side runs — so a record this door writes is one `verify` can never call
     # malformed, and the verdict/reason/residual rules exist in exactly one place.
     check_report(rec, "the report you asked to write (--verdict/--deferred-reason/--residual-risk/--summary)")
-    sys.stdout.write(write_line(path, text, rec, lambda after: check_report_file(after, path)))
+    write_line(path, text, rec, lambda after: check_report_file(after, path))
     return 0
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
+++ b/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
@@ -86,8 +86,9 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    so), it becomes a follow-up for a human, and it MUST NOT make your verdict NOT SATISFIED. That is not
    a licence to lower your bar — it is the difference between a defect and a true statement nobody can
    act on. Return NOT SATISFIED if and only if at least one GATING finding stands. The tool tells you
-   which one you just recorded, every time, so you are never guessing: it prints GATING or NON-GATING as
-   it writes the line. A finding cannot be blocking in the artifact and ignorable in the verdict — if you
+   which one you just recorded, every time, so you are never guessing: successful finding writes are
+   silent, and the recorded fields determine whether the finding is GATING or NON-GATING. A finding
+   cannot be blocking in the artifact and ignorable in the verdict — if you
    record a GATING finding you MUST return NOT SATISFIED, and if what you found does not really block the
    PR then it is one of those FIELDS that is wrong, not the verdict — the anchor (--purpose - with a
    driver-only/hand-edit/dev-time writer) or the base answer (--base pre-existing with the run that


### PR DESCRIPTION
- Gauntlet UX-1: successful artifact writes are silent on diagnostic stdout.
- Verification: the review-pass self-test passes 90 rules, and a direct report write is silent.
