### PR TITLE
serialize rebases and tally the status labels

### DIFF
--- a/plugins/gauntlet/skills/campaign/README.md
+++ b/plugins/gauntlet/skills/campaign/README.md
@@ -130,16 +130,23 @@ It also doesn't wait around. Everything long-running — reviews, CI watches, fi
 in the background across all the adopted PRs at once, so at any moment it's doing all the work that's
 ready to do.
 
-You can follow along on GitHub: each PR is labeled `gauntlet-reviewing` while it's working through
-the loop, and that flips to `gauntlet-accepted` once it has passed the review(s) its tier requires —
-one for a TRIVIAL docs-only PR, two for anything touching code or agent-facing files (the skill
-creates the labels if your repo doesn't have them).
+You can follow along on GitHub. Each PR is labeled `gauntlet-reviewing 0/2` while it's working through
+the loop — the count is how many of the reviews its tier requires have come back clean, so a PR halfway
+there reads `gauntlet-reviewing 1/2` — and that flips to `gauntlet-accepted` once it has them all. A
+TRIVIAL docs-only PR needs one review, anything touching code or agent-facing files needs two. The skill
+creates whichever labels your repo is missing, as it needs them.
 
 The label flips **back** just as readily. Anything that changes a PR's content after it was accepted —
 a CI fix, a rebase that had to resolve conflicts, a stray push to the branch — invalidates the reviews
-it had passed, so the PR returns to `gauntlet-reviewing` and must earn its verdicts again on the new
-content. The label always describes the code that is on the PR *right now*, so `gauntlet-accepted`
+it had passed, so the PR returns to a `gauntlet-reviewing` count and must earn its verdicts again on the
+new content. The label always describes the code that is on the PR *right now*, so `gauntlet-accepted`
 never means "this passed at some point" — it means "this, as it currently stands, passed."
+
+A third label, `gauntlet-rebase-pending`, says a PR has fallen behind its base branch because something
+else merged ahead of it. It is **not** a problem to fix: the PR keeps being reviewed exactly as it is, and
+it gets rebased when its turn to merge comes up. Rebasing every waiting PR every time one merges would
+re-run your whole CI suite over and over for no benefit, so the skill rebases one PR at a time — the one
+it is about to merge. An accepted PR waiting its turn wears both labels at once, and that is normal.
 
 By default it checks with you before changing anything in your public API — exported signatures,
 formats, CLI flags, defaults, or any behavior callers depend on — so it never merges a breaking

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -234,7 +234,9 @@ every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snaps
 
 24. A merge candidate is not held, on a live SHA, with `reviews_ok >= required(tier)` and
     `ci == green`. Merge one at a time until no candidate remains immediately ready after base
-    refresh. Campaign never passes `--delete-branch` — the repo's *Automatically delete head branches*
+    refresh. **REBASES are serialized with the merges, and only the candidate rebases**: after a merge,
+    other PRs are re-measured and labelled `gauntlet-rebase-pending`, never rebased
+    (`references/stage-3-merge.md`, "Step 6"). Campaign never passes `--delete-branch` — the repo's *Automatically delete head branches*
     setting governs the remote branch; local cleanup follows the per-PR `worktree_owned` /
     `branch_owned` flags. Execute each candidate through `merge.py run`; re-run that command after any
     partial failure instead of hand-running its later phases.
@@ -294,7 +296,7 @@ a line the tool writes.
 | `emit-amendment.py` | Reviewer's door: raise one plan amendment (the only sanctioned way; `ts` is tool-stamped, the proposed unit is validated like a plan unit) | `references/stage-2-review-gate.md` |
 | `emit-report.py` | Reviewer's door: write the pass's ONE report record and its verdict (the only sanctioned way, on every route — the report was the last free-text artifact) | `references/stage-2-review-gate.md` |
 | `reviewer-liveness.py` | Probe whether a dispatched reviewer's output stream is still moving; decides nothing, always exits 0 | `references/stage-2-review-gate.md` |
-| `base-preflight.py` | Decide proceed / rebase-first / recheck / park from live merge-state plus fetched base ancestry before review or fix; performs no rebase — with `--file`, `proceed` records `base_ok_sha` and `park` records the ledger-owned machine blocker | `references/stage-2-review-gate.md` |
+| `base-preflight.py` | Decide proceed / rebase-first / recheck / park from live merge-state plus fetched base ancestry before review or fix; `rebase-first` means a CONFLICT — a base that merely ADVANCED proceeds and is RECORDED, never refused. Performs no rebase — with `--file`, `proceed` records `base_ok_sha` + `base_current` and `park` records the ledger-owned machine blocker | `references/stage-2-review-gate.md` |
 | `base-retarget.py` | `resolve` — decide what a live base divergence MEANS for one row and perform the one ledger write it implies: MIGRATE the row (`ledger.py retarget`) when GitHub's own retarget explains it — the recorded base's PR merged AND GitHub's timeline records that merge moving THIS PR — and PARK it on the user otherwise; `decide` is the pure surface | `references/loop-control.md`, `references/pr-adoption.md` |
 | `format-preflight.py` | `check` — refuse to format any file whose formatter-write could escape the worktree (the file, or any path component, is a symlink); reads only, formats nothing | `references/stage-2-ci.md` |
 | `worker-prompt.py` | `fix` — bind one complete review/CI fix prompt and logical model class, then atomically publish its exact bytes + metadata | `references/fix-subagent-contract.md` |
@@ -304,7 +306,7 @@ a line the tool writes.
 | `mutate-ci-snapshot.py` | Mutation harness proving `ci-snapshot.py`'s rules are fixture-pinned; run by validation/CI, not the driver | `references/ci-derivation-spec.md` |
 | `merge-check.py` | `check` — decide merge-readiness (`merge` / `not-yet <reason>`) from the ledger row, live PR view, and fetched base ancestry | `references/stage-3-merge.md` |
 | `merge.py` | `run` — resumably execute one merge-check-approved PR merge, base sync, owned local cleanup, and terminal ledger write | `references/stage-3-merge.md` |
-| `label-mirror.py` | `mirror` — reconcile a PR's status label with its review gate (the canonical idempotent `gauntlet-accepted`/`gauntlet-reviewing` swap), computed from the ledger row; touches only the two status labels | `references/stage-2-review-gate.md` |
+| `label-mirror.py` | `mirror` — reconcile a PR's status labels with its ledger row: the gate label (`gauntlet-accepted`, else the tallied `gauntlet-reviewing <ok>/<required>`) and `gauntlet-rebase-pending`, creating each label it adds and sweeping off every other status label; never touches the run-owner label | `references/stage-2-review-gate.md` |
 | `reconcile.py` | `fetch` — construct, validate, and atomically promote the canonical run-scoped PR snapshot; `detect` — compare it against the ledger and emit per-PR FACTS. Names no action; routing is skill policy | `references/files-and-ledger.md`, `references/loop-control.md` |
 | `repair-pass.py` | Reassessment pass's door: `permitted` / `bundle` / `decide` — deterministic complete-history prompt, bundle hash binding, closed decision enum, ownership guardrail, repair cap | `references/repair-pass.md` |
 | `followups.py` | Schema-owning accessor for the follow-up store (`.gauntlet/followups.jsonl`) — a durable work QUEUE, not an archive: entries are deleted once recorded elsewhere, kept when nothing else would remember | `references/followups.md` |

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -172,7 +172,7 @@
   the head branch, **or a depth-raising tier escalation, which voids the tally on unchanged content**), OR
   a tier **de-escalation** that lowers `required(tier)` on unchanged content — MUST also reconcile the
   label by running `label-mirror.py mirror` for the PR — the ONE way that swap is applied — which restores
-  `gauntlet-reviewing` on a PR carrying `gauntlet-accepted` (`stage-2-review-gate.md`, "Status labels
+  the reviewing label on a PR carrying `gauntlet-accepted` (`stage-2-review-gate.md`, "Status labels
   mirror the review gate", owns the two-direction split). Never defer the swap to the next heartbeat — that leaves the label lying
   until reconcile, and lying forever if the session dies first. A **clean base-only rebase** with an
   unchanged PR diff does NOT reset the gate, so it correctly KEEPS `gauntlet-accepted` — it sets
@@ -224,7 +224,7 @@
   `<rundir>/audit-<pr>-<n>.jsonl` through `finding-audit.py`) and
   **commit it**. A refutation is a COMMIT, a commit is PR CONTENT, and PR content **RESETS THE GATE** and
   is **REVIEWED** — route it through the same "any campaign commit resets the gate" rule (`reviews_ok` →
-  0, restore `gauntlet-reviewing`, re-derive CI for the new tip). **Refutation CI watch action.** Run
+  0, restore the reviewing label, re-derive CI for the new tip). **Refutation CI watch action.** Run
   `liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`
   (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not override that result. Re-enter
   Stage 2a; never invent a second mechanism. Nothing is slipped past the reviewer: the argument is IN the diff, so a bogus refutation is
@@ -267,7 +267,8 @@
   The user's answer unparks it (`status` → `in_review`, recorded durably per park class; a declined
   API change or a `blocker_ruling` of `abort` → `aborted`), and the ONE machine release — an explained base
   retarget — is defined with the rest at `loop-control.md` step 3, "Who unparks a PR"; a parked PR that fell
-  behind its base stays behind until then. **Held-PR watch action.** Observing a PR is not mutating it. Run
+  behind its base stays behind until then (as does every UNparked one — nothing rebases until it reaches the
+  front of the merge drain, `stage-3-merge.md`, "Step 6"). **Held-PR watch action.** Observing a PR is not mutating it. Run
   `liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`
   (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked status does not override that result. Do not
   dispatch a CI fix.
@@ -436,7 +437,7 @@
 - **ANY campaign commit to the PR head resets the gate** (`stage-2-ci.md`, "Any campaign commit to the PR
   head resets the gate") — economy-class CI-fix, `session`-class CI-fix, review-fix, or **refutation commit** alike. In the SAME step: reset
   `reviews_ok` to 0 AND reconcile the label by running `label-mirror.py mirror` for the PR (it restores
-  `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`); the new commit
+  the reviewing label on a PR carrying `gauntlet-accepted`); the new commit
   moves `head_sha`, so writing it through the accessor fires the head-move reset at the door
   (`files-and-ledger.md`, the `head_sha` field, "What a genuine head move resets"); re-derive CI for the
   new tip. **Campaign-commit CI watch action.** Run `liveness`, then ensure or relaunch a watch only when

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -237,8 +237,9 @@ earned under the **narrower** scope, and a header write moves **no head SHA**, s
 that tally — the PR could otherwise merge with the now-in-scope area **never reviewed**. Reset those rows
 first (`ledger.py set --pr <N> --reviews-ok 0`, re-opening each for a fresh review under the broadened
 scope) and, **in that same step, run `label-mirror.py mirror` for each** so its public status label is
-restored to `gauntlet-reviewing` — a `reviews_ok`→0 reset owes the relabel exactly like any other
-(`stage-2-review-gate.md`, status-label projection); then re-declare. **ADDING** a default **narrows** scope, under which banked credit stays valid, so an
+restored to the reviewing label for the voided tally — a `reviews_ok`→0 reset owes the relabel exactly like
+any other (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the label and its
+spelling); then re-declare. **ADDING** a default **narrows** scope, under which banked credit stays valid, so an
 add is always allowed. This banked-credit guard covers a PR that has **already** banked SATISFIED credit;
 the complementary window — a PR at `reviews_ok = 0` with a review **in flight** — is closed at tally time,
 not here: `verify --ledger` refuses a verdict whose DISPATCH-TIME `pass_identity.default_non_goals` binding
@@ -331,7 +332,8 @@ Header field notes (the header fields above; per-row fields follow):
 
   **What a genuine head move resets — THE CANONICAL SET; every other site POINTS here and re-lists
   nothing:** the liveness counters (`stage-2-ci.md`, "THE LIVENESS COUNTERS", owns that set and every
-  member) **and** the base-preflight stamp `base_ok_sha` (the `base_ok_sha` field below owns it) — both
+  member) **and** the base-preflight readings (`PREFLIGHT_OWNED` in `ledger.py` names that set; the
+  `base_ok_sha` and `base_current` fields below own what each means) — all
   read from `ROW_DEFAULTS` by `apply_head_sha`, never a list retyped anywhere. The review **gate** is a
   SEPARATE decision and is NOT in this set: `reviews_ok` carries forward on a clean base-only rebase, and
   every other reset of the gate tally is owned by `stage-2-review-gate.md`, "Status labels mirror the
@@ -364,17 +366,32 @@ Header field notes (the header fields above; per-row fields follow):
   fix, a rebase or a content change: a **SATISFIED** verdict, and a **non-abort reassessment decision**
   (`repair-pass.py decide`, which `repair-pass.md` owns). Same absent flag as `review_rounds`, same reason —
   the second writer is a tool that must SPEND a repair to clear it, not a door a driver can type at.
-- `base_ok_sha` — the head a base-preflight **`proceed`** was last decided for: the **MECHANICAL** form of the
-  rebase-before-review precondition. **`ledger.py verdict` refuses unless `base_ok_sha == head_sha`** — for a
+- `base_ok_sha` — the head a base-preflight **`proceed`** was last decided for: the **MECHANICAL** form of
+  "a review is measured only against a head a preflight has cleared".
+  **`ledger.py verdict` refuses unless `base_ok_sha == head_sha`** — for a
   SATISFIED **or** a NOT SATISFIED, since a counted NOT SATISFIED spends `review_rounds`/`ns_streak` toward the
   caps just the same — so a review verdict can never be recorded over a base no fresh `proceed` cleared.
   **Written by exactly one thing: `base-preflight.py check`**, through `ledger.py base-ok`, when — and only
   when — it decides `proceed` for the live head. It has **no `set`/`add-row` flag** (the same absent-door
   mechanism as `review_rounds`): a hand-written stamp would forge a `proceed` no preflight ever decided,
-  recording a verdict over a conflicting or stale base, which is the exact waste this guard exists to stop. It
+  recording a verdict over a conflicting base, which is the exact waste this guard exists to stop. It
   is SHA-bound and voided on a head move exactly like the liveness counters (`head_sha` above, the reset
   family), and stamping it is **not activity** (it records a precondition, like re-arming the watchdog). The
   default is `-`, which no 40-char head equals, so `verdict` **fails closed** until base-preflight runs.
+- `base_current` — **`yes`**, **`no`**, or **`-`**: what that same `proceed`'s Git ancestry probe saw for that
+  head. `no` means the base has advanced past this head, so the PR owes a rebase **before it merges** — a base
+  that merely advanced does **not** block a review (`stage-2-review-gate.md`, "2a preconditions"; only a
+  CONFLICT does). Written by the same one writer through the same one door, `ledger.py base-ok`, in the SAME
+  write as `base_ok_sha` — they describe one probe of one head, so they can never disagree — and closed to
+  `set`/`add-row` for a different reason than its neighbour: it gates nothing, so nothing could be forged with
+  it, but it is a **sensor reading**, and a hand-typed reading is the forged-sensor failure `last_activity` is
+  closed against.
+
+  **NO GATE READS IT.** `merge-check.py` runs its own live probe at the merge, so the one decision that turns
+  on base currency is made from a fresh reading rather than a remembered one. This field exists so
+  `label-mirror.py` can project `gauntlet-rebase-pending` onto GitHub: a stale value costs a wrong label,
+  never a wrong merge. `-` makes **no claim in either direction**, so a head nothing has probed yet wears no
+  rebase label rather than a guessed one.
 
   **What READS these counters is `ledger.py verdict` itself, and at a cap it STOPS THE LOOP.** They are
   sensors, and the reader is fused into the one door that cannot be skipped — deliberately: a cap
@@ -722,7 +739,8 @@ ledger.py --file <state.jsonl> add-row --pr N [--<field> <val> …] # register a
 ledger.py --file <state.jsonl> set --pr N --<field> <val> [--<field> <val> …]  # update named fields on the row for PR N
 ledger.py --file <state.jsonl> verdict --pr N --head-sha <sha> --verdict satisfied|not-satisfied
                                                                   # record ONE landed review verdict — the ONLY sanctioned path (refused unless base_ok_sha == head_sha)
-ledger.py --file <state.jsonl> base-ok --pr N --head-sha <sha>    # record a base-preflight `proceed` for the head (base_ok_sha) — written only by base-preflight.py, never hand-set
+ledger.py --file <state.jsonl> base-ok --pr N --head-sha <sha> --base-current yes|no
+                                                                  # record a base-preflight `proceed` for the head (base_ok_sha + base_current) — written only by base-preflight.py, never hand-set
 ledger.py --file <state.jsonl> get --pr N [--field <f>]           # print the row as JSON, or one field
 ledger.py --file <state.jsonl> list [--where <field>=<val>]       # print matching rows' pr numbers (all if no filter)
 ledger.py --file <state.jsonl> table [--all] [--fields <f>,<f>,…] # print run header + the live rows as an aligned table (read-only; the header status_verbosity decides whether the run-config block prints)

--- a/plugins/gauntlet/skills/campaign/references/finding-audit.md
+++ b/plugins/gauntlet/skills/campaign/references/finding-audit.md
@@ -242,7 +242,7 @@ On REFUTED:
   does not apply (this also matches the user's standing rule for not-applicable review feedback).
 - **Commit it.** The refutation commit is a **PR-content change**, so it **RESETS THE GATE** exactly like
   any other campaign commit: route it through the existing "any campaign commit to the PR head resets the
-  gate" rule (`reviews_ok` → 0, restore `gauntlet-reviewing` — "Status labels mirror the review gate" —
+  gate" rule (`reviews_ok` → 0, restore the reviewing label — "Status labels mirror the review gate" —
   re-derive CI for the new tip). **Refutation CI watch action.** Run `liveness`, then ensure or relaunch
   a watch only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE").
   Parked status does not override that result. Re-enter Stage 2a on the new tip. Do **NOT** invent a

--- a/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
+++ b/plugins/gauntlet/skills/campaign/references/fix-subagent-contract.md
@@ -27,11 +27,15 @@ is an **assertion** that must equal the row's effective base, and the helper als
 `baseRefName` against it. It fetches the base and prints ONE of four verdicts, and the action
 **splits by verdict** — only `proceed` clears the dispatch:
 
-- **`proceed`** → the base is current; **dispatch the fix**. The `--file` makes the `proceed` record
-  `base_ok_sha` for the current head — the MECHANICAL precondition `ledger.py verdict` enforces
-  (`stage-2-review-gate.md`, "Recording a verdict"): a review verdict is refused for a head with no fresh
-  `proceed`.
-- **`rebase-first`** → the branch conflicts with its base or lacks the refreshed base; do **NOT** dispatch.
+- **`proceed`** → the branch does not conflict with its base; **dispatch the fix**. The `--file` makes the
+  `proceed` record `base_ok_sha` for the current head — the MECHANICAL precondition `ledger.py verdict`
+  enforces (`stage-2-review-gate.md`, "Recording a verdict"): a review verdict is refused for a head with no
+  fresh `proceed` — **and `base_current` in the same write**, so run `label-mirror.py mirror` for the PR
+  after the check (`stage-2-review-gate.md`, "`gauntlet-rebase-pending` — the SECOND label axis").
+  **A `proceed` carrying `base_current: no` still dispatches.** The base advanced under this PR; that owes a
+  rebase before the MERGE, not before the fix, and the fix is not wasted by it — a clean base-only rebase at
+  the front of the drain carries the work forward unchanged.
+- **`rebase-first`** → the branch CONFLICTS with its base; do **NOT** dispatch.
   **REBASE the PR onto `<base>`** through `stage-2-review-gate.md`'s base-currency handling, which runs
   `clean-rebase.py` FIRST: a clean base-only rebase (exit 0) PRESERVES the verdicts and label, and only its
   **exit 3** — conflict OR diff-changed — falls back to the JUDGMENT path that resets the gate and re-mirrors
@@ -48,9 +52,9 @@ is an **assertion** that must equal the row's effective base, and the helper als
   helper has already written the `ledger.py park` machine-blocker transition, naming the value verbatim.
   Do **NOT** dispatch or re-poll; leave the held candidate until the user rules on the blocker.
 
-A fix authored on a stale or conflicting base is wasted work: it is re-reviewed against the rebased tip
-anyway, and its diff may not even apply. The tool fetches and decides only — it performs no rebase; the
-driver rebases only on `rebase-first`, exactly as at the review-gate site.
+A fix authored on a CONFLICTING base is wasted work: its diff may not even apply, and it fights the merge.
+That is why a conflict — and only a conflict — withholds the dispatch. The tool fetches and decides only; it
+performs no rebase, and the driver rebases only on `rebase-first`, exactly as at the review-gate site.
 
 ### Materialize the exact prompt bundle
 

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -105,8 +105,8 @@ rules keep their own wording; these are illustrations of them, not a second copy
      **This refresh is itself a gate-reset site — relabel here, in this step.** When it detects that a
      PR's live `head_sha` has moved with the PR diff changed (a formatter/bot commit, a manual push,
      any content change this run did not dispatch), it resets `reviews_ok` to 0 — and MUST, in the same
-     step, reconcile the label by running `label-mirror.py mirror` for that PR, which restores
-     `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`
+     step, reconcile the label by running `label-mirror.py mirror` for that PR, which restores the
+     reviewing label on a PR carrying `gauntlet-accepted`
      (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool).
      Do NOT defer this to the label-reconcile pass below — that pass is only the **backstop** ("This
      reconcile is a backstop, not the mechanism", below). (A clean base-only advance with the PR
@@ -250,38 +250,30 @@ rules keep their own wording; these are illustrations of them, not a second copy
    prompt (run `gauntlet:review`, or pass PR numbers), exactly like a bare no-arg first run, and mints
    no run-id/`<rundir>`/lease.
 
-   **Reconcile labels too** (idempotent, retroactive, **scoped to this run**). Ensure the labels exist
-   (`gh label create … --force`, including this run's `gauntlet-run-<run-id>`), then for every PR **of
-   this run** (its `gauntlet-run-<run-id>` label — the only ownership marker for adopted PRs): ensure
-   it carries `gauntlet-run-<run-id>`, and **reconcile its status label by running `label-mirror.py
-   mirror` for it** — the tool overwrites the status label to match the PR's **live** gate state. (The
+   **Reconcile labels too** (idempotent, retroactive, **scoped to this run**). Ensure this run's
+   `gauntlet-run-<run-id>` label exists (`gh label create … --force`), then for every PR **of
+   this run** (that label — the only ownership marker for adopted PRs): ensure
+   it carries `gauntlet-run-<run-id>`, and **reconcile its status labels by running `label-mirror.py
+   mirror` for it** — the tool overwrites them to match the PR's **live** row state. (The
    `gauntlet-run-<run-id>` ownership label is adoption's, and the tool never touches it — ensure it
-   separately, as above.) **Never touch another run's PRs.**
+   separately, as above. The status labels themselves need no bootstrap: the tool creates each one it is
+   about to add.) **Never touch another run's PRs.**
 
