### PR TITLE
move campaign startup into code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,11 @@ jobs:
       - name: Ledger contract
         run: python3 plugins/gauntlet/skills/campaign/scripts/ledger.py self-test
 
+      # Fresh startup is a resumable command protocol. These offline fixtures pin its full-set preflight,
+      # complete-header write, host handoffs, semantic boundaries, and ready commit point.
+      - name: Campaign startup protocol
+        run: python3 plugins/gauntlet/skills/campaign/scripts/campaign-start.py self-test
+
       # The REPAIR PASS's contract, executed — the mechanism that stops the review loop from running
       # forever. Its fixtures REPLAY the two PRs that actually spiralled (21 and 14 adversarial rounds,
       # 8.5 hours, neither converging) and assert the trigger fires where the design says AND stays silent

--- a/docs/designs/code-driven-campaign-startup.md
+++ b/docs/designs/code-driven-campaign-startup.md
@@ -1,0 +1,87 @@
+# Code-driven campaign startup
+
+## Goal
+
+Move fresh Gauntlet campaign startup from a long sequence that the driver reproduces from instructions
+into one resumable command protocol. The driver should make only decisions that require model judgment or
+invoke capabilities owned by the active host.
+
+The canonical runtime contract is
+`plugins/gauntlet/skills/campaign/references/startup.md`. This document records the design and implementation
+task list; it does not replace that contract.
+
+## Boundary
+
+`campaign-start.py` owns the mechanical sequence:
+
+1. Resolve the supplied checkout and derive every repository-local path.
+2. Confirm `.gauntlet/` is ignored.
+3. Canonicalize the complete requested PR set.
+4. Read-only preflight every PR before creating state.
+5. Mint the run directory and atomically publish a complete run header.
+6. Mint the owner token and request the active host's continuity action.
+7. Acquire the lease only after continuity exists.
+8. Adopt each PR mechanically.
+9. Prepare SHA-bound tier and intent inputs for the driver.
+10. Validate and bind the driver's tier and intent decisions.
+11. Initialize required-check, CI, and liveness state.
+12. Clear the durable startup checkpoint and return `ready`.
+
+The driver retains four responsibilities because standalone repository code cannot perform them safely:
+
+- It resolves the reviewer from explicit or trusted host state. Candidate-checkout content is not a source.
+- It invokes host-only scheduling or bounded-wait capabilities.
+- It decides the review tier above the mechanical floor and authors an intent when the PR did not state one.
+- It reviews uncertain carryover pruning candidates without blocking adoption.
+
+## State model
+
+The command emits one JSON object per invocation. Its `state` selects the only permitted next action.
+
+| State | Meaning | Next actor |
+|---|---|---|
+| `needs-host-arm` | Run intent exists; the lease is not held. | Host establishes continuity; driver calls `take`. |
+| `needs-pr-judgment` | An adopted PR needs its decisions. | The driver supplies tier and intent through `bind`. |
+| `needs-user` | A fresh lease belongs to another driver. | The user decides whether to leave it or take over. |
+| `ready` | Every requested PR is adopted, bound, and initialized. | The normal heartbeat loop starts. |
+| `refused` | An input or prerequisite failed closed. | The driver reports the reason and makes no later mutation. |
+
+The existing ledger is the only durable startup state:
+
+- The header's `pending_adoption` field is the run-level checkpoint.
+- A pending row with `intent = -` still needs its semantic binding.
+- A row with `intent = stated@…` or `authored@…` has completed that binding.
+- Clearing `pending_adoption` is the startup commit point.
+
+`startup-judgment-<pr>.json` and `startup-diff-<pr>.patch` are temporary, SHA-bound byte-files used to cross
+the model boundary. They are deleted after `bind` and are never an independent state machine.
+
+## Failure and resume rules
+
+- Full-set preflight happens before `run-id.py new`, so a refused set leaves no orphan run.
+- `ledger.py init` validates every fresh header input before one atomic write. No partial header prefix is
+  durable.
+- Re-entry derives the next step from the ledger instead of replaying already-completed adoption.
+- A judgment artifact names the PR and exact head SHA. `bind` refuses it after a head move.
+- Tier validation reruns at bind time, so a decision below the current mechanical floor cannot land.
+- The lease remains advisory by repository policy, but every mutation after host arming requires ownership.
+- CI initialization must finish before `pending_adoption` is cleared.
+
+## Detailed implementation task list
+
+- [x] Add an atomic fresh-header initializer to the ledger accessor.
+- [x] Add ledger fixtures for complete initialization, invalid PR sets, and existing-state refusal.
+- [x] Add `campaign-start.py` with `new`, `take`, `advance`, `bind`, `resume`, and `self-test` commands.
+- [x] Make `new` preflight the complete PR set before creating a run directory.
+- [x] Emit typed host actions for scheduled-heartbeat and scheduler-less hosts.
+- [x] Reuse the existing lease, adoption, triage, intent, label, and CI accessors instead of copying rules.
+- [x] Bind semantic inputs to the adopted row's current head SHA.
+- [x] Use `pending_adoption` and row intent provenance as the resumable checkpoint.
+- [x] Add offline fixtures for repository scoping, preflight ordering, atomic initialization, host handoffs,
+  exact stated-intent extraction, and SHA binding.
+- [x] Add transition fixtures for adoption-to-judgment and initialized-to-ready paths.
+- [x] Replace the fresh-start procedure in campaign instructions with the command protocol.
+- [x] Point lease, adoption, ledger, carryover, loop, and runtime references at one startup owner.
+- [x] Add the coordinator to the complete bundled-script inventory and CI.
+- [x] Validate the skill, both plugin formats, focused suites, and the repository-wide Python checks.
+- [x] Sweep every restatement of fresh startup and confirm both plugin manifest versions are unchanged.

--- a/plugins/gauntlet/skills/campaign/SKILL.md
+++ b/plugins/gauntlet/skills/campaign/SKILL.md
@@ -27,6 +27,8 @@ At every entry/resume, before any other work:
   one final-report producer.
 - Read `references/run-identity-and-lease.md` and `references/files-and-ledger.md` before touching run
   state.
+- Read `references/startup.md` before starting or resuming a run whose `pending_adoption` checkpoint is
+  still set. Its command protocol owns fresh-run setup.
 
 The **adversarial reviewer** is a selectable role: by default the cross-engine route (Claude Code
 reviews with `codex exec`, Codex reviews with `claude -p`), launched at native-limitation level
@@ -73,45 +75,31 @@ it — no trigger means the step runs unconditionally at that point in the seque
 
 1. Resolve args to a run intent (`references/run-identity-and-lease.md`, "Resolving a heartbeat",
    owns resolution).
-2. Fresh run -> `run-id.py new`: mint the run-id and ATOMICALLY create its run directory, then apply
-   carryover from earlier runs (`references/carryover.md`).
-3. `lease.py acquire` (`refresh` on resume): take or keep the run lease; stand down if a fresh lease
-   names a different owner. One active driver per run — never double-drive. **Take a run in order**
-   (`references/run-identity-and-lease.md`, "Take a run"): BEFORE arming, record the run intent
-   (`ledger.py header set pending_adoption "<pr>…"`, cleared when adoption finishes) and — where the
-   host supports it — ensure the session watchdog nudge
-   (`references/runtime-adapter.md`, "Session watchdog nudge"). It audits a live session's campaign
-   soundness; it does not recover a dead session.
-4. Run start -> `ledger.py --file <state.jsonl> header set skill_version <version>`: record the
-   `version` read from the **running plugin's** `plugin.json`. The harness loads this skill from the
-   **installed plugin cache**, so a merged, version-bumped rule governs nothing until that cache
-   refreshes; record what is actually running.
-5. Run start -> set `reviewer` in the ledger header (`references/reviewer.md`) — once, never
-   re-derived from memory. Header fields are DATA: re-read `reviewer` from the ledger every heartbeat,
-   never trust memory. The base a PR merges into is **per-row** now (`effective_base` — the row's
-   recorded base, else the header's legacy `base_branch` fallback), so **re-resolve each active PR's
-   effective base every heartbeat**, never assume `main`. To rule a class out of scope for the WHOLE run
-   in one place, set the run's default Non-goals once (`ledger.py header set default_non_goals '["<body>",
-   …]'`, `references/files-and-ledger.md`); `pr-adopt.py intent-sync` folds them into every adopted PR's
-   intent, so you never hand-edit each `intent-<pr>.md`.
+2. Fresh run -> `campaign-start.py new`: pass the complete PR set, supplied checkout, active host,
+   reviewer already resolved from trusted state, and any run-default Non-goals. Then obey only the JSON
+   state it returns (`references/startup.md`). The coordinator owns full-set preflight, run creation,
+   complete-header initialization, lease take, adoption, semantic handoffs, and CI initialization.
+3. Incomplete startup -> continue the command returned by its prior state. A wake produced by
+   `needs-host-arm` runs the returned `take` with that arming's proof; an acquired owner runs `advance`;
+   a manual entry with no usable token runs `resume`. Continue until `ready`; never replay setup by hand.
+4. Existing completed run -> `lease.py refresh`: keep the run lease and stand down on `superseded` or
+   any refusal. One active driver per run. Re-read every header field, including `reviewer`, every
+   heartbeat. Resolve each row's base through `effective_base`, never assume `main`.
 
 **Adoption** (`references/pr-adoption.md`) — for each explicit `#PR` arg, and on every heartbeat for
 every PR carrying this run's `gauntlet-run-<run-id>` label (from a batched snapshot):
 
-6. Fetch the PR; REFUSE foreign-owned and cross-repo/fork PRs. REFUSE an existing terminal row before
-   any refresh, label, worktree, or intent work. For new and existing non-terminal rows, register the
-   ledger row (refresh in place on re-adoption, never duplicate), run label, status label, and worktree.
-   THEN write (or preserve) the PR's **base** intent artifact (`intent-<pr>.md`: `## Purpose` /
-   `## Non-goals` / `## Threat model`;
-   local, git-ignored, never written back to the PR) and `pr-adopt.py intent-sync` to fold the run's
-   default Non-goals into its managed block — the row must exist FIRST, because `intent-sync` REFUSES a PR
-   with no ledger row (`pr-adoption.md`). Before gate work, follow
-   `references/stage-2-review-gate.md`, "2a-triage", for the complete adoption-time procedure.
-   Apply item 21, "CI watch action".
-7. `review-pass.py intent-check --file <rundir>/intent-<pr>.md --ledger <rundir>/state.jsonl`: run
-   immediately after writing an intent artifact and syncing it, before dispatching the PR's first review —
-   the same parser every pass later loads, plus a check that the managed block is in sync with the run
-   header's `default_non_goals`, so a malformed or stale intent fails before review work is spent.
+5. Fresh-run adoption is performed by `campaign-start.py`; the driver supplies only the returned tier and
+   intent judgment. The coordinator calls the adoption, triage, intent, label, and CI owners and returns
+   `ready` only after their preconditions pass (`references/startup.md`). The tier decision remains owned
+   by `references/stage-2-review-gate.md`, "2a-triage"; the coordinator executes its mechanical floor and
+   veto around the returned judgment.
+6. Heartbeat discovery or re-adoption -> `pr-adopt.py adopt`: follow `references/pr-adoption.md`. It
+   refuses foreign-owned, fork, non-open, and terminal rows before their prohibited mutations, and it
+   refreshes a non-terminal row in place.
+7. Before any first review dispatch, require the row's current tier and validated intent. Fresh startup
+   establishes both through `campaign-start.py`; re-adoption follows the existing checks in
+   `references/pr-adoption.md` and `references/stage-2-review-gate.md`.
 
 **Heartbeat loop** (`references/loop-control.md` — read at each heartbeat before dispatch)
 
@@ -284,6 +272,7 @@ a line the tool writes.
 |---|---|---|
 | `run-id.py` | Mint a run-id and ATOMICALLY create its run directory (`new`) | `references/run-identity-and-lease.md` |
 | `lease.py` | Run-lease accessor: `mint` / `acquire` / `refresh` / `release` / `read` | `references/run-identity-and-lease.md` |
+| `campaign-start.py` | Resumable fresh-run coordinator: full-set preflight, atomic complete header, host handoffs, lease take, adoption, semantic binding, and CI initialization | `references/startup.md` |
 | `pr-adopt.py` | `plan` / `adopt` — mechanically adopt an existing first-party PR into a run: refuse fork/foreign/non-open, register the ledger row + ownership/status labels, discover-or-create the PR-head worktree | `references/pr-adoption.md` |
 | `triage.py` | `derive` — classify one stable, SHA-pinned PR diff and emit the per-file inventory + reasons and a mechanical FLOOR tier (SENSITIVE→HIGH, any non-prose→STANDARD, all-prose→no floor; never TRIVIAL — the orchestrator decides the tier); optional `--tier` vetoes a below-floor tier | `references/stage-2-review-gate.md` |
 | `heartbeat.py` | Emit the lean same-session wake prompts (scheduled heartbeat and session watchdog) the driver arms for its next wake | `references/runtime-adapter.md` |
@@ -384,6 +373,8 @@ Always read before touching run state:
 
 - `references/run-identity-and-lease.md`
 - `references/files-and-ledger.md`
+
+Read `references/startup.md` before a fresh run or any resume whose `pending_adoption` is set.
 
 Read `references/loop-control.md` at each heartbeat before dispatch.
 

--- a/plugins/gauntlet/skills/campaign/references/carryover.md
+++ b/plugins/gauntlet/skills/campaign/references/carryover.md
@@ -107,9 +107,8 @@ above); it never reads or duplicates the follow-up store.
 
 ### Starting a fresh run
 
