### PR TITLE
scope unusable-engine to the reviewer launch

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -155,12 +155,15 @@ owner; `runtime-adapter.md`'s transition table consumes it.
   error). → `fallback-native`, disclosed. Do not spend a retry first: the next launch fails identically.
   **"Could not run" means THIS attempt's reviewer process, at launch — never a child process it spawned
   later.** Once an attempt has written **launch evidence** (`critical-rules.md` owns the term), that
-  ground is spent: the engine demonstrably ran, so a later failure is `transient` unless quota or
-  credentials are themselves shown. A mid-run spawn or tool error names a process the reviewer started,
-  not the reviewer, and its diagnostic can read exactly like a launch failure — words such as `exec`,
-  `CreateProcess`, `failed`, or `No such file or directory` are about the child. Reading them as an
-  engine that cannot run gives up the second engine for the rest of the pass on a failure that a retry
-  may well clear.
+  ground is spent FOR THIS BULLET'S "could not run" GROUND ALONE: the engine demonstrably ran, so a later
+  failure that reads as the REVIEWER PROCESS failing to run is `transient` unless quota or credentials are
+  themselves shown. **It reclassifies nothing outside `unusable-engine`.** A refusal shown after launch
+  evidence stays `content-refusal` and still parks — that class is post-launch BY DEFINITION, so launch
+  evidence is its precondition, never an argument against it. A mid-run spawn or tool error names a
+  process the reviewer started, not the reviewer, and its diagnostic can read exactly like a launch
+  failure — words such as `exec`, `CreateProcess`, `failed`, or `No such file or directory` are about the
+  child. Reading them as an engine that cannot run gives up the second engine for the rest of the pass on
+  a failure that a retry may well clear.
 - **`content-refusal` — the engine started, declined to review THIS content, and produced no verdict.**
   Its safety or content filter answered instead of the review (for example `codex exec` printing that the
   content was flagged for possible cybersecurity risk on a security-hardening diff). → **park the PR for

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -150,9 +150,17 @@ one of three classes, and only two of them ever reach a fallback. This section i
 owner; `runtime-adapter.md`'s transition table consumes it.
 
 - **`unusable-engine` — the engine itself cannot produce a verdict, and relaunching the same argv cannot
-  change that.** Quota, rate-limit, or usage exhaustion; rejected or missing credentials; a process that
-  could not run at all (exec failure, immediate crash, an engine-reported internal fatal error). →
-  `fallback-native`, disclosed. Do not spend a retry first: the next launch fails identically.
+  change that.** Quota, rate-limit, or usage exhaustion; rejected or missing credentials; the REVIEWER
+  PROCESS ITSELF could not run (it failed to exec, crashed immediately, or reported an internal fatal
+  error). → `fallback-native`, disclosed. Do not spend a retry first: the next launch fails identically.
+  **"Could not run" means THIS attempt's reviewer process, at launch — never a child process it spawned
+  later.** Once an attempt has written **launch evidence** (`critical-rules.md` owns the term), that
+  ground is spent: the engine demonstrably ran, so a later failure is `transient` unless quota or
+  credentials are themselves shown. A mid-run spawn or tool error names a process the reviewer started,
+  not the reviewer, and its diagnostic can read exactly like a launch failure — words such as `exec`,
+  `CreateProcess`, `failed`, or `No such file or directory` are about the child. Reading them as an
+  engine that cannot run gives up the second engine for the rest of the pass on a failure that a retry
+  may well clear.
 - **`content-refusal` — the engine started, declined to review THIS content, and produced no verdict.**
   Its safety or content filter answered instead of the review (for example `codex exec` printing that the
   content was flagged for possible cybersecurity risk on a security-hardening diff). → **park the PR for

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -846,6 +846,16 @@ def check_document_contract() -> None:
         "it selects only the transition",
     ):
         require(needle in reviewer_flat, f"reviewer.md external failure classes drifted: {needle}")
+    # The post-launch-evidence rule lives INSIDE the `unusable-engine` bullet and must stay scoped to it.
+    # Unscoped, it reads over every later failure and re-routes a shown `content-refusal` — which is
+    # post-launch by definition — to `transient`, i.e. to `retry-external` then `fallback-native`, the two
+    # actions the refusal bullet forbids.
+    for needle in (
+        "It reclassifies nothing outside `unusable-engine`.",
+        "A refusal shown after launch evidence stays `content-refusal` and still parks",
+    ):
+        require(needle in reviewer_flat,
+                f"reviewer.md post-launch-evidence rule is no longer scoped to `unusable-engine`: {needle}")
     stage_flat = " ".join(stage.split())
     require('"--file", ledger_file' in stage_flat and
             '"--prompt-profile", prompt_profile' in stage_flat and


### PR DESCRIPTION
- A mid-run child-process error reads like a launch failure, so `unusable-engine` could claim it and skip the retry.
- The class now covers only the reviewer process at launch; launch evidence rules that ground out.
- Wording only, and no misroute was observed — the current text merely permits one.
