### PR TITLE
bump fusion to 0.1.0

### DIFF
--- a/plugins/fusion/.claude-plugin/plugin.json
+++ b/plugins/fusion/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Query the Autodesk Fusion 360 Python API from a pre-compiled reference database.",
   "author": {
     "name": "lestrrat"

--- a/plugins/fusion/.codex-plugin/plugin.json
+++ b/plugins/fusion/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fusion",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Query the Autodesk Fusion 360 Python API from a pre-compiled reference database.",
   "author": {
     "name": "lestrrat",


### PR DESCRIPTION
- Release the query-session workflow and the stub-only member cleanup that landed since fusion 0.0.1.
- Refresh the installed plugin cache for both Claude Code and Codex.
