### PR TITLE
fix historical audit validation

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/repair-pass.md
+++ b/plugins/gauntlet/skills/campaign/references/repair-pass.md
@@ -167,7 +167,8 @@ Use this fail-closed procedure:
 3. Use only that final round's `findings` artifact. Require `present = true`; require SHA-256 of its embedded
    UTF-8 `content` to equal its `sha256`; require its `path` to be the active findings path derived from the
    final round's progress artifact; and validate each JSONL row through the historical, non-re-anchoring
-   schema path owned by `review-pass.py`'s `load_historical_findings`. If the active findings file still
+   schema path owned by `review-pass.py`'s `load_historical_findings`. Validate each historical audit through
+   `finding-audit.py`'s full historical schema validator, which skips only current-intent re-anchoring. If the active findings file still
    exists, its bytes must equal the embedded content. If it is absent, the validated embedded content is the
    bundle-bound source of truth.
 4. Record one follow-up for every row in that recovered final-cap list, leave every row unfixed, and use the

--- a/plugins/gauntlet/skills/campaign/scripts/finding-audit.py
+++ b/plugins/gauntlet/skills/campaign/scripts/finding-audit.py
@@ -415,6 +415,16 @@ def check_landed_audit_complete(text: str, path: Path) -> None:
         )
 
 
+def check_historical_audit_complete(text: str, path: Path) -> None:
+    """Validate a LANDED audit through the full schema without current-intent re-anchoring.
+
+    Historical audit evidence keeps the source digest, gating IDs, result rows, standoff rows, and
+    completeness checks from ``validate_audit``. Only current-intent re-anchoring is skipped by reading
+    source findings through ``read_source_historical``.
+    """
+    validate_audit(text, path, require_complete=True, historical=True)
+
+
 def _replace(path: Path, text: str) -> None:
     try:
         replace_text(path, text, temp_prefix=f".{path.name}.", encoding="utf-8")

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass-test.py
@@ -1092,7 +1092,7 @@ def t_bundle_refuses_a_header_only_audit(tmp: Path) -> None:
     `finding-audit.py init` writes the header and zero `audit_result` rows. Those bytes are well-formed
     JSONL with a valid header, so `parse_lines` alone would embed them as `present: True` indistinguishably
     from a complete audit — the one landed artifact re-validated only for well-formedness. The bundle now
-    also runs finding-audit.py's header-internal completeness check, so a round whose header names gating
+    also runs finding-audit.py's historical full-schema validator, so a round whose header names gating
     findings but records no result for them fails closed. (Red before the fix: the header-only audit passed
     as complete and the bundle succeeded.)
     """
@@ -1111,15 +1111,14 @@ def t_bundle_refuses_a_header_only_audit(tmp: Path) -> None:
           "a refused bundle must leave no output")
 
 
-def t_bundle_audit_completeness_is_header_internal(tmp: Path) -> None:
-    """The bundle's audit COMPLETENESS check reads only the audit's own header — it NEVER re-anchors.
+def t_bundle_audit_historical_schema_does_not_re_anchor(tmp: Path) -> None:
+    """The bundle's historical audit schema skips current-intent re-anchoring, but validates all rows.
 
     A COMPLETE audit whose source purpose was later dropped from `intent-<pr>.md` must still validate as
     complete, exactly as `t_bundle_audit_read_does_not_re_anchor` requires of the whole bundle. If the new
-    completeness check went through finding-audit.py's re-anchoring door (`verify`/`load_audit`), it would
+    completeness check went through finding-audit.py's current-intent door (`verify`/`load_audit`), it would
     re-read the round's source findings, fail to anchor the dropped purpose, reject the audit, and WEDGE the
-    bundle. This pins that the check stays header-internal: `verify` rejects the same audit, the
-    header-internal check accepts it.
+    bundle. The historical full-schema check accepts the valid audit while retaining its source and row validation.
     """
     case = bundle_setup(tmp, rounds=2, origin="external")  # round 1 non-cap with a REAL complete audit
     audit_path = case["rundir"] / "audit-1-1.jsonl"