-   **The tool applies one status label AND removes the other — never merely add.** The two status labels
-   are mutually exclusive, so a purely additive reconcile cannot repair the one state it most needs to: a
-   PR wearing **both** labels (what a missed swap at a reset site actually produces) would keep the
-   contradictory label forever, because adding a label it already carries changes nothing. The swap it
-   applies — shown as the SPEC it implements, one call per PR, direction picked from the live gate, NOT a
-   command to paste by hand:
-
-   ```
-   # current HEAD holds required(tier) SATISFIED verdicts:
-   gh pr edit <pr> --add-label gauntlet-accepted  --remove-label gauntlet-reviewing
-   # otherwise:
-   gh pr edit <pr> --add-label gauntlet-reviewing --remove-label gauntlet-accepted
-   ```
-
-   Both forms are idempotent (`--add-label` of a label already present and `--remove-label` of one that
-   is absent are both no-ops), so this converges from **any** starting state — neither label, one label,
-   the wrong label, or both.
+   **The tool ADDS what the row says and REMOVES every other status label — never merely add.** A purely
+   additive reconcile cannot repair the one state it most needs to: a
+   PR wearing a stale tally **and** a current one (what a missed swap at a reset site actually produces)
+   would keep the contradictory label forever, because adding a label it already carries changes nothing.
+   `stage-2-review-gate.md`, "Status labels mirror the review gate", owns the labels, their spelling, and
+   both axes; do not restate the `gh pr edit` here, and do not hand-run one.
 
    This reconcile is a **backstop, not the mechanism**. The relabel is owed at the moment the gate
    projection changes, in the same step that writes `reviews_ok = 0` (which includes a depth-raising tier
    escalation) or decides a de-escalation that lowers `required(tier)`
-   (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the two-direction split); this pass only
+   (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the two-direction split), and
+   the base-currency label is owed at the moment `base-preflight.py check --file` records a fresh reading
+   (same file, "`gauntlet-rebase-pending` — the SECOND label axis"); this pass only
    *self-heals* a swap that was somehow missed. A PR that
-   reaches this point wearing a stale `gauntlet-accepted` — or both labels at once — means some reset
+   reaches this point wearing a stale `gauntlet-accepted` — or two gate labels at once — means some reset
    site skipped its relabel: fix the label here, and treat it as a bug in that site, not as normal
    operation.
 
@@ -384,7 +376,8 @@ rules keep their own wording; these are illustrations of them, not a second copy
    it already did: this guard once listed four (review, CI fix, review fix, merge) and missed
    `stage-3-merge.md` step 6, whose post-merge rebase of PRs that fell behind would have moved a held
    PR's `head_sha`, reset its gate, and **changed the very PR content the user was parked to
-   adjudicate**. Any site the skill grows later is covered the moment it would mutate a held PR, with
+   adjudicate**. (Step 6a no longer rebases those PRs at all, which removes that particular reach — but
+   the guard is the property, not the list, and step 6b still rebases the PR at the front of the drain.) Any site the skill grows later is covered the moment it would mutate a held PR, with
    no edit to this list. When unsure whether an action mutates, treat it as mutating and skip it.
    - **The sole mutating exception is a non-legacy recorded repair's required clean base-only rebase.** It
      applies only to `repairing` after `dispatch-check --action repair` succeeds; `repair-pass.md`, **A
@@ -518,9 +511,10 @@ rules keep their own wording; these are illustrations of them, not a second copy
        `required(tier)` moves.
      **Then, in that SAME step, run `label-mirror.py mirror` for that PR** — idempotent, a no-op when the
      label already matches — so the tier, `required(tier)`, and the public status label move together: it
