### PR TITLE
add Fusion query sessions

### DIFF
--- a/plugins/fusion/skills/query-api/SKILL.md
+++ b/plugins/fusion/skills/query-api/SKILL.md
@@ -58,5 +58,9 @@ this database does not list is one a call cannot reach — that is the answer to
 work around. `info` names what the database in use dropped (`stub_only_members_dropped`);
 `compile-api`'s `STUB_ONLY_MEMBERS` owns the list and the reasoning.
 
+For several related lookups, start the optional local JSON Lines session with `serve` and keep the
+child process for the questions. Its exact request and response schema, error behavior, and database
+snapshot contract are documented in [the query session protocol](query-session.md).
+
 Read-only. The bundled database ships with the plugin; NEVER edit or regenerate it here — regeneration
 is `compile-api`'s job.

--- a/plugins/fusion/skills/query-api/query-session.md
+++ b/plugins/fusion/skills/query-api/query-session.md
@@ -1,0 +1,43 @@
+# Fusion query session protocol
+
+`query_fusion_api.py serve` is an optional local child process for clients that need several Fusion
+API lookups. It reads and writes UTF-8 JSON Lines on standard input and output. It is not a socket
+server or a background daemon.
+
+Clients pass `--db PATH` before `serve`, using the same database selection rules as the one-shot
+CLI. The process opens that database read-only once and emits this first line only after the open
+and schema checks succeed:
+
+```json
+{"type":"ready","protocol":1,"commands":["show","members","search"]}
+```
+
+Each request is a JSON object with an optional scalar `id` and an `argv` array of strings. The array
+uses the existing command argument rules, but a session accepts only `show`, `members`, and
+`search`. `members` accepts `--own`. A request never evaluates a shell command, and it cannot select
+a different database.
+
+```json
+{"id":1,"argv":["show","Sketch"]}
+```
+
+A successful parse and handler call produces one result line. Its `stdout`, `stderr`, and
+`returncode` fields contain the existing one-shot command's textual output and exit code exactly.
+Lookup misses and ambiguous names remain results with their existing nonzero return code.
+
+```json
+{"id":1,"type":"result","returncode":0,"stdout":"...","stderr":""}
+```
+
+Malformed JSON, malformed request objects, unsupported session commands, invalid arguments, and
+database or inheritance failures produce an error line. A missing or unusable `id` is represented by
+JSON `null`; request errors do not prevent later requests when the database remains usable.
+
+```json
+{"id":2,"type":"error","message":"..."}
+```
+
+The process flushes every response. It closes the database on EOF, on a fatal database failure, or
+when the parent closes its output. A session reads the database opened at startup. A new generation
+or compile check starts a new session; replacing the database during a session is outside the
+session's snapshot contract.

--- a/plugins/fusion/skills/query-api/scripts/query_fusion_api.py
+++ b/plugins/fusion/skills/query-api/scripts/query_fusion_api.py
@@ -26,6 +26,7 @@ Subcommands:
     members <class>          list a class's members; --own omits inherited ones
     tree <class>             base chain and direct subclasses
     doc-search <term>        substring search over docstrings
+    serve                    serve show, members, and search over JSON Lines
 
 Member lookups resolve inherited members by default: ``show Class.member``,
 ``show Class``, and ``members Class`` all walk the class's bases and report
@@ -46,7 +47,10 @@ Stdlib only. Read-only: the database is opened with ``mode=ro``.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
+import math
 import re
 import shlex
 import sqlite3
@@ -186,17 +190,29 @@ def fail(message: str) -> NoReturn:
     raise SystemExit(1)
 
 
+class DatabaseOpenError(Exception):
+    """A database could not be opened or did not have the query schema."""
+
+
+def database_path(arg: Path | None) -> Path:
+    return arg if arg is not None else default_db_path()
+
+
 def open_db(arg: Path | None) -> sqlite3.Connection:
-    path = arg if arg is not None else default_db_path()
+    path = database_path(arg)
     if not path.exists():
-        fail(f"database not found at {path}; rebuild it with: {rebuild_command(path)}")
+        raise DatabaseOpenError(
+            f"database not found at {path}; rebuild it with: {rebuild_command(path)}"
+        )
     # as_uri() percent-encodes '?' and '#'. Interpolating the path into the URI instead lets
     # either character end the path component, which opens a different file and drops mode=ro.
     uri = f"{path.resolve().as_uri()}?mode=ro"
     try:
         conn = sqlite3.connect(uri, uri=True)
     except sqlite3.Error as exc:
-        fail(f"cannot open {path} ({exc}); rebuild it with: {rebuild_command(path)}")
+        raise DatabaseOpenError(
+            f"cannot open {path} ({exc}); rebuild it with: {rebuild_command(path)}"
+        ) from exc
     conn.row_factory = sqlite3.Row
     try:
         for probe in (
@@ -207,10 +223,10 @@ def open_db(arg: Path | None) -> sqlite3.Connection:
             conn.execute(probe).fetchone()
     except sqlite3.Error as exc:
         conn.close()
-        fail(
+        raise DatabaseOpenError(
             f"{path} is not a Fusion API database ({exc});"
             f" rebuild it with: {rebuild_command(path)}"
-        )
+        ) from exc
     return conn
 
 
@@ -841,11 +857,24 @@ def cmd_doc_search(conn: sqlite3.Connection, args: argparse.Namespace) -> int:
     return print_capped(lines, total, f"no docstrings mention {args.term!r}")
 
 
-def main() -> int:
+HANDLERS = {
+    "info": cmd_info,
+    "search": cmd_search,
+    "show": cmd_show,
+    "members": cmd_members,
+    "tree": cmd_tree,
+    "doc-search": cmd_doc_search,
+}
+SESSION_COMMANDS = frozenset(("show", "members", "search"))
+PROTOCOL_VERSION = 1
+
+
+def build_parser(*, include_db: bool = True) -> SanitizedParser:
     parser = SanitizedParser(description=__doc__)
-    parser.add_argument(
-        "--db", type=Path, help="explicit database path (goes before the subcommand)"
-    )
+    if include_db:
+        parser.add_argument(
+            "--db", type=Path, help="explicit database path (goes before the subcommand)"
+        )
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("info", help="database provenance and counts")
@@ -872,29 +901,164 @@ def main() -> int:
     p_doc = sub.add_parser("doc-search", help="substring search over docstrings")
     p_doc.add_argument("term")
 
-    args = parser.parse_args()
-    conn = open_db(args.db)
-    handlers = {
-        "info": cmd_info,
-        "search": cmd_search,
-        "show": cmd_show,
-        "members": cmd_members,
-        "tree": cmd_tree,
-        "doc-search": cmd_doc_search,
-    }
+    sub.add_parser("serve", help="serve query requests over JSON Lines")
+    return parser
+
+
+def handler_error_message(
+    db_path: Path, command: str, exc: sqlite3.Error
+) -> str:
+    return (
+        f"{db_path} could not answer {command!r} ({exc});"
+        f" rebuild it with: {rebuild_command(db_path)}"
+    )
+
+
+def protocol_write(payload: dict[str, object]) -> bool:
+    """Write and flush one protocol response, returning false when the parent went away."""
     try:
-        return handlers[args.command](conn, args)
+        sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+    except (BrokenPipeError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def protocol_error(request_id: object, message: str) -> dict[str, object]:
+    return {"id": request_id, "type": "error", "message": message}
+
+
+def usable_request_id(request: object) -> object:
+    if not isinstance(request, dict):
+        return None
+    value = request.get("id")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (str, int)):
+        return value
+    if isinstance(value, float) and math.isfinite(value):
+        return value
+    return None
+
+
+def parse_session_argv(argv: list[str]) -> tuple[argparse.Namespace | None, str | None]:
+    """Parse one session argv while keeping argparse diagnostics inside the error envelope."""
+    parser = build_parser(include_db=False)
+    captured_out = io.StringIO()
+    captured_err = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(captured_out), contextlib.redirect_stderr(captured_err):
+            args = parser.parse_args(argv)
+    except SystemExit as exc:
+        diagnostics = (captured_err.getvalue() or captured_out.getvalue()).strip()
+        if exc.code == 0:
+            diagnostics = "help is not a session query"
+        return None, f"invalid arguments{': ' + diagnostics if diagnostics else ''}"
+    return args, None
+
+
+def session_request(
+    conn: sqlite3.Connection, db_path: Path, request: object
+) -> tuple[dict[str, object], bool]:
+    """Execute one request and return its response plus whether the session must stop."""
+    request_id = usable_request_id(request)
+    if not isinstance(request, dict):
+        return protocol_error(request_id, "request must be a JSON object"), False
+    unknown = sorted(set(request) - {"id", "argv"})
+    if unknown:
+        return protocol_error(request_id, f"unknown request field(s): {', '.join(unknown)}"), False
+    argv = request.get("argv")
+    if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
+        return protocol_error(request_id, "request argv must be an array of strings"), False
+    args, parse_error = parse_session_argv(argv)
+    if parse_error is not None:
+        return protocol_error(request_id, parse_error), False
+    assert args is not None
+    if args.command not in SESSION_COMMANDS:
+        return (
+            protocol_error(request_id, f"unsupported session command: {args.command}"),
+            False,
+        )
+
+    captured_out = io.StringIO()
+    captured_err = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(captured_out), contextlib.redirect_stderr(captured_err):
+            returncode = HANDLERS[args.command](conn, args)
+    except InconsistentHierarchy as exc:
+        return protocol_error(request_id, f"error: {exc}"), False
+    except sqlite3.Error as exc:
+        return protocol_error(request_id, f"error: {handler_error_message(db_path, args.command, exc)}"), True
+    return (
+        {
+            "id": request_id,
+            "type": "result",
+            "returncode": returncode,
+            "stdout": captured_out.getvalue(),
+            "stderr": captured_err.getvalue(),
+        },
+        False,
+    )
+
+
+def serve(arg: Path | None) -> int:
+    """Serve query requests until EOF, keeping one read-only connection for the session."""
+    db_path = database_path(arg)
+    try:
+        conn = open_db(arg)
+    except DatabaseOpenError as exc:
+        protocol_write(protocol_error(None, f"error: {exc}"))
+        return 1
+    try:
+        if not protocol_write(
+            {
+                "type": "ready",
+                "protocol": PROTOCOL_VERSION,
+                "commands": ["show", "members", "search"],
+            }
+        ):
+            return 1
+        input_stream = getattr(sys.stdin, "buffer", sys.stdin)
+        for raw_line in input_stream:
+            try:
+                line = (
+                    raw_line.decode("utf-8")
+                    if isinstance(raw_line, bytes)
+                    else raw_line
+                )
+                request = json.loads(line)
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                response, fatal = protocol_error(None, f"malformed JSON: {exc}"), False
+            else:
+                response, fatal = session_request(conn, db_path, request)
+            if not protocol_write(response):
+                return 1
+            if fatal:
+                return 1
+        return 0
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "serve":
+        return serve(args.db)
+    try:
+        conn = open_db(args.db)
+    except DatabaseOpenError as exc:
+        fail(str(exc))
+    try:
+        return HANDLERS[args.command](conn, args)
     except InconsistentHierarchy as exc:
         # A real failure, not a lookup miss: the database records a hierarchy that cannot exist, so
         # there is no member answer to give. Reported on stderr, where the other real failures go.
         err(f"error: {exc}")
         return 1
     except sqlite3.Error as exc:
-        db_path = args.db if args.db is not None else default_db_path()
-        err(
-            f"error: {db_path} could not answer {args.command!r} ({exc});"
-            f" rebuild it with: {rebuild_command(db_path)}"
-        )
+        err(f"error: {handler_error_message(database_path(args.db), args.command, exc)}")
         return 1
     finally:
         conn.close()

--- a/plugins/fusion/skills/query-api/scripts/test_query_fusion_api.py
+++ b/plugins/fusion/skills/query-api/scripts/test_query_fusion_api.py
@@ -47,7 +47,9 @@ def make_database(path: Path, *, inconsistent: bool = False) -> None:
             "INSERT INTO symbols(module,name,qualname,kind,bases,signature,doc) VALUES(?,?,?,?,?,?,?)",
             (module, name, qualname, "class", json.dumps(bases or []), None, doc),
         )