@@ -1138,11 +1137,45 @@ def t_bundle_audit_completeness_is_header_internal(tmp: Path) -> None:
     code_v, _, err_v = capture_cli(FA.main, ["verify", "--file", str(audit_path)])
     check(code_v == 1 and "Purpose" in err_v,
           f"the re-anchoring door unexpectedly accepted the post-repair audit — the contrast is moot: {err_v!r}")
-    # The header-internal completeness check reads only the audit's own bytes, so the complete audit passes.
+    # The historical full-schema check uses the landed source purpose, so the complete audit passes.
     try:
-        FA.check_landed_audit_complete(text, audit_path)
+        FA.check_historical_audit_complete(text, audit_path)
     except FA.AuditError as exc:
-        check(False, f"the completeness check re-anchored or mis-read a complete historical audit: {exc}")
+        check(False, f"the historical schema check re-anchored or mis-read a complete audit: {exc}")
+
+
+def t_bundle_refuses_invalid_historical_audit_rows(tmp: Path) -> None:
+    """Historical audits reject malformed verdict, evidence, duplicate, and standoff rows."""
+    variants = {
+        "invalid-verdict": lambda rows: {**json.loads(rows[1]), "verdict": "NOT-A-VERDICT"},
+        "missing-evidence": lambda rows: {**json.loads(rows[1]), "evidence": ""},
+        "duplicate-id": lambda rows: json.loads(rows[1]),
+        "invalid-standoff": lambda rows: {
+            "type": FA.STANDOFF,
+            "finding_id": json.loads(rows[1])["finding_id"],
+            "ruling": "valid",
+            "counter": "the counter",
+            "evidence": "the evidence",
+        },
+    }
+    for name, mutate in variants.items():
+        case = bundle_setup(tmp / name, rounds=2)
+        audit_path = case["rundir"] / "audit-1-1.jsonl"
+        rows = audit_path.read_text().splitlines()
+        changed = mutate(rows)
+        audit_rows = [rows[0], json.dumps(changed)]
+        if name == "duplicate-id":
+            audit_rows.append(json.dumps(changed))
+        elif name == "invalid-standoff":
+            audit_rows = [rows[0], rows[1], json.dumps(changed)]
+        audit_path.write_text("\n".join(audit_rows) + "\n")
+
+        output = case["rundir"] / "bundle.txt"
+        code, _, err = run_bundle(case, output)
+        check(code == 1 and "finding audit is unusable" in err,
+              f"{name} historical audit row was accepted: {err!r}")
+        check(not output.exists() and not R.bundle_manifest_path(output).exists(),
+              f"{name} left bundle output after refusal")
 
 
 def t_bundle_refuses_a_cap_round_with_no_gating_finding(tmp: Path) -> None:
@@ -1747,7 +1780,8 @@ CASES = [
     ("bundle-prior-cap", "a second cap builds; every earlier cap round's absent audit is exempt", t_bundle_exempts_every_prior_cap_round),
     ("bundle-audit-no-re-anchor", "a historical audit reads back after the intent is re-authored (no re-anchor)", t_bundle_audit_read_does_not_re_anchor),
     ("bundle-audit-header-only", "a header-only (incomplete) audit is refused, not embedded as present", t_bundle_refuses_a_header_only_audit),
-    ("bundle-audit-complete-header-internal", "the completeness check is header-internal, never re-anchoring", t_bundle_audit_completeness_is_header_internal),
+    ("bundle-audit-historical-schema", "the historical audit schema skips current-intent re-anchoring", t_bundle_audit_historical_schema_does_not_re_anchor),
+    ("bundle-audit-invalid-rows", "historical audits reject invalid verdict, evidence, duplicate, and standoff rows", t_bundle_refuses_invalid_historical_audit_rows),
     ("bundle-cap-needs-finding", "a cap round with no gating finding is unusable history and refused", t_bundle_refuses_a_cap_round_with_no_gating_finding),
     ("bundle-report-needs-verdict", "a report that is not one valid record fails closed through parse_report", t_bundle_refuses_a_report_with_no_verdict),
     ("bundle-base-sha-pinned", "the base is pinned to one SHA before any read; a racing fetch cannot mix bases", t_bundle_pins_base_sha_against_a_racing_fetch),

--- a/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/repair-pass.py
@@ -95,7 +95,7 @@ RP = load_review_pass()
 
 
 def load_finding_audit():
-    """Load `finding-audit.py` BY PATH — it owns the audit schema and its header-internal completeness check.
+    """Load `finding-audit.py` BY PATH — it owns the audit schema and historical validation.
 
     Same reason as the loaders above: the cwd is the driver's worktree, the schema owner lives with the
     installed plugin. The bundle validates a landed audit's COMPLETENESS through this owner, never by
@@ -526,30 +526,11 @@ def collect_rounds(rundir: Path, pr: str, expected_rounds: int) -> "tuple[list[d
                  f"the ledger or artifacts")
         if audit_file.exists():
             audit_text = read_utf8(audit_file, "finding audit")
-            # A landed round's finding audit is HISTORICAL EVIDENCE embedded for the reassessment worker —
-            # NOT re-judged against the current intent. Read it structurally symmetric with the findings read
-            # in `review-pass.py load_historical_findings` right above, through the SAME non-re-anchoring rule:
-            # review-pass.py's
-            # `parse_lines` proves the JSONL is well-formed and loads NO intent. NEVER read the audit through
-            # finding-audit.py's own door (`verify` / `load_audit`), which re-reads the round's source findings
-            # and re-anchors their `purpose` strings to the CURRENT `intent-<pr>.md`. After a REPAIR-INTENT
-            # re-authors that intent and drops a purpose an earlier round anchored to, that door would reject
-            # the round's audit and WEDGE the bundle — the same break `review-pass.py load_historical_findings` and
-            # `t_bundle_exempts_every_prior_cap_round` exist to prevent, on the audit's side.
-            #
-            # Well-formedness alone is NOT soundness: a HEADER-ONLY audit (`finding-audit.py init` with zero
-            # `record` calls) parses cleanly yet has no `audit_result` rows, so `parse_lines` would embed it
-            # as present indistinguishably from a complete one — the one landed artifact re-validated only for
-            # well-formedness while every other soundness gap here fails closed. So ALSO run finding-audit.py's
-            # HEADER-INTERNAL completeness check (`check_landed_audit_complete`): it reads only the audit's own
-            # header and rows — no source findings, no intent — so it stays on the same non-re-anchoring door,
-            # and it REFUSES an incomplete audit rather than embedding it as sound history.
+            # A landed round's finding audit is HISTORICAL EVIDENCE embedded for the reassessment worker.
+            # The historical full-schema validator skips only current-intent re-anchoring while retaining
+            # source binding, result validation, standoff validation, and completeness checks.
             try:
-                RP.parse_lines(audit_text, audit_file.name)
-            except RP.Defect as exc:
-                fail(f"pr {pr} review round {round_no} finding audit is unusable: {exc}")
-            try:
-                FA.check_landed_audit_complete(audit_text, audit_file)
+                FA.check_historical_audit_complete(audit_text, audit_file)
             except FA.AuditError as exc:
                 fail(f"pr {pr} review round {round_no} finding audit is unusable: {exc}")
             audit_artifact = artifact(audit_file, audit_text)


### PR DESCRIPTION
- API-1 trigger/impact: malformed verdicts, evidence, duplicate IDs, and standoff rows passed historical bundles.
- Fix: repair-pass uses finding-audit.py's historical full-schema validator; only intent re-anchoring is skipped.
- Tests: focused self-tests, py_compile, and validate-plugins.sh. Untouched: live validation and header-only helper.