-     restores `gauntlet-reviewing` on a depth-raising escalation (the voided tally no longer meets
+     restores the reviewing label on a depth-raising escalation (the voided tally no longer meets
      `required`) and swaps a standing tally to `gauntlet-accepted` on a de-escalation that now meets the
-     lowered `required` (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and
+     lowered `required` — and it moves on ANY tier change, because the tally is spelled into the label name
+     and `required(tier)` is half of it (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and
      the tool). On refusal,
      refresh the moving or mismatched input and retry; never carry a tier across content the command did
      not classify.
@@ -556,7 +550,9 @@ rules keep their own wording; these are illustrations of them, not a second copy
      `base-preflight.py check --pr <N> --worktree <worktree> --base <base> --file <state.jsonl>`; only
      `proceed` clears the review launch, and — because a verdict follows — the `--file` is REQUIRED: on
      `proceed` it records `base_ok_sha` for the head, without which `ledger.py verdict` refuses the verdict
-     it later records (Stage 2a, "Recording a verdict"). Rebase on `rebase-first`, re-poll on `recheck`, or
+     it later records (Stage 2a, "Recording a verdict") **and `base_current`, so run `label-mirror.py
+     mirror` for the PR after the check**. Rebase on `rebase-first` — a CONFLICT, the only verdict that
+     still asks for one — re-poll on `recheck`, or
      leave the ledger-held candidate alone on `park` per Stage 2a, then restart this precondition sequence.
      With `proceed`, pass the freshly read ledger-row `head_sha` to `review-dispatch.py prepare`. Its
      `--file` head assertion refuses before writing an allocation or reviewer artifact if the PR moved;
@@ -571,7 +567,8 @@ rules keep their own wording; these are illustrations of them, not a second copy
      review pass as a **background**
      task (one at a time per PR — the second, when the tier requires two, only after the first is
      SATISFIED; Stage 2a). If a precondition is dirty, clear it first (address Copilot items / fix CI /
-     rebase) instead of spending a review;
+     resolve a conflict) instead of spending a review. A base that merely ADVANCED is not a dirty
+     precondition and blocks nothing here (Stage 2a, Preconditions);
    - a review pass is in flight but the **active attempt's** progress file holds **no launch evidence**
      — no reviewer-written line of ANY kind after `pass_identity` (a `progress` `started`/`done` event
      *or* a `plan_amendment_request` all count) — past its **~5-min launch deadline** (measured from

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -35,14 +35,18 @@ Campaign **never** deletes the adopted PR's **remote** head branch. Stage 3,
 decide whether the worktree/local branch is removed. A reused worktree, the root/main checkout, and a
 reused local branch are always left in place (see "Stage 3 — Merge").
 
-**Ensure the labels exist** first — the two shared status labels plus this run's owner label
-(idempotent — `--force` creates or updates, safe on every resume):
+**Ensure this run's owner label exists** first (idempotent — `--force` creates or updates, safe on every
+resume):
 
 ```
-gh label create gauntlet-reviewing --color FBCA04 --description "gauntlet: under review" --force
-gh label create gauntlet-accepted  --color 0E8A16 --description "gauntlet: passed its reviews" --force
 gh label create gauntlet-run-<run-id> --color 5319E7 --description "gauntlet: run <run-id>" --force
 ```
+
+**The STATUS labels need no bootstrap, and must not get one.** A reviewing label carries its own tally
+(`gauntlet-reviewing 1/2`), so which ones a repository needs depends on how its PRs get triaged — a fixed
+list here would go stale the first time that changed. Every tool that ADDS a status label creates it first,
+in the same step (`pr-adopt.py` at step 4, `label-mirror.py` at every later reconcile).
+`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the vocabulary.
 
 ### Adopt one PR
 
@@ -148,8 +152,9 @@ For each `#PR` to adopt:
    A stack gate makes the recorded base branch disappear: merging the lower PR removes its branch and GitHub
    retargets the upper PR onto the lower PR's own base. That is the ONE divergence the campaign can explain
    without asking, so it **migrates the row in place** and keeps going — the row records the new base, the
-   review tally survives (a retarget moves no content), and the base-preflight rebase onto the new base is
-   the ordinary next step. `base-retarget.py` establishes both the merged parent and GitHub's own recorded retarget of this PR, then
+   review tally survives (a retarget moves no content), and the row simply carries on against the new base —
+   base-preflight measures it there, and the rebase onto it is owed at the merge like any other
+   (`stage-3-merge.md`, "Step 6"). `base-retarget.py` establishes both the merged parent and GitHub's own recorded retarget of this PR, then
    performs the write through `ledger.py retarget`; nothing here is a user decision.
 
    A divergence it CANNOT explain still parks, and a parked row is answered by the user through the ordinary
@@ -192,11 +197,11 @@ For each `#PR` to adopt:
      `reviews_ok` to `0` and re-triage `tier` only if** reconciliation detects a PR-content change
      since the recorded `head_sha` (per the gate's SHA-pinning rules). **That reset is a gate-reset
      site: in the same step, reconcile the label by running `label-mirror.py mirror` for the PR**, which
-     restores `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`
+     restores the reviewing label on a PR carrying `gauntlet-accepted`
      (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool). A
-     bare `--add-label gauntlet-reviewing` is NOT sufficient: it would leave the stale `gauntlet-accepted`
-     in place, so the PR would carry **both** status labels and still publicly claim it passed — the tool
-     removes the other label in the same call.
+     bare `--add-label` is NOT sufficient: it would leave the stale `gauntlet-accepted`
+     in place, so the PR would carry **two** gate labels and still publicly claim it passed — the tool
+     removes every other status label in the same call.
 
      **PRESERVE EVERY FIELD THIS STEP DOES NOT EXPLICITLY RECOMPUTE.**
      That is a **property, not a list** — and deliberately so, because the list that stood here was one:
@@ -360,34 +365,31 @@ For each `#PR` to adopt:
 
 #### Step 4 — Label it ours, and set the status label from the LIVE gate
 
-4. **Label it ours, and set the status label from the LIVE gate.** Add this run's owner label, then
-   apply the status label that matches the PR's gate state **as it stands after step 3** — never a
-   hardcoded `gauntlet-reviewing`.
+4. **Label it ours, and set the status labels from the LIVE gate.** Add this run's owner label, then
+   apply the status labels that match the PR's row state **as it stands after step 3** — never a
+   hardcoded label name.
 
-   **This ADOPTION-time labeling stays a raw `gh pr edit`, NOT `label-mirror.py mirror`** — because the
-   same call also adds this run's `gauntlet-run-<run-id>` ownership label, which is out of the tool's
-   scope (the tool touches only the two status labels). Once the row is adopted, every LATER status-label
-   reconcile is the tool's job ("Status labels mirror the review gate").
+   **`pr-adopt.py adopt` performs this step**, and it stays a raw `gh pr edit` rather than a call to
+   `label-mirror.py mirror` — because the same call also adds this run's `gauntlet-run-<run-id>` ownership
+   label, which is out of the tool's scope (the tool never touches the ownership label). It computes the
+   same labels the mirror would, from the same shared vocabulary. Once the row is adopted, every LATER
+   status-label reconcile is the mirror's job ("Status labels mirror the review gate").
 
-   **The status labels are mutually exclusive** — a PR carries exactly one — so whichever you apply,
-   remove the other in the same call. Which one you apply is decided by the live gate, not by the fact
-   that you are adopting:
+   **Which labels it applies is decided by the live row, not by the fact that you are adopting:**
 
-   ```
-   # Gate NOT met at the current HEAD — a fresh adoption (reviews_ok = 0), or a non-terminal re-adoption whose
-   # content changed (step 3 just reset reviews_ok). The common case:
-   gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-reviewing --remove-label gauntlet-accepted
-
-   # Gate ALREADY met at the current HEAD — non-terminal re-adoption of a PR whose content did NOT change, so step 3
-   # preserved reviews_ok >= required(tier). Its acceptance is still valid; do not revoke it:
-   gh pr edit <pr> --add-label gauntlet-run-<run-id> --add-label gauntlet-accepted --remove-label gauntlet-reviewing
-   ```
-
-   Applying the first form unconditionally would **strip a valid `gauntlet-accepted`** from a PR whose
-   verdicts step 3 just preserved, sending an already-passed PR back under review — the mirror-image bug
-   of leaving a stale `gauntlet-accepted` in place. The label tracks the gate in **both** directions.
-   (`--remove-label` on a label the PR does not carry is a harmless no-op, so neither form needs a
-   pre-check for the label's presence — only for the gate's state.)
+   - Gate NOT met at the current HEAD — a fresh adoption (`reviews_ok = 0`), or a non-terminal re-adoption
+     whose content changed (step 3 just reset `reviews_ok`) — gets the reviewing label for the standing
+     tally. This is the common case.
+   - Gate ALREADY met at the current HEAD — a non-terminal re-adoption of a PR whose content did NOT
+     change, so step 3 preserved `reviews_ok >= required(tier)` — gets `gauntlet-accepted`. Its acceptance
+     is still valid; do not revoke it. Applying the reviewing label unconditionally would **strip a valid
+     `gauntlet-accepted`** from a PR whose verdicts step 3 just preserved, sending an already-passed PR
+     back under review — the mirror-image bug of leaving a stale one in place.
+   - Either way, **every OTHER status label the PR currently wears comes off in the same call** — a stale
+     tally, a stale `gauntlet-accepted`, the legacy bare `gauntlet-reviewing`. The run-owner label and
+     `gauntlet-authored` are never swept.
+   - **Each label it adds is created first** (`gh label create … --force`), because a tallied name is one
+     no bootstrap list could have known to create ("Ensure this run's owner label exists", above).
 
 #### Step 5 — Create the PR-head worktree before the first review pass
 
@@ -519,9 +521,10 @@ already matches — so the tier, `required(tier)`, and the public status label m
 (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap and the tool). **Run it
 on an UNCHANGED non-terminal re-adoption too, NOT only a fresh one:** step 4 labelled against the *preserved* tier
 before this decision, so a PR left `gauntlet-accepted` under a preserved lower tier keeps that false label
-until the mirror flips it to `gauntlet-reviewing` (the escalation reset above took the tally below
-`required`). Never skip it as a presumed no-op — a fresh adoption's `reviews_ok=0` is the ONLY case the
-mirror is a guaranteed no-op.
+until the mirror flips it back to a reviewing label (the escalation reset above took the tally below
+`required`). Never skip it as a presumed no-op — and note that a fresh adoption's `reviews_ok=0` is no
+longer even that: step 4 labelled it against the BOOTSTRAP tier, and a decision that changes the tier
+changes `required(tier)`, which is half the label's name.
 
 ```
 python3 <skill-dir>/scripts/label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name

--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -231,6 +231,12 @@ repair rather than unholding the PR. An undecided `repairing` row, every legacy 
 row remain refused. A conflict or a diff-changing rebase remains outside this exception:
 `clean-rebase.py` exits 3 and never resolves it.
 
+**`rebase-first` now means a CONFLICT and nothing else**, so this exception fires only when the branch
+genuinely conflicts with its base. A repair whose PR is merely BEHIND its base gets `proceed` and is
+dispatched as it stands: the rebase it owes is taken at the merge, by the drain
+(`stage-3-merge.md`, "Step 6"). Run `label-mirror.py mirror` after the check either way — the check records
+`base_current` (`stage-2-review-gate.md`, "`gauntlet-rebase-pending` — the SECOND label axis").
+
 When the repair has landed, return the row to the gate (`ledger.py … set --pr <N> --status in_review`) and
 let the review gauntlet run again from the top. **`review_rounds` is not reset** — it never is. A PR that
 comes back to a cap has spent another repair.

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -80,7 +80,7 @@ its `state.jsonl`, and only PRs carrying its `gauntlet-run-<run-id>` label (adop
 branch names, so the **label alone** — not any branch prefix — scopes ownership), and only those
 PRs' branches/worktrees. It MUST NOT reconcile, relabel, review, fix, merge, or clean up another run's
 PRs/branches — **every git/gh scan is filtered to this run's owner label.** The status labels
-`gauntlet-reviewing` / `gauntlet-accepted` describe gate state and are shared across runs; ownership is
+The status labels (`stage-2-review-gate.md` owns them) describe gate and base-currency state and are shared across runs; ownership is
 the per-run label, never a status label. Refuse to adopt a PR already carrying a **different**
 `gauntlet-run-*` label — never steal or transfer another run's marker (see "PR adoption").
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -820,7 +820,7 @@ REFUTATION of a review finding (`finding-audit.md`, "Audit every finding before 
 Every one of them MUST, in the same step:
 
 - **reset `reviews_ok` to 0 AND reconcile the label by running `label-mirror.py mirror` for the PR** (it
-  restores `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`) — the gate and its label move
+  restores the reviewing label on a PR carrying `gauntlet-accepted`) — the gate and its label move
   together, never one without the other (`stage-2-review-gate.md`, "Status labels mirror the review
   gate", owns the swap and the tool);
 - **re-derive `ci` from a fresh snapshot for the NEW `head_sha`, and launch a watch if — and only if —

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -122,12 +122,12 @@ that one decided-repair path.
 #### Preconditions — clear Copilot items, CI, and conflicts before reviewing
 
 **Only launch a review pass once all three are clear for the current tip.** Clear Copilot items, CI,
-and conflicts before reviewing: a review pass is
+and conflicts before reviewing — a base that has merely advanced is **not** one of the three and blocks
+nothing (the base-currency bullet owns why). A review pass is
 expensive and is invalidated by any PR-content change, so never spend one on a PR whose current tip
 still has review-blocking issues. Before launching a pass on a **non-parked** PR, check three things
-and clear any that are dirty. Each fix changes PR content, so `reviews_ok` resets to 0 **and the status label is restored to
-`gauntlet-reviewing` in that same step** if the PR was `gauntlet-accepted` ("Status labels mirror the
-review gate"), and the review re-starts on the clean tip:
+and clear any that are dirty. Each fix changes PR content, so `reviews_ok` resets to 0 **and the status label is reconciled in that same
+step** ("Status labels mirror the review gate"), and the review re-starts on the clean tip:
 
 - **GitHub Copilot review items.** If the PR has any unresolved Copilot review comments, address them
   with the active host form of `gauntlet:copilot-address-reviews <pr>` before reviewing (that skill verifies each item against source
@@ -146,9 +146,13 @@ review gate"), and the review re-starts on the clean tip:
   scripts/base-preflight.py check --pr <pr> --worktree <worktree> --base <base> --file <state.jsonl>`. With
   `--file`, the ROW owns the base: `--base` is an **assertion** that must equal the row's effective base, and
   the helper also compares the PR's **live** `baseRefName` against it. It checks GitHub's merge states and
-  whether the fetched base is an ancestor of the PR worktree's `HEAD`. A `rebase-first` verdict covers
-  a conflict, GitHub reporting behind, or a CLEAN PR whose branch lacks the refreshed base — a base that
-  merely **ADVANCED** (same branch NAME, new commits). `recheck` covers an uncomputed GitHub value,
+  whether the fetched base is an ancestor of the PR worktree's `HEAD`. **`rebase-first` covers a CONFLICT and
+  nothing else** — GitHub reporting `CONFLICTING`, or `DIRTY`. A base that merely **ADVANCED** (same branch
+  NAME, new commits) is **NOT** a rebase-first: it reaches `proceed` carrying `base_current: no`, because the
+  rebase it calls for is owed before the **MERGE**, not before the review. Rebasing every behind PR the
+  moment a sibling merges is what made one N-PR run pay for N(N-1)/2 CI cycles, and each of those rebases is
+  undone by the next merge into the base; the ONE PR at the front of the drain rebases instead
+  (`stage-3-merge.md`, "Step 6"). `recheck` covers an uncomputed GitHub value,
   ancestry the helper cannot verify, **or a live retarget** — the PR now targets a different branch
   NAME, which the helper refuses with the same machine-blocker reason every base-change park records
   (`base changed from <recorded> to <live>; not supported mid-run`). The helper never decides why the base
@@ -161,7 +165,9 @@ review gate"), and the review re-starts on the clean tip:
   (`fix-subagent-contract.md`, PRE-FLIGHT). **Run it with `--file <state.jsonl>`:** on `proceed` it records
   `base_ok_sha` for the current head — the MECHANICAL precondition `ledger.py verdict` then enforces
   ("Recording a verdict", below), so a review verdict can never be recorded for a head with no fresh
-  `proceed`.
+  `proceed` — **and `base_current` in the same write.** That makes this a label-reconcile site: run
+  `label-mirror.py mirror` for the PR after the check, in the same step
+  ("`gauntlet-rebase-pending` — the SECOND label axis", below, owns the rule).
   Once it says `rebase-first`, **the CLEAN
   base-only case is EXECUTED — not hand-run — by `python3 scripts/clean-rebase.py run --ledger
   <state.jsonl> --pr <pr> --worktree <worktree> --base <base>`**: it does the fetch/rebase/`--force-with-lease`
@@ -961,7 +967,7 @@ Then, per verdict:
 
 1. **Void the tally and restore the label in the same step.** The SHA's tally is void (`ledger.py verdict
    … --verdict not-satisfied` does it) **and, in the same step, reconcile the label by running
-   `label-mirror.py mirror` for this PR** — it restores `gauntlet-reviewing` on a PR carrying
+   `label-mirror.py mirror` for this PR** — it restores the reviewing label on a PR carrying
    `gauntlet-accepted` ("Status labels mirror the review gate", below, owns the swap and the tool). This
    applies the moment the verdict lands, *before* any fix is written: a PR whose latest verdict says NOT
    SATISFIED must never still read `gauntlet-accepted` on GitHub.
@@ -1007,8 +1013,9 @@ Then, per verdict:
   `required==2` PR — the next heartbeat launches the next (corroborating) review on the same SHA. When the
   tally **reaches** `required(tier)` on the same SHA, the review gate is met for this HEAD — swap the
   PR's label by running `label-mirror.py mirror` for it ("Status labels mirror the review gate", below,
-  owns the swap; it applies `--add-label gauntlet-accepted --remove-label gauntlet-reviewing` from the
-  live gate).
+  owns the swap and every label name it moves). **A SATISFIED that leaves the tally SHORT still moves the
+  label** — the tally is spelled into the name, so `0/2` becomes `1/2` — so run the mirror on every landed
+  verdict, not only on the one that completes the gate.
 
 The audit contract — verdicts, reachability test, refutation handling, termination — is `finding-audit.md`; a reviewer's finding is a CLAIM, and no fix is dispatched for an unaudited finding.
 
@@ -1074,8 +1081,13 @@ one adversarial pass is proportionate.
 
 ### Status labels mirror the review gate — relabel is part of the reset, not a later chore
 
-A PR carries `gauntlet-reviewing` until its current HEAD holds `required(tier)` SATISFIED verdicts for
-the same live PR content, then `gauntlet-accepted`. The label is a **projection of `reviews_ok` AND
+A PR carries **`gauntlet-reviewing <reviews_ok>/<required(tier)>`** until its current HEAD holds
+`required(tier)` SATISFIED verdicts for
+the same live PR content, then `gauntlet-accepted`. The tally is spelled INTO the label name — a PR one
+verdict short of a STANDARD gate wears `gauntlet-reviewing 1/2`, a fresh one wears `gauntlet-reviewing 0/2`
+— so the one piece of run state a human reads on GitHub says how far along a PR is, not merely that it is
+not done. `_gauntlet/labels.py` OWNS the spelling and every tool computes it from there; no site retypes a
+label name. The label is a **projection of `reviews_ok` AND
 `required(tier)`**, so it is only ever as true as the moment it was last written — and because the tier
 is itself a per-heartbeat DECISION (`loop-control.md` re-triage runs the judgment for every PR every
 heartbeat), a tier change moves the projection. **A same-SHA tier change is NOT one event — it is two,
@@ -1099,26 +1111,29 @@ was cast, so it only satisfies tiers **at or below** that depth:
 projection — one that takes `reviews_ok` to `0` (or otherwise voids the tally, **which now includes a
 depth-raising tier escalation**), OR a **de-escalation** that lowers `required(tier)` on unchanged content
 (e.g. STANDARD→TRIVIAL flips `required` from 2 to 1) —
-MUST, in that same step, reconcile the label: restore `gauntlet-reviewing` on a PR that currently carries
-`gauntlet-accepted` when the tally no longer meets `required(tier)`
+MUST, in that same step, reconcile the label: restore the reviewing label for the standing tally on a PR
+that currently carries `gauntlet-accepted` when the tally no longer meets `required(tier)`
 — and, symmetrically, an action that brings `reviews_ok` up to `required(tier)` (a new verdict, or a
 de-escalation that LOWERS `required(tier)` to a tally already standing) swaps it to `gauntlet-accepted`.
+**A verdict that lands but does NOT complete the gate still moves the label** (`0/2` → `1/2`): the tally is
+in the name, so every change to the tally is a change to the label.
 
 **`label-mirror.py mirror` is THE way that swap is applied — never a hand-run `gh pr edit`.** It reads the
-PR's ledger row, computes the desired label from `reviews_ok` and `required(tier)` exactly as the gate
-does, and applies the canonical idempotent swap only if the label is not already right (a terminal row is
-skipped; a tier nobody set is refused). Run it in the same step as the reset, once per PR:
+PR's ledger row, computes the desired labels from it exactly as the gate
+does, creates any label it is about to add, and applies ONE idempotent edit — only if something actually
+needs to move (a terminal row is skipped; a tier nobody set is refused). It sweeps off every OTHER status
+label the PR wears, so a stale tally, a stale `gauntlet-accepted`, and the legacy bare
+`gauntlet-reviewing` all come off in the same call; it never touches `gauntlet-run-<id>` or
+`gauntlet-authored`. Run it in the same step as the reset, once per PR:
 
 ```
 python3 <skill-dir>/scripts/label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name
 ```
 
-The swap it applies — shown as the SPEC it implements, NOT a command to paste by hand (the tool picks the
-direction from the live gate; here is the reviewing-restoring one):
-
-```
-gh pr edit <pr> --remove-label gauntlet-accepted --add-label gauntlet-reviewing
-```
+Do **not** hand-write the `gh pr edit` it runs. The tool picks the direction from the live gate, spells the
+tally, creates the label first (`gh pr edit --add-label` fails outright on a label the repository does not
+have, and a tallied name is one no bootstrap list could have known to create), and removes only labels the
+PR actually carries. Every one of those is a step a hand-typed command gets wrong.
 
 Never write the ledger reset and defer the label to "the next heartbeat". A `gauntlet-accepted` label on a
 PR whose live content no longer holds `required(tier)` verdicts is a **false public claim that the PR
@@ -1136,11 +1151,11 @@ event that drops `reviews_ok` to 0, which now includes a **depth-raising tier es
 | Review-fix **or refutation** commit pushed (both are campaign commits to the PR head) | this file, verdict tally |
 | CI-fix commit pushed — economy tier **or** `session` tier | `stage-2-ci.md`, "Any campaign commit to the PR head resets the gate" |
 | Copilot-item fix pushed | Stage 2a preconditions, above |
-| Judgment-path rebase (conflict-resolving **or** diff-changed) — at **either** of the two sites that rebase a PR | **Stage 2a preconditions, above** (the pre-review rebase of a `CONFLICTING`/`DIRTY`/`BEHIND` PR) **and** `stage-3-merge.md`'s step-6 reconcile. Both `clean-rebase.py` exit-3 subcases reset the gate — a conflict AND a no-conflict rebase that changed the PR's own diff — so naming only the conflict one, or only one of the two sites, is how the relabel goes missing; the *event* owes the relabel, wherever it happens |
-| Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — `gauntlet-reviewing` here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it removes the other label) |
+| Judgment-path rebase (conflict-resolving **or** diff-changed) — at **either** of the two sites that rebase a PR | **Stage 2a preconditions, above** (the pre-review rebase of a `CONFLICTING`/`DIRTY` PR) **and** `stage-3-merge.md`'s step-6 refresh. Both `clean-rebase.py` exit-3 subcases reset the gate — a conflict AND a no-conflict rebase that changed the PR's own diff — so naming only the conflict one, or only one of the two sites, is how the relabel goes missing; the *event* owes the relabel, wherever it happens |
+| Re-adoption refresh detects changed content | `pr-adoption.md` step 3 (step 4 then sets the status label from the **live** gate — the zero tally here, but `gauntlet-accepted` for a re-adoption whose content did **not** change and whose verdicts step 3 preserved; either way it sweeps off every other status label the PR wears) |
 | Any other PR-content change on the head branch — formatter/bot commit, manual push | **Loop control step 1's ledger refresh** — the heartbeat that *detects* it resets the gate, so it relabels there |
-| `default_non_goals` **broadening reset** — the operator clears banked credit before REMOVING a run default (the broadening guard refuses the header write while any non-terminal PR holds `reviews_ok > 0`) | **`files-and-ledger.md`, "default_non_goals"** — the operator runs `ledger.py set --pr <N> --reviews-ok 0` per credited PR to re-open it under the broadened scope. That is a `reviews_ok`→0 event on unchanged content (no head SHA moves), so each reset MUST, in the SAME step, run `label-mirror.py mirror` for that PR, restoring `gauntlet-reviewing` because the voided tally no longer meets `required(tier)` |
-| Tier DECISION is a **depth-raising escalation** (orchestrator re-triage raises the tier to a strictly deeper one — TRIVIAL→STANDARD, TRIVIAL→HIGH, STANDARD→HIGH — on unchanged content) | **`loop-control.md` re-triage step, the tier write** — this is a `reviews_ok`→0 event ("Status labels mirror the review gate" owns why): the same re-triage step writes the deeper tier and voids `reviews_ok` in ONE ledger write, requires a fresh tier-sized plan before the next dispatch, and runs `label-mirror.py mirror`, which restores `gauntlet-reviewing` because the voided tally no longer meets `required(tier)`. The adoption-time tier write (`pr-adoption.md`, "Adoption-time tier decision") is the SAME event: an UNCHANGED re-adoption PRESERVES `reviews_ok` (>= 1) (`pr-adopt.py` preserves it when the head did not move), so a depth-raising decision there must void that preserved tally too — it is NOT a case that can be skipped |
+| `default_non_goals` **broadening reset** — the operator clears banked credit before REMOVING a run default (the broadening guard refuses the header write while any non-terminal PR holds `reviews_ok > 0`) | **`files-and-ledger.md`, "default_non_goals"** — the operator runs `ledger.py set --pr <N> --reviews-ok 0` per credited PR to re-open it under the broadened scope. That is a `reviews_ok`→0 event on unchanged content (no head SHA moves), so each reset MUST, in the SAME step, run `label-mirror.py mirror` for that PR, restoring the reviewing label because the voided tally no longer meets `required(tier)` |
+| Tier DECISION is a **depth-raising escalation** (orchestrator re-triage raises the tier to a strictly deeper one — TRIVIAL→STANDARD, TRIVIAL→HIGH, STANDARD→HIGH — on unchanged content) | **`loop-control.md` re-triage step, the tier write** — this is a `reviews_ok`→0 event ("Status labels mirror the review gate" owns why): the same re-triage step writes the deeper tier and voids `reviews_ok` in ONE ledger write, requires a fresh tier-sized plan before the next dispatch, and runs `label-mirror.py mirror`, which restores the reviewing label because the voided tally no longer meets `required(tier)`. The adoption-time tier write (`pr-adoption.md`, "Adoption-time tier decision") is the SAME event: an UNCHANGED re-adoption PRESERVES `reviews_ok` (>= 1) (`pr-adopt.py` preserves it when the head did not move), so a depth-raising decision there must void that preserved tally too — it is NOT a case that can be skipped |
 | Tier DECISION is a **de-escalation** that lowers `required(tier)` (STANDARD→TRIVIAL, on unchanged content, so `reviews_ok` is untouched) | **`loop-control.md` re-triage step, the tier write** — the same step runs `label-mirror.py mirror`; the verdicts STAY (they were earned at a deeper depth), and the mirror swaps a standing tally to `gauntlet-accepted` when the lowered `required(tier)` is now met. The adoption-time tier write (`pr-adoption.md`, "Adoption-time tier decision") co-locates the SAME mirror; a FRESH adoption has `reviews_ok=0`, so it is a no-op there, but an UNCHANGED re-adoption whose preserved tally now meets the lowered `required` flips to `gauntlet-accepted` |
 
 **Every row names a place where the gate PROJECTION changes — `reviews_ok` written to 0, or
@@ -1168,3 +1183,27 @@ events, and this row is exactly where they part company.
 **Reconcile is the backstop, not the mechanism.** Loop control re-derives every label from the live
 gate each heartbeat so a missed swap self-heals, exactly as the CI-watch heartbeat backstops a missed watch.
 Relying on it as the primary path is the bug this rule exists to prevent.
+
+### `gauntlet-rebase-pending` — the SECOND label axis, and it is not the gate
+
+**A PR wears `gauntlet-rebase-pending` exactly while its row records `base_current = no`** — its head no
+longer contains its base, so a rebase is owed **before it merges**. The label answers the question a human
+asks when an accepted PR just sits there: it is waiting its turn in the serialized drain
+(`stage-3-merge.md`, "Step 6"), not stuck.
+
+**It is INDEPENDENT of the gate, and treating the two axes as one is the mistake to avoid.** An accepted PR
+that is behind its base wears **both** `gauntlet-accepted` and `gauntlet-rebase-pending`, and that pair is
+the NORMAL state of a PR queued behind another. `label-mirror.py mirror` moves both axes in the one call it
+already makes; there is no second command and no second trigger table.
+
+**Where the reading comes from:** `base-preflight.py check --file` records `base_current` on every
+`proceed`, from the Git ancestry probe it already runs (`files-and-ledger.md`, the `base_current` field).
+**So every `base-preflight.py check --file` is a label-reconcile site** — run `label-mirror.py mirror` for
+that PR after it, in the same step, exactly as a gate reset does. The sites that run the check are named by
+their own steps: the pre-review precondition (Stage 2a, above), `stage-3-merge.md`'s step-6 refresh, and
+`repair-pass.md`'s pre-repair check.
+
+**A rebase LANDING clears it by voiding the reading, not by writing `yes`.** A rebase moves `head_sha`, and
+that write voids both base-preflight readings to `-` at the door (`files-and-ledger.md`, "What a genuine
+head move resets"). `-` makes no claim, so the label comes off at the next mirror and stays off until a
+fresh probe says otherwise. Nothing hand-writes `base_current`; it has no `set` door.

--- a/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-3-merge.md
@@ -45,7 +45,9 @@ the row when GitHub's own retarget explains it and parking it otherwise. Act on 
 - `not-yet <reason>` → do **NOT** merge; the reason names the block. Route on the reason's **action**
   (the phrase the tool emits), never on a hand-copied list of enum values — a value the tool newly parks
   then routes correctly with no edit here:
-  - `rebase` reasons (base moved ahead / conflicts) → refresh the PR per step 6. A `BLOCKED` merge state
+  - `rebase` reasons (base moved ahead / conflicts) → refresh the PR per **step 6b**. **This is the ONE
+    place a merely-behind PR rebases** — at its own merge, having reached the front of the drain, not when
+    some sibling merged (step 6a owns why). A `BLOCKED` merge state
     that is merely **behind its base** emits a `rebase` reason here (the tool probes ancestry before
     parking), so it refreshes and re-gates rather than escalating to the user.
   - the tool's **`— park`** reasons (any `not-yet` reason that ends in `— park` / `park awaiting-user`)
@@ -100,8 +102,9 @@ green, no CI event will ever fire, campaign never approves PRs and never asks th
 settled PR forever. **Probe the base ancestry before parking: a `BLOCKED` PR that is only behind its base
 rebases (`merge-check.py` emits the `rebase` reason, verdicts carried), and only a `BLOCKED` PR proven up to
 date parks — name the blocker instead.** GitHub's merge-state enum is not a reliable "behind" signal (a
-behind PR can read `CLEAN` or `BLOCKED` under the same ruleset), so the Git ancestry check is the sound one,
-which is why `base-preflight.py` already runs it and the merge gate now matches.
+behind PR can read `CLEAN` or `BLOCKED` under the same ruleset), so the Git ancestry check is the sound one.
+`base-preflight.py` runs the same probe, but **RECORDS** its answer rather than acting on it; here the answer
+is a hard precondition, and this is the gate that keeps a PR from merging over a base it does not contain.
 
 **`UNSTABLE` means non-*passing*, which includes *pending*.** Treating it as red would dispatch a CI-fix
 subagent at a check that is merely **still running**.
@@ -172,9 +175,12 @@ foreign refs, root/reused cleanup targets, and cleanup before confirmed `MERGED`
 
 Never hand-run a later phase after this command fails. Fix the named cause, then re-run the command so its
 ownership checks and phase order remain in force.
-6. After each merge+sync+cleanup, reconcile other open PRs (write any `reviews_ok`/`head_sha`/`ci`
+6. After each merge+sync+cleanup, reconcile other open PRs — **REMEASURE them; do NOT rebase them**
+   (write any `reviews_ok`/`head_sha`/`ci`
    change below through `scripts/ledger.py … set --pr <N> --<field> <val>` by field name, never by
-   hand-editing the row by column position).
+   hand-editing the row by column position). Step 6 is TWO jobs, and separating them is the point of this
+   step: **6a** re-measures every other open PR against the base that just moved, and **6b** refreshes the
+   ONE PR whose merge the base is actually blocking.
 
    **SKIP HELD PRs FIRST — before any base refresh, rebase, or conflict handling.** A **HELD** PR
    (`ledger.py … dispatch-check --pr <N>` — parked on a human, or `repairing`) is **FROZEN**
@@ -193,13 +199,31 @@ ownership checks and phase order remain in force.
    only when returned `watch_warranted` is `true` (`stage-2-ci.md`, "WATCH ONLY WHAT CAN MOVE"). Parked
    status does not override that result.
 
+   **6a — REMEASURE, and LABEL. One PR rebases per merge, and it is the one at the front.**
    For each **non-parked** open PR, run `python3 scripts/base-preflight.py check --pr <pr> --worktree
    <worktree> --base <base> --file <state.jsonl>`, where `<base>` is that row's **effective base** (its
    explicit `base_branch`, else the legacy header — a run may hold PRs on different bases, so it is resolved
-   per PR, and `--base` is asserted against it). It fetches the base and requires it to be an ancestor
-   of `HEAD` even when GitHub still reports CLEAN. On `recheck`, re-poll and leave the candidate alone. On
+   per PR, and `--base` is asserted against it). It fetches the base and records whether it is an ancestor
+   of `HEAD` even when GitHub still reports CLEAN. Then **run `label-mirror.py mirror` for that PR**, which
+   projects the fresh reading as `gauntlet-rebase-pending` (`stage-2-review-gate.md`,
+   "`gauntlet-rebase-pending` — the SECOND label axis").
+
+   **A `proceed` carrying `base_current: no` is NOT a reason to rebase here.** Leave that PR exactly where it
+   is: behind, labelled, and fully reviewable. It rebases when it reaches the front of this drain and
+   `merge-check.py` says its merge is blocked on the base — **once**, not once per sibling merge. Rebasing
+   every behind PR after every merge is what turns an N-PR run into N(N-1)/2 force-pushes and the same number
+   of full CI cycles, and each of those rebases is undone by the very next merge into the base. It also buys
+   nothing: the reviews carried forward across a clean base-only rebase are the SAME reviews either way, and
+   the merge gate re-proves base currency from a live probe before anything merges.
+
+   On `recheck`, re-poll and leave the candidate alone. On
    `park`, the helper has already sent the unrecognized enum value through `ledger.py park`; leave the
-   now-held candidate alone. On `rebase-first`, rebase before considering the candidate for another review or merge:
+   now-held candidate alone. On `rebase-first` — **a CONFLICT, which is the only thing that still yields
+   it** — the branch cannot be reviewed or fixed as it stands, so refresh it now per 6b.
+
+   **6b — REFRESH the ONE PR that needs it.** Two things route here, and nothing else: a `rebase-first` from
+   6a (a conflict), and a `rebase` reason from `merge-check.py` on the PR the drain is currently trying to
+   merge (base moved ahead, or conflicts — "The merge precondition", above). Refresh that PR:
    - Clean rebase (no conflicts, PR diff unchanged) → **EXECUTED — not hand-run — by `python3
      scripts/clean-rebase.py run --ledger <state.jsonl> --pr <N> --worktree <worktree> --base <base>`**: it
      does the fetch/rebase/`--force-with-lease` push, verifies the PR's own diff is unchanged, and writes the
@@ -216,8 +240,8 @@ ownership checks and phase order remain in force.
 
    - Judgment-path rebase — a conflict resolved by hand, OR a no-conflict rebase that reshaped the PR's own
      diff (both `clean-rebase.py` exit-3 subcases) → PR content changed → **reset `reviews_ok` to 0 AND, in that
-     same step, reconcile the label by running `label-mirror.py mirror` for the PR** (it restores
-     `gauntlet-reviewing` on a PR carrying `gauntlet-accepted`) — the gate and its
+     same step, reconcile the label by running `label-mirror.py mirror` for the PR** (it restores the
+     reviewing label on a PR carrying `gauntlet-accepted`) — the gate and its
      label move together (`stage-2-review-gate.md`, "Status labels mirror the review gate", owns the swap
      and the tool). Update
      `head_sha` to the
@@ -235,5 +259,19 @@ The drain stays **serialized — one PR at a time across the whole run**, even w
 (`v3`, `main`). There is no run-wide checkout pinned to one branch: each merge resolves, validates, and syncs
 its own row's base, so a mixed-base run drains in one serial order and each merge updates only its base's
 local ref. Stop the merge loop only when no remaining PR is immediately mergeable after the latest base refresh.
+
+**The REBASES are serialized by the same drain, and that is the whole reason 6a does not rebase.** A PR is
+rebased when it is the one being merged, so a run pays **one** rebase and **one** CI cycle per PR rather than
+one per PR per sibling merge. Reviews are untouched by this: they run concurrently across PRs
+(`stage-2-review-gate.md`, Preconditions) on whatever base each PR currently sits on, because a base that
+merely advanced blocks no review. What is serialized is the **rebase-and-remerge**, not the gate.
+
+**What this deliberately gives up, stated plainly:** a PR can be reviewed against a base that a sibling PR
+has since advanced, and if its later rebase is clean with the diff unchanged, those verdicts carry forward
+without a re-review against the new base. That exposure is NOT new — the carry-forward rule has always
+allowed a clean base-only rebase after the verdicts landed ("Status labels mirror the review gate", the
+clean-base-only exception) — but deferring the rebase makes it the common case rather than the rare one.
+What still holds: nothing merges over a base it does not contain (`merge-check.py` proves ancestry from a
+live probe), and a rebase that CONFLICTS or reshapes the PR's own diff resets the gate and re-reviews.
 
 ---

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/labels.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/labels.py
@@ -1,0 +1,160 @@
+"""The campaign's GitHub label VOCABULARY — the ONE owner of every label name the gauntlet writes.
+
+Three tools write labels (`label-mirror.py` reconciles them, `pr-adopt.py` applies them at adoption,
+`reconcile.py` reports them), and each of them used to carry its own copy of the two names. That was
+survivable while the vocabulary was two fixed strings. It is not survivable now: a reviewing label
+carries its own TALLY (`gauntlet-reviewing 1/2`), so the name is COMPUTED, and a second copy of the
+computation is a second answer to "which label does this row wear".
+
+TWO INDEPENDENT AXES, and keeping them independent is the point:
+
+* the **GATE** axis — exactly one of `gauntlet-accepted` / `gauntlet-reviewing <ok>/<required>`, a
+  projection of `reviews_ok` against `required(tier)` (`stage-2-review-gate.md`, "Status labels mirror
+  the review gate");
+* the **BASE-CURRENCY** axis — `gauntlet-rebase-pending`, present exactly while the row records that its
+  head no longer contains its base. It says only that a rebase is OWED, never that the gate moved, so a
+  PR can wear `gauntlet-accepted` and `gauntlet-rebase-pending` at once — that pair is the normal state
+  of an accepted PR waiting its turn in the serialized drain (`stage-3-merge.md`, "Step 6").
+
+Nothing here decides anything and nothing here talks to GitHub. It computes NAMES and ARGUMENT VECTORS;
+each caller runs them through its own `gh` seam, because which door a tool exits through is that tool's
+business (the stance `repository.py` takes).
+
+`required(tier)` is NOT defined here. It belongs to the review gate, and its callers already hold the
+owner they trust (`nudge.required` / `review-pass.required_reviews`); every function below takes the
+count as an ARGUMENT so this module can never become a third opinion about it.
+"""
+
+from __future__ import annotations
+
+# --- the run-ownership axis, which this module NEVER sweeps --------------------
+#
+# `gauntlet-run-<id>` is ADOPTION's business (`pr-adoption.md`) and `gauntlet-authored` is the review
+# handoff's. They are named here only so a reader sees the whole vocabulary in one place, and so
+# `is_status_label` can be read against the complete list of what it deliberately EXCLUDES. No function
+# in this module ever adds or removes either one.
+RUN_PREFIX = "gauntlet-run-"
+RUN_COLOR = "5319E7"
+AUTHORED = "gauntlet-authored"
+
+# --- the gate axis -------------------------------------------------------------
+ACCEPTED = "gauntlet-accepted"
+ACCEPTED_COLOR = "0E8A16"
+ACCEPTED_DESCRIPTION = "gauntlet: passed its reviews"
+
+# The STEM of every reviewing label. A live reviewing label is this stem plus a space and the tally
+# (`gauntlet-reviewing 1/2`); the BARE stem is the LEGACY name every PR wore before the tally existed,
+# and it is still recognised as a gate label so a reconcile sweeps it off rather than leaving two.
+REVIEWING = "gauntlet-reviewing"
+REVIEWING_COLOR = "FBCA04"
+
+# --- the base-currency axis ----------------------------------------------------
+REBASE_PENDING = "gauntlet-rebase-pending"
+REBASE_PENDING_COLOR = "1D76DB"
+REBASE_PENDING_DESCRIPTION = "gauntlet: behind its base; rebases when it reaches the merge front"
+
+
+def gate_label(reviews_ok: int, required: int) -> str:
+    """The ONE gate label a row wears. PURE.
+
+    `gauntlet-accepted` once the tally meets the floor, else `gauntlet-reviewing <ok>/<required>`. The
+    tally is spelled into the name so the ONE piece of run state a human reads on GitHub says how far
+    along a PR is, not merely that it is not done.
+    """
+    if reviews_ok >= required:
+        return ACCEPTED
+    return f"{REVIEWING} {reviews_ok}/{required}"
+
+
+def is_status_label(name: str) -> bool:
+    """Is `name` a label THIS machinery owns and may therefore remove? PURE.
+
+    True for the gate axis (`gauntlet-accepted`, the legacy bare `gauntlet-reviewing`, and any tallied
+    `gauntlet-reviewing <n>/<m>`) and for the base-currency axis (`gauntlet-rebase-pending`).
+
+    FALSE for `gauntlet-run-<id>` and `gauntlet-authored`, which are other owners' state: a sweep that
+    took the run label off would drop the PR out of its own run, and one that took `gauntlet-authored`
+    off would rewrite the PR's recorded provenance. The exclusion is the load-bearing half of this
+    predicate, which is why both names are defined above rather than left implicit.
+    """
+    return name in (ACCEPTED, REVIEWING, REBASE_PENDING) or name.startswith(REVIEWING + " ")
+
+
+def desired_labels(reviews_ok: int, required: int, *, rebase_pending: bool) -> list[str]:
+    """Every status label the row SHOULD wear, gate axis first. PURE."""
+    labels = [gate_label(reviews_ok, required)]
+    if rebase_pending:
+        labels.append(REBASE_PENDING)
+    return labels
+
+
+def reconcile(current: "list[str]", desired: "list[str]") -> "tuple[list[str], list[str]]":
+    """`(to_add, to_remove)` for one PR, given its LIVE labels and the labels it should wear. PURE.
+
+    `to_add` is every desired label not already present. `to_remove` is every label this machinery owns
+    (`is_status_label`) that is present and not desired — which is what sweeps a stale tally, a stale
+    `gauntlet-accepted`, and the legacy bare `gauntlet-reviewing` off in one pass. A label this machinery
+    does not own is never in either list.
+
+    Both lists empty means the labels are already right, and the caller makes no GitHub call at all.
+    Order is stable (desired order for adds, live order for removes) so a caller's argv is a FUNCTION of
+    its inputs and a fixture can pin it.
+    """
+    have = set(current)
+    to_add = [name for name in desired if name not in have]
+    want = set(desired)
+    to_remove = [name for name in current if is_status_label(name) and name not in want]
+    return to_add, to_remove
+
+
+def describe(name: str) -> "tuple[str, str]":
+    """`(color, description)` for a label this machinery creates. PURE.
+
+    Every label is created — never merely added — because a tallied name is COMPUTED, so the set of
+    reviewing labels a repository needs depends on the tiers its PRs get triaged to. A bootstrap list
+    typed into a doc would go stale the first time `required(tier)` grew a value; creating on demand
+    cannot. Callers pass the result to `create_argv`.
+
+    An unrecognised name raises `KeyError` rather than defaulting: a label whose spelling this module
+    does not recognise is one it has no business creating in the repository.
+    """
+    if name == ACCEPTED:
+        return ACCEPTED_COLOR, ACCEPTED_DESCRIPTION
+    if name == REBASE_PENDING:
+        return REBASE_PENDING_COLOR, REBASE_PENDING_DESCRIPTION
+    if name == REVIEWING or name.startswith(REVIEWING + " "):
+        tally = name[len(REVIEWING):].strip()
+        detail = f" ({tally} verdicts)" if tally else ""
+        return REVIEWING_COLOR, f"gauntlet: under review{detail}"
+    raise KeyError(name)
+
+
+def create_argv(name: str, repo: "str | None" = None) -> list[str]:
+    """The idempotent `gh label create … --force` argv for `name`. PURE.
+
+    `--force` creates the label or updates it in place, so running this before every add is safe on every
+    resume — the same idempotent-create idiom `pr-adoption.md` already uses for the run-owner label.
+    """
+    color, description = describe(name)
+    argv = ["gh", "label", "create", name, "--color", color, "--description", description, "--force"]
+    if repo:
+        argv += ["--repo", repo]
+    return argv
+
+
+def edit_argv(pr: str, to_add: "list[str]", to_remove: "list[str]",
+              repo: "str | None" = None) -> list[str]:
+    """The ONE `gh pr edit` argv that applies a reconcile. PURE.
+
+    Only labels that actually need to move appear: a `--remove-label` is emitted for a label the PR
+    genuinely carries, never speculatively. Returns the bare `gh pr edit` prefix when there is nothing to
+    do, which no caller should run — check `to_add`/`to_remove` first.
+    """
+    argv = ["gh", "pr", "edit", str(pr)]
+    if repo:
+        argv += ["--repo", repo]
+    for name in to_add:
+        argv += ["--add-label", name]
+    for name in to_remove:
+        argv += ["--remove-label", name]
+    return argv

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -73,8 +73,15 @@ def t_dirty_rebases():
     expect(view(mergeStateStatus="DIRTY"), "rebase-first", "conflicts with base — rebase before reviewing/fixing")
 
 
-def t_behind_rebases():
-    expect(view(mergeStateStatus="BEHIND"), "rebase-first", "base has moved ahead — rebase first")
+def t_behind_reaches_the_enum_screen():
+    """BEHIND does NOT block a review. It is a base that ADVANCED, not one that conflicts, and the rebase it
+    calls for is owed at the MERGE (`REVIEWABLE_STATES` owns why). `decide` therefore passes it to the graph
+    check exactly like CLEAN; what the probe SEES is then recorded, never turned into a refusal.
+
+    THE MUTATION PIN: put `BEHIND` back on a `rebase-first` rule and this goes red — which is the whole
+    serialized-drain change, so it must not be reintroduced by accident.
+    """
+    expect(view(mergeStateStatus="BEHIND"), "proceed", "GitHub merge state permits base check")
 
 
 def t_unknown_mergestate_rechecks():
@@ -370,8 +377,13 @@ _GIT = GitFixture(M.SelfTestFailure)
 _git = _GIT.run
 
 
-def t_clean_view_with_stale_base_rebases():
-    """A prior campaign merge advances main while GitHub still calls the second PR CLEAN."""
+def t_clean_view_with_stale_base_records_no():
+    """A prior campaign merge advances main while GitHub still calls the second PR CLEAN.
+
+    The enums cannot see it; the fetched graph can. What changed is what the tool DOES with that: the PR is
+    still cleared to be reviewed (`proceed`), and the staleness is carried as `base_current: no` for the
+    label and the drain to act on. The rebase is owed at the merge, not here.
+    """
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         remote = root / "remote.git"
@@ -415,10 +427,11 @@ def t_clean_view_with_stale_base_rebases():
             ["check", "--pr", "9", "--view-json", str(vjson), "--worktree", str(candidate),
              "--base", "main"],
         )
-        check(code != 0,
-              f"a CLEAN view whose worktree lacks the advanced base must stop for rebase (stderr: {err})")
-        check(json.loads(out) == {"verdict": "rebase-first", "reason": "base has moved ahead — rebase first"},
-              f"a stale base must rebase despite CLEAN GitHub enums, got {out!r}")
+        check(code == 0,
+              f"a CLEAN view whose worktree lacks the advanced base is still reviewable (stderr: {err})")
+        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check",
+                                  "base_current": "no"},
+              f"a stale base must proceed and REPORT the staleness, got {out!r}")
 
 
 def t_clean_view_with_current_base_proceeds():
@@ -446,8 +459,9 @@ def t_clean_view_with_current_base_proceeds():
              "--base", "main"],
         )
         check(code == 0, f"a candidate containing the fetched base must proceed (stderr: {err})")
-        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check"},
-              f"a current base must permit the candidate, got {out!r}")
+        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check",
+                                  "base_current": "yes"},
+              f"a current base must permit the candidate and report it, got {out!r}")
 
 
 def t_force_rewritten_base_refreshes_and_rebases():
@@ -595,19 +609,21 @@ def t_dash_leading_current_base_refreshes_and_proceeds():
         code, result, err, refreshed, remote_head = _dash_base_ancestry(Path(d), current=True)
         check(code == 0,
               f"a current candidate on a dash-leading base must pass the CLI (code={code}, err={err!r})")
-        check(result == {"verdict": "proceed", "reason": "GitHub merge state permits base check"},
+        check(result == {"verdict": "proceed", "reason": "GitHub merge state permits base check",
+                         "base_current": "yes"},
               f"a current candidate on a dash-leading base must proceed, got {result!r}")
         check(refreshed == remote_head,
               "the dash-leading base fetch must refresh its remote-tracking ref before the current verdict")
 
 
-def t_dash_leading_stale_base_refreshes_and_rebases():
+def t_dash_leading_stale_base_refreshes_and_reports_no():
     with tempfile.TemporaryDirectory() as d:
         code, result, err, refreshed, remote_head = _dash_base_ancestry(Path(d), current=False)
-        check(code != 0,
-              f"a stale candidate on a dash-leading base must stop the CLI (code={code}, err={err!r})")
-        check(result == {"verdict": "rebase-first", "reason": "base has moved ahead — rebase first"},
-              f"a stale candidate on a dash-leading base must request a rebase, got {result!r}")
+        check(code == 0,
+              f"a stale candidate on a dash-leading base is still reviewable (code={code}, err={err!r})")
+        check(result == {"verdict": "proceed", "reason": "GitHub merge state permits base check",
+                         "base_current": "no"},
+              f"a stale candidate on a dash-leading base must report the staleness, got {result!r}")
         check(refreshed == remote_head,
               "the dash-leading base fetch must refresh its remote-tracking ref before the stale verdict")
 
@@ -750,9 +766,59 @@ def _current_base_worktree(root: Path) -> "tuple[Path, str]":
     return candidate, head
 
 
+def _stale_base_worktree(root: Path) -> "tuple[Path, str]":
+    """A candidate clone whose HEAD does NOT contain fetched main — main advanced after the clone, exactly
+    as it does when a sibling campaign PR merges. Returns (worktree, HEAD sha)."""
+    remote, seed, candidate = root / "remote.git", root / "seed", root / "candidate"
+    _GIT.init_bare(remote)
+    _GIT.clone(remote, seed)
+    (seed / "f").write_text("base\n", encoding="utf-8")
+    _git(seed, "add", "f")
+    _git(seed, "commit", "-m", "base")
+    _git(seed, "push", "origin", "main")
+    _GIT.clone(remote, candidate)
+    head = _git(candidate, "rev-parse", "HEAD").stdout.strip()
+    (seed / "later").write_text("sibling merged\n", encoding="utf-8")
+    _git(seed, "add", "later")
+    _git(seed, "commit", "-m", "a sibling PR merged")
+    _git(seed, "push", "origin", "main")
+    return candidate, head
+
+
+def t_stale_base_with_file_still_stamps_and_records_no():
+    """A BEHIND PR is cleared to be reviewed, and BOTH readings land in one write.
+
+    This is the pin on the deadlock the serialized drain would otherwise create. `ledger.py verdict` refuses
+    unless `base_ok_sha == head_sha`, so if a behind PR could not reach `proceed` it could never record a
+    verdict — and a PR that cannot be reviewed can never reach the front of the drain to be rebased. So the
+    stamp MUST land for a stale base, and the staleness must ride along as `base_current: no` for the label
+    to project.
+
+    THE MUTATION PIN: make a stale ancestry withhold `proceed` again and this goes red.
+    """
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        candidate, head = _stale_base_worktree(root)
+        vjson = root / "clean.json"
+        vjson.write_text(json.dumps(view()), encoding="utf-8")
+        ledger = root / "state.jsonl"
+        _ledger_row(ledger, "9", head)
+        code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
+                                              "--worktree", str(candidate), "--base", "main",
+                                              "--file", str(ledger)])
+        check(code == 0, f"a behind PR must still be cleared to review (stderr: {err})")
+        check(json.loads(out)["base_current"] == "no", f"the staleness must be reported, got {out!r}")
+        check(_base_ok_sha(ledger, "9") == head,
+              f"a behind PR must still be stamped, or its verdicts can never land: "
+              f"{_base_ok_sha(ledger, '9')!r}")
+        check(_ledger_field(ledger, "9", "base_current") == "no",
+              f"the ledger must record the staleness: {_ledger_field(ledger, '9', 'base_current')!r}")
+
+
 def t_proceed_with_file_records_base_ok():
-    """A final `proceed` with `--file` stamps `base_ok_sha` = the worktree HEAD; the SAME check WITHOUT `--file`
-    writes nothing (the pure decider is preserved)."""
+    """A final `proceed` with `--file` stamps `base_ok_sha` = the worktree HEAD AND records the ancestry
+    reading in the same write; the SAME check WITHOUT `--file` writes nothing (the pure decider is
+    preserved)."""
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         candidate, head = _current_base_worktree(root)
@@ -766,10 +832,13 @@ def t_proceed_with_file_records_base_ok():
         code, out, err = capture_cli(M.main, ["check", "--pr", "9", "--view-json", str(vjson),
                                               "--worktree", str(candidate), "--base", "main", "--file", str(ledger)])
         check(code == 0, f"a current base with --file must proceed (stderr: {err})")
-        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check"},
+        check(json.loads(out) == {"verdict": "proceed", "reason": "GitHub merge state permits base check",
+                                  "base_current": "yes"},
               f"a current base must proceed, got {out!r}")
         check(_base_ok_sha(ledger, "9") == head,
               f"proceed with --file did not record base_ok_sha = {head!r}: {_base_ok_sha(ledger, '9')!r}")
+        check(_ledger_field(ledger, "9", "base_current") == "yes",
+              f"proceed with --file did not record base_current: {_ledger_field(ledger, '9', 'base_current')!r}")
 
         # WITHOUT --file: still proceed, but NOTHING is written to a ledger.
         ledger2 = root / "state2.jsonl"
@@ -1080,7 +1149,8 @@ CASES = [
     ("unstable-proceeds", "UNSTABLE is a check signal and reaches the graph check", t_unstable_proceeds),
     ("blocked-proceeds", "BLOCKED is a permission signal and reaches the graph check", t_blocked_proceeds),
     ("dirty-rebases", "DIRTY -> rebase-first", t_dirty_rebases),
-    ("behind-rebases", "BEHIND -> rebase-first", t_behind_rebases),
+    ("behind-reviewable", "BEHIND -> proceed: an advanced base no longer blocks a review",
+     t_behind_reaches_the_enum_screen),
     ("unknown-mergestate-rechecks", "UNKNOWN merge state -> recheck", t_unknown_mergestate_rechecks),
     ("mergestate-total", "every mergeStateStatus value maps to a verdict (totality)",
      t_every_mergestate_value_is_mapped),
@@ -1121,9 +1191,9 @@ CASES = [
      t_cli_legacy_view_errors_keep_their_exact_wording),
     ("gh-writing-restores-absent-path", "gh_writing restores an absent PATH by deleting it, never as ''",
      t_gh_writing_restores_an_absent_path),
-    ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling rebases",
-     t_clean_view_with_stale_base_rebases),
-    ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds",
+    ("clean-view-stale-base", "a CLEAN second candidate behind a merged sibling proceeds, reporting no",
+     t_clean_view_with_stale_base_records_no),
+    ("clean-view-current-base", "a CLEAN candidate containing fetched base proceeds, reporting yes",
      t_clean_view_with_current_base_proceeds),
     ("force-rewritten-base", "a rewritten remote base is refreshed before ancestry reports stale",
      t_force_rewritten_base_refreshes_and_rebases),
@@ -1133,11 +1203,13 @@ CASES = [
     ("dash-base-current", "a dash-leading base refreshes its tracking ref and reports current ancestry",
      t_dash_leading_current_base_refreshes_and_proceeds),
     ("dash-base-stale", "a dash-leading base refreshes its tracking ref and reports stale ancestry",
-     t_dash_leading_stale_base_refreshes_and_rebases),
+     t_dash_leading_stale_base_refreshes_and_reports_no),
     ("candidate-revision-not-head", "an explicit candidate revision is checked instead of a moved local HEAD",
      t_candidate_revision_is_checked_instead_of_moved_head),
     ("proceed-file-records-base-ok", "a proceed with --file stamps base_ok_sha = HEAD; without --file writes nothing",
      t_proceed_with_file_records_base_ok),
+    ("stale-base-still-stamps", "a BEHIND PR still stamps base_ok_sha and records base_current=no",
+     t_stale_base_with_file_still_stamps_and_records_no),
     ("non-proceed-file-no-stamp", "rebase-first/recheck never stamp base_ok_sha, even with --file",
      t_non_proceed_with_file_leaves_base_ok),
     ("file-base-assertion-mismatch", "--file: --base disagreeing with the row's effective base rechecks",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
-"""DECIDE whether a PR's branch is current with its base BEFORE a review or a fix is authored on it.
+"""DECIDE whether a PR's branch can be reviewed or fixed as it stands — and RECORD how it sits on its base.
 
 This enforces the rebase-before-review/fix precondition `stage-2-review-gate.md` states in prose: if a PR
-conflicts with `<base>` or lacks its refreshed tip, rebase it before reviewing or fixing. GitHub may still
-report MERGEABLE/CLEAN after another campaign PR advances an unprotected base, so the check combines its
-merge states with fetched Git ancestry. A fix authored on a stale/conflicting base is wasted — it is
-re-reviewed against the rebased tip anyway. This turns the prose into an enforced check.
+CONFLICTS with `<base>`, rebase it before reviewing or fixing, because a fix authored on a conflicting base
+fights the merge and may not even apply.
+
+A base that has merely ADVANCED is NOT that case and no longer withholds `proceed`. GitHub still reports
+MERGEABLE/CLEAN after another campaign PR advances an unprotected base, so the fetched Git ancestry probe is
+the only sound reading of base currency — but the rebase it calls for is owed before the MERGE, not before
+the review. Rebasing every behind PR the moment a sibling merges is how one N-PR run pays for N(N-1)/2 CI
+cycles, and each of those rebases is undone by the next merge into the base. So the probe's answer is
+RECORDED on the row (`base_current`) instead of being turned into a refusal: `label-mirror.py` projects it
+as `gauntlet-rebase-pending`, and the serialized drain (`stage-3-merge.md`, "Step 6") rebases the ONE PR at
+the front. The merge gate (`merge-check.py`) runs its own live probe and there base currency IS a hard
+precondition, so nothing merges over a base it does not contain.
 
 It DECIDES one of `proceed` / `rebase-first` / `recheck` / `park` from the live PR view plus fetched base ancestry
 and PERFORMS NO REBASE: the driver rebases when told `rebase-first`, then re-runs this. Deciding and doing
@@ -23,10 +31,11 @@ retargeted to a different branch NAME, so it fails closed to `recheck` with the 
 wording every base-change park records. This tool never decides WHY the base moved and never migrates a row —
 that is `base-retarget.py`, which the heartbeat runs first and which releases the park when GitHub's own
 retarget explains the move; this stays a pure fail-closed refusal so a divergence can never be reviewed past.
-(A base that merely ADVANCED — same branch, new commits — is NOT a retarget; that stays the ancestry
-`rebase-first` below.)
+(A base that merely ADVANCED — same branch, new commits — is NOT a retarget; that is the recorded
+`base_current` reading below.)
 
-With `--file <ledger>`, a final `proceed` records that base check through `ledger.py base-ok`, while `park`
+With `--file <ledger>`, a final `proceed` records that base check through `ledger.py base-ok` — both the
+`base_ok_sha` stamp and the `base_current` ancestry reading, in one write — while `park`
 records an unrecognized enum through `ledger.py park`. The latter is the existing machine-blocker transition:
 it atomically sets `status = awaiting-user`, names the unrecognized value in `ci_reason`, and clears
 `blocker_ruling`. Without `--file` the tool is the pure decider it always was (it writes nothing, and `--base`
@@ -73,10 +82,12 @@ def _base_change_reason(recorded: str, live: str) -> str:
 
 # --- the verdicts -------------------------------------------------------------
 #
-# `proceed` is the ONLY verdict that clears a review/fix onto this branch; `rebase-first` says the base is
-# stale/conflicting and a rebase must land first; `recheck` is NEVER a verdict — it says the mergeability is
-# not yet computed, so re-poll and decide again; `park` says an enum value is unrecognized and records the
-# existing machine-blocker transition when a ledger is supplied. Every non-`proceed` outcome fails CLOSED.
+# `proceed` is the ONLY verdict that clears a review/fix onto this branch, and it carries a `base_current`
+# reading (`yes`/`no`) saying whether the branch holds the fetched base; `rebase-first` says the branch
+# CONFLICTS with its base and a rebase must land first; `recheck` is NEVER a verdict — it says the
+# mergeability is not yet computed, so re-poll and decide again; `park` says an enum value is unrecognized and
+# records the existing machine-blocker transition when a ledger is supplied. Every non-`proceed` outcome fails
+# CLOSED.
 PROCEED = "proceed"
 REBASE_FIRST = "rebase-first"
 RECHECK = "recheck"
@@ -94,13 +105,15 @@ MERGEABLE_VALUES = frozenset({"MERGEABLE", "CONFLICTING", "UNKNOWN"})
 MERGE_STATE_STATUS_VALUES = frozenset(
     {"DIRTY", "UNKNOWN", "BLOCKED", "BEHIND", "UNSTABLE", "HAS_HOOKS", "CLEAN"})
 
-# The `mergeStateStatus` values that pass the ENUM screen. UNSTABLE and BLOCKED are about
-# CHECKS/PERMISSIONS, not a stale base. This is not proof the branch contains the refreshed base; the graph
-# check in `check` supplies that proof. DIRTY/BEHIND/UNKNOWN are deliberately ABSENT: each is handled by an
-# earlier rule in `decide`. NOTE: the downstream merge gate (`merge-check.py`) now runs this SAME
-# `check_base_ancestry` probe on BLOCKED before it parks — a BLOCKED PR that is only behind its base rebases
-# rather than escalating — so both gates treat BLOCKED identically (enum screen, then graph proof).
-BASE_CURRENT_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE", "BLOCKED"})
+# The `mergeStateStatus` values that pass the ENUM screen — the ones that do not block REVIEWING or FIXING
+# this branch. UNSTABLE and BLOCKED are about CHECKS/PERMISSIONS, not the base. BEHIND says the base has
+# advanced, which this gate deliberately does NOT treat as a blocker: the rebase it calls for is owed before
+# the MERGE, and taking it now would only be undone by the next merge into the base (`stage-3-merge.md`,
+# "Step 6"). The graph check in `check` still runs and RECORDS what it saw, so a behind branch is labelled
+# rather than stopped. Only DIRTY and UNKNOWN are absent: each is handled by an earlier rule in `decide`.
+# NOTE: the downstream merge gate (`merge-check.py`) runs the SAME `check_base_ancestry` probe and DOES
+# insist on it — that gate is where base currency is a real precondition, and this one is not.
+REVIEWABLE_STATES = frozenset({"CLEAN", "HAS_HOOKS", "UNSTABLE", "BLOCKED", "BEHIND"})
 
 
 def _verdict(verdict: str, reason: str) -> dict:
@@ -169,19 +182,17 @@ def decide(view: dict) -> dict:
     if mergeable == "UNKNOWN" or mss == "UNKNOWN":
         return _verdict(RECHECK, "mergeability not computed yet — re-poll")
 
-    # 3. CONFLICTS WITH BASE — the branch cannot combine with its base. A fix authored here fights the merge.
+    # 3. CONFLICTS WITH BASE — the branch cannot combine with its base. A fix authored here fights the merge,
+    #    and this is the ONLY thing that still forces a rebase before a review or a fix.
     if mergeable == "CONFLICTING" or mss == "DIRTY":
         return _verdict(REBASE_FIRST, "conflicts with base — rebase before reviewing/fixing")
 
-    # 4. BASE MOVED AHEAD — no conflict, but the base has commits this branch lacks; rebase to review the tip.
-    if mss == "BEHIND":
-        return _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
-
-    # 5. ENUM SCREEN PASSES — the graph check in `check` decides whether this becomes final `proceed`.
-    if mergeable == "MERGEABLE" and mss in BASE_CURRENT_STATES:
+    # 4. ENUM SCREEN PASSES — the graph check in `check` records base currency; it no longer withholds
+    #    `proceed`. A base that merely MOVED AHEAD is in `REVIEWABLE_STATES` (which owns why).
+    if mergeable == "MERGEABLE" and mss in REVIEWABLE_STATES:
         return _verdict(PROCEED, "GitHub merge state permits base check")
 
-    # 6. DEFENSIVE CATCH-ALL — unreachable after step 1 pinned both enums to their schema sets and steps 2-5
+    # 5. DEFENSIVE CATCH-ALL — unreachable after step 1 pinned both enums to their schema sets and steps 2-4
     #    covered every recognised combination. Fail closed rather than fall off the end of the function.
     return _verdict(RECHECK, "mergeability not computed yet — re-poll")
 
@@ -231,9 +242,11 @@ def load_view(pr: str, repo: "str | None", view_json: "str | None",
     return cast(dict, view)
 
 
-def record_base_ok(ledger_file: str, pr: str, worktree: "str | None") -> "str | None":
-    """On a `proceed`, stamp the ledger's `base_ok_sha` for the worktree's CURRENT head. Returns an error
-    string on failure, else `None`. Called ONLY from `check`'s proceed branch, so it never touches `decide`.
+def record_base_ok(ledger_file: str, pr: str, worktree: "str | None",
+                   base_current: str) -> "str | None":
+    """On a `proceed`, stamp the ledger's `base_ok_sha` and `base_current` for the worktree's CURRENT head.
+    Returns an error string on failure, else `None`. Called ONLY from `check`'s proceed branch, so it never
+    touches `decide`.
 
     A `proceed` clears a review or fix onto THIS head, and the stamp is what lets the later `ledger.py verdict`
     land: that door refuses unless `base_ok_sha == head_sha`. Resolving the head HERE (never trusting a caller
@@ -249,7 +262,8 @@ def record_base_ok(ledger_file: str, pr: str, worktree: "str | None") -> "str | 
         return f"could not resolve HEAD in {worktree}: {head.stderr.strip()}"
     sha = head.stdout.strip()
     stamp = subprocess.run(  # noqa: S603
-        [sys.executable, str(LEDGER), "--file", ledger_file, "base-ok", "--pr", str(pr), "--head-sha", sha],
+        [sys.executable, str(LEDGER), "--file", ledger_file, "base-ok", "--pr", str(pr), "--head-sha", sha,
+         "--base-current", base_current],
         capture_output=True, text=True, check=False)
     if stamp.returncode != 0:
         return f"`ledger.py base-ok` exited {stamp.returncode}: {stamp.stderr.strip()}"
@@ -336,16 +350,23 @@ def check(pr: str, repo: "str | None", view_json: "str | None", project_root: "s
         err = record_park(ledger_file, pr, result["reason"])
         if err is not None:
             result = _verdict(RECHECK, f"could not record machine-blocker park: {err}")
+    base_current = None
     if result["verdict"] == PROCEED:
         ancestry, detail = check_base_ancestry(worktree, base, remote)
-        if ancestry == "stale":
-            result = _verdict(REBASE_FIRST, "base has moved ahead — rebase first")
-        elif ancestry == "unverified":
+        # A base that has ADVANCED past this head no longer withholds `proceed` — the rebase it calls for is
+        # owed before the MERGE, not before the review (`REVIEWABLE_STATES` owns why). The reading is carried
+        # on the verdict and recorded, so the driver can label the PR rather than stop it. `unverified` is
+        # still fail-CLOSED: an ancestry question we could not ask is not an answer of `no`.
+        if ancestry == "unverified":
             result = _verdict(RECHECK, f"could not verify base ancestry: {detail}")
-    # ONLY on a final `proceed`, and ONLY when a ledger was named, record the proceed as `base_ok_sha` for the
-    # live head. Fail CLOSED to `recheck` on a recording failure so a `proceed` always implies the stamp landed.
-    if result["verdict"] == PROCEED and ledger_file is not None:
-        err = record_base_ok(ledger_file, pr, worktree)
+        else:
+            base_current = "yes" if ancestry == "current" else "no"
+            result = dict(result, base_current=base_current)
+    # ONLY on a final `proceed`, and ONLY when a ledger was named, record the proceed as `base_ok_sha` plus the
+    # ancestry reading for the live head. Fail CLOSED to `recheck` on a recording failure so a `proceed`
+    # always implies both landed.
+    if result["verdict"] == PROCEED and ledger_file is not None and base_current is not None:
+        err = record_base_ok(ledger_file, pr, worktree, base_current)
         if err is not None:
             result = _verdict(RECHECK, f"could not record base_ok_sha: {err}")
     print(json.dumps(result))

--- a/plugins/gauntlet/skills/campaign/scripts/base-retarget-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-retarget-test.py
@@ -508,7 +508,7 @@ def t_resolve_migrates_the_row():
         # The gate state a live row accumulates, EARNED through the real doors: a base-preflight stamp for
         # the head, two landed verdicts on it (a hand-raised tally is refused), a green ci and a read
         # required set. All of it describes the OLD base.
-        _run_ledger(ledger, "base-ok", "--pr", "36", "--head-sha", "a" * 40)
+        _run_ledger(ledger, "base-ok", "--pr", "36", "--head-sha", "a" * 40, "--base-current", "yes")
         for _ in range(2):
             _run_ledger(ledger, "verdict", "--pr", "36", "--head-sha", "a" * 40, "--verdict", "satisfied")
         _run_ledger(ledger, "set", "--pr", "36", "--ci", "green",

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -134,7 +134,7 @@ class Scenario:
         # `verdict` refuses unless a base-preflight `proceed` is on record for this head
         # (base_ok_sha == head_sha); stamp it first, as the real flow does (base-preflight.py -> base-ok).
         if reviews_ok:
-            _ledger("--file", str(self.ledger), "base-ok", "--pr", PR_NUMBER, "--head-sha", self.orig_head)
+            _ledger("--file", str(self.ledger), "base-ok", "--pr", PR_NUMBER, "--head-sha", self.orig_head, "--base-current", "yes")
         for _ in range(reviews_ok):
             _ledger("--file", str(self.ledger), "verdict", "--pr", PR_NUMBER,
                     "--head-sha", self.orig_head, "--verdict", "satisfied")

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror-test.py
@@ -12,6 +12,7 @@ promise there.
 
 from __future__ import annotations
 
+import ast
 import json
 import subprocess
 import tempfile
@@ -33,13 +34,14 @@ check = checker(M.SelfTestFailure)
 
 
 class FakeGh:
-    """A recorded `gh` runner. Answers `pr view` and `pr edit` from canned responses, records every argv,
-    and REFUSES any other command — a fixture that reaches an unexpected `gh` call is a fixture testing
-    something it did not mean to."""
+    """A recorded `gh` runner. Answers `pr view`, `pr edit` and `label create` from canned responses, records
+    every argv, and REFUSES any other command — a fixture that reaches an unexpected `gh` call is a fixture
+    testing something it did not mean to."""
 
-    def __init__(self, *, view=None, edit=(0, "", "")) -> None:
+    def __init__(self, *, view=None, edit=(0, "", ""), create=(0, "", "")) -> None:
         self.view = view          # (returncode, stdout, stderr) for `gh pr view`, or None to refuse it
         self.edit = edit          # (returncode, stdout, stderr) for `gh pr edit`
+        self.create = create      # (returncode, stdout, stderr) for `gh label create`
         self.calls: list[list[str]] = []
 
     def __call__(self, argv: list[str]) -> "subprocess.CompletedProcess[str]":
@@ -48,6 +50,8 @@ class FakeGh:
             resp = self.view
         elif argv[:3] == ["gh", "pr", "edit"]:
             resp = self.edit
+        elif argv[:3] == ["gh", "label", "create"]:
+            resp = self.create
         else:
             raise AssertionError(f"unexpected gh call: {argv}")
         if resp is None:
@@ -59,18 +63,24 @@ class FakeGh:
     def edited(self) -> bool:
         return any(a[:3] == ["gh", "pr", "edit"] for a in self.calls)
 
+    @property
+    def created(self) -> "list[str]":
+        """The label NAMES this fixture created, in call order."""
+        return [a[3] for a in self.calls if a[:3] == ["gh", "label", "create"]]
+
 
 def view_with(*labels: str) -> tuple:
     """A successful `gh pr view --json labels` response carrying exactly these label names."""
     return (0, json.dumps({"labels": [{"name": n} for n in labels]}), "")
 
 
-def build_ledger(d: Path, *, status="in_review", tier="STANDARD", reviews_ok="0", pr="9") -> Path:
+def build_ledger(d: Path, *, status="in_review", tier="STANDARD", reviews_ok="0", pr="9",
+                 base_current="-") -> Path:
     led = d / "state.jsonl"
     header = dict(L.HEADER_DEFAULTS)
     header["run_id"] = "g1"
     row = dict(L.ROW_DEFAULTS)
-    row.update(pr=pr, status=status, tier=tier, reviews_ok=reviews_ok)
+    row.update(pr=pr, status=status, tier=tier, reviews_ok=reviews_ok, base_current=base_current)
     L.dump(led, header, [row])
     return led
 
@@ -101,10 +111,12 @@ def drive(led: Path, pr: str, repo: str, fake: FakeGh, *,
 
 
 REPO = "o/n"
+ACCEPTED = "gauntlet-accepted"
+REBASE_PENDING = "gauntlet-rebase-pending"
 SWAP_TO_ACCEPTED = ["gh", "pr", "edit", "9", "--repo", REPO,
-                    "--add-label", "gauntlet-accepted", "--remove-label", "gauntlet-reviewing"]
+                    "--add-label", ACCEPTED, "--remove-label", "gauntlet-reviewing 1/2"]
 SWAP_TO_REVIEWING = ["gh", "pr", "edit", "9", "--repo", REPO,
-                     "--add-label", "gauntlet-reviewing", "--remove-label", "gauntlet-accepted"]
+                     "--add-label", "gauntlet-reviewing 1/2", "--remove-label", ACCEPTED]
 
 
 # --- the swap is applied, with the EXACT argv ---------------------------------
@@ -112,17 +124,35 @@ SWAP_TO_REVIEWING = ["gh", "pr", "edit", "9", "--repo", REPO,
 def t_reviewing_to_accepted_swaps():
     with tempfile.TemporaryDirectory() as d:
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")   # 2/2 -> accepted
-        fake = FakeGh(view=view_with("gauntlet-reviewing", "gauntlet-run-g1"))
+        fake = FakeGh(view=view_with("gauntlet-reviewing 1/2", "gauntlet-run-g1"))
         code, out, _err = drive(led, "9", REPO, fake)
         out = verdict(out)
     check(code == 0, f"a met gate must reconcile and exit 0, got {code}")
     out = verdict(out)
     check(out["changed"] is True, f"a reviewing->accepted swap must report changed, got {out!r}")
-    check(out["desired"] == "gauntlet-accepted", f"desired must be accepted, got {out!r}")
+    check(out["desired"] == [ACCEPTED], f"desired must be accepted alone, got {out!r}")
     check(out["required"] == 2 and out["reviews_ok"] == 2, f"tier/tally must be reported, got {out!r}")
-    check(out["current"] == ["gauntlet-reviewing", "gauntlet-run-g1"], f"current labels must be reported, got {out!r}")
+    check(out["current"] == ["gauntlet-reviewing 1/2", "gauntlet-run-g1"], f"current labels must be reported, got {out!r}")
     check(out["argv"] == SWAP_TO_ACCEPTED, f"the argv must be the canonical idempotent swap, got {out.get('argv')!r}")
+    check(fake.created == [ACCEPTED], f"the label added must be created first, got {fake.created!r}")
     check(fake.edited, "the swap must actually call `gh pr edit`")
+
+
+# --- the run-owner label is never swept, whatever else moves -------------------
+
+def t_run_label_is_never_removed():
+    """A sweep that took `gauntlet-run-<id>` off would drop the PR out of its own run — every later
+    label-scoped query stops seeing it. `gauntlet-authored` is another owner's state for the same reason.
+    Both must survive a reconcile that moves everything around them."""
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
+        fake = FakeGh(view=view_with("gauntlet-reviewing 0/2", "gauntlet-run-g1", "gauntlet-authored"))
+        code, out, _err = drive(led, "9", REPO, fake)
+        out = verdict(out)
+    check(code == 0, f"the reconcile must exit 0, got {code}")
+    removed = [out["argv"][i + 1] for i, a in enumerate(out["argv"]) if a == "--remove-label"]
+    check(removed == ["gauntlet-reviewing 0/2"],
+          f"only the stale gate label may be removed, got {removed!r}")
 
 
 # --- already right: no swap, no edit call -------------------------------------
@@ -130,7 +160,7 @@ def t_reviewing_to_accepted_swaps():
 def t_accepted_stays():
     with tempfile.TemporaryDirectory() as d:
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
-        fake = FakeGh(view=view_with("gauntlet-accepted"), edit=None)  # edit=None => any edit is a failure
+        fake = FakeGh(view=view_with(ACCEPTED), edit=None, create=None)  # any edit/create is a failure
         code, out, _err = drive(led, "9", REPO, fake)
         out = verdict(out)
     check(code == 0, f"an already-accepted PR reconciles to a no-op, got {code}")
@@ -142,11 +172,12 @@ def t_accepted_stays():
 def t_reviewing_stays():
     with tempfile.TemporaryDirectory() as d:
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="1")   # 1/2 -> reviewing
-        fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=None)
+        fake = FakeGh(view=view_with("gauntlet-reviewing 1/2"), edit=None, create=None)
         code, out, _err = drive(led, "9", REPO, fake)
         out = verdict(out)
     check(code == 0, f"a short gate already reviewing is a no-op, got {code}")
-    check(out["desired"] == "gauntlet-reviewing" and out["changed"] is False, f"expected reviewing no-op, got {out!r}")
+    check(out["desired"] == ["gauntlet-reviewing 1/2"] and out["changed"] is False,
+          f"expected reviewing no-op, got {out!r}")
     check(not fake.edited, "an already-reviewing label must trigger NO edit")
 
 
@@ -160,16 +191,16 @@ def t_readopt_escalation_flips_accepted_to_reviewing():
     # "Adoption-time tier decision", is what makes that happen. It is NOT a no-op here.
     with tempfile.TemporaryDirectory() as d:
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="1")   # 1/2 -> reviewing
-        fake = FakeGh(view=view_with("gauntlet-accepted", "gauntlet-run-g1"))
+        fake = FakeGh(view=view_with(ACCEPTED, "gauntlet-run-g1"))
         code, out, _err = drive(led, "9", REPO, fake)
         out = verdict(out)
     check(code == 0, f"a short gate after escalation must reconcile and exit 0, got {code}")
     out = verdict(out)
     check(out["changed"] is True,
           f"an accepted->reviewing swap must report changed, got {out!r}")
-    check(out["desired"] == "gauntlet-reviewing", f"desired must be reviewing after escalation, got {out!r}")
+    check(out["desired"] == ["gauntlet-reviewing 1/2"], f"desired must be reviewing after escalation, got {out!r}")
     check(out["required"] == 2 and out["reviews_ok"] == 1, f"tier/tally must be reported, got {out!r}")
-    check(out["current"] == ["gauntlet-accepted", "gauntlet-run-g1"],
+    check(out["current"] == [ACCEPTED, "gauntlet-run-g1"],
           f"current labels must be reported, got {out!r}")
     check(out["argv"] == SWAP_TO_REVIEWING,
           f"the argv must be the canonical reviewing-restoring swap, got {out.get('argv')!r}")
@@ -229,7 +260,7 @@ def t_gh_view_failure_exit_1():
 def t_gh_edit_failure_exit_1():
     with tempfile.TemporaryDirectory() as d:
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
-        fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=(1, "", "gh: label not found"))
+        fake = FakeGh(view=view_with("gauntlet-reviewing 0/2"), edit=(1, "", "gh: label not found"))
         code, out, err = drive(led, "9", REPO, fake)
     check(code == 1, f"a failed `gh pr edit` must fail closed (exit 1), got {code}")
     check(out is None, "a failed edit prints no success JSON — the swap did not land")
@@ -242,7 +273,7 @@ def t_gh_edit_failure_exit_1():
 def t_dry_run_no_edit():
     with tempfile.TemporaryDirectory() as d:
         led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2")
-        fake = FakeGh(view=view_with("gauntlet-reviewing"), edit=None)  # any edit fails the fixture
+        fake = FakeGh(view=view_with("gauntlet-reviewing 1/2"), edit=None, create=None)  # any write fails the fixture
         code, out, _err = drive(led, "9", REPO, fake, dry_run=True)
         out = verdict(out)
     check(code == 0, f"a dry-run exits 0, got {code}")
@@ -254,23 +285,110 @@ def t_dry_run_no_edit():
 # --- the required(tier) boundary, exactly, for TRIVIAL(1) and STANDARD(2) -----
 
 def t_required_boundary():
-    # (tier, reviews_ok, expected desired) — each straddles required(tier) by exactly one.
+    # (tier, reviews_ok, expected desired) — each straddles required(tier) by exactly one, and each short
+    # gate spells its OWN tally, which is the whole point of the tallied name: 0/1 and 1/2 are different
+    # labels, so a reader sees how far along a PR is, not merely that it is not done.
     for tier, ok, desired in [
-        ("TRIVIAL", "1", "gauntlet-accepted"),    # 1/1 meets the floor
-        ("TRIVIAL", "0", "gauntlet-reviewing"),   # 0/1 short
-        ("STANDARD", "2", "gauntlet-accepted"),   # 2/2 meets the floor
-        ("STANDARD", "1", "gauntlet-reviewing"),  # 1/2 short
-        ("HIGH", "2", "gauntlet-accepted"),       # HIGH needs 2, like STANDARD
+        ("TRIVIAL", "1", ACCEPTED),                 # 1/1 meets the floor
+        ("TRIVIAL", "0", "gauntlet-reviewing 0/1"),  # 0/1 short
+        ("STANDARD", "2", ACCEPTED),                 # 2/2 meets the floor
+        ("STANDARD", "1", "gauntlet-reviewing 1/2"),  # 1/2 short — one verdict in
+        ("STANDARD", "0", "gauntlet-reviewing 0/2"),  # 0/2 short — none yet
+        ("HIGH", "2", ACCEPTED),                     # HIGH needs 2, like STANDARD
     ]:
         with tempfile.TemporaryDirectory() as d:
             led = build_ledger(Path(d), tier=tier, reviews_ok=ok)
-            # Seed current with the OTHER label so the swap is always "changed" and observable.
-            other = "gauntlet-reviewing" if desired == "gauntlet-accepted" else "gauntlet-accepted"
+            # Seed current with a DIFFERENT gate label so the swap is always "changed" and observable.
+            other = "gauntlet-reviewing 9/9" if desired == ACCEPTED else ACCEPTED
             fake = FakeGh(view=view_with(other))
             code, out, _err = drive(led, "9", REPO, fake)
             out = verdict(out)
         check(code == 0, f"[{tier} {ok}] exit 0, got {code}")
-        check(out["desired"] == desired, f"[{tier} {ok}/{out['required']}] desired must be {desired}, got {out!r}")
+        check(out["desired"] == [desired],
+              f"[{tier} {ok}/{out['required']}] desired must be {desired!r}, got {out!r}")
+        check(fake.created == [desired], f"[{tier} {ok}] the added label must be created, got {fake.created!r}")
+
+
+def t_rebase_pending_is_an_independent_axis():
+    """`gauntlet-rebase-pending` tracks `base_current`, NOT the gate — so an ACCEPTED PR that is behind its
+    base wears both labels at once. That pair is the normal state of a PR waiting its turn in the serialized
+    drain, and a reconcile that treated the two axes as one label would keep swapping them forever.
+
+    Only an explicit `no` claims the PR is behind: `-` means nothing has probed this head yet, which is not
+    a claim in either direction, so no label is applied for it.
+    """
+    cases = [
+        # (reviews_ok, base_current, desired labels)
+        ("2", "no", [ACCEPTED, REBASE_PENDING]),        # accepted AND behind — both, together
+        ("2", "yes", [ACCEPTED]),                       # accepted and current — gate label alone
+        ("2", "-", [ACCEPTED]),                         # no reading yet — never a guessed label
+        ("1", "no", ["gauntlet-reviewing 1/2", REBASE_PENDING]),   # short AND behind
+    ]
+    for ok, base_current, desired in cases:
+        with tempfile.TemporaryDirectory() as d:
+            led = build_ledger(Path(d), tier="STANDARD", reviews_ok=ok, base_current=base_current)
+            fake = FakeGh(view=view_with())            # a bare PR: everything desired must be added
+            code, out, _err = drive(led, "9", REPO, fake)
+            out = verdict(out)
+        check(code == 0, f"[{ok},{base_current}] exit 0, got {code}")
+        check(out["desired"] == desired, f"[{ok},{base_current}] desired must be {desired!r}, got {out!r}")
+        added = [out["argv"][i + 1] for i, a in enumerate(out["argv"]) if a == "--add-label"]
+        check(added == desired, f"[{ok},{base_current}] the argv must add exactly those, got {added!r}")
+
+
+def t_rebase_pending_is_swept_when_the_row_says_current():
+    """A PR whose rebase LANDED must lose the label in the same reconcile that sees the row say so —
+    a `gauntlet-rebase-pending` left behind is a false public claim that a PR is still stuck."""
+    with tempfile.TemporaryDirectory() as d:
+        led = build_ledger(Path(d), tier="STANDARD", reviews_ok="2", base_current="yes")
+        fake = FakeGh(view=view_with(ACCEPTED, REBASE_PENDING, "gauntlet-run-g1"))
+        code, out, _err = drive(led, "9", REPO, fake)
+        out = verdict(out)
+    check(code == 0, f"the reconcile must exit 0, got {code}")
+    check(out["argv"] == ["gh", "pr", "edit", "9", "--repo", REPO, "--remove-label", REBASE_PENDING],
+          f"only the stale rebase label may move, got {out.get('argv')!r}")
+    check(fake.created == [], f"a reconcile that ADDS nothing must create nothing, got {fake.created!r}")
+
+
+def t_no_tool_spells_a_label_itself():
+    """NO bundled tool may carry a label NAME as a string literal — `_gauntlet/labels.py` owns every
+    spelling and every tool computes from it.
+
+    This is the mechanical form of a rule that would otherwise be an exhortation. The vocabulary used to be
+    two fixed strings copied into three tools, which was survivable; a tallied name is COMPUTED, so a
+    second copy of the computation is a second answer to "which label does this row wear", and the copy
+    goes wrong silently — on GitHub, where a human reads it.
+
+    It reads STRING LITERALS through `ast`, not raw text: comments and docstrings explaining the labels are
+    exactly what a doc-heavy tree is made of, and flagging those would make the check unusable. A docstring
+    is a string literal, so docstrings are skipped explicitly. Sibling `*-test.py` suites are exempt —
+    a fixture must be able to name the label it asserts, or it is asserting the code's own opinion.
+    """
+    names = (M.labels.ACCEPTED, M.labels.REVIEWING, M.labels.REBASE_PENDING)
+    owner = Path(M.labels.__file__).resolve()
+    offenders: list[str] = []
+    for path in sorted(OWNER.parent.rglob("*.py")):
+        if path.name.endswith("-test.py") or path.resolve() == owner:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        docstrings: set[int] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.body:
+                continue
+            first = node.body[0]
+            if (isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant)
+                    and isinstance(first.value.value, str)):
+                docstrings.add(id(first.value))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                    and id(node) not in docstrings
+                    and any(name in node.value for name in names)):
+                offenders.append(f"{path.name}:{node.lineno}: {node.value!r}")
+    check(not offenders,
+          "a label name is spelled inside a tool instead of coming from `_gauntlet/labels.py`:\n  "
+          + "\n  ".join(offenders))
 
 
 def t_malformed_repo_fails_before_any_gh_call():
@@ -299,5 +417,9 @@ CASES = [
     ("view-failure", "a failed `gh pr view` fails closed (exit 1), never reaches the edit", t_gh_view_failure_exit_1),
     ("edit-failure", "a failed `gh pr edit` fails closed (exit 1), no success JSON", t_gh_edit_failure_exit_1),
     ("dry-run", "a dry-run shows the swap argv but applies nothing", t_dry_run_no_edit),
-    ("required-boundary", "reviews_ok at exactly required(tier) picks accepted; one under picks reviewing", t_required_boundary),
+    ("required-boundary", "reviews_ok at exactly required(tier) picks accepted; one under spells its own tally", t_required_boundary),
+    ("run-label-never-removed", "a reconcile never sweeps gauntlet-run-<id> or gauntlet-authored", t_run_label_is_never_removed),
+    ("rebase-pending-axis", "gauntlet-rebase-pending tracks base_current independently of the gate", t_rebase_pending_is_an_independent_axis),
+    ("rebase-pending-swept", "a row that says current loses a standing gauntlet-rebase-pending", t_rebase_pending_is_swept_when_the_row_says_current),
+    ("no-tool-spells-a-label", "no bundled tool carries a label name as a string literal — labels.py owns every spelling", t_no_tool_spells_a_label_itself),
 ]

--- a/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
+++ b/plugins/gauntlet/skills/campaign/scripts/label-mirror.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Reconcile a PR's STATUS LABEL with its review gate — the ONE way the label swap is done.
+"""Reconcile a PR's STATUS LABELS with its ledger row — the ONE way the label swap is done.
 
 THE RULE THIS ENCODES: the gate and its label move together (`stage-2-review-gate.md`, "Status labels
 mirror the review gate"). A PR whose tip holds `required(tier)` SATISFIED verdicts wears
-`gauntlet-accepted`; otherwise it wears `gauntlet-reviewing`. The label is a PROJECTION of `reviews_ok`,
+`gauntlet-accepted`; otherwise it wears `gauntlet-reviewing <ok>/<required>`, which says how far along it
+is rather than merely that it is not done. The label is a PROJECTION of `reviews_ok`,
 and it is the one piece of run state a human reads on GitHub — a stale `gauntlet-accepted` is a false
 PUBLIC claim that a PR passed a gauntlet it did not.
+
+A SECOND, INDEPENDENT AXIS rides the same reconcile: `gauntlet-rebase-pending`, projected from the row's
+`base_current` reading. It says the PR is behind its base and will be rebased when it reaches the front of
+the serialized drain (`stage-3-merge.md`, "Step 6"). It is INDEPENDENT of the gate — an accepted PR waiting
+its turn wears both labels, and that pair is the normal state, not a contradiction. The vocabulary and the
+two axes belong to `_gauntlet/labels.py`; this tool holds no second copy of either.
 
 WHY THIS IS A COMMAND AND NOT A `gh pr edit` A DRIVER TYPES BY HAND. The swap was a two-command idiom the
 orchestrator ran at every gate-reset site — the verdict tally, a CI/review fix push, a content-changing
@@ -17,11 +24,17 @@ swap — so no driver hand-runs it and no driver runs it wrong.
     label-mirror.py mirror --ledger <state.jsonl> --pr <N> --repo owner/name [--dry-run]
     label-mirror.py self-test   run every fixture (label-mirror-test.py)
 
-It touches EXACTLY the two status labels and nothing else. A run's ownership label (`gauntlet-run-<id>`)
-is adoption's business (`pr-adoption.md`) and is NEVER added or removed here. A terminal row
+It touches EXACTLY the labels `labels.is_status_label` claims and nothing else. A run's ownership label
+(`gauntlet-run-<id>`) is adoption's business (`pr-adoption.md`), `gauntlet-authored` is the review
+handoff's, and NEITHER is ever added or removed here. A terminal row
 (`merged`/`aborted`) is DONE: the tool skips it and makes no GitHub call at all. It FAILS CLOSED — a row
 that is missing, or whose `tier` nobody set, is refused loudly (exit 2), never defaulted; a `gh` call that
 fails or returns output it cannot parse is exit 1 with the stderr shown, never a guess.
+
+EVERY LABEL IT ADDS IS CREATED FIRST (`gh label create … --force`, idempotent). A tallied name is COMPUTED
+from `required(tier)`, so which reviewing labels a repository needs depends on how its PRs get triaged; a
+bootstrap list typed into a doc would go stale the first time that changed, and `gh pr edit --add-label`
+fails outright on a label the repository does not have.
 
 `required(tier)` is REUSED from `nudge.py`, never retyped — the same helper `merge-check.py` borrows. This
 tool holds no second opinion about how many verdicts a tier needs.
@@ -40,6 +53,7 @@ import sys
 from pathlib import Path
 from typing import Callable, NoReturn
 
+from _gauntlet import labels
 from _gauntlet.modules import load_sibling
 from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
@@ -57,9 +71,11 @@ L = load_sibling("label_mirror_ledger", _HERE, "ledger.py")
 _N = load_sibling("label_mirror_nudge", _HERE, "nudge.py")
 REQUIRED = _N.required
 
-# --- the two labels, and NOTHING ELSE is ever added or removed ------------------------------------
-ACCEPTED = "gauntlet-accepted"
-REVIEWING = "gauntlet-reviewing"
+# The label VOCABULARY and both axes live in `_gauntlet/labels.py` — imported above, never re-spelled here.
+# The reading that drives the second axis: a row records `yes`/`no`/`-`, and ONLY an explicit `no` claims the
+# PR is behind. `-` (nothing has probed this head yet) and `yes` both mean no rebase is known to be owed, so
+# a row nobody has measured wears no rebase label rather than a guessed one.
+BEHIND_BASE = "no"
 
 # TERMINAL — a DONE row is skipped, no GitHub call at all. `merged`/`aborted` are the two terminal
 # statuses (the ledger `status` field, `files-and-ledger.md`, owns the vocabulary).
@@ -103,15 +119,14 @@ def parse_reviews_ok(row: dict) -> int:
     return int(value)
 
 
-def desired_and_other(tier: str, reviews_ok: int) -> "tuple[str, str]":
-    """(desired label, the OTHER label) for a row whose `tier` is already known-valid. PURE.
+def desired_labels(tier: str, reviews_ok: int, base_current: str) -> list[str]:
+    """Every status label a row should wear, for a row whose `tier` is already known-valid. PURE.
 
-    `gauntlet-accepted` iff the tally meets `required(tier)`, else `gauntlet-reviewing`. The count is
-    `required(tier)`'s to own; this only compares against it.
+    The gate axis is `labels.gate_label`'s to name and `required(tier)`'s to size; the base-currency axis is
+    an explicit `no` reading and nothing else. This function only supplies the row's values to them.
     """
-    if reviews_ok >= REQUIRED(tier):
-        return ACCEPTED, REVIEWING
-    return REVIEWING, ACCEPTED
+    return labels.desired_labels(reviews_ok, REQUIRED(tier),
+                                 rebase_pending=base_current == BEHIND_BASE)
 
 
 def current_labels(run: Runner, pr: str, repo: str) -> list[str]:
@@ -145,21 +160,27 @@ def current_labels(run: Runner, pr: str, repo: str) -> list[str]:
 
 
 def apply_swap(run: Runner, argv: list[str], pr: str) -> None:
-    """Run the canonical idempotent swap. A spawn failure or non-zero exit raises `LabelError` — exit 1."""
+    """Run one prepared `gh` argv. A spawn failure or non-zero exit raises `LabelError` — exit 1.
+
+    Used for BOTH the `gh label create` calls and the single `gh pr edit`, because the failure handling is
+    identical: a create that did not land makes the add that follows it fail anyway, so there is nothing to
+    gain by continuing past either.
+    """
     try:
         proc = run(argv)
     except OSError as exc:
-        raise LabelError(f"could not run `gh pr edit {pr}`: {exc}") from exc
+        raise LabelError(f"could not run `{' '.join(argv[:3])}` for {pr}: {exc}") from exc
     if proc.returncode != 0:
-        raise LabelError(f"`gh pr edit {pr}` exited {proc.returncode}: {proc.stderr.strip()}")
+        raise LabelError(f"`{' '.join(argv[:3])}` for {pr} exited {proc.returncode}: {proc.stderr.strip()}")
 
 
 def mirror(ledger_path: Path, pr: str, repo: str, *, dry_run: bool = False,
            run: Runner = _real_run) -> int:
-    """Reconcile ONE PR's status label with its gate. Print one JSON object; return the exit code.
+    """Reconcile ONE PR's status labels with its row. Print one JSON object; return the exit code.
 
     Order: no row -> refuse (2); a terminal row -> skip, no GitHub call; a tier nobody set -> refuse (2);
-    then read the live labels and apply the idempotent swap only if the label is not already right.
+    then read the live labels, create any label about to be added, and apply ONE `gh pr edit` — only if
+    something actually needs to move.
     """
     _header, rows = L.load(ledger_path)
     pr = str(pr)
@@ -180,8 +201,7 @@ def mirror(ledger_path: Path, pr: str, repo: str, *, dry_run: bool = False,
 
     reviews_ok = parse_reviews_ok(row)
     required = REQUIRED(tier)
-    desired, other = desired_and_other(tier, reviews_ok)
-    argv = ["gh", "pr", "edit", pr, "--repo", repo, "--add-label", desired, "--remove-label", other]
+    desired = desired_labels(tier, reviews_ok, row["base_current"])
 
     try:
         current = current_labels(run, pr, repo)
@@ -189,18 +209,27 @@ def mirror(ledger_path: Path, pr: str, repo: str, *, dry_run: bool = False,
         print(f"label-mirror: {exc}", file=sys.stderr)
         return 1
 
-    # Already right: the desired label is present AND the other absent. Anything else needs the swap —
-    # desired missing, the other lingering, or both labels at once (what a missed swap actually leaves).
-    changed = not (desired in current and other not in current)
+    # What must MOVE, from the live labels alone. A label already right is never re-added, and a label this
+    # tool does not own is never removed — including the run-owner label and a stale tally's neighbours on a
+    # PR two runs have touched.
+    to_add, to_remove = labels.reconcile(current, desired)
+    changed = bool(to_add or to_remove)
+    edit = labels.edit_argv(pr, to_add, to_remove, repo)
+    creates = [labels.create_argv(name, repo) for name in to_add]
 
     out: dict = {"pr": pr, "tier": tier, "reviews_ok": reviews_ok, "required": required,
                  "desired": desired, "current": current, "changed": changed}
     if changed or dry_run:
-        out["argv"] = argv
+        out["argv"] = edit
+        out["create_argv"] = creates
 
     if changed and not dry_run:
         try:
-            apply_swap(run, argv, pr)
+            # CREATE BEFORE ADD, every time: `gh pr edit --add-label` fails outright on a label the
+            # repository does not have, and a tallied name is one no bootstrap could have listed in advance.
+            for create in creates:
+                apply_swap(run, create, pr)
+            apply_swap(run, edit, pr)
         except LabelError as exc:
             print(f"label-mirror: {exc}", file=sys.stderr)
             return 1

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -1626,47 +1626,73 @@ def t_verdict_refused_without_base_ok(L: ModuleType, tmp: Path) -> None:
 
 
 def t_head_move_voids_base_ok(L: ModuleType, tmp: Path) -> None:
-    """A genuine head MOVE through `set --head-sha` voids `base_ok_sha` to `-`; a SAME-VALUE write leaves it.
+    """A genuine head MOVE through `set --head-sha` voids BOTH `PREFLIGHT_OWNED` readings to `-`; a
+    SAME-VALUE write leaves them.
 
     A new head is UNVERIFIED until a fresh proceed — so the verdict allowed on the old head is now refused, and
-    only re-running base-preflight (here, `base-ok`) on the new head clears it again. THE MUTATION PIN: delete
-    the `base_ok_sha` reset in `apply_head_sha` and the first block goes red.
+    only re-running base-preflight (here, `base-ok`) on the new head clears it again. `base_current` rides the
+    same reset for the same reason: a rebase IS a head move, so the `no` recorded for the old head is exactly
+    the answer that has just stopped being true. THE MUTATION PIN: delete either reset in `apply_head_sha` and
+    the first block goes red.
     """
     path = write_lines(tmp / "void.jsonl", header_line(L),
-                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A))
+                       row_line(L, pr="1", head_sha=SHA_A, base_ok_sha=SHA_A, base_current="no"))
     code, out, err = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", SHA_B])
     check(code == 0, f"set exited {code}: {err!r}")
     check(json.loads(out)["base_ok_sha"] == L.ROW_DEFAULTS["base_ok_sha"],
           f"a head MOVE left base_ok_sha standing: {json.loads(out)['base_ok_sha']!r} — the proceed for the "
           f"old head must not authorize the new content")
+    check(json.loads(out)["base_current"] == L.ROW_DEFAULTS["base_current"],
+          f"a head MOVE left base_current standing: {json.loads(out)['base_current']!r} — an ancestry answer "
+          f"about the old head must not label the new one")
     code, _, err = cli(L, ["--file", str(path), "verdict", "--pr", "1", "--head-sha", SHA_B, "--verdict", "satisfied"])
     check(code == 1, "a verdict landed on a moved head whose proceed was voided")
 
-    # …and a SAME-VALUE head write is not a move: a stamp for that head is left standing.
-    cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_B])
+    # …and a SAME-VALUE head write is not a move: the readings for that head are left standing.
+    cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_B, "--base-current", "no"])
     code, out, _ = cli(L, ["--file", str(path), "set", "--pr", "1", "--head-sha", SHA_B])
     check(json.loads(out)["base_ok_sha"] == SHA_B,
           f"a SAME-VALUE head write voided a stamp it must not touch: {json.loads(out)['base_ok_sha']!r}")
+    check(json.loads(out)["base_current"] == "no",
+          f"a SAME-VALUE head write voided a reading it must not touch: {json.loads(out)['base_current']!r}")
 
 
 def t_base_ok_writes_and_refuses(L: ModuleType, tmp: Path) -> None:
-    """`base-ok` records `base_ok_sha` for the row's CURRENT head, and REFUSES a non-40-hex value, a head
-    mismatch, or a missing row — writing NOTHING on any refusal."""
+    """`base-ok` records BOTH readings for the row's CURRENT head, and REFUSES a non-40-hex value, a head
+    mismatch, a missing row, or an ancestry answer outside the closed vocabulary — writing NOTHING on any
+    refusal."""
     path = write_lines(tmp / "bok.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
-    code, out, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A])
+    code, out, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A, "--base-current", "yes"])
     check(code == 0, f"base-ok on the current head exited {code}: {err!r}")
     check(json.loads(out)["base_ok_sha"] == SHA_A, f"base-ok did not stamp base_ok_sha: {out!r}")
+    check(json.loads(out)["base_current"] == "yes", f"base-ok did not record base_current: {out!r}")
+
+    # A `no` reading lands the same way — the field carries the probe's answer, not a fixed value.
+    code, out, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A, "--base-current", "no"])
+    check(code == 0 and json.loads(out)["base_current"] == "no",
+          f"base-ok did not record a `no` ancestry reading: {out!r} (exit {code}, {err!r})")
+
+    # `--base-current` is REQUIRED and its vocabulary is CLOSED. `-` is the row's "no reading" spelling and
+    # is refused here: a check that reached `proceed` always saw one answer or the other.
+    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A])
+    check(code == 2, f"base-ok with no --base-current was accepted (exit {code}) — the reading is required")
+    for bad in ("-", "maybe", "YES"):
+        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A,
+                               "--base-current", bad])
+        check(code == 2, f"base-ok --base-current {bad!r} was accepted (exit {code})")
+    code, out, _ = cli(L, ["--file", str(path), "get", "--pr", "1", "--field", "base_current"])
+    check(out == "no\n", f"a refused base-ok changed base_current: {out!r}")
 
     for bad in (SHA_A[:7], "g" * 40, SHA_A.upper()):
-        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", bad])
+        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", bad, "--base-current", "yes"])
         check(code == 1, f"base-ok --head-sha {bad!r} was accepted (exit {code})")
         check("40 LOWERCASE hex" in err, f"[{bad!r}] refused for the wrong reason: {err!r}")
 
-    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_B])
+    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_B, "--base-current", "yes"])
     check(code == 1, "base-ok stamped a head that is not the row's current one")
     check("does not match" in err, f"refused for the wrong reason: {err!r}")
 
-    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "9", "--head-sha", SHA_A])
+    code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "9", "--head-sha", SHA_A, "--base-current", "yes"])
     check(code == 1, "base-ok wrote a stamp for a PR with no row")
     check("no row for pr 9" in err, f"refused for the wrong reason: {err!r}")
 
@@ -1682,19 +1708,25 @@ def t_base_ok_sha_has_no_set_door(L: ModuleType, tmp: Path) -> None:
     `--base-ok-sha` flag: argparse refuses it, and only `base-ok` writes the field."""
     check("base_ok_sha" in L.PREFLIGHT_OWNED, "base_ok_sha must be in PREFLIGHT_OWNED, or a set door can forge it")
     check(not L.settable("base_ok_sha"), "settable() must refuse base_ok_sha — PREFLIGHT_OWNED")
+    # `base_current` is closed for a DIFFERENT reason — it is a sensor READING, and a typed reading is a
+    # forged one — but through the SAME mechanism, so the door check covers both fields together.
+    check("base_current" in L.PREFLIGHT_OWNED, "base_current must be in PREFLIGHT_OWNED — no hand-written readings")
+    check(not L.settable("base_current"), "settable() must refuse base_current — PREFLIGHT_OWNED")
     path = write_lines(tmp / "bnodoor.jsonl", header_line(L), row_line(L, pr="1", head_sha=SHA_A))
     for door in (["set", "--pr", "1"], ["add-row", "--pr", "77"]):
-        code, _, err = cli(L, ["--file", str(path), *door, "--base-ok-sha", SHA_A])
-        check(code == 2, f"`{door[0]} --base-ok-sha` was accepted (exit {code}) — a hand-write door can forge a proceed")
-        check("unrecognized arguments" in err,
-              f"`{door[0]} --base-ok-sha` failed, but not because the flag is ABSENT: {err!r}")
+        for flag, value in (("--base-ok-sha", SHA_A), ("--base-current", "yes")):
+            code, _, err = cli(L, ["--file", str(path), *door, flag, value])
+            check(code == 2, f"`{door[0]} {flag}` was accepted (exit {code}) — a hand-write door can forge a reading")
+            check("unrecognized arguments" in err,
+                  f"`{door[0]} {flag}` failed, but not because the flag is ABSENT: {err!r}")
 
 
 def t_base_ok_is_not_activity(L: ModuleType, tmp: Path) -> None:
     """`base-ok` writes with `activity=False` — recording a precondition is not the run doing meaningful work,
     exactly as re-arming the watchdog is not. Also asserts base_ok_sha IS in ACTIVITY_EXEMPT (name the set)."""
-    check("base_ok_sha" in L.ACTIVITY_EXEMPT,
-          "base_ok_sha must be in ACTIVITY_EXEMPT — stamping a precondition must not reset the quiet sensor")
+    for field in L.PREFLIGHT_OWNED:
+        check(field in L.ACTIVITY_EXEMPT,
+              f"{field} must be in ACTIVITY_EXEMPT — stamping a precondition must not reset the quiet sensor")
     path = write_lines(tmp / "boa.jsonl", header_line(L, run_id="r1"),
                        row_line(L, pr="1", head_sha=SHA_A, status="in_review"))
     with frozen_clock(L, FROZEN_A):  # a real change first, to give last_activity a known value
@@ -1702,7 +1734,7 @@ def t_base_ok_is_not_activity(L: ModuleType, tmp: Path) -> None:
         check(code == 0, f"baseline set exited {code}: {err!r}")
     check(last_activity(L, path) == FROZEN_A, "the baseline change did not stamp last_activity")
     with frozen_clock(L, FROZEN_B):  # a base-ok write — must NOT re-stamp
-        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A])
+        code, _, err = cli(L, ["--file", str(path), "base-ok", "--pr", "1", "--head-sha", SHA_A, "--base-current", "yes"])
         check(code == 0, f"base-ok exited {code}: {err!r}")
     check(last_activity(L, path) == FROZEN_A,
           f"base-ok re-stamped last_activity to {last_activity(L, path)!r} — stamping a precondition is not "
@@ -1836,7 +1868,7 @@ def verdicts(L: ModuleType, path: Path, seq: str, pr: str = "1", move_head: bool
         if move_head and v == "N":
             sha = f"{i:040x}"
             cli(L, ["--file", str(path), "set", "--pr", pr, "--head-sha", sha])
-            cli(L, ["--file", str(path), "base-ok", "--pr", pr, "--head-sha", sha])  # re-preflight the new head
+            cli(L, ["--file", str(path), "base-ok", "--pr", pr, "--head-sha", sha, "--base-current", "yes"])  # re-preflight the new head
     return len(seq), 0
 
 
@@ -2129,7 +2161,7 @@ def replay(L: ModuleType, tmp: Path, pr: str, stop_after: "int | None" = None) -
         if v == "N":  # a fix was dispatched and pushed: the head MOVED, and base-preflight re-ran on the new tip
             sha = f"{i:040x}"
             cli(L, ["--file", str(path), "set", "--pr", pr, "--head-sha", sha])
-            cli(L, ["--file", str(path), "base-ok", "--pr", pr, "--head-sha", sha])
+            cli(L, ["--file", str(path), "base-ok", "--pr", pr, "--head-sha", sha, "--base-current", "yes"])
     return None
 
 
@@ -3144,7 +3176,7 @@ def _retarget_row(L: ModuleType, tmp: Path, name: str, *, base: str = "fix-a") -
     cli(L, ["--file", str(path), "add-row", "--pr", "36", "--head-sha", "a" * 40, "--base-branch", base])
     cli(L, ["--file", str(path), "set", "--pr", "36", "--status", "in_review", "--ci", "green",
             "--required-set", "declared:[]"])
-    cli(L, ["--file", str(path), "base-ok", "--pr", "36", "--head-sha", "a" * 40])
+    cli(L, ["--file", str(path), "base-ok", "--pr", "36", "--head-sha", "a" * 40, "--base-current", "yes"])
     cli(L, ["--file", str(path), "verdict", "--pr", "36", "--head-sha", "a" * 40, "--verdict", "satisfied"])
     return path
 

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -248,6 +248,22 @@ ROW_FIELDS = (
     # The default is `-`, the schema's own "not set" spelling: an old ledger, or a head with no `proceed` yet,
     # reads back `-`, which never equals a 40-hex head, so `verdict` fails CLOSED until base-preflight runs.
     "base_ok_sha",
+    # WHETHER THAT SAME `proceed` FOUND THE BASE INSIDE THE HEAD — `yes`, `no`, or `-` for no reading.
+    # `base-preflight.py check` records it through `base-ok`, in the SAME write as `base_ok_sha`, from the
+    # Git ancestry probe it already runs. A `no` means the base has advanced past this head, so the PR owes
+    # a rebase BEFORE IT MERGES — not before it is reviewed (stage-2-review-gate.md, "2a preconditions"; a
+    # base that merely ADVANCED no longer blocks a review, only a CONFLICT does).
+    #
+    # IT DECIDES NOTHING, and that is deliberate. No gate reads it: `merge-check.py` runs its OWN live probe
+    # at the merge, so the one decision that turns on base currency is made from a fresh reading rather than
+    # a remembered one. This field exists so `label-mirror.py` can PROJECT `gauntlet-rebase-pending` onto
+    # GitHub — it is display state, and a stale value costs a wrong label, never a wrong merge.
+    #
+    # SHA-bound exactly like `base_ok_sha` beside it: `apply_head_sha` voids it to `-` on a genuine head
+    # move (a rebase moves the head, so the old reading describes a commit that is no longer the tip), it has
+    # NO `set` door (`PREFLIGHT_OWNED`), and its writes are activity-EXEMPT. `-` makes NO claim in either
+    # direction, so a row nothing has probed yet wears no rebase label rather than a guessed one.
+    "base_current",
     # THE BASE THIS ROW MERGES INTO — the target `baseRefName` from live GitHub, written once at row
     # creation (`add-row --base-branch`; adoption records it). A run may hold rows on
     # DIFFERENT bases (`v3`, `main`), so the base is per-ROW, not per-run: the header `base_branch` is only
@@ -326,7 +342,7 @@ ROW_DEFAULTS = {
     "tier": "-", "attempts": "0", "started": "-", "api_approval": "-", "status": "pending",
     "ci_fingerprint": "-", "settled_strikes": "0", "unusable_refetches": "0",
     "ci_stalled_since": "-", "ci_reason": "-", "blocker_ruling": "-",
-    "review_rounds": "0", "ns_streak": "0", "base_ok_sha": "-",
+    "review_rounds": "0", "ns_streak": "0", "base_ok_sha": "-", "base_current": "-",
     "base_branch": "-", "required_set": "-", "intent": "-",
     "pr_origin": "external", "repair_count": "0", "repair_decision": "-",
 }
@@ -354,7 +370,8 @@ LIVENESS_COUNTERS = ("ci_fingerprint", "settled_strikes", "unusable_refetches", 
 #   * `base_ok_sha` — the base-preflight `proceed` stamp. Recording that the base is current for a head is a
 #     PRECONDITION being met, not the run advancing: `base-ok` writes it with `activity=False`, and this
 #     exemption is what guarantees a bare stamp cannot masquerade as activity and reset the quiet sensor.
-ACTIVITY_EXEMPT = frozenset(LIVENESS_COUNTERS + ("last_activity", "watchdog_due", "base_ok_sha"))
+ACTIVITY_EXEMPT = frozenset(
+    LIVENESS_COUNTERS + ("last_activity", "watchdog_due", "base_ok_sha", "base_current"))
 
 # THE HEADER FIELDS WITH NO HAND-WRITE DOOR — `header set <field>` is REFUSED for each, mapped to the exact
 # refusal message. Both are TOOL-STAMPED: `last_activity` by `save()`'s side effect on a real change,
@@ -396,13 +413,24 @@ VERDICT_OWNED = ("review_rounds", "ns_streak")
 # forever. The tool that decides a repair is the only thing that writes what it spent.
 REPAIR_OWNED = ("repair_count", "repair_decision")
 
-# The base-preflight stamp `base-ok` OWNS — settable through NO flag, the same mechanism as VERDICT_OWNED and
-# REPAIR_OWNED, for the same reason. `base_ok_sha` is the MECHANICAL base-currency precondition `verdict`
+# The base-preflight readings `base-ok` OWNS — settable through NO flag, the same mechanism as VERDICT_OWNED
+# and REPAIR_OWNED, for the same reason. `base_ok_sha` is the MECHANICAL base-currency precondition `verdict`
 # enforces (it refuses unless the stamp equals the row's head). A door that can hand-write it is a door that
-# can FORGE a `proceed` no base-preflight ever decided — recording a verdict over a conflicting or stale base,
+# can FORGE a `proceed` no base-preflight ever decided — recording a verdict over a conflicting base,
 # the exact waste this guard exists to stop. So there is no `--base-ok-sha` flag: `base-preflight.py check`
 # writes it, through `base-ok`, only when it actually decides `proceed`, and nothing else writes it at all.
-PREFLIGHT_OWNED = ("base_ok_sha",)
+#
+# `base_current` rides the SAME door for a DIFFERENT reason. It gates nothing, so nothing could be forged
+# with it; it is closed to `set` because it is a SENSOR READING — the answer to a Git ancestry probe — and a
+# hand-typed reading is exactly the forged-sensor failure `last_activity` and `review_rounds` are closed
+# against. Writing it beside `base_ok_sha`, in the one call, also keeps the two coherent: they describe the
+# same probe of the same head, and a door that could write one without the other would let them disagree.
+PREFLIGHT_OWNED = ("base_ok_sha", "base_current")
+
+# The CLOSED vocabulary `base-ok --base-current` accepts. The row's third value, `-` (its `ROW_DEFAULTS`
+# spelling for "no reading"), is deliberately ABSENT: `-` is what `apply_head_sha` writes when a head move
+# voids the old answer, and a `proceed` that reached the probe always has one of these two instead.
+BASE_CURRENT_VALUES = ("yes", "no")
 
 # The row fields that `add-row` may write ONCE, at row creation, and that `set` may NEVER change afterward.
 # `base_branch` is the target `baseRefName` recorded from live GitHub at adoption, and it is TOOL-OWNED: no
@@ -1070,7 +1098,7 @@ def guard_default_non_goals_change(header: dict, rows: "list[dict]", new_default
     So a broadening change is refused whenever any non-terminal PR holds credit (`prs_with_review_credit`);
     the operator resets those rows first (`set --pr N --reviews-ok 0`, re-opening them for a fresh review
     under the wider scope) and, in that same step, runs `label-mirror.py mirror` for each to restore its
-    `gauntlet-reviewing` label (a `reviews_ok`->0 reset owes the relabel; `stage-2-review-gate.md`), then
+    reviewing label (a `reviews_ok`->0 reset owes the relabel; `stage-2-review-gate.md`), then
     re-declares. The asymmetry is deliberate and load-bearing: ADDING a
     default NARROWS scope, under which banked credit stays valid, so an add is always allowed. This is ONE
     guard, not a per-pass versioning subsystem — the single-user operator resets and re-declares.
@@ -1094,7 +1122,7 @@ def guard_default_non_goals_change(header: dict, rows: "list[dict]", new_default
          f"with the now-in-scope area never reviewed. Reset each first "
          f"(`ledger.py set --pr <N> --reviews-ok 0`, re-opening it for a fresh review under the broadened "
          f"scope) AND, in that same step, run `label-mirror.py mirror --pr <N>` to restore its "
-         f"`gauntlet-reviewing` label; then re-run `header set default_non_goals`. The ledger is unchanged")
+         f"reviewing label; then re-run `header set default_non_goals`. The ledger is unchanged")
 
 
 # --- subcommands --------------------------------------------------------------
@@ -1278,27 +1306,28 @@ def cmd_add_row(path: Path, args) -> int:
 
 
 def apply_head_sha(row: dict, new_sha: str) -> None:
-    """Write `new_sha` to `row['head_sha']`, resetting THE LIVENESS COUNTERS and the base-preflight stamp
-    `base_ok_sha` on a genuine head MOVE.
+    """Write `new_sha` to `row['head_sha']`, resetting THE LIVENESS COUNTERS and both base-preflight
+    readings (`base_ok_sha`, `base_current`) on a genuine head MOVE.
 
     THE PROPERTY, enforced at the write door rather than by prose at each caller (stage-2-ci.md, "THE
     LIVENESS COUNTERS", reset-site class 1): a NEW `head_sha` is NEW evidence, so the old head's CI-liveness
     says nothing about it — and neither does a `proceed` decided for the old head. When `new_sha !=
-    row['head_sha']` this writes the head AND resets every `LIVENESS_COUNTERS` field, AND `base_ok_sha`, to its
-    `ROW_DEFAULTS` value — READ from the defaults, never retyped — mutating the SAME `row` dict, so the
-    caller's single `dump()` lands the head move and the reset in ONE atomic write. A SAME-VALUE write
-    (`new_sha == row['head_sha']`) is not a move and changes NOTHING.
+    row['head_sha']` this writes the head AND resets every `LIVENESS_COUNTERS` field, AND both
+    `PREFLIGHT_OWNED` readings, to its `ROW_DEFAULTS` value — READ from the defaults, never retyped —
+    mutating the SAME `row` dict, so the caller's single `dump()` lands the head move and the reset in ONE
+    atomic write. A SAME-VALUE write (`new_sha == row['head_sha']`) is not a move and changes NOTHING.
 
     The shape is validated with `SHA_RE` FIRST and REFUSED otherwise (40 lowercase hex): a value that cannot
     be a commit id has no business becoming a row's head, and refusing before any mutation keeps a bad
     `--head-sha` from resetting the counters.
 
     PRECEDENCE — an explicit counter flag in the SAME `set` call WINS over the automatic reset. This helper
-    resets `head_sha`, the liveness counters, AND `base_ok_sha`; `cmd_set` calls it and THEN applies the
-    remaining named updates, so an explicit liveness-counter flag is written AFTER the reset. `set --head-sha
-    <new> --settled-strikes 5` records 5, while every counter NOT named still resets to its default (pinned by
-    `t_head_sha_explicit_counter_wins`). This precedence concerns the liveness-counter flags ALONE:
-    `base_ok_sha` has no `set` door of its own, so it is reset here and can never be re-set in the same call.
+    resets `head_sha`, the liveness counters, AND the `PREFLIGHT_OWNED` readings; `cmd_set` calls it and THEN
+    applies the remaining named updates, so an explicit liveness-counter flag is written AFTER the reset.
+    `set --head-sha <new> --settled-strikes 5` records 5, while every counter NOT named still resets to its
+    default (pinned by `t_head_sha_explicit_counter_wins`). This precedence concerns the liveness-counter
+    flags ALONE: neither `PREFLIGHT_OWNED` field has a `set` door of its own, so both are reset here and
+    neither can be re-set in the same call.
     """
     if not SHA_RE.match(new_sha):
         fail(f"--head-sha {new_sha!r} is not a git object id (40 LOWERCASE hex) — a value that cannot be a "
@@ -1308,11 +1337,15 @@ def apply_head_sha(row: dict, new_sha: str) -> None:
     row["head_sha"] = new_sha
     for field in LIVENESS_COUNTERS:
         row[field] = ROW_DEFAULTS[field]  # fresh head, fresh budget — the value comes from ROW_DEFAULTS
-    # A new head is UNVERIFIED until a fresh base-preflight `proceed`: void the recorded proceed here too, so a
-    # `proceed` decided for the OLD head can never authorize a `verdict` on new content (the `base_ok_sha`
-    # field definition; `cmd_verdict`). Read from `ROW_DEFAULTS`, never a retyped literal, exactly like the
-    # counters above — a fresh-head `base_ok_sha` is its default `-`, which no 40-hex head equals.
-    row["base_ok_sha"] = ROW_DEFAULTS["base_ok_sha"]
+    # A new head is UNVERIFIED until a fresh base-preflight `proceed`: void BOTH recorded readings here too,
+    # so a `proceed` decided for the OLD head can never authorize a `verdict` on new content (the
+    # `base_ok_sha` field definition; `cmd_verdict`), and an ancestry answer about the OLD head can never
+    # label the new one (the `base_current` field definition — a rebase is precisely a head move that makes
+    # the previous `no` wrong). Read from `ROW_DEFAULTS`, never a retyped literal, exactly like the counters
+    # above — a fresh-head `base_ok_sha` is its default `-`, which no 40-hex head equals, and a fresh-head
+    # `base_current` is `-`, which makes no claim.
+    for field in PREFLIGHT_OWNED:
+        row[field] = ROW_DEFAULTS[field]
 
 
 def cmd_set(path: Path, args) -> int:
@@ -1472,14 +1505,20 @@ def cmd_verdict(path: Path, args) -> int:
 
 
 def cmd_base_ok(path: Path, args) -> int:
-    """Record a base-preflight `proceed` for the row's CURRENT head — the ONLY sanctioned writer of
-    `base_ok_sha`, and the MECHANICAL half of the rebase-before-review precondition.
+    """Record a base-preflight `proceed` for the row's CURRENT head — the ONLY sanctioned writer of the two
+    `PREFLIGHT_OWNED` readings, and the MECHANICAL half of the rebase-before-review precondition.
 
     `cmd_verdict` refuses unless `base_ok_sha == head_sha`; this is what makes that pass. It is written by
     `base-preflight.py check` when — and ONLY when — the decider reaches `proceed` for the live head, so the
     stamp is a BYPRODUCT of the check actually running, never a value a driver types in (there is no `set`
     flag: `PREFLIGHT_OWNED`). A forged stamp would authorize a verdict over a base no `proceed` ever cleared,
     which is the waste this guard exists to stop.
+
+    `--base-current` carries the OTHER half of the same probe: `yes` when the fetched base is an ancestor of
+    that head, `no` when it is not. It is REQUIRED, and its vocabulary is closed (`BASE_CURRENT_VALUES`),
+    because a `proceed` that forgot to say which it saw would leave the row claiming the previous head's
+    answer — and `-`, the "no reading" spelling, is deliberately NOT accepted here: a check that ran and
+    reached `proceed` always has an answer.
 
     Refusals, none of which write anything:
       * no row — `fail` (exit 1);
@@ -1489,7 +1528,7 @@ def cmd_base_ok(path: Path, args) -> int:
       * a `--head-sha` that is not the row's current head — a `proceed` is meaningful for the LIVE head only,
         so a stamp for any other SHA is refused (the same coherence rule `verdict` enforces).
 
-    The write is activity-EXEMPT (`base_ok_sha` is in `ACTIVITY_EXEMPT`): stamping a precondition is not the
+    The write is activity-EXEMPT (both fields are in `ACTIVITY_EXEMPT`): stamping a precondition is not the
     run doing meaningful work, exactly as re-arming the watchdog is not.
     """
     header, rows = load(path)
@@ -1506,6 +1545,7 @@ def cmd_base_ok(path: Path, args) -> int:
              f"clears the LIVE head only, so a stamp for any other SHA is refused. Reconcile the row against "
              f"`gh` and re-run base-preflight on the current tip")
     row["base_ok_sha"] = args.head_sha
+    row["base_current"] = args.base_current
     save(path, header, rows, activity=False)  # exempt: stamping a precondition is not meaningful activity
     print(json.dumps(row))
     return 0
@@ -2062,15 +2102,20 @@ def build_parser() -> argparse.ArgumentParser:
     v.add_argument("--verdict", required=True, choices=VERDICTS,
                    help="the reviewer's VERDICT line, as the orchestrator read it")
 
-    # The ONLY sanctioned writer of `base_ok_sha` — there is no `--base-ok-sha` flag at `set`/`add-row`
-    # (PREFLIGHT_OWNED). `base-preflight.py check` calls this on a real `proceed`; nothing else records it.
+    # The ONLY sanctioned writer of the two PREFLIGHT_OWNED readings — there is no `--base-ok-sha` or
+    # `--base-current` flag at `set`/`add-row`. `base-preflight.py check` calls this on a real `proceed`;
+    # nothing else records either field.
     b = sub.add_parser("base-ok", help="record a base-preflight `proceed` for the row's current head "
-                                       "(base_ok_sha) — the precondition `verdict` enforces; written only by "
-                                       "base-preflight.py on a real proceed, never hand-set")
+                                       "(base_ok_sha + base_current) — the precondition `verdict` enforces; "
+                                       "written only by base-preflight.py on a real proceed, never hand-set")
     b.add_argument("--pr", required=True, help="PR number (row key)")
     b.add_argument("--head-sha", dest="head_sha", required=True,
                    help="the head the `proceed` was decided for — must equal the row's head_sha, or the "
                         "stamp describes a base check for content that is not the live tip and is refused")
