### PR TITLE
bind review artifact writers

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -258,15 +258,15 @@ enforced: the progress file is a plaintext file in a directory the reviewer can 
     # record that ONE default dimension does not apply ("Review work-plan ledger" owns the rule)
 ["python3", review_pass_script, "plan-check", "--file", plan_file, "--tier", tier]
     # every default dimension covered or waived? MUST pass before dispatch — a refusal blocks the launch
-["python3", review_pass_script, "emit", "--file", progress_file,
+["python3", review_pass_script, "emit", "--run-dir", review_root, "--file", progress_file,
  "--unit", unit, "--status", status, "--evidence", evidence]
-["python3", review_pass_script, "amend", "--file", progress_file,
+["python3", review_pass_script, "amend", "--run-dir", review_root, "--file", progress_file,
  "--reason", reason, "--id", unit, "--kind", kind, "--target", target, "--check", check]
     # raise ONE plan_amendment_request; ts stamped by the tool (what emit-amendment.py calls)
-["python3", review_pass_script, "finding-add", "--file", findings_file,
+["python3", review_pass_script, "finding-add", "--run-dir", review_root, "--file", findings_file,
  "--path", path, "--line", line, "--writer", writer, "--purpose", purpose,
  "--base", base, "--base-repro", base_repro, "--repro", repro, "--fix", fix]
-["python3", review_pass_script, "report-write", "--file", report_file,
+["python3", review_pass_script, "report-write", "--run-dir", review_root, "--file", report_file,
  "--verdict", verdict, "--deferred-reason", deferred_reason, "--summary", summary,
  "--residual-risk", record, ...]
     # write the pass's ONE report record (what emit-report.py calls). `--residual-risk` repeats and is
@@ -447,8 +447,9 @@ reviewer never supplies the clock; the read rule here is what a hand-written lin
 **Calling `emit-progress.py` is the ONLY sanctioned way to record a unit-progress event
 (`started`/`done`).** The reviewer MUST NOT ever write those unit-progress events into the progress
 file directly — no hand-written JSON, no `echo`/`printf`/redirection into it, no editor append. Every
-unit-progress event reaches the file through the tool and no other path. **Its CLI is unchanged**
-(`--file --unit --status --evidence`); it now forwards to `review-pass.py emit`, which enforces the
+unit-progress event reaches the file through the tool and no other path. **Its writer is bound to the
+active run root** (`--run-dir`); the resolved artifact parent must remain below that transport root. Its
+CLI forwards to `review-pass.py emit` with `--run-dir --file --unit --status --evidence`, which enforces the
 unit-progress rules above at the write door (the `--unit` is NOT trimmed — pass the id exactly as the
 plan spells it) and — the refusal that is not about the event at all — refuses **a progress file
 `verify` could not read**, which most often means one carrying no `pass_identity` yet. The emit-only rule is not
@@ -712,7 +713,8 @@ The reviewer now records **every** finding through the tool (its CLI is defined 
 
 ```text
 run_argv([
-  "python3", transport.emit_finding_path, "--file", transport.findings_path,
+  "python3", transport.emit_finding_path, "--run-dir", transport.review_root,
+  "--file", transport.findings_path,
   "--path", file, "--line", line, "--writer", writer, "--purpose", purpose,
   "--base", base, "--base-repro", base_repro, "--repro", repro, "--fix", fix
 ])

--- a/plugins/gauntlet/skills/campaign/scripts/emit-amendment.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-amendment.py
@@ -25,7 +25,7 @@ this pass verifies `amended` until the orchestrator folds the proposed unit into
 plan and restarts the pass (or records why not), and you write your report with `--verdict deferred`.
 
 A non-zero exit means the amendment was REJECTED, not that the tool is broken: read the message, fix the
-call, re-run. The flags are `--file --reason --id --kind --target --check`, and they are defined in ONE
+call, re-run. The flags are `--run-dir --file --reason --id --kind --target --check`, and they are defined in ONE
 place — `review-pass.py`'s `add_amendment_args`, which this door and the owner's `amend` subcommand both
 call, so `--help` here can never advertise a command the tool refuses.
 """

--- a/plugins/gauntlet/skills/campaign/scripts/emit-finding.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-finding.py
@@ -67,7 +67,7 @@ reachable from a real GitHub response, found in code an earlier fix round had it
 `writer=network`, it defends the PR's whole purpose, and it GATES. Look for its kind.
 
 A non-zero exit means the finding was REJECTED, not that the tool is broken: read the message, fix the call,
-re-run. The flags are `--file --path --line --writer --purpose --base --base-repro --repro --fix`, and they
+re-run. The flags are `--run-dir --file --path --line --writer --purpose --base --base-repro --repro --fix`, and they
 are defined in ONE
 place — `review-pass.py`'s `add_finding_args`, which this door and the owner's `finding-add` subcommand both
 call, so `--help` here can never advertise a command the tool refuses.

--- a/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
+++ b/plugins/gauntlet/skills/campaign/scripts/emit-progress.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Append one canonical reviewer progress event — the reviewer's door into `review-pass.py`.
 
-**THIS FILE'S CLI IS A PUBLIC CONTRACT AND IT HAS NOT MOVED.** `--file --unit --status --evidence`: same
+**THIS FILE'S CLI IS A PUBLIC CONTRACT AND IT HAS NOT MOVED.** `--run-dir --file --unit --status --evidence`: same
 flags, same meanings, same "a non-zero exit means your inputs were rejected — fix them and re-run". It is
 named in SKILL.md, in `stage-2-review-gate.md`, in `files-and-ledger.md`, and — the reason it can never be
 renamed on a whim — inside every review prompt the orchestrator dispatches. Those prompts are already

--- a/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-dispatch-test.py
@@ -182,7 +182,7 @@ def _write_report(args: SimpleNamespace, verdict: str) -> None:
     paths = D.attempt_paths(Path(args.run_dir), args.pr, args.review_pass, args.launch_attempt)
     reason = "-" if verdict != D.RP.DEFERRED else "fixture deferred the review"
     code, _out, err = capture_cli(D.RP.main, [
-        "report-write", "--file", os.fspath(paths["report"]), "--verdict", verdict,
+        "report-write", "--run-dir", os.fspath(Path(args.run_dir)), "--file", os.fspath(paths["report"]), "--verdict", verdict,
         "--deferred-reason", reason, "--summary", "Fixture report.",
     ])
     check(code == 0 and err == "", f"fixture report-write failed: code={code}, stderr={err!r}")
@@ -191,8 +191,8 @@ def _write_report(args: SimpleNamespace, verdict: str) -> None:
 def _complete_usable_binary_review(args: SimpleNamespace) -> None:
     paths = D.attempt_paths(Path(args.run_dir), args.pr, args.review_pass, args.launch_attempt)
     for argv in (
-        ["emit", "--file", os.fspath(paths["progress"]), "--unit", "u01", "--status", "started"],
-        ["emit", "--file", os.fspath(paths["progress"]), "--unit", "u01", "--status", "done",
+        ["emit", "--run-dir", os.fspath(Path(args.run_dir)), "--file", os.fspath(paths["progress"]), "--unit", "u01", "--status", "started"],
+        ["emit", "--run-dir", os.fspath(Path(args.run_dir)), "--file", os.fspath(paths["progress"]), "--unit", "u01", "--status", "done",
          "--evidence", "review-dispatch-test.py:1"],
     ):
         code, _out, err = capture_cli(D.RP.main, argv)

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -1221,6 +1221,7 @@ class Tables:
             "--reason": ["no unit covers the harness"],
             "--dimension": ["docs"], "--tier": ["TRIVIAL"],
             "--amendments-ruled": ["0"], "--verdict": [R.SATISFIED],
+            "--run-dir": ["."],
             "--path": ["scripts/ci-status.py"], "--line": ["769"], "--writer": ["network"],
             "--purpose": [PURPOSE_GREEN], "--repro": ["a reply with no rows"], "--fix": ["refuse it"],
             "--base": [R.INTRODUCED], "--base-repro": [R.NO_BASE_REPRO],
@@ -1592,6 +1593,7 @@ RULE_FUNCTIONS = (
     "plan_records", "load_plan",
     "check_event", "check_progress", "walk_progress", "check_identity_shape", "check_identity",
     "check_head", "check_scope", "check_progress_file", "check_plan_file", "parse_report", "decide", "parse_name", "check_ruled",
+    "check_writer_path",
     "before_text", "write_line", "cmd_emit", "cmd_identity", "cmd_plan_add", "cmd_plan_waive",
     "cmd_plan_check", "cmd_verify",
     # …and the FINDINGS side: the intent, the anchor, the writer, and the artifact they live in.
@@ -1614,6 +1616,10 @@ def check(cond: bool, msg: str) -> None:
 
 def run_cli_streams(mod: types.ModuleType, argv: "list[str]") -> "tuple[int, str, str]":
     """Drive the REAL CLI in-process: (exit code, stdout, stderr), never its internals."""
+    if argv and argv[0] in {"emit", "amend", "finding-add", "report-write"} and "--run-dir" not in argv:
+        file_value_index = argv.index("--file") + 1
+        target = Path(argv[file_value_index])
+        argv = [*argv[:file_value_index + 1], "--run-dir", str(target.parent), *argv[file_value_index + 1:]]
     out, err = io.StringIO(), io.StringIO()
     try:
         with redirect_stdout(out), redirect_stderr(err):
@@ -1909,6 +1915,7 @@ def run_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[s
             got[f"[ledger] {name}"] = (f"crash:{type(exc).__name__}", str(exc))
     got.update(round_trip(mod, T, tmp))
     got.update(cross_door(mod, tmp))
+    got.update(writer_path_cases(mod, T, tmp))
     return got
 
 
@@ -1947,6 +1954,13 @@ def expectations(T: Tables) -> "dict[str, tuple[str, str, str]]":
         f"`plan-add --id {uid!r}` then `emit --unit {uid!r}`: the PLAN door must refuse the id, or the "
         f"EMIT door must be able to name the unit it planned")
         for uid in CROSS_DOOR_IDS.values()})
+    out.update({f"[writer-path] {name}": ("exit1", needle,
+                                           "reviewer artifact writers stay inside the active run directory")
+                for name, needle in (
+                    ("emit", "outside"), ("amend", "outside"), ("finding-add", "outside"),
+                    ("report-write", "outside"), ("relative-run-root", "absolute"),
+                    ("missing-run-root", "active run directory"),
+                )})
     return out
 
 
@@ -2238,6 +2252,8 @@ def check_door(T: Tables, door: str, parser: argparse.ArgumentParser, tmp: Path)
         for flag in sorted(flags):
             if flag == "--file":
                 argv += seed_door(T, tmp, door, case)
+            elif flag == "--run-dir":
+                argv += ["--run-dir", str(tmp / f"door-{door}-{case}")]
             elif door in ("intent-check", "verify") and flag == "--ledger":
                 # `--ledger` must name a REAL ledger in the SAME run dir as the seeded --file (a static
                 # FLAG_VALUES path could satisfy neither the same-dir guard nor F1's existence guard), so
@@ -2773,7 +2789,7 @@ def check_amendment_door(R: types.ModuleType, tmp: Path) -> int:
     progress = d / PROGRESS_FILE
     run_cli(R, ["identity", "--file", str(progress), "--head-sha", SHA, "--dispatched-at", TS, "--default-non-goals", "[]"])
     run = subprocess.run(  # noqa: S603 - our own script
-        [sys.executable, str(AMENDMENT_WRAPPER), "--file", str(progress), "--reason", "harness gap",
+        [sys.executable, str(AMENDMENT_WRAPPER), "--run-dir", str(d), "--file", str(progress), "--reason", "harness gap",
          "--id", "u09", "--kind", "docs", "--target", "y.md", "--check", "b"],
         capture_output=True, text=True, check=False)
     if run.returncode != 0 or run.stdout:
@@ -2986,6 +3002,72 @@ def check_unwritable_target(R: types.ModuleType, T: Tables, tmp: Path) -> int:
     return failures
 
 
+def writer_path_cases(R: types.ModuleType, T: Tables, tmp: Path) -> "dict[str, tuple[str, str]]":
+    """Return mutation-matrix cases for reviewer destinations outside their bound run root."""
+    root = tmp / "writer-case-root"
+    outside = tmp / "writer-case-outside"
+    root.mkdir()
+    cases = (
+        ("emit", ["--unit", "u01", "--status", "started"], PROGRESS_FILE),
+        ("amend", ["--reason", "gap", "--id", "u09", "--kind", "file", "--target", "x.py",
+                    "--check", "a"], PROGRESS_FILE),
+        ("finding-add", T.FINDING_CLI_CASES[0][1], FINDINGS_FILE),
+        ("report-write", ["--verdict", R.SATISFIED, "--deferred-reason", R.NO_DEFERRED_REASON,
+                           "--summary", "Report body."], REPORT_FILE),
+    )
+    got: "dict[str, tuple[str, str]]" = {}
+    for command, args, filename in cases:
+        target = outside / filename
+        code, text = run_cli(R, [command, "--file", str(target), "--run-dir", str(root), *args])
+        got[f"[writer-path] {command}"] = (f"exit{code}", text)
+
+    for name, run_dir in (("relative-run-root", Path("relative-run-root")),
+                          ("missing-run-root", tmp / "missing-run-root")):
+        target = (root if name == "relative-run-root" else run_dir) / REPORT_FILE
+        code, text = run_cli(R, ["report-write", "--file", str(target), "--run-dir", str(run_dir),
+                                 "--verdict", R.SATISFIED, "--deferred-reason", R.NO_DEFERRED_REASON,
+                                 "--summary", "Report body."])
+        got[f"[writer-path] {name}"] = (f"exit{code}", text)
+    return got
+
+
+def check_writer_path_boundaries(R: types.ModuleType, T: Tables, tmp: Path) -> int:
+    """Every reviewer writer rejects a valid artifact basename outside the bound run root."""
+    root = tmp / "writer-root"
+    outside = tmp / "writer-outside"
+    root.mkdir()
+    cases = (
+        ("emit", ["--unit", "u01", "--status", "started"], PROGRESS_FILE),
+        ("amend", ["--reason", "gap", "--id", "u09", "--kind", "file", "--target", "x.py",
+                    "--check", "a"], PROGRESS_FILE),
+        ("finding-add", T.FINDING_CLI_CASES[0][1], FINDINGS_FILE),
+        ("report-write", ["--verdict", R.SATISFIED, "--deferred-reason", R.NO_DEFERRED_REASON,
+                           "--summary", "Report body."], REPORT_FILE),
+    )
+    failures = 0
+    for command, args, filename in cases:
+        target = outside / filename
+        code, text = run_cli(R, [command, "--file", str(target), "--run-dir", str(root), *args])
+        if code == 0 or target.exists() or outside.exists():
+            print(f"FAIL     [writer-path] {command} accepted or created {target} outside {root}: {text.strip()}")
+            failures += 1
+        else:
+            print(f"ok       [writer-path] {command} rejects a destination outside the active run directory")
+
+    for run_dir, needle in ((Path("relative-run-root"), "absolute"),
+                            (tmp / "missing-run-root", "active run directory")):
+        target = (root if run_dir.name == "relative-run-root" else run_dir) / REPORT_FILE
+        code, text = run_cli(R, ["report-write", "--file", str(target), "--run-dir", str(run_dir),
+                                 "--verdict", R.SATISFIED, "--deferred-reason", R.NO_DEFERRED_REASON,
+                                 "--summary", "Report body."])
+        if code == 0 or needle not in text:
+            print(f"FAIL     [writer-path] run root {run_dir} was not rejected: {text.strip()}")
+            failures += 1
+        else:
+            print(f"ok       [writer-path] run root {run_dir} is rejected")
+    return failures
+
+
 def run(R: types.ModuleType, tmp: Path) -> int:
     """Every family, then the mutation matrix. Non-zero on any failure.
 
@@ -3053,6 +3135,8 @@ def run(R: types.ModuleType, tmp: Path) -> int:
     failures += run_status_cases(R, T, tmp)
     print()
     failures += check_unwritable_target(R, T, tmp)
+    print()
+    failures += check_writer_path_boundaries(R, T, tmp)
     print()
     if failures:
         print(f"{failures} check(s) FAILED — the review-pass contract is broken.")

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -630,6 +630,32 @@ class OperatorError(Exception):
     """The CALLER is wrong, not the artifacts. A verdict about the wrong question is worse than none."""
 
 
+def check_writer_path(path: Path, run_dir: Path) -> None:
+    """Require a reviewer writer's resolved destination to stay inside the active run directory."""
+    if not run_dir.is_absolute():
+        # MUTATE:writer-path-absolute:pass
+        raise Defect(
+            f"--run-dir {run_dir} is not an absolute active run directory — the reviewer transport binds "
+            f"this root as an absolute path"
+        )
+    root = run_dir.resolve()
+    target = path.resolve()
+    if not root.is_dir():
+        # MUTATE:writer-path-directory:pass
+        raise Defect(
+            f"--run-dir {run_dir} is not an active run directory — the reviewer writer must use the "
+            f"directory from its transport"
+        )
+    try:
+        target.parent.relative_to(root)
+    except ValueError as exc:
+        # MUTATE:writer-path-containment:pass
+        raise Defect(
+            f"artifact {path} resolves outside the active run directory {run_dir} — reviewer artifact "
+            f"writers may only write below the transport's `review_root`"
+        ) from exc
+
+
 # --- the strict JSONL reader (shared by both artifacts) -----------------------------------------
 
 def strict_object(name: str, n: int):
@@ -2366,6 +2392,7 @@ def cmd_emit(args) -> int:
     fifteen minutes later by a `verify` the reviewer never sees.
     """
     path = Path(args.file)
+    check_writer_path(path, Path(args.run_dir))
     parse_name(path)  # validates the filename; return discarded
     # The RECORD IS THE FLAGS — VERBATIM. `--status done` with no `--evidence` is an event with no
     # `evidence` key, and `--status started --evidence x` is one carrying a key nothing reads, so the flags
@@ -2417,6 +2444,7 @@ def cmd_amend(args) -> int:
     amendments in order; a clock the reviewer typed is a clock the reviewer could get wrong.
     """
     path = Path(args.file)
+    check_writer_path(path, Path(args.run_dir))
     parse_name(path)  # validates the filename; return discarded
     # The RECORD IS THE FLAGS, plus a `ts` the TOOL stamps. The `proposed_unit` is built exactly as
     # `plan-add` builds a unit, and `check_event` runs `check_unit` over it — so an id the plan door would
@@ -2580,6 +2608,7 @@ def cmd_finding_add(args) -> int:
     cannot pass those is a finding the reviewer can still FIX while it is holding the evidence.
     """
     path = Path(args.file)
+    check_writer_path(path, Path(args.run_dir))
     rec: "dict[str, object]" = {
         "type": FINDING, "file": args.path, "line": args.line, "writer": args.writer,
         "purpose": args.purpose, "base": args.base, "base_repro": args.base_repro,
@@ -2617,6 +2646,7 @@ def cmd_report_write(args) -> int:
     legitimately GROWS after the identity; a report never does.
     """
     path = Path(args.file)
+    check_writer_path(path, Path(args.run_dir))
     # The NAME first, and by the SAME statement the read door runs: a path that is not a report artifact's
     # name is not a file this tool reads at all, so `before_text` is not asked about it.
     report_name(path)
@@ -3246,6 +3276,8 @@ def add_emit_args(p: argparse.ArgumentParser) -> None:
     help instead: `--help` printed a command (`emit-progress.py emit …`) that the wrapper itself refuses.
     """
     p.add_argument("--file", required=True, help="the launch attempt's progress.jsonl")
+    p.add_argument("--run-dir", required=True,
+                   help="the absolute active run-artifact directory from the reviewer transport")
     p.add_argument("--unit", required=True, help="a PLANNED unit's id — an unplanned one is refused")
     p.add_argument("--status", required=True, choices=STATUSES)
     p.add_argument("--evidence", help="concrete citation; REQUIRED for --status done")
@@ -3263,6 +3295,8 @@ def add_finding_args(p: argparse.ArgumentParser) -> None:
     about.
     """
     p.add_argument("--file", required=True, help="the launch attempt's findings.jsonl")
+    p.add_argument("--run-dir", required=True,
+                   help="the absolute active run-artifact directory from the reviewer transport")
     p.add_argument("--path", required=True, help="the FILE the defect is in (the citation's first half)")
     p.add_argument("--line", required=True, help="the LINE it is on — a decimal from 1 up")
     p.add_argument("--writer", required=True, choices=WRITERS,
@@ -3305,6 +3339,8 @@ def add_amendment_args(p: argparse.ArgumentParser) -> None:
     advertise a command the write path refuses.
     """
     p.add_argument("--file", required=True, help="the launch attempt's progress.jsonl")
+    p.add_argument("--run-dir", required=True,
+                   help="the absolute active run-artifact directory from the reviewer transport")
     p.add_argument("--reason", required=True,
                    help="what dimension the plan MISSES — the orchestrator RULES on it, so a blank one is "
                         "refused (it is the evidence-free `done` of the amendment world)")
@@ -3326,6 +3362,8 @@ def add_report_args(p: argparse.ArgumentParser) -> None:
     deficient one. It repeats because a reviewer may name several, and each stays its own record.
     """
     p.add_argument("--file", required=True, help="the launch attempt's report.jsonl — it must not exist yet")
+    p.add_argument("--run-dir", required=True,
+                   help="the absolute active run-artifact directory from the reviewer transport")
     p.add_argument("--verdict", required=True, choices=VERDICT_CHOICES,
                    help=f"{SATISFIED} or {NOT_SATISFIED} — the rule is an IF AND ONLY IF: "
                         f"{NOT_SATISFIED} exactly when at least one GATING finding stands. "

--- a/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
+++ b/plugins/gauntlet/skills/campaign/scripts/review-prompt.txt
@@ -25,7 +25,8 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    stage-2-review-gate.md, "Review work-plan ledger", owns this rule; this prompt is self-contained —
    you need not read that file.) If an important dimension
    is missing, a unit is wrong, or a waiver's reason does not hold, raise it by running
-   RUN_ARGV(["python3", TRANSPORT.emit_amendment_path, "--file", TRANSPORT.progress_path,
+   RUN_ARGV(["python3", TRANSPORT.emit_amendment_path, "--run-dir", TRANSPORT.review_root,
+   "--file", TRANSPORT.progress_path,
    "--reason", reason, "--id", unit_id, "--kind", kind, "--target", target, "--check", check]) naming
    the gap — --check may repeat, and the tool STAMPS the timestamp so you supply no clock; a non-zero
    exit means your inputs were rejected (fix them and re-run). Hand-writing the event instead does NOT
@@ -37,7 +38,8 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    through a tool any longer: EVERY artifact you write reaches disk through one — unit progress via
    emit-progress, findings via emit-finding, plan amendments via emit-amendment (above), and your REPORT
    via emit-report (below). Run
-   RUN_ARGV(["python3", TRANSPORT.emit_progress_path, "--file", TRANSPORT.progress_path,
+   RUN_ARGV(["python3", TRANSPORT.emit_progress_path, "--run-dir", TRANSPORT.review_root,
+   "--file", TRANSPORT.progress_path,
    "--unit", unit_id, "--status", "started"]) when a planned unit begins, and the same argv with
    "--status", "done", "--evidence", evidence when it finishes. The tool appends the canonical
    progress event; a non-zero exit means your inputs
@@ -64,7 +66,8 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    RECORD EVERY FINDING BY RUNNING THE TOOL. It is the ONLY way to report one, and your VERDICT and your
    FINDINGS must agree — the tool checks it BOTH WAYS, and either mismatch is a DEFECTIVE PASS that cannot
    count: a NOT SATISFIED with no recorded GATING finding, and a SATISFIED with one. Invoke
-   RUN_ARGV(["python3", TRANSPORT.emit_finding_path, "--file", TRANSPORT.findings_path,
+   RUN_ARGV(["python3", TRANSPORT.emit_finding_path, "--run-dir", TRANSPORT.review_root,
+   "--file", TRANSPORT.findings_path,
    "--path", file, "--line", line, "--writer", writer, "--purpose", purpose,
    "--base", base, "--base-repro", base_repro, "--repro", repro, "--fix", fix]) for each finding.
    EVERY FINDING MUST ANCHOR. Name EITHER the Purpose line it defends (--purpose, quoted VERBATIM — the
@@ -102,7 +105,8 @@ THE QUESTION YOU ARE ANSWERING IS: does this PR achieve its stated Purpose, with
    DELIVER YOUR REPORT BY RUNNING THE TOOL — ONCE, WHEN YOU ARE DONE, AND ON EVERY ROUTE. It is the
    ONLY producer of TRANSPORT.report.path: returning the report as your final message and writing that
    path by hand BOTH produce no report, and a pass with no report cannot count. Invoke
-   RUN_ARGV(["python3", TRANSPORT.emit_report_path, "--file", TRANSPORT.report.path,
+   RUN_ARGV(["python3", TRANSPORT.emit_report_path, "--run-dir", TRANSPORT.review_root,
+   "--file", TRANSPORT.report.path,
    "--verdict", verdict, "--deferred-reason", deferred_reason, "--summary", summary]) with zero or more
    "--residual-risk", record members. A non-zero exit means your inputs were rejected — fix them and
    re-run. Run it EXACTLY ONCE: a pass yields ONE report, so the tool refuses a second call rather than


### PR DESCRIPTION
- SEC-5: valid basenames let reviewer writers create files outside the active run root.
- Fix: bind absolute `review_root` as `--run-dir`; reject resolved parents outside it.
- Tests and validators pass; untouched: plan, identity, read-only, and unrelated paths.
