### PR TITLE
fix safe branch handling in clean rebase

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -121,6 +121,12 @@ For each `#PR` to adopt:
 
 #### Step 3 — Register the ledger row — refresh, never duplicate
 
+**Validate the PR head branch before any registration or label mutation.** Run the typed operation
+`run_argv(["git", "check-ref-format", "--branch", headRefName], repository.project_root)` and require
+success. Refuse an unresolved or invalid branch, including a leading-dash option such as `--all`, before
+writing the ledger, creating labels, or resolving a worktree. Later mutation doors repeat this validation
+before using the row's stored branch.
+
 3. **Register the ledger row — refresh, never duplicate.** Write the row through
    `scripts/ledger.py` (the schema-owning accessor — `references/files-and-ledger.md`), addressing
    every field **by name**; never hand-edit `state.jsonl` rows by column position. Look the PR up first

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/git_refs.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/git_refs.py
@@ -15,6 +15,19 @@ class BaseFetchRefs:
     local_ref: str
 
 
+def branch_problem(worktree: str, branch: object) -> "str | None":
+    """Return a refusal reason when ``branch`` is not a safe Git branch shorthand."""
+    if not isinstance(branch, str) or not branch or branch == "-":
+        return "branch is unresolved"
+    checked = subprocess.run(  # noqa: S603
+        ["git", "-C", worktree, "check-ref-format", "--branch", branch],
+        capture_output=True, text=True, check=False)
+    if checked.returncode != 0:
+        detail = checked.stderr.strip() or checked.stdout.strip() or "invalid branch name"
+        return f"{branch!r} is not a valid Git branch name: {detail}"
+    return None
+
+
 def select_base_fetch_refs(
         worktree: str, remote: str, base: str) -> "tuple[BaseFetchRefs | None, str | None]":
     """Select a safe destination for fetching ``refs/heads/<base>``.

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -479,6 +479,46 @@ def t_wrong_branch_refused():
         check('"refused": "wrong-branch"' in out, f"the refusal names the branch mismatch; got {out!r}")
 
 
+def t_invalid_row_branch_refused():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        header, rows = M.L.load(s.ledger)
+        row = M.L.find_row(rows, PR_NUMBER)
+        check(row is not None, "fixture setup: the ledger row exists")
+        row["branch"] = "--all"
+        M.L.save(s.ledger, header, rows, activity=True)
+        ledger_before = s.ledger.read_bytes()
+        s.advance_base({12: "12-BASE"})
+        code, out, _ = s.invoke()
+        check(code == M.EXIT_PRECONDITION,
+              f"an option-looking stored branch must be refused at mutation (code={code})")
+        check('"refused": "invalid-branch"' in out and "--all" in out,
+              f"the refusal must name the invalid stored branch: {out!r}")
+        check(head(s.wt) == s.orig_head, "invalid branch refusal must happen before rebase")
+        check(s.ledger.read_bytes() == ledger_before,
+              "invalid branch refusal must leave the ledger unchanged")
+
+
+def t_push_uses_option_terminator():
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _scenario(tmp)
+        s.advance_base({12: "12-BASE"})
+        pushes = []
+        real_git = M._git
+
+        def record_push(worktree, *args):
+            if args and args[0] == "push":
+                pushes.append(args)
+                return subprocess.CompletedProcess(["git", "-C", worktree, *args], 0, "", "")
+            return real_git(worktree, *args)
+
+        with patch.object(M, "_git", side_effect=record_push):
+            code, _, err = s.invoke()
+        check(code == M.EXIT_OK, f"a clean rebase still succeeds with the safe push argv (err={err})")
+        check(pushes == [("push", "--force-with-lease", "origin", "--", PR_BRANCH)],
+              f"the push must terminate options before the branch ref: {pushes!r}")
+
+
 def t_head_mismatch_refused():
     with tempfile.TemporaryDirectory() as tmp:
         s = _scenario(tmp)
@@ -827,6 +867,10 @@ CASES = [
      t_patch_id_failure_after_rebase_resets_and_refuses),
     ("dirty-refused", "a dirty worktree is refused at exit 2", t_dirty_worktree_refused),
     ("wrong-branch-refused", "a worktree on the wrong branch is refused at exit 2", t_wrong_branch_refused),
+    ("invalid-row-branch-refused", "an option-looking stored branch is refused before mutation",
+     t_invalid_row_branch_refused),
+    ("push-option-terminator", "the force-with-lease push terminates options before the branch ref",
+     t_push_uses_option_terminator),
     ("head-mismatch-refused", "HEAD != ledger head_sha is refused at exit 2, naming both values",
      t_head_mismatch_refused),
     ("undecided-repair-refused", "an undecided repairing row is refused at exit 2 and never rebased",

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase.py
@@ -45,7 +45,7 @@ import sys
 from pathlib import Path
 
 from _gauntlet.argv import bind_separate_option_value
-from _gauntlet.git_refs import select_base_fetch_refs
+from _gauntlet.git_refs import branch_problem, select_base_fetch_refs
 from _gauntlet.modules import load_sibling
 from _gauntlet.testing import run_sibling_suite
 
@@ -201,6 +201,12 @@ def run(args) -> int:
                       f"{worktree} is missing or is not a git worktree — cannot rebase there",
                       EXIT_PRECONDITION)
 
+    row_branch = row.get("branch", "-")
+    branch_error = branch_problem(worktree, row_branch)
+    if branch_error is not None:
+        return refuse("invalid-branch", f"pr {pr} row branch is invalid: {branch_error}",
+                      EXIT_PRECONDITION)
+
     # 4. The remote must exist. `--remote` defaults to `origin`; an ABSENT remote is refused, never guessed
     #    at (fetch/push would fail mid-flight otherwise).
     if _git(worktree, "remote", "get-url", remote).returncode != 0:
@@ -221,7 +227,6 @@ def run(args) -> int:
         return refuse("worktree-error", f"cannot read the checked-out branch in {worktree}: "
                       f"{br.stderr.strip()}", EXIT_PRECONDITION)
     checked_out = br.stdout.strip()
-    row_branch = row.get("branch", "-")
     if checked_out != row_branch:
         return refuse("wrong-branch",
                       f"{worktree} has {checked_out!r} checked out but pr {pr}'s row branch is "
@@ -324,7 +329,7 @@ def run(args) -> int:
 
     # Clean AND diff-preserving — the ONLY path that mutates the remote. Never `--force`, only
     # `--force-with-lease`: a concurrent push to this branch makes the lease fail rather than clobber.
-    push = _git(worktree, "push", "--force-with-lease", remote, row_branch)
+    push = _git(worktree, "push", "--force-with-lease", remote, "--", row_branch)
     if push.returncode != 0:
         # The rebase is done and correct LOCALLY; only the push was rejected. Do NOT auto-reset — that
         # would silently destroy the completed rebase. Do NOT write the ledger — head_sha is not yet the

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -139,6 +139,22 @@ def t_adopt_same_repo():
           "worktree_owned/branch_owned are decided at step 5, never in the plan row")
 
 
+def t_invalid_head_branch_refused():
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        code, _, err, rec = _adopt(d, ledger, view(headRefName="--all"), wroot=d / "wt")
+        check(code != 0, "an option-looking PR head branch must be refused")
+        check("invalid" in err.lower() and "--all" in err,
+              f"the refusal must name the invalid branch: {err!r}")
+        check(rec.one("gh", "pr", "edit") is None,
+              "invalid branch adoption must stop before applying labels")
+        _, rows = M.L.load(ledger)
+        check(M.L.find_row(rows, "12") is None,
+              "invalid branch adoption must register no ledger row")
+
+
 def t_adopt_when_already_ours():
     p = plan(labels=[lbl("gauntlet-run-g1"), lbl("gauntlet-reviewing 0/2")])
     check(p["verdict"] == "adopt", "a PR already carrying OUR run label re-adopts, never refuses")
@@ -353,6 +369,9 @@ class Recorder:
                 return CompletedProcess(argv, 0, "", "")
             if sub == "show-ref":
                 return CompletedProcess(argv, 0 if self.local_branch_exists else 1, "", "")
+            if sub == "check-ref-format":
+                checked = subprocess.run(argv, capture_output=True, text=True, check=False)
+                return CompletedProcess(argv, checked.returncode, checked.stdout, checked.stderr)
             if sub == "status":
                 return CompletedProcess(argv, 0, "M file\n" if self.dirty else "", "")
             if sub == "merge":
@@ -1441,6 +1460,8 @@ CASES = [
     ("refuse_foreign_run", "a PR owned by another run is refused", t_refuse_foreign_run),
     ("refuse_closed", "a MERGED/CLOSED PR is refused", t_refuse_closed),
     ("refuse_unknown_tier", "an unknown tier is refused before row, worktree, or label mutation", t_refuse_unknown_tier_before_mutation),
+    ("invalid_head_branch_refused", "an option-looking PR head branch is refused before adoption mutation",
+     t_invalid_head_branch_refused),
     ("adopt_same_repo", "a clean same-repo OPEN PR adopts with the computed row", t_adopt_same_repo),
     ("adopt_when_already_ours", "a PR already carrying our run label re-adopts", t_adopt_when_already_ours),
     ("slugify", "slugify yields a lowercase, dash-collapsed, untrimmed-dash-free slug", t_slugify),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tempfile
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -45,6 +45,7 @@ from pathlib import Path
 
 from _gauntlet import labels
 from _gauntlet.atomic import replace_text
+from _gauntlet.git_refs import branch_problem
 from _gauntlet.modules import load_sibling
 from _gauntlet.repository import repo_problem
 from _gauntlet.testing import run_sibling_suite
@@ -367,7 +368,11 @@ def cmd_adopt(args) -> int:
     if plan["verdict"] == "refuse":
         return _refuse(str(plan["reason"]))
 
-    branch = str(plan["branch"])
+    branch = plan["branch"]
+    branch_error = branch_problem(args.project_root, branch)
+    if branch_error is not None:
+        return _refuse(f"PR {pr} head branch is invalid: {branch_error}")
+    branch = str(branch)
     base = str(plan["base"])
     row = plan["row"]
     planned_head = str(row["head_sha"])


### PR DESCRIPTION
- SEC-4: `--all` can reach clean-rebase push as an option and push unrelated branches.
- Fix: run `git check-ref-format --branch` at adoption and mutation; add `--` before the push ref.
- Tests: adoption/rebase suites, compileall, diff check, plugin validation. Merge/reconcile/ownership stayed unchanged.