+    b.add_argument("--base-current", dest="base_current", required=True, choices=BASE_CURRENT_VALUES,
+                   help="what the ancestry probe saw for that head: `yes` if the fetched base is an "
+                        "ancestor of it, `no` if the base has advanced past it. Display state only — it "
+                        "projects the rebase-pending status label; no gate reads it")
 
     d = sub.add_parser("dispatch-check", help="may campaign ACT on this PR? run before every action that "
                                               f"MUTATES a PR; an ALLOW-LIST — exits {EXIT_STOP} unless the "

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -110,8 +110,8 @@ def t_adopt_same_repo():
     check(row["status"] == "in_review", "status initializes to in_review")
     check(row["reviews_ok"] == "0", "reviews_ok initializes to 0 (no verdicts yet)")
     check(row["pr_origin"] == "external", "pr_origin = the input")
-    check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing"],
-          "labels_add == [our owner label, gauntlet-reviewing]")
+    check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing 0/2"],
+          "labels_add == [our owner label, the ZERO tally for this tier]")
     check(p["worktree"] == str(Path("/wt") / "feat-x"), "worktree == worktrees_root / headRefName")
     check(p["base"] == "main", "base == baseRefName, carried under `base` for the executor to record per-row")
     # teeth: base/worktree/ownership flags are NOT in the PLAN row — the executor writes the row base_branch
