### PR TITLE
fix status ledger scope

### DIFF
--- a/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass-test.py
@@ -2907,6 +2907,43 @@ def run_status_cases(mod: types.ModuleType, T: Tables, tmp: Path) -> int:
             print(f"ok       [status] {name:24} {case['why'][:58]}")
         else:
             failures += 1
+
+    # `status --ledger` is advisory, but its tally still has to come from the selected run. The path check
+    # catches a sibling run, and the identity check catches a copied ledger placed under the selected run.
+    # A matching in-tree ledger proves the guard does not reject the normal status invocation.
+    d = tmp / "status-ledger-scope"
+    d.mkdir(parents=True, exist_ok=True)
+    build(tmp, d.name, T.PLAN, T.WORKED, report=None)
+    foreign = d.parent / "status-ledger-foreign"
+    foreign.mkdir(parents=True, exist_ok=True)
+    foreign_ledger = foreign / "state.jsonl"
+    foreign_ledger.write_text("\n".join([
+        json.dumps({"type": "header", "run_id": foreign.name, "default_non_goals": "[]"}),
+        json.dumps({"type": "row", "pr": "41", "tier": "HIGH", "reviews_ok": "2"}),
+    ]) + "\n", encoding="utf-8")
+    cases = [
+        ("foreign-path", foreign_ledger, 2, "does not resolve under selected run"),
+        ("foreign-identity", d / "state.jsonl", 2, "has run_id"),
+        ("matching-identity", d / "state.jsonl", 0, "2/2"),
+    ]
+    for name, ledger, want_code, needle in cases:
+        if name == "foreign-identity":
+            ledger.write_text("\n".join([
+                json.dumps({"type": "header", "run_id": foreign.name, "default_non_goals": "[]"}),
+                json.dumps({"type": "row", "pr": "41", "tier": "HIGH", "reviews_ok": "2"}),
+            ]) + "\n", encoding="utf-8")
+        elif name == "matching-identity":
+            ledger.write_text("\n".join([
+                json.dumps({"type": "header", "run_id": d.name, "default_non_goals": "[]"}),
+                json.dumps({"type": "row", "pr": "41", "tier": "HIGH", "reviews_ok": "2"}),
+            ]) + "\n", encoding="utf-8")
+        code, text = run_cli(mod, ["status", "--run", str(d), "--ledger", str(ledger), "--history",
+                                   "--now", "2026-07-06T00:03:00Z"])
+        if code != want_code or needle not in text:
+            print(f"FAIL     [status] {name}: exit {code}, expected {want_code}, missing {needle!r}\n{text}")
+            failures += 1
+        else:
+            print(f"ok       [status] {name:24} selected-run ledger scope and identity")
     return failures
 
 

--- a/plugins/gauntlet/skills/campaign/scripts/review-pass.py
+++ b/plugins/gauntlet/skills/campaign/scripts/review-pass.py
@@ -3046,6 +3046,29 @@ def load_ledger_module() -> types.ModuleType:
     return mod
 
 
+def load_status_ledger(ledger_path: Path, rundir: Path, ledger_module: types.ModuleType) -> tuple[dict, list[dict]]:
+    """Load a status tally only from the selected run's resolved tree and identity."""
+    run_root = rundir.resolve()
+    resolved_ledger = ledger_path.resolve()
+    try:
+        resolved_ledger.relative_to(run_root)
+    except ValueError as exc:
+        raise OperatorError(
+            f"--ledger {ledger_path} does not resolve under selected run {rundir} — status must render "
+            f"the selected run's own ledger"
+        ) from exc
+
+    header, rows = ledger_module.load(resolved_ledger)
+    expected_run_id = run_root.name
+    actual_run_id = header.get("run_id")
+    if actual_run_id != expected_run_id:
+        raise OperatorError(
+            f"--ledger {ledger_path} has run_id {actual_run_id!r}, but selected run {rundir} has run_id "
+            f"{expected_run_id!r} — status must render the selected run's own ledger"
+        )
+    return header, rows
+
+
 def status_row(progress: Path, now: datetime, want_verify: bool,
                ledger_rows: "list[dict] | None", superseded: bool = False) -> "list[str]":
     """One pass's cells, rendered in isolation so ONE malformed pass cannot crash the whole table.
@@ -3137,7 +3160,7 @@ def cmd_status(args) -> int:
     reviewer: "str | None" = None
     if args.ledger:
         L = load_ledger_module()
-        _header, ledger_rows = L.load(Path(args.ledger))
+        _header, ledger_rows = load_status_ledger(Path(args.ledger), rundir, L)
         reviewer = _header.get("reviewer")
 
     columns = ["pass", "units", "now", "find", "elapsed", "health", "verdict"]
@@ -3478,7 +3501,7 @@ def build_parser() -> "tuple[argparse.ArgumentParser, list[str]]":
     st.add_argument("--pr", help="show only this PR's passes")
     st.add_argument("--verify", action="store_true",
                     help="add evaluate()'s authoritative verdict column (ok/incomplete/amended/unusable)")
-    st.add_argument("--ledger", help="a state.jsonl — adds a reviews_ok/required(tier) tally column")
+    st.add_argument("--ledger", help="the selected run's state.jsonl — adds a reviews_ok/required(tier) tally column")
     st.add_argument("--history", dest="history", action="store_true",
                     help="show TERMINAL passes too — done (finished) and gone (superseded/relaunched) — plus "
                          "superseded launch attempts, dimmed on a TTY. The default hides them and prints a "


### PR DESCRIPTION
- UX-3 trigger: sibling ledger accepted; impact: foreign tally shown as selected-run data.
- Fix: resolve `--ledger` under `--run`; match header `run_id` to the run directory.
- Tests: repro, 3 status fixtures, self-test, plugin validation. Untouched: verify, intent-check, other consumers.
