### PR TITLE
fix malformed PR view refusal

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -214,6 +214,10 @@ def t_cli_plan_refuses_malformed_views():
         ({**view(), "labels": {"name": "x"}}, "field 'labels' must be a list, got dict"),
         ({**view(), "labels": [{"name": 7}]},
          "field 'labels' must hold string names, got int"),
+        # A bare-string label is a shape `gh pr view --json labels` never emits; adoption refuses it
+        # rather than reading it as a usable name (the rule `_repository_problem` already applies).
+        ({**view(), "labels": ["gauntlet-authored"]},
+         "field 'labels' must hold objects, got str"),
         ({**view(), "headRepositoryOwner": []},
          "field 'headRepositoryOwner' must be an object, got list"),
         ({**view(), "headRepository": {"name": 7}},

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -175,7 +175,7 @@ def t_slugify():
 
 # --- the `plan` CLI (the testable surface) ------------------------------------
 
-def _write_view(d: str, v: dict) -> str:
+def _write_view(d: str, v: object) -> str:
     f = Path(d) / "view.json"
     f.write_text(json.dumps(v), encoding="utf-8")
     return str(f)
@@ -202,6 +202,33 @@ def t_cli_plan_adopts():
         check(p["row"]["head_sha"] == "c" * 40, "the printed row's head_sha = headRefOid")
         check(p["labels_add"] == ["gauntlet-run-g1", "gauntlet-reviewing 0/2"],
               "the printed labels_add == [owner label, the zero tally]")
+
+
+def t_cli_plan_refuses_malformed_views():
+    """Malformed decoded GitHub views produce the normal pure-plan refusal instead of a traceback."""
+    cases = (
+        (["not an object"], "view is not a JSON object (got list)"),
+        ({k: v for k, v in view().items() if k != "number"}, "missing field 'number'"),
+        ({**view(), "number": True}, "field 'number' must be an integer, got bool"),
+        ({k: v for k, v in view().items() if k != "headRefName"}, "missing field 'headRefName'"),
+        ({**view(), "labels": {"name": "x"}}, "field 'labels' must be a list, got dict"),
+        ({**view(), "labels": [{"name": 7}]},
+         "field 'labels' must hold string names, got int"),
+        ({**view(), "headRepositoryOwner": []},
+         "field 'headRepositoryOwner' must be an object, got list"),
+        ({**view(), "headRepository": {"name": 7}},
+         "field headRepository.name must be a string, got int"),
+    )
+    for malformed, detail in cases:
+        with tempfile.TemporaryDirectory() as d:
+            f = _write_view(d, malformed)
+            code, out, err = capture_cli(
+                M.main, ["plan", "--view-json", f, "--run-id", "g1", "--tier", "HIGH"])
+            check(code == 0, f"malformed view {detail!r} must use the plan command's normal exit code")
+            check(err == "", f"malformed view {detail!r} must not print a traceback: {err!r}")
+            p = json.loads(out)
+            check(p == {"verdict": "refuse", "reason": f"malformed GitHub PR view: {detail}"},
+                  f"malformed view {detail!r} must produce the normal refusal result, got {p!r}")
 
 
 # --- pr_origin is DERIVED from labels, never a caller flag (fix 3) -------------
@@ -454,6 +481,24 @@ def t_view_omits_body():
         expected = {"number", "title", "headRefName", "headRefOid", "baseRefName", "labels", "state",
                     "isCrossRepository", "headRepositoryOwner", "headRepository"}
         check(fields == expected, f"the view field set must be exactly the decision metadata; got {sorted(fields)}")
+
+
+def t_adopt_refuses_malformed_view_before_mutation():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        malformed = view()
+        del malformed["title"]
+        code, out, err, rec = _adopt(d, ledger, malformed, wroot=d / "wt")
+        check(code != 0, "adoption must refuse a malformed GitHub view")
+        check(out == "", f"a malformed view refusal must not print an adoption result: {out!r}")
+        check(err.strip() == "pr-adopt: REFUSED — malformed GitHub PR view: missing field 'title'",
+              f"the malformed view must use the normal refusal result, got {err!r}")
+        check([c["argv"][:3] for c in rec.gh_calls()] == [["gh", "pr", "view"]],
+              f"a malformed view must stop after the GitHub read, got {rec.gh_calls()!r}")
+        check(not rec.any_call(lambda a: a[0] == "python3"),
+              "a malformed view must not write the ledger")
 
 
 # --- fix 2: every gh command is scoped to project-root ------------------------
@@ -1468,9 +1513,11 @@ CASES = [
     ("slugify", "slugify yields a lowercase, dash-collapsed, untrimmed-dash-free slug", t_slugify),
     ("cli_plan_refuses_fork", "the plan CLI prints a refuse verdict and exits 0", t_cli_plan_refuses_fork),
     ("cli_plan_adopts", "the plan CLI prints an adopt verdict and exits 0", t_cli_plan_adopts),
+    ("cli_plan_refuses_malformed_views", "malformed decoded GitHub views produce normal plan refusals", t_cli_plan_refuses_malformed_views),
     ("pr_origin_from_label", "pr_origin is DERIVED from the gauntlet-authored label (fix 3)", t_pr_origin_from_label),
     ("driver_cannot_assert_origin", "the --pr-origin flag is gone; a driver cannot claim gauntlet (fix 3)", t_driver_cannot_assert_origin),
     ("view_omits_body", "`gh pr view` requests metadata only, never body (fix 1)", t_view_omits_body),
+    ("adopt_refuses_malformed_view", "adoption refuses malformed GitHub metadata before mutation (API-2)", t_adopt_refuses_malformed_view_before_mutation),
     ("gh_scoped_to_project_root", "every gh command runs in project-root (fix 2)", t_gh_scoped_to_project_root),
     ("process_start_failure_refused", "process-start errors use the adoption refusal contract", t_process_start_failure_refused),
     ("readopt_preserves_ownership", "re-adopting the same worktree keeps created-ownership (fix 4)", t_readopt_preserves_ownership),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -42,6 +42,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import cast
 
 from _gauntlet import labels
 from _gauntlet.atomic import replace_text
@@ -49,6 +50,7 @@ from _gauntlet.git_refs import branch_problem
 from _gauntlet.modules import load_sibling
 from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
+from _gauntlet.view import field_problem
 
 DESCRIPTION = next(iter((__doc__ or "").splitlines()), "")
 
@@ -90,6 +92,66 @@ LIVENESS_COUNTERS = L.LIVENESS_COUNTERS
 # release a park the evidence has answered, so a second spelling here would silently stop that release from
 # recognising the park this tool opened. Search `not supported mid-run` to reach every site.
 BASE_CHANGE_PARK_REASON = L.BASE_CHANGE_PARK_REASON
+
+# The GitHub boundary returns exactly the metadata requested below. `build_plan` consumes every field in the
+# view, so validate the complete shape before any decision branch can dereference it.
+VIEW_FIELDS = (
+    "number,title,headRefName,headRefOid,baseRefName,labels,state,"
+    "isCrossRepository,headRepositoryOwner,headRepository"
+)
+_VIEW_STR_FIELDS = ("title", "headRefName", "headRefOid", "baseRefName", "state")
+
+
+def _labels_problem(view: dict) -> "str | None":
+    """Return the first malformed label shape, or None when every label has a usable string name."""
+    if "labels" not in view:
+        return "missing field 'labels'"
+    raw = view["labels"]
+    if not isinstance(raw, list):
+        return f"field 'labels' must be a list, got {type(raw).__name__}"
+    for item in raw:
+        if isinstance(item, dict):
+            if "name" not in item:
+                return "field 'labels' contains an object without a 'name'"
+            name = item["name"]
+        else:
+            name = item
+        if not isinstance(name, str):
+            return f"field 'labels' must hold string names, got {type(name).__name__}"
+    return None
+
+
+def _repository_problem(view: dict, field: str, child: str) -> "str | None":
+    if field not in view:
+        return f"missing field {field!r}"
+    value = view[field]
+    if not isinstance(value, dict):
+        return f"field {field!r} must be an object, got {type(value).__name__}"
+    if child not in value:
+        return f"missing field {field}.{child}"
+    if not isinstance(value[child], str):
+        return f"field {field}.{child} must be a string, got {type(value[child]).__name__}"
+    return None
+
+
+def validate_view(view: object) -> "str | None":
+    """Return None for a complete `gh pr view` payload, or a refusal reason for its first shape defect."""
+    problem = field_problem(view, strings=_VIEW_STR_FIELDS, bools=("isCrossRepository",))
+    if problem is not None:
+        return problem
+    shaped = cast(dict, view)
+    if "number" not in shaped:
+        return "missing field 'number'"
+    if not isinstance(shaped["number"], int) or isinstance(shaped["number"], bool):
+        return f"field 'number' must be an integer, got {type(shaped['number']).__name__}"
+    problem = _labels_problem(shaped)
+    if problem is not None:
+        return problem
+    for field, child in (("headRepositoryOwner", "login"), ("headRepository", "name")):
+        problem = _repository_problem(shaped, field, child)
+        if problem is not None:
+            return problem
+    return None
 
 
 # --- pure decision surface ----------------------------------------------------
@@ -160,16 +222,21 @@ def _fork_ref(view: dict) -> str:
     return f"{owner_s}/{repo_s}"
 
 
-def build_plan(view: dict, *, run_id: str, tier: str, worktrees_root: str) -> dict:
+def build_plan(view: object, *, run_id: str, tier: str, worktrees_root: str) -> dict:
     """Decide adoptability and compute the row — PURE, from a parsed `gh pr view` dict.
 
     Returns `{"verdict": "refuse", "reason": ...}` for a PR that must NOT be adopted (pr-adoption.md
     step 2), else `{"verdict": "adopt", "row": {...computed fields...}, "labels_add": [...], "branch": ...,
-    "worktree": ..., "base": ...}`. FAIL CLOSED: every refusal is checked before any adopt field is built.
+    "worktree": ..., "base": ...}`. FAIL CLOSED: every refusal, including a malformed view, is checked
+    before any adopt field is built.
     """
     if tier not in TIER_VALUES:
         return {"verdict": "refuse",
                 "reason": f"tier {tier!r} is not one of {', '.join(sorted(TIER_VALUES))}"}
+    problem = validate_view(view)
+    if problem is not None:
+        return {"verdict": "refuse", "reason": f"malformed GitHub PR view: {problem}"}
+    view = cast(dict, view)
 
     # A fork PR is untrusted, attacker-controllable content this autonomous pipeline would read and act on,
     # and it has no push target for fix commits — campaign gates SAME-REPO PRs only (step 2).
@@ -353,8 +420,7 @@ def cmd_adopt(args) -> int:
     view_argv = ["gh", "pr", "view", pr]
     if args.repo:
         view_argv += ["--repo", args.repo]
-    view_argv += ["--json", "number,title,headRefName,headRefOid,baseRefName,labels,state,"
-                            "isCrossRepository,headRepositoryOwner,headRepository"]
+    view_argv += ["--json", VIEW_FIELDS]
     proc = _run(view_argv, cwd=gh_cwd)
     if proc.returncode != 0:
         return _refuse(f"`gh pr view {pr}` exited {proc.returncode}: {proc.stderr.strip()}")

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -103,21 +103,24 @@ _VIEW_STR_FIELDS = ("title", "headRefName", "headRefOid", "baseRefName", "state"
 
 
 def _labels_problem(view: dict) -> "str | None":
-    """Return the first malformed label shape, or None when every label has a usable string name."""
+    """Return the first malformed label shape, or None when every label is an object with a string name.
+
+    `gh pr view --json labels` emits label OBJECTS, so a bare string is a shape the GitHub boundary never
+    produces and this validator refuses it — the same rule `_repository_problem` applies to
+    `headRepositoryOwner`/`headRepository`. Consumers keep an older `isinstance(lbl, dict)` fallback; that
+    is defence in depth behind this check, not a shape adoption accepts."""
     if "labels" not in view:
         return "missing field 'labels'"
     raw = view["labels"]
     if not isinstance(raw, list):
         return f"field 'labels' must be a list, got {type(raw).__name__}"
     for item in raw:
-        if isinstance(item, dict):
-            if "name" not in item:
-                return "field 'labels' contains an object without a 'name'"
-            name = item["name"]
-        else:
-            name = item
-        if not isinstance(name, str):
-            return f"field 'labels' must hold string names, got {type(name).__name__}"
+        if not isinstance(item, dict):
+            return f"field 'labels' must hold objects, got {type(item).__name__}"
+        if "name" not in item:
+            return "field 'labels' contains an object without a 'name'"
+        if not isinstance(item["name"], str):
+            return f"field 'labels' must hold string names, got {type(item['name']).__name__}"
     return None
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/reconcile.py
+++ b/plugins/gauntlet/skills/campaign/scripts/reconcile.py
@@ -171,7 +171,8 @@ def sfield(entry: object, key: str, index: int) -> object:
 
 def label_names(entry: object, index: int) -> list[str]:
     """The label NAMES on one entry. `labels` itself enters through `sfield` (a required list); each element
-    is a GitHub label object `{"name": ...}` (a bare string is tolerated, mirroring `pr-adopt.py`). A
+    is a GitHub label object `{"name": ...}`; a bare string is tolerated HERE because this reader parses a
+    snapshot file rather than the live `gh` boundary (adoption's view validator refuses that shape). A
     malformed element is refused — the run-scope check below depends on reading every name, so a name we
     cannot read is a file we cannot trust."""
     labels = sfield(entry, "labels", index)


### PR DESCRIPTION
- API-2 trigger: malformed `gh pr view` data crashed adoption instead of returning a refusal.
- Fix: validate all requested metadata before planning and refuse before ledger, label, or worktree mutation.
- Tests: 49 fixtures, related contracts, Pyright, and plugin validation pass; field-list sites stay unchanged.
