### PR TITLE
fix missing base option values

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/argv.py
@@ -6,19 +6,18 @@ import sys
 
 
 def bind_separate_option_value(argv: "list[str] | None", option: str) -> "list[str]":
-    """Bind the argv member after ``option`` as its value, even when it begins with ``-``.
+    """Bind a non-option argv member after ``option`` as its value.
 
     Campaign instructions construct selected data-bearing options as two argv members. ``argparse`` treats a
-    dash-leading second member as another option, so join only the named option and its immediate value into
-    the equivalent ``--option=value`` form before parsing. Leave a trailing option unchanged so ``argparse``
-    still reports its missing value.
+    dash-leading second member as another option, so preserve it as a separate token and let ``argparse``
+    report the missing value. A legitimate dash-leading value must use the equivalent ``--option=value`` form.
     """
     source = list(sys.argv[1:] if argv is None else argv)
     bound: list[str] = []
     index = 0
     while index < len(source):
         token = source[index]
-        if token == option and index + 1 < len(source):
+        if token == option and index + 1 < len(source) and not source[index + 1].startswith("-"):
             bound.append(f"{option}={source[index + 1]}")
             index += 2
             continue

--- a/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/base-preflight-test.py
@@ -625,7 +625,7 @@ def _dash_base_ancestry(root: Path, *, current: bool) -> "tuple[int, dict, str, 
     code, out, err = capture_cli(
         M.main,
         ["check", "--pr", "9", "--view-json", str(vjson), "--worktree", str(candidate),
-         "--base", DASH_BASE],
+         f"--base={DASH_BASE}"],
     )
     refreshed_base = _git(candidate, "rev-parse", tracking_ref).stdout.strip()
     return code, json.loads(out), err, refreshed_base, advanced_base
@@ -653,6 +653,13 @@ def t_dash_leading_stale_base_refreshes_and_reports_no():
               f"a stale candidate on a dash-leading base must report the staleness, got {result!r}")
         check(refreshed == remote_head,
               "the dash-leading base fetch must refresh its remote-tracking ref before the stale verdict")
+
+
+def t_missing_base_does_not_consume_repo():
+    code, _out, err = capture_cli(M.main, ["check", "--pr", "9", "--base", "--repo"])
+    check(code == 2, f"a missing --base value must be rejected by argparse (code={code}, err={err!r})")
+    check("argument --base: expected one argument" in err,
+          f"the missing --base value must be named in the parser error, got {err!r}")
 
 
 def t_candidate_revision_is_checked_instead_of_moved_head():
@@ -1233,6 +1240,8 @@ CASES = [
      t_dash_leading_current_base_refreshes_and_proceeds),
     ("dash-base-stale", "a dash-leading base refreshes its tracking ref and reports stale ancestry",
      t_dash_leading_stale_base_refreshes_and_reports_no),
+    ("missing-base-value", "--base does not consume a following --repo option",
+     t_missing_base_does_not_consume_repo),
     ("candidate-revision-not-head", "an explicit candidate revision is checked instead of a moved local HEAD",
      t_candidate_revision_is_checked_instead_of_moved_head),
     ("proceed-file-records-base-ok", "a proceed with --file stamps base_ok_sha = HEAD; without --file writes nothing",

--- a/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/clean-rebase-test.py
@@ -180,7 +180,10 @@ class Scenario:
 
     def invoke(self, *extra):
         argv = ["run", "--ledger", str(self.ledger), "--pr", PR_NUMBER, "--worktree", str(self.wt)]
-        argv += ["--base", self.base]
+        if self.base.startswith("-"):
+            argv.append(f"--base={self.base}")
+        else:
+            argv += ["--base", self.base]
         argv += list(extra)
         return capture_cli(M.main, argv)
 
@@ -788,6 +791,16 @@ def t_dry_run_mutates_nothing():
         check(s.remote_pr_head() == s.orig_head, "dry-run does not push")
 
 
+def t_missing_base_does_not_consume_dry_run():
+    code, _out, err = capture_cli(
+        M.main,
+        ["run", "--ledger", "state.jsonl", "--pr", PR_NUMBER, "--worktree", ".", "--base", "--dry-run"],
+    )
+    check(code == 2, f"a missing --base value must be rejected by argparse (code={code}, err={err!r})")
+    check("argument --base: expected one argument" in err,
+          f"the missing --base value must be named in the parser error, got {err!r}")
+
+
 CASES = [
     ("clean-rebase-e2e", "a clean base-only rebase pushes and updates the ledger, keeping reviews_ok",
      t_clean_rebase_end_to_end),
@@ -852,4 +865,6 @@ CASES = [
      "ledger (exit 1)", t_push_rejected_preserves_local_rebase),
     ("dry-run-noop", "--dry-run mutates nothing (no fetch, rebase, push, or ledger write)",
      t_dry_run_mutates_nothing),
+    ("missing-base-value", "--base does not consume a following --dry-run flag",
+     t_missing_base_does_not_consume_dry_run),
 ]


### PR DESCRIPTION
- UX-6: `clean-rebase --base --dry-run` consumed the flag as base, so dry-run silently stayed off.
- Fix: preserve option tokens; require `--base=<dash-leading-name>` for dash-leading values.
- Tests: 30+51 fixtures, Pyright, syntax, diff, validators. Untouched: other parsers and generic `<base>` docs.
