### PR TITLE
fix ancestry spawn rechecks

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -163,6 +163,33 @@ def t_cli_missing_ancestry_rechecks():
         }, f"the CLI should demand base ancestry before proceeding, got {out!r}")
 
 
+def t_cli_ancestry_spawn_failure_rechecks():
+    """A Git process that cannot start must fail closed through the structured ancestry recheck."""
+    def boom(*_args, **_kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "git")
+
+    real_run = M.subprocess.run
+    setattr(M.subprocess, "run", boom)
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            vjson = Path(d) / "view.json"
+            vjson.write_text(json.dumps(view()), encoding="utf-8")
+            code, out, err = capture_cli(
+                M.main,
+                ["check", "--pr", "9", "--view-json", str(vjson), "--worktree", d, "--base", "main"],
+            )
+    finally:
+        setattr(M.subprocess, "run", real_run)
+
+    check(code != 0, f"a Git spawn failure must exit non-zero (fail closed), got {code} (stderr: {err})")
+    check(err == "", f"a Git spawn failure must NOT print a traceback, got stderr {err!r}")
+    result = json.loads(out)
+    check(result["verdict"] == "recheck",
+          f"a Git spawn failure must decide recheck, never proceed, got {result!r}")
+    check(result["reason"].startswith("could not verify base ancestry:"),
+          f"the reason must name the failed ancestry check, got {result!r}")
+
+
 def t_cli_rebase_first():
     with tempfile.TemporaryDirectory() as d:
         vjson = Path(d) / "view.json"
@@ -1173,6 +1200,8 @@ CASES = [
     ("file-unknown-rechecks", "Stage 3 preflight leaves recognized UNKNOWN active for re-poll",
      t_unknown_view_with_file_rechecks_without_park),
     ("cli-missing-ancestry", "a CLEAN view without base ancestry fails closed", t_cli_missing_ancestry_rechecks),
+    ("cli-ancestry-spawn-failure", "a Git spawn failure fails closed to a structured ancestry recheck",
+     t_cli_ancestry_spawn_failure_rechecks),
     ("cli-rebase-first", "check --view-json on a DIRTY view exits non-zero with rebase-first", t_cli_rebase_first),
     ("cli-malformed", "a view missing a field fails closed to recheck, never KeyError", t_cli_malformed),
     ("cli-bad-project-root", "an invalid --project-root fails closed to recheck, no traceback",

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight.py
@@ -134,23 +134,26 @@ def check_base_ancestry(worktree: "str | None", base: "str | None", remote: str,
     """
     if not worktree or not base:
         return "unverified", "base ancestry requires --worktree and --base"
-    selected, selection_problem = select_base_fetch_refs(worktree, remote, base)
-    if selection_problem is not None or selected is None:
-        return "unverified", selection_problem or "could not select a base fetch destination"
-    fetch = subprocess.run(  # noqa: S603
-        ["git", "-C", worktree, "fetch", remote, selected.refspec],
-        capture_output=True, text=True, check=False)
-    if fetch.returncode != 0:
-        return "unverified", f"could not fetch {selected.refspec}: {fetch.stderr.strip()}"
-    probe = subprocess.run(  # noqa: S603
-        ["git", "-C", worktree, "merge-base", "--is-ancestor", selected.local_ref, candidate_revision],
-        capture_output=True, text=True, check=False)
-    if probe.returncode == 0:
-        return "current", ""
-    if probe.returncode == 1:
-        return "stale", ""
-    return ("unverified",
-            f"could not compare {candidate_revision} with {selected.local_ref}: {probe.stderr.strip()}")
+    try:
+        selected, selection_problem = select_base_fetch_refs(worktree, remote, base)
+        if selection_problem is not None or selected is None:
+            return "unverified", selection_problem or "could not select a base fetch destination"
+        fetch = subprocess.run(  # noqa: S603
+            ["git", "-C", worktree, "fetch", remote, selected.refspec],
+            capture_output=True, text=True, check=False)
+        if fetch.returncode != 0:
+            return "unverified", f"could not fetch {selected.refspec}: {fetch.stderr.strip()}"
+        probe = subprocess.run(  # noqa: S603
+            ["git", "-C", worktree, "merge-base", "--is-ancestor", selected.local_ref, candidate_revision],
+            capture_output=True, text=True, check=False)
+        if probe.returncode == 0:
+            return "current", ""
+        if probe.returncode == 1:
+            return "stale", ""
+        return ("unverified",
+                f"could not compare {candidate_revision} with {selected.local_ref}: {probe.stderr.strip()}")
+    except OSError as exc:
+        return "unverified", str(exc)
 
 
 def decide(view: dict) -> dict:


### PR DESCRIPTION
- UX-5: missing Git during ancestry checking escaped; preflight printed no structured `recheck`.
- Fix: catch process-start `OSError` in `check_base_ancestry`; untouched: `merge-check.py`, `_gauntlet/git_refs.py`.
- Tests: base/merge self-tests, runner, plugin validation, compile, and Pyright pass.