@@ -123,7 +123,7 @@ def t_adopt_same_repo():
 
 
 def t_adopt_when_already_ours():
-    p = plan(labels=[lbl("gauntlet-run-g1"), lbl("gauntlet-reviewing")])
+    p = plan(labels=[lbl("gauntlet-run-g1"), lbl("gauntlet-reviewing 0/2")])
     check(p["verdict"] == "adopt", "a PR already carrying OUR run label re-adopts, never refuses")
     check(p["row"]["status"] == "in_review", "re-adoption still yields the computed row")
 
@@ -166,8 +166,8 @@ def t_cli_plan_adopts():
         check(p["verdict"] == "adopt", "`plan` prints the adopt verdict")
         check(p["row"]["tier"] == "HIGH", "the printed row carries the input tier")
         check(p["row"]["head_sha"] == "c" * 40, "the printed row's head_sha = headRefOid")
-        check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing"],
-              "the printed labels_add == [owner label, gauntlet-reviewing]")
+        check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing 0/2"],
+              "the printed labels_add == [owner label, the zero tally]")
 
 
 # --- pr_origin is DERIVED from labels, never a caller flag (fix 3) -------------
@@ -253,7 +253,7 @@ def _set_row(ledger: Path, pr, **fields) -> None:
 def _record_verdict(ledger: Path, pr, head_sha, verdict="satisfied") -> None:
     # `verdict` refuses unless a base-preflight `proceed` is on record for THIS head
     # (base_ok_sha == head_sha); stamp it first, exactly as the real flow does (base-preflight.py -> base-ok).
