### PR TITLE
fix detached reviewer launches

### DIFF
--- a/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
+++ b/plugins/gauntlet/skills/campaign/references/cross-agent-reviewers.md
@@ -8,9 +8,9 @@ Before preparing a record or prompt, evaluate `runtime-adapter.md`'s `ReviewIsol
 its transition. Only `launch-external` or `retry-external` uses the commands below; every other action
 stays with the owner.
 A capable adapter runs `review-dispatch.py prepare` through the exact invocation in `review-dispatch.md`,
-then launches the process from its returned transport as a background task whose completion triggers a
-reconcile. Prompt bytes — including verbatim GitHub-derived intent — and dynamic paths never enter shell
-source.
+then launches the process from its returned transport under `runtime-adapter.md`, **Direct asynchronous
+process launch**, as a background task whose completion triggers a reconcile. Prompt bytes — including
+verbatim GitHub-derived intent — and dynamic paths never enter shell source.
 
 `runtime-adapter.md`, **Review preparation mapping**, owns retry profile selection. A retry uses the same
 canonical argv below in a fresh process; never resume a failed external session or select a profile by

--- a/plugins/gauntlet/skills/campaign/references/review-dispatch.md
+++ b/plugins/gauntlet/skills/campaign/references/review-dispatch.md
@@ -182,7 +182,8 @@ by running `transport.emit_report_path`, and neither transport captures a final-
 `transport.report.path` (`runtime-adapter.md`, "Review transport record and report ownership").
 
 Never embed the prompt in an argument or shell source. External prompt stdin is the prepared prompt file,
-which supplies immediate EOF. Launch in the background so completion triggers reconcile.
+which supplies immediate EOF. Launch under runtime-adapter.md, **Direct asynchronous process launch**;
+completion triggers reconcile.
 
 Never pass destructive instructions to an external reviewer. Keep Codex on `--sandbox workspace-write`;
 never use `--dangerously-bypass-approvals-and-sandbox`. At native-limitation level, `transport.review_root`

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -99,6 +99,15 @@ of publishing a command-source template:
 - `dispatch_native(message: Bytes, class: ModelClass)` sends exactly `message` as task data to a fresh
   native worker. It never puts message bytes in command source.
 
+### Direct asynchronous process launch
+
+**Use host's background task/process mechanism to launch the direct child process.** Pass canonical argv
+through `run_argv` (or its host equivalent), and let that process own task lifetime. NEVER wrap a launch in
+`nohup`, shell `&`, `disown`, `setsid`, or another detached shell wrapper. A wrapper can finish while its
+child continues, causing its completion notification to be mistaken for worker completion. If the host
+accepts only shell source, mechanically encode the direct argv and keep the wrapper attached until the child
+exits; do not detach it.
+
 `RepositoryContext`, `Path`, `Text`, `Bytes`, and `ModelClass` above are data types, not angle-bracket
 substitution syntax.
 Composition such as `concat("refs/heads/", base)` happens **before** the operation and produces one

--- a/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
+++ b/plugins/gauntlet/skills/campaign/references/stage-2-review-gate.md
@@ -191,7 +191,8 @@ Run reviews **one at a time per PR** — never two at once for the same SHA. Whe
 (`head_sha`) has fewer than `required(tier)` SATISFIED verdicts (2a-triage owns the formula) and no review
 already running for it, the heartbeat's dispatch step launches **one** review pass by the selected reviewer
 (see "The reviewer") — a **fresh**, context-isolated pass over the whole `origin/<base>...HEAD` diff, run as
-a **background** task (its completion is a heartbeat; the loop folds the verdict in at step 2). For a
+a **background** task under `runtime-adapter.md`, **Direct asynchronous process launch** (its completion is
+a heartbeat; the loop folds the verdict in at step 2). For a
 `required==2` tier the second, corroborating review is launched only **after** the first comes back
 SATISFIED — so a still-broken commit never burns the second review before the first has said "fix it"
 (a TRIVIAL PR needs no second pass). (Reviews for *different* PRs still run concurrently, up to the ~8


### PR DESCRIPTION
- Prevent detached shell wrappers from being mistaken for completed reviewer processes.
- Keep report verification authoritative after asynchronous launch completion.
