### PR TITLE
fix ci liveness evidence binding

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -481,7 +481,8 @@ Header field notes (the header fields above; per-row fields follow):
   policy. This field records the orchestrator's decided tier (never below the tool's floor; `TRIVIAL` only
   as the orchestrator's all-prose call); it drives `required(tier)` and review depth.
 - `ci` — `green` / `red` / `pending` for `head_sha`. Recorded by `ci-status.py liveness` from `derive`'s
-  JSON (`stage-2-ci.md`, "THE BOOKKEEPING IS A COMMAND"). (**There is no `none`.** It was documented but
+  JSON after the promoted-snapshot verification owned by `stage-2-ci.md`, "THE BOOKKEEPING IS A COMMAND".
+  (**There is no `none`.** It was documented but
   no procedure could ever write it.)
 - `ci_fingerprint` — digest of the last trusted current-head evidence, written by `ci-status.py liveness`
   **verbatim from the `fingerprint` field of `derive`'s JSON** (`null` there → the derivation had no trusted

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -481,7 +481,8 @@ Header field notes (the header fields above; per-row fields follow):
   policy. This field records the orchestrator's decided tier (never below the tool's floor; `TRIVIAL` only
   as the orchestrator's all-prose call); it drives `required(tier)` and review depth.
 - `ci` — `green` / `red` / `pending` for `head_sha`. Recorded by `ci-status.py liveness` from `derive`'s
-  JSON after the promoted-snapshot verification owned by `stage-2-ci.md`, "THE BOOKKEEPING IS A COMMAND".
+  JSON after the input checks owned by the liveness owner block (`stage-2-ci.md`, "NOT VERIFIED — the
+  refetch is BOUNDED"), which is also where **what those checks do and do not cover** is stated.
   (**There is no `none`.** It was documented but
   no procedure could ever write it.)
 - `ci_fingerprint` — digest of the last trusted current-head evidence, written by `ci-status.py liveness`

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -490,6 +490,20 @@ Header field notes (the header fields above; per-row fields follow):
   current-head evidence and this field is not written). **What it covers and exactly how it is serialized is
   DEFINED in `stage-2-ci.md`, "SETTLED" — and is NEVER restated here**, because a fingerprint reconstructed
   from a paraphrase is a different fingerprint. **UNCHANGED + nothing RUNNING == SETTLED.**
+<!-- REFUTED — about the `ci_fingerprint` row above. A review pass claimed it conflicts with
+     `ci-status.py`, which recomputes the digest from the promoted artifact and refuses a mismatch, so
+     (it argued) "verbatim from the `fingerprint` field" is wrong and every envelope-provenance bullet
+     needs the same edit. Verified against the source, not assumed: the two describe the SAME BYTES.
+     `liveness` writes `put("ci_fingerprint", derived["fingerprint"])` — the recorded value literally is
+     that JSON field — and `verify_derived_artifact` substitutes nothing: it recomputes the digest from
+     the promoted artifact and fails the whole command (exit 2) on disagreement. `main` calls it before
+     `liveness`, and both the check and the write are gated on `trusted_current_head`, so no write to
+     this field escapes the recomputation. This row states PROVENANCE only; it never calls the value
+     trusted or unchecked, and it delegates the definition — and what is recomputed versus attested —
+     to `stage-2-ci.md`, "SETTLED", machine-held by `ci-status.py doc-check`. The `null` clause holds
+     too: `derive` emits no fingerprint for a not-verified verdict, and the held and not-trusted
+     branches of `liveness` never touch this field. Do NOT rewrite the row above; that would be fixing
+     a refuted finding. -->
 - `settled_strikes` — consecutive derivations seen **SETTLED but not green** *while no machine action was
   due or in flight* for the PR at this `head_sha` (`stage-2-ci.md`, "SETTLED", owns the gate — a PR the
   driver is actively repairing is never struck). Counted by `ci-status.py liveness`, never by hand. At

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -4,7 +4,8 @@ Each PR has a background task that waits on `gh pr checks --watch`. **The watch 
 never evidence.** When the task completes, a heartbeat **fetches a fresh snapshot pinned to the PR's current
 `head_sha`**, verifies it, and decides `ci` **from the snapshot's contents — NEVER from the watch's exit
 code** — and records the result by handing `derive`'s JSON to `ci-status.py liveness` ("THE BOOKKEEPING
-IS A COMMAND", below), which writes `ci` and the liveness counters through the ledger accessor **by field
+IS A COMMAND", below). `liveness` independently verifies the JSON against the promoted snapshot before it
+writes `ci` and the liveness counters through the ledger accessor **by field
 name** (`files-and-ledger.md`), never by hand-editing the row by column position. (`reviews_ok` is a
 different write: its `0`-reset belongs **only** to a campaign commit landing on the PR head — "Any
 campaign commit to the PR head resets the gate", below, through `scripts/ledger.py … set --pr <N>
@@ -37,9 +38,10 @@ trusted evidence for the PR's current head — including a moved-head result who
 retained — while `liveness` reduces `buckets.RUNNING` to the `watch_warranted` fact the watch policy acts
 on, and reads it directly for its SETTLED/RUNNING-STALL split), and the path to the snapshot it left
 behind. It exits `0` **only** on green.
-**Write `ci` from that JSON; never from an impression of some command's output** — and then hand that
-same JSON to `ci-status.py liveness` ("THE BOOKKEEPING IS A COMMAND", below), which records it and does
-the counter arithmetic.
+**Pass that JSON to `ci-status.py liveness`; never derive `ci` from an impression of some command's output.**
+The liveness command verifies the producer's exact envelope and recomputes its verdict, evidence counts,
+fingerprint, and bucket tally from the promoted snapshot before it records the result and does the counter
+arithmetic.
 
 **THE REQUIRED SET IS NAMED, AND IT HAS NO DEFAULT.** `--ledger` resolves the selected **row's**
 `effective_required_set` — its explicit `required_set`, else the legacy header value — because the required
@@ -111,7 +113,7 @@ to hand-run.**
 | Actor | Does | Does NOT |
 |---|---|---|
 | **The background task** | **BLOCKS on `gh pr checks <pr> --watch`, and NOTHING else.** Its **ONLY** job is to block, so that **its completion becomes a heartbeat**. | It **NEVER** fetches, **NEVER** writes `ci-<pr>-<head_sha>.txt`, and **NEVER** produces evidence of any kind. |
-| **The heartbeat** | **RUNS `scripts/ci-status.py derive`** (above), which **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci` — then **RUNS `scripts/ci-status.py liveness`** on that JSON, which **RECORDS** `ci` and the counters and **PARKS at any cap** ("THE BOOKKEEPING IS A COMMAND", below). | It **NEVER** derives `ci` by READING the output of `gh pr checks` — or of anything else — and **NEVER** applies the counter arithmetic by hand. |
+| **The heartbeat** | **RUNS `scripts/ci-status.py derive`** (above), which **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci` — then **RUNS `scripts/ci-status.py liveness`** on that JSON, which **RE-VERIFIES** the promoted snapshot, **RECORDS** `ci` and the counters, and **PARKS at any cap** ("THE BOOKKEEPING IS A COMMAND", below). | It **NEVER** derives `ci` by READING the output of `gh pr checks` — or of anything else — and **NEVER** applies the counter arithmetic by hand. |
 
 **WHY the fetch cannot live in the background task:** the fetch must be pinned to the `head_sha` **the
 LEDGER currently holds**, and **only the heartbeat knows that**. A background task that fetched at its own
@@ -133,7 +135,7 @@ shape and every fail-closed rule), CROSS-FETCH AGREEMENT, CLASSIFY (the enums an
 (the outcome bullets, first match wins) live in **`ci-derivation-spec.md`** — the specification
 `ci-status.py derive` and `ci-snapshot.py` implement, held to the code by `doc-check`, executed fixtures,
 and the mutation harness. **Read it to review or change the tools; never to derive `ci` by hand.** The
-driver acts on `derive`'s JSON alone:
+driver passes `derive`'s JSON to `liveness`, which checks its claims against the promoted snapshot:
 
 #### ACT ON THE VERDICT — the driver's move for each outcome
 

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -94,7 +94,9 @@ it means *wait*. This means **re-derive**: refresh the PR's `head_sha` into the 
 **A failed or incomplete fetch promotes no artifact and reports `snapshot: null`.** A **short read**, a
 **rollup entry the REST families cannot see**, and every other FETCH refusal (`ci-derivation-spec.md`) stop
 before promotion. Each emits `verdict = unusable`, **`ci = pending`**, `snapshot: null`,
-`fingerprint: null`, and `buckets: null`, then requires a **refetch**. An older artifact — including one for
+`evidence: {}`, `fingerprint: null`, and `buckets: null`, then requires a **refetch**. The empty
+`evidence` object is the honest shape and `liveness` requires it: three **zero** counts would claim the
+three sources were read and found empty, which is the one thing a failed fetch cannot say. An older artifact — including one for
 the same PR and `head_sha` — may remain in the persistent rundir; the failed call neither reports it nor
 makes it current evidence. This is distinct from a moved head: the moved-head fetch completed and retained
 its newly promoted artifact about the requested old commit, while a failed or incomplete fetch produced no

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -4,9 +4,10 @@ Each PR has a background task that waits on `gh pr checks --watch`. **The watch 
 never evidence.** When the task completes, a heartbeat **fetches a fresh snapshot pinned to the PR's current
 `head_sha`**, verifies it, and decides `ci` **from the snapshot's contents — NEVER from the watch's exit
 code** — and records the result by handing `derive`'s JSON to `ci-status.py liveness` ("THE BOOKKEEPING
-IS A COMMAND", below). `liveness` independently verifies the JSON against the promoted snapshot before it
-writes `ci` and the liveness counters through the ledger accessor **by field
-name** (`files-and-ledger.md`), never by hand-editing the row by column position. (`reviews_ok` is a
+IS A COMMAND", below). `liveness` checks that JSON field by field — each in the class the liveness owner
+block names ("NOT VERIFIED — the refetch is BOUNDED", below) — before it writes `ci` and the liveness
+counters through the ledger accessor **by field name** (`files-and-ledger.md`), never by hand-editing the
+row by column position. (`reviews_ok` is a
 different write: its `0`-reset belongs **only** to a campaign commit landing on the PR head — "Any
 campaign commit to the PR head resets the gate", below, through `scripts/ledger.py … set --pr <N>
 --reviews_ok 0`. An ordinary derivation is observation, not a content change, and never touches it.)
@@ -39,9 +40,10 @@ retained — while `liveness` reduces `buckets.RUNNING` to the `watch_warranted`
 on, and reads it directly for its SETTLED/RUNNING-STALL split), and the path to the snapshot it left
 behind. It exits `0` **only** on green.
 **Pass that JSON to `ci-status.py liveness`; never derive `ci` from an impression of some command's output.**
-The liveness command verifies the producer's exact envelope and recomputes its verdict, evidence counts,
-fingerprint, and bucket tally from the promoted snapshot before it records the result and does the counter
-arithmetic.
+The liveness command refuses anything that is not the producer's exact envelope, then re-derives the
+`recomputed_from_artifact` set from the promoted snapshot and refuses any disagreement, before it records
+the result and does the counter arithmetic. **That set, and the `producer_attested` fields it deliberately
+excludes, are defined once** in the liveness owner block ("NOT VERIFIED — the refetch is BOUNDED", below).
 
 **THE REQUIRED SET IS NAMED, AND IT HAS NO DEFAULT.** `--ledger` resolves the selected **row's**
 `effective_required_set` — its explicit `required_set`, else the legacy header value — because the required
@@ -78,6 +80,10 @@ moved_head.ci = pending
 moved_head.fingerprint = null
 moved_head.buckets = null
 ```
+
+**Only `derive` can apply this rule, and no later step can re-apply it.** `head_sha_now` and `head_moved`
+are `producer_attested` to every consumer downstream — the liveness owner block ("NOT VERIFIED — the
+refetch is BOUNDED", below) owns what that means and what it costs.
 
 **Do NOT read this as "checks have not started"** — that is `verdict = pending` (zero evidence rows), and
 it means *wait*. This means **re-derive**: refresh the PR's `head_sha` into the ledger
@@ -747,7 +753,8 @@ an absorbing state with no exit, which the invariant forbids. Their exact verdic
 command** ("THE BOOKKEEPING IS A COMMAND", above), except the `head_sha changed` line, which belongs to the
 sites that write a new head ("THE LIVENESS COUNTERS").
 
-This is the machine-checked owner block for that counter:
+This is the machine-checked owner block for that counter — and for what `liveness` checks about its input
+before any counter moves:
 
 ```text
 liveness.untrusted_verdicts = unusable unverifiable
@@ -759,8 +766,21 @@ liveness.refetch_cap = unusable_refetches >= 3
 liveness.refetch_diagnostic = exact verdict + exact derive refusal reason
 liveness.unusable_refusal = snapshot/fetch/head-trust failure; may name VERIFY rule and line/row
 liveness.unverifiable_refusal = witness-identity containment failure; line/row not required
+liveness.recomputed_from_artifact = verdict reason evidence fingerprint buckets
+liveness.producer_attested = head_sha_now head_moved
 ```
 
+- **`recomputed_from_artifact` and `producer_attested` are the two halves of what `liveness` can know.**
+  The first set is re-derived from the promoted snapshot's bytes and refused on any disagreement, so the
+  producer's copy of it is never what gets recorded. The second is **the producer's word, by design**:
+  `ci-snapshot.py` is a pure function from bytes to a verdict — handed no PR, making no network call
+  ("THE DERIVATION IS A COMMAND", above) — so the PR's live head never enters the artifact and nothing on
+  disk can confirm or contradict it. `liveness` makes no network call either. The remaining fields are
+  matched against the ledger row and the artifact's own path, or are a total function of a recomputed
+  field. **What that costs, plainly:** a moved head reported as moved is held to the moved-head result
+  above and cannot be dressed up as a green; a moved head **denied** in the envelope is indistinguishable
+  from a head that never moved, because everything else then recomputes correctly. Only `derive`, which
+  read the head, can refuse that — and it does. Nothing else writes this envelope.
 - **The counter follows the final derivation's trust for the current head, never artifact verification.**
   A retained moved-head artifact was verified as an artifact for the requested old commit, but the final
   result is untrusted for the current PR and increments the counter. A trusted current-head result resets

--- a/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-ci.md
@@ -40,10 +40,12 @@ retained — while `liveness` reduces `buckets.RUNNING` to the `watch_warranted`
 on, and reads it directly for its SETTLED/RUNNING-STALL split), and the path to the snapshot it left
 behind. It exits `0` **only** on green.
 **Pass that JSON to `ci-status.py liveness`; never derive `ci` from an impression of some command's output.**
-The liveness command refuses anything that is not the producer's exact envelope, then re-derives the
-`recomputed_from_artifact` set from the promoted snapshot and refuses any disagreement, before it records
-the result and does the counter arithmetic. **That set, and the `producer_attested` fields it deliberately
-excludes, are defined once** in the liveness owner block ("NOT VERIFIED — the refetch is BOUNDED", below).
+The liveness command refuses anything that is not the producer's exact envelope, then — **when the
+derivation promoted a snapshot** — re-derives the `recomputed_from_artifact` set from that snapshot and
+refuses any disagreement, before it records the result and does the counter arithmetic. **That set, the
+`producer_attested` fields it deliberately excludes, and the `no_artifact_producer_copy` fields a
+`snapshot: null` derivation gets instead of a recomputation, are defined once** in the liveness owner block
+("NOT VERIFIED — the refetch is BOUNDED", below).
 
 **THE REQUIRED SET IS NAMED, AND IT HAS NO DEFAULT.** `--ledger` resolves the selected **row's**
 `effective_required_set` — its explicit `required_set`, else the legacy header value — because the required
@@ -121,7 +123,7 @@ to hand-run.**
 | Actor | Does | Does NOT |
 |---|---|---|
 | **The background task** | **BLOCKS on `gh pr checks <pr> --watch`, and NOTHING else.** Its **ONLY** job is to block, so that **its completion becomes a heartbeat**. | It **NEVER** fetches, **NEVER** writes `ci-<pr>-<head_sha>.txt`, and **NEVER** produces evidence of any kind. |
-| **The heartbeat** | **RUNS `scripts/ci-status.py derive`** (above), which **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci` — then **RUNS `scripts/ci-status.py liveness`** on that JSON, which **RE-VERIFIES** the promoted snapshot, **RECORDS** `ci` and the counters, and **PARKS at any cap** ("THE BOOKKEEPING IS A COMMAND", below). | It **NEVER** derives `ci` by READING the output of `gh pr checks` — or of anything else — and **NEVER** applies the counter arithmetic by hand. |
+| **The heartbeat** | **RUNS `scripts/ci-status.py derive`** (above), which **FETCHES** (SHA-pinned, both families), **PROMOTES** atomically, **VERIFIES** the stamp, **PARSES**, and **DECIDES** `ci` — then **RUNS `scripts/ci-status.py liveness`** on that JSON, which **RE-VERIFIES** any promoted snapshot, **RECORDS** `ci` and the counters, and **PARKS at any cap** ("THE BOOKKEEPING IS A COMMAND", below). | It **NEVER** derives `ci` by READING the output of `gh pr checks` — or of anything else — and **NEVER** applies the counter arithmetic by hand. |
 
 **WHY the fetch cannot live in the background task:** the fetch must be pinned to the `head_sha` **the
 LEDGER currently holds**, and **only the heartbeat knows that**. A background task that fetched at its own
@@ -143,7 +145,9 @@ shape and every fail-closed rule), CROSS-FETCH AGREEMENT, CLASSIFY (the enums an
 (the outcome bullets, first match wins) live in **`ci-derivation-spec.md`** — the specification
 `ci-status.py derive` and `ci-snapshot.py` implement, held to the code by `doc-check`, executed fixtures,
 and the mutation harness. **Read it to review or change the tools; never to derive `ci` by hand.** The
-driver passes `derive`'s JSON to `liveness`, which checks its claims against the promoted snapshot:
+driver passes `derive`'s JSON to `liveness`, which checks its claims against the promoted snapshot — or,
+when the derivation promoted none, against what the "NOT VERIFIED — the refetch is BOUNDED" owner block
+below says such an envelope may carry:
 
 #### ACT ON THE VERDICT — the driver's move for each outcome
 
@@ -770,19 +774,37 @@ liveness.unusable_refusal = snapshot/fetch/head-trust failure; may name VERIFY r
 liveness.unverifiable_refusal = witness-identity containment failure; line/row not required
 liveness.recomputed_from_artifact = verdict reason evidence fingerprint buckets
 liveness.producer_attested = head_sha_now head_moved
+liveness.no_artifact_producer_copy = verdict reason
 ```
 
 - **`recomputed_from_artifact` and `producer_attested` are the two halves of what `liveness` can know.**
-  The first set is re-derived from the promoted snapshot's bytes and refused on any disagreement, so the
-  producer's copy of it is never what gets recorded. The second is **the producer's word, by design**:
+  The first set is re-derived from the promoted snapshot's bytes and refused on any disagreement, so **on a
+  derivation that promoted one**, the producer's copy of that set is never what gets recorded. (A
+  derivation that promoted nothing is the next bullet — there, no member of the set is recomputed.) The
+  second is **the producer's word, by design**:
   `ci-snapshot.py` is a pure function from bytes to a verdict — handed no PR, making no network call
   ("THE DERIVATION IS A COMMAND", above) — so the PR's live head never enters the artifact and nothing on
   disk can confirm or contradict it. `liveness` makes no network call either. The remaining fields are
   matched against the ledger row and the artifact's own path, or are a total function of a recomputed
-  field. **What that costs, plainly:** a moved head reported as moved is held to the moved-head result
-  above and cannot be dressed up as a green; a moved head **denied** in the envelope is indistinguishable
-  from a head that never moved, because everything else then recomputes correctly. Only `derive`, which
-  read the head, can refuse that — and it does. Nothing else writes this envelope.
+  field. **What the ATTESTATION costs, plainly:** a moved head reported as moved is held to the moved-head
+  result above and cannot be dressed up as a green; a moved head **denied** in the envelope is
+  indistinguishable from a head that never moved, because everything else then recomputes correctly. Only
+  `derive`, which read the head, can refuse that — and it does. Nothing else writes this envelope.
+- **A `snapshot: null` derivation gets `no_artifact_producer_copy` instead of a recomputation — and that
+  is the whole of the second gap.** A failed or incomplete fetch promoted nothing ("FAILED OR INCOMPLETE
+  FETCHES PROMOTE NOTHING", above), so there are no bytes to re-derive against and `liveness` recomputes
+  **no** member of `recomputed_from_artifact` on that branch. **The gap is not that whole set.** The
+  members outside `no_artifact_producer_copy` are pinned by the envelope validator to the ONE value such a
+  derivation may carry — the shape "FAILED OR INCOMPLETE FETCHES PROMOTE NOTHING" above already states,
+  restated nowhere else — and any other value is refused at the door with **exit 2**, writing nothing.
+  What is recorded on the producer's word is `verdict`, free only within `untrusted_verdicts` and so
+  changing nothing but the cap diagnostic's label, and `reason`, which nothing checks and which the
+  REFETCH CAP embeds verbatim into `ci_reason`. **What that costs, plainly:** at the cap, the `ci_reason`
+  a human reads can carry producer text no recomputation stands behind. **It decides nothing.** No green is
+  reachable — a trusted verdict beside a null snapshot is refused, and every verdict that survives records
+  `ci = pending` — `unusable_refetches` still increments, the row still parks, and `ci_reason` is the open
+  question a person rules on (`blocker_ruling`), never a value a machine reads. As above, nothing but
+  `derive` writes this envelope.
 - **The counter follows the final derivation's trust for the current head, never artifact verification.**
   A retained moved-head artifact was verified as an artifact for the requested old commit, but the final
   result is untrusted for the current PR and increments the counter. A trusted current-head result resets

--- a/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-snapshot.py
@@ -858,11 +858,44 @@ def evaluate(
     `expect_filename_sha` is OFF only for the fixtures, which are named by the PROPERTY they pin
     (`green.jsonl`, `wrong-sha.jsonl`, …) rather than by a SHA — their names are documentation. It is ON
     for every real artifact, and `self-test` proves the check still fires (FILENAME_CASES below).
+
+    THIS ENTRY POINT READS THE FILE. A caller that already holds the rows — because it derives something
+    else from the SAME bytes and those answers must agree — calls `evaluate_rows` instead and reads once.
     """
     try:
         if expect_filename_sha:
             verify_filename(path, expected_sha)
         rows = parse(path)
+    except Unverifiable as exc:
+        return UNVERIFIABLE, str(exc)
+    except SnapshotError as exc:
+        return UNUSABLE, str(exc)
+    # The name was checked above and `rows` ARE the bytes just read, so this call touches the file no
+    # second time: `evaluate` reads exactly once, like `evaluate_rows` reads not at all.
+    return evaluate_rows(path, rows, expected_sha, required=required, expect_filename_sha=False)
+
+
+def evaluate_rows(
+    path: Path, rows: list[dict], expected_sha: str, *, required: RequiredSet,
+    expect_filename_sha: bool = True,
+) -> tuple[str, str]:
+    """`evaluate` with the READ already done — the SAME rules, applied to rows the caller parsed.
+
+    THE VERDICT AND WHATEVER ELSE THE CALLER DERIVES ARE THEN BOUND TO ONE BYTE SEQUENCE, which is the
+    only reason this entry point exists. `ci-status.py`'s `verify_derived_artifact` recomputes FIVE
+    envelope fields — verdict, reason, evidence counts, fingerprint, buckets — and they are a single
+    account of a single artifact or they are not evidence at all. Calling `evaluate(path, …)` beside a
+    `parse(path)` of its own read the file TWICE, so verdict and reason came from one read while the
+    other three came from another, and two reads of one file are two files whenever anything writes
+    between them.
+
+    `path` is still required, and still only for its NAME: `verify_filename` compares the artifact's
+    filename and opens nothing. `expect_filename_sha` means here exactly what it means above, and
+    `evaluate` passes it FALSE because it has already applied that rule itself.
+    """
+    try:
+        if expect_filename_sha:
+            verify_filename(path, expected_sha)
         verify_sha(rows, expected_sha)
         verify_sources(rows, expected_sha)
         check_containment(rows)

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1539,6 +1539,136 @@ def liveness_no_artifact_cli_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
+def liveness_no_artifact_boundary_cases(ci, tmp: Path) -> list[str]:
+    """WHERE THE NO-ARTIFACT BRANCH'S HOLE STOPS — the claim the docs make, held to the CLI.
+
+    `verify_derived_artifact` returns at `snapshot: null`, so NO member of `RECOMPUTED_FROM_ARTIFACT` is
+    recomputed there. `doc-check` compares set NAMES, which by construction cannot see a branch, so the
+    partition comment and the liveness owner block both state the branch in prose — and prose that no
+    test drives is prose that drifts. This suite is the mechanical half of that statement: each field the
+    docs call PINNED is forged and must exit 2 writing nothing, and each field they call the producer's
+    copy is forged and must be RECORDED. Both directions gate. A doc that under-claims the hole hides a
+    real cost; a doc that over-claims it documents a weakness that does not exist, and the next reader
+    builds machinery against a forgery the validator already refuses.
+    """
+    problems: list[str] = []
+    if not (ci.NO_ARTIFACT_PRODUCER_COPY < ci.RECOMPUTED_FROM_ARTIFACT):
+        problems.append(f"[SEC-2] NO_ARTIFACT_PRODUCER_COPY {sorted(ci.NO_ARTIFACT_PRODUCER_COPY)!r} is "
+                        f"not a proper subset of RECOMPUTED_FROM_ARTIFACT "
+                        f"{sorted(ci.RECOMPUTED_FROM_ARTIFACT)!r} — it names what that set's promise does "
+                        f"NOT cover on the null-snapshot branch, so anything outside it is a field the "
+                        f"docs claim is pinned while nothing pins it")
+        return problems
+
+    member = None
+    for fixture in cases(ci):
+        fx, derived, rundir, _before = run_fixture(ci, fixture, tmp / "no-artifact-boundary")
+        if derived["snapshot"] is None:
+            member = (fixture, fx, derived, rundir)
+            break
+    if member is None:
+        problems.append("[SEC-2] no fixture derives a null snapshot — the no-artifact boundary is untested")
+        return problems
+    fixture, fx, derived, rundir = member
+
+    pr = fx.get("pr", "35")
+    head_sha = fx.get("head_sha", ci.FIXTURE_SHA)
+    ledger = rundir / "state.jsonl"
+    header = dict(ci.LEDGER.HEADER_DEFAULTS)
+    header["run_id"] = "sec2"
+
+    def record(envelope: dict, name: str, refetches: int = 0) -> tuple[int, str, dict, bool]:
+        row = dict(ci.LEDGER.ROW_DEFAULTS)
+        row.update({"pr": pr, "head_sha": head_sha, "status": "in_review",
+                    "required_set": fx["required_set"], "unusable_refetches": str(refetches)})
+        ci.LEDGER.dump(ledger, header, [row])
+        before_bytes = ledger.read_bytes()
+        payload = rundir / f"boundary-{name}.json"
+        payload.write_text(json.dumps(envelope), encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(ledger), "--pr", pr,
+             "--derive-json", str(payload), "--machine-action", "none",
+             "--now", "2026-08-26T00:00:00+00:00"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+        )
+        return (proc.returncode, proc.stderr, ci.LEDGER.load(ledger)[1][0],
+                ledger.read_bytes() != before_bytes)
+
+    # PINNED — the three `RECOMPUTED_FROM_ARTIFACT` members outside `NO_ARTIFACT_PRODUCER_COPY`. Nothing
+    # recomputes them here either; `derive_output` allows each exactly one value beside a null snapshot,
+    # so a forgery never reaches the recorder at all.
+    pinned = {
+        "evidence": {"checkrun": 3, "status": 2, "witness": 1},
+        "fingerprint": "f" * 64,
+        "buckets": {key: 0 for key in ci.BUCKET_KEYS.values()},
+    }
+    if set(pinned) != set(ci.RECOMPUTED_FROM_ARTIFACT) - set(ci.NO_ARTIFACT_PRODUCER_COPY):
+        problems.append(f"[SEC-2] this suite forges {sorted(pinned)!r}, which is no longer the pinned "
+                        f"remainder of RECOMPUTED_FROM_ARTIFACT — a member gained or lost a pin with no "
+                        f"case saying so")
+    for field, value in pinned.items():
+        forged = dict(derived)
+        forged[field] = value
+        code, stderr, _after, wrote = record(forged, f"pinned-{field}")
+        if code != 2:
+            problems.append(f"[SEC-2] {fixture}: a forged {field!r} beside a null snapshot exited {code}, "
+                            f"not 2 — the docs call it pinned to one legal value: {stderr!r}")
+        if wrote:
+            problems.append(f"[SEC-2] {fixture}: a forged {field!r} beside a null snapshot changed the "
+                            f"ledger")
+
+    # AND NO GREEN IS REACHABLE. `verdict` is in the producer-copy set, but only WITHIN the untrusted
+    # pair: a trusted verdict beside a null snapshot names no promoted snapshot and is refused.
+    for verdict in sorted(set(ci.LEDGER_CI) - set(ci.NOT_VERIFIED_VERDICTS)):
+        forged = dict(derived)
+        forged.update({"verdict": verdict, "ci": ci.LEDGER_CI[verdict]})
+        code, stderr, _after, wrote = record(forged, f"trusted-{verdict}")
+        if code != 2:
+            problems.append(f"[SEC-2] {fixture}: verdict {verdict!r} beside a null snapshot exited "
+                            f"{code}, not 2 — only the untrusted pair may survive this branch: {stderr!r}")
+        if wrote:
+            problems.append(f"[SEC-2] {fixture}: verdict {verdict!r} beside a null snapshot changed the "
+                            f"ledger")
+
+    # THE PRODUCER-COPY SET, in the direction that makes the disclosure true rather than alarmist. Both
+    # members are RECORDED unrecomputed, and the cap diagnostic carries `reason` verbatim.
+    others = [v for v in ci.NOT_VERIFIED_VERDICTS if v != derived["verdict"]]
+    if not others:
+        problems.append(f"[SEC-2] NOT_VERIFIED_VERDICTS holds only {derived['verdict']!r} — the swap the "
+                        f"docs disclose cannot be exercised")
+    else:
+        swapped = dict(derived)
+        swapped.update({"verdict": others[0], "ci": ci.LEDGER_CI[others[0]]})
+        code, stderr, after, _wrote = record(swapped, "swapped-verdict",
+                                             refetches=ci.REFETCH_CAP - 1)
+        # EXIT 3 IS THE PARK, NOT A REFUSAL — the run reached the REFETCH CAP and escalated, which is the
+        # whole point of driving it there. A refusal would be 2 and would write nothing.
+        if code != 3:
+            problems.append(f"[SEC-2] {fixture}: swapping the verdict within the untrusted pair exited "
+                            f"{code}, not 3 — the docs disclose this as recorded and parked: {stderr!r}")
+        elif not after["ci_reason"].startswith(f"{others[0].upper()} at the REFETCH CAP"):
+            problems.append(f"[SEC-2] {fixture}: the swapped verdict did not reach the cap diagnostic "
+                            f"label: ci_reason={after['ci_reason']!r}")
+        elif after["ci"] != "pending":
+            problems.append(f"[SEC-2] {fixture}: a swapped untrusted verdict recorded ci "
+                            f"{after['ci']!r}, not 'pending' — the swap must change nothing but the label")
+
+    marker = "NO-RECOMPUTATION-MARKER-c0ffee"
+    rewritten = dict(derived)
+    rewritten["reason"] = marker
+    code, stderr, after, _wrote = record(rewritten, "rewritten-reason", refetches=ci.REFETCH_CAP - 1)
+    if code != 3:
+        problems.append(f"[SEC-2] {fixture}: a rewritten `reason` beside a null snapshot exited {code}, "
+                        f"not 3 — the docs disclose it as recorded unchecked and parked: {stderr!r}")
+    elif marker not in after["ci_reason"]:
+        problems.append(f"[SEC-2] {fixture}: the rewritten `reason` did not reach `ci_reason` at the "
+                        f"REFETCH CAP: {after['ci_reason']!r}")
+    elif after["status"] != "awaiting-user" or after["ci"] != "pending":
+        problems.append(f"[SEC-2] {fixture}: the cap did not park on pending: status="
+                        f"{after['status']!r} ci={after['ci']!r} — the disclosed cost claims it still does")
+    return problems
+
+
 def liveness_field_class_cases(ci) -> list[str]:
     """THE PARTITION IS TOTAL — no envelope field escapes being classified.
 
@@ -2437,6 +2567,15 @@ def run(ci, tmp: Path) -> int:
     if not no_artifact_problems:
         print(f"ok       {'the no-artifact class':32} -> every fixture that promotes nothing records its "
               f"refetch strike through the real CLI, while a fabricated count on either side is refused")
+
+    no_artifact_boundary_problems = liveness_no_artifact_boundary_cases(ci, tmp)
+    for problem in no_artifact_boundary_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not no_artifact_boundary_problems:
+        print(f"ok       {'the no-artifact boundary':32} -> beside a null snapshot the pinned fields and "
+              f"every trusted verdict are refused at exit 2, while the producer-copy set is recorded and "
+              f"reaches the cap diagnostic")
 
     field_class_problems = liveness_field_class_cases(ci)
     for problem in field_class_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1129,7 +1129,10 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
                 head_sha: str = sha, fail: int = 0, unknown: int = 0) -> dict:
         trusted_current_head = verdict not in ("unusable", "unverifiable")
         return ci.derive_output({
-            "head_sha": head_sha, "verdict": verdict, "ci": ci_value, "reason": "row X made it fire",
+            "pr": "35", "head_sha": head_sha, "verdict": verdict, "ci": ci_value,
+            "reason": "row X made it fire", "snapshot": "synthetic",
+            "evidence": {"checkrun": 0, "status": 0, "witness": 0},
+            "head_sha_now": head_sha, "head_moved": False, "required_set": "none",
             "fingerprint": fp1 if trusted_current_head else None,
             "buckets": ({"PASS": 1, "RUNNING": running, "FAIL": fail, "UNKNOWN_VALUE": unknown}
                         if trusted_current_head else None),
@@ -1212,10 +1215,16 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
         duplicate_path, sha, required=ci.SNAP.NO_REQUIRED, expect_filename_sha=False
     )
     duplicate_derived = ci.derive_output({
+        "pr": "35",
         "head_sha": sha,
         "verdict": duplicate_verdict,
         "ci": "pending",
         "reason": duplicate_refusal,
+        "snapshot": str(duplicate_path),
+        "evidence": {"checkrun": 0, "status": 0, "witness": 0},
+        "head_sha_now": sha,
+        "head_moved": False,
+        "required_set": "none",
         "fingerprint": None,
         "buckets": None,
     })
@@ -1336,6 +1345,56 @@ def liveness_cases(ci, tmp: Path) -> list[str]:
     watch("a held row with a RUNNING row still warrants a watch", True, "still RUNNING",
           derived(running=1), status="awaiting-user", ci_reason="the open question", ci_fingerprint=fp1)
 
+    return problems
+
+
+def liveness_cli_cases(ci, tmp: Path) -> list[str]:
+    """The CLI refuses a forged trusted derivation before it writes the ledger."""
+    problems: list[str] = []
+    fx, derived, rundir, _before = run_fixture(ci, "green.json", tmp / "sec2-forged")
+    ledger = rundir / "state.jsonl"
+    header = dict(ci.LEDGER.HEADER_DEFAULTS)
+    header["run_id"] = "sec2"
+    row = dict(ci.LEDGER.ROW_DEFAULTS)
+    row.update({"pr": fx.get("pr", "35"), "head_sha": ci.FIXTURE_SHA, "status": "in_review",
+                "required_set": ci.SNAP.NONE_DECLARED})
+    ci.LEDGER.dump(ledger, header, [row])
+
+    valid_payload = rundir / "valid-derive.json"
+    valid_payload.write_text(json.dumps(derived), encoding="utf-8")
+    valid_before = ledger.read_bytes()
+    valid_proc = subprocess.run(
+        [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(ledger), "--pr", "35",
+         "--derive-json", str(valid_payload), "--machine-action", "none",
+         "--now", "2026-08-26T00:00:00+00:00"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+    )
+    if valid_proc.returncode != 0:
+        problems.append(f"[SEC-2] producer derive JSON exited {valid_proc.returncode}, not 0: "
+                        f"{valid_proc.stderr!r}")
+    elif ci.LEDGER.load(ledger)[1][0]["ci"] != "green":
+        problems.append("[SEC-2] producer derive JSON did not record its canonical green result")
+    elif ledger.read_bytes() == valid_before:
+        problems.append("[SEC-2] producer derive JSON was rejected without a ledger change")
+
+    ci.LEDGER.dump(ledger, header, [row])
+    forged = dict(derived)
+    forged["fingerprint"] = "0" * 64
+    payload = rundir / "forged-derive.json"
+    payload.write_text(json.dumps(forged), encoding="utf-8")
+    before = ledger.read_bytes()
+    proc = subprocess.run(
+        [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(ledger), "--pr", "35",
+         "--derive-json", str(payload), "--machine-action", "none",
+         "--now", "2026-08-26T00:00:00+00:00"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+    )
+    if proc.returncode != 2:
+        problems.append(f"[SEC-2] forged trusted derive JSON exited {proc.returncode}, not 2: {proc.stderr!r}")
+    if "fingerprint" not in proc.stderr:
+        problems.append(f"[SEC-2] forged trusted derive JSON did not name the rejected fingerprint: {proc.stderr!r}")
+    if ledger.read_bytes() != before:
+        problems.append("[SEC-2] forged trusted derive JSON changed the ledger")
     return problems
 
 
@@ -2083,6 +2142,14 @@ def run(ci, tmp: Path) -> int:
               f"to the cap, the stall clock, the refetch cap, machine-action stop, held observation, "
               f"both exact not-verified verdicts, stale-head refusal, retained moved-head artifact, and "
               f"the watch_warranted reduction (incl. the UNCLASSIFIED exclusion)")
+
+    liveness_cli_problems = liveness_cli_cases(ci, tmp)
+    for problem in liveness_cli_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not liveness_cli_problems:
+        print(f"ok       {'liveness input binding':32} -> forged trusted verdicts, fingerprints, and bucket "
+              f"tallies cannot reach the ledger without matching promoted snapshot bytes")
 
     verdict_doc_problems = verdict_doc_cases(ci)
     for problem in verdict_doc_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1398,6 +1398,144 @@ def liveness_cli_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
+def liveness_field_class_cases(ci) -> list[str]:
+    """THE PARTITION IS TOTAL — no envelope field escapes being classified.
+
+    This is the guard that outlives the reader. `verify_derived_artifact` checks each field in one of
+    three classes and records one class on the producer's word; a field added to `result()` later is
+    checked by NOBODY unless someone places it. The classes are declared as sets precisely so that
+    omission is a failing test rather than a silent belief.
+    """
+    problems: list[str] = []
+    classes = {
+        "RECOMPUTED_FROM_ARTIFACT": ci.RECOMPUTED_FROM_ARTIFACT,
+        "CHECKED_AGAINST_CANONICAL_STATE": ci.CHECKED_AGAINST_CANONICAL_STATE,
+        "DERIVED_FROM_A_CHECKED_FIELD": ci.DERIVED_FROM_A_CHECKED_FIELD,
+        "PRODUCER_ATTESTED": ci.PRODUCER_ATTESTED,
+    }
+    union: set[str] = set()
+    for name, members in classes.items():
+        overlap = union & set(members)
+        if overlap:
+            problems.append(f"[SEC-2] {name} shares {sorted(overlap)!r} with an earlier class — a field "
+                            f"in two classes has two different accounts of how it was checked")
+        union |= set(members)
+    if union != ci.DERIVE_FIELDS:
+        problems.append(f"[SEC-2] the liveness field classes cover {sorted(union)!r}, not the producer "
+                        f"envelope {sorted(ci.DERIVE_FIELDS)!r} — an unclassified field is one the "
+                        f"recorder simply believes")
+    return problems
+
+
+def liveness_head_attestation_cases(ci, tmp: Path) -> list[str]:
+    """THE MOVED-HEAD ENVELOPE — three rewrites the recorder refuses, and the one it cannot.
+
+    `head_sha_now` is `PRODUCER_ATTESTED`: the PR's live head never enters the promoted artifact, so
+    `liveness` has nothing on disk to check it against. These cases pin exactly how far the recomputation
+    reaches, so that neither the reach nor its limit can change without a test saying so.
+    """
+    problems: list[str] = []
+    fx, derived, rundir, _before = run_fixture(ci, "head-moves-mid-fetch.json", tmp / "sec2-attested")
+    if derived["verdict"] != ci.SNAP.UNUSABLE or not derived["head_moved"]:
+        problems.append(f"[SEC-2] the recorded moved-head fixture no longer derives a moved head: "
+                        f"verdict={derived['verdict']!r} head_moved={derived['head_moved']!r}")
+        return problems
+
+    pr = fx.get("pr", "35")
+    ledger = rundir / "state.jsonl"
+    header = dict(ci.LEDGER.HEADER_DEFAULTS)
+    header["run_id"] = "sec2"
+    row = dict(ci.LEDGER.ROW_DEFAULTS)
+    row.update({"pr": pr, "head_sha": ci.FIXTURE_SHA, "status": "in_review",
+                "required_set": ci.SNAP.NONE_DECLARED})
+
+    def record(envelope: dict, name: str) -> tuple[int, str, bool]:
+        ci.LEDGER.dump(ledger, header, [row])
+        payload = rundir / f"{name}.json"
+        payload.write_text(json.dumps(envelope), encoding="utf-8")
+        before_bytes = ledger.read_bytes()
+        proc = subprocess.run(
+            [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(ledger), "--pr", pr,
+             "--derive-json", str(payload), "--machine-action", "none",
+             "--now", "2026-08-26T00:00:00+00:00"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+        )
+        return proc.returncode, proc.stderr, ledger.read_bytes() != before_bytes
+
+    # What the artifact itself says about the commit it was pinned to — the same recomputation
+    # `verify_derived_artifact` performs, and the material any forged envelope has to agree with.
+    snapshot = Path(derived["snapshot"])
+    required = ci.SNAP.parse_required_set(ci.SNAP.NONE_DECLARED)
+    artifact_rows = ci.SNAP.parse(snapshot)
+    artifact_verdict, artifact_reason = ci.SNAP.evaluate(
+        snapshot, ci.FIXTURE_SHA, required=required, expect_filename_sha=True
+    )
+
+    # (1) DENIED BUT NOT REWRITTEN — `head_moved` flipped to false while the moved-head verdict and reason
+    # stay. The recomputation is real, so this is refused: the artifact says one thing and the envelope
+    # another.
+    half = dict(derived)
+    half.update({"head_sha_now": ci.FIXTURE_SHA, "head_moved": False})
+    code, stderr, wrote = record(half, "denied-head-move")
+    if code != 2:
+        problems.append(f"[SEC-2] a denied head move with a retained moved-head verdict exited {code}, "
+                        f"not 2: {stderr!r}")
+    if wrote:
+        problems.append("[SEC-2] a denied head move with a retained moved-head verdict changed the ledger")
+
+    # (2) CLAIMED BUT NOT THE MOVED-HEAD RESULT — `head_moved` left true beside the artifact's own green.
+    # Refused at the door: a trusted current-head verdict must name a current head equal to the pinned
+    # one, which a moved head by definition does not.
+    dressed = dict(derived)
+    dressed.update({"verdict": artifact_verdict, "ci": ci.LEDGER_CI[artifact_verdict],
+                    "reason": artifact_reason})
+    code, stderr, wrote = record(dressed, "dressed-head-move")
+    if code != 2:
+        problems.append(f"[SEC-2] a moved head reported with the artifact's own verdict exited {code}, "
+                        f"not 2: {stderr!r}")
+    if wrote:
+        problems.append("[SEC-2] a moved head reported with the artifact's own verdict changed the ledger")
+
+    # (3) CLAIMED, WITH THE REFUSAL REWORDED — still `unusable`, still moved, but the reason no longer
+    # says what `derive` would have said. Refused by the moved-head branch itself, which rebuilds
+    # `moved_head_reason()` from the artifact and accepts nothing else: the `ci_reason` a park shows the
+    # user is evidence too, and an envelope may not author it.
+    reworded = dict(derived)
+    reworded["reason"] = "HEAD MOVED — nothing to worry about, record the old snapshot"
+    code, stderr, wrote = record(reworded, "reworded-head-move")
+    if code != 2:
+        problems.append(f"[SEC-2] a moved-head refusal with a rewritten reason exited {code}, not 2: "
+                        f"{stderr!r}")
+    if wrote:
+        problems.append("[SEC-2] a moved-head refusal with a rewritten reason changed the ledger")
+
+    # (4) THE DOCUMENTED BOUNDARY — the whole envelope rewritten to the derivation `derive` WOULD have
+    # printed had the head not moved. Every recomputed field then agrees with the artifact, and
+    # `head_sha_now` is the one input no local check can contradict, so this IS recorded. That is the
+    # cost `stage-2-ci.md`'s liveness owner block states, pinned here so it cannot change unnoticed and
+    # be reported as unchanged. Making this case fail requires the recorder to learn the live head —
+    # a network call inside `liveness`, or the head inside the artifact — and both are refused by design.
+    consistent = dict(derived)
+    consistent.update({
+        "head_sha_now": ci.FIXTURE_SHA, "head_moved": False,
+        "verdict": artifact_verdict, "ci": ci.LEDGER_CI[artifact_verdict], "reason": artifact_reason,
+        "fingerprint": ci.SNAP.fingerprint(artifact_rows, ci.FIXTURE_SHA),
+        "buckets": ci.bucket_counts(artifact_rows),
+    })
+    code, stderr, wrote = record(consistent, "consistent-denied-head-move")
+    if code != 0:
+        problems.append(f"[SEC-2] the attested-head boundary changed: a fully consistent denied head move "
+                        f"exited {code}, not 0 ({stderr!r}). If `liveness` can now detect this, say so in "
+                        f"the liveness owner block and in the partition above `derive_output` before "
+                        f"changing this case")
+    elif ci.LEDGER.load(ledger)[1][0]["ci"] != ci.LEDGER_CI[artifact_verdict]:
+        problems.append("[SEC-2] a fully consistent denied head move was accepted without recording the "
+                        "artifact's own ledger value")
+    elif not wrote:
+        problems.append("[SEC-2] a fully consistent denied head move recorded nothing at all")
+    return problems
+
+
 def verdict_doc_cases(ci) -> list[str]:
     """Pin both no-fingerprint verdicts in the DECIDE doc order independently of `doc-check`."""
     problems: list[str] = []
@@ -2150,6 +2288,22 @@ def run(ci, tmp: Path) -> int:
     if not liveness_cli_problems:
         print(f"ok       {'liveness input binding':32} -> forged trusted verdicts, fingerprints, and bucket "
               f"tallies cannot reach the ledger without matching promoted snapshot bytes")
+
+    field_class_problems = liveness_field_class_cases(ci)
+    for problem in field_class_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not field_class_problems:
+        print(f"ok       {'liveness field classes':32} -> every producer envelope field lands in exactly "
+              f"one check class; nothing is recorded unclassified")
+
+    attestation_problems = liveness_head_attestation_cases(ci, tmp)
+    for problem in attestation_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not attestation_problems:
+        print(f"ok       {'the attested head boundary':32} -> a moved head cannot be dressed up as a "
+              f"verdict, and a fully consistent denial is recorded exactly as the doc says it is")
 
     verdict_doc_problems = verdict_doc_cases(ci)
     for problem in verdict_doc_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1698,6 +1698,102 @@ def liveness_field_class_cases(ci) -> list[str]:
     return problems
 
 
+def liveness_single_parse_cases(ci, tmp: Path) -> list[str]:
+    """ONE READ OF THE PROMOTED ARTIFACT — the five recomputed fields are one account of one artifact.
+
+    `RECOMPUTED_FROM_ARTIFACT` names verdict, reason, evidence, fingerprint and buckets, and the whole
+    worth of that promise is that they describe THE SAME BYTES. `verify_derived_artifact` used to parse
+    the file for the counts and then hand the PATH to `SNAP.evaluate`, which opened it AGAIN for the
+    verdict — two reads, so two byte sequences whenever anything wrote between them, and an envelope
+    could then carry one read's verdict beside the other read's evidence with nothing to say so.
+
+    The case swaps the file's contents at the first parse and hands the recorder an envelope forged out
+    of BOTH fixtures: the green artifact's verdict and reason, the red artifact's evidence, fingerprint
+    and buckets. Under one read the swap is never seen, the rows stay red, and the green verdict is
+    refused. It also counts the parses, so a refactor that reintroduces the second read fails here even
+    if it happens to stay coherent.
+    """
+    problems: list[str] = []
+    _red_fx, red, red_dir, _ = run_fixture(ci, "red-status-only.json", tmp / "sec2-one-read-red")
+    _green_fx, green, _green_dir, _ = run_fixture(ci, "green.json", tmp / "sec2-one-read-green")
+    if red["verdict"] != ci.SNAP.RED or green["verdict"] != ci.SNAP.GREEN:
+        problems.append(f"[SEC-2] the one-read fixtures no longer derive red and green: "
+                        f"{red['verdict']!r} / {green['verdict']!r}")
+        return problems
+    red_path, green_path = Path(red["snapshot"]), Path(green["snapshot"])
+    if red_path.name != green_path.name:
+        problems.append(f"[SEC-2] the one-read fixtures no longer promote the same artifact name "
+                        f"({red_path.name} vs {green_path.name}), so the swap this case performs is not "
+                        f"the swap a second read of ONE path would see")
+        return problems
+    green_bytes = green_path.read_bytes()
+    red_bytes = red_path.read_bytes()
+
+    pr = red["pr"]
+    ledger = red_dir / "state.jsonl"
+    header = dict(ci.LEDGER.HEADER_DEFAULTS)
+    header["run_id"] = "sec2"
+    row = dict(ci.LEDGER.ROW_DEFAULTS)
+    row.update({"pr": pr, "head_sha": red["head_sha"], "status": "in_review",
+                "required_set": ci.SNAP.NONE_DECLARED})
+    ci.LEDGER.dump(ledger, header, [row])
+
+    def verify(envelope: dict, swap: bool) -> tuple[int, int]:
+        """Run the recomputation with the artifact rewritten to the GREEN bytes after the first parse.
+
+        Returns (exit code, parses). `SNAP.parse` is the module attribute `evaluate` itself resolves, so
+        one wrapper counts BOTH entry points' reads.
+        """
+        red_path.write_bytes(red_bytes)
+        seen = [0]
+        real_parse = ci.SNAP.parse
+
+        def counting_parse(path):
+            seen[0] += 1
+            rows = real_parse(path)
+            if swap and seen[0] == 1:
+                Path(path).write_bytes(green_bytes)
+            return rows
+
+        ci.SNAP.parse = counting_parse
+        try:
+            ci.verify_derived_artifact(ledger, pr, ci.derive_output(json.loads(json.dumps(envelope))))
+        except SystemExit as exc:
+            return int(exc.code or 0), seen[0]
+        finally:
+            ci.SNAP.parse = real_parse
+        return 0, seen[0]
+
+    # (1) THE HONEST ENVELOPE, unswapped — the recomputation still accepts what `derive` actually printed.
+    # Without this, "refuse everything" would pass case (2) and pin nothing.
+    code, parses = verify(red, swap=False)
+    if code != 0:
+        problems.append(f"[SEC-2] the recorder refused `derive`'s own red envelope (exit {code}) — the "
+                        f"one-read recomputation must still accept a consistent derivation")
+    if parses != 1:
+        problems.append(f"[SEC-2] verifying one envelope parsed the promoted artifact {parses} times, not "
+                        f"once — verdict, reason, evidence, fingerprint and buckets are only ONE account "
+                        f"of ONE artifact while they all come off a single read")
+
+    # (2) THE FORGERY THE SECOND READ ADMITTED — green verdict and reason over red evidence, fingerprint
+    # and buckets, with the bytes swapped green after the first parse. One read never sees the swap, so
+    # the rows stay red and the green verdict has nothing to agree with.
+    forged = dict(red)
+    forged.update({"verdict": green["verdict"], "ci": ci.LEDGER_CI[green["verdict"]],
+                   "reason": green["reason"]})
+    code, parses = verify(forged, swap=True)
+    if code != 2:
+        problems.append(f"[SEC-2] an envelope carrying the GREEN verdict beside RED evidence, fingerprint "
+                        f"and buckets exited {code}, not 2 — the artifact was re-read after the counts "
+                        f"were taken, so the verdict was checked against bytes the rest of the "
+                        f"recomputation never saw")
+    if parses != 1:
+        problems.append(f"[SEC-2] the forged envelope parsed the promoted artifact {parses} times, not "
+                        f"once")
+    red_path.write_bytes(red_bytes)
+    return problems
+
+
 def liveness_head_attestation_cases(ci, tmp: Path) -> list[str]:
     """THE MOVED-HEAD ENVELOPE — three rewrites the recorder refuses, and the one it cannot.
 
@@ -1738,8 +1834,8 @@ def liveness_head_attestation_cases(ci, tmp: Path) -> list[str]:
     snapshot = Path(derived["snapshot"])
     required = ci.SNAP.parse_required_set(ci.SNAP.NONE_DECLARED)
     artifact_rows = ci.SNAP.parse(snapshot)
-    artifact_verdict, artifact_reason = ci.SNAP.evaluate(
-        snapshot, ci.FIXTURE_SHA, required=required, expect_filename_sha=True
+    artifact_verdict, artifact_reason = ci.SNAP.evaluate_rows(
+        snapshot, artifact_rows, ci.FIXTURE_SHA, required=required, expect_filename_sha=True
     )
 
     # (1) DENIED BUT NOT REWRITTEN — `head_moved` flipped to false while the moved-head verdict and reason
@@ -2584,6 +2680,14 @@ def run(ci, tmp: Path) -> int:
     if not field_class_problems:
         print(f"ok       {'liveness field classes':32} -> every producer envelope field lands in exactly "
               f"one check class; nothing is recorded unclassified")
+
+    single_parse_problems = liveness_single_parse_cases(ci, tmp)
+    for problem in single_parse_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not single_parse_problems:
+        print(f"ok       {'[SEC-2] one read':32} -> the promoted artifact is parsed exactly once per "
+              f"verification, and every recomputed field is bound to those bytes")
 
     attestation_problems = liveness_head_attestation_cases(ci, tmp)
     for problem in attestation_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status-test.py
@@ -1398,6 +1398,147 @@ def liveness_cli_cases(ci, tmp: Path) -> list[str]:
     return problems
 
 
+def liveness_no_artifact_cli_cases(ci, tmp: Path) -> list[str]:
+    """THE NO-ARTIFACT CLASS, DRIVEN END TO END: real producer output, real CLI, real ledger.
+
+    A derivation that promoted nothing is the ONE class whose whole point is to be RECORDED. It carries
+    no verdict anyone can act on, so the only thing it leaves behind is a strike on `unusable_refetches`
+    — and that strike is the only bound on "refetch until it works" (`stage-2-ci.md`, "NOT VERIFIED —
+    the refetch is BOUNDED"). An envelope this class refuses at the door records NO strike, so the
+    REFETCH CAP never fires and the absorbing state the cap exists to close is re-opened. That failure
+    is invisible to every suite that hands `liveness` a hand-built envelope, because a hand-built one
+    can be given whatever shape the validator happens to want.
+
+    So this suite builds NOTHING. It drives every recorded fixture through the real producer, keeps the
+    ones that promoted no artifact, and feeds each unedited envelope to the real `liveness` CLI as a
+    subprocess. THE CLASS IS DISCOVERED, NEVER LISTED: a new fixture whose fetch fails joins it without
+    anyone remembering to, and a fixture that stops failing simply leaves. `fetch-fails.json` is one
+    member of it, not the case — the class spans a dead source, refused page shapes, truncated payloads,
+    and every rollup the coverage rule will not accept, and each of them reaches this path identically.
+
+    The two fabricated envelopes at the end pin the OTHER direction, which is why the check is
+    conditional and not merely absent: three zero counts beside a null snapshot assert three
+    observations nobody made, and an empty object beside a promoted snapshot drops counts that exist.
+    """
+    problems: list[str] = []
+    members: list[tuple[str, dict, dict, Path]] = []
+    for fixture in cases(ci):
+        fx, derived, rundir, _before = run_fixture(ci, fixture, tmp / "no-artifact")
+        if derived["snapshot"] is None:
+            members.append((fixture, fx, derived, rundir))
+
+    # A SUITE WITH NOTHING IN IT PASSES VACUOUSLY. Two is not an arbitrary floor: one member could be a
+    # single fixture's quirk, and the claim here is about a CLASS every `FetchError` lands in.
+    if len(members) < 2:
+        problems.append(f"[SEC-2] the no-artifact class has {len(members)} member(s) among {len(cases(ci))} "
+                        f"fixtures — this suite would pass without exercising the path it exists for")
+        return problems
+
+    for fixture, fx, derived, rundir in members:
+        if derived["evidence"] != {}:
+            problems.append(f"[SEC-2] {fixture}: a derivation that promoted no artifact reported "
+                            f"evidence {derived['evidence']!r}, not the `{{}}` `result()` documents for "
+                            f"'nothing was ever fetched'")
+            continue
+        pr = fx.get("pr", "35")
+        head_sha = fx.get("head_sha", ci.FIXTURE_SHA)
+        ledger = rundir / "state.jsonl"
+        header = dict(ci.LEDGER.HEADER_DEFAULTS)
+        header["run_id"] = "sec2"
+        row = dict(ci.LEDGER.ROW_DEFAULTS)
+        row.update({"pr": pr, "head_sha": head_sha, "status": "in_review",
+                    "required_set": fx["required_set"]})
+
+        def record(envelope: dict, name: str) -> tuple[int, str, dict]:
+            ci.LEDGER.dump(ledger, header, [row])
+            payload = rundir / f"{name}.json"
+            payload.write_text(json.dumps(envelope), encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(ledger), "--pr", pr,
+                 "--derive-json", str(payload), "--machine-action", "none",
+                 "--now", "2026-08-26T00:00:00+00:00"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+            )
+            return proc.returncode, proc.stderr, ci.LEDGER.load(ledger)[1][0]
+
+        code, stderr, after = record(derived, "producer-derive")
+        if code != 0:
+            problems.append(f"[SEC-2] {fixture}: the producer's own no-artifact envelope exited {code}, "
+                            f"not 0: {stderr!r}")
+        elif after["unusable_refetches"] != "1":
+            problems.append(f"[SEC-2] {fixture}: a not-verified derivation left unusable_refetches at "
+                            f"{after['unusable_refetches']!r} — the REFETCH CAP counts nothing and the "
+                            f"refetch is unbounded")
+        elif after["ci"] != "pending":
+            problems.append(f"[SEC-2] {fixture}: a not-verified derivation recorded ci "
+                            f"{after['ci']!r}, not 'pending'")
+
+    # THE HONESTY DIRECTION, on one member: zero is a COUNT, and counting to zero is a claim that the
+    # source was read. Nothing read it.
+    fixture, fx, derived, rundir = members[0]
+    pr = fx.get("pr", "35")
+    head_sha = fx.get("head_sha", ci.FIXTURE_SHA)
+    ledger = rundir / "state.jsonl"
+    header = dict(ci.LEDGER.HEADER_DEFAULTS)
+    header["run_id"] = "sec2"
+    row = dict(ci.LEDGER.ROW_DEFAULTS)
+    row.update({"pr": pr, "head_sha": head_sha, "status": "in_review",
+                "required_set": fx["required_set"]})
+
+    def refuse(envelope: dict, name: str) -> tuple[int, str, bool]:
+        ci.LEDGER.dump(ledger, header, [row])
+        payload = rundir / f"{name}.json"
+        payload.write_text(json.dumps(envelope), encoding="utf-8")
+        before_bytes = ledger.read_bytes()
+        proc = subprocess.run(
+            [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(ledger), "--pr", pr,
+             "--derive-json", str(payload), "--machine-action", "none",
+             "--now", "2026-08-26T00:00:00+00:00"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+        )
+        return proc.returncode, proc.stderr, ledger.read_bytes() != before_bytes
+
+    counted = dict(derived)
+    counted["evidence"] = {"checkrun": 0, "status": 0, "witness": 0}
+    code, stderr, wrote = refuse(counted, "zero-counts-no-artifact")
+    if code != 2:
+        problems.append(f"[SEC-2] {fixture}: three zero counts beside a null snapshot exited {code}, not "
+                        f"2 — a fetch that never happened may not report three observations: {stderr!r}")
+    if wrote:
+        problems.append(f"[SEC-2] {fixture}: three zero counts beside a null snapshot changed the ledger")
+
+    # THE PROMOTED DIRECTION, so the conditional cannot decay into "any dict is fine": a promoted
+    # snapshot means `build_snapshot` returned, and its three counts are recomputed from the artifact.
+    _gfx, green_derived, green_rundir, _gbefore = run_fixture(ci, "green.json", tmp / "no-artifact-green")
+    if green_derived["snapshot"] is None:
+        problems.append("[SEC-2] green.json no longer promotes an artifact — the promoted half of the "
+                        "evidence-shape rule is untested")
+        return problems
+    green_pr = _gfx.get("pr", "35")
+    green_ledger = green_rundir / "state.jsonl"
+    green_row = dict(ci.LEDGER.ROW_DEFAULTS)
+    green_row.update({"pr": green_pr, "head_sha": _gfx.get("head_sha", ci.FIXTURE_SHA),
+                      "status": "in_review", "required_set": _gfx["required_set"]})
+    ci.LEDGER.dump(green_ledger, header, [green_row])
+    stripped = dict(green_derived)
+    stripped["evidence"] = {}
+    payload = green_rundir / "empty-evidence-promoted.json"
+    payload.write_text(json.dumps(stripped), encoding="utf-8")
+    before_bytes = green_ledger.read_bytes()
+    proc = subprocess.run(
+        [sys.executable, str(STATUS_PY), "liveness", "--ledger", str(green_ledger), "--pr", green_pr,
+         "--derive-json", str(payload), "--machine-action", "none",
+         "--now", "2026-08-26T00:00:00+00:00"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False,
+    )
+    if proc.returncode != 2:
+        problems.append(f"[SEC-2] an empty `evidence` beside a PROMOTED snapshot exited "
+                        f"{proc.returncode}, not 2: {proc.stderr!r}")
+    if green_ledger.read_bytes() != before_bytes:
+        problems.append("[SEC-2] an empty `evidence` beside a PROMOTED snapshot changed the ledger")
+    return problems
+
+
 def liveness_field_class_cases(ci) -> list[str]:
     """THE PARTITION IS TOTAL — no envelope field escapes being classified.
 
@@ -2288,6 +2429,14 @@ def run(ci, tmp: Path) -> int:
     if not liveness_cli_problems:
         print(f"ok       {'liveness input binding':32} -> forged trusted verdicts, fingerprints, and bucket "
               f"tallies cannot reach the ledger without matching promoted snapshot bytes")
+
+    no_artifact_problems = liveness_no_artifact_cli_cases(ci, tmp)
+    for problem in no_artifact_problems:
+        failures += 1
+        print(f"FAIL     {problem}")
+    if not no_artifact_problems:
+        print(f"ok       {'the no-artifact class':32} -> every fixture that promotes nothing records its "
+              f"refetch strike through the real CLI, while a fabricated count on either side is refused")
 
     field_class_problems = liveness_field_class_cases(ci)
     for problem in field_class_problems:

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1859,6 +1859,7 @@ def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
 
     The JSON is a transport envelope, not evidence. Every field is checked in the class the partition
     above this function's validator puts it in — `RECOMPUTED_FROM_ARTIFACT` against the promoted bytes,
+    all five of them bound to a SINGLE read of those bytes (see the recomputation below),
     `CHECKED_AGAINST_CANONICAL_STATE` against the ledger row and the artifact's own path,
     `DERIVED_FROM_A_CHECKED_FIELD` against the field it is a function of — with the TWO bounded exceptions
     that partition names and explains, and no others: the `PRODUCER_ATTESTED` class, and the
@@ -1894,10 +1895,17 @@ def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
     if (snapshot_resolved.parent != rundir
             or snapshot.name != f"ci-{pr}-{derived['head_sha']}.txt"):
         fail("liveness: derive JSON `snapshot` is not the promoted artifact for this PR and head")
+    # ONE READ, AND EVERY RECOMPUTED FIELD COMES OFF IT. `RECOMPUTED_FROM_ARTIFACT` names five fields, and
+    # they are ONE account of ONE artifact or they are not evidence: a verdict from one read of the file
+    # beside a fingerprint from another is two claims about two byte sequences that nothing made agree.
+    # So the artifact is parsed HERE, once, and `evaluate_rows` — which reads nothing, and wants `snapshot`
+    # only for the FILENAME rule — decides on those same rows, as do the evidence counts, the fingerprint
+    # and the buckets below. `SNAP.evaluate(snapshot, …)` re-opens the path, so calling it here would put
+    # the second read back. `ci-status-test.py`'s `[SEC-2] one read` case pins the count at one.
     try:
         artifact_rows = SNAP.parse(snapshot)
-        artifact_verdict, artifact_reason = SNAP.evaluate(
-            snapshot, derived["head_sha"], required=required, expect_filename_sha=True
+        artifact_verdict, artifact_reason = SNAP.evaluate_rows(
+            snapshot, artifact_rows, derived["head_sha"], required=required, expect_filename_sha=True
         )
     except (OSError, SNAP.SnapshotError) as exc:
         fail(f"liveness: the promoted snapshot cannot be independently verified: {exc}")

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1527,6 +1527,17 @@ def head_moved(head_sha: str, head_now: object) -> bool:
     return bool(head_now) and head_now != head_sha
 
 
+def moved_head_reason(head_sha: str, head_now: str, verdict: str, reason: str) -> str:
+    """Name the retained artifact's trust boundary after the PR head moved."""
+    return (
+        f"HEAD MOVED — this evidence was fetched for {head_sha}, but the PR's head is NOW {head_now}. "
+        f"It describes a commit that is no longer this PR's head, so it is not evidence about this PR "
+        f"at all: NOT green (the evidence is stale), and NOT red (that would be a claim about the wrong "
+        f"commit). Re-derive with --head-sha {head_now} once the ledger holds it. "
+        f"(what the stale snapshot said, for the record: {verdict} — {reason})"
+    )
+
+
 def derive(fetch: Fetch, repo: str, pr: str, head_sha: str, rundir: Path, required) -> dict:
     """FETCH -> PROMOTE -> VERIFY -> DECIDE, and then: IS THIS EVIDENCE EVEN ABOUT THIS PR?
 
@@ -1584,13 +1595,7 @@ def derive(fetch: Fetch, repo: str, pr: str, head_sha: str, rundir: Path, requir
     # instead of guessed. Both map to ledger `ci = pending` (LEDGER_CI is lossy, and that is why `verdict` is
     # emitted BESIDE `ci` and not collapsed into it).
     if head_moved(head_sha, head_now):
-        verdict, reason = SNAP.UNUSABLE, (
-            f"HEAD MOVED — this evidence was fetched for {head_sha}, but the PR's head is NOW {head_now}. "
-            f"It describes a commit that is no longer this PR's head, so it is not evidence about this PR "
-            f"at all: NOT green (the evidence is stale), and NOT red (that would be a claim about the wrong "
-            f"commit). Re-derive with --head-sha {head_now} once the ledger holds it. "
-            f"(what the stale snapshot said, for the record: {verdict} — {reason})"
-        )
+        verdict, reason = SNAP.UNUSABLE, moved_head_reason(head_sha, head_now, verdict, reason)
 
     # THE FINGERPRINT IS COMPUTED HERE, NEVER BY THE DRIVER — a hash a driver reassembles by hand from the
     # doc's spec is a hash that drifts, and every drifted byte reads as "CI moved", which resets the very
@@ -1696,35 +1701,139 @@ def derive_output(raw: object) -> dict:
 
     The same fail-closed posture as every other input: a field missing or of the wrong shape is refused
     at the door, because a liveness pass run on a hand-assembled approximation of `derive`'s output is
-    the hand-run bookkeeping this command exists to remove, wearing the command as a costume.
+    the hand-run bookkeeping this command exists to remove, wearing the command as a costume. The CLI
+    then independently verifies the producer's claims against the promoted snapshot before recording.
     """
     if not isinstance(raw, dict):
         fail("liveness: the derive JSON is not an object — hand this command the JSON `derive` printed, "
              "unedited")
+    expected_keys = {
+        "pr", "head_sha", "verdict", "ci", "reason", "snapshot", "evidence", "head_sha_now",
+        "head_moved", "required_set", "fingerprint", "buckets",
+    }
+    if set(raw) != expected_keys:
+        fail(f"liveness: the derive JSON fields are {sorted(raw)!r}, not the exact producer shape "
+             f"{sorted(expected_keys)!r}")
     out: dict = {}
-    for key in ("head_sha", "verdict", "ci", "reason"):
+    for key in ("pr", "head_sha", "verdict", "ci", "reason"):
         value = raw.get(key)
         if not isinstance(value, str) or not value:
             fail(f"liveness: the derive JSON carries no usable {key!r} — it is not `derive`'s output")
         out[key] = value
+    if not out["pr"].isdigit():
+        fail(f"liveness: derive JSON `pr` is {out['pr']!r}, not a PR number")
+    if not SHA_RE.fullmatch(out["head_sha"]):
+        fail(f"liveness: derive JSON `head_sha` is {out['head_sha']!r}, not a 40-hex object id")
+    if out["verdict"] not in LEDGER_CI:
+        fail(f"liveness: derive JSON `verdict` is {out['verdict']!r}, not a known CI verdict")
     if out["ci"] not in LEDGER_CI_VALUES:
         fail(f"liveness: derive JSON `ci` is {out['ci']!r}, not one of {'/'.join(LEDGER_CI_VALUES)}")
+    if ledger_ci(out["verdict"]) != out["ci"]:
+        fail(f"liveness: derive JSON `ci` {out['ci']!r} does not match verdict {out['verdict']!r}")
+    if not isinstance(raw["snapshot"], (str, type(None))):
+        fail(f"liveness: derive JSON `snapshot` is {raw['snapshot']!r}, not a path or null")
+    evidence = raw["evidence"]
+    if (not isinstance(evidence, dict) or set(evidence) != {"checkrun", "status", "witness"}
+            or any(type(value) is not int or value < 0 for value in evidence.values())):
+        fail(f"liveness: derive JSON `evidence` is not the three nonnegative producer counts: {evidence!r}")
+    head_now = raw["head_sha_now"]
+    if head_now is not None and (not isinstance(head_now, str) or not SHA_RE.fullmatch(head_now)):
+        fail(f"liveness: derive JSON `head_sha_now` is {head_now!r}, not a 40-hex object id or null")
+    if type(raw["head_moved"]) is not bool:
+        fail(f"liveness: derive JSON `head_moved` is {raw['head_moved']!r}, not a boolean")
+    if raw["head_moved"] != head_moved(out["head_sha"], head_now):
+        fail(f"liveness: derive JSON `head_moved` does not match `head_sha_now` for {out['head_sha']}")
+    if raw["required_set"] not in (SNAP.DECLARED, SNAP.NONE_DECLARED, SNAP.CANNOT_READ):
+        fail(f"liveness: derive JSON `required_set` is {raw['required_set']!r}, not a known state")
+    out.update({
+        "snapshot": raw["snapshot"], "evidence": evidence, "head_sha_now": head_now,
+        "head_moved": raw["head_moved"], "required_set": raw["required_set"],
+    })
     fp, buckets = raw.get("fingerprint"), raw.get("buckets")
     trusted_current_head = out["verdict"] not in NOT_VERIFIED_VERDICTS
     if trusted_current_head:
+        if raw["snapshot"] is None or raw["head_moved"] or head_now != out["head_sha"]:
+            fail("liveness: a trusted current-head derivation must name its promoted snapshot and "
+                 "matching current head")
         if not isinstance(fp, str) or not re.fullmatch(r"[0-9a-f]{64}", fp):
             fail(f"liveness: a derivation with trusted current-head evidence must carry a 64-hex "
                  f"`fingerprint`; got {fp!r}")
         if (not isinstance(buckets, dict) or set(buckets) != set(BUCKET_KEYS.values())
-                or any(not isinstance(v, int) or v < 0 for v in buckets.values())):
+                or any(type(v) is not int or v < 0 for v in buckets.values())):
             fail(f"liveness: a derivation with trusted current-head evidence must carry the four-key "
                  f"`buckets` tally; got {buckets!r}")
     elif fp is not None or buckets is not None:
         fail(f"liveness: verdict {out['verdict']!r} has no trusted current-head evidence, yet the JSON "
              f"carries fingerprint={fp!r} buckets={buckets!r} — that is not `derive`'s output")
+    if raw["snapshot"] is None and (evidence != {"checkrun": 0, "status": 0, "witness": 0}
+                                     or head_now is not None or raw["head_moved"]):
+        fail("liveness: a derivation without a promoted snapshot must carry no evidence and no current "
+             "head claim")
     out["fingerprint"], out["buckets"] = fp, buckets
     out["trusted_current_head"] = trusted_current_head
     return out
+
+
+def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
+    """Recompute liveness inputs from the promoted artifact before recording them.
+
+    The JSON is a transport envelope, not evidence. The artifact path, ledger row, required-set state,
+    verdict, reason, evidence counts, fingerprint, and bucket tally must all agree with canonical state.
+    """
+    header, rows = LEDGER.load(ledger_path)
+    row = LEDGER.find_row(rows, pr)
+    if row is None:
+        fail(f"liveness: no ledger row for PR {pr}")
+    if derived["pr"] != pr or derived["head_sha"] != row["head_sha"]:
+        fail("liveness: derive JSON does not name the requested PR's current ledger head")
+    try:
+        required = SNAP.parse_required_set(LEDGER.effective_required_set(header, row))
+    except SNAP.SpecError as exc:
+        fail(f"liveness: the ledger's required-set state cannot be verified: {exc}")
+    if derived["required_set"] != required.state:
+        fail("liveness: derive JSON `required_set` does not match the ledger row")
+
+    snapshot_name = derived["snapshot"]
+    if snapshot_name is None:
+        return
+    rundir = ledger_path.resolve().parent
+    try:
+        snapshot = Path(snapshot_name)
+        snapshot_resolved = snapshot.resolve()
+    except (OSError, RuntimeError, ValueError) as exc:
+        fail(f"liveness: derive JSON `snapshot` is not a usable path: {exc}")
+    if (snapshot_resolved.parent != rundir
+            or snapshot.name != f"ci-{pr}-{derived['head_sha']}.txt"):
+        fail("liveness: derive JSON `snapshot` is not the promoted artifact for this PR and head")
+    try:
+        artifact_rows = SNAP.parse(snapshot)
+        artifact_verdict, artifact_reason = SNAP.evaluate(
+            snapshot, derived["head_sha"], required=required, expect_filename_sha=True
+        )
+    except (OSError, SNAP.SnapshotError) as exc:
+        fail(f"liveness: the promoted snapshot cannot be independently verified: {exc}")
+    evidence = {kind: sum(1 for item in artifact_rows if item["row"] == kind)
+                for kind in ("checkrun", "status", "witness")}
+    if derived["evidence"] != evidence:
+        fail(f"liveness: derive JSON `evidence` {derived['evidence']!r} does not match the promoted "
+             f"snapshot {evidence!r}")
+
+    if derived["head_moved"]:
+        expected_reason = moved_head_reason(
+            derived["head_sha"], derived["head_sha_now"], artifact_verdict, artifact_reason
+        )
+        if ((derived["verdict"], derived["ci"], derived["reason"])
+                != (SNAP.UNUSABLE, LEDGER_CI[SNAP.UNUSABLE], expected_reason)):
+            fail("liveness: moved-head derive JSON does not match the promoted artifact")
+        return
+
+    if (derived["verdict"], derived["reason"]) != (artifact_verdict, artifact_reason):
+        fail("liveness: derive JSON verdict or reason does not match the promoted snapshot")
+    if derived["trusted_current_head"]:
+        expected_fp = SNAP.fingerprint(artifact_rows, derived["head_sha"])
+        expected_buckets = bucket_counts(artifact_rows)
+        if derived["fingerprint"] != expected_fp or derived["buckets"] != expected_buckets:
+            fail("liveness: derive JSON fingerprint or bucket tally does not match the promoted snapshot")
 
 
 def liveness(ledger_path: Path, pr: str, derived: dict, machine_action: str, now: datetime) -> dict:
@@ -3214,7 +3323,9 @@ def main() -> int:
         except ValueError as exc:
             fail(f"liveness: --derive-json is not JSON ({exc}) — hand it the JSON `derive` printed")
         now = check_now("--now", args.now) if args.now else datetime.now(timezone.utc)
-        out = liveness(args.ledger, args.pr, derive_output(raw), args.machine_action, now)
+        derived = derive_output(raw)
+        verify_derived_artifact(args.ledger, args.pr, derived)
+        out = liveness(args.ledger, args.pr, derived, args.machine_action, now)
         print(json.dumps(out, indent=2, ensure_ascii=False))
         # 3, not 1: the command DID its job and the answer is "this PR is now parked on you" — the same
         # STOP semantics as `ledger.py dispatch-check` (EXIT_STOP), distinct from an input error's 2.

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -982,7 +982,10 @@ class Snapshot(NamedTuple):
     """What `build_snapshot` hands `derive`. `rows` are the ARTIFACT'S LINES — dicts this file built, on
     their way to `promote()`, never read again by anything here."""
     rows: list
-    head_sha_now: object
+    # `str`, NEVER `object`: `fetch_rollup` raises rather than return a head it could not read, so a
+    # Snapshot that exists has one. Widening this to `object` would not describe the value better — it
+    # would only re-open, for every consumer, the "we cannot tell" case the fetch already refused.
+    head_sha_now: str
     evidence: dict
 
 
@@ -1183,7 +1186,7 @@ def fetch_statuses(fetch: Fetch, head_sha: str) -> tuple[list[dict], dict, list[
     return rows, {"row": "source", "source": "status", "sha": sha, "count": str(len(rows))}, seen
 
 
-def fetch_rollup(fetch: Fetch, pr: str) -> tuple[list[dict], dict, object, list[RollupStatus],
+def fetch_rollup(fetch: Fetch, pr: str) -> tuple[list[dict], dict, str, list[RollupStatus],
                                                  list[RollupRun]]:
     """(3) ROLLUP — its ROWS are WITNESSES ONLY (identity, no verdict), for the containment test.
 

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1701,10 +1701,16 @@ def check_now(source: str, value: str) -> datetime:
 
 # WHAT CHECK EACH ENVELOPE FIELD GETS BEFORE IT IS RECORDED — the ONE defining site of that partition.
 # `derive_output` refuses any envelope whose fields are not exactly `DERIVE_FIELDS`,
-# `verify_derived_artifact` applies the three classes, the driver doc's liveness owner block restates the
-# two a reader has to know, and `doc-check` holds those two to these names. The partition is TOTAL, and
-# `ci-status-test.py` asserts that it is: a field added to `result()` cannot reach the recording path
-# without someone saying which class it belongs to. The alternative is a new field nobody ever checked.
+# `verify_derived_artifact` applies the three classes WHENEVER THERE IS A PROMOTED ARTIFACT TO APPLY THEM
+# AGAINST, the driver doc's liveness owner block restates the sets a reader has to know, and `doc-check`
+# holds those sets to these names. The partition is TOTAL, and `ci-status-test.py` asserts that it is: a
+# field added to `result()` cannot reach the recording path without someone saying which class it belongs
+# to. The alternative is a new field nobody ever checked.
+#
+# TWO BOUNDED EXCEPTIONS, BOTH NAMED HERE. `PRODUCER_ATTESTED` is a field class and holds on every branch;
+# `NO_ARTIFACT_PRODUCER_COPY` is a BRANCH, not a class, and is stated below the moved-head cost. Neither is
+# a gap waiting to be closed, and there is no third: past the null-snapshot return,
+# `verify_derived_artifact` recomputes or refuses everything else it records.
 #
 # `PRODUCER_ATTESTED` NAMES A REAL BOUNDARY — it is not a gap waiting to be closed. The PR's head as of
 # the fetch is the ONE liveness input the promoted artifact cannot answer for: `ci-snapshot.py` is a pure
@@ -1714,13 +1720,32 @@ def check_now(source: str, value: str) -> datetime:
 # either one here would mean a network call inside the recorder, which is exactly what this architecture
 # refuses; putting the head into the artifact would end its auditability as a pure function of bytes.
 #
-# WHAT THAT COSTS, STATED WHERE IT CAN BE READ. The recorder catches a moved head reported as anything
+# WHAT THAT COSTS, STATED WHERE IT CAN BE READ — the cost of `PRODUCER_ATTESTED`, and only that; the
+# no-artifact branch's own cost is stated below. The recorder catches a moved head reported as anything
 # but the moved-head result — the `head_moved` branch below rebuilds `moved_head_reason()` and refuses
 # any other verdict, reason, or ledger value. It CANNOT catch a moved head DENIED: an envelope whose
 # `head_sha_now` says the pinned head is still current is indistinguishable from a genuine unmoved-head
 # derivation, because every remaining field then recomputes from the artifact exactly as it should.
 # Only `derive`, which saw the head, can refuse that — and it does. Nothing but `derive` writes this
 # envelope in real operation, so denying a moved head means editing the producer's own output.
+#
+# WITH NO PROMOTED ARTIFACT THERE IS NOTHING TO RECOMPUTE AGAINST — the second exception, and it is a
+# BRANCH rather than a field class. A failed or incomplete fetch promotes nothing and reports
+# `snapshot: null` (`stage-2-ci.md`, "FAILED OR INCOMPLETE FETCHES PROMOTE NOTHING"), so
+# `verify_derived_artifact` returns before any recomputation and NO member of
+# `RECOMPUTED_FROM_ARTIFACT` is re-derived on that branch. THE HOLE IS NOT THE WHOLE SET. `derive_output`
+# pins three of those five to their ONE legal value for such an envelope and refuses anything else at the
+# door, which is exit 2 rather than a belief. What survives to be recorded on the producer's word is
+# exactly `NO_ARTIFACT_PRODUCER_COPY`.
+#
+# WHAT THAT COSTS, on this branch. `reason` is arbitrary text nothing recomputes, and `liveness` embeds it
+# verbatim in the REFETCH CAP diagnostic it writes to `ci_reason`; `verdict` can be swapped for the other
+# member of `NOT_VERIFIED_VERDICTS`, which changes only that diagnostic's label. NO GREEN IS REACHABLE
+# THIS WAY, and no bound is escaped: a trusted verdict beside a null snapshot is refused by
+# `derive_output`, both surviving verdicts map to `ci = pending`, `unusable_refetches` still increments,
+# and the row still parks at the cap. `ci_reason` is the open question a human rules on through
+# `blocker_ruling`, and nothing machine-readable parses its text. As above, only `derive` writes this
+# envelope in real operation.
 DERIVE_FIELDS = frozenset({
     "pr", "head_sha", "verdict", "ci", "reason", "snapshot", "evidence", "head_sha_now",
     "head_moved", "required_set", "fingerprint", "buckets",
@@ -1729,6 +1754,9 @@ RECOMPUTED_FROM_ARTIFACT = frozenset({"verdict", "reason", "evidence", "fingerpr
 CHECKED_AGAINST_CANONICAL_STATE = frozenset({"pr", "head_sha", "required_set", "snapshot"})
 DERIVED_FROM_A_CHECKED_FIELD = frozenset({"ci"})   # `ledger_ci(verdict)`, refused when they disagree
 PRODUCER_ATTESTED = frozenset({"head_sha_now", "head_moved"})
+# NOT a fifth class — a subset of `RECOMPUTED_FROM_ARTIFACT`, naming what that set's promise does NOT
+# cover on the null-snapshot branch. Its complement within that set is what `derive_output` pins.
+NO_ARTIFACT_PRODUCER_COPY = frozenset({"verdict", "reason"})
 
 
 def derive_output(raw: object) -> dict:
@@ -1832,9 +1860,11 @@ def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
     The JSON is a transport envelope, not evidence. Every field is checked in the class the partition
     above this function's validator puts it in — `RECOMPUTED_FROM_ARTIFACT` against the promoted bytes,
     `CHECKED_AGAINST_CANONICAL_STATE` against the ledger row and the artifact's own path,
-    `DERIVED_FROM_A_CHECKED_FIELD` against the field it is a function of — with the single exception the
-    partition names and explains: `PRODUCER_ATTESTED`. Read that comment before adding a field here; a
-    field this function does not check is a field the recorder believes.
+    `DERIVED_FROM_A_CHECKED_FIELD` against the field it is a function of — with the TWO bounded exceptions
+    that partition names and explains, and no others: the `PRODUCER_ATTESTED` class, and the
+    `NO_ARTIFACT_PRODUCER_COPY` branch reached at the `snapshot: null` return below, where there are no
+    promoted bytes to recompute anything against. Read that comment before adding a field here; a field
+    this function does not check is a field the recorder believes.
     """
     header, rows = LEDGER.load(ledger_path)
     row = LEDGER.find_row(rows, pr)
@@ -1849,6 +1879,9 @@ def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
     if derived["required_set"] != required.state:
         fail("liveness: derive JSON `required_set` does not match the ledger row")
 
+    # NOTHING WAS PROMOTED, SO THERE IS NOTHING TO RECOMPUTE AGAINST. This return is the
+    # `NO_ARTIFACT_PRODUCER_COPY` branch; the partition above `derive_output` owns what reaches the ledger
+    # unrecomputed here, what `derive_output` pins instead, and what that costs.
     snapshot_name = derived["snapshot"]
     if snapshot_name is None:
         return
@@ -2245,7 +2278,7 @@ def parse_liveness_contract(blocks: list[str]) -> dict[str, str]:
         "untrusted_verdicts", "untrusted_action", "trusted_current_head_action",
         "retained_moved_head_artifact", "head_sha_changed_action", "refetch_cap",
         "refetch_diagnostic", "unusable_refusal", "unverifiable_refusal",
-        "recomputed_from_artifact", "producer_attested",
+        "recomputed_from_artifact", "producer_attested", "no_artifact_producer_copy",
     }
     for block in blocks:
         if "liveness.untrusted_verdicts" not in block:
@@ -3018,8 +3051,9 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
          current-PR verdict, fingerprint, or buckets; and the liveness owner block says that a final
          untrusted result increments the refetch counter while trusted current-head evidence resets it,
-         and names the envelope fields `liveness` recomputes from the promoted artifact and the ones it
-         records on the producer's attestation (the partition above `derive_output` owns those two sets).
+         and names the envelope fields `liveness` recomputes from the promoted artifact, the ones it
+         records on the producer's attestation, and the ones a `snapshot: null` derivation gets recorded
+         unrecomputed instead (the partition above `derive_output` owns all three sets).
 
     (The doc's three snapshot `jq` filters are executed by `ci-snapshot.py` over recorded, multi-page API
     payloads. The required-set reads are production functions here, covered by `ci-status-test.py`.)
@@ -3136,6 +3170,16 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          set(PRODUCER_ATTESTED),
          "the fields the artifact cannot answer for must be named as the producer's attestation — a doc "
          "that omits one is claiming a verification the recorder never performs"),
+        # THE NAME-ONLY COMPARISON ABOVE CANNOT SEE A BRANCH. `recomputed_from_artifact` names the set;
+        # it says nothing about the null-snapshot path, where none of that set is recomputed. So the
+        # branch gets its OWN named set, held to the code the same way — otherwise the doc can keep
+        # promising a recomputation on a branch that performs none, and every check still passes.
+        ("liveness no-artifact copy",
+         set(liveness_contract.get("no_artifact_producer_copy", "").split()),
+         set(NO_ARTIFACT_PRODUCER_COPY),
+         "with no promoted snapshot nothing is recomputed, so the doc must name exactly the fields that "
+         "reach the ledger as the producer wrote them — the rest of the recomputed set is pinned by "
+         "`derive_output` to its one legal value there"),
         ("the STRIKE CAP", caps.get("STRIKE"), STRIKE_CAP,
          "the bound `liveness` fires at and the bound the doc promises are different numbers"),
         ("the REFETCH CAP", caps.get("REFETCH"), REFETCH_CAP,

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1699,24 +1699,53 @@ def check_now(source: str, value: str) -> datetime:
     return ts
 
 
+# WHAT CHECK EACH ENVELOPE FIELD GETS BEFORE IT IS RECORDED — the ONE defining site of that partition.
+# `derive_output` refuses any envelope whose fields are not exactly `DERIVE_FIELDS`,
+# `verify_derived_artifact` applies the three classes, the driver doc's liveness owner block restates the
+# two a reader has to know, and `doc-check` holds those two to these names. The partition is TOTAL, and
+# `ci-status-test.py` asserts that it is: a field added to `result()` cannot reach the recording path
+# without someone saying which class it belongs to. The alternative is a new field nobody ever checked.
+#
+# `PRODUCER_ATTESTED` NAMES A REAL BOUNDARY — it is not a gap waiting to be closed. The PR's head as of
+# the fetch is the ONE liveness input the promoted artifact cannot answer for: `ci-snapshot.py` is a pure
+# function from bytes to a verdict, handed no PR and making no network call (see `derive`), so the head
+# never enters the artifact and nothing on disk can contradict the producer about it. `head_moved` is
+# `head_moved(head_sha, head_sha_now)`, so it stands or falls with that same attestation. Re-deriving
+# either one here would mean a network call inside the recorder, which is exactly what this architecture
+# refuses; putting the head into the artifact would end its auditability as a pure function of bytes.
+#
+# WHAT THAT COSTS, STATED WHERE IT CAN BE READ. The recorder catches a moved head reported as anything
+# but the moved-head result — the `head_moved` branch below rebuilds `moved_head_reason()` and refuses
+# any other verdict, reason, or ledger value. It CANNOT catch a moved head DENIED: an envelope whose
+# `head_sha_now` says the pinned head is still current is indistinguishable from a genuine unmoved-head
+# derivation, because every remaining field then recomputes from the artifact exactly as it should.
+# Only `derive`, which saw the head, can refuse that — and it does. Nothing but `derive` writes this
+# envelope in real operation, so denying a moved head means editing the producer's own output.
+DERIVE_FIELDS = frozenset({
+    "pr", "head_sha", "verdict", "ci", "reason", "snapshot", "evidence", "head_sha_now",
+    "head_moved", "required_set", "fingerprint", "buckets",
+})
+RECOMPUTED_FROM_ARTIFACT = frozenset({"verdict", "reason", "evidence", "fingerprint", "buckets"})
+CHECKED_AGAINST_CANONICAL_STATE = frozenset({"pr", "head_sha", "required_set", "snapshot"})
+DERIVED_FROM_A_CHECKED_FIELD = frozenset({"ci"})   # `ledger_ci(verdict)`, refused when they disagree
+PRODUCER_ATTESTED = frozenset({"head_sha_now", "head_moved"})
+
+
 def derive_output(raw: object) -> dict:
     """Validate the derive JSON handed to `liveness` — the UNEDITED output of `derive`, nothing else.
 
     The same fail-closed posture as every other input: a field missing or of the wrong shape is refused
     at the door, because a liveness pass run on a hand-assembled approximation of `derive`'s output is
     the hand-run bookkeeping this command exists to remove, wearing the command as a costume. The CLI
-    then independently verifies the producer's claims against the promoted snapshot before recording.
+    then checks every field of the envelope in the class the partition above puts it in, before it
+    records anything.
     """
     if not isinstance(raw, dict):
         fail("liveness: the derive JSON is not an object — hand this command the JSON `derive` printed, "
              "unedited")
-    expected_keys = {
-        "pr", "head_sha", "verdict", "ci", "reason", "snapshot", "evidence", "head_sha_now",
-        "head_moved", "required_set", "fingerprint", "buckets",
-    }
-    if set(raw) != expected_keys:
+    if set(raw) != DERIVE_FIELDS:
         fail(f"liveness: the derive JSON fields are {sorted(raw)!r}, not the exact producer shape "
-             f"{sorted(expected_keys)!r}")
+             f"{sorted(DERIVE_FIELDS)!r}")
     out: dict = {}
     for key in ("pr", "head_sha", "verdict", "ci", "reason"):
         value = raw.get(key)
@@ -1780,8 +1809,12 @@ def derive_output(raw: object) -> dict:
 def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
     """Recompute liveness inputs from the promoted artifact before recording them.
 
-    The JSON is a transport envelope, not evidence. The artifact path, ledger row, required-set state,
-    verdict, reason, evidence counts, fingerprint, and bucket tally must all agree with canonical state.
+    The JSON is a transport envelope, not evidence. Every field is checked in the class the partition
+    above this function's validator puts it in — `RECOMPUTED_FROM_ARTIFACT` against the promoted bytes,
+    `CHECKED_AGAINST_CANONICAL_STATE` against the ledger row and the artifact's own path,
+    `DERIVED_FROM_A_CHECKED_FIELD` against the field it is a function of — with the single exception the
+    partition names and explains: `PRODUCER_ATTESTED`. Read that comment before adding a field here; a
+    field this function does not check is a field the recorder believes.
     """
     header, rows = LEDGER.load(ledger_path)
     row = LEDGER.find_row(rows, pr)
@@ -1821,6 +1854,11 @@ def verify_derived_artifact(ledger_path: Path, pr: str, derived: dict) -> None:
         fail(f"liveness: derive JSON `evidence` {derived['evidence']!r} does not match the promoted "
              f"snapshot {evidence!r}")
 
+    # THE BRANCH IS TAKEN ON AN ATTESTED FIELD, AND ONE DIRECTION OF IT CANNOT BE CHECKED HERE. Reported
+    # as moved, the result is rebuilt from the artifact and refused unless it IS the moved-head result —
+    # a moved head cannot be dressed up as anything else. Reported as NOT moved, there is nothing on disk
+    # to contradict it: `head_sha_now` is `PRODUCER_ATTESTED` (see the partition above `derive_output`),
+    # so this falls through to the recomputation below, which is the whole check such an envelope gets.
     if derived["head_moved"]:
         expected_reason = moved_head_reason(
             derived["head_sha"], derived["head_sha_now"], artifact_verdict, artifact_reason
@@ -2182,11 +2220,12 @@ def parse_moved_head_contract(blocks: list[str]) -> dict[str, str]:
 
 
 def parse_liveness_contract(blocks: list[str]) -> dict[str, str]:
-    """The refetch-counter owner block -> trust, actions, cap, and diagnostic shape."""
+    """The refetch-counter owner block -> trust, actions, cap, diagnostic shape, and the input classes."""
     keys = {
         "untrusted_verdicts", "untrusted_action", "trusted_current_head_action",
         "retained_moved_head_artifact", "head_sha_changed_action", "refetch_cap",
         "refetch_diagnostic", "unusable_refusal", "unverifiable_refusal",
+        "recomputed_from_artifact", "producer_attested",
     }
     for block in blocks:
         if "liveness.untrusted_verdicts" not in block:
@@ -2957,8 +2996,10 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
          MARKED `ci-status.py` block against the command `canonical_command()` generates for its id, which
          its body must EQUAL and whose opener must have a conforming CLOSE.
       6. the moved-head owner block says the old-head artifact is retained for audit but contributes no
-         current-PR verdict, fingerprint, or buckets; and the liveness owner block says that final
-         untrusted result increments the refetch counter while trusted current-head evidence resets it.
+         current-PR verdict, fingerprint, or buckets; and the liveness owner block says that a final
+         untrusted result increments the refetch counter while trusted current-head evidence resets it,
+         and names the envelope fields `liveness` recomputes from the promoted artifact and the ones it
+         records on the producer's attestation (the partition above `derive_output` owns those two sets).
 
     (The doc's three snapshot `jq` filters are executed by `ci-snapshot.py` over recorded, multi-page API
     payloads. The required-set reads are production functions here, covered by `ci-status-test.py`.)
@@ -3067,6 +3108,14 @@ def doc_check(spec_doc: "Path | None" = None, driver_doc: "Path | None" = None) 
         ("liveness UNVERIFIABLE refusal", liveness_contract.get("unverifiable_refusal"),
          "witness-identity containment failure; line/row not required",
          "witness identity can prevent containment proof without identifying an evidence row"),
+        ("liveness recomputed fields", set(liveness_contract.get("recomputed_from_artifact", "").split()),
+         set(RECOMPUTED_FROM_ARTIFACT),
+         "a field the doc promises is recomputed from the promoted artifact, but is not, is recorded on "
+         "the producer's word while the doc says it was checked"),
+        ("liveness attested fields", set(liveness_contract.get("producer_attested", "").split()),
+         set(PRODUCER_ATTESTED),
+         "the fields the artifact cannot answer for must be named as the producer's attestation — a doc "
+         "that omits one is claiming a verification the recorder never performs"),
         ("the STRIKE CAP", caps.get("STRIKE"), STRIKE_CAP,
          "the bound `liveness` fires at and the bound the doc promises are different numbers"),
         ("the REFETCH CAP", caps.get("REFETCH"), REFETCH_CAP,

--- a/plugins/gauntlet/skills/campaign/scripts/ci-status.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ci-status.py
@@ -1765,9 +1765,8 @@ def derive_output(raw: object) -> dict:
     if not isinstance(raw["snapshot"], (str, type(None))):
         fail(f"liveness: derive JSON `snapshot` is {raw['snapshot']!r}, not a path or null")
     evidence = raw["evidence"]
-    if (not isinstance(evidence, dict) or set(evidence) != {"checkrun", "status", "witness"}
-            or any(type(value) is not int or value < 0 for value in evidence.values())):
-        fail(f"liveness: derive JSON `evidence` is not the three nonnegative producer counts: {evidence!r}")
+    if not isinstance(evidence, dict):
+        fail(f"liveness: derive JSON `evidence` is not an object: {evidence!r}")
     head_now = raw["head_sha_now"]
     if head_now is not None and (not isinstance(head_now, str) or not SHA_RE.fullmatch(head_now)):
         fail(f"liveness: derive JSON `head_sha_now` is {head_now!r}, not a 40-hex object id or null")
@@ -1797,10 +1796,31 @@ def derive_output(raw: object) -> dict:
     elif fp is not None or buckets is not None:
         fail(f"liveness: verdict {out['verdict']!r} has no trusted current-head evidence, yet the JSON "
              f"carries fingerprint={fp!r} buckets={buckets!r} — that is not `derive`'s output")
-    if raw["snapshot"] is None and (evidence != {"checkrun": 0, "status": 0, "witness": 0}
-                                     or head_now is not None or raw["head_moved"]):
-        fail("liveness: a derivation without a promoted snapshot must carry no evidence and no current "
-             "head claim")
+    # THE EVIDENCE SHAPE FOLLOWS FROM WHETHER ANYTHING WAS FETCHED, which is exactly what `snapshot`
+    # already says — so it is decided HERE, beside the snapshot-null guard, and not as a free-standing
+    # shape rule that would have to guess. `result()` states the producer's contract in one line
+    # (`evidence` is "`{}` when nothing was ever fetched"), and `derive`'s `FetchError` branch emits
+    # precisely that beside `snapshot: null`. THREE ZERO COUNTS WOULD BE THE WRONG DEMAND HERE, in both
+    # directions: no producer output can satisfy it, and satisfying it would mean asserting three
+    # observations nobody made. A promoted snapshot is the other side of the same fact — `build_snapshot`
+    # returned, so all three counts exist, and `verify_derived_artifact` recomputes them from the
+    # artifact's own rows.
+    #
+    # REFUSING THE EMPTY OBJECT HERE WOULD RE-OPEN THE UNBOUNDED REFETCH. Every `FetchError` inside
+    # `build_snapshot` lands in this class — a source that could not be read, a page shape the reader
+    # refuses, a truncated payload, a rollup the coverage rule will not accept — and this class is the
+    # ONLY thing `unusable_refetches` counts. An envelope refused at the door records no strike, so the
+    # REFETCH CAP (`stage-2-ci.md`, "NOT VERIFIED — the refetch is BOUNDED") never fires and "refetch
+    # until it works" has nothing left to end it. Accepting `{}` weakens no binding: `evidence` is
+    # never recomputed for this class (`verify_derived_artifact` returns at a null snapshot) and
+    # `liveness` never reads it.
+    if raw["snapshot"] is None:
+        if evidence != {} or head_now is not None or raw["head_moved"]:
+            fail("liveness: a derivation without a promoted snapshot must carry no evidence and no "
+                 "current head claim")
+    elif (set(evidence) != {"checkrun", "status", "witness"}
+            or any(type(value) is not int or value < 0 for value in evidence.values())):
+        fail(f"liveness: derive JSON `evidence` is not the three nonnegative producer counts: {evidence!r}")
     out["fingerprint"], out["buckets"] = fp, buckets
     out["trusted_current_head"] = trusted_current_head
     return out

--- a/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
+++ b/plugins/gauntlet/skills/campaign/scripts/mutate-ci-snapshot.py
@@ -74,7 +74,8 @@ SCRIPT = Path(__file__).parent / "ci-snapshot.py"
 FIXTURES = Path(__file__).parent / "fixtures" / "ci-snapshot"
 
 # The functions that ENFORCE the contract. Every enforcement point inside them must carry a marker.
-# `evaluate` is not one: it MAPS an exception to a verdict, it does not decide anything.
+# Neither `evaluate` entry point is one: `evaluate` and `evaluate_rows` MAP an exception to a verdict,
+# they do not decide anything.
 RULE_FUNCTIONS = ("parse", "verify_filename", "verify_sha", "verify_sources", "check_containment", "decide")
 
 # What "enforcement" looks like in those functions.


### PR DESCRIPTION
- SEC-2: forged derive JSON could record green CI without snapshot-backed evidence.
- Fix: liveness requires exact fields and recomputes verdict, counts, fingerprint, and buckets from the ledger snapshot.
- Tests pass focused, mutation, validator, and self-tests; fetch, production, arithmetic, and watch stay untouched.