-    _ledger("--file", str(ledger), "base-ok", "--pr", str(pr), "--head-sha", head_sha)
+    _ledger("--file", str(ledger), "base-ok", "--pr", str(pr), "--head-sha", head_sha, "--base-current", "yes")
     _ledger("--file", str(ledger), "verdict", "--pr", str(pr), "--head-sha", head_sha, "--verdict", verdict)
 
 
@@ -410,7 +410,10 @@ def t_gh_scoped_to_project_root():
         code, _, err, rec = _adopt(d, ledger, view(), wroot=d / "wt")
         check(code == 0, f"adopt succeeds (got {code}: {err})")
         ghs = rec.gh_calls()
-        check(len(ghs) == 3, f"expected 3 gh calls (view, label create, pr edit); got {len(ghs)}")
+        # view, the run-owner label create, the gate label create, then the one pr edit. Every label this
+        # adoption ADDS is created first, and a fresh adoption adds exactly one gate label.
+        check(len(ghs) == 4,
+              f"expected 4 gh calls (view, run-label create, gate-label create, pr edit); got {len(ghs)}")
         for c in ghs:
             check(c["cwd"] == str(d),
                   f"every gh call must run in project-root {d}, not the invoking cwd; "
@@ -584,15 +587,18 @@ def t_readopt_accepted_unchanged_head_labels():
                  tier="HIGH")
         _record_verdict(ledger, 12, sha)
         _record_verdict(ledger, 12, sha)          # reviews_ok=2 == required(HIGH)