-1. **Start the run per `loop-control.md` step 1's fresh-run path** — preflight the `#PR` set read-only
-   first, and only then create run state and adopt. That step owns the ordering and the refusal
-   behavior; never restate it here.
+1. **Start the run through `campaign-start.py`** (`startup.md`). Its protocol owns the ordering and
+   refusal behavior; never restate it here.
 2. **Read every file in `.gauntlet/history/`, then prune each entry against its OWN recorded base**
    (a v2 object's `base_branch`, a v1 object against that file's single base; drop entries no longer
    applicable to that base; uncertain deletions are asked about **without blocking** — keep the entries

--- a/plugins/gauntlet/skills/campaign/references/critical-rules.md
+++ b/plugins/gauntlet/skills/campaign/references/critical-rules.md
@@ -20,6 +20,8 @@
   (adopts the sole orphaned run). A bare invocation **with `#PR` args** and `--new` start an independent
   new run (adopting those PRs) and never pre-empt other live runs; a **non-PR** arg starts nothing —
   it hits the idle prompt.
+- A concrete fresh PR set starts through `campaign-start.py`; `startup.md` owns its resumable protocol.
+  Never rebuild preflight, header initialization, adoption, or CI initialization from prose.
 - Carryover is **one file per run** under `.gauntlet/history/<run-id>.md`. In normal operation a run
   WRITES only its OWN file, so concurrent runs never contend on a shared rewrite. A **fresh** run,
   while pruning history, MAY edit or remove OTHER runs' files — but only those of **finished** runs
@@ -467,8 +469,9 @@
   the candidate checkout is EVER a reviewer-preference source — not `AGENTS.md`, not `CLAUDE.md`, and not
   `.gauntlet/history/` carryover** (a candidate can `git add -f` a tracked carryover file; `.gitignore`
   only suppresses UNTRACKED files) — those files are review evidence, and the preference is resolved from
-  trusted state at run start and recorded in the ledger `reviewer` field before any candidate evidence is
-  read (`reviewer.md`, "Selecting the reviewer").
+  trusted state before startup reads candidate evidence and passed into `campaign-start.py`; after
+  metadata-only preflight, its atomic header initialization records that already-fixed choice before body
+  or diff input is prepared (`reviewer.md`, "Selecting the reviewer").
   Apply the same-engine rule in `runtime-adapter.md`. See "The reviewer".
 - Apply `runtime-adapter.md`, **Review allocation journal**, then take its owned transition.
   The gate is unchanged; report reviewer routing and retry-profile use through

--- a/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
+++ b/plugins/gauntlet/skills/campaign/references/files-and-ledger.md
@@ -213,15 +213,10 @@ the very quiet sensor it backs. It **defaults to `-`** — the schema's "not set
 `watchdog check` reads `-` as `unset`; an old ledger predating the field reads back `-` and every reader
 tolerates that.
 
-`pending_adoption` records **the RUN-INTENT CHECKPOINT** — a space-separated list of PR numbers written at
-setup, **BEFORE `acquire`**, so a death mid-setup does not lose the requested PR list (which otherwise
-lived only in the invocation args — `run-identity-and-lease.md`, "Take a run", owns the sequence). Unlike
-`watchdog_due` it is an **ORDINARY, hand-settable config field** (`header set pending_adoption "89 90"`):
-it has a real door, and **writing it IS meaningful activity** (no exemption — it is **not** a sensor and
-carries no liveness meaning). Adoption clears it back to `-` as its final step, and any later entry — the
-armed wake, a watchdog nudge after it refreshes this owner, or a manual resume — that finds it set resumes
-setup idempotently from exactly those PRs (`loop-control.md` step 1). It **defaults to `-`**: nothing is
-pending.
+`pending_adoption` records **the RUN-INTENT CHECKPOINT** — a canonical space-separated PR set published
+with the rest of a fresh header by `ledger.py init`. `campaign-start.py` is its normal writer and reader;
+`startup.md` owns when it is created, resumed, and cleared. The ordinary `header set` door remains for
+recovery and compatibility, and its writes count as meaningful activity. `-` means startup is complete.
 
 `default_non_goals` records **the RUN-WIDE DEFAULT NON-GOALS** — the exclusions the operator declares
 **ONCE** for the whole run, so several PRs need not be hand-edited one at a time. It is a **JSON ARRAY
@@ -749,6 +744,9 @@ and pass that path to subtasks, exactly as with `emit-progress.py`. Subcommands
 # The synopsis abbreviates that `python3 <skill-dir>/scripts/ledger.py` prefix to `ledger.py`.
 ledger.py --file <state.jsonl> header get <field>                 # read a run-config header field
 ledger.py --file <state.jsonl> header set <field> <value>         # set a run-config header field (refused for a TOOL-STAMPED field: last_activity, watchdog_due)
+ledger.py --file <state.jsonl> init --run-id <id> --pending-adoption "<prs>" \
+  --reviewer <r> --skill-version <v> [--default-non-goals <json>]
+                                                                  # atomically publish one complete fresh-run header; refuses existing state
 ledger.py --file <state.jsonl> watchdog arm                       # stamp watchdog_due = now + WATCHDOG_INTERVAL (activity-EXEMPT)
 ledger.py --file <state.jsonl> watchdog check                     # print unset|ok <rem>|due <age>|invalid — re-arm (read-only, always exit 0)
 ledger.py watchdog interval                                       # print the interval in minutes (reads NO ledger; scheduler adapter consumes THIS)

--- a/plugins/gauntlet/skills/campaign/references/loop-control.md
+++ b/plugins/gauntlet/skills/campaign/references/loop-control.md
@@ -51,6 +51,11 @@ rules keep their own wording; these are illustrations of them, not a second copy
    only on an `owned`/`adopted` verdict; on `superseded` or any refusal, **stand down**.
    This lease gate is what guarantees **no two agents drive one ledger**.
 
+   A fresh startup wake is the one exception to the ordinary `refresh` entry: when the prior
+   `campaign-start.py` state was `needs-host-arm`, this wake runs its returned `take` command with the
+   proof for the arming that produced the wake. That command acquires before it advances. Every later
+   startup wake is already owned and uses `advance` (`startup.md`).
+
    Once you own the run and have loaded its ledger, run
    `scripts/nudge.py --file <rundir>/state.jsonl --followups <project_root>/.gauntlet/followups.jsonl --rundir <rundir>`
    and **READ its output** before reconciling. It is the **advisory reminder list** — computed from durable
@@ -205,40 +210,17 @@ rules keep their own wording; these are illustrations of them, not a second copy
      `#PR` args (a bare or non-`#PR` invocation that found no live run to resume — likewise `--new`
      with no `#PR` args), **create nothing** — no run-id, no `<rundir>`, no lease, no `state.jsonl` — and
      show the **idle prompt** (`run-identity-and-lease.md`, "Resolving a heartbeat", owns its wording).
-     Creating `<rundir>`/lease/header before a PR is confirmed would leave an empty
-     orphan run that later no-arg invocations rediscover as bogus state.
-
-     When there **are** `#PR` args, **preflight the whole set FIRST — read-only, before creating any
-     run state**: read every PR's metadata (`gh pr view`, including each PR's `baseRefName`) and run the
-     refusal checks (foreign-owned, cross-repo/fork per `pr-adoption.md`). **The PRs need NOT share a
-     base** — one run may hold PRs targeting different bases, each driven against its own recorded base
-     (`run-identity-and-lease.md`, "Base branch"). Preflight imposes no cross-row base agreement; every
-     PR must still pass all `pr-adoption.md` refusal checks (foreign-owner, cross-repo/fork).
-     This touches **no** run-id, `<rundir>`, lease, `state.jsonl`, label, worktree, or CI watch. **If any
-     PR is refused, prompt and create nothing** — so a rejected set never leaves an
-     empty orphan run behind. **Only once the full set passes preflight**: call `create_run_directory`
-     **first** — it mints the run-id and atomically creates `<rundir>` — and derive `run_id` from the
-     returned directory's final path component; **then** take the run per `run-identity-and-lease.md`,
-     "Take a run" (which, BEFORE arming, records `pending_adoption` = this set's PR list; then token,
-     heartbeat arming, `lease.py acquire` — in that order),
-     — the `state.jsonl` header's `run_id` is written by adoption below, not here. **The header `base_branch` stays its `-`
-     default** — the base is per-row now, recorded on each row at adoption from that PR's live
-     `baseRefName`, never a run-wide header value (`files-and-ledger.md`, the row `base_branch` field).
-     Then **adopt** each PR
-     (ledger row + labels + worktree, then **Run `liveness`, then ensure or relaunch a watch only when
-     returned `watch_warranted` is `true`** — `pr-adoption.md`, "Step 6 — Run liveness, then act on its
-     CI watch warrant"; adoption fetches **each PR's own base ref**, so a
-     set spanning several bases fetches each of them once at its adoption). A death mid-adoption still
-     leaves a discoverable, adoptable run. **When the whole requested set is adopted, clear the checkpoint —
-     `ledger.py … header set pending_adoption -`** (this is adoption's final step; a later entry that
-     still sees it set knows setup did not finish and resumes it). Then fall through to dispatch/reschedule.
+     With a concrete PR set, run `campaign-start.py new` and obey its JSON states through `ready`.
+     `startup.md` owns the command, full-set preflight-before-state guarantee, host handoff, atomic header,
+     adoption, semantic judgment boundaries, CI initialization, and checkpoint clearing. Do not expand
+     those operations here or perform them separately.
    - **This run's `state.jsonl` is fully terminal — every row `merged`/`aborted`, no open PR carrying this
      run's label → the run is finished.** Do **not** silently exit "all fixed" (the old bug) and do **not**
      silently restart. **Ask the user** whether to gate more PRs — e.g. "gauntlet run
      <run-id> finished (N merged, M aborted). Gate more PRs? Pass PR numbers (or run gauntlet:review
      first)." A new run needs a `#PR` set, so collect PR numbers (equivalently direct the user to
      `<campaign-invocation> --new #PR...`); on a PR set, start a fresh run **with carryover** (see "Fresh
-     runs and carryover") — **no run-id/lease/`state.jsonl` is created until that set passes preflight**.
+     runs and carryover") through `campaign-start.py` (`startup.md`).
      With no PR numbers (or "no"), emit that run's final report and stop. This prompt is the *only* heartbeat
      that asks the user about scope.
 
@@ -672,7 +654,7 @@ resume. This block OWNS when the loop continues; every other site points here, n
      resume path (see "Resume after a killed session"). **Size the scheduled delay or bounded wait to the
      nearest stall it guards:**
      - **Run setup still owed — the lease not yet acquired, or adoption / first dispatches not yet
-       run (a fresh run's arm-ended setup turn, `run-identity-and-lease.md` "Take a run") → ~60 s:**
+       run (a fresh run's `needs-host-arm` state, `startup.md`) → ~60 s:**
        on a turn-ending scheduler the wakeup IS the continuation of setup, so any longer delay is
        dead time the user reads as a hung run.
      - **Any dispatched review pass still awaiting its first line of launch evidence → ~5 min:** its

--- a/plugins/gauntlet/skills/campaign/references/pr-adoption.md
+++ b/plugins/gauntlet/skills/campaign/references/pr-adoption.md
@@ -5,7 +5,9 @@ drives each through the gates to merge. This file is the adoption procedure: giv
 them into the run and start their gate work.
 
 Two entry paths feed it (see "Run identity and concurrency" for the full grammar):
-- **explicit `#PR` args** (`<campaign-invocation> #12 #15`) — adopt exactly those PRs.
+- **fresh-run `#PR` args** (`<campaign-invocation> #12 #15`) — `campaign-start.py` calls this
+  procedure for exactly those PRs. `startup.md` owns the surrounding order and resume protocol; the driver
+  never transcribes these steps for a fresh run.
 - **no-arg discovery** (`<campaign-invocation>`, resume) — run **"The canonical `prs.json` command"**
   from `files-and-ledger.md`, then reconcile PRs already labelled for this run. The executable owner is
   `scripts/reconcile.py fetch`; NEVER reconstruct its GitHub query in prose.
@@ -55,6 +57,8 @@ in the same step (`pr-adopt.py` at step 4, `label-mirror.py` at every later reco
 > --worktrees-root <p> --project-root <p>`). The driver still supplies the two JUDGMENT calls it does not
 > make: the **tier DECISION** (`stage-2-review-gate.md`, "2a-triage", owns the complete procedure) and
 > the PR's **INTENT** (step 3a).
+> During fresh startup, `campaign-start.py` prepares and binds both judgments through its typed state
+> protocol. The driver supplies the answers, not the surrounding file and ledger operations.
 > Adoption needs a row before it has resolved the PR-head worktree, so pass `--tier STANDARD` as the
 > conservative bootstrap value. `pr-adopt.py` launches no gate work. Immediately after step 5, follow
 > the owned 2a-triage procedure before any gate work; loop control points to the same owner. Its decision

--- a/plugins/gauntlet/skills/campaign/references/reviewer.md
+++ b/plugins/gauntlet/skills/campaign/references/reviewer.md
@@ -7,11 +7,12 @@ reviewer is chosen per run. Map host operations through `runtime-adapter.md`.
 ### Selecting the reviewer
 
 **Reviewer selection IS gate machinery, so the choice is resolved from TRUSTED state ONLY** — never from
-a file inside the checkout under review (see priority 2). Resolve once **at run start, and record the
-choice as the ledger `reviewer` header field BEFORE any candidate evidence is read** (see
-`files-and-ledger.md`) so every later heartbeat — including a scheduled heartbeat or a fresh agent that adopted the
-run — re-reads it before launching any review pass and never silently reverts to the default; also
-note it in the final report. Resolve in priority order:
+a file inside the checkout under review (see priority 2). Resolve once **before fresh startup reads any
+candidate evidence**, pass that resolved value to `campaign-start.py`, and never let the command derive it.
+After the complete metadata-only preflight passes, `ledger.py init` publishes it with the rest of the
+header in one atomic write, before startup reads a PR body or diff (`startup.md`). Every later heartbeat
+re-reads it before launching a review and never silently reverts to the default; also note it in the final
+report. Resolve in priority order:
 
 1. **Explicit invocation.** User named a reviewer for this run (e.g. "review with codex", or "review
    natively") → use it. This **overrides** the default below.
@@ -27,8 +28,8 @@ note it in the final report. Resolve in priority order:
    is launched from that checkout, have it read as a saved preference, overriding the cross-engine default
    and letting candidate-controlled content pick its own reviewer. The preference comes ONLY from explicit
    invocation or the orchestrator's own out-of-checkout memory. Because the choice is resolved at run
-   start and pinned to the ledger `reviewer` field before the first pass reads the diff, no candidate
-   file can reach the selection.
+   start and is already fixed before any candidate input is read, no candidate file can reach the
+   selection. Its later atomic ledger write makes that choice durable before any review input is prepared.
 3. **Default — the cross-engine route for the active host.** No preference → Claude Code reviews with
    Codex (`codex exec`) and Codex reviews with Claude Code (`claude -p`), launched at native-limitation
    level whenever the paired CLI is present. Fall back to a fresh, context-isolated **native worker** on

--- a/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
+++ b/plugins/gauntlet/skills/campaign/references/run-identity-and-lease.md
@@ -55,21 +55,19 @@ never silently share a directory:
 run-id.py new --runs-dir <repository.scratch_root>   # -> {"run_id": "g260704-0915-a3f29c1b", "rundir": "…"}
 ```
 
-Invoke it through `runtime-adapter.md`'s `create_run_directory(repository)`, which resolves the
-host-specific `repository.scratch_root` and owns that invocation. The atomic create and the collision
-retry live in `run-id.py`; the caller no longer mints an id or retries. Do not unpack that operation here.
+Fresh startup invokes it through `campaign-start.py`; `startup.md` owns that surrounding protocol. The
+runtime adapter still owns the typed repository context, and `run-id.py` owns atomic creation and collision
+retry. No driver mints an ID or retries by hand.
 
-The ledger header field `run_id` records it, and **adoption writes that field itself** — `pr-adopt.py
-adopt` sets it when the header has none and REFUSES a ledger that already names a different run. The
-driver does not set it by hand: it used to, and a driver that forgot left the field unset until
-`merge.py` refused a fully-gated PR with `ledger run_id is unresolved`, after every review had been
-spent. Re-read it every heartbeat (`ledger.py … header get run_id`, like `reviewer`); never trust
-in-context memory for it — a heartbeat may be a fresh agent instance. It flows into:
+The ledger header field `run_id` records it. `ledger.py init` publishes it with the complete fresh header;
+`pr-adopt.py adopt` validates it and fills it only for a legacy ledger whose header has none. The driver
+never sets it by hand. Re-read it every heartbeat (`ledger.py … header get run_id`, like `reviewer`);
+never trust in-context memory for it. It flows into:
 
 | Owned by the run | Namespaced form |
 |------------------|-----------------|
 | tmp working dir  | `<rundir>` from the runtime adapter's run-directory operation (all state/pr/review/ci/abort/lease files) |
-| ledger header    | the `run_id` header field (written by `pr-adopt.py adopt`; read via `ledger.py … header get run_id`) |
+| ledger header    | the `run_id` header field (published by `ledger.py init`; read via `ledger.py … header get run_id`) |
 | PR owner label   | `gauntlet-run-<run-id>` — the **authoritative "mine" marker**. Every adopted PR is tagged with it; it, not any branch name, is what makes a PR this run's. |
 | branch           | the **adopted PR's own `headRefName`** — campaign reuses the PR's existing branch and does NOT mint a `fix-<run-id>-...` branch, so ownership can't be read off the branch name (that's the label's job). |
 | worktree         | the ledger-recorded `worktree` path resolved by the repository-context-aware adoption operation; only a campaign-created worktree (`worktree_owned = yes`) is ever removed (see "PR adoption" / Stage 3) |
@@ -105,32 +103,12 @@ that a busy driver is never mistaken for a dead one, so staleness flags a *dead*
 corrupt-lease refusal, and the read-back. Do not unpack those mechanics here: present a token, act on
 the verdict the tool prints.
 
-- **Take a run** — at fresh-run start or on adoption — **in this order**: (1) `lease.py mint` prints
-  your agent token; **then, BEFORE arming (the arm ends the setup turn on a turn-ending scheduler), do
-  the durable-setup step that must survive a mid-setup death:** record the run intent —
-  `ledger.py --file <rundir>/state.jsonl header set pending_adoption "<pr> <pr> …"`, which creates the
-  ledger + header if missing — so a death before `acquire` does not lose the requested PR list (it
-  otherwise lived only in the invocation args), and any later entry that finds `pending_adoption` set
-  resumes setup idempotently from adoption of exactly those PRs (`files-and-ledger.md`; adoption clears it
-  back to `-` as its final step, `loop-control.md` step 1). Then (2) call the session watchdog's
-  `available?` operation. When available, ensure its recurring nudge using `heartbeat.py watchdog --run
-  <run-id> --token <tok> --invocation <campaign-invocation>` (`runtime-adapter.md`, "Session watchdog
-  nudge"). When unavailable or when `ensure` fails, report that the run has no separate audit wake and
-  continue. The nudge does not end this turn and exists only while this session lives. Then (3) arm the
-  scheduled heartbeat carrying
-  the token (`--token <tok>`, via `heartbeat.py callback` — `runtime-adapter.md` owns the host
-  mechanism); (4) `lease.py --file <rundir>/lease.json
-  acquire --token <tok> --heartbeat-id <proof>`, where the proof names the arming you ALREADY did
-  (`runtime-adapter.md` says what your host's proof is). `acquire` refuses without both and never mints
-  a token itself — arming comes FIRST, so a live session can resume after a turn ends mid-work. **On a host
-  whose scheduler ends the turn (`runtime-adapter.md`, "Scheduled-heartbeat
-  host"), step 3 is the setup turn's LAST action and step 4 plus the rest of setup (header, adoption,
-  first dispatches) run on the heartbeat it armed** — the proof then names the arming that delivered
-  the very turn you are in, which is exactly "something already done". Size that first arm to the
-  setup delay (`loop-control.md`, "Reschedule or exit"): a fresh run resumes in about a minute, not a
-  full idle interval that the user reads as a hung run. Keep the token in context; the heartbeat
-  prompt already carries it, so a summarized/amnesiac heartbeat recovers it from the prompt instead of
-  guessing.
+- **Take a run.** Fresh startup and recovery while `pending_adoption` is set go through
+  `campaign-start.py`'s state protocol; `startup.md` owns the complete sequence. Its `needs-host-arm`
+  state is the only handoff here: the host establishes the returned continuity action before the returned
+  `take` command presents its token and proof to `lease.py acquire`. Never reconstruct header setup,
+  arming, or acquisition as separate driver instructions. For a completed startup, the ordinary
+  `refresh` rule below applies.
 - **You own the run iff the verdict says so.** `acquire`/`refresh` print a verdict, and the verdict —
   not your write, not an eyeballed read of the file — is the proof: `owned`/`adopted` → drive;
   `superseded`/`lost-race`/any refusal → you are NOT the driver — do not review, fix, merge, or
@@ -171,10 +149,12 @@ the verdict the tool prints.
 
 1. **`--run <id>` given** (every scheduled heartbeat, session watchdog nudge, or manual targeted resume).
    Load `<rundir>/state.jsonl`, then present a token to `lease.py`. **Scheduled heartbeat** (token in
-   the prompt's `--token`, without `--watchdog`) → `refresh`: `owned` → reconcile, continue;
-   `superseded` → stand down; refused because the lease is gone → re-arm, then `acquire` (the turn-split
-   in "Take a run" applies on a turn-ending scheduler: the `acquire` runs on the wake the re-arm
-   produces). **Session watchdog** (`--run <id> --token <tok> --watchdog`) → run the runtime
+   the prompt's `--token`, without `--watchdog`) → when this is the wake produced by a startup
+   `needs-host-arm`, run its returned `take` command with that arming's proof; otherwise `refresh`:
+   `owned` → reconcile, continue;
+   `superseded` → stand down; refused because the lease is gone → use `campaign-start.py resume` and obey
+   its returned host-arm state (`startup.md`). **Session watchdog** (`--run <id> --token <tok>
+   --watchdog`) → run the runtime
    adapter's capability-aware inspections (`runtime-adapter.md`, "Session watchdog nudge" — `primary
    inspect` is optional and advisory; where the host exposes no such operation it records `unavailable`
    or `not-applicable` without inventing a host call), then take the same `refresh`: `owned` → run
@@ -182,8 +162,9 @@ the verdict the tool prints.
    or `superseded` → report the inspections and stop. It NEVER calls `acquire`,
    `--allow-takeover`, or adoption: it is a live-session audit, not a recovery path.
    **Manual `--run` with no token in hand** → `lease.py read` (advisory status only):
-   `absent`/`stale` → adopt (mint + arm + `acquire`, per "Take a run"); `held` → another agent
-   appears active, so **confirm takeover with the user** before `acquire --allow-takeover`; `corrupt` →
+   `absent`/`stale` → adopt through `campaign-start.py resume` (`startup.md`); `held` → another agent
+   appears active, so **confirm takeover with the user** before `campaign-start.py resume
+   --allow-takeover`; `corrupt` →
    see "Adopt only an orphaned run".
 
 2. **Bare invocation** → the arg decides intent:

--- a/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
+++ b/plugins/gauntlet/skills/campaign/references/runtime-adapter.md
@@ -450,11 +450,11 @@ For the heartbeat fallback, choose exactly one lifecycle:
    scheduler answers that there is nothing more to do this turn and the harness yields until the wakeup
    fires (verified empirically on Claude Code) — so the schedule call is ALWAYS the LAST action of a
    turn, and everything the turn still owes (status render, ledger writes, dispatches) happens BEFORE
-   it. The same property is why fresh-run setup spans two turns: "Take a run"'s arm step ends the setup
-   turn, and `acquire` plus the rest of setup run on the heartbeat that arming produced — the acquire
-   proof is that arming, which is already done (`run-identity-and-lease.md`, "Take a run" owns the
-   sequence; `loop-control.md` "Reschedule or exit" sizes the setup delay so a fresh run resumes in
-   about a minute instead of idling a full interval looking stalled). Letting the tool build the prompt
+   it. The same property is why fresh-run setup may span two turns: `campaign-start.py` returns
+   `needs-host-arm`, the arm ends the setup turn, and its returned `take` command runs on the wake that
+   arming produced. The acquire proof names that completed host action (`startup.md` owns the protocol;
+   `loop-control.md` "Reschedule or exit" sizes the setup delay so a fresh run resumes in about a minute
+   instead of idling a full interval looking stalled). Letting the tool build the prompt
    is what enforces the guarantee: the wake
    carries **only** `--run` and `--token` and **never** `--new`/`#PR` (start-time args that would mint a
    fresh run each heartbeat) or `--heartbeat-id` (an acquire-time proof) — and the tool refuses any value
@@ -514,8 +514,8 @@ dispatched worker dies or returns an unusable report.
   the driver where to look; it never replaces a guard.
 - A `superseded` or refused lease verdict in the report stands the driver down exactly as if it had
   run Step 1 inline.
-- First invocation, fresh-run setup, adoption of `#PR` args, and the finished-run prompt stay in the
-  driver: they are arg-driven and interactive. A worker that finds nothing live — or every row
+- First invocation, the `campaign-start.py` protocol, and the finished-run prompt stay in the driver:
+  they are arg-driven or interactive. A worker that finds nothing live — or every row
   terminal — reports that fact, and the driver takes the matching Step 1 branch itself.
 
 ### Session watchdog nudge

--- a/plugins/gauntlet/skills/campaign/references/startup.md
+++ b/plugins/gauntlet/skills/campaign/references/startup.md
@@ -1,0 +1,108 @@
+## Code-driven campaign startup
+
+> **Read when:** a fresh run has a concrete PR set, or an entry finds `pending_adoption` still set.
+
+`scripts/campaign-start.py` owns fresh-run startup as a resumable command protocol. Do not reproduce its
+preflight, run creation, header writes, lease acquisition, adoption, triage preparation, intent write,
+label mirror, CI initialization, or checkpoint clearing as separate driver steps.
+
+The command owns mechanics. The driver supplies only trusted-host facts, host-only actions, and semantic
+judgments. `runtime-adapter.md` owns the typed process boundary and host mappings; `reviewer.md` owns
+reviewer selection; `pr-adoption.md` and the stage references still own the rules the coordinator calls.
+
+### Start a fresh run
+
+First resolve the invocation to a fresh-run intent and select the reviewer from explicit or trusted host
+state. Never derive the reviewer from the candidate checkout. Then run:
+
+```text
+python3 <skill-dir>/scripts/campaign-start.py new \
+  --checkout <supplied-checkout> \
+  --host claude-code|codex \
+  --reviewer <resolved-reviewer> \
+  --pr <N> [--pr <N> ...] \
+  [--default-non-goals '<json-array-string>']
+```
+
+An empty or malformed PR set is refused. The command resolves the checkout once, checks the ignore
+boundary, and read-only preflights the complete PR set before it creates a run directory. A refusal during
+that preflight creates no run state, label, worktree, lease, or CI watch.
+
+On success, `new` atomically writes the complete header through `ledger.py init`, mints the owner token,
+and returns `needs-host-arm`. The header already records the run ID, complete `pending_adoption` set,
+reviewer, running skill version, and run-default Non-goals. No driver writes those fields one at a time.
+
+### Obey the returned state
+
+Read the JSON `state` and perform only its matching action.
+
+#### `needs-host-arm`
+
+Perform each returned `host_actions` item through the active host adapter. The optional session-watchdog
+action does not gate startup. The primary action does:
+
+- On a scheduled-heartbeat host, arm the returned prompt at the setup delay as the turn's last action. On
+  the wake it produced, run the returned `take` command with the proof for that completed arming.
+- On a scheduler-less host, establish the bounded-wait continuation and use its run-bound proof in the
+  returned `take` command without ending the current invocation.
+
+Never substitute a made-up proof or acquire before the host action. `take` presents the token and proof to
+`lease.py acquire`; only an owned/adopted verdict advances startup.
+
+#### `needs-pr-judgment`
+
+Read the returned `judgment_file`. It contains the PR title and body, the path to its exact diff byte-file,
+adopted worktree, effective base, current head SHA, mechanically derived triage evidence and floor, and
+any usable stated intent.
+
+Choose a tier from `allowed_tiers`. Use `suggested_tier` unless repository evidence supports a deeper tier.
+The coordinator reruns triage with the selected tier at bind time and refuses a below-floor decision.
+
+For intent, choose exactly one returned route:
+
+- When `intent_source` is `stated`, pass `--use-stated-intent` to copy the three usable PR-body sections.
+- When it is `author-required`, author the exact three-section base intent from the judgment file's diff,
+  title, and body, write those bytes to a separate file, and pass `--intent-file <path>`.
+
+Then run the returned `bind` operation with `--tier` and the chosen intent input. `bind` checks that the
+judgment still matches the row's current head, validates and syncs the intent, records its provenance,
+mirrors labels, and advances to the next pending PR. Do not edit `state.jsonl` or `intent-<pr>.md` directly.
+
+#### `ready`
+
+Every requested PR now has a row, head worktree, selected tier, validated intent, required-check state,
+and initial CI/liveness record. `pending_adoption` is `-`.
+
+Run `liveness`, then ensure or relaunch a watch only when returned `watch_warranted` is `true`; the
+coordinator performs the first half and includes only those warranted watches in `host_actions`. Launch
+those actions, then enter `loop-control.md` at the normal heartbeat path. The returned `carryover_review`
+is advisory and nonblocking: follow its owner after adoption, keep uncertain history entries, and let the
+gate work continue.
+
+#### `needs-user` or `refused`
+
+`needs-user` means another driver holds a fresh lease. Report the returned owner and permitted decisions;
+do not take over without the user's answer. After approval, rerun `resume` with `--allow-takeover`, perform
+its returned host action, and run the returned `take` command; the approval flag reaches `lease.py` only at
+that acquisition door. `refused` is fail-closed. Report its reason and do not continue with hand-written
+startup steps.
+
+### Resume an incomplete startup
+
+When a bound run's header still has `pending_adoption` set:
+
+- A scheduled wake carrying the owner token calls `advance --checkout <path> --run <id> --token <tok>`.
+  It refreshes ownership and resumes at the first missing row or judgment.
+- A manual entry without a usable owner token calls
+  `resume --checkout <path> --host <host> --run <id>`. An absent or stale lease returns a new
+  `needs-host-arm`; a fresh foreign lease returns `needs-user`; corrupt state refuses.
+
+Each invocation performs at most one host/model handoff before returning. Re-run the next command from the
+returned record until it says `ready`. Never infer progress from temporary files; the ledger fields above
+are the durable state.
+
+### What remains outside code
+
+Standalone Python cannot invoke a host's scheduler, keep a Codex bounded wait alive, read trusted global
+reviewer preferences, or make model judgments about intent and review depth. Those boundaries remain
+explicit JSON states. Everything between them is code-owned and fixture-tested.

--- a/plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
+++ b/plugins/gauntlet/skills/campaign/scripts/_gauntlet/atomic.py
@@ -1,4 +1,4 @@
-"""Atomic text-file replacement shared by Gauntlet's local stores."""
+"""Atomic file replacement shared by Gauntlet's local stores."""
 
 from __future__ import annotations
 
@@ -34,6 +34,27 @@ def replace_text(
             stream = os.fdopen(fd, "w", encoding=encoding)
         with stream:  # fdopen owns and closes the descriptor
             stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if mode is not None:
+            os.chmod(temp, mode)
+        os.replace(temp, path)
+    except BaseException:
+        temp.unlink(missing_ok=True)
+        raise
+
+
+def replace_bytes(path: Path, payload: bytes, *, temp_prefix: str, mode: int | None = None) -> None:
+    """Durably replace ``path`` with exact bytes through a same-directory temp file."""
+    fd, temp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=temp_prefix,
+        suffix=".tmp",
+    )
+    temp = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(payload)
             stream.flush()
             os.fsync(stream.fileno())
         if mode is not None:

--- a/plugins/gauntlet/skills/campaign/scripts/campaign-start-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/campaign-start-test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Offline fixtures for the code-owned fresh campaign startup protocol."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from _gauntlet.modules import load_sibling
+from _gauntlet.testing import checker
+
+HERE = Path(__file__).resolve().parent
+C = load_sibling("campaign_start_subject", HERE, "campaign-start.py", register=True)
+check = checker(C.SelfTestFailure)
+
+
+def init_repository(work: Path) -> Path:
+    repository = work / "repository"
+    repository.mkdir()
+    proc = subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch=main", str(repository)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    check(proc.returncode == 0, f"git init failed: {proc.stderr}")
+    (repository / ".gitignore").write_text(".gauntlet/\n", encoding="utf-8")
+    return repository
+
+
+def view(pr: int, *, fork: bool = False, labels: "list[dict] | None" = None) -> dict:
+    return {
+        "number": pr,
+        "title": f"PR {pr}",
+        "headRefName": f"feature-{pr}",
+        "headRefOid": f"{pr:x}"[-1] * 40,
+        "baseRefName": "main",
+        "labels": labels or [],
+        "state": "OPEN",
+        "isCrossRepository": fork,
+        "headRepositoryOwner": {"login": "owner"},
+        "headRepository": {"name": "repository"},
+    }
+
+
+def fetcher(views: dict[int, dict]):
+    def fetch(pr: str, *, fields: str, cwd: str):
+        check(fields == C.A.VIEW_FIELDS, "preflight must request the adoption owner's complete view")
+        check(Path(cwd).name == "repository", "preflight must run in the resolved repository root")
+        return views[int(pr)], None
+
+    return fetch
+
+
+def run_creator(run_id: str = "g260829-1200-aabbccdd"):
+    def create(scratch_root: Path):
+        rundir = scratch_root / run_id
+        rundir.mkdir(parents=True)
+        return run_id, rundir
+
+    return create
+
+
+def initialized_run(repository: Path, run_id: str, pending: str) -> tuple[dict, Path, Path]:
+    context = C.resolve_repository_context(repository)
+    rundir = context["scratch_root"] / run_id
+    rundir.mkdir(parents=True)
+    ledger = rundir / "state.jsonl"
+    C.L.init_run(
+        ledger,
+        run_id=run_id,
+        pending_adoption=pending,
+        reviewer="claude",
+        skill_version="0.9.1",
+    )
+    return context, rundir, ledger
+
+
+def add_bound_row(
+    ledger: Path,
+    repository: Path,
+    pr: str,
+    *,
+    intent: str,
+    status: str = "in_review",
+) -> None:
+    proc = subprocess.run([
+        sys.executable,
+        str(C.LEDGER_PY),
+        "--file",
+        str(ledger),
+        "add-row",
+        "--pr",
+        pr,
+        "--branch",
+        f"feature-{pr}",
+        "--worktree",
+        str(repository),
+        "--worktree-owned",
+        "no",
+        "--branch-owned",
+        "no",
+        "--head-sha",
+        f"{int(pr):x}"[-1] * 40,
+        "--base-branch",
+        "main",
+        "--tier",
+        "STANDARD",
+        "--ci",
+        "pending",
+        "--status",
+        status,
+        "--intent",
+        intent,
+    ], capture_output=True, text=True, check=False)
+    check(proc.returncode == 0, f"could not prepare test row: {proc.stderr}")
+
+
+def t_normalize_pr_set(_work: Path) -> None:
+    check(C.normalize_prs(["#09", "10"]) == ["9", "10"], "PRs must be canonical positive integers")
+    for values in ([], ["0"], ["x"], ["9", "#09"]):
+        try:
+            C.normalize_prs(values)
+        except C.Refusal:
+            continue
+        raise C.SelfTestFailure(f"startup accepted malformed PR set {values!r}")
+
+
+def t_repository_context_is_explicit(work: Path) -> None:
+    repository = init_repository(work)
+    nested = repository / "nested"
+    nested.mkdir()
+    context = C.resolve_repository_context(nested)
+    check(context["project_root"] == repository.resolve(), "checkout resolution must return the git root")
+    check(context["scratch_root"] == repository.resolve() / ".gauntlet" / "tmp",
+          "scratch state must be rooted under the supplied checkout")
+    C.require_gauntlet_ignored(repository)
+
+
+def t_active_manifest_version(_work: Path) -> None:
+    claude = C.active_skill_version("claude-code")
+    codex = C.active_skill_version("codex")
+    check(claude == codex, "both host manifests beside the active skill must report the same version")
+    check(bool(claude), "the active skill version must not be empty")
+
+
+def t_preflight_finishes_before_state(work: Path) -> None:
+    repository = init_repository(work)
+    created = False
+
+    def must_not_create(_scratch_root: Path):
+        nonlocal created
+        created = True
+        raise C.SelfTestFailure("run state was created before every PR passed preflight")
+
+    try:
+        C.prepare_new(
+            checkout=repository,
+            host="codex",
+            reviewer="claude",
+            prs=["1", "2"],
+            default_non_goals="[]",
+            fetch=fetcher({1: view(1), 2: view(2, fork=True)}),
+            run_creator=must_not_create,
+            token_mint=lambda: "token",
+            version="0.9.1",
+        )
+    except C.Refusal as exc:
+        check("fork PR" in str(exc), f"preflight returned the wrong refusal: {exc}")
+    else:
+        raise C.SelfTestFailure("startup accepted a fork PR")
+    check(not created, "startup must not create a run before full-set preflight succeeds")
+    check(not (repository / ".gauntlet").exists(), "failed preflight must leave no campaign state")
+
+
+def t_new_publishes_complete_header(work: Path) -> None:
+    repository = init_repository(work)
+    result = C.prepare_new(
+        checkout=repository,
+        host="codex",
+        reviewer="claude",
+        prs=["#01", "2"],
+        default_non_goals='["generated files"]',
+        fetch=fetcher({1: view(1), 2: view(2)}),
+        run_creator=run_creator(),
+        token_mint=lambda: "token-aabbccdd",
+        version="0.9.1",
+    )
+    ledger = Path(result["rundir"]) / "state.jsonl"
+    header, rows = C.L.load(ledger)
+    check(result["state"] == "needs-host-arm", "new must stop at the host-continuity boundary")
+    check(header["run_id"] == result["run_id"], "the complete header must own the minted run id")
+    check(header["pending_adoption"] == "1 2", "the complete header must publish the full PR checkpoint")
+    check(header["reviewer"] == "claude", "the complete header must publish the trusted reviewer choice")
+    check(header["skill_version"] == "0.9.1", "the complete header must publish the active skill version")
+    check(C.L.default_non_goals(header) == ["generated files"], "run defaults must be canonicalized at init")
+    check(rows == [], "new must not adopt a PR before the host establishes continuity")
+    check(sorted(path.name for path in Path(result["rundir"]).iterdir()) == ["state.jsonl"],
+          "the ledger must be the only durable startup state")
+
+
+def t_host_actions_are_typed(work: Path) -> None:
+    repository = init_repository(work)
+    context = C.resolve_repository_context(repository)
+    rundir = repository / ".gauntlet" / "tmp" / "g260829-1200-aabbccdd"
+    claude = C.host_arm_state(
+        host="claude-code",
+        repository=context,
+        run_id=rundir.name,
+        rundir=rundir,
+        token="token",
+        reviewer="codex",
+        skill_version="0.9.1",
+    )
+    codex = C.host_arm_state(
+        host="codex",
+        repository=context,
+        run_id=rundir.name,
+        rundir=rundir,
+        token="token",
+        reviewer="claude",
+        skill_version="0.9.1",
+    )
+    check(claude["host_actions"][-1]["kind"] == "arm-primary-heartbeat",
+          "Claude Code must receive the scheduled-heartbeat action")
+    check(claude["host_actions"][-1]["must_run_last"] is True,
+          "the scheduled heartbeat must remain the host's last action")
+    check(codex["host_actions"][-1]["kind"] == "establish-bounded-wait",
+          "Codex must receive its scheduler-less continuation action")
+    check(codex["host_actions"][-1]["suggested_heartbeat_id"] == f"bounded-wait:{rundir.name}",
+          "the bounded-wait host action must suggest a run-bound proof")
+    takeover = C.host_arm_state(
+        host="codex",
+        repository=context,
+        run_id=rundir.name,
+        rundir=rundir,
+        token="token",
+        reviewer="claude",
+        skill_version="0.9.1",
+        allow_takeover=True,
+    )
+    check(takeover["next"]["argv"][-1] == "--allow-takeover",
+          "an approved takeover must remain explicit at the lease acquisition door")
+
+
+def t_stated_intent_is_exact(_work: Path) -> None:
+    valid = (
+        "Introduction.\n\n"
+        "## Purpose\n- Start campaigns deterministically.\n"
+        "## Non-goals\n"
+        "## Threat model\n- The repository owner supplies PR metadata.\n"
+        "## Notes\n- Outside the intent.\n"
+    )
+    expected = (
+        "## Purpose\n- Start campaigns deterministically.\n"
+        "## Non-goals\n"
+        "## Threat model\n- The repository owner supplies PR metadata.\n"
+    )
+    check(C.extract_stated_intent(valid) == expected, "usable stated intent must be extracted verbatim")
+    check(C.extract_stated_intent("## Purpose\n- x\n## Threat model\n- y\n") is None,
+          "a body missing one intent section must require authorship")
+    managed = expected.replace("## Non-goals\n", f"## Non-goals\n{C.RP.MANAGED_START}\n")
+    check(C.extract_stated_intent(managed) is None, "managed run defaults must never be accepted as PR input")
+
+
+def t_judgment_is_bound_to_head(work: Path) -> None:
+    path = work / "startup-judgment-7.json"
+    path.write_text(json.dumps({
+        "type": "campaign-start-judgment",
+        "pr": "7",
+        "head_sha": "a" * 40,
+    }), encoding="utf-8")
+    check(C.load_judgment(path, "7", "a" * 40)["pr"] == "7",
+          "a matching judgment artifact must load")
+    try:
+        C.load_judgment(path, "7", "b" * 40)
+    except C.Refusal:
+        return
+    raise C.SelfTestFailure("a judgment prepared for an old head was accepted")
+
+
+def t_diff_transport_preserves_bytes(work: Path) -> None:
+    proc = C.run_bytes([
+        sys.executable,
+        "-c",
+        "import sys; sys.stdout.buffer.write(bytes([255, 0, 10]))",
+    ])
+    check(proc.returncode == 0, "the exact-byte subprocess fixture failed")
+    path = work / "startup-diff-7.patch"
+    C.replace_bytes(path, proc.stdout, temp_prefix=".startup-diff-7.patch.")
+    check(path.read_bytes() == bytes([255, 0, 10]), "diff transport decoded or changed non-UTF-8 bytes")
+
+
+def t_label_mirror_is_repo_scoped(work: Path) -> None:
+    ledger = work / "state.jsonl"
+    argv = C.label_mirror_argv(ledger, "7", "owner/repository")
+    check(argv[-2:] == ["--repo", "owner/repository"], "label mirror must receive an explicit owner/name")
+    check(argv[argv.index("--ledger") + 1] == str(ledger), "label mirror must receive this run's ledger")
+
+
+def t_advance_adopts_then_requests_judgment(work: Path) -> None:
+    repository = init_repository(work)
+    run_id = "g260829-1200-aabbccdd"
+    context, rundir, ledger = initialized_run(repository, run_id, "7")
+    adopted: list[str] = []
+    real_adopt = getattr(C, "adopt_one")
+    real_prepare = getattr(C, "prepare_judgment")
+
+    def adopt(_context: dict, target: Path, actual_run: str, pr: str) -> None:
+        check(target == ledger and actual_run == run_id, "advance must adopt into the bound run ledger")
+        adopted.append(pr)
+        add_bound_row(target, repository, pr, intent="-")
+
+    def prepare(_context: dict, actual_rundir: Path, target: Path, pr: str, token: str) -> dict:
+        check(actual_rundir == rundir and target == ledger, "judgment must use the adopted run artifacts")
+        check(token == "token-aabbccdd", "judgment handoff must preserve the owner token")
+        return {"state": "needs-pr-judgment", "pr": pr}
+
+    setattr(C, "adopt_one", adopt)
+    setattr(C, "prepare_judgment", prepare)
+    try:
+        result = C.advance_startup(context, run_id, "token-aabbccdd", refresh=False)
+    finally:
+        setattr(C, "adopt_one", real_adopt)
+        setattr(C, "prepare_judgment", real_prepare)
+    check(adopted == ["7"], "advance must adopt the first missing checkpoint row exactly once")
+    check(result == {"state": "needs-pr-judgment", "pr": "7"},
+          "advance must stop at the semantic boundary after adoption")
+
+
+def t_advance_initializes_then_commits_ready(work: Path) -> None:
+    repository = init_repository(work)
+    run_id = "g260829-1200-aabbccdd"
+    context, rundir, ledger = initialized_run(repository, run_id, "7")
+    add_bound_row(ledger, repository, "7", intent="stated@2026-08-29T12:00:00+00:00")
+    real_initialize = getattr(C, "initialize_ci")
+
+    def initialize(actual_context: dict, actual_rundir: Path, target: Path, rows: list[dict]) -> list[dict]:
+        check(actual_context == context and actual_rundir == rundir and target == ledger,
+              "CI initialization must use the bound repository and run")
+        check([row["pr"] for row in rows] == ["7"], "CI initialization must receive every bound row")
+        return [{"kind": "ci-watch", "pr": "7"}]
+
+    setattr(C, "initialize_ci", initialize)
+    try:
+        result = C.advance_startup(context, run_id, "token-aabbccdd", refresh=False)
+    finally:
+        setattr(C, "initialize_ci", real_initialize)
+    header, _rows = C.L.load(ledger)
+    check(result["state"] == "ready", "fully bound startup must return ready")
+    check(result["host_actions"] == [{"kind": "ci-watch", "pr": "7"}],
+          "ready must return only CI watches warranted by initialization")
+    check(header["pending_adoption"] == "-", "ready must atomically expose the cleared startup checkpoint")
+
+
+def t_advance_refuses_a_held_row(work: Path) -> None:
+    repository = init_repository(work)
+    run_id = "g260829-1200-aabbccdd"
+    context, _rundir, ledger = initialized_run(repository, run_id, "7")
+    add_bound_row(ledger, repository, "7", intent="-", status="awaiting-user")
+    try:
+        C.advance_startup(context, run_id, "token-aabbccdd", refresh=False)
+    except C.Refusal as exc:
+        check("awaiting-user" in str(exc), f"held startup row was refused for the wrong reason: {exc}")
+    else:
+        raise C.SelfTestFailure("startup prepared a judgment for a held PR")
+    header, _rows = C.L.load(ledger)
+    check(header["pending_adoption"] == "7", "a held startup row must preserve the recovery checkpoint")
+
+
+CASES = [
+    ("pr-set", "startup canonicalizes the complete nonempty PR set", t_normalize_pr_set),
+    ("repository-context", "all startup paths derive from the supplied checkout", t_repository_context_is_explicit),
+    ("active-version", "startup reads the synchronized manifests beside the active skill",
+     t_active_manifest_version),
+    ("preflight-before-state", "every PR passes read-only preflight before state exists",
+     t_preflight_finishes_before_state),
+    ("atomic-complete-header", "new publishes one complete recoverable header", t_new_publishes_complete_header),
+    ("typed-host-actions", "the protocol stops only at explicit host capability boundaries", t_host_actions_are_typed),
+    ("stated-intent", "only a complete exact PR-body intent bypasses authorship", t_stated_intent_is_exact),
+    ("head-bound-judgment", "semantic input cannot cross a head-SHA change", t_judgment_is_bound_to_head),
+    ("exact-diff-bytes", "diff transport preserves bytes that are not UTF-8", t_diff_transport_preserves_bytes),
+    ("repo-scoped-label", "status-label mutation names the repository explicitly", t_label_mirror_is_repo_scoped),
+    ("adopt-to-judgment", "advance adopts one missing row and stops at its semantic boundary",
+     t_advance_adopts_then_requests_judgment),
+    ("initialized-to-ready", "CI initialization precedes the startup commit point",
+     t_advance_initializes_then_commits_ready),
+    ("held-row-frozen", "startup does not bind or initialize a held PR", t_advance_refuses_a_held_row),
+]

--- a/plugins/gauntlet/skills/campaign/scripts/campaign-start.py
+++ b/plugins/gauntlet/skills/campaign/scripts/campaign-start.py
@@ -1,0 +1,1087 @@
+#!/usr/bin/env python3
+"""Drive fresh campaign startup as a resumable command protocol.
+
+The campaign used to ask the orchestrator to transcribe fresh-run setup from several reference files:
+resolve the checkout, preflight every PR, create the run, initialize the ledger, mint a token, prepare host
+continuity, acquire the lease, adopt each PR, request the two semantic judgments, initialize CI, and clear
+the checkpoint.  This command owns that sequence.  It emits one JSON state after each invocation; the host
+performs only the named host action or supplies the named judgment, then calls the returned next command.
+
+The durable state is the existing ledger.  ``pending_adoption`` is the run-level startup checkpoint, and a
+pending row's ``intent`` provenance says whether its judgment has landed.  No parallel startup state file
+can drift from those owners.
+
+Commands:
+
+  campaign-start.py new --checkout <path> --host <host> --reviewer <choice> --pr <N> [--pr <N> ...]
+  campaign-start.py take --checkout <path> --run <id> --token <tok> --heartbeat-id <proof>
+                            [--allow-takeover]
+  campaign-start.py advance --checkout <path> --run <id> --token <tok>
+  campaign-start.py bind --checkout <path> --run <id> --token <tok> --pr <N> --tier <tier>
+                         (--use-stated-intent | --intent-file <path>)
+  campaign-start.py resume --checkout <path> --host <host> --run <id> [--allow-takeover]
+  campaign-start.py self-test
+
+``new`` performs the whole read-only PR preflight before creating anything.  It then atomically publishes
+the complete header through ``ledger.py init`` and returns ``needs-host-arm``.  A scheduled host arms the
+returned prompt as its last action; a scheduler-less host establishes its bounded-wait continuation.  The
+resulting proof is passed to ``take``.  ``take`` acquires the lease and enters ``advance``.
+
+``advance`` adopts one unbound PR at a time and returns ``needs-pr-judgment`` with exact title/body and
+diff byte-files, the mechanically derived triage floor, and any usable stated intent. ``bind`` accepts the
+orchestrator's tier decision and either that stated intent or a separate authored byte-file, validates both
+before writing, records them, and advances again.  Once every requested PR is bound, the command initializes
+required-check state and CI liveness, clears ``pending_adoption``, and returns ``ready`` plus typed CI-watch
+host actions.  It never launches a background task itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, NoReturn, cast
+
+from _gauntlet import gh
+from _gauntlet.atomic import replace_bytes, replace_text
+from _gauntlet.git_refs import branch_problem
+from _gauntlet.modules import load_sibling
+from _gauntlet.repository import repo_problem
+from _gauntlet.testing import run_sibling_suite
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE / "campaign-start-test.py"
+
+LEDGER_PY = HERE / "ledger.py"
+LEASE_PY = HERE / "lease.py"
+RUN_ID_PY = HERE / "run-id.py"
+PR_ADOPT_PY = HERE / "pr-adopt.py"
+TRIAGE_PY = HERE / "triage.py"
+HEARTBEAT_PY = HERE / "heartbeat.py"
+REVIEW_PASS_PY = HERE / "review-pass.py"
+CI_STATUS_PY = HERE / "ci-status.py"
+LABEL_MIRROR_PY = HERE / "label-mirror.py"
+
+L = load_sibling("campaign_start_ledger", HERE, LEDGER_PY.name)
+A = load_sibling("campaign_start_adopt", HERE, PR_ADOPT_PY.name)
+T = load_sibling("campaign_start_triage", HERE, TRIAGE_PY.name, register=True)
+H = load_sibling("campaign_start_heartbeat", HERE, HEARTBEAT_PY.name)
+RP = load_sibling("campaign_start_review_pass", HERE, REVIEW_PASS_PY.name)
+LEASE = load_sibling("campaign_start_lease", HERE, LEASE_PY.name)
+
+DESCRIPTION = "Resumable code-owned startup for a fresh Gauntlet campaign run."
+HOST_INVOCATIONS = {"claude-code": "/gauntlet:campaign", "codex": "$gauntlet:campaign"}
+RUN_ID_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+TERMINAL = frozenset(L.TERMINAL_STATUSES)
+STANDARD = "STANDARD"
+
+
+class Refusal(Exception):
+    """Startup cannot safely advance; no later mutation in this invocation may run."""
+
+
+class SelfTestFailure(AssertionError):
+    """A rule this command claims to enforce does not hold."""
+
+
+def refuse(message: str) -> NoReturn:
+    raise Refusal(message)
+
+
+def emit(payload: dict) -> None:
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def run_argv(argv: list[str], *, cwd: "Path | None" = None, stdin: "str | None" = None) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            argv,
+            cwd=str(cwd) if cwd is not None else None,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(argv, 127, "", str(exc))
+
+
+def run_bytes(argv: list[str], *, cwd: "Path | None" = None) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            argv,
+            cwd=os.fsencode(cwd) if cwd is not None else None,
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(argv, 127, b"", os.fsencode(str(exc)))
+
+
+def tool_json(
+    argv: list[str],
+    *,
+    cwd: "Path | None" = None,
+    stdin: "str | None" = None,
+    accepted: "tuple[int, ...]" = (0,),
+) -> "tuple[dict, int]":
+    proc = run_argv(argv, cwd=cwd, stdin=stdin)
+    if proc.returncode not in accepted:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "no diagnostic"
+        refuse(f"{Path(argv[1]).name if len(argv) > 1 else argv[0]} exited {proc.returncode}: {detail}")
+    try:
+        payload = json.loads(proc.stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        refuse(f"{Path(argv[1]).name if len(argv) > 1 else argv[0]} returned non-JSON output ({exc})")
+    if not isinstance(payload, dict):
+        refuse(f"{Path(argv[1]).name if len(argv) > 1 else argv[0]} returned {type(payload).__name__}, not an object")
+    return payload, proc.returncode
+
+
+def resolve_repository_context(checkout: Path) -> dict[str, Path]:
+    """Resolve the supplied checkout exactly once, preserving the runtime adapter's byte boundary."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", os.fspath(checkout), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        refuse(f"cannot resolve checkout {checkout}: {exc}")
+    if proc.returncode != 0:
+        detail = os.fsdecode(proc.stderr).strip() or f"git exited {proc.returncode}"
+        refuse(f"cannot resolve checkout {checkout}: {detail}")
+    raw = proc.stdout
+    if not raw.endswith(b"\n"):
+        refuse("git rev-parse output has no terminating LF")
+    text = os.fsdecode(raw[:-1])
+    root = Path(text)
+    if not text or not root.is_absolute():
+        refuse(f"git rev-parse returned a non-absolute repository root {text!r}")
+    return {
+        "project_root": root,
+        "scratch_root": root / ".gauntlet" / "tmp",
+        "worktrees_root": root / ".worktrees",
+    }
+
+
+def require_gauntlet_ignored(project_root: Path) -> None:
+    probe = ".gauntlet/campaign-start-ignore-probe"
+    proc = run_argv(["git", "-C", os.fspath(project_root), "check-ignore", "-q", "--no-index", probe])
+    if proc.returncode != 0:
+        refuse(".gauntlet/ is not ignored by this repository; add `.gauntlet/` to `.gitignore` before startup")
+
+
+def resolve_github_repo(project_root: Path) -> str:
+    payload, _ = tool_json([
+        "gh",
+        "repo",
+        "view",
+        "--json",
+        "nameWithOwner",
+    ], cwd=project_root)
+    repo = payload.get("nameWithOwner")
+    if not isinstance(repo, str) or repo_problem(repo) is not None:
+        refuse(f"gh repo view returned unusable nameWithOwner {repo!r}")
+    return repo
+
+
+def label_mirror_argv(ledger: Path, pr: str, github_repo: str) -> list[str]:
+    return [
+        sys.executable,
+        os.fspath(LABEL_MIRROR_PY),
+        "mirror",
+        "--ledger",
+        os.fspath(ledger),
+        "--pr",
+        pr,
+        "--repo",
+        github_repo,
+    ]
+
+
+def normalize_prs(values: list[str]) -> list[str]:
+    if not values:
+        refuse("new requires at least one --pr; an empty run is never created")
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        value = raw[1:] if raw.startswith("#") else raw
+        if not value.isascii() or not value.isdigit() or int(value) <= 0:
+            refuse(f"invalid PR number {raw!r}; use a positive integer")
+        pr = str(int(value))
+        if pr in seen:
+            refuse(f"duplicate PR {pr} in one startup request")
+        seen.add(pr)
+        out.append(pr)
+    return out
+
+
+def load_ledger(path: Path) -> tuple[dict, list[dict]]:
+    """Turn the ledger accessor's in-process refusal into this protocol's structured refusal."""
+    try:
+        return L.load(path)
+    except SystemExit as exc:
+        refuse(f"ledger accessor refused {path} (exit {exc.code})")
+
+
+def active_skill_version(host: str) -> str:
+    manifest_name = ".claude-plugin" if host == "claude-code" else ".codex-plugin"
+    manifest = HERE.parents[2] / manifest_name / "plugin.json"
+    try:
+        raw = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        refuse(f"cannot read active {host} plugin manifest {manifest}: {exc}")
+    version = raw.get("version") if isinstance(raw, dict) else None
+    if not isinstance(version, str) or not version.strip():
+        refuse(f"active {host} plugin manifest {manifest} has no usable version")
+    return version
+
+
+def validate_reviewer(value: str) -> str:
+    reviewer = value.strip()
+    if not reviewer or reviewer == "-" or "\n" in value or "\r" in value:
+        refuse("--reviewer must be the nonempty, single-line choice resolved from trusted host state")
+    return reviewer
+
+
+def _run_labels(view: dict) -> list[str]:
+    out: list[str] = []
+    for item in view.get("labels", []):
+        name = item.get("name") if isinstance(item, dict) else None
+        if isinstance(name, str) and name.startswith(A.RUN_LABEL_PREFIX):
+            out.append(name)
+    return out
+
+
+def preflight_views(
+    prs: list[str],
+    repository: dict[str, Path],
+    *,
+    fetch: Callable[..., tuple[object, "str | None"]] = gh.pr_view_json,
+) -> list[dict]:
+    """Read and validate the whole PR set before any run directory or ledger exists."""
+    views: list[dict] = []
+    for pr in prs:
+        view, error = fetch(pr, fields=A.VIEW_FIELDS, cwd=os.fspath(repository["project_root"]))
+        if error is not None:
+            refuse(f"PR {pr} preflight could not read GitHub metadata: {error}")
+        problem = A.validate_view(view)
+        if problem is not None:
+            refuse(f"PR {pr} preflight received malformed GitHub metadata: {problem}")
+        shaped = cast(dict, view)
+        if str(shaped["number"]) != pr:
+            refuse(f"PR {pr} preflight returned metadata for PR {shaped['number']}")
+        owners = _run_labels(shaped)
+        if owners:
+            refuse(f"PR {pr} is already owned by {', '.join(owners)}")
+        plan = A.build_plan(
+            shaped,
+            run_id="fresh-preflight",
+            tier=STANDARD,
+            worktrees_root=os.fspath(repository["worktrees_root"]),
+        )
+        if plan.get("verdict") != "adopt":
+            refuse(f"PR {pr} preflight refused: {plan.get('reason', 'unknown refusal')}")
+        branch_error = branch_problem(os.fspath(repository["project_root"]), str(plan["branch"]))
+        if branch_error is not None:
+            refuse(f"PR {pr} head branch is invalid: {branch_error}")
+        views.append(shaped)
+    return views
+
+
+def create_run_directory(scratch_root: Path) -> tuple[str, Path]:
+    payload, _ = tool_json(
+        [sys.executable, os.fspath(RUN_ID_PY), "new", "--runs-dir", os.fspath(scratch_root)]
+    )
+    run_id, rundir = payload.get("run_id"), payload.get("rundir")
+    if not isinstance(run_id, str) or not isinstance(rundir, str):
+        refuse("run-id.py returned no usable run_id/rundir pair")
+    path = Path(rundir)
+    if path != scratch_root / run_id or not path.is_dir():
+        refuse("run-id.py returned a run directory outside the repository scratch root")
+    return run_id, path
+
+
+def host_arm_state(
+    *,
+    host: str,
+    repository: dict[str, Path],
+    run_id: str,
+    rundir: Path,
+    token: str,
+    reviewer: str,
+    skill_version: str,
+    allow_takeover: bool = False,
+) -> dict:
+    invocation = HOST_INVOCATIONS[host]
+    primary = H.callback_command(invocation, run_id, token)
+    watchdog = H.watchdog_command(invocation, run_id, token)
+    proof = f"bounded-wait:{run_id}" if host == "codex" else None
+    take_argv = [
+        sys.executable,
+        os.fspath(Path(__file__).resolve()),
+        "take",
+        "--checkout",
+        os.fspath(repository["project_root"]),
+        "--run",
+        run_id,
+        "--token",
+        token,
+        "--heartbeat-id",
+        "<host-proof>",
+    ]
+    if allow_takeover:
+        take_argv.append("--allow-takeover")
+    return {
+        "state": "needs-host-arm",
+        "run_id": run_id,
+        "rundir": os.fspath(rundir),
+        "token": token,
+        "reviewer": reviewer,
+        "skill_version": skill_version,
+        "host_actions": [
+            {
+                "kind": "ensure-session-watchdog",
+                "optional": True,
+                "key": f"gauntlet-watchdog-{run_id}",
+                "prompt": watchdog,
+            },
+            {
+                "kind": "arm-primary-heartbeat" if host == "claude-code" else "establish-bounded-wait",
+                "must_run_last": host == "claude-code",
+                "prompt": primary,
+                "suggested_heartbeat_id": proof,
+            },
+        ],
+        "next": {
+            "command": "take",
+            "argv": take_argv,
+        },
+    }
+
+
+def prepare_new(
+    *,
+    checkout: Path,
+    host: str,
+    reviewer: str,
+    prs: list[str],
+    default_non_goals: str,
+    fetch: Callable[..., tuple[object, "str | None"]] = gh.pr_view_json,
+    run_creator: Callable[[Path], tuple[str, Path]] = create_run_directory,
+    token_mint: Callable[[], str] = LEASE.mint_token,
+    version: "str | None" = None,
+) -> dict:
+    repository = resolve_repository_context(checkout)
+    require_gauntlet_ignored(repository["project_root"])
+    normalized = normalize_prs(prs)
+    selected = validate_reviewer(reviewer)
+    running_version = version or active_skill_version(host)
+    preflight_views(normalized, repository, fetch=fetch)
+
+    run_id, rundir = run_creator(repository["scratch_root"])
+    ledger = rundir / "state.jsonl"
+    try:
+        tool_json([
+            sys.executable,
+            os.fspath(LEDGER_PY),
+            "--file",
+            os.fspath(ledger),
+            "init",
+            "--run-id",
+            run_id,
+            "--pending-adoption",
+            " ".join(normalized),
+            "--reviewer",
+            selected,
+            "--skill-version",
+            running_version,
+            "--default-non-goals",
+            default_non_goals,
+        ])
+    except Refusal:
+        if not any(rundir.iterdir()):
+            rundir.rmdir()
+        raise
+    token = token_mint()
+    return host_arm_state(
+        host=host,
+        repository=repository,
+        run_id=run_id,
+        rundir=rundir,
+        token=token,
+        reviewer=selected,
+        skill_version=running_version,
+    )
+
+
+def validate_run_id(run_id: str) -> str:
+    if RUN_ID_RE.fullmatch(run_id) is None:
+        refuse(f"invalid run id {run_id!r}")
+    return run_id
+
+
+def load_run(repository: dict[str, Path], run_id: str) -> tuple[Path, Path, dict, list[dict]]:
+    validate_run_id(run_id)
+    rundir = repository["scratch_root"] / run_id
+    ledger = rundir / "state.jsonl"
+    if not rundir.is_dir() or not ledger.is_file():
+        refuse(f"run {run_id} has no startup ledger at {ledger}")
+    header, rows = load_ledger(ledger)
+    if header.get("run_id") != run_id:
+        refuse(f"ledger {ledger} belongs to run {header.get('run_id')!r}, not {run_id}")
+    return rundir, ledger, header, rows
+
+
+def pending_prs(header: dict) -> list[str]:
+    value = str(header.get("pending_adoption", "-"))
+    if value == "-":
+        return []
+    return normalize_prs(value.split())
+
+
+def extract_stated_intent(body: str) -> "str | None":
+    """Return the three usable intent sections verbatim, or None when the body needs authorship."""
+    if RP.MANAGED_START in body or RP.MANAGED_END in body:
+        return None
+    lines = body.splitlines(keepends=True)
+    starts: dict[str, int] = {}
+    for index, raw in enumerate(lines):
+        line = raw.strip()
+        if line in RP.INTENT_SECTIONS:
+            if line in starts:
+                return None
+            starts[line] = index
+    if set(starts) != set(RP.INTENT_SECTIONS):
+        return None
+    positions = [starts[name] for name in RP.INTENT_SECTIONS]
+    if positions != sorted(positions):
+        return None
+    chunks: list[str] = []
+    for start in positions:
+        stop = len(lines)
+        for index in range(start + 1, len(lines)):
+            if lines[index].strip().startswith("#"):
+                stop = index
+                break
+        chunks.append("".join(lines[start:stop]).rstrip())
+    candidate = "\n".join(chunks).rstrip() + "\n"
+    try:
+        RP.parse_intent(candidate, Path("PR body"))
+    except RP.Defect:
+        return None
+    return candidate
+
+
+def judgment_path(rundir: Path, pr: str) -> Path:
+    return rundir / f"startup-judgment-{pr}.json"
+
+
+def diff_path(rundir: Path, pr: str) -> Path:
+    return rundir / f"startup-diff-{pr}.patch"
+
+
+def prepare_judgment(
+    repository: dict[str, Path],
+    rundir: Path,
+    ledger: Path,
+    pr: str,
+    token: str,
+) -> dict:
+    header, rows = load_ledger(ledger)
+    row = L.find_row(rows, pr)
+    if row is None:
+        refuse(f"cannot prepare judgment for PR {pr}: no adopted row")
+    base, problem = L.require_effective_base(header, row, pr)
+    if problem is not None:
+        refuse(problem)
+    view, error = gh.pr_view_json(
+        pr,
+        fields="number,title,body,headRefOid",
+        cwd=os.fspath(repository["project_root"]),
+    )
+    if error is not None:
+        refuse(f"cannot read PR {pr} intent inputs: {error}")
+    if not isinstance(view, dict):
+        refuse(f"PR {pr} intent input is {type(view).__name__}, not an object")
+    if str(view.get("headRefOid")) != row.get("head_sha"):
+        refuse(f"PR {pr} moved while startup prepared its judgment; reconcile the row and retry")
+    body = view.get("body")
+    title = view.get("title")
+    if not isinstance(body, str) or not isinstance(title, str):
+        refuse(f"PR {pr} title/body is malformed")
+
+    triage, _ = tool_json([
+        sys.executable,
+        os.fspath(TRIAGE_PY),
+        "derive",
+        "--worktree",
+        str(row["worktree"]),
+        "--base",
+        f"origin/{base}",
+        "--head-sha",
+        str(row["head_sha"]),
+        "--file",
+        os.fspath(ledger),
+        "--pr",
+        pr,
+    ], cwd=repository["project_root"])
+    floor = triage.get("floor")
+    if floor not in (None, STANDARD, "HIGH"):
+        refuse(f"triage returned unknown floor {floor!r} for PR {pr}")
+    diff = run_bytes([
+        "git",
+        "-C",
+        str(row["worktree"]),
+        "diff",
+        "--no-ext-diff",
+        "--binary",
+        f"origin/{base}...{row['head_sha']}",
+        "--",
+    ])
+    if diff.returncode != 0:
+        detail = os.fsdecode(diff.stderr).strip() or "git diff failed"
+        refuse(f"cannot prepare PR {pr} intent diff: {detail}")
+    diff_file = diff_path(rundir, pr)
+    replace_bytes(diff_file, diff.stdout, temp_prefix=f".{diff_file.name}.")
+    stated = extract_stated_intent(body)
+    artifact = {
+        "type": "campaign-start-judgment",
+        "pr": pr,
+        "head_sha": row["head_sha"],
+        "title": title,
+        "body": body,
+        "diff_file": os.fspath(diff_file),
+        "worktree": row["worktree"],
+        "base": base,
+        "triage": triage,
+        "stated_intent": stated,
+    }
+    path = judgment_path(rundir, pr)
+    replace_text(
+        path,
+        json.dumps(artifact, indent=2, ensure_ascii=False) + "\n",
+        temp_prefix=f".{path.name}.",
+        encoding="utf-8",
+    )
+    allowed = [
+        tier
+        for tier in sorted(T.TIER_VALUES, key=T._TIER_RANK.__getitem__)
+        if floor is None or T._TIER_RANK[tier] >= T._TIER_RANK[floor]
+    ]
+    return {
+        "state": "needs-pr-judgment",
+        "run_id": str(header["run_id"]),
+        "pr": pr,
+        "judgment_file": os.fspath(path),
+        "head_sha": row["head_sha"],
+        "tier_floor": floor,
+        "suggested_tier": floor or STANDARD,
+        "allowed_tiers": allowed,
+        "intent_source": "stated" if stated is not None else "author-required",
+        "next": {
+            "command": "bind",
+            "required_inputs": ["tier", "use-stated-intent" if stated is not None else "intent-file"],
+            "argv": [
+                sys.executable,
+                os.fspath(Path(__file__).resolve()),
+                "bind",
+                "--checkout",
+                os.fspath(repository["project_root"]),
+                "--run",
+                str(header["run_id"]),
+                "--token",
+                token,
+                "--pr",
+                pr,
+                "--tier",
+                "<tier>",
+                "<intent-option>",
+            ],
+        },
+    }
+
+
+def refresh_lease(ledger: Path, token: str) -> None:
+    payload, _ = tool_json([
+        sys.executable,
+        os.fspath(LEASE_PY),
+        "--file",
+        os.fspath(ledger.parent / "lease.json"),
+        "refresh",
+        "--token",
+        token,
+    ])
+    if payload.get("verdict") != "owned":
+        refuse(f"lease refresh did not confirm ownership: {payload}")
+
+
+def adopt_one(repository: dict[str, Path], ledger: Path, run_id: str, pr: str) -> None:
+    proc = run_argv([
+        sys.executable,
+        os.fspath(PR_ADOPT_PY),
+        "adopt",
+        "--pr",
+        pr,
+        "--run-id",
+        run_id,
+        "--file",
+        os.fspath(ledger),
+        "--tier",
+        STANDARD,
+        "--worktrees-root",
+        os.fspath(repository["worktrees_root"]),
+        "--project-root",
+        os.fspath(repository["project_root"]),
+    ], cwd=repository["project_root"])
+    if proc.returncode != 0:
+        refuse(f"PR {pr} adoption failed: {proc.stderr.strip() or proc.stdout.strip()}")
+
+
+def initialize_ci(repository: dict[str, Path], rundir: Path, ledger: Path, rows: list[dict]) -> list[dict]:
+    required = run_argv([
+        sys.executable,
+        os.fspath(CI_STATUS_PY),
+        "required-set",
+        "--ledger",
+        os.fspath(ledger),
+    ], cwd=repository["project_root"])
+    if required.returncode not in (0, 1):
+        refuse(f"required-set initialization failed: {required.stderr.strip() or required.stdout.strip()}")
+    actions: list[dict] = []
+    for row in rows:
+        pr, head_sha = str(row["pr"]), str(row["head_sha"])
+        derived = run_argv([
+            sys.executable,
+            os.fspath(CI_STATUS_PY),
+            "derive",
+            "--pr",
+            pr,
+            "--head-sha",
+            head_sha,
+            "--rundir",
+            os.fspath(rundir),
+            "--ledger",
+            os.fspath(ledger),
+        ], cwd=repository["project_root"])
+        if derived.returncode not in (0, 1):
+            refuse(f"CI derivation for PR {pr} failed: {derived.stderr.strip() or derived.stdout.strip()}")
+        try:
+            envelope = json.loads(derived.stdout)
+        except ValueError as exc:
+            refuse(f"CI derivation for PR {pr} returned non-JSON output ({exc})")
+        machine_action = "due" if envelope.get("ci") == "red" else "none"
+        live = run_argv([
+            sys.executable,
+            os.fspath(CI_STATUS_PY),
+            "liveness",
+            "--ledger",
+            os.fspath(ledger),
+            "--pr",
+            pr,
+            "--derive-json",
+            "-",
+            "--machine-action",
+            machine_action,
+        ], cwd=repository["project_root"], stdin=derived.stdout)
+        if live.returncode not in (0, 3):
+            refuse(f"CI liveness for PR {pr} failed: {live.stderr.strip() or live.stdout.strip()}")
+        try:
+            live_state = json.loads(live.stdout)
+        except ValueError as exc:
+            refuse(f"CI liveness for PR {pr} returned non-JSON output ({exc})")
+        if live_state.get("watch_warranted") is True:
+            actions.append({
+                "kind": "ci-watch",
+                "pr": pr,
+                "cwd": os.fspath(repository["project_root"]),
+                "argv": ["gh", "pr", "checks", pr, "--watch"],
+            })
+    return actions
+
+
+def ready_state(repository: dict[str, Path], rundir: Path, run_id: str, actions: list[dict]) -> dict:
+    return {
+        "state": "ready",
+        "run_id": run_id,
+        "rundir": os.fspath(rundir),
+        "host_actions": actions,
+        "carryover_review": {
+            "history_dir": os.fspath(repository["project_root"] / ".gauntlet" / "history"),
+            "blocking": False,
+            "rule_owner": "references/carryover.md#pruning-the-ledger",
+        },
+    }
+
+
+def advance_startup(
+    repository: dict[str, Path],
+    run_id: str,
+    token: str,
+    *,
+    refresh: bool,
+) -> dict:
+    rundir, ledger, header, rows = load_run(repository, run_id)
+    if refresh:
+        refresh_lease(ledger, token)
+        header, rows = load_ledger(ledger)
+    pending = pending_prs(header)
+    if not pending:
+        return ready_state(repository, rundir, run_id, [])
+
+    for pr in pending:
+        row = L.find_row(rows, pr)
+        if row is not None and row.get("status") in TERMINAL:
+            refuse(f"pending startup PR {pr} already has terminal status {row.get('status')}")
+        if row is None:
+            adopt_one(repository, ledger, run_id, pr)
+            header, rows = load_ledger(ledger)
+            row = L.find_row(rows, pr)
+        if row is None:
+            refuse(f"PR {pr} adoption returned without a ledger row")
+        if row.get("status") != L.LIVE_STATUS:
+            refuse(f"pending startup PR {pr} is {row.get('status')}, not {L.LIVE_STATUS}; resolve its hold first")
+        if row.get("intent", "-") == "-":
+            return prepare_judgment(repository, rundir, ledger, pr, token)
+        judgment_path(rundir, pr).unlink(missing_ok=True)
+        diff_path(rundir, pr).unlink(missing_ok=True)
+
+    actions = initialize_ci(repository, rundir, ledger, rows)
+    proc = run_argv([
+        sys.executable,
+        os.fspath(LEDGER_PY),
+        "--file",
+        os.fspath(ledger),
+        "header",
+        "set",
+        "pending_adoption",
+        "-",
+    ])
+    if proc.returncode != 0:
+        refuse(f"could not clear startup checkpoint: {proc.stderr.strip() or proc.stdout.strip()}")
+    return ready_state(repository, rundir, run_id, actions)
+
+
+def acquire_and_advance(
+    repository: dict[str, Path],
+    run_id: str,
+    token: str,
+    heartbeat_id: str,
+    *,
+    allow_takeover: bool,
+) -> dict:
+    _rundir, ledger, _header, _rows = load_run(repository, run_id)
+    acquire = [
+        sys.executable,
+        os.fspath(LEASE_PY),
+        "--file",
+        os.fspath(ledger.parent / "lease.json"),
+        "acquire",
+        "--token",
+        token,
+        "--heartbeat-id",
+        heartbeat_id,
+    ]
+    if allow_takeover:
+        acquire.append("--allow-takeover")
+    payload, _ = tool_json(acquire)
+    if payload.get("verdict") not in ("owned", "adopted"):
+        refuse(f"lease acquire did not grant ownership: {payload}")
+    return advance_startup(repository, run_id, token, refresh=False)
+
+
+def load_judgment(path: Path, pr: str, head_sha: str) -> dict:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        refuse(f"cannot read startup judgment {path}: {exc}")
+    if not isinstance(raw, dict) or raw.get("type") != "campaign-start-judgment":
+        refuse(f"startup judgment {path} has no campaign-start-judgment record")
+    if str(raw.get("pr")) != pr or raw.get("head_sha") != head_sha:
+        refuse(f"startup judgment {path} is not bound to PR {pr} at {head_sha}")
+    return raw
+
+
+def validate_tier(repository: dict[str, Path], ledger: Path, row: dict, pr: str, tier: str) -> None:
+    header, _ = load_ledger(ledger)
+    base, problem = L.require_effective_base(header, row, pr)
+    if problem is not None:
+        refuse(problem)
+    proc = run_argv([
+        sys.executable,
+        os.fspath(TRIAGE_PY),
+        "derive",
+        "--worktree",
+        str(row["worktree"]),
+        "--base",
+        f"origin/{base}",
+        "--head-sha",
+        str(row["head_sha"]),
+        "--file",
+        os.fspath(ledger),
+        "--pr",
+        pr,
+        "--tier",
+        tier,
+    ], cwd=repository["project_root"])
+    if proc.returncode != 0:
+        refuse(f"tier {tier} was refused for PR {pr}: {proc.stderr.strip() or proc.stdout.strip()}")
+
+
+def bind_judgment(
+    repository: dict[str, Path],
+    run_id: str,
+    token: str,
+    pr: str,
+    tier: str,
+    *,
+    use_stated: bool,
+    intent_file: "Path | None",
+) -> dict:
+    rundir, ledger, header, rows = load_run(repository, run_id)
+    refresh_lease(ledger, token)
+    pending = pending_prs(header)
+    if pr not in pending:
+        refuse(f"PR {pr} is not in run {run_id}'s pending startup checkpoint")
+    row = L.find_row(rows, pr)
+    if row is None or row.get("intent", "-") != "-":
+        refuse(f"PR {pr} does not have an unbound startup row")
+    if row.get("status") != L.LIVE_STATUS:
+        refuse(f"PR {pr} is {row.get('status')}, not {L.LIVE_STATUS}; startup will not change its binding")
+    if str(row.get("reviews_ok", "0")) != "0":
+        refuse(f"PR {pr} has banked review credit; startup will not rewrite its tier/intent")
+    if tier not in T.TIER_VALUES:
+        refuse(f"tier {tier!r} is not one of {', '.join(sorted(T.TIER_VALUES))}")
+    validate_tier(repository, ledger, row, pr, tier)
+
+    artifact_path = judgment_path(rundir, pr)
+    artifact = load_judgment(artifact_path, pr, str(row["head_sha"]))
+    if use_stated:
+        raw_intent = artifact.get("stated_intent")
+        if not isinstance(raw_intent, str):
+            refuse(f"PR {pr} has no usable stated intent; supply --intent-file")
+        provenance = "stated"
+    else:
+        if intent_file is None:
+            refuse("authored intent requires --intent-file")
+        try:
+            raw_intent = intent_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            refuse(f"cannot read authored intent {intent_file}: {exc}")
+        provenance = "authored"
+    target = RP.intent_path(rundir, pr)
+    try:
+        RP.parse_intent(raw_intent, target)
+        defaults = L.default_non_goals(header)
+        final_intent = RP.merge_default_non_goals(raw_intent, defaults, target)
+        RP.parse_intent(final_intent, target)
+        RP.check_default_non_goals(final_intent, defaults, target)
+    except (RP.Defect, ValueError) as exc:
+        refuse(f"PR {pr} intent is unusable: {exc}")
+    replace_text(
+        target,
+        final_intent,
+        temp_prefix=f".{target.name}.",
+        encoding="utf-8",
+    )
+    check = run_argv([
+        sys.executable,
+        os.fspath(REVIEW_PASS_PY),
+        "intent-check",
+        "--file",
+        os.fspath(target),
+        "--ledger",
+        os.fspath(ledger),
+    ])
+    if check.returncode != 0:
+        refuse(f"PR {pr} intent-check failed: {check.stderr.strip() or check.stdout.strip()}")
+    tier_update = run_argv([
+        sys.executable,
+        os.fspath(LEDGER_PY),
+        "--file",
+        os.fspath(ledger),
+        "set",
+        "--pr",
+        pr,
+        "--tier",
+        tier,
+    ])
+    if tier_update.returncode != 0:
+        refuse(f"could not bind PR {pr} tier: {tier_update.stderr.strip() or tier_update.stdout.strip()}")
+    dispatch = run_argv([
+        sys.executable,
+        os.fspath(LEDGER_PY),
+        "--file",
+        os.fspath(ledger),
+        "dispatch-check",
+        "--pr",
+        pr,
+    ])
+    if dispatch.returncode != 0:
+        refuse(f"PR {pr} label binding is not permitted: {dispatch.stderr.strip() or dispatch.stdout.strip()}")
+    github_repo = resolve_github_repo(repository["project_root"])
+    mirror = run_argv(
+        label_mirror_argv(ledger, pr, github_repo),
+        cwd=repository["project_root"],
+    )
+    if mirror.returncode != 0:
+        refuse(f"could not mirror PR {pr} labels: {mirror.stderr.strip() or mirror.stdout.strip()}")
+    stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    complete = run_argv([
+        sys.executable,
+        os.fspath(LEDGER_PY),
+        "--file",
+        os.fspath(ledger),
+        "set",
+        "--pr",
+        pr,
+        "--intent",
+        f"{provenance}@{stamp}",
+    ])
+    if complete.returncode != 0:
+        refuse(f"could not complete PR {pr} intent binding: {complete.stderr.strip() or complete.stdout.strip()}")
+    artifact_path.unlink(missing_ok=True)
+    diff_path(rundir, pr).unlink(missing_ok=True)
+    return advance_startup(repository, run_id, token, refresh=False)
+
+
+def resume_state(repository: dict[str, Path], host: str, run_id: str, *, allow_takeover: bool) -> dict:
+    rundir, _ledger, header, _rows = load_run(repository, run_id)
+    lease, code = tool_json([
+        sys.executable,
+        os.fspath(LEASE_PY),
+        "--file",
+        os.fspath(rundir / "lease.json"),
+        "read",
+    ], accepted=(0, 1))
+    verdict = lease.get("verdict")
+    if verdict == "corrupt" or code not in (0,):
+        return {"state": "refused", "run_id": run_id, "reason": lease.get("error", "corrupt lease")}
+    if verdict == "held" and not allow_takeover:
+        return {
+            "state": "needs-user",
+            "run_id": run_id,
+            "reason": "another agent holds a fresh lease",
+            "held_by": lease.get("agent"),
+            "allowed_decisions": ["leave-running", "take-over"],
+        }
+    if verdict not in ("absent", "stale"):
+        if verdict != "held":
+            refuse(f"lease read returned unknown verdict {verdict!r}")
+    token = LEASE.mint_token()
+    return host_arm_state(
+        host=host,
+        repository=repository,
+        run_id=run_id,
+        rundir=rundir,
+        token=token,
+        reviewer=str(header["reviewer"]),
+        skill_version=str(header["skill_version"]),
+        allow_takeover=allow_takeover,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    new = sub.add_parser("new", help="preflight a complete PR set, then create one resumable fresh run")
+    new.add_argument("--checkout", required=True)
+    new.add_argument("--host", required=True, choices=tuple(HOST_INVOCATIONS))
+    new.add_argument("--reviewer", required=True,
+                     help="choice already resolved from explicit invocation/trusted host state")
+    new.add_argument("--pr", action="append", default=[])
+    new.add_argument("--default-non-goals", default="[]")
+
+    take = sub.add_parser("take", help="acquire after host continuity is established, then advance startup")
+    take.add_argument("--checkout", required=True)
+    take.add_argument("--run", required=True)
+    take.add_argument("--token", required=True)
+    take.add_argument("--heartbeat-id", required=True)
+    take.add_argument("--allow-takeover", action="store_true",
+                      help="take a fresh foreign lease only after the user approved takeover")
+
+    advance = sub.add_parser("advance", help="refresh ownership and resume startup from durable state")
+    advance.add_argument("--checkout", required=True)
+    advance.add_argument("--run", required=True)
+    advance.add_argument("--token", required=True)
+
+    bind = sub.add_parser("bind", help="bind one PR's semantic tier and intent, then advance startup")
+    bind.add_argument("--checkout", required=True)
+    bind.add_argument("--run", required=True)
+    bind.add_argument("--token", required=True)
+    bind.add_argument("--pr", required=True)
+    bind.add_argument("--tier", required=True)
+    intent = bind.add_mutually_exclusive_group(required=True)
+    intent.add_argument("--use-stated-intent", action="store_true")
+    intent.add_argument("--intent-file", type=Path)
+
+    resume = sub.add_parser("resume", help="classify an existing startup and return its next host action")
+    resume.add_argument("--checkout", required=True)
+    resume.add_argument("--host", required=True, choices=tuple(HOST_INVOCATIONS))
+    resume.add_argument("--run", required=True)
+    resume.add_argument("--allow-takeover", action="store_true",
+                        help="continue a previously reported held lease after user approval")
+
+    sub.add_parser("self-test", help="run the sibling startup protocol fixtures")
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.cmd == "self-test":
+        return run_sibling_suite(
+            SIBLING,
+            "campaign_start_test",
+            failure=SelfTestFailure,
+            subject="the code-driven campaign startup protocol",
+            per_case_dir=True,
+        )
+    try:
+        if args.cmd == "new":
+            result = prepare_new(
+                checkout=Path(args.checkout),
+                host=args.host,
+                reviewer=args.reviewer,
+                prs=args.pr,
+                default_non_goals=args.default_non_goals,
+            )
+        else:
+            repository = resolve_repository_context(Path(args.checkout))
+            if args.cmd == "take":
+                result = acquire_and_advance(
+                    repository,
+                    args.run,
+                    args.token,
+                    args.heartbeat_id,
+                    allow_takeover=args.allow_takeover,
+                )
+            elif args.cmd == "advance":
+                result = advance_startup(repository, args.run, args.token, refresh=True)
+            elif args.cmd == "bind":
+                result = bind_judgment(
+                    repository,
+                    args.run,
+                    args.token,
+                    normalize_prs([args.pr])[0],
+                    args.tier,
+                    use_stated=args.use_stated_intent,
+                    intent_file=args.intent_file,
+                )
+            else:
+                result = resume_state(repository, args.host, args.run, allow_takeover=args.allow_takeover)
+    except Refusal as exc:
+        emit({"state": "refused", "reason": str(exc)})
+        return 1
+    emit(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger-test.py
@@ -2871,6 +2871,61 @@ def t_pending_adoption_is_an_ordinary_field(L: ModuleType, tmp: Path) -> None:
     check(header_field(L, path, "last_activity") == FROZEN_B, "clearing pending_adoption is also activity")
 
 
+def t_init_writes_one_complete_fresh_header(L: ModuleType, tmp: Path) -> None:
+    """`init` publishes the run identity, checkpoint, reviewer, version and defaults in one fresh header."""
+    path = tmp / "state.jsonl"
+    with frozen_clock(L, FROZEN_A):
+        code, out, err = cli(L, [
+            "--file", str(path), "init",
+            "--run-id", "g260829-1200-aabbccdd",
+            "--pending-adoption", "09 12",
+            "--reviewer", "codex",
+            "--skill-version", "0.9.1",
+            "--default-non-goals", '["out of scope"]',
+        ])
+    check(code == 0, f"init exited {code}: {err!r}")
+    check(json.loads(out) == {"run_id": "g260829-1200-aabbccdd", "pending_adoption": "9 12"},
+          f"init summary is not canonical: {out!r}")
+    header, rows = L.load(path)
+    check(rows == [], "a fresh startup header must contain no PR rows before adoption")
+    check(header["run_id"] == "g260829-1200-aabbccdd", "init lost the run id")
+    check(header["pending_adoption"] == "9 12", "init did not canonicalize the PR checkpoint")
+    check(header["reviewer"] == "codex" and header["skill_version"] == "0.9.1",
+          "init did not bind reviewer and running skill version")
+    check(header["default_non_goals"] == '["out of scope"]', "init did not validate/store defaults")
+    check(header["status_verbosity"] == L.STATUS_VERBOSITY_BRIEF,
+          "init must use the fresh-run brief status default")
+    check(header["last_activity"] == FROZEN_A, "the initial durable checkpoint must stamp activity")
+
+
+def t_init_refuses_partial_or_existing_state(L: ModuleType, tmp: Path) -> None:
+    """`init` creates no empty run and never replaces an existing ledger during recovery."""
+    base = ["init", "--run-id", "g1", "--reviewer", "default", "--skill-version", "0.9.1"]
+    invalid = tmp / "invalid.jsonl"
+    code, _, err = cli(L, ["--file", str(invalid), *base, "--pending-adoption", "-"])
+    check(code == 1 and not invalid.exists(), f"empty init must write nothing: code={code}, err={err!r}")
+    duplicate = tmp / "duplicate.jsonl"
+    code, _, err = cli(L, ["--file", str(duplicate), *base, "--pending-adoption", "7 07"])
+    check(code == 1 and not duplicate.exists(),
+          f"duplicate PR checkpoint must write nothing: code={code}, err={err!r}")
+    unresolved = tmp / "unresolved.jsonl"
+    code, _, err = cli(L, [
+        "--file", str(unresolved), "init",
+        "--run-id", "g1",
+        "--pending-adoption", "7",
+        "--reviewer", " - ",
+        "--skill-version", "0.9.1",
+    ])
+    check(code == 1 and not unresolved.exists(),
+          f"a padded unresolved header value must write nothing: code={code}, err={err!r}")
+
+    existing = write_lines(tmp / "existing.jsonl", header_line(L, run_id="old"))
+    before = existing.read_bytes()
+    code, _, err = cli(L, ["--file", str(existing), *base, "--pending-adoption", "7"])
+    check(code == 1 and "existing ledger" in err, f"existing init refusal is unclear: {err!r}")
+    check(existing.read_bytes() == before, "refused init replaced an existing recovery ledger")
+
+
 # --- status_verbosity: the operator's display setting, and the lines it may NEVER drop -------------------
 #
 # The field is PRESENTATION. These fixtures pin the two halves that matter: the write door refuses anything
@@ -3541,6 +3596,8 @@ CASES = [
     ("watchdog-due-no-door", "`header set watchdog_due` is refused and writes nothing", t_watchdog_due_has_no_door),
     ("watchdog-interval", "watchdog interval prints the constant in minutes, reads no ledger", t_watchdog_interval_prints_the_constant),
     ("pending-adoption-ordinary", "pending_adoption is an ordinary settable field; setting it IS activity", t_pending_adoption_is_an_ordinary_field),
+    ("init-complete-header", "init atomically publishes one complete fresh-run header", t_init_writes_one_complete_fresh_header),
+    ("init-refuses-partial", "init refuses empty/duplicate PR sets and never replaces recovery state", t_init_refuses_partial_or_existing_state),
     ("verbosity-defaults", "new status_verbosity runs use `brief`; existing ledgers keep the `full` fallback", t_status_verbosity_defaults_to_full),
     ("verbosity-help-defaults", "table help names the new-run `brief` default and existing-ledger `full` fallback", t_table_help_describes_verbosity_defaults),
     ("verbosity-legacy-block-frozen", "a pre-status_verbosity ledger prints the SAME block — pinned against a frozen, retyped list", t_legacy_config_block_is_unchanged),

--- a/plugins/gauntlet/skills/campaign/scripts/ledger.py
+++ b/plugins/gauntlet/skills/campaign/scripts/ledger.py
@@ -1169,6 +1169,82 @@ def guard_default_non_goals_change(header: dict, rows: "list[dict]", new_default
 
 # --- subcommands --------------------------------------------------------------
 
+def init_run(
+    path: Path,
+    *,
+    run_id: str,
+    pending_adoption: str,
+    reviewer: str,
+    skill_version: str,
+    default_non_goals_value: str = "[]",
+) -> dict:
+    """Create one fresh run header in one atomic write and return it.
+
+    ``campaign-start.py`` calls this after the complete PR set has passed read-only preflight.  The fresh
+    header used to be assembled through several independent ``header set`` calls, which left every prefix
+    of startup as a possible durable state after a process death.  This door validates every caller-owned
+    value before writing and publishes the complete header once.
+
+    An existing path is always refused.  Startup recovery reads the existing header and resumes from its
+    ``pending_adoption`` checkpoint; silently replacing it would discard that recovery state.
+    """
+    if path.exists():
+        fail(f"init refuses existing ledger {path} — resume it through campaign-start.py; never replace it")
+
+    values = {
+        "run_id": run_id,
+        "pending_adoption": pending_adoption,
+        "reviewer": reviewer,
+        "skill_version": skill_version,
+    }
+    for field, value in values.items():
+        if (not isinstance(value, str) or not value.strip() or value.strip() == "-"
+                or "\n" in value or "\r" in value):
+            fail(f"init requires a nonempty, single-line {field}; got {value!r}")
+
+    pending: list[str] = []
+    seen: set[str] = set()
+    for raw in pending_adoption.split():
+        if not raw.isascii() or not raw.isdigit() or int(raw) <= 0:
+            fail(f"init pending_adoption contains invalid PR number {raw!r}")
+        canonical = str(int(raw))
+        if canonical in seen:
+            fail(f"init pending_adoption contains duplicate PR {canonical}")
+        seen.add(canonical)
+        pending.append(canonical)
+    if not pending:
+        fail("init requires at least one pending PR; an empty startup would create an orphan run")
+
+    try:
+        defaults = parse_default_non_goals(default_non_goals_value)
+    except ValueError as exc:
+        fail(f"init default_non_goals {exc} — no ledger was written")
+
+    header = dict(NEW_HEADER_DEFAULTS)
+    header.update({
+        "run_id": run_id.strip(),
+        "pending_adoption": " ".join(pending),
+        "reviewer": reviewer.strip(),
+        "skill_version": skill_version.strip(),
+        "default_non_goals": json.dumps(defaults),
+    })
+    save(path, header, [], activity=True)
+    return header
+
+
+def cmd_init(path: Path, args) -> int:
+    header = init_run(
+        path,
+        run_id=args.run_id,
+        pending_adoption=args.pending_adoption,
+        reviewer=args.reviewer,
+        skill_version=args.skill_version,
+        default_non_goals_value=args.default_non_goals,
+    )
+    print(json.dumps({"run_id": header["run_id"], "pending_adoption": header["pending_adoption"]}))
+    return 0
+
+
 def cmd_header(path: Path, args) -> int:
     header, rows = load(path)
     check_field(args.field, HEADER_FIELDS)
@@ -2087,6 +2163,17 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--file", help="path to the ledger (state.jsonl)")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
+    i = sub.add_parser("init", help="atomically create one fresh run header after read-only PR preflight")
+    i.add_argument("--run-id", required=True, help="fresh run id returned by run-id.py new")
+    i.add_argument("--pending-adoption", required=True,
+                   help="space-separated positive PR numbers; the durable startup checkpoint")
+    i.add_argument("--reviewer", required=True,
+                   help="reviewer choice already resolved from trusted state by the host adapter")
+    i.add_argument("--skill-version", required=True,
+                   help="version read from the active host manifest beside the running skill")
+    i.add_argument("--default-non-goals", default="[]",
+                   help="run-wide Non-goal bodies as a JSON-array string (default: [])")
+
     h = sub.add_parser("header", help="get/set a run-config header field")
     h.add_argument("action", choices=("get", "set"))
     h.add_argument("field")
@@ -2239,7 +2326,8 @@ def main(argv: list[str]) -> int:
         parser.error("the following arguments are required: --file")
     path = Path(args.file)
     handlers = {
-        "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set, "verdict": cmd_verdict,
+        "init": cmd_init, "header": cmd_header, "add-row": cmd_add_row, "set": cmd_set,
+        "verdict": cmd_verdict,
         "base-ok": cmd_base_ok,
         "get": cmd_get, "list": cmd_list, "table": cmd_table,
         "dispatch-check": cmd_dispatch_check, "park": cmd_park, "unpark": cmd_unpark,

--- a/plugins/gauntlet/skills/campaign/scripts/run-id.py
+++ b/plugins/gauntlet/skills/campaign/scripts/run-id.py
@@ -5,8 +5,8 @@ A run-id namespaces everything a run owns — its `<rundir>`, its ledger, and it
 PR labels. Until now, minting one was an inline shell snippet in `run-identity-and-lease.md`
 (a minute-resolution timestamp plus a short random hex suffix) and the "create the run dir atomically, retry on
 the rare clash" step was adapter **pseudocode** (`create_run_directory(...)`) with no bundled
-implementation. THIS script now owns both — the mint and the atomic create + retry — and the adapter's
-`create_run_directory` delegates here. That
+implementation. THIS script now owns both — the mint and the atomic create + retry — and both the
+adapter operation and `campaign-start.py` delegate here. That
 atomicity is a real correctness property, not a detail: the `mkdir` that FAILS when the directory already
 exists is the single thing that stops two freshly-started runs from silently sharing one rundir and ledger
 — the exact double-drive the lease exists to prevent, one layer up. Prose a driver reproduces by hand is

--- a/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
+++ b/plugins/gauntlet/skills/campaign/scripts/transport-contract-test.py
@@ -320,17 +320,17 @@ def check_additional_triage_consumers(root_cause: str, pr_adopt: str) -> None:
         check_consumer_triage_region(name, body, expected_owner)
 
 
-def check_watch_consumers(adoption: str, loop_control: str) -> None:
-    loop_start = loop_control.index("Then **adopt** each PR")
-    loop_end = loop_control.index("A death mid-adoption still", loop_start)
-    loop_adoption = loop_control[loop_start:loop_end]
+def check_watch_consumers(adoption: str, startup: str) -> None:
+    startup_start = startup.index("#### `ready`")
+    startup_end = startup.index("#### `needs-user`", startup_start)
+    startup_ready = startup[startup_start:startup_end]
 
     summary_start = adoption.index("Adoption produces only")
     summary_end = adoption.index("\n\n", summary_start)
     adoption_summary = adoption[summary_start:summary_end]
 
     for name, region in (
-        ("loop-control.md adoption consumer", loop_adoption),
+        ("startup.md ready consumer", startup_ready),
         ("pr-adoption.md summary consumer", adoption_summary),
     ):
         require(WATCH_ACTION in normalized(region),
@@ -518,7 +518,7 @@ INVENTED negative fixture: run `triage.py` `derive` with these caller inputs:
         )
 
     skill_fixtures = (
-        ("adoption", "for the complete adoption-time procedure."),
+        ("adoption", "veto around the returned judgment."),
         ("heartbeat", "triage procedure, then launch ALL due work up to caps"),
     )
     runnable_reconstruction = """
@@ -649,7 +649,7 @@ def check_document_contract() -> None:
     reviewer = read("reviewer.md")
     cross = read("cross-agent-reviewers.md")
     adoption = read("pr-adoption.md")
-    run_identity = read("run-identity-and-lease.md")
+    startup = read("startup.md")
     merge = read("stage-3-merge.md")
     merge_runner = (ROOT / "scripts" / "merge.py").read_text(encoding="utf-8")
     root_cause = read("root-cause-pass.md")
@@ -658,10 +658,11 @@ def check_document_contract() -> None:
     final_report = read("bailout-and-final-report.md")
     skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
     pr_adopt = (ROOT / "scripts" / "pr-adopt.py").read_text(encoding="utf-8")
+    campaign_start = (ROOT / "scripts" / "campaign-start.py").read_text(encoding="utf-8")
     copilot = (COPILOT / "SKILL.md").read_text(encoding="utf-8")
 
     check_campaign_triage_contract(stage, adoption, loop_control, skill)
-    check_watch_consumers(adoption, loop_control)
+    check_watch_consumers(adoption, startup)
     new_row_summary = delimited_region(
         adoption,
         "   - **On a NEW row only, initialize:**",
@@ -893,7 +894,8 @@ def check_document_contract() -> None:
             "adoption no longer preserves typed branch/path data")
     require("path_join(project_root" not in adoption and "], project_root)" not in adoption,
             "adoption restored an unresolved project_root consumer")
-    require("create_run_directory(repository)" in run_identity,
+    require("repository = resolve_repository_context(checkout)" in campaign_start and
+            'run_creator(repository["scratch_root"])' in campaign_start,
             "fresh-run creation bypasses the repository context owner")
     require("root = resolve_project_root(project_root)" in merge_runner and
             '["git", "-C", str(root), "fetch"' in merge_runner and

--- a/scripts/validate-plugins.sh
+++ b/scripts/validate-plugins.sh
@@ -689,10 +689,14 @@ fi
 campaign=plugins/gauntlet/skills/campaign
 [[ -f $campaign/references/runtime-adapter.md ]] ||
   fail "campaign is missing references/runtime-adapter.md"
+[[ -f $campaign/references/startup.md ]] ||
+  fail "campaign is missing references/startup.md"
 [[ -f $campaign/references/cross-agent-reviewers.md ]] ||
   fail "campaign is missing references/cross-agent-reviewers.md"
 grep -Fq 'references/runtime-adapter.md' "$campaign/SKILL.md" ||
   fail "campaign SKILL.md does not load the runtime adapter"
+grep -Fq 'references/startup.md' "$campaign/SKILL.md" ||
+  fail "campaign SKILL.md does not load the startup protocol"
 grep -Fq 'the default per host, overridable' "$campaign/references/cross-agent-reviewers.md" ||
   fail "cross-agent review must document the cross-engine default per host"
 grep -Fq '"codex", "exec", "--sandbox", "workspace-write"' "$campaign/references/cross-agent-reviewers.md" ||
@@ -708,6 +712,7 @@ grep -Fq 'ReviewIsolationCapability' "$campaign/references/runtime-adapter.md" |
 python3 "$campaign/scripts/review-dispatch.py" self-test || status=1
 python3 "$campaign/scripts/transport-contract-test.py" || status=1
 python3 "$campaign/scripts/worker-prompt.py" self-test || status=1
+python3 "$campaign/scripts/campaign-start.py" self-test || status=1
 
 campaign_host_leaks=$(
   grep -rnE 'ScheduleWakeup|\$\{CLAUDE_PLUGIN_ROOT\}|Subagent Dispatch|fresh-subagent' \


### PR DESCRIPTION
- Make fresh campaign startup resumable and code-owned.
- Keep host-only actions and semantic judgments as typed handoffs.
- Fail closed before partial run state or stale SHA-bound inputs.