-        return cursor.lastrowid
+        row_id = cursor.lastrowid
+        assert row_id is not None, "symbol insert did not produce a row ID"
+        return row_id
 
     def member(symbol_id: int, name: str, *, doc: str = "") -> None:
         conn.execute(

--- a/plugins/fusion/skills/query-api/scripts/test_query_fusion_api.py
+++ b/plugins/fusion/skills/query-api/scripts/test_query_fusion_api.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Local fixture tests for the one-shot Fusion query CLI and JSON Lines session."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).resolve().with_name("query_fusion_api.py")
+SPEC = importlib.util.spec_from_file_location("query_fusion_api", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+QUERY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(QUERY)
+
+
+def make_database(path: Path, *, inconsistent: bool = False) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE symbols(
+            id INTEGER PRIMARY KEY, module TEXT NOT NULL, name TEXT NOT NULL,
+            qualname TEXT NOT NULL UNIQUE, kind TEXT NOT NULL, bases TEXT NOT NULL DEFAULT '[]',
+            signature TEXT, doc TEXT
+        );
+        CREATE TABLE members(
+            id INTEGER PRIMARY KEY, symbol_id INTEGER NOT NULL, name TEXT NOT NULL,
+            kind TEXT NOT NULL, signature TEXT, returns TEXT, settable INTEGER NOT NULL DEFAULT 0,
+            value TEXT, doc TEXT
+        );
+        INSERT INTO meta VALUES ('schema_version', '1');
+        """
+    )
+
+    def symbol(module: str, name: str, bases: list[str] | None = None, doc: str = "") -> int:
+        qualname = f"{module}.{name}"
+        cursor = conn.execute(
+            "INSERT INTO symbols(module,name,qualname,kind,bases,signature,doc) VALUES(?,?,?,?,?,?,?)",
+            (module, name, qualname, "class", json.dumps(bases or []), None, doc),
+        )
+        return cursor.lastrowid
+
+    def member(symbol_id: int, name: str, *, doc: str = "") -> None:
+        conn.execute(
+            "INSERT INTO members(symbol_id,name,kind,signature,returns,settable,value,doc)"
+            " VALUES(?,?,?,?,?,?,?,?)",
+            (symbol_id, name, "method", "(self)", None, 0, None, doc),
+        )
+
+    base = symbol("pkg", "Base", doc="A base with Unicode café documentation.")
+    left = symbol("pkg", "Left", ["pkg.Base"])
+    right = symbol("pkg", "Right", ["pkg.Base"])
+    diamond_bases = ["pkg.Left", "pkg.Right"]
+    diamond = symbol("pkg", "Diamond", diamond_bases)
+    one = symbol("pkg.one", "Widget")
+    two = symbol("pkg.two", "Widget")
+    cafe = symbol("pkg", "Café")
+    member(base, "shared", doc="Inherited member.")
+    member(left, "left_only")
+    member(right, "right_only")
+    member(diamond, "diamond_only")
+    member(one, "widget_method")
+    member(two, "widget_method")
+    member(cafe, "décrire")
+    if inconsistent:
+        conn.execute("UPDATE symbols SET bases = ? WHERE qualname = ?", (json.dumps(["pkg.Right"]), "pkg.Left"))
+        conn.execute("UPDATE symbols SET bases = ? WHERE qualname = ?", (json.dumps(["pkg.Left"]), "pkg.Right"))
+    conn.commit()
+    conn.close()
+
+
+class QuerySessionTests(unittest.TestCase):
+    def run_cli(self, db: Path, *argv: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--db", str(db), *argv],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def run_session(self, db: Path, requests: list[str]) -> tuple[int, list[dict], str]:
+        process = subprocess.Popen(
+            [sys.executable, str(SCRIPT), "--db", str(db), "serve"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert process.stdin is not None
+        assert process.stdout is not None
+        assert process.stderr is not None
+        ready = process.stdout.readline()
+        self.assertTrue(ready)
+        for line in requests:
+            process.stdin.write(line + "\n")
+        process.stdin.close()
+        lines = [ready, *process.stdout.readlines()]
+        stderr = process.stderr.read()
+        returncode = process.wait()
+        process.stdout.close()
+        process.stderr.close()
+        return returncode, [json.loads(line) for line in lines], stderr
+
+    def test_session_results_match_cli_and_keep_association(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            db = Path(directory) / "fixture with spaces.db"
+            make_database(db)
+            queries = [
+                ["show", "pkg.Diamond"],
+                ["members", "pkg.Diamond"],
+                ["members", "pkg.Diamond", "--own"],
+                ["search", "café"],
+                ["show", "absent"],
+                ["show", "Widget"],
+            ]
+            requests = [
+                json.dumps({"id": index, "argv": argv}, ensure_ascii=False)
+                for index, argv in enumerate(queries)
+            ]
+            returncode, responses, stderr = self.run_session(db, requests)
+            self.assertEqual(returncode, 0)
+            self.assertEqual(stderr, "")
+            self.assertEqual(
+                responses[0],
+                {"type": "ready", "protocol": 1, "commands": ["show", "members", "search"]},
+            )
+            for index, (response, argv) in enumerate(zip(responses[1:], queries)):
+                cli = self.run_cli(db, *argv)
+                self.assertEqual(response["id"], index)
+                self.assertEqual(response["type"], "result")
+                self.assertEqual(response["returncode"], cli.returncode)
+                self.assertEqual(response["stdout"], cli.stdout)
+                self.assertEqual(response["stderr"], cli.stderr)
+
+    def test_request_errors_do_not_corrupt_next_response(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            db = Path(directory) / "fixture.db"
+            make_database(db)
+            requests = [
+                "not JSON",
+                json.dumps({"id": {"bad": True}, "argv": ["info"]}),
+                json.dumps({"id": 3, "argv": ["show", 4]}),
+                json.dumps({"id": 4, "argv": ["search", "café"]}, ensure_ascii=False),
+            ]
+            returncode, responses, _ = self.run_session(db, requests)
+            self.assertEqual(returncode, 0)
+            self.assertEqual(responses[1]["type"], "error")
+            self.assertIsNone(responses[1]["id"])
+            self.assertEqual(
+                responses[2],
+                {"id": None, "type": "error", "message": "unsupported session command: info"},
+            )
+            self.assertEqual(responses[3]["type"], "error")
+            self.assertEqual(responses[4]["id"], 4)
+            self.assertEqual(responses[4]["type"], "result")
+
+    def test_bad_database_fails_before_ready(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            missing = Path(directory) / "missing.db"
+            process = subprocess.run(
+                [sys.executable, str(SCRIPT), "--db", str(missing), "serve"],
+                input="",
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(process.returncode, 1)
+            self.assertEqual(process.stderr, "")
+            response = json.loads(process.stdout)
+            self.assertEqual(response["type"], "error")
+            self.assertIsNone(response["id"])
+            self.assertIn("database not found", response["message"])
+
+    def test_inconsistent_hierarchy_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            db = Path(directory) / "fixture.db"
+            make_database(db, inconsistent=True)
+            returncode, responses, _ = self.run_session(
+                db,
+                [
+                    json.dumps({"id": 1, "argv": ["show", "pkg.Diamond"]}),
+                    json.dumps({"id": 2, "argv": ["search", "café"]}, ensure_ascii=False),
+                ],
+            )
+            self.assertEqual(returncode, 0)
+            self.assertEqual(responses[1]["type"], "error")
+            self.assertEqual(responses[1]["id"], 1)
+            self.assertIn("no consistent resolution order", responses[1]["message"])
+            self.assertEqual(responses[2]["type"], "result")
+
+    def test_session_opens_one_connection_for_many_requests(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            db = Path(directory) / "fixture.db"
+            make_database(db)
+            request_lines = "\n".join(
+                json.dumps({"id": index, "argv": ["search", "café"]}, ensure_ascii=False)
+                for index in range(10)
+            )
+            stdin = io.StringIO(request_lines + "\n")
+            stdout = io.StringIO()
+            with (
+                patch.object(QUERY.sqlite3, "connect", wraps=sqlite3.connect) as connect,
+                patch("sys.stdin", stdin),
+                patch("sys.stdout", stdout),
+            ):
+                returncode = QUERY.serve(db)
+            self.assertEqual(returncode, 0)
+            self.assertEqual(connect.call_count, 1)
+            responses = [json.loads(line) for line in stdout.getvalue().splitlines()]
+            self.assertEqual([response["id"] for response in responses[1:]], list(range(10)))
+
+    def test_single_command_exit_codes_stay_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            db = Path(directory) / "fixture.db"
+            make_database(db)
+            miss = self.run_cli(db, "show", "absent")
+            self.assertEqual(miss.returncode, 1)
+            self.assertIn("no symbol or member", miss.stdout)
+            usage = self.run_cli(db, "members", "pkg.Base", "--unknown")
+            self.assertEqual(usage.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Reuse one read-only Fusion database connection across local JSON Lines queries.
- Preserve one-shot output while returning malformed requests and database failures as protocol errors.
- Warm median for 30 queries is 1.322s baseline CLI versus 0.128s session; tests and plugin validation pass.