-        code, _, err, rec = _adopt(d, ledger, view(headRefOid=sha), wroot=wroot, worktree_head=sha,
+        # The PR is WEARING a stale tally, so the sweep has something real to take off. (The removal used to
+        # be unconditional, which meant no fixture ever proved the label was actually there.)
+        live = view(headRefOid=sha, labels=[lbl("gauntlet-run-g1"), lbl("gauntlet-reviewing 1/2")])
+        code, _, err, rec = _adopt(d, ledger, live, wroot=wroot, worktree_head=sha,
                                    checkouts=[(str(wt), "refs/heads/feat-x")])
         check(code == 0, f"accepted re-adopt succeeds (got {code}: {err})")
         e = rec.one("gh", "pr", "edit")
         check(e is not None, "a gh pr edit is issued")
         check(_labelset(e, "--add-label") == {"gauntlet-run-g1", "gauntlet-accepted"},
               f"an already-passed PR (gate met, unchanged head) ADDS run+accepted; got {e}")
-        check(_labelset(e, "--remove-label") == {"gauntlet-reviewing"},
-              f"and REMOVES the other status label in the same call; got {e}")
+        check(_labelset(e, "--remove-label") == {"gauntlet-reviewing 1/2"},
+              f"and REMOVES the stale tally in the same call; got {e}")
 
 
 def t_readopt_changed_head_labels():
@@ -605,11 +611,12 @@ def t_readopt_changed_head_labels():
         _add_row(ledger, 12, head_sha=old, tier="HIGH")
         _record_verdict(ledger, 12, old)
         _record_verdict(ledger, 12, old)          # was accepted at the OLD head
-        code, _, err, rec = _adopt(d, ledger, view(headRefOid=new), wroot=wroot, worktree_head=new)
+        live = view(headRefOid=new, labels=[lbl("gauntlet-accepted")])   # the label it earned at the OLD head
+        code, _, err, rec = _adopt(d, ledger, live, wroot=wroot, worktree_head=new)
         check(code == 0, f"changed-head re-adopt succeeds (got {code}: {err})")
         e = rec.one("gh", "pr", "edit")
-        check(_labelset(e, "--add-label") == {"gauntlet-run-g1", "gauntlet-reviewing"},
-              f"a moved head (reviews_ok reset) goes back under review; got {e}")
+        check(_labelset(e, "--add-label") == {"gauntlet-run-g1", "gauntlet-reviewing 0/2"},
+              f"a moved head (reviews_ok reset) goes back under review at a zero tally; got {e}")
         check(_labelset(e, "--remove-label") == {"gauntlet-accepted"},
               f"and the stale gauntlet-accepted is removed in the same call; got {e}")
 
@@ -1026,7 +1033,7 @@ def t_mixed_base_end_to_end():
             return {"number": number, "headRefName": branch, "headRefOid": head, "title": f"t{number}",
                     "baseRefName": base, "state": "OPEN", "mergeable": "MERGEABLE",
                     "mergeStateStatus": "CLEAN",
-                    "labels": [{"name": run_label}, {"name": M.REVIEWING_LABEL}]}
+                    "labels": [{"name": run_label}, {"name": "gauntlet-reviewing 0/2"}]}
 
         prs.write_text(json.dumps([entry(41, "fix-v3", "main", sha_v3),
                                    entry(52, "fix-main", "main", sha_main)]), encoding="utf-8")

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from _gauntlet import labels
 from _gauntlet.atomic import replace_text
 from _gauntlet.modules import load_sibling
 from _gauntlet.repository import repo_problem
