### PR TITLE
validate adoption tier before writes

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt-test.py
@@ -96,6 +96,23 @@ def t_refuse_closed():
     check(plan(state="OPEN")["verdict"] == "adopt", "an OPEN PR must adopt")
 
 
+def t_refuse_unknown_tier_before_mutation():
+    """An adoption tier must be in triage's closed vocabulary before any row, worktree, or label write."""
+    with tempfile.TemporaryDirectory() as dd:
+        d = Path(dd)
+        ledger = d / "state.jsonl"
+        _init_ledger(ledger)
+        code, _, err, rec = _adopt(d, ledger, view(), wroot=d / "wt", tier="BOGUS")
+        check(code != 0, "an unknown tier must refuse adoption")
+        check("BOGUS" in err, f"the refusal must name the unknown tier, got {err!r}")
+        check(M.L.find_row(M.L.load(ledger)[1], "12") is None,
+              "an unknown tier must not register a ledger row")
+        check(not rec.any_call(lambda a: a[0] == "git"),
+              "an unknown tier must refuse before resolving or creating a worktree")
+        check(rec.one("gh", "label", "create") is None and rec.one("gh", "pr", "edit") is None,
+              "an unknown tier must refuse before writing labels")
+
+
 # --- adopt --------------------------------------------------------------------
 
 def t_adopt_same_repo():
@@ -1402,6 +1419,7 @@ CASES = [
     ("refuse_fork", "a fork PR is refused, fail closed", t_refuse_fork),
     ("refuse_foreign_run", "a PR owned by another run is refused", t_refuse_foreign_run),
     ("refuse_closed", "a MERGED/CLOSED PR is refused", t_refuse_closed),
+    ("refuse_unknown_tier", "an unknown tier is refused before row, worktree, or label mutation", t_refuse_unknown_tier_before_mutation),
     ("adopt_same_repo", "a clean same-repo OPEN PR adopts with the computed row", t_adopt_same_repo),
     ("adopt_when_already_ours", "a PR already carrying our run label re-adopts", t_adopt_when_already_ours),
     ("slugify", "slugify yields a lowercase, dash-collapsed, untrimmed-dash-free slug", t_slugify),

--- a/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
+++ b/plugins/gauntlet/skills/campaign/scripts/pr-adopt.py
@@ -70,6 +70,10 @@ BASE_RETARGET_PY = _HERE / "base-retarget.py"   # the ONE decider of what a live
 
 
 L = load_sibling("pr_adopt_ledger", _HERE, "ledger.py")
+# The triage tiers are a closed vocabulary owned by `triage.py`; adoption validates against that set before
+# it computes anything that can reach the ledger, worktree, or GitHub label writers.
+T = load_sibling("pr_adopt_triage", _HERE, "triage.py", register=True)
+TIER_VALUES = T.TIER_VALUES
 # `required(tier)` — the review gate's SATISFIED-verdict floor — is OWNED by review-pass.py
 # (`required_reviews`); the status label mirrors that gate, so reuse the owner rather than retype the rule.
 RP = load_sibling("pr_adopt_review_pass", _HERE, "review-pass.py")
@@ -162,6 +166,10 @@ def build_plan(view: dict, *, run_id: str, tier: str, worktrees_root: str) -> di
     step 2), else `{"verdict": "adopt", "row": {...computed fields...}, "labels_add": [...], "branch": ...,
     "worktree": ..., "base": ...}`. FAIL CLOSED: every refusal is checked before any adopt field is built.
     """
+    if tier not in TIER_VALUES:
+        return {"verdict": "refuse",
+                "reason": f"tier {tier!r} is not one of {', '.join(sorted(TIER_VALUES))}"}
+
     # A fork PR is untrusted, attacker-controllable content this autonomous pipeline would read and act on,
     # and it has no push target for fix commits — campaign gates SAME-REPO PRs only (step 2).
     if view.get("isCrossRepository") is True:


### PR DESCRIPTION
- API-3 trigger: invalid `--tier` reached ledger state; impact: closed-enum checks failed later.
- Fix: validate against `triage.py:TIER_VALUES` before row, worktree, or label writes; add regression coverage.
- Tests pass: adoption, triage, label self-tests, validator; untouched: `label-mirror.py`, `merge.py`, tier docs.