@@ -54,17 +55,16 @@ _HERE = Path(__file__).resolve().parent
 SIBLING = _HERE / "pr-adopt-test.py"
 LEDGER_PY = _HERE / "ledger.py"
 
-# The run owner label's prefix and the two MUTUALLY EXCLUSIVE status labels. The owner label's colour
-# matches the one pr-adoption.md's `gh label create` uses, so an idempotent `--force` create never churns
-# it. A PR carries exactly ONE status label, mirroring the live review gate (pr-adoption.md, step 4).
-RUN_LABEL_PREFIX = "gauntlet-run-"
-REVIEWING_LABEL = "gauntlet-reviewing"
-ACCEPTED_LABEL = "gauntlet-accepted"
-RUN_LABEL_COLOR = "5319E7"
+# The label vocabulary is `_gauntlet/labels.py`'s — imported, never re-spelled. These names survive as the
+# spellings this module and its fixtures use; each one IS the shared owner's value, not a copy of it. A PR
+# carries exactly ONE gate label, mirroring the live review gate (pr-adoption.md, step 4), and its NAME
+# carries the tally, so adoption computes it from the row rather than naming a fixed label.
+RUN_LABEL_PREFIX = labels.RUN_PREFIX
+RUN_LABEL_COLOR = labels.RUN_COLOR
 
 # The label that marks a PR as authored by this pipeline (gauntlet:review's handoff applies it to every PR
 # it opens). It is the ONLY thing that makes `pr_origin` = `gauntlet`; a driver cannot assert it by flag.
-GAUNTLET_AUTHORED_LABEL = "gauntlet-authored"
+GAUNTLET_AUTHORED_LABEL = labels.AUTHORED
 
 BASE_RETARGET_PY = _HERE / "base-retarget.py"   # the ONE decider of what a live base divergence means
 
@@ -198,7 +198,11 @@ def build_plan(view: dict, *, run_id: str, tier: str, worktrees_root: str) -> di
     return {
         "verdict": "adopt",
         "row": row,
-        "labels_add": [ours, REVIEWING_LABEL],
+        # A fresh adoption has NO verdicts yet, so its gate label is the zero tally for this tier — a name
+        # the shared vocabulary computes (`labels.gate_label`), never a fixed `gauntlet-reviewing` that
+        # would be wrong the moment the tally is spelled into it. The executor recomputes the label from the
+        # LIVE row at step 6, because a re-adoption may preserve verdicts this plan knows nothing about.
+        "labels_add": [ours, labels.gate_label(0, RP.required_reviews(tier))],
         "branch": branch,
         "worktree": str(Path(worktrees_root) / branch),
         "base": view["baseRefName"],
@@ -556,18 +560,33 @@ def cmd_adopt(args) -> int:
     if proc.returncode != 0:
         return _refuse(f"ledger set of worktree fields for PR {pr} failed: {proc.stderr.strip()}")
 
-    # 6. Label it ours and set the ONE status label from the LIVE gate. The two status labels are mutually
-    # exclusive, so whichever we apply, we remove the other IN THE SAME CALL. `gauntlet-accepted` only when
-    # the (preserved-or-reset) gate is met at THIS head — reviews_ok >= required(tier); otherwise it is
-    # under review. A fresh adoption and a head change both reset reviews_ok to 0, so they read as reviewing.
+    # 6. Label it ours and set the status labels from the LIVE row. `gauntlet-accepted` only when the
+    # (preserved-or-reset) gate is met at THIS head — reviews_ok >= required(tier); otherwise the tallied
+    # reviewing name for what stands. A fresh adoption and a head change both reset reviews_ok to 0, so they
+    # read as `0/<required>`. Whatever the gate says, every OTHER status label the PR wears comes off in the
+    # SAME call: a stale tally, a stale `gauntlet-accepted`, or the legacy bare `gauntlet-reviewing` from a
+    # run that predates the tally. The sweep is `labels.reconcile`'s to compute, so it can never take off the
+    # run-owner label it is being handed alongside.
     final = L.find_row(L.load(Path(args.file))[1], pr) or {}
     reviews_ok = int(final.get("reviews_ok", "0") or "0")
     tier_now = final.get("tier", str(row["tier"]))
-    gate_met = reviews_ok >= RP.required_reviews(tier_now)
-    status_label = ACCEPTED_LABEL if gate_met else REVIEWING_LABEL
-    other_label = REVIEWING_LABEL if gate_met else ACCEPTED_LABEL
-    edit_argv = ["gh", "pr", "edit", pr, "--add-label", run_label,
-                 "--add-label", status_label, "--remove-label", other_label]
+    desired = labels.desired_labels(reviews_ok, RP.required_reviews(tier_now),
+                                    rebase_pending=final.get("base_current") == "no")
+    current = [n.get("name") for n in (view.get("labels") or []) if isinstance(n, dict)]
+    to_add, to_remove = labels.reconcile([n for n in current if isinstance(n, str)], desired)
+    # CREATE BEFORE ADD: `gh pr edit --add-label` fails outright on a label the repository does not have, and
+    # a tallied name is one no bootstrap list could have known to create in advance.
+    for name in to_add:
+        create_argv = labels.create_argv(name, args.repo)
+        proc = _run(create_argv, cwd=gh_cwd)
+        if proc.returncode != 0:
+            return _refuse(f"`gh label create {name}` for PR {pr} failed: {proc.stderr.strip()} "
+                           f"(the ledger row and worktree for PR {pr} were already written)")
+    edit_argv = ["gh", "pr", "edit", pr, "--add-label", run_label]
+    for name in to_add:
+        edit_argv += ["--add-label", name]
+    for name in to_remove:
+        edit_argv += ["--remove-label", name]
     if args.repo:
         edit_argv += ["--repo", args.repo]
     proc = _run(edit_argv, cwd=gh_cwd)
@@ -593,8 +612,8 @@ def cmd_adopt(args) -> int:
         "row_written": True,
         "worktree": worktree,
         "worktree_owned": worktree_owned,
-        "labels_added": [run_label, status_label],
-        "label_removed": other_label,
+        "labels_added": [run_label, *to_add],
+        "labels_removed": to_remove,
         "intent_sync": intent_sync,
     }))
     return 0

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile-test.py
@@ -39,8 +39,9 @@ LED = M.L                                   # the ledger schema owner reconcile 
 
 RUN_ID = "grec-0001"
 RUN_LABEL = M.RUN_LABEL_PREFIX + RUN_ID
-REVIEWING = M.REVIEWING_LABEL
-ACCEPTED = M.ACCEPTED_LABEL
+REVIEWING = "gauntlet-reviewing 0/2"        # a tallied gate label, the shape every live PR now wears
+ACCEPTED = "gauntlet-accepted"
+REBASE_PENDING = M.REBASE_PENDING_LABEL
 SHA_A = "a" * 40
 SHA_B = "b" * 40
 
@@ -441,7 +442,7 @@ def t_all_quiet():
     check(res["rows"]["41"] == {
         "absent_from_snapshot": False, "state": "OPEN", "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",
-        "label_facts": {REVIEWING: True, ACCEPTED: False},
+        "label_facts": {"status_labels": [REVIEWING], REBASE_PENDING: False},
     }, f"a quiet present row must carry ONLY the neutral observations, got {res['rows']['41']!r}")
     check(res["unadopted"] == [], f"nothing unadopted, got {res['unadopted']!r}")
     check(res["counts"] == {
@@ -530,7 +531,7 @@ def t_all_three_changes_together():
         "base_changed": {"ledger": "main", "snapshot": "develop"},
         "branch_mismatch": {"ledger": "b1", "snapshot": "b2"},
         "state": "OPEN", "mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY",
-        "label_facts": {REVIEWING: True, ACCEPTED: False},
+        "label_facts": {"status_labels": [REVIEWING], REBASE_PENDING: False},
     }, f"combined-change facts drifted, got {facts!r}")
 
 
@@ -553,23 +554,35 @@ def t_label_drift_reported_not_judged():
     code, res, err = scenario([row(41)], [entry(41, label_names=[RUN_LABEL, ACCEPTED])])
     check(code == 0, f"exit 0, got {code} (stderr {err!r})")
     facts = res["rows"]["41"]
-    check(facts["label_facts"] == {REVIEWING: False, ACCEPTED: True},
+    check(facts["label_facts"] == {"status_labels": [ACCEPTED], REBASE_PENDING: False},
           f"label_facts must mirror the snapshot labels, got {facts['label_facts']!r}")
     check(set(facts) == {"absent_from_snapshot", "state", "mergeable", "mergeStateStatus", "label_facts"},
           f"a label mismatch must add NO judgment key — keys were {sorted(facts)!r}")
 
 
 def t_both_status_labels_reported():
+    """A missed swap leaves a PR wearing two gate labels at once — the list reports BOTH, in snapshot order.
+    A boolean per fixed name could not have said this once the reviewing name carries a tally."""
     _c, res, _e = scenario([row(41)], [entry(41, label_names=[RUN_LABEL, REVIEWING, ACCEPTED])])
-    check(res["rows"]["41"]["label_facts"] == {REVIEWING: True, ACCEPTED: True},
-          f"a PR wearing BOTH status labels reports both true, got {res['rows']['41']['label_facts']!r}")
+    check(res["rows"]["41"]["label_facts"] == {"status_labels": [REVIEWING, ACCEPTED],
+                                               REBASE_PENDING: False},
+          f"a PR wearing BOTH status labels reports both, got {res['rows']['41']['label_facts']!r}")
 
 
 def t_neither_status_label_reported():
     code, res, err = scenario([row(41)], [entry(41, label_names=[RUN_LABEL])])
     check(code == 0, f"exit 0, got {code} (stderr {err!r})")
-    check(res["rows"]["41"]["label_facts"] == {REVIEWING: False, ACCEPTED: False},
-          f"neither status label -> both false, got {res['rows']['41']['label_facts']!r}")
+    check(res["rows"]["41"]["label_facts"] == {"status_labels": [], REBASE_PENDING: False},
+          f"no status label -> an empty list, got {res['rows']['41']['label_facts']!r}")
+
+
+def t_rebase_pending_reported_on_its_own_axis():
+    """`gauntlet-rebase-pending` is base-currency state, not gate state, so it is reported separately AND
+    appears in the swept set — an accepted PR waiting its turn in the drain wears both."""
+    _c, res, _e = scenario([row(41)], [entry(41, label_names=[RUN_LABEL, ACCEPTED, REBASE_PENDING])])
+    check(res["rows"]["41"]["label_facts"] == {"status_labels": [ACCEPTED, REBASE_PENDING],
+                                               REBASE_PENDING: True},
+          f"the rebase label must be reported on both axes, got {res['rows']['41']['label_facts']!r}")
 
 
 # --- unadopted ----------------------------------------------------------------
@@ -775,6 +788,8 @@ CASES = [
      t_all_three_changes_together),
     ("verbatim-github-fields", "state/mergeable/mergeStateStatus pass through unjudged",
      t_state_and_merge_fields_verbatim),
+    ("rebase-pending-axis", "gauntlet-rebase-pending is reported on its own axis and in the swept set",
+     t_rebase_pending_reported_on_its_own_axis),
     ("label-drift", "accepted shown while reviewing expected -> label_facts, NO judgment key",
      t_label_drift_reported_not_judged),
     ("both-status-labels", "a PR wearing both status labels -> both true", t_both_status_labels_reported),

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -64,6 +64,7 @@ import tempfile
 from pathlib import Path
 from typing import Callable
 
+from _gauntlet import labels
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
 
@@ -88,12 +89,11 @@ CANONICAL_FIELDS: tuple[str, ...] = (
 SNAPSHOT_LIMIT = 1000
 SNAPSHOT_STATE = "open"
 
-# The run-owner label prefix (`gauntlet-run-<run-id>`) and the two mutually-exclusive status labels whose
-# presence reconcile REPORTS (never judges). These mirror `pr-adopt.py`/loop-control.md; the labels are a
-# tiny, stable vocabulary, reported verbatim.
-RUN_LABEL_PREFIX = "gauntlet-run-"
-REVIEWING_LABEL = "gauntlet-reviewing"
-ACCEPTED_LABEL = "gauntlet-accepted"
+# The run-owner label prefix (`gauntlet-run-<run-id>`), from the shared vocabulary owner. The status labels
+# reconcile REPORTS (never judges) are whatever `labels.is_status_label` claims — a SET, not a fixed pair,
+# because a reviewing label now carries its own tally and there is no finite list to retype here.
+RUN_LABEL_PREFIX = labels.RUN_PREFIX
+REBASE_PENDING_LABEL = labels.REBASE_PENDING
 
 # The two TERMINAL row statuses. A terminal row is DONE and reconcile does not compare it against the
 # snapshot at all (see `detect`). The status taxonomy is owned by `references/files-and-ledger.md`,
@@ -401,9 +401,13 @@ def _facts_for_present_row(row: dict, effective_base: str, entry: dict) -> dict:
     facts["state"] = entry["state"]
     facts["mergeable"] = entry["mergeable"]
     facts["mergeStateStatus"] = entry["mergeStateStatus"]
+    # The status labels the PR is WEARING, verbatim and in the order GitHub returned them, plus the
+    # base-currency flag on its own. A tallied reviewing name has no fixed spelling to key a boolean on, so
+    # the fact is the LIST — which also reports the pathological cases a boolean pair could not, such as a
+    # PR wearing two different tallies at once after a missed swap.
     facts["label_facts"] = {
-        REVIEWING_LABEL: REVIEWING_LABEL in entry["label_names"],
-        ACCEPTED_LABEL: ACCEPTED_LABEL in entry["label_names"],
+        "status_labels": [n for n in entry["label_names"] if labels.is_status_label(n)],
+        REBASE_PENDING_LABEL: REBASE_PENDING_LABEL in entry["label_names"],
     }
     return facts
 

--- a/plugins/gauntlet/skills/review/SKILL.md
+++ b/plugins/gauntlet/skills/review/SKILL.md
@@ -432,8 +432,9 @@ or **Adjusted** finding only (skip Refuted and Uncertain), in its own branch off
    trigger, impact, and fix. Do **NOT** apply any `gauntlet-run-*` owner label — review does not know
    a campaign run-id, and pre-labelling with a fabricated run-id would make campaign's adoption refuse
    the PR (pr-adoption rejects a PR already owned by a *different* run). Leave each PR with **no
-   run-owner label**; a neutral `gauntlet-reviewing` status label is fine but is not required. Create
-   the status label with `gh label create` if you apply it and the repo lacks it.
+   run-owner label**, and apply **no status label either**: a gate label carries the PR's verdict tally
+   (`campaign/references/stage-2-review-gate.md`, "Status labels mirror the review gate"), which review has
+   not run and cannot know. Campaign applies the right one at adoption, creating it if the repo lacks it.
 
    **DO apply the `gauntlet-authored` label to every PR you open here** (`gh label create
    gauntlet-authored --force`, then `gh pr create … --label gauntlet-authored`). It is not a status and it


### PR DESCRIPTION
- Only the PR at the merge front rebases; an advanced base no longer blocks a review.
- Status labels carry the tally, plus a rebase-pending label for a PR queued behind another.
- The merge gate still proves base ancestry live, so no PR merges over a base it lacks.
